### PR TITLE
fix(messaging): align durable questionnaire test ordering

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9971,14 +9971,20 @@ describe("MessagingController", () => {
     harness.delivered.length = 0;
     await harness.controller.handleInboundEvent(buildTextEvent("Keep it pragmatic."));
 
-    expect(harness.delivered.at(-1)).toMatchObject({
+    expect(harness.delivered.at(-2)).toMatchObject({
       kind: "questionnaire",
+      phase: "submitted",
       answers: [
         {
           kind: "custom",
           value: "Keep it pragmatic.",
         },
       ],
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "activity",
+      activity: "typing",
+      state: "active",
     });
   });
 


### PR DESCRIPTION
## Summary

The durable Plan questionnaire regression test now matches the controller's actual final-answer sequence: the submitted questionnaire is delivered, then the resumed turn emits an active typing signal. This keeps the test checking the 30-day callback lifetime without failing on the expected post-submit activity intent.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts -t "keeps Plan questionnaires active for the durable callback lifetime"`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts -t questionnaire`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
