### PR TITLE
fix(desktop): show pricing running totals consistently

### DIFF
--- a/apps/desktop/e2e/thread-pricing-panel.spec.ts
+++ b/apps/desktop/e2e/thread-pricing-panel.spec.ts
@@ -48,7 +48,7 @@ test("hydrates provider-scoped pricing totals in the context rail", async () => 
     await expect(
       contextRail.getByRole("heading", { level: 3, name: "Pricing" }),
     ).toBeVisible();
-    await expect(contextRail.getByText("$0.020")).toBeVisible();
+    await expect(contextRail.getByText("$0.020", { exact: true })).toBeVisible();
     await expect(contextRail.getByText("3 (2 priced, 1 unpriced)")).toBeVisible();
     await expect(
       contextRail.getByText("1 usage row could not be priced."),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11408,6 +11408,7 @@ command = "pnpm dev"
       turnId: "turn-2",
       uncachedInputTokens: 800,
     });
+    expect(pricing.lines[0]?.cumulativeTotalCostMicros).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2162,17 +2162,6 @@ function buildLiveThreadUsageLine(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
-  const cumulativeCost = cumulativeTokens
-    ? estimateOpenAiTokenUsageCost({
-        cachedInputTokens: cumulativeTokens.cachedInputTokens,
-        fastMode: params.fastMode,
-        model: params.model,
-        outputTokens: cumulativeTokens.outputTokens,
-        reasoningOutputTokens: cumulativeTokens.reasoningOutputTokens,
-        serviceTier: params.serviceTier,
-        uncachedInputTokens: cumulativeTokens.uncachedInputTokens,
-      })
-    : undefined;
   const pricingServiceTier = resolveOpenAiPricingServiceTier({
     fastMode: params.fastMode,
     serviceTier: params.serviceTier,
@@ -2199,9 +2188,6 @@ function buildLiveThreadUsageLine(params: {
           cumulativeInputTokens: cumulativeTokens.inputTokens,
           cumulativeOutputTokens: cumulativeTokens.outputTokens,
           cumulativeReasoningOutputTokens: cumulativeTokens.reasoningOutputTokens,
-          ...(cumulativeCost
-            ? { cumulativeTotalCostMicros: cumulativeCost.totalCostMicros }
-            : {}),
           cumulativeTotalTokens: cumulativeTokens.totalTokens,
           cumulativeUncachedInputTokens: cumulativeTokens.uncachedInputTokens,
         }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -438,7 +438,7 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.getByRole("heading", { level: 3, name: "Pricing" })).toBeInTheDocument();
-    expect(screen.getByText("$0.042")).toBeInTheDocument();
+    expect(screen.getByText("$0.010")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.5 · high · Fast")).toBeInTheDocument();
     expect(
       screen.queryByText("gpt-5.5 · high · Fast · priority"),
@@ -447,7 +447,7 @@ describe("ThreadContextPanel", () => {
       screen.getByText("1,500 uncached in · 500 cached · 300 out (120 reasoning)"),
     ).toBeInTheDocument();
     expect(screen.getByText("$0.010 list price this turn")).toBeInTheDocument();
-    expect(screen.getByText("Running total: $0.042 list price")).toBeInTheDocument();
+    expect(screen.getByText("Running total: $0.010 list price")).toBeInTheDocument();
   });
 
   it("renders Codex Credits as an optional pricing display unit", () => {
@@ -512,7 +512,7 @@ describe("ThreadContextPanel", () => {
       threadPricingSummaryEnabled: true,
     });
 
-    expect(screen.getByText("$0.042")).toBeInTheDocument();
+    expect(screen.getByText("$0.010 · 1.3 Codex Credits")).toBeInTheDocument();
     expect(screen.queryByText("$0.042 · 1.3 Codex Credits")).not.toBeInTheDocument();
     expect(
       screen.getByText("$0.010 list price this turn · 1.3 Codex Credits this turn"),
@@ -521,24 +521,24 @@ describe("ThreadContextPanel", () => {
       screen.queryByText("Running total: $0.042 list price · 1.3 Codex Credits"),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText("Running total: $0.042 list price"),
+      screen.getByText("Running total: $0.010 list price · 1.3 Codex Credits"),
     ).toBeInTheDocument();
   });
 
-  it("uses cumulative running totals for the pricing header and Codex Credits", () => {
+  it("uses ledger running totals instead of cumulative aggregate cost fields", () => {
     const summary: ThreadPricingSummary = {
       backend: "codex",
       threadId: "thread-1",
       currency: "USD",
-      inputTokens: 559_270,
-      uncachedInputTokens: 77_990,
-      cachedInputTokens: 481_280,
-      outputTokens: 2_451,
-      reasoningOutputTokens: 200,
-      totalTokens: 561_721,
-      totalCostMicros: 720_000,
-      usageLineCount: 2,
-      pricedUsageLineCount: 2,
+      inputTokens: 722_086,
+      uncachedInputTokens: 96_934,
+      cachedInputTokens: 625_152,
+      outputTokens: 3_601,
+      reasoningOutputTokens: 255,
+      totalTokens: 725_942,
+      totalCostMicros: 749_421,
+      usageLineCount: 3,
+      pricedUsageLineCount: 3,
       unpricedUsageLineCount: 0,
       provider: "openai",
       updatedAt: 1_800_000_060_000,
@@ -574,6 +574,31 @@ describe("ThreadContextPanel", () => {
       provider: "openai",
       createdAt: 1_800_000_060_000,
     };
+    const monitorLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "monitor-line",
+      threadId: "monitor-thread",
+      parentThreadId: "thread-1",
+      turnId: "monitor-turn",
+      scope: "monitor",
+      source: "monitor",
+      status: "finalized",
+      model: "gpt-5.4-mini",
+      inputTokens: 162_816,
+      uncachedInputTokens: 18_944,
+      cachedInputTokens: 143_872,
+      outputTokens: 1_150,
+      reasoningOutputTokens: 55,
+      totalTokens: 164_021,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 10_000,
+      cachedInputCostMicros: 8_000,
+      outputCostMicros: 12_421,
+      totalCostMicros: 30_421,
+      provider: "openai",
+      createdAt: 1_800_000_030_000,
+    };
     const previousLine: ThreadUsageLineRecord = {
       backend: "codex",
       usageLineId: "line-previous",
@@ -604,7 +629,7 @@ describe("ThreadContextPanel", () => {
       activeTab: "pricing",
       pinned: true,
       pricing: {
-        lines: [latestLine, previousLine],
+        lines: [latestLine, monitorLine, previousLine],
         summaries: [summary],
       },
       pricingDisplayOptions: {
@@ -614,14 +639,17 @@ describe("ThreadContextPanel", () => {
       threadPricingSummaryEnabled: true,
     });
 
-    expect(screen.getByText("$21.44 · 1,423 Codex Credits")).toBeInTheDocument();
-    expect(screen.queryByText("$0.72 · 18 Codex Credits")).not.toBeInTheDocument();
+    expect(screen.getByText("$0.75 · 19 Codex Credits")).toBeInTheDocument();
+    expect(screen.queryByText("$21.44 · 1,423 Codex Credits")).not.toBeInTheDocument();
     expect(
-      screen.getByText("2,788,759 uncached, 70,463,104 cached"),
+      screen.getByText("96,934 uncached, 625,152 cached"),
     ).toBeInTheDocument();
-    expect(screen.getByText("221,675 (37,030 reasoning)")).toBeInTheDocument();
+    expect(screen.getByText("3,601 (255 reasoning)")).toBeInTheDocument();
     expect(
-      screen.getByText("Running total: $21.44 list price · 1,423 Codex Credits"),
+      screen.getByText("Running total: $0.75 list price · 19 Codex Credits"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Running total: $0.080 list price · 2 Codex Credits"),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -631,7 +659,7 @@ describe("ThreadContextPanel", () => {
     expect(
       screen.queryByText("Running total: $20.77 list price · 1.2 Codex Credits"),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("Running total: $20.77 list price")).toBeInTheDocument();
+    expect(screen.getByText("Running total: $0.049 list price · 1.2 Codex Credits")).toBeInTheDocument();
   });
 
   it("makes pricing row timestamps scroll the transcript to their turn", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -408,13 +408,7 @@ describe("ThreadContextPanel", () => {
       totalTokens: 2_420,
       priceStatus: "priced",
       currency: "USD",
-      cumulativeCachedInputTokens: 5_000,
-      cumulativeInputTokens: 8_000,
-      cumulativeOutputTokens: 700,
-      cumulativeReasoningOutputTokens: 240,
       cumulativeTotalCostMicros: 42_000,
-      cumulativeTotalTokens: 8_940,
-      cumulativeUncachedInputTokens: 3_000,
       uncachedInputCostMicros: 7_500,
       cachedInputCostMicros: 500,
       outputCostMicros: 1_500,
@@ -525,7 +519,7 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
-  it("uses ledger running totals instead of cumulative aggregate cost fields", () => {
+  it("uses cumulative token gaps but ignores cumulative aggregate cost fields", () => {
     const summary: ThreadPricingSummary = {
       backend: "codex",
       threadId: "thread-1",
@@ -639,14 +633,20 @@ describe("ThreadContextPanel", () => {
       threadPricingSummaryEnabled: true,
     });
 
-    expect(screen.getByText("$0.75 · 19 Codex Credits")).toBeInTheDocument();
+    expect(screen.getByText("$56.98 · 1,424 Codex Credits estimated")).toBeInTheDocument();
     expect(screen.queryByText("$21.44 · 1,423 Codex Credits")).not.toBeInTheDocument();
     expect(
-      screen.getByText("96,934 uncached, 625,152 cached"),
+      screen.getByText("2,807,703 uncached, 70,606,976 cached"),
     ).toBeInTheDocument();
-    expect(screen.getByText("3,601 (255 reasoning)")).toBeInTheDocument();
+    expect(screen.getByText("222,825 (37,085 reasoning)")).toBeInTheDocument();
+    expect(screen.getByText("Historical usage estimate")).toBeInTheDocument();
     expect(
-      screen.getByText("Running total: $0.75 list price · 19 Codex Credits"),
+      screen.getByText("$56.23 estimated list price · 1,406 Codex Credits estimated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Running total: $56.98 list price · 1,424 Codex Credits (includes estimates)",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Running total: $0.080 list price · 2 Codex Credits"),
@@ -660,6 +660,122 @@ describe("ThreadContextPanel", () => {
       screen.queryByText("Running total: $20.77 list price · 1.2 Codex Credits"),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Running total: $0.049 list price · 1.2 Codex Credits")).toBeInTheDocument();
+  });
+
+  it("inserts estimated historical gap rows from unexplained cumulative token jumps", () => {
+    const firstObservedLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-first-observed",
+      threadId: "thread-1",
+      turnId: "turn-first-observed",
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      model: "gpt-5.5",
+      serviceTier: "priority",
+      fastMode: true,
+      inputTokens: 150,
+      uncachedInputTokens: 100,
+      cachedInputTokens: 50,
+      outputTokens: 10,
+      reasoningOutputTokens: 0,
+      totalTokens: 160,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeInputTokens: 3_150,
+      cumulativeCachedInputTokens: 2_050,
+      cumulativeUncachedInputTokens: 1_100,
+      cumulativeOutputTokens: 110,
+      cumulativeReasoningOutputTokens: 20,
+      cumulativeTotalTokens: 3_280,
+      uncachedInputCostMicros: 10_000,
+      cachedInputCostMicros: 1_000,
+      outputCostMicros: 4_000,
+      totalCostMicros: 15_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+    const laterObservedLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-later-observed",
+      threadId: "thread-1",
+      turnId: "turn-later-observed",
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      model: "gpt-5.5",
+      serviceTier: "standard",
+      fastMode: false,
+      inputTokens: 50,
+      uncachedInputTokens: 20,
+      cachedInputTokens: 30,
+      outputTokens: 5,
+      reasoningOutputTokens: 0,
+      totalTokens: 55,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeInputTokens: 4_700,
+      cumulativeCachedInputTokens: 3_080,
+      cumulativeUncachedInputTokens: 1_620,
+      cumulativeOutputTokens: 165,
+      cumulativeReasoningOutputTokens: 20,
+      cumulativeTotalTokens: 4_885,
+      uncachedInputCostMicros: 1_000,
+      cachedInputCostMicros: 100,
+      outputCostMicros: 900,
+      totalCostMicros: 2_000,
+      provider: "openai",
+      createdAt: 1_800_000_060_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [laterObservedLine, firstObservedLine],
+        summaries: [
+          {
+            backend: "codex",
+            cachedInputTokens: 80,
+            currency: "USD",
+            inputTokens: 200,
+            outputTokens: 15,
+            pricedUsageLineCount: 2,
+            provider: "openai",
+            reasoningOutputTokens: 0,
+            threadId: "thread-1",
+            totalCostMicros: 17_000,
+            totalTokens: 215,
+            uncachedInputTokens: 120,
+            unpricedUsageLineCount: 0,
+            updatedAt: 1_800_000_060_000,
+            usageLineCount: 2,
+          },
+        ],
+      },
+      pricingDisplayOptions: {
+        codexCredits: true,
+        usd: true,
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("$0.032 · 0.4 Codex Credits estimated")).toBeInTheDocument();
+    expect(document.body).toHaveTextContent("4 (4 priced, 0 unpriced)");
+    expect(screen.getAllByText("Historical usage estimate")).toHaveLength(2);
+    expect(screen.getByText("1,000 uncached in · 2,000 cached · 100 out (20 reasoning)")).toBeInTheDocument();
+    expect(screen.getByText("500 uncached in · 1,000 cached · 50 out")).toBeInTheDocument();
+    expect(
+      screen.getByText("$0.010 estimated list price · 0.2 Codex Credits estimated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("$0.005 estimated list price · 0.1 Codex Credits estimated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Running total: $0.032 list price · 0.4 Codex Credits (includes estimates)",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("makes pricing row timestamps scroll the transcript to their turn", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -438,7 +438,7 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.getByRole("heading", { level: 3, name: "Pricing" })).toBeInTheDocument();
-    expect(screen.getAllByText("$0.010")[0]).toBeInTheDocument();
+    expect(screen.getByText("$0.042")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.5 · high · Fast")).toBeInTheDocument();
     expect(
       screen.queryByText("gpt-5.5 · high · Fast · priority"),
@@ -512,13 +512,126 @@ describe("ThreadContextPanel", () => {
       threadPricingSummaryEnabled: true,
     });
 
-    expect(screen.getByText("$0.010 · 1.3 Codex Credits")).toBeInTheDocument();
+    expect(screen.getByText("$0.042")).toBeInTheDocument();
+    expect(screen.queryByText("$0.042 · 1.3 Codex Credits")).not.toBeInTheDocument();
     expect(
       screen.getByText("$0.010 list price this turn · 1.3 Codex Credits this turn"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Running total: $0.042 list price · 1.3 Codex Credits"),
+      screen.queryByText("Running total: $0.042 list price · 1.3 Codex Credits"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Running total: $0.042 list price"),
     ).toBeInTheDocument();
+  });
+
+  it("uses cumulative running totals for the pricing header and Codex Credits", () => {
+    const summary: ThreadPricingSummary = {
+      backend: "codex",
+      threadId: "thread-1",
+      currency: "USD",
+      inputTokens: 559_270,
+      uncachedInputTokens: 77_990,
+      cachedInputTokens: 481_280,
+      outputTokens: 2_451,
+      reasoningOutputTokens: 200,
+      totalTokens: 561_721,
+      totalCostMicros: 720_000,
+      usageLineCount: 2,
+      pricedUsageLineCount: 2,
+      unpricedUsageLineCount: 0,
+      provider: "openai",
+      updatedAt: 1_800_000_060_000,
+    };
+    const latestLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-latest",
+      threadId: "thread-1",
+      turnId: "turn-latest",
+      scope: "turn",
+      source: "hydration",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 493_365,
+      uncachedInputTokens: 76_981,
+      cachedInputTokens: 416_384,
+      outputTokens: 2_124,
+      reasoningOutputTokens: 154,
+      totalTokens: 495_643,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeCachedInputTokens: 70_463_104,
+      cumulativeInputTokens: 73_251_863,
+      cumulativeOutputTokens: 221_675,
+      cumulativeReasoningOutputTokens: 37_030,
+      cumulativeTotalCostMicros: 21_440_000,
+      cumulativeTotalTokens: 73_510_568,
+      cumulativeUncachedInputTokens: 2_788_759,
+      uncachedInputCostMicros: 620_000,
+      cachedInputCostMicros: 5_000,
+      outputCostMicros: 45_000,
+      totalCostMicros: 670_000,
+      provider: "openai",
+      createdAt: 1_800_000_060_000,
+    };
+    const previousLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-previous",
+      threadId: "thread-1",
+      turnId: "turn-previous",
+      scope: "turn",
+      source: "hydration",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 65_905,
+      uncachedInputTokens: 1_009,
+      cachedInputTokens: 64_896,
+      outputTokens: 327,
+      reasoningOutputTokens: 46,
+      totalTokens: 66_278,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeTotalCostMicros: 20_770_000,
+      uncachedInputCostMicros: 30_000,
+      cachedInputCostMicros: 1_000,
+      outputCostMicros: 18_000,
+      totalCostMicros: 49_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [latestLine, previousLine],
+        summaries: [summary],
+      },
+      pricingDisplayOptions: {
+        codexCredits: true,
+        usd: true,
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("$21.44 · 1,423 Codex Credits")).toBeInTheDocument();
+    expect(screen.queryByText("$0.72 · 18 Codex Credits")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("2,788,759 uncached, 70,463,104 cached"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("221,675 (37,030 reasoning)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Running total: $21.44 list price · 1,423 Codex Credits"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Running tokens: 2,788,759 uncached in · 70,463,104 cached · 221,675 out (37,030 reasoning)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Running total: $20.77 list price · 1.2 Codex Credits"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Running total: $20.77 list price")).toBeInTheDocument();
   });
 
   it("makes pricing row timestamps scroll the transcript to their turn", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -34,48 +34,57 @@ export function PricingPanel(props: PricingPanelProps) {
   const summary = aggregateSummaries(summaries) ?? aggregateUsageLines(lines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   const codexCreditTotals = buildCodexCreditTotals(lines);
+  const latestRunningTotalLine = findLatestRunningTotalLine(lines);
+  const displaySummary = applyRunningTotalsToSummary(
+    summary,
+    latestRunningTotalLine,
+  );
+  const summaryCreditMicros = selectSummaryCreditMicros({
+    codexCreditTotals,
+    line: latestRunningTotalLine,
+  });
 
   return (
     <section className="context-panel__section">
       <h3>Pricing</h3>
-      {summary ? (
+      {displaySummary ? (
         <>
           <dl className="context-grid">
-            <dt>Total</dt>
+            <dt>Running total</dt>
             <dd>
               {formatSummaryEstimates({
-                codexCreditMicros: codexCreditTotals.totalCreditMicros,
+                codexCreditMicros: summaryCreditMicros,
                 displayOptions,
-                summary,
+                summary: displaySummary,
               })}
             </dd>
             <dt>Usage rows</dt>
             <dd>
-              {summary.usageLineCount.toLocaleString()}{" "}
+              {displaySummary.usageLineCount.toLocaleString()}{" "}
               <span className="context-list__meta">
-                ({summary.pricedUsageLineCount.toLocaleString()} priced,{" "}
-                {summary.unpricedUsageLineCount.toLocaleString()} unpriced)
+                ({displaySummary.pricedUsageLineCount.toLocaleString()} priced,{" "}
+                {displaySummary.unpricedUsageLineCount.toLocaleString()} unpriced)
               </span>
             </dd>
             <dt>Input</dt>
             <dd>
-              {formatTokenCount(summary.uncachedInputTokens)} uncached,{" "}
-              {formatTokenCount(summary.cachedInputTokens)} cached
+              {formatTokenCount(displaySummary.uncachedInputTokens)} uncached,{" "}
+              {formatTokenCount(displaySummary.cachedInputTokens)} cached
             </dd>
             <dt>Output</dt>
             <dd>
-              {formatTokenCount(summary.outputTokens)}
-              {summary.reasoningOutputTokens > 0
-                ? ` (${formatTokenCount(summary.reasoningOutputTokens)} reasoning)`
+              {formatTokenCount(displaySummary.outputTokens)}
+              {displaySummary.reasoningOutputTokens > 0
+                ? ` (${formatTokenCount(displaySummary.reasoningOutputTokens)} reasoning)`
                 : ""}
             </dd>
             <dt>Updated</dt>
-            <dd>{formatTimestamp(summary.updatedAt)}</dd>
+            <dd>{formatTimestamp(displaySummary.updatedAt)}</dd>
           </dl>
-          {summary.unpricedUsageLineCount > 0 ? (
+          {displaySummary.unpricedUsageLineCount > 0 ? (
             <p className="context-empty context-empty--warning">
-              {summary.unpricedUsageLineCount.toLocaleString()} usage row
-              {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
+              {displaySummary.unpricedUsageLineCount.toLocaleString()} usage row
+              {displaySummary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
           ) : null}
           {summaries.length > 1 ? (
@@ -119,6 +128,7 @@ export function PricingPanel(props: PricingPanelProps) {
               displayOptions,
               line,
             });
+            const runningTokens = formatUsageLineRunningTokens(line);
 
             return (
               <li key={line.usageLineId} className="rail-card pricing-usage-row">
@@ -145,7 +155,16 @@ export function PricingPanel(props: PricingPanelProps) {
                 {usageLineEstimate ? (
                   <p className="rail-card__usage">{usageLineEstimate}</p>
                 ) : null}
-                {runningTotal ? (
+                {runningTokens ? (
+                  <details className="pricing-running-total">
+                    <summary className="pricing-running-total__summary">
+                      {runningTotal ?? "Running total"}
+                    </summary>
+                    <p className="rail-card__usage pricing-running-total__tokens">
+                      {runningTokens}
+                    </p>
+                  </details>
+                ) : runningTotal ? (
                   <p className="rail-card__usage">{runningTotal}</p>
                 ) : null}
               </li>
@@ -155,6 +174,37 @@ export function PricingPanel(props: PricingPanelProps) {
       ) : null}
     </section>
   );
+}
+
+function applyRunningTotalsToSummary(
+  summary: ThreadPricingSummary | undefined,
+  line: ThreadUsageLineRecord | undefined,
+): ThreadPricingSummary | undefined {
+  if (!summary || !line) {
+    return summary;
+  }
+  const cumulativeCachedInputTokens = line.cumulativeCachedInputTokens;
+  const cumulativeUncachedInputTokens = readCumulativeUncachedInputTokens(line);
+  const cumulativeInputTokens =
+    line.cumulativeInputTokens ??
+    (cumulativeCachedInputTokens !== undefined &&
+    cumulativeUncachedInputTokens !== undefined
+      ? cumulativeCachedInputTokens + cumulativeUncachedInputTokens
+      : undefined);
+
+  return {
+    ...summary,
+    cachedInputTokens: cumulativeCachedInputTokens ?? summary.cachedInputTokens,
+    inputTokens: cumulativeInputTokens ?? summary.inputTokens,
+    outputTokens: line.cumulativeOutputTokens ?? summary.outputTokens,
+    reasoningOutputTokens:
+      line.cumulativeReasoningOutputTokens ?? summary.reasoningOutputTokens,
+    totalCostMicros: line.cumulativeTotalCostMicros ?? summary.totalCostMicros,
+    totalTokens: line.cumulativeTotalTokens ?? summary.totalTokens,
+    uncachedInputTokens:
+      cumulativeUncachedInputTokens ?? summary.uncachedInputTokens,
+    updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
+  };
 }
 
 function formatServiceTierLabel(line: ThreadUsageLineRecord): string {
@@ -213,8 +263,36 @@ function aggregateUsageLines(lines: ThreadUsageLineRecord[]): ThreadPricingSumma
   );
 }
 
+function findLatestRunningTotalLine(
+  lines: ThreadUsageLineRecord[],
+): ThreadUsageLineRecord | undefined {
+  return lines
+    .filter(
+      (line) =>
+        line.cumulativeTotalCostMicros !== undefined ||
+        hasCumulativeTokenBreakdown(line),
+    )
+    .sort((left, right) => lineTimestamp(right) - lineTimestamp(left))[0];
+}
+
+function selectSummaryCreditMicros(params: {
+  codexCreditTotals: ReturnType<typeof buildCodexCreditTotals>;
+  line: ThreadUsageLineRecord | undefined;
+}): number | undefined {
+  if (!params.line) {
+    return params.codexCreditTotals.totalCreditMicros;
+  }
+  return params.codexCreditTotals.byLineId.get(
+    params.line.usageLineId,
+  )?.cumulativeTotalCreditMicros;
+}
+
+function lineTimestamp(line: ThreadUsageLineRecord): number {
+  return line.completedAt ?? line.createdAt;
+}
+
 function formatSummaryEstimates(params: {
-  codexCreditMicros: number;
+  codexCreditMicros: number | undefined;
   displayOptions: PricingDisplayOptions;
   summary: ThreadPricingSummary;
 }): string {
@@ -222,7 +300,11 @@ function formatSummaryEstimates(params: {
   if (params.displayOptions.usd) {
     estimates.push(formatMoney(params.summary.totalCostMicros, params.summary.currency));
   }
-  if (params.displayOptions.codexCredits && params.codexCreditMicros > 0) {
+  if (
+    params.displayOptions.codexCredits &&
+    params.codexCreditMicros !== undefined &&
+    params.codexCreditMicros > 0
+  ) {
     estimates.push(formatCodexCredits(params.codexCreditMicros));
   }
   if (estimates.length > 0) {
@@ -249,6 +331,7 @@ function formatUsageLineEstimates(params: {
   if (
     params.displayOptions.codexCredits &&
     params.creditEstimate &&
+    params.creditEstimate.totalCreditMicros !== undefined &&
     params.creditEstimate.totalCreditMicros > 0
   ) {
     const suffix = formatUsageLineCreditSuffix(params.line);
@@ -276,11 +359,59 @@ function formatUsageLineRunningTotal(params: {
   if (
     params.displayOptions.codexCredits &&
     params.creditEstimate &&
+    params.creditEstimate.cumulativeTotalCreditMicros !== undefined &&
     params.creditEstimate.cumulativeTotalCreditMicros > 0
   ) {
     estimates.push(formatCodexCredits(params.creditEstimate.cumulativeTotalCreditMicros));
   }
   return estimates.length > 0 ? `Running total: ${estimates.join(" · ")}` : undefined;
+}
+
+function formatUsageLineRunningTokens(line: ThreadUsageLineRecord): string | undefined {
+  if (!hasCumulativeTokenBreakdown(line)) {
+    return undefined;
+  }
+  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
+  if (
+    uncachedInputTokens === undefined ||
+    line.cumulativeCachedInputTokens === undefined ||
+    line.cumulativeOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+  const tokens = [
+    `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    `${formatTokenCount(line.cumulativeCachedInputTokens)} cached`,
+    line.cumulativeReasoningOutputTokens && line.cumulativeReasoningOutputTokens > 0
+      ? `${formatTokenCount(line.cumulativeOutputTokens)} out (${formatTokenCount(
+          line.cumulativeReasoningOutputTokens,
+        )} reasoning)`
+      : `${formatTokenCount(line.cumulativeOutputTokens)} out`,
+  ].join(" · ");
+  return `Running tokens: ${tokens}`;
+}
+
+function hasCumulativeTokenBreakdown(line: ThreadUsageLineRecord): boolean {
+  return (
+    line.cumulativeCachedInputTokens !== undefined &&
+    line.cumulativeOutputTokens !== undefined &&
+    readCumulativeUncachedInputTokens(line) !== undefined
+  );
+}
+
+function readCumulativeUncachedInputTokens(
+  line: ThreadUsageLineRecord,
+): number | undefined {
+  if (line.cumulativeUncachedInputTokens !== undefined) {
+    return line.cumulativeUncachedInputTokens;
+  }
+  if (
+    line.cumulativeInputTokens !== undefined &&
+    line.cumulativeCachedInputTokens !== undefined
+  ) {
+    return Math.max(0, line.cumulativeInputTokens - line.cumulativeCachedInputTokens);
+  }
+  return undefined;
 }
 
 function hasSelectedEstimateUnit(displayOptions: PricingDisplayOptions): boolean {
@@ -407,8 +538,8 @@ function formatMoney(valueMicros: number, currency: string): string {
 }
 
 type CodexCreditLineEstimate = {
-  cumulativeTotalCreditMicros: number;
-  totalCreditMicros: number;
+  cumulativeTotalCreditMicros?: number;
+  totalCreditMicros?: number;
 };
 
 function buildCodexCreditTotals(lines: ThreadUsageLineRecord[]): {
@@ -420,19 +551,35 @@ function buildCodexCreditTotals(lines: ThreadUsageLineRecord[]): {
       (left.startedAt ?? left.createdAt) - (right.startedAt ?? right.createdAt),
   );
   const byLineId = new Map<string, CodexCreditLineEstimate>();
-  let totalCreditMicros = 0;
+  let visibleLineTotalCreditMicros = 0;
+  let latestCumulativeCreditMicros: number | undefined;
+  let latestCumulativeCreditTimestamp = Number.NEGATIVE_INFINITY;
   for (const line of sortedLines) {
     const estimate = estimateCodexCreditsForLine(line);
-    if (!estimate) {
-      continue;
+    const cumulativeEstimate = estimateCodexCreditsForCumulativeLine(line);
+    if (estimate) {
+      visibleLineTotalCreditMicros += estimate.totalCreditMicros;
     }
-    totalCreditMicros += estimate.totalCreditMicros;
-    byLineId.set(line.usageLineId, {
-      cumulativeTotalCreditMicros: totalCreditMicros,
-      totalCreditMicros: estimate.totalCreditMicros,
-    });
+    if (cumulativeEstimate) {
+      const timestamp = lineTimestamp(line);
+      if (timestamp >= latestCumulativeCreditTimestamp) {
+        latestCumulativeCreditTimestamp = timestamp;
+        latestCumulativeCreditMicros = cumulativeEstimate.totalCreditMicros;
+      }
+    }
+    if (estimate || cumulativeEstimate) {
+      byLineId.set(line.usageLineId, {
+        ...(cumulativeEstimate
+          ? { cumulativeTotalCreditMicros: cumulativeEstimate.totalCreditMicros }
+          : {}),
+        ...(estimate ? { totalCreditMicros: estimate.totalCreditMicros } : {}),
+      });
+    }
   }
-  return { byLineId, totalCreditMicros };
+  return {
+    byLineId,
+    totalCreditMicros: latestCumulativeCreditMicros ?? visibleLineTotalCreditMicros,
+  };
 }
 
 function estimateCodexCreditsForLine(line: ThreadUsageLineRecord):
@@ -452,6 +599,35 @@ function estimateCodexCreditsForLine(line: ThreadUsageLineRecord):
     reasoningOutputTokens: line.reasoningOutputTokens,
     serviceTier: line.serviceTier,
     uncachedInputTokens: line.uncachedInputTokens,
+  });
+  return estimate ? { totalCreditMicros: estimate.totalCreditMicros } : undefined;
+}
+
+function estimateCodexCreditsForCumulativeLine(line: ThreadUsageLineRecord):
+  | {
+      totalCreditMicros: number;
+    }
+  | undefined {
+  if (line.provider !== "openai") {
+    return undefined;
+  }
+  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
+  if (
+    uncachedInputTokens === undefined ||
+    line.cumulativeCachedInputTokens === undefined ||
+    line.cumulativeOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+  const estimate = estimateOpenAiCodexCreditUsage({
+    at: line.createdAt,
+    cachedInputTokens: line.cumulativeCachedInputTokens,
+    fastMode: line.fastMode,
+    model: line.model,
+    outputTokens: line.cumulativeOutputTokens,
+    reasoningOutputTokens: line.cumulativeReasoningOutputTokens,
+    serviceTier: line.serviceTier,
+    uncachedInputTokens,
   });
   return estimate ? { totalCreditMicros: estimate.totalCreditMicros } : undefined;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -4,6 +4,7 @@ import type {
 } from "@pwragent/shared";
 import {
   estimateOpenAiCodexCreditUsage,
+  estimateOpenAiTokenUsageCost,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
 import { formatTimestamp } from "./context-rail-shared";
@@ -23,6 +24,10 @@ type PricingDisplayOptions = {
   usd: boolean;
 };
 
+type PricingUsageLine = ThreadUsageLineRecord & {
+  estimatedUsageGap?: true;
+};
+
 const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
   codexCredits: false,
   usd: true,
@@ -31,9 +36,13 @@ const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
 export function PricingPanel(props: PricingPanelProps) {
   const summaries = props.pricing?.summaries ?? [];
   const lines = props.pricing?.lines ?? [];
-  const summary = aggregateSummaries(summaries) ?? aggregateUsageLines(lines);
+  const displayLines = buildPricingDisplayLines(lines);
+  const estimatedLines = displayLines.filter(isEstimatedUsageGap);
+  const displaySummaries = addEstimatedLinesToSummaries(summaries, estimatedLines);
+  const summary =
+    aggregateSummaries(displaySummaries) ?? aggregateUsageLines(displayLines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
-  const pricingTotals = buildPricingRunningTotals(lines);
+  const pricingTotals = buildPricingRunningTotals(displayLines);
 
   return (
     <section className="context-panel__section">
@@ -46,6 +55,7 @@ export function PricingPanel(props: PricingPanelProps) {
               {formatSummaryEstimates({
                 codexCreditMicros: pricingTotals.totalCreditMicros,
                 displayOptions,
+                hasEstimates: pricingTotals.hasEstimatedRows,
                 summary,
               })}
             </dd>
@@ -78,9 +88,9 @@ export function PricingPanel(props: PricingPanelProps) {
               {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
           ) : null}
-          {summaries.length > 1 ? (
+          {displaySummaries.length > 1 ? (
             <ul className="context-list context-list--cards pricing-provider-list">
-              {summaries.map((providerSummary) => (
+              {displaySummaries.map((providerSummary) => (
                 <li
                   key={`${providerSummary.provider}:${providerSummary.currency}`}
                   className="rail-card pricing-provider-row"
@@ -101,13 +111,13 @@ export function PricingPanel(props: PricingPanelProps) {
             </ul>
           ) : null}
         </>
-      ) : lines.length === 0 ? (
+      ) : displayLines.length === 0 ? (
         <p className="context-empty">No usage pricing recorded yet.</p>
       ) : null}
 
-      {lines.length > 0 ? (
+      {displayLines.length > 0 ? (
         <ul className="context-list context-list--cards pricing-usage-list">
-          {lines.map((line) => {
+          {displayLines.map((line) => {
             const lineTotals = pricingTotals.byLineId.get(line.usageLineId);
             const usageLineEstimate = formatUsageLineEstimates({
               displayOptions,
@@ -177,32 +187,98 @@ function formatServiceTierLabel(line: ThreadUsageLineRecord): string {
   return ` · ${line.serviceTier}`;
 }
 
-function aggregateUsageLines(lines: ThreadUsageLineRecord[]): ThreadPricingSummary | undefined {
+function buildPricingDisplayLines(lines: ThreadUsageLineRecord[]): PricingUsageLine[] {
+  const chronologicalLines = [...lines].sort(compareUsageLinesAscending);
+  const displayLines: PricingUsageLine[] = [];
+  let accountedMainTokens = emptyPricingTokenBreakdown();
+
+  for (const line of chronologicalLines) {
+    if (!isMainThreadUsageLine(line)) {
+      displayLines.push(line);
+      continue;
+    }
+
+    const cumulativeTokens = readCumulativeTokenBreakdown(line);
+    const lineTokens = tokenBreakdownFromUsageLine(line);
+    const gapTokens = cumulativeTokens
+      ? subtractPricingTokenBreakdowns(
+          cumulativeTokens,
+          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
+        )
+      : emptyPricingTokenBreakdown();
+    const gapLine = hasPricingTokenBreakdownValue(gapTokens)
+      ? buildEstimatedHistoricalGapLine({
+          anchorLine: line,
+          gapTokens,
+        })
+      : undefined;
+    if (gapLine) {
+      displayLines.push(gapLine);
+      accountedMainTokens = addPricingTokenBreakdowns(accountedMainTokens, gapTokens);
+    }
+
+    displayLines.push(line);
+    accountedMainTokens = cumulativeTokens
+      ? maxPricingTokenBreakdowns(
+          addPricingTokenBreakdowns(accountedMainTokens, lineTokens),
+          cumulativeTokens,
+        )
+      : addPricingTokenBreakdowns(accountedMainTokens, lineTokens);
+  }
+
+  return displayLines.sort(compareUsageLinesDescending);
+}
+
+function addEstimatedLinesToSummaries(
+  summaries: ThreadPricingSummary[],
+  estimatedLines: PricingUsageLine[],
+): ThreadPricingSummary[] {
+  if (summaries.length === 0 || estimatedLines.length === 0) {
+    return summaries;
+  }
+
+  const byKey = new Map<string, ThreadPricingSummary>();
+  for (const summary of summaries) {
+    byKey.set(summaryKey(summary), { ...summary });
+  }
+  for (const line of estimatedLines) {
+    const key = usageLineSummaryKey(line);
+    const existing =
+      byKey.get(key) ??
+      ({
+        backend: line.backend,
+        cachedInputTokens: 0,
+        currency: line.currency,
+        inputTokens: 0,
+        outputTokens: 0,
+        pricedUsageLineCount: 0,
+        provider: line.provider,
+        reasoningOutputTokens: 0,
+        threadId: line.parentThreadId ?? line.threadId,
+        totalCostMicros: 0,
+        totalTokens: 0,
+        uncachedInputTokens: 0,
+        unpricedUsageLineCount: 0,
+        updatedAt: 0,
+        usageLineCount: 0,
+      } satisfies ThreadPricingSummary);
+    byKey.set(key, addUsageLineToSummary(existing, line));
+  }
+  return [...byKey.values()].sort((left, right) => {
+    const providerCompare = left.provider.localeCompare(right.provider);
+    return providerCompare !== 0
+      ? providerCompare
+      : left.currency.localeCompare(right.currency);
+  });
+}
+
+function aggregateUsageLines(lines: PricingUsageLine[]): ThreadPricingSummary | undefined {
   if (lines.length === 0) {
     return undefined;
   }
   const firstLine = lines[0];
   return lines.reduce<ThreadPricingSummary>(
-    (summary, line) => ({
-      backend: summary.backend,
-      cachedInputTokens: summary.cachedInputTokens + line.cachedInputTokens,
-      currency: summary.currency,
-      inputTokens: summary.inputTokens + line.inputTokens,
-      outputTokens: summary.outputTokens + line.outputTokens,
-      pricedUsageLineCount:
-        summary.pricedUsageLineCount + (line.priceStatus === "priced" ? 1 : 0),
-      provider: summary.provider,
-      reasoningOutputTokens:
-        summary.reasoningOutputTokens + line.reasoningOutputTokens,
-      threadId: summary.threadId,
-      totalCostMicros: summary.totalCostMicros + line.totalCostMicros,
-      totalTokens: summary.totalTokens + line.totalTokens,
-      uncachedInputTokens: summary.uncachedInputTokens + line.uncachedInputTokens,
-      unpricedUsageLineCount:
-        summary.unpricedUsageLineCount + (line.priceStatus === "priced" ? 0 : 1),
-      updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
-      usageLineCount: summary.usageLineCount + 1,
-    }),
+    (summary, line) => addUsageLineToSummary(summary, line),
     {
       backend: firstLine.backend,
       cachedInputTokens: 0,
@@ -223,9 +299,253 @@ function aggregateUsageLines(lines: ThreadUsageLineRecord[]): ThreadPricingSumma
   );
 }
 
+type PricingTokenBreakdown = {
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+  uncachedInputTokens: number;
+};
+
+function addUsageLineToSummary(
+  summary: ThreadPricingSummary,
+  line: PricingUsageLine,
+): ThreadPricingSummary {
+  return {
+    backend: summary.backend,
+    cachedInputTokens: summary.cachedInputTokens + line.cachedInputTokens,
+    currency: summary.currency,
+    inputTokens: summary.inputTokens + line.inputTokens,
+    outputTokens: summary.outputTokens + line.outputTokens,
+    pricedUsageLineCount:
+      summary.pricedUsageLineCount + (line.priceStatus === "priced" ? 1 : 0),
+    provider: summary.provider,
+    reasoningOutputTokens:
+      summary.reasoningOutputTokens + line.reasoningOutputTokens,
+    threadId: summary.threadId,
+    totalCostMicros: summary.totalCostMicros + line.totalCostMicros,
+    totalTokens: summary.totalTokens + line.totalTokens,
+    uncachedInputTokens: summary.uncachedInputTokens + line.uncachedInputTokens,
+    unpricedUsageLineCount:
+      summary.unpricedUsageLineCount + (line.priceStatus === "priced" ? 0 : 1),
+    updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
+    usageLineCount: summary.usageLineCount + 1,
+  };
+}
+
+function summaryKey(summary: ThreadPricingSummary): string {
+  return [
+    summary.backend,
+    summary.threadId,
+    summary.provider,
+    summary.currency,
+  ].join(":");
+}
+
+function usageLineSummaryKey(line: PricingUsageLine): string {
+  return [
+    line.backend,
+    line.parentThreadId ?? line.threadId,
+    line.provider,
+    line.currency,
+  ].join(":");
+}
+
+function compareUsageLinesAscending(
+  left: ThreadUsageLineRecord,
+  right: ThreadUsageLineRecord,
+): number {
+  const leftTimestamp = lineSortTimestamp(left);
+  const rightTimestamp = lineSortTimestamp(right);
+  if (leftTimestamp !== rightTimestamp) {
+    return leftTimestamp - rightTimestamp;
+  }
+  return left.usageLineId.localeCompare(right.usageLineId);
+}
+
+function compareUsageLinesDescending(
+  left: ThreadUsageLineRecord,
+  right: ThreadUsageLineRecord,
+): number {
+  const leftTimestamp = lineSortTimestamp(left);
+  const rightTimestamp = lineSortTimestamp(right);
+  if (leftTimestamp !== rightTimestamp) {
+    return rightTimestamp - leftTimestamp;
+  }
+  return right.usageLineId.localeCompare(left.usageLineId);
+}
+
+function lineSortTimestamp(line: ThreadUsageLineRecord): number {
+  return line.startedAt ?? line.createdAt;
+}
+
+function emptyPricingTokenBreakdown(): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    uncachedInputTokens: 0,
+  };
+}
+
+function tokenBreakdownFromUsageLine(
+  line: ThreadUsageLineRecord,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(0, line.cachedInputTokens),
+    outputTokens: Math.max(0, line.outputTokens),
+    reasoningOutputTokens: Math.max(0, line.reasoningOutputTokens),
+    uncachedInputTokens: Math.max(0, line.uncachedInputTokens),
+  };
+}
+
+function readCumulativeTokenBreakdown(
+  line: ThreadUsageLineRecord,
+): PricingTokenBreakdown | undefined {
+  if (!hasCumulativeTokenBreakdown(line)) {
+    return undefined;
+  }
+  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
+  if (
+    uncachedInputTokens === undefined ||
+    line.cumulativeCachedInputTokens === undefined ||
+    line.cumulativeOutputTokens === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    cachedInputTokens: Math.max(0, line.cumulativeCachedInputTokens),
+    outputTokens: Math.max(0, line.cumulativeOutputTokens),
+    reasoningOutputTokens: Math.max(0, line.cumulativeReasoningOutputTokens ?? 0),
+    uncachedInputTokens: Math.max(0, uncachedInputTokens),
+  };
+}
+
+function addPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningOutputTokens:
+      left.reasoningOutputTokens + right.reasoningOutputTokens,
+    uncachedInputTokens: left.uncachedInputTokens + right.uncachedInputTokens,
+  };
+}
+
+function subtractPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(0, left.cachedInputTokens - right.cachedInputTokens),
+    outputTokens: Math.max(0, left.outputTokens - right.outputTokens),
+    reasoningOutputTokens: Math.max(
+      0,
+      left.reasoningOutputTokens - right.reasoningOutputTokens,
+    ),
+    uncachedInputTokens: Math.max(
+      0,
+      left.uncachedInputTokens - right.uncachedInputTokens,
+    ),
+  };
+}
+
+function maxPricingTokenBreakdowns(
+  left: PricingTokenBreakdown,
+  right: PricingTokenBreakdown,
+): PricingTokenBreakdown {
+  return {
+    cachedInputTokens: Math.max(left.cachedInputTokens, right.cachedInputTokens),
+    outputTokens: Math.max(left.outputTokens, right.outputTokens),
+    reasoningOutputTokens: Math.max(
+      left.reasoningOutputTokens,
+      right.reasoningOutputTokens,
+    ),
+    uncachedInputTokens: Math.max(
+      left.uncachedInputTokens,
+      right.uncachedInputTokens,
+    ),
+  };
+}
+
+function hasPricingTokenBreakdownValue(tokens: PricingTokenBreakdown): boolean {
+  return (
+    tokens.cachedInputTokens > 0 ||
+    tokens.outputTokens > 0 ||
+    tokens.reasoningOutputTokens > 0 ||
+    tokens.uncachedInputTokens > 0
+  );
+}
+
+function isMainThreadUsageLine(line: ThreadUsageLineRecord): boolean {
+  return line.scope !== "monitor";
+}
+
+function buildEstimatedHistoricalGapLine(params: {
+  anchorLine: ThreadUsageLineRecord;
+  gapTokens: PricingTokenBreakdown;
+}): PricingUsageLine | undefined {
+  const cost = estimateOpenAiTokenUsageCost({
+    at: params.anchorLine.createdAt,
+    cachedInputTokens: params.gapTokens.cachedInputTokens,
+    fastMode: false,
+    model: params.anchorLine.model,
+    outputTokens: params.gapTokens.outputTokens,
+    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
+    serviceTier: "standard",
+    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
+  });
+  const inputTokens =
+    params.gapTokens.cachedInputTokens + params.gapTokens.uncachedInputTokens;
+  const totalTokens =
+    inputTokens +
+    params.gapTokens.outputTokens +
+    params.gapTokens.reasoningOutputTokens;
+  const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
+    cost ? undefined : params.anchorLine.model ? "missing-rate" : "missing-model";
+
+  return {
+    backend: params.anchorLine.backend,
+    cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
+    cachedInputTokens: params.gapTokens.cachedInputTokens,
+    createdAt: Math.max(0, lineSortTimestamp(params.anchorLine) - 1),
+    currency: cost?.currency ?? params.anchorLine.currency,
+    estimatedUsageGap: true,
+    inputTokens,
+    model: params.anchorLine.model,
+    outputCostMicros: cost?.outputCostMicros ?? 0,
+    outputTokens: params.gapTokens.outputTokens,
+    parentThreadId: params.anchorLine.parentThreadId,
+    priceStatus: cost ? "priced" : "unpriced",
+    ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
+    provider: cost?.provider ?? params.anchorLine.provider,
+    ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
+    ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
+    ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
+    reasoningEffort: params.anchorLine.reasoningEffort,
+    reasoningOutputTokens: params.gapTokens.reasoningOutputTokens,
+    scope: "backfill",
+    serviceTier: "standard",
+    settingsConfidence: "fallback",
+    settingsSource: "observed-settings",
+    source: "backfill",
+    sourceItemId: `estimated-gap:${params.anchorLine.usageLineId}`,
+    status: "finalized",
+    threadId: params.anchorLine.threadId,
+    totalCostMicros: cost?.totalCostMicros ?? 0,
+    totalTokens,
+    uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
+    uncachedInputTokens: params.gapTokens.uncachedInputTokens,
+    usageLineId: `estimated-gap:${params.anchorLine.usageLineId}`,
+    usageTurnId: `estimated-gap:${params.anchorLine.usageTurnId ?? params.anchorLine.usageLineId}`,
+  };
+}
+
 function formatSummaryEstimates(params: {
   codexCreditMicros: number | undefined;
   displayOptions: PricingDisplayOptions;
+  hasEstimates?: boolean;
   summary: ThreadPricingSummary;
 }): string {
   const estimates: string[] = [];
@@ -240,7 +560,7 @@ function formatSummaryEstimates(params: {
     estimates.push(formatCodexCredits(params.codexCreditMicros));
   }
   if (estimates.length > 0) {
-    return estimates.join(" · ");
+    return `${estimates.join(" · ")}${params.hasEstimates ? " estimated" : ""}`;
   }
   return hasSelectedEstimateUnit(params.displayOptions)
     ? "No selected estimates available"
@@ -249,7 +569,7 @@ function formatSummaryEstimates(params: {
 
 function formatUsageLineEstimates(params: {
   displayOptions: PricingDisplayOptions;
-  line: ThreadUsageLineRecord;
+  line: PricingUsageLine;
   lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
   const estimates: string[] = [];
@@ -275,7 +595,7 @@ function formatUsageLineEstimates(params: {
 
 function formatUsageLineRunningTotal(params: {
   displayOptions: PricingDisplayOptions;
-  line: ThreadUsageLineRecord;
+  line: PricingUsageLine;
   lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
   const estimates: string[] = [];
@@ -291,7 +611,9 @@ function formatUsageLineRunningTotal(params: {
   ) {
     estimates.push(formatCodexCredits(params.lineTotals.runningCreditMicros));
   }
-  return estimates.length > 0 ? `Running total: ${estimates.join(" · ")}` : undefined;
+  return estimates.length > 0
+    ? `Running total: ${estimates.join(" · ")}${params.lineTotals?.runningHasEstimate ? " (includes estimates)" : ""}`
+    : undefined;
 }
 
 function formatUsageLineRunningTokens(line: ThreadUsageLineRecord): string | undefined {
@@ -345,9 +667,12 @@ function hasSelectedEstimateUnit(displayOptions: PricingDisplayOptions): boolean
   return displayOptions.usd || displayOptions.codexCredits;
 }
 
-function formatUsageLineTitle(line: ThreadUsageLineRecord): string {
+function formatUsageLineTitle(line: PricingUsageLine): string {
   if (line.scope === "monitor") {
     return "Sub-agent usage";
+  }
+  if (isEstimatedUsageGap(line)) {
+    return "Historical usage estimate";
   }
   if (isHistoricalUsageSummary(line)) {
     return "Historical usage summary";
@@ -358,7 +683,10 @@ function formatUsageLineTitle(line: ThreadUsageLineRecord): string {
   return "Turn usage";
 }
 
-function formatUsageLineCostSuffix(line: ThreadUsageLineRecord): string {
+function formatUsageLineCostSuffix(line: PricingUsageLine): string {
+  if (isEstimatedUsageGap(line)) {
+    return "estimated list price";
+  }
   if (line.scope === "latest-request") {
     return "list price this request";
   }
@@ -368,7 +696,10 @@ function formatUsageLineCostSuffix(line: ThreadUsageLineRecord): string {
   return "list price";
 }
 
-function formatUsageLineCreditSuffix(line: ThreadUsageLineRecord): string {
+function formatUsageLineCreditSuffix(line: PricingUsageLine): string {
+  if (isEstimatedUsageGap(line)) {
+    return "estimated";
+  }
   if (line.scope === "latest-request") {
     return "this request";
   }
@@ -376,6 +707,10 @@ function formatUsageLineCreditSuffix(line: ThreadUsageLineRecord): string {
     return "this turn";
   }
   return "";
+}
+
+function isEstimatedUsageGap(line: ThreadUsageLineRecord): boolean {
+  return "estimatedUsageGap" in line && line.estimatedUsageGap === true;
 }
 
 function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
@@ -466,27 +801,26 @@ function formatMoney(valueMicros: number, currency: string): string {
 
 type PricingRunningLineTotals = {
   creditMicros?: number;
+  runningHasEstimate?: boolean;
   runningCostMicros: number;
   runningCreditMicros?: number;
 };
 
-function buildPricingRunningTotals(lines: ThreadUsageLineRecord[]): {
+function buildPricingRunningTotals(lines: PricingUsageLine[]): {
   byLineId: Map<string, PricingRunningLineTotals>;
+  hasEstimatedRows: boolean;
   totalCreditMicros: number;
 } {
-  const sortedLines = [...lines].sort((left, right) => {
-    const leftTimestamp = left.startedAt ?? left.createdAt;
-    const rightTimestamp = right.startedAt ?? right.createdAt;
-    if (leftTimestamp !== rightTimestamp) {
-      return leftTimestamp - rightTimestamp;
-    }
-    return left.usageLineId.localeCompare(right.usageLineId);
-  });
+  const sortedLines = [...lines].sort(compareUsageLinesAscending);
   const byLineId = new Map<string, PricingRunningLineTotals>();
+  let hasEstimatedRows = false;
   let runningCostMicros = 0;
   let runningCreditMicros = 0;
   for (const line of sortedLines) {
     const estimate = estimateCodexCreditsForLine(line);
+    if (isEstimatedUsageGap(line)) {
+      hasEstimatedRows = true;
+    }
     if (line.priceStatus === "priced") {
       runningCostMicros += Math.max(0, line.totalCostMicros);
     }
@@ -495,17 +829,19 @@ function buildPricingRunningTotals(lines: ThreadUsageLineRecord[]): {
     }
     byLineId.set(line.usageLineId, {
       ...(estimate ? { creditMicros: estimate.totalCreditMicros } : {}),
+      ...(hasEstimatedRows ? { runningHasEstimate: true } : {}),
       runningCostMicros,
       ...(runningCreditMicros > 0 ? { runningCreditMicros } : {}),
     });
   }
   return {
     byLineId,
+    hasEstimatedRows,
     totalCreditMicros: runningCreditMicros,
   };
 }
 
-function estimateCodexCreditsForLine(line: ThreadUsageLineRecord):
+function estimateCodexCreditsForLine(line: PricingUsageLine):
   | {
       totalCreditMicros: number;
     }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -33,58 +33,49 @@ export function PricingPanel(props: PricingPanelProps) {
   const lines = props.pricing?.lines ?? [];
   const summary = aggregateSummaries(summaries) ?? aggregateUsageLines(lines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
-  const codexCreditTotals = buildCodexCreditTotals(lines);
-  const latestRunningTotalLine = findLatestRunningTotalLine(lines);
-  const displaySummary = applyRunningTotalsToSummary(
-    summary,
-    latestRunningTotalLine,
-  );
-  const summaryCreditMicros = selectSummaryCreditMicros({
-    codexCreditTotals,
-    line: latestRunningTotalLine,
-  });
+  const pricingTotals = buildPricingRunningTotals(lines);
 
   return (
     <section className="context-panel__section">
       <h3>Pricing</h3>
-      {displaySummary ? (
+      {summary ? (
         <>
           <dl className="context-grid">
             <dt>Running total</dt>
             <dd>
               {formatSummaryEstimates({
-                codexCreditMicros: summaryCreditMicros,
+                codexCreditMicros: pricingTotals.totalCreditMicros,
                 displayOptions,
-                summary: displaySummary,
+                summary,
               })}
             </dd>
             <dt>Usage rows</dt>
             <dd>
-              {displaySummary.usageLineCount.toLocaleString()}{" "}
+              {summary.usageLineCount.toLocaleString()}{" "}
               <span className="context-list__meta">
-                ({displaySummary.pricedUsageLineCount.toLocaleString()} priced,{" "}
-                {displaySummary.unpricedUsageLineCount.toLocaleString()} unpriced)
+                ({summary.pricedUsageLineCount.toLocaleString()} priced,{" "}
+                {summary.unpricedUsageLineCount.toLocaleString()} unpriced)
               </span>
             </dd>
             <dt>Input</dt>
             <dd>
-              {formatTokenCount(displaySummary.uncachedInputTokens)} uncached,{" "}
-              {formatTokenCount(displaySummary.cachedInputTokens)} cached
+              {formatTokenCount(summary.uncachedInputTokens)} uncached,{" "}
+              {formatTokenCount(summary.cachedInputTokens)} cached
             </dd>
             <dt>Output</dt>
             <dd>
-              {formatTokenCount(displaySummary.outputTokens)}
-              {displaySummary.reasoningOutputTokens > 0
-                ? ` (${formatTokenCount(displaySummary.reasoningOutputTokens)} reasoning)`
+              {formatTokenCount(summary.outputTokens)}
+              {summary.reasoningOutputTokens > 0
+                ? ` (${formatTokenCount(summary.reasoningOutputTokens)} reasoning)`
                 : ""}
             </dd>
             <dt>Updated</dt>
-            <dd>{formatTimestamp(displaySummary.updatedAt)}</dd>
+            <dd>{formatTimestamp(summary.updatedAt)}</dd>
           </dl>
-          {displaySummary.unpricedUsageLineCount > 0 ? (
+          {summary.unpricedUsageLineCount > 0 ? (
             <p className="context-empty context-empty--warning">
-              {displaySummary.unpricedUsageLineCount.toLocaleString()} usage row
-              {displaySummary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
+              {summary.unpricedUsageLineCount.toLocaleString()} usage row
+              {summary.unpricedUsageLineCount === 1 ? "" : "s"} could not be priced.
             </p>
           ) : null}
           {summaries.length > 1 ? (
@@ -117,16 +108,16 @@ export function PricingPanel(props: PricingPanelProps) {
       {lines.length > 0 ? (
         <ul className="context-list context-list--cards pricing-usage-list">
           {lines.map((line) => {
-            const creditEstimate = codexCreditTotals.byLineId.get(line.usageLineId);
+            const lineTotals = pricingTotals.byLineId.get(line.usageLineId);
             const usageLineEstimate = formatUsageLineEstimates({
-              creditEstimate,
               displayOptions,
               line,
+              lineTotals,
             });
             const runningTotal = formatUsageLineRunningTotal({
-              creditEstimate,
               displayOptions,
               line,
+              lineTotals,
             });
             const runningTokens = formatUsageLineRunningTokens(line);
 
@@ -174,37 +165,6 @@ export function PricingPanel(props: PricingPanelProps) {
       ) : null}
     </section>
   );
-}
-
-function applyRunningTotalsToSummary(
-  summary: ThreadPricingSummary | undefined,
-  line: ThreadUsageLineRecord | undefined,
-): ThreadPricingSummary | undefined {
-  if (!summary || !line) {
-    return summary;
-  }
-  const cumulativeCachedInputTokens = line.cumulativeCachedInputTokens;
-  const cumulativeUncachedInputTokens = readCumulativeUncachedInputTokens(line);
-  const cumulativeInputTokens =
-    line.cumulativeInputTokens ??
-    (cumulativeCachedInputTokens !== undefined &&
-    cumulativeUncachedInputTokens !== undefined
-      ? cumulativeCachedInputTokens + cumulativeUncachedInputTokens
-      : undefined);
-
-  return {
-    ...summary,
-    cachedInputTokens: cumulativeCachedInputTokens ?? summary.cachedInputTokens,
-    inputTokens: cumulativeInputTokens ?? summary.inputTokens,
-    outputTokens: line.cumulativeOutputTokens ?? summary.outputTokens,
-    reasoningOutputTokens:
-      line.cumulativeReasoningOutputTokens ?? summary.reasoningOutputTokens,
-    totalCostMicros: line.cumulativeTotalCostMicros ?? summary.totalCostMicros,
-    totalTokens: line.cumulativeTotalTokens ?? summary.totalTokens,
-    uncachedInputTokens:
-      cumulativeUncachedInputTokens ?? summary.uncachedInputTokens,
-    updatedAt: Math.max(summary.updatedAt, line.completedAt ?? line.createdAt),
-  };
 }
 
 function formatServiceTierLabel(line: ThreadUsageLineRecord): string {
@@ -263,34 +223,6 @@ function aggregateUsageLines(lines: ThreadUsageLineRecord[]): ThreadPricingSumma
   );
 }
 
-function findLatestRunningTotalLine(
-  lines: ThreadUsageLineRecord[],
-): ThreadUsageLineRecord | undefined {
-  return lines
-    .filter(
-      (line) =>
-        line.cumulativeTotalCostMicros !== undefined ||
-        hasCumulativeTokenBreakdown(line),
-    )
-    .sort((left, right) => lineTimestamp(right) - lineTimestamp(left))[0];
-}
-
-function selectSummaryCreditMicros(params: {
-  codexCreditTotals: ReturnType<typeof buildCodexCreditTotals>;
-  line: ThreadUsageLineRecord | undefined;
-}): number | undefined {
-  if (!params.line) {
-    return params.codexCreditTotals.totalCreditMicros;
-  }
-  return params.codexCreditTotals.byLineId.get(
-    params.line.usageLineId,
-  )?.cumulativeTotalCreditMicros;
-}
-
-function lineTimestamp(line: ThreadUsageLineRecord): number {
-  return line.completedAt ?? line.createdAt;
-}
-
 function formatSummaryEstimates(params: {
   codexCreditMicros: number | undefined;
   displayOptions: PricingDisplayOptions;
@@ -316,9 +248,9 @@ function formatSummaryEstimates(params: {
 }
 
 function formatUsageLineEstimates(params: {
-  creditEstimate: CodexCreditLineEstimate | undefined;
   displayOptions: PricingDisplayOptions;
   line: ThreadUsageLineRecord;
+  lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
   const estimates: string[] = [];
   if (params.displayOptions.usd) {
@@ -330,39 +262,34 @@ function formatUsageLineEstimates(params: {
   }
   if (
     params.displayOptions.codexCredits &&
-    params.creditEstimate &&
-    params.creditEstimate.totalCreditMicros !== undefined &&
-    params.creditEstimate.totalCreditMicros > 0
+    params.lineTotals?.creditMicros !== undefined &&
+    params.lineTotals.creditMicros > 0
   ) {
     const suffix = formatUsageLineCreditSuffix(params.line);
     estimates.push(
-      `${formatCodexCredits(params.creditEstimate.totalCreditMicros)}${suffix ? ` ${suffix}` : ""}`,
+      `${formatCodexCredits(params.lineTotals.creditMicros)}${suffix ? ` ${suffix}` : ""}`,
     );
   }
   return estimates.length > 0 ? estimates.join(" · ") : undefined;
 }
 
 function formatUsageLineRunningTotal(params: {
-  creditEstimate: CodexCreditLineEstimate | undefined;
   displayOptions: PricingDisplayOptions;
   line: ThreadUsageLineRecord;
+  lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
   const estimates: string[] = [];
-  if (
-    params.displayOptions.usd &&
-    params.line.cumulativeTotalCostMicros !== undefined
-  ) {
+  if (params.displayOptions.usd && params.lineTotals?.runningCostMicros !== undefined) {
     estimates.push(
-      `${formatMoney(params.line.cumulativeTotalCostMicros, params.line.currency)} list price`,
+      `${formatMoney(params.lineTotals.runningCostMicros, params.line.currency)} list price`,
     );
   }
   if (
     params.displayOptions.codexCredits &&
-    params.creditEstimate &&
-    params.creditEstimate.cumulativeTotalCreditMicros !== undefined &&
-    params.creditEstimate.cumulativeTotalCreditMicros > 0
+    params.lineTotals?.runningCreditMicros !== undefined &&
+    params.lineTotals.runningCreditMicros > 0
   ) {
-    estimates.push(formatCodexCredits(params.creditEstimate.cumulativeTotalCreditMicros));
+    estimates.push(formatCodexCredits(params.lineTotals.runningCreditMicros));
   }
   return estimates.length > 0 ? `Running total: ${estimates.join(" · ")}` : undefined;
 }
@@ -537,48 +464,44 @@ function formatMoney(valueMicros: number, currency: string): string {
   return `${currency} ${(valueMicros / 1_000_000).toFixed(4)}`;
 }
 
-type CodexCreditLineEstimate = {
-  cumulativeTotalCreditMicros?: number;
-  totalCreditMicros?: number;
+type PricingRunningLineTotals = {
+  creditMicros?: number;
+  runningCostMicros: number;
+  runningCreditMicros?: number;
 };
 
-function buildCodexCreditTotals(lines: ThreadUsageLineRecord[]): {
-  byLineId: Map<string, CodexCreditLineEstimate>;
+function buildPricingRunningTotals(lines: ThreadUsageLineRecord[]): {
+  byLineId: Map<string, PricingRunningLineTotals>;
   totalCreditMicros: number;
 } {
-  const sortedLines = [...lines].sort(
-    (left, right) =>
-      (left.startedAt ?? left.createdAt) - (right.startedAt ?? right.createdAt),
-  );
-  const byLineId = new Map<string, CodexCreditLineEstimate>();
-  let visibleLineTotalCreditMicros = 0;
-  let latestCumulativeCreditMicros: number | undefined;
-  let latestCumulativeCreditTimestamp = Number.NEGATIVE_INFINITY;
+  const sortedLines = [...lines].sort((left, right) => {
+    const leftTimestamp = left.startedAt ?? left.createdAt;
+    const rightTimestamp = right.startedAt ?? right.createdAt;
+    if (leftTimestamp !== rightTimestamp) {
+      return leftTimestamp - rightTimestamp;
+    }
+    return left.usageLineId.localeCompare(right.usageLineId);
+  });
+  const byLineId = new Map<string, PricingRunningLineTotals>();
+  let runningCostMicros = 0;
+  let runningCreditMicros = 0;
   for (const line of sortedLines) {
     const estimate = estimateCodexCreditsForLine(line);
-    const cumulativeEstimate = estimateCodexCreditsForCumulativeLine(line);
+    if (line.priceStatus === "priced") {
+      runningCostMicros += Math.max(0, line.totalCostMicros);
+    }
     if (estimate) {
-      visibleLineTotalCreditMicros += estimate.totalCreditMicros;
+      runningCreditMicros += estimate.totalCreditMicros;
     }
-    if (cumulativeEstimate) {
-      const timestamp = lineTimestamp(line);
-      if (timestamp >= latestCumulativeCreditTimestamp) {
-        latestCumulativeCreditTimestamp = timestamp;
-        latestCumulativeCreditMicros = cumulativeEstimate.totalCreditMicros;
-      }
-    }
-    if (estimate || cumulativeEstimate) {
-      byLineId.set(line.usageLineId, {
-        ...(cumulativeEstimate
-          ? { cumulativeTotalCreditMicros: cumulativeEstimate.totalCreditMicros }
-          : {}),
-        ...(estimate ? { totalCreditMicros: estimate.totalCreditMicros } : {}),
-      });
-    }
+    byLineId.set(line.usageLineId, {
+      ...(estimate ? { creditMicros: estimate.totalCreditMicros } : {}),
+      runningCostMicros,
+      ...(runningCreditMicros > 0 ? { runningCreditMicros } : {}),
+    });
   }
   return {
     byLineId,
-    totalCreditMicros: latestCumulativeCreditMicros ?? visibleLineTotalCreditMicros,
+    totalCreditMicros: runningCreditMicros,
   };
 }
 
@@ -599,35 +522,6 @@ function estimateCodexCreditsForLine(line: ThreadUsageLineRecord):
     reasoningOutputTokens: line.reasoningOutputTokens,
     serviceTier: line.serviceTier,
     uncachedInputTokens: line.uncachedInputTokens,
-  });
-  return estimate ? { totalCreditMicros: estimate.totalCreditMicros } : undefined;
-}
-
-function estimateCodexCreditsForCumulativeLine(line: ThreadUsageLineRecord):
-  | {
-      totalCreditMicros: number;
-    }
-  | undefined {
-  if (line.provider !== "openai") {
-    return undefined;
-  }
-  const uncachedInputTokens = readCumulativeUncachedInputTokens(line);
-  if (
-    uncachedInputTokens === undefined ||
-    line.cumulativeCachedInputTokens === undefined ||
-    line.cumulativeOutputTokens === undefined
-  ) {
-    return undefined;
-  }
-  const estimate = estimateOpenAiCodexCreditUsage({
-    at: line.createdAt,
-    cachedInputTokens: line.cumulativeCachedInputTokens,
-    fastMode: line.fastMode,
-    model: line.model,
-    outputTokens: line.cumulativeOutputTokens,
-    reasoningOutputTokens: line.cumulativeReasoningOutputTokens,
-    serviceTier: line.serviceTier,
-    uncachedInputTokens,
   });
   return estimate ? { totalCreditMicros: estimate.totalCreditMicros } : undefined;
 }

--- a/apps/desktop/src/renderer/src/icons/PricingIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/PricingIcon.tsx
@@ -1,15 +1,12 @@
 import { resolveIconSvgProps, type IconProps } from "./icon-types";
 
-/** Pricing: compact receipt/cost mark for thread usage accounting. */
+/** Pricing: dollar mark for thread usage accounting. */
 export function PricingIcon(props: IconProps) {
   return (
     <svg {...resolveIconSvgProps(props)}>
-      <path d="M7 3h10a2 2 0 0 1 2 2v16l-3-1.5L13 21l-3-1.5L7 21V5a2 2 0 0 1 2-2Z" />
-      <path d="M9.5 8h5" />
-      <path d="M9.5 12h5" />
-      <path d="M15.5 16h-1.75a1.75 1.75 0 0 1 0-3.5h.5a1.75 1.75 0 0 0 0-3.5H12.5" />
-      <path d="M14 7.75v1.25" />
-      <path d="M14 16v1.25" />
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 6.75v10.5" />
+      <path d="M15.5 8.75H10.8a2.05 2.05 0 0 0 0 4.1h2.4a2.05 2.05 0 0 1 0 4.1H8.5" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -355,6 +355,14 @@ describe("Tangerine Terminal theme contract", () => {
     expect(copyButtonRule).toContain("opacity: 1;");
   });
 
+  it("keeps pricing usage cards selectable and directly copyable", () => {
+    const pricingRowRule = extractRuleBody(css, ".pricing-usage-row");
+    const pricingRunningTotalRule = extractRuleBody(css, ".pricing-running-total");
+
+    expect(pricingRowRule).toContain("user-select: text;");
+    expect(pricingRunningTotalRule).toContain("user-select: text;");
+  });
+
   it("anchors the context rail below the header and reserves one shared width for the chat", () => {
     // The rail is anchored to `.thread-view__layout` (absolute), NOT the
     // window, so it starts below the thread header. The header therefore owns

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11708,6 +11708,46 @@ textarea,
   color: var(--text-secondary);
 }
 
+.pricing-usage-row {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.pricing-running-total {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.pricing-running-total__summary {
+  cursor: pointer;
+  list-style: none;
+  overflow-wrap: anywhere;
+}
+
+.pricing-running-total__summary::-webkit-details-marker {
+  display: none;
+}
+
+.pricing-running-total__summary::before {
+  content: "›";
+  display: inline-block;
+  margin-right: 4px;
+  color: var(--text-muted);
+  transition: transform 120ms ease;
+}
+
+.pricing-running-total[open] .pricing-running-total__summary::before {
+  transform: rotate(90deg);
+}
+
+.pricing-running-total__tokens {
+  margin-top: 4px;
+}
+
 /* Sub-agent Details modal — a centered, in-window dialog (mirrors the
    transcript image lightbox) portaled to the body so it escapes the rail's
    clipping. Opened from the card's Details button. */


### PR DESCRIPTION
## Summary

The Pricing rail now uses ledger row totals for the header and each card's running totals, so USD and Codex Credits advance from the same chronological set of priced rows. This fixes mixed Fast/standard histories where persisted cumulative dollar fields could reprice old usage under the current turn's tier and make the running total jump backward.

When Codex replay does not include historical token-usage rows but live rows expose larger cumulative token counters, the panel now derives explicit `Historical usage estimate` rows for the unexplained cumulative deltas. Those synthetic display rows are priced at standard OpenAI/Codex Credit rates using the known model when available, marked as estimated, and folded into the same running totals. If later real rows explain the gap, the derived estimate shrinks or disappears because it is computed from the current ledger rows at render time rather than persisted as its own DB row.

Sub-agent/monitor rows participate in the same running totals, while remaining excluded from main-thread cumulative-gap detection. Existing cumulative token counters are still shown as expandable running-token detail, but cumulative dollar fields are ignored by the UI and are no longer written by the live usage path.

The Pricing rail icon is now a dollar mark, usage card text remains selectable for copying, and the pricing panel E2E assertion was tightened for the new running-total copy.

## Tests

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "persists live thread pricing from turn usage"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test:desktop-e2e apps/desktop/e2e/thread-pricing-panel.spec.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
