### PR TITLE
feat(desktop): group deprecated experimental settings into a collapsed drawer

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -3,6 +3,7 @@ import {
   SettingsField,
   SettingsPanelHead,
   SettingsSection,
+  SettingsSectionGroup,
   SettingsSectionStack,
 } from "./SettingsLayout";
 import { SettingsSwitch } from "./SettingsSwitch";
@@ -91,6 +92,10 @@ export function ExperimentalSettings(props: {
   const knownCondensationModel = DIFF_CONDENSATION_MODEL_OPTIONS.some(
     (option) => option.value === condensation.model.value,
   );
+  const discontinuedEnabledCount =
+    (condensation.enabled.value ? 1 : 0) +
+    (agentCoreGrok.value ? 1 : 0) +
+    (liveTranscriptEventFiltering.value ? 1 : 0);
 
   return (
     <SettingsSectionStack paneId="experimental" aria-label="Experimental settings">
@@ -99,75 +104,6 @@ export function ExperimentalSettings(props: {
         title="Experimental features"
         help="Opt-in features that may change shape or be removed without notice."
       />
-
-      <SettingsSection
-        eyebrow="Experimental"
-        title="Diff Condensation"
-        description="Send focused-diff hunks to xAI for a judgment call on what to hide. Disabled by default — every diff renders in full and no xAI request fires."
-        chip={condensation.enabled.value ? "On" : "Off"}
-        chipKind={condensation.enabled.value ? "ok" : "default"}
-      >
-        <div className="settings-fields">
-          <SettingsField
-            label="Enable diff condensation"
-            sub="When on, focused-diff requests fire an xAI judgment call to decide which hunks to elide."
-            source={sourceBadge(condensation.enabled)}
-            control={
-              <SettingsSwitch
-                checked={condensation.enabled.value}
-                disabled={props.saving}
-                label="Enable diff condensation"
-                onChange={(enabled) => {
-                  void props.onDiffCondensationEnabledChange(enabled);
-                }}
-              />
-            }
-          />
-
-          <SettingsField
-            label="Eliding model"
-            sub="Which model decides which hunks to elide."
-            help="Auto matches the thread's primary backend. Pinning a specific model uses it for every eliding request, regardless of backend."
-            source={sourceBadge(condensation.model)}
-            control={
-              <div
-                className="settings-segmented"
-                role="radiogroup"
-                aria-label="Diff condensation model"
-              >
-                {DIFF_CONDENSATION_MODEL_OPTIONS.map((option) => (
-                  <button
-                    key={option.value}
-                    aria-checked={condensation.model.value === option.value}
-                    className={`settings-segmented__button${
-                      condensation.model.value === option.value ? " is-active" : ""
-                    }`}
-                    disabled={props.saving || !condensation.enabled.value}
-                    role="radio"
-                    type="button"
-                    onClick={() => {
-                      void props.onDiffCondensationModelChange(option.value);
-                    }}
-                  >
-                    {option.label}
-                  </button>
-                ))}
-                {!knownCondensationModel ? (
-                  <button
-                    aria-checked
-                    className="settings-segmented__button is-active"
-                    disabled
-                    role="radio"
-                    type="button"
-                  >
-                    {condensation.model.value} (custom)
-                  </button>
-                ) : null}
-              </div>
-            }
-          />
-        </div>
-      </SettingsSection>
 
       <SettingsSection
         eyebrow="Experimental"
@@ -251,57 +187,137 @@ export function ExperimentalSettings(props: {
         </div>
       </SettingsSection>
 
-      <SettingsSection
-        eyebrow="Experimental"
-        title="AgentCore - Grok"
-        description="Legacy direct-xAI Grok backend. Disabled by default. Prefer the Grok CLI (ACP) backend instead — set up under Settings → ACP Agents."
-        chip={agentCoreGrok.value ? "On" : "Off"}
-        chipKind={agentCoreGrok.value ? "ok" : "default"}
+      <SettingsSectionGroup
+        groupId="experimental-discontinued"
+        eyebrow="Deprecated"
+        title="Soon to be discontinued"
+        description="These features are being phased out and may be removed in a future release."
+        chip={discontinuedEnabledCount > 0 ? `${discontinuedEnabledCount} on` : "Off"}
+        chipKind={discontinuedEnabledCount > 0 ? "ok" : "default"}
+        defaultCollapsed
+        aria-label="Soon to be discontinued experimental settings"
       >
-        <div className="settings-fields">
-          <SettingsField
-            label="Enable AgentCore - Grok"
-            sub="When on, the legacy agent-core Grok backend appears in the backend picker. Uses the Grok API key from Settings → Models → Grok."
-            source={sourceBadge(agentCoreGrok)}
-            control={
-              <SettingsSwitch
-                checked={agentCoreGrok.value}
-                disabled={props.saving}
-                label="Enable AgentCore - Grok"
-                onChange={(enabled) => {
-                  void props.onAgentCoreGrokChange(enabled);
-                }}
-              />
-            }
-          />
-        </div>
-      </SettingsSection>
+        <SettingsSection
+          eyebrow="Experimental"
+          title="Diff Condensation"
+          description="Send focused-diff hunks to xAI for a judgment call on what to hide. Disabled by default — every diff renders in full and no xAI request fires."
+          chip={condensation.enabled.value ? "On" : "Off"}
+          chipKind={condensation.enabled.value ? "ok" : "default"}
+        >
+          <div className="settings-fields">
+            <SettingsField
+              label="Enable diff condensation"
+              sub="When on, focused-diff requests fire an xAI judgment call to decide which hunks to elide."
+              source={sourceBadge(condensation.enabled)}
+              control={
+                <SettingsSwitch
+                  checked={condensation.enabled.value}
+                  disabled={props.saving}
+                  label="Enable diff condensation"
+                  onChange={(enabled) => {
+                    void props.onDiffCondensationEnabledChange(enabled);
+                  }}
+                />
+              }
+            />
 
-      <SettingsSection
-        eyebrow="Experimental"
-        title="Live Transcript Event Filtering"
-        description="Reduce renderer work from live transcript notifications by ignoring unrelated thread-local events and skipping duplicate activity updates. Disabled by default."
-        chip={liveTranscriptEventFiltering.value ? "On" : "Off"}
-        chipKind={liveTranscriptEventFiltering.value ? "ok" : "default"}
-      >
-        <div className="settings-fields">
-          <SettingsField
-            label="Enable live transcript event filtering"
-            sub="When on, live transcript notifications for other threads no longer update the focused thread view."
-            source={sourceBadge(liveTranscriptEventFiltering)}
-            control={
-              <SettingsSwitch
-                checked={liveTranscriptEventFiltering.value}
-                disabled={props.saving}
-                label="Enable live transcript event filtering"
-                onChange={(enabled) => {
-                  void props.onLiveTranscriptEventFilteringChange(enabled);
-                }}
-              />
-            }
-          />
-        </div>
-      </SettingsSection>
+            <SettingsField
+              label="Eliding model"
+              sub="Which model decides which hunks to elide."
+              help="Auto matches the thread's primary backend. Pinning a specific model uses it for every eliding request, regardless of backend."
+              source={sourceBadge(condensation.model)}
+              control={
+                <div
+                  className="settings-segmented"
+                  role="radiogroup"
+                  aria-label="Diff condensation model"
+                >
+                  {DIFF_CONDENSATION_MODEL_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      aria-checked={condensation.model.value === option.value}
+                      className={`settings-segmented__button${
+                        condensation.model.value === option.value ? " is-active" : ""
+                      }`}
+                      disabled={props.saving || !condensation.enabled.value}
+                      role="radio"
+                      type="button"
+                      onClick={() => {
+                        void props.onDiffCondensationModelChange(option.value);
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                  {!knownCondensationModel ? (
+                    <button
+                      aria-checked
+                      className="settings-segmented__button is-active"
+                      disabled
+                      role="radio"
+                      type="button"
+                    >
+                      {condensation.model.value} (custom)
+                    </button>
+                  ) : null}
+                </div>
+              }
+            />
+          </div>
+        </SettingsSection>
+
+        <SettingsSection
+          eyebrow="Experimental"
+          title="AgentCore - Grok"
+          description="Legacy direct-xAI Grok backend. Disabled by default. Prefer the Grok CLI (ACP) backend instead — set up under Settings → ACP Agents."
+          chip={agentCoreGrok.value ? "On" : "Off"}
+          chipKind={agentCoreGrok.value ? "ok" : "default"}
+        >
+          <div className="settings-fields">
+            <SettingsField
+              label="Enable AgentCore - Grok"
+              sub="When on, the legacy agent-core Grok backend appears in the backend picker. Uses the Grok API key from Settings → Models → Grok."
+              source={sourceBadge(agentCoreGrok)}
+              control={
+                <SettingsSwitch
+                  checked={agentCoreGrok.value}
+                  disabled={props.saving}
+                  label="Enable AgentCore - Grok"
+                  onChange={(enabled) => {
+                    void props.onAgentCoreGrokChange(enabled);
+                  }}
+                />
+              }
+            />
+          </div>
+        </SettingsSection>
+
+        <SettingsSection
+          eyebrow="Experimental"
+          title="Live Transcript Event Filtering"
+          description="Reduce renderer work from live transcript notifications by ignoring unrelated thread-local events and skipping duplicate activity updates. Disabled by default."
+          chip={liveTranscriptEventFiltering.value ? "On" : "Off"}
+          chipKind={liveTranscriptEventFiltering.value ? "ok" : "default"}
+        >
+          <div className="settings-fields">
+            <SettingsField
+              label="Enable live transcript event filtering"
+              sub="When on, live transcript notifications for other threads no longer update the focused thread view."
+              source={sourceBadge(liveTranscriptEventFiltering)}
+              control={
+                <SettingsSwitch
+                  checked={liveTranscriptEventFiltering.value}
+                  disabled={props.saving}
+                  label="Enable live transcript event filtering"
+                  onChange={(enabled) => {
+                    void props.onLiveTranscriptEventFilteringChange(enabled);
+                  }}
+                />
+              }
+            />
+          </div>
+        </SettingsSection>
+      </SettingsSectionGroup>
     </SettingsSectionStack>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -192,7 +192,7 @@ export function ExperimentalSettings(props: {
         eyebrow="Deprecated"
         title="Soon to be discontinued"
         description="These features are being phased out and may be removed in a future release."
-        chip={discontinuedEnabledCount > 0 ? `${discontinuedEnabledCount} on` : "Off"}
+        chip={discontinuedEnabledCount > 0 ? `${discontinuedEnabledCount} on` : "All off"}
         chipKind={discontinuedEnabledCount > 0 ? "ok" : "default"}
         defaultCollapsed
         aria-label="Soon to be discontinued experimental settings"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -436,7 +436,8 @@ export function SettingsSection(props: {
  */
 export function SettingsSectionGroup(props: {
   /** Stable id used both to persist collapse state and to seed the nested
-   *  pane id — must be unique within the surface. */
+   *  pane id. Must be globally unique — collapse state is keyed by this id in
+   *  a module-level map shared across every group in the app. */
   groupId: string;
   title: string;
   eyebrow?: string;
@@ -468,6 +469,10 @@ export function SettingsSectionGroup(props: {
     });
   };
 
+  // Disclosure-style: Enter/Space toggle. Unlike `SettingsSection`, the group
+  // is not registered in a pane, so it intentionally omits the Arrow/Home/End
+  // roving navigation — it is a standalone control reached via Tab, and its
+  // children get their own arrow-key ring inside the nested stack.
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
@@ -476,9 +481,11 @@ export function SettingsSectionGroup(props: {
   };
 
   return (
+    // The outer region is named by its heading (`aria-labelledby`); the
+    // `aria-label` prop instead names the nested stack below so we don't end up
+    // with two identically-named region landmarks.
     <section
       aria-labelledby={headingId}
-      aria-label={props["aria-label"]}
       className={`settings-panel settings-panel--has-body settings-panel--collapsible settings-section-group${
         collapsed ? " settings-panel--is-collapsed" : ""
       }`}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsLayout.tsx
@@ -65,6 +65,7 @@ const SettingsSectionPaneContext =
 
 const savedCollapsedSectionsByPane = new Map<string, Record<string, boolean>>();
 const savedVisitedSectionByPane = new Map<string, string>();
+const savedGroupCollapsed = new Map<string, boolean>();
 
 function slugForSettingsId(value: string): string {
   return value
@@ -414,6 +415,110 @@ export function SettingsSection(props: {
         inert={collapsed ? true : undefined}
       >
         <div className="settings-section__body">{props.children}</div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Collapsible drawer that wraps a set of `SettingsSection` cards under a
+ * single section-style header. Unlike `SettingsSection`, the group owns its
+ * own collapse state (so it can start collapsed without a first-paint flash
+ * or a special case in the pane reducer), and it renders its children inside
+ * a fresh `SettingsSectionStack`. That nested stack gives the child sections
+ * their own pane so they keep full collapsible headers without registering
+ * into — and polluting the "Collapse all / Expand all" controls and arrow-key
+ * navigation of — the parent pane.
+ *
+ * Header chrome reuses the same class hierarchy as `SettingsSection` so the
+ * eyebrow / title / chevron / chip read identically (see the chrome-reuse
+ * rule in CLAUDE.md).
+ */
+export function SettingsSectionGroup(props: {
+  /** Stable id used both to persist collapse state and to seed the nested
+   *  pane id — must be unique within the surface. */
+  groupId: string;
+  title: string;
+  eyebrow?: string;
+  description?: ReactNode;
+  children: ReactNode;
+  /** Optional right-side chip in the group header. */
+  chip?: ReactNode;
+  chipKind?: SettingsChipTone;
+  /** Initial collapse state on first mount (before any user toggle). */
+  defaultCollapsed?: boolean;
+  "aria-label"?: string;
+}) {
+  const [collapsed, setCollapsed] = useState<boolean>(
+    () => savedGroupCollapsed.get(props.groupId) ?? props.defaultCollapsed ?? false,
+  );
+  const headingId = `settings-group-${props.groupId}-heading`;
+  const bodyId = `settings-group-${props.groupId}-body`;
+
+  const chipClass =
+    props.chipKind && props.chipKind !== "default" && props.chipKind !== "muted"
+      ? `settings-card__chip settings-card__chip--${props.chipKind}`
+      : "settings-card__chip";
+
+  const toggle = () => {
+    setCollapsed((current) => {
+      const next = !current;
+      savedGroupCollapsed.set(props.groupId, next);
+      return next;
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      aria-label={props["aria-label"]}
+      className={`settings-panel settings-panel--has-body settings-panel--collapsible settings-section-group${
+        collapsed ? " settings-panel--is-collapsed" : ""
+      }`}
+    >
+      <div
+        aria-controls={bodyId}
+        aria-expanded={!collapsed}
+        aria-label={props.title}
+        className="settings-panel__header settings-section__header-button"
+        role="button"
+        tabIndex={0}
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+      >
+        <span className="settings-section__chevron" aria-hidden="true" />
+        <div className="settings-section__header-main">
+          {props.eyebrow ? <p className="eyebrow">{props.eyebrow}</p> : null}
+          <h2 id={headingId}>{props.title}</h2>
+          {props.description ? (
+            <p className="settings-section__description">{props.description}</p>
+          ) : null}
+        </div>
+        <span className="settings-section__header-actions">
+          {props.chip ? <span className={chipClass}>{props.chip}</span> : null}
+        </span>
+      </div>
+      <div
+        id={bodyId}
+        aria-hidden={collapsed}
+        className="settings-section__body-clip"
+        inert={collapsed ? true : undefined}
+      >
+        <div className="settings-section__body settings-section-group__body">
+          <SettingsSectionStack
+            aria-label={props["aria-label"] ?? props.title}
+            paneId={`${props.groupId}-nested`}
+          >
+            {props.children}
+          </SettingsSectionStack>
+        </div>
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -47,6 +47,23 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/**
+ * The Experimental tab tucks its deprecated features (Diff Condensation,
+ * AgentCore - Grok, Live Transcript Event Filtering) inside a collapsed-by-
+ * default "Soon to be discontinued" drawer, where they are hidden from the
+ * accessibility tree until expanded. Idempotent (checks `aria-expanded`) so
+ * it is safe regardless of the drawer's persisted collapse state from a
+ * prior test in this file.
+ */
+function openDiscontinuedDrawer() {
+  const header = screen.getByRole("button", {
+    name: "Soon to be discontinued",
+  });
+  if (header.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(header);
+  }
+}
+
 function createSnapshot(
   overrides: Partial<DesktopSettingsSnapshot> = {},
 ): DesktopSettingsSnapshot {
@@ -602,6 +619,7 @@ describe("SettingsScreen", () => {
 
     fireEvent.click(within(sections).getByRole("button", { name: "Experimental" }));
     expect(screen.queryByRole("radiogroup", { name: "Chat Reply Composer" })).not.toBeInTheDocument();
+    openDiscontinuedDrawer();
     fireEvent.click(screen.getByRole("switch", { name: "Enable diff condensation" }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
@@ -900,6 +918,7 @@ describe("SettingsScreen", () => {
       />,
     );
 
+    openDiscontinuedDrawer();
     const filteringSwitch = screen.getByRole("switch", {
       name: "Enable live transcript event filtering",
     });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5622,6 +5622,23 @@ textarea,
   opacity: 0;
 }
 
+/* Deprecation drawer: nested SettingsSection cards are inset from the group
+   card edges and rendered without the sticky/elevated header treatment so a
+   card-in-card stack reads as a calm sub-list rather than a pile of floating
+   panels. */
+.settings-section-group__body {
+  padding: 14px;
+}
+
+.settings-section-group__body .settings-stack {
+  gap: 12px;
+}
+
+.settings-section-group__body .settings-section__header-button {
+  position: static;
+  box-shadow: 0 1px 0 var(--border-subtle);
+}
+
 .settings-source {
   display: inline-flex;
   align-self: flex-start;


### PR DESCRIPTION
## What changed

Reworks the **Experimental** settings tab so the two features under active investigation lead, and the rest move into a collapsed drawer.

New top-to-bottom order:

1. **Thread Pricing Summary** (pricing card)
2. **Codex Skill Questions** (questionnaire)
3. **Soon to be discontinued** — a collapsed-by-default drawer containing **Diff Condensation**, **AgentCore – Grok**, and **Live Transcript Event Filtering**, each keeping its own section header and On/Off toggle.

The drawer header carries a summary chip — `"N on"` (green) when any of the three are enabled, `"Off"` otherwise — so active deprecated features are visible without expanding it.

## Why

The pricing and questionnaire features are the ones we want operators to see and try first; the others are on the way out. Surfacing the keepers at the top and tucking the rest behind a collapsed drawer makes the tab's priorities legible at a glance.

## How

`SettingsSection` cards can't start collapsed — their collapse state lives in a shared per-pane reducer that always opens expanded. Forcing a default onto it would cause a first-paint expand→collapse flash and pull the deprecated sections into the pane's "Collapse all / Expand all" controls and arrow-key nav.

So instead of hacking the shared reducer, this adds a small primitive:

- **`SettingsSectionGroup`** (in `SettingsLayout.tsx`) — a collapsible drawer that owns its own collapse state (`defaultCollapsed`, persisted in-session like the pane map, no flash) and renders its children inside a *fresh* `SettingsSectionStack`. That nested stack gives the deprecated cards their own pane, isolating them from the parent pane's bulk controls and keyboard nav while preserving their individual collapsible headers and toggles.
- Header chrome (eyebrow / title / chevron / chip / collapse animation) reuses the exact same classes as `SettingsSection` — no new tokens, per the chrome-reuse rule in `CLAUDE.md`.
- A few CSS rules inset the nested cards and drop the sticky/elevated header treatment inside the drawer so the card-in-card stack reads as a calm sub-list.

`ExperimentalSettings.tsx` only reorders the two keepers to the top and wraps the other three in the group — no handler or logic changes.

## Reviewer notes

- No behavior change to any toggle; this is layout/grouping only.
- Verified locally: `typecheck`, `lint:colors` (renderer raw-color guard), and `lint:boundaries` (dependency-cruiser) all pass.
- The docs-site `settings-experimental.png` capture lives in the sibling `docs.pwragent.ai` repo and will now show the collapsed drawer — a manual `screenshot:docs-site` regen, not gated by this repo's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)