### PR TITLE
fix(desktop): refresh PR chip checks accurately

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -17,6 +17,13 @@ import type {
   RestoreThreadRequest,
 } from "@pwragent/shared";
 
+const mockAppServerLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const listThreads = vi.fn(async (request?: {
   archived?: boolean;
@@ -382,6 +389,10 @@ vi.mock("electron", () => ({
   },
 }));
 
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => mockAppServerLog),
+}));
+
 vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({
     reconcileNavigationSnapshot,
@@ -484,6 +495,10 @@ describe("app server ipc", () => {
     fetchPullRequestByUrl.mockResolvedValue(undefined);
     detectPullRequestsForThread.mockReset();
     detectPullRequestsForThread.mockResolvedValue([]);
+    mockAppServerLog.debug.mockClear();
+    mockAppServerLog.error.mockClear();
+    mockAppServerLog.info.mockClear();
+    mockAppServerLog.warn.mockClear();
   });
 
   afterEach(async () => {
@@ -1004,6 +1019,83 @@ describe("app server ipc", () => {
         pr: refreshedPrs[1],
       },
     ]);
+  });
+
+  it("logs user-triggered PR refresh decisions and background completion with PR ids", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "019ed359-0b92-7ca2-ae05-a5837cc80df8",
+      trigger: "user",
+      branch: "fix/live-diff-activity-normalization",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: request.threadId,
+      branch: request.branch,
+      directoryPaths: request.directoryPaths,
+    });
+    const stalePr = githubPr({
+      number: 845,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/845",
+    });
+    const passingPr = githubPr({
+      number: 845,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/845",
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: request.threadId,
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [stalePr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([passingPr]);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+
+    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      "threadPullRequestsRefresh:requested",
+      expect.objectContaining({
+        branch: "fix/live-diff-activity-normalization",
+        previousPrIds: ["github.com/pwrdrvr/pwragent#845"],
+        threadId: "019ed359-0b92-7ca2-ae05-a5837cc80df8",
+        trigger: "user",
+      }),
+    );
+    expect(mockAppServerLog.info).toHaveBeenCalledWith(
+      "threadPullRequestsRefresh:background-start",
+      expect.objectContaining({
+        previousPrIds: ["github.com/pwrdrvr/pwragent#845"],
+        threadId: "019ed359-0b92-7ca2-ae05-a5837cc80df8",
+        trigger: "user",
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(mockAppServerLog.info).toHaveBeenCalledWith(
+        "threadPullRequestsRefresh:background-complete",
+        expect.objectContaining({
+          changedThreadCount: 1,
+          fetchedPrIds: ["github.com/pwrdrvr/pwragent#845"],
+          previousPrIds: ["github.com/pwrdrvr/pwragent#845"],
+          subscriberCount: 1,
+          threadId: "019ed359-0b92-7ca2-ae05-a5837cc80df8",
+          trigger: "user",
+        }),
+      );
+    });
   });
 
   it("serves the same canonical PR state across different thread overlays", async () => {
@@ -2235,11 +2327,33 @@ describe("app server ipc", () => {
       await vi.waitFor(() => {
         expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
       });
+      await vi.waitFor(() => {
+        expect(mockAppServerLog.info).toHaveBeenCalledWith(
+          "threadPullRequestsRefresh:background-complete",
+          expect.objectContaining({
+            fetchedPrIds: ["github.com/pwrdrvr/pwragent#434"],
+            threadId: "thread-1",
+            trigger: "user",
+          }),
+        );
+      });
+      mockAppServerLog.info.mockClear();
 
       vi.setSystemTime(2_000_000 + 9_000);
       await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
       await Promise.resolve();
       expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
+      expect(mockAppServerLog.info).toHaveBeenCalledWith(
+        "threadPullRequestsRefresh:skipped",
+        expect.objectContaining({
+          minIntervalMs: 10_000,
+          nextAllowedInMs: 1_000,
+          previousPrIds: ["github.com/pwrdrvr/pwragent#434"],
+          reason: "cooldown",
+          threadId: "thread-1",
+          trigger: "user",
+        }),
+      );
 
       vi.setSystemTime(2_000_000 + 10_000);
       await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -159,6 +159,29 @@ describe("derive PR states", () => {
     ).toBe("passing");
   });
 
+  it("treats a successful conclusion as final even when gh reports stale progress status", () => {
+    expect(
+      deriveChipState({
+        ...rawMergedPr(),
+        state: "OPEN",
+        statusCheckRollup: [
+          {
+            __typename: "CheckRun",
+            conclusion: "SUCCESS",
+            status: "IN_PROGRESS",
+            name: "Install Dependencies",
+          },
+          {
+            __typename: "CheckRun",
+            conclusion: "SUCCESS",
+            status: "COMPLETED",
+            name: "Test",
+          },
+        ],
+      }),
+    ).toBe("passing");
+  });
+
   it("returns failing when any check FAILED / CANCELLED / TIMED_OUT", () => {
     for (const conclusion of ["FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED"]) {
       expect(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -525,6 +525,19 @@ type PrLookupSubscriber = {
   previousPrs: PrSummary[];
 };
 
+type PrLookupRefreshClaim =
+  | {
+      refreshKey: string;
+      skippedReason?: undefined;
+    }
+  | {
+      refreshKey?: undefined;
+      skippedReason: "cooldown" | "scheduled-token-bucket";
+      ageMs?: number;
+      minIntervalMs?: number;
+      nextAllowedInMs?: number;
+    };
+
 class PrStatusTokenBucket {
   private tokens = PR_STATUS_TOKEN_BUCKET_CAPACITY;
   private updatedAt = Date.now();
@@ -545,6 +558,42 @@ class PrStatusTokenBucket {
     this.tokens -= 1;
     return true;
   }
+}
+
+function prLogIds(prs: PrSummary[]): string[] {
+  return prs.map((pr) => getPrStatusKey(pr));
+}
+
+function userPrRefreshLogPayload(params: {
+  backend: AppServerBackendKind;
+  branch: string;
+  directoryPathCount: number;
+  existingLookupMatches?: boolean;
+  ghAvailable?: boolean;
+  lookupCacheHit?: boolean;
+  lookupKey?: string;
+  previousPrs?: PrSummary[];
+  provider: string;
+  reason?: string;
+  requestKey?: string;
+  threadId: string;
+  trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>;
+}): Record<string, unknown> {
+  return {
+    backend: params.backend,
+    branch: params.branch,
+    directoryPathCount: params.directoryPathCount,
+    existingLookupMatches: params.existingLookupMatches,
+    ghAvailable: params.ghAvailable,
+    lookupCacheHit: params.lookupCacheHit,
+    lookupKey: params.lookupKey,
+    previousPrIds: prLogIds(params.previousPrs ?? []),
+    provider: params.provider,
+    reason: params.reason,
+    requestKey: params.requestKey,
+    threadId: params.threadId,
+    trigger: params.trigger,
+  };
 }
 
 class DesktopAppServerService {
@@ -1680,6 +1729,16 @@ class DesktopAppServerService {
     const requestKey = getThreadPullRequestsRequestKey(backend, request);
     const pending = this.pendingThreadPullRequestRefreshes.get(requestKey);
     if (pending) {
+      if (request.trigger === "user") {
+        logDebug("threadPullRequestsRefresh:coalesced-request", {
+          backend,
+          branch: request.branch.trim(),
+          directoryPathCount: request.directoryPaths.length,
+          requestKey,
+          threadId: request.threadId,
+          trigger: request.trigger,
+        });
+      }
       return await pending;
     }
 
@@ -1702,9 +1761,23 @@ class DesktopAppServerService {
     requestKey: string,
   ): Promise<RefreshThreadPullRequestsResponse> {
     const provider = normalizePullRequestProvider(request.provider);
+    const trigger = request.trigger ?? "scheduled";
     const fetcher = this.getPrFetcher();
     const ghAvailable = await fetcher.isGhAvailable();
     if (!ghAvailable) {
+      if (trigger === "user") {
+        logDebug("threadPullRequestsRefresh:skipped", userPrRefreshLogPayload({
+          backend,
+          branch: request.branch.trim(),
+          directoryPathCount: request.directoryPaths.length,
+          ghAvailable,
+          provider,
+          reason: "gh-unavailable",
+          requestKey,
+          threadId: request.threadId,
+          trigger,
+        }));
+      }
       return {
         backend,
         threadId: request.threadId,
@@ -1747,6 +1820,22 @@ class DesktopAppServerService {
         ? existingPrs
         : [];
     const knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
+    if (trigger === "user") {
+      logDebug("threadPullRequestsRefresh:requested", userPrRefreshLogPayload({
+        backend,
+        branch,
+        directoryPathCount: request.directoryPaths.length,
+        existingLookupMatches,
+        ghAvailable,
+        lookupCacheHit: Boolean(lookupEntry),
+        lookupKey,
+        previousPrs: knownPrs,
+        provider,
+        requestKey,
+        threadId: request.threadId,
+        trigger,
+      }));
+    }
     if (lookupEntry && lookupEntry.fetchedAt > 0) {
       await this.persistPullRequestLookupHit({
         backend,
@@ -1793,6 +1882,20 @@ class DesktopAppServerService {
     }
 
     if (!branch || request.directoryPaths.length === 0) {
+      if (trigger === "user") {
+        logDebug("threadPullRequestsRefresh:skipped", userPrRefreshLogPayload({
+          backend,
+          branch,
+          directoryPathCount: request.directoryPaths.length,
+          ghAvailable: true,
+          previousPrs: knownPrs,
+          provider,
+          reason: !branch ? "missing-branch" : "missing-directory-paths",
+          requestKey,
+          threadId: request.threadId,
+          trigger,
+        }));
+      }
       return {
         backend,
         threadId: request.threadId,
@@ -1928,38 +2031,110 @@ class DesktopAppServerService {
     lookupDirectoryPaths: string[];
     previousPrs: PrSummary[];
   }): void {
+    const trigger = params.request.trigger ?? "scheduled";
+    const provider = normalizePullRequestProvider(params.request.provider);
     const pending = this.pendingPrLookupRefreshes.get(params.lookupKey);
     if (pending) {
       this.addPullRequestLookupSubscriber(params.lookupKey, params);
+      if (trigger === "user") {
+        logDebug("threadPullRequestsRefresh:coalesced-background", userPrRefreshLogPayload({
+          backend: params.backend,
+          branch: params.request.branch.trim(),
+          directoryPathCount: params.request.directoryPaths.length,
+          lookupKey: params.lookupKey,
+          previousPrs: params.previousPrs,
+          provider,
+          requestKey: params.requestKey,
+          threadId: params.request.threadId,
+          trigger,
+        }));
+      }
       return;
     }
 
-    const refreshKey = this.claimPullRequestLookupRefreshKey(
+    const claim = this.claimPullRequestLookupRefreshKey(
       params.lookupKey,
-      params.request.trigger ?? "scheduled",
-      normalizePullRequestProvider(params.request.provider),
+      trigger,
+      provider,
       params.previousPrs.length > 0
         && params.previousPrs.every(
           (pr) => pr.lifecycleState === "merged" || pr.lifecycleState === "closed",
         ),
     );
-    if (!refreshKey) {
+    if (claim.skippedReason) {
+      if (trigger === "user") {
+        logDebug("threadPullRequestsRefresh:skipped", {
+          ...userPrRefreshLogPayload({
+            backend: params.backend,
+            branch: params.request.branch.trim(),
+            directoryPathCount: params.request.directoryPaths.length,
+            lookupKey: params.lookupKey,
+            previousPrs: params.previousPrs,
+            provider,
+            reason: claim.skippedReason,
+            requestKey: params.requestKey,
+            threadId: params.request.threadId,
+            trigger,
+          }),
+          ageMs: claim.ageMs,
+          minIntervalMs: claim.minIntervalMs,
+          nextAllowedInMs: claim.nextAllowedInMs,
+        });
+      }
       return;
     }
+    const refreshKey = claim.refreshKey;
 
     this.addPullRequestLookupSubscriber(params.lookupKey, params);
+    if (trigger === "user") {
+      logDebug("threadPullRequestsRefresh:background-start", userPrRefreshLogPayload({
+        backend: params.backend,
+        branch: params.request.branch.trim(),
+        directoryPathCount: params.request.directoryPaths.length,
+        lookupKey: params.lookupKey,
+        previousPrs: params.previousPrs,
+        provider,
+        requestKey: params.requestKey,
+        threadId: params.request.threadId,
+        trigger,
+      }));
+    }
     const promise = this.fetchPullRequestLookup(params)
       .then(async ({ prs, fetchedAt }) => {
-        await this.persistPullRequestLookupSubscribers({
+        const publishResult = await this.persistPullRequestLookupSubscribers({
           lookupKey: params.lookupKey,
           prs,
           fetchedAt,
         });
+        if (trigger === "user") {
+          logDebug("threadPullRequestsRefresh:background-complete", {
+            ...userPrRefreshLogPayload({
+              backend: params.backend,
+              branch: params.request.branch.trim(),
+              directoryPathCount: params.request.directoryPaths.length,
+              lookupKey: params.lookupKey,
+              previousPrs: params.previousPrs,
+              provider,
+              requestKey: params.requestKey,
+              threadId: params.request.threadId,
+              trigger,
+            }),
+            changedThreadCount: publishResult.changedThreadCount,
+            fetchedAt,
+            fetchedPrIds: prLogIds(prs),
+            subscriberCount: publishResult.subscriberCount,
+          });
+        }
       })
       .catch((error) => {
         appServerLog.warn("background PR lookup refresh failed", {
           threadId: params.request.threadId,
+          branch: params.request.branch.trim(),
+          previousPrIds: prLogIds(params.previousPrs),
+          provider,
           refreshKey,
+          requestKey: params.requestKey,
+          trigger,
           error: error instanceof Error ? error.message : String(error),
         });
       })
@@ -2000,12 +2175,13 @@ class DesktopAppServerService {
     lookupKey: string;
     prs: PrSummary[];
     fetchedAt: number;
-  }): Promise<void> {
+  }): Promise<{ changedThreadCount: number; subscriberCount: number }> {
     const subscribers = this.prLookupSubscribers.get(params.lookupKey);
     if (!subscribers?.size) {
-      return;
+      return { changedThreadCount: 0, subscriberCount: 0 };
     }
 
+    let changedThreadCount = 0;
     await Promise.all(
       [...subscribers.values()].map(async (subscriber) => {
         const nextPrs = this.mergePrHistory(subscriber.previousPrs, params.prs);
@@ -2018,6 +2194,7 @@ class DesktopAppServerService {
         });
 
         if (!prSummariesEqual(subscriber.previousPrs, nextPrs)) {
+          changedThreadCount += 1;
           await this.publishThreadPullRequestsUpdated({
             backend: subscriber.backend,
             threadId: subscriber.threadId,
@@ -2026,6 +2203,7 @@ class DesktopAppServerService {
         }
       }),
     );
+    return { changedThreadCount, subscriberCount: subscribers.size };
   }
 
   private async persistPullRequestLookupHit(params: {
@@ -2067,7 +2245,7 @@ class DesktopAppServerService {
     trigger: NonNullable<RefreshThreadPullRequestsRequest["trigger"]>,
     provider: string,
     terminalOnly: boolean,
-  ): string | undefined {
+  ): PrLookupRefreshClaim {
     const now = Date.now();
     const minInterval =
       trigger === "post-turn"
@@ -2086,12 +2264,18 @@ class DesktopAppServerService {
       entry?.[timestampField] ?? 0,
       entry?.fetchedAt ?? 0,
     );
-    const due = now - lastRequestedAt >= minInterval;
+    const ageMs = now - lastRequestedAt;
+    const due = ageMs >= minInterval;
     if (!due) {
-      return undefined;
+      return {
+        skippedReason: "cooldown",
+        ageMs,
+        minIntervalMs: minInterval,
+        nextAllowedInMs: minInterval - ageMs,
+      };
     }
     if (trigger === "scheduled" && !this.prStatusTokenBucket.tryTake(now)) {
-      return undefined;
+      return { skippedReason: "scheduled-token-bucket" };
     }
 
     if (entry) {
@@ -2107,7 +2291,7 @@ class DesktopAppServerService {
       });
     }
 
-    return lookupKey;
+    return { refreshKey: lookupKey };
   }
 
   private rememberPrStatuses(prs: PrSummary[], fetchedAt: number): PrSummary[] {

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -479,19 +479,15 @@ export function deriveChipState(row: GhPrPayload): PrChipState {
     if (check.conclusion && failingConclusions.has(check.conclusion)) {
       return "failing";
     }
-    if (
-      check.status
-      && check.status !== "COMPLETED"
-      // Some legacy StatusContext entries omit status entirely.
-      && check.status !== "STATUS_CONTEXT"
-    ) {
-      pendingCount += 1;
-    } else if (!check.conclusion) {
-      pendingCount += 1;
-    } else if (!passingConclusions.has(check.conclusion)) {
-      // Conclusion we don't recognize as either pass or fail — be conservative.
-      return "unknown";
+    if (check.conclusion && passingConclusions.has(check.conclusion)) {
+      continue;
     }
+    if (!check.conclusion) {
+      pendingCount += 1;
+      continue;
+    }
+    // Conclusion we don't recognize as either pass or fail — be conservative.
+    return "unknown";
   }
   if (pendingCount > 0) return "pending";
   return "passing";


### PR DESCRIPTION
## Summary

PR chip hover refreshes now correctly turn green when GitHub reports a successful check conclusion, even if the same `statusCheckRollup` entry still carries a stale `IN_PROGRESS` status. That was the reason PR 845 kept reading as "checks pending": the refresh ran and found the PR, but the parser treated GitHub's stale status field as more important than the final `SUCCESS` conclusion.

The hover refresh path also now leaves diagnostics for the cases that were previously silent: requests, coalescing, cooldown skips, unavailable `gh`, background completion, and background failures all include thread, branch, request, and PR ids.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
