### PR TITLE
fix(desktop): show file-change approval context

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18538,6 +18538,83 @@ command = "pnpm dev"
       await registry.close();
     });
 
+    it("embeds nested file-change diffs in native approval intents", async () => {
+      resetNotificationMocks();
+      const registry = makeRegistry();
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "file-change-1",
+              type: "fileChange",
+              status: "inProgress",
+              changes: [
+                {
+                  path: "/Users/huntharo/huntharo_rocks.txt",
+                  kind: {
+                    type: "update",
+                    unified_diff:
+                      "@@ -1 +1 @@\n-old dumb sentence\n+new dumb sentence",
+                  },
+                },
+                {
+                  path: "/tmp/huntharo_rocks.txt",
+                  kind: {
+                    type: "add",
+                    content: "first dumb line\nsecond dumb line\n",
+                  },
+                },
+              ],
+            },
+          },
+        } as AppServerNotification,
+      });
+
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "file-change-1",
+            requestId: "approval-1",
+            prompt: "Approve file edit?",
+          },
+        } as AppServerNotification,
+      });
+
+      const call = desktopNotificationServiceMock.notifyApproval.mock.calls[0]?.[0];
+      expect(call?.intent.context).toMatchObject({
+        action: "update",
+        path: "/Users/huntharo/huntharo_rocks.txt",
+        diff: "@@ -1 +1 @@\n-old dumb sentence\n+new dumb sentence",
+      });
+      expect(call?.intent.context?.files).toEqual([
+        expect.objectContaining({
+          action: "update",
+          path: "/Users/huntharo/huntharo_rocks.txt",
+          diff: "@@ -1 +1 @@\n-old dumb sentence\n+new dumb sentence",
+        }),
+        expect.objectContaining({
+          action: "add",
+          path: "/tmp/huntharo_rocks.txt",
+          diff: expect.stringContaining("+second dumb line"),
+        }),
+      ]);
+      expect(call?.intent.body).toContain("Files:");
+      expect(call?.intent.body).toContain("- /Users/huntharo/huntharo_rocks.txt (update)");
+      expect(call?.intent.body).toContain("- /tmp/huntharo_rocks.txt (add)");
+      expect(call?.intent.body).toContain("Diff: 2 files, +3 -1");
+
+      await registry.close();
+    });
+
     it("notification approval for a later request resolves that request, not the first request on the thread", async () => {
       resetNotificationMocks();
       const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -221,7 +221,9 @@ describe("buildApprovalIntent", () => {
               {
                 action: "add",
                 path: "/repo/pwragent/pwragent-pr-refresh-body.md",
-                diff: "+Draft PR body",
+                diff: "@@ -0,0 +1 @@\n+Draft PR body",
+                additions: 1,
+                removals: 0,
               },
             ],
           },
@@ -233,9 +235,11 @@ describe("buildApprovalIntent", () => {
       action: "add",
       path: "/repo/pwragent/pwragent-pr-refresh-body.md",
       displayPath: "pwragent-pr-refresh-body.md",
-      diff: "+Draft PR body",
+      diff: "@@ -0,0 +1 @@\n+Draft PR body",
     });
     expect(intent.body).toContain("Context:\nAction: add\nFile: pwragent-pr-refresh-body.md");
-    expect(intent.body).toContain("```diff\n+Draft PR body\n```");
+    expect(intent.body).toContain("Diff: 1 file, +1 -0");
+    expect(intent.body).not.toContain("```diff");
+    expect(intent.body).not.toContain("Draft PR body");
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -204,4 +204,38 @@ describe("buildApprovalIntent", () => {
     );
     expect(intent.body).not.toContain("```shell");
   });
+
+  it("renders file-change context embedded on the approval request", () => {
+    const intent = buildApprovalIntent({
+      id: "approval-4",
+      createdAt: 1000,
+      directoryPaths: ["/repo/pwragent"],
+      request: {
+        method: "item/fileChange/requestApproval",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-4",
+          prompt: "Write file?",
+          _pwragentApprovalContext: {
+            files: [
+              {
+                action: "add",
+                path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+                diff: "+Draft PR body",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(intent.context).toMatchObject({
+      action: "add",
+      path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+      displayPath: "pwragent-pr-refresh-body.md",
+      diff: "+Draft PR body",
+    });
+    expect(intent.body).toContain("Context:\nAction: add\nFile: pwragent-pr-refresh-body.md");
+    expect(intent.body).toContain("```diff\n+Draft PR body\n```");
+  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -177,6 +177,7 @@ describe("buildApprovalIntent", () => {
     const intent = buildApprovalIntent({
       id: "approval-3",
       createdAt: 1000,
+      directoryPaths: ["/repo/pwragent"],
       request: {
         method: "item/fileChange/requestApproval",
         params: {
@@ -184,13 +185,23 @@ describe("buildApprovalIntent", () => {
           requestId: "request-3",
           prompt: "Write file?",
           action: "write",
-          path: "src/app.ts",
+          path: "/repo/pwragent/src/app.ts",
+          grantRoot: "/repo/pwragent",
         },
       },
     });
 
     expect(intent.title).toBe("File Change Approval");
-    expect(intent.body).toContain("Context:\nwrite src/app.ts");
+    expect(intent.context).toMatchObject({
+      action: "write",
+      path: "/repo/pwragent/src/app.ts",
+      displayPath: "src/app.ts",
+      grantRoot: "/repo/pwragent",
+      displayGrantRoot: ".",
+    });
+    expect(intent.body).toContain(
+      "Context:\nAction: write\nFile: src/app.ts\nWrite root: .",
+    );
     expect(intent.body).not.toContain("```shell");
   });
 });

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -587,7 +587,9 @@ describe("RendererHotCpuProfiler", () => {
     expect(sessionResult.ok).toBe(true);
     if (!sessionResult.ok) return;
 
-    const { target } = createTarget();
+    vi.useFakeTimers();
+
+    const { target, debuggerApi } = createTarget();
     const onHeapSnapshotLimitReached = vi.fn(async () => undefined);
     const onProfileWritten = vi.fn();
     let nowCallCount = 0;
@@ -596,9 +598,10 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 101.5),
       createMetric(4, 103),
     ];
+    const getAppMetrics = vi.fn(() => [metrics.shift() ?? createMetric(0)]);
     const profiler = new RendererHotCpuProfiler({
       config,
-      getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
+      getAppMetrics,
       onHeapSnapshotLimitReached,
       onProfileWritten,
       session: sessionResult.session,
@@ -611,15 +614,27 @@ describe("RendererHotCpuProfiler", () => {
       now: () => new Date(1_780_000_000_000 + nowCallCount++ * 2_000),
     });
 
-    await profiler.start();
+    try {
+      await profiler.start();
 
-    await vi.waitFor(() => {
-      expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(3);
-    });
-    await vi.waitFor(() => {
-      expect(onHeapSnapshotLimitReached).toHaveBeenCalledTimes(1);
-    });
-    await profiler.stop("test-complete");
+      await vi.advanceTimersByTimeAsync(config.startDelayMs);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      await vi.waitFor(() => expect(getAppMetrics).toHaveBeenCalledTimes(3));
+      await vi.waitFor(() => expect(debuggerApi.attach).toHaveBeenCalledWith("1.3"));
+      await vi.advanceTimersByTimeAsync(config.profileDurationMs);
+
+      await vi.waitFor(() => {
+        expect(target.takeHeapSnapshot).toHaveBeenCalledTimes(3);
+      });
+      await vi.waitFor(() => {
+        expect(onHeapSnapshotLimitReached).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await profiler.stop("test-complete");
+    }
 
     const snapshotFilenames = target.takeHeapSnapshot.mock.calls.map((call) =>
       // The product builds snapshot paths with path.join, so on Windows they

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1248,6 +1248,10 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 function readFileChangeApprovalFile(
   value: unknown,
 ): NonNullable<PendingRequestApprovalContext["files"]>[number] | undefined {
@@ -1261,17 +1265,65 @@ function readFileChangeApprovalFile(
     readNonEmptyString(kind?.type) ??
     readNonEmptyString(record.kind) ??
     readNonEmptyString(record.action);
+  const directDiff =
+    readNonEmptyString(kind?.unified_diff) ??
+    readNonEmptyString(kind?.unifiedDiff) ??
+    readFileChangeApprovalDiff(record) ??
+    readFileChangeApprovalDiff(kind);
+  const content =
+    readOptionalString(kind?.content) ?? readOptionalString(record.content);
   const diff =
-    readNonEmptyString(record.diff) ??
-    readNonEmptyString(record.patch) ??
-    readNonEmptyString(record.unifiedDiff) ??
-    readNonEmptyString(record.unified_diff);
+    buildFileChangeApprovalContentDiff({ action, content, filePath }) ??
+    directDiff;
   return {
     ...(action ? { action } : {}),
     ...(diff ? { diff } : {}),
     displayPath: filePath,
     path: filePath,
   };
+}
+
+function readFileChangeApprovalDiff(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+  const direct =
+    readNonEmptyString(record.diff) ??
+    readNonEmptyString(record.patch) ??
+    readNonEmptyString(record.unifiedDiff) ??
+    readNonEmptyString(record.unified_diff);
+  if (direct) {
+    return direct;
+  }
+  return readFileChangeApprovalDiff(readRecord(record.diff));
+}
+
+function buildFileChangeApprovalContentDiff(params: {
+  action: string | undefined;
+  content: string | undefined;
+  filePath: string;
+}): string | undefined {
+  if (
+    params.content === undefined ||
+    (params.action !== "add" && params.action !== "delete")
+  ) {
+    return undefined;
+  }
+
+  const lines = params.content.length ? params.content.split("\n") : [];
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  const hunkLineCount = lines.length;
+  const displayPath = params.filePath.replace(/^\/+/, "") || "file";
+  const header =
+    params.action === "add"
+      ? [`--- /dev/null`, `+++ b/${displayPath}`, `@@ -0,0 +1,${hunkLineCount} @@`]
+      : [`--- a/${displayPath}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
+  const prefix = params.action === "add" ? "+" : "-";
+  return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
 }
 
 function fileChangeApprovalContextKey(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -148,6 +148,7 @@ import {
   isThreadSearchContentMode,
   isThreadSearchSemanticMode,
   type PendingRequestDecision,
+  type PendingRequestApprovalContext,
   readCodexEnvironmentActionRuns,
   DEFAULT_TASK_MONITOR_MODEL,
   DEFAULT_TASK_MONITOR_POLL_INTERVAL_SECONDS,
@@ -1245,6 +1246,46 @@ function readNotificationProjectLabel(
 
 function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readFileChangeApprovalFile(
+  value: unknown,
+): NonNullable<PendingRequestApprovalContext["files"]>[number] | undefined {
+  const record = readRecord(value);
+  const filePath = readNonEmptyString(record?.path);
+  if (!record || !filePath) {
+    return undefined;
+  }
+  const kind = readRecord(record.kind);
+  const action =
+    readNonEmptyString(kind?.type) ??
+    readNonEmptyString(record.kind) ??
+    readNonEmptyString(record.action);
+  const diff =
+    readNonEmptyString(record.diff) ??
+    readNonEmptyString(record.patch) ??
+    readNonEmptyString(record.unifiedDiff) ??
+    readNonEmptyString(record.unified_diff);
+  return {
+    ...(action ? { action } : {}),
+    ...(diff ? { diff } : {}),
+    displayPath: filePath,
+    path: filePath,
+  };
+}
+
+function fileChangeApprovalContextKey(params: {
+  backend: AppServerBackendKind;
+  itemId?: string;
+  threadId: string;
+  turnId?: string;
+}): string {
+  return [
+    params.backend,
+    params.threadId,
+    params.turnId ?? "",
+    params.itemId ?? "__latest__",
+  ].join(":");
 }
 
 function isAcpPermissionRequest(
@@ -3383,6 +3424,10 @@ export class DesktopBackendRegistry {
   private latestCodexConfigWarning?: AgentEvent;
   private readonly unsubscribers: Array<() => void> = [];
   private readonly pendingServerRequests = new Map<string, PendingServerRequest>();
+  private readonly fileChangeApprovalContexts = new Map<
+    string,
+    PendingRequestApprovalContext
+  >();
   private readonly pendingTitleGenerations = new Map<
     string,
     {
@@ -13706,7 +13751,129 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private rememberFileChangeApprovalContext(event: AgentEvent): void {
+    if (
+      event.notification.method !== "item/started" &&
+      event.notification.method !== "item/completed"
+    ) {
+      return;
+    }
+    const params = readRecord(event.notification.params);
+    const item = readRecord(params?.item);
+    const itemType = readNonEmptyString(item?.type)?.toLowerCase();
+    if (!params || !item || itemType !== "filechange") {
+      return;
+    }
+    const threadId = readNonEmptyString(params.threadId);
+    const turnId = readNonEmptyString(params.turnId);
+    const itemId = readNonEmptyString(item.id);
+    if (!threadId || !itemId) {
+      return;
+    }
+
+    const files = Array.isArray(item.changes)
+      ? item.changes
+          .map((change) => readFileChangeApprovalFile(change))
+          .filter(
+            (
+              file,
+            ): file is NonNullable<PendingRequestApprovalContext["files"]>[number] =>
+              Boolean(file),
+          )
+      : [];
+    if (!files.length) {
+      return;
+    }
+
+    const primary = files[0]!;
+    const context: PendingRequestApprovalContext = {
+      ...(primary.action ? { action: primary.action } : {}),
+      ...(primary.diff ? { diff: primary.diff } : {}),
+      displayPath: primary.displayPath,
+      files,
+      path: primary.path,
+    };
+    this.fileChangeApprovalContexts.set(
+      fileChangeApprovalContextKey({
+        backend: event.backend,
+        threadId,
+        turnId,
+        itemId,
+      }),
+      context,
+    );
+    this.fileChangeApprovalContexts.set(
+      fileChangeApprovalContextKey({
+        backend: event.backend,
+        threadId,
+        turnId,
+      }),
+      context,
+    );
+    if (this.fileChangeApprovalContexts.size > 500) {
+      const oldestKey = this.fileChangeApprovalContexts.keys().next().value;
+      if (oldestKey) {
+        this.fileChangeApprovalContexts.delete(oldestKey);
+      }
+    }
+  }
+
+  private withEmbeddedFileChangeApprovalContext(event: AgentEvent): AgentEvent {
+    if (event.notification.method !== "item/fileChange/requestApproval") {
+      return event;
+    }
+    const request = event.notification as AppServerPendingRequestNotification;
+    if (request.params._pwragentApprovalContext) {
+      return event;
+    }
+    const threadId = readNonEmptyString(request.params.threadId);
+    const turnId = readNonEmptyString(request.params.turnId);
+    const itemId =
+      readNonEmptyString(request.params.itemId) ??
+      readNonEmptyString(request.params.item_id) ??
+      readNonEmptyString(request.params.callId) ??
+      readNonEmptyString(request.params.call_id);
+    if (!threadId) {
+      return event;
+    }
+    const context =
+      (itemId
+        ? this.fileChangeApprovalContexts.get(
+            fileChangeApprovalContextKey({
+              backend: event.backend,
+              threadId,
+              turnId,
+              itemId,
+            }),
+          )
+        : undefined) ??
+      this.fileChangeApprovalContexts.get(
+        fileChangeApprovalContextKey({
+          backend: event.backend,
+          threadId,
+          turnId,
+        }),
+      );
+    if (!context) {
+      return event;
+    }
+
+    return {
+      ...event,
+      notification: {
+        ...request,
+        params: {
+          ...request.params,
+          _pwragentApprovalContext: context,
+        },
+      } as AppServerPendingRequestNotification,
+    };
+  }
+
   private async emit(event: AgentEvent): Promise<void> {
+    this.rememberFileChangeApprovalContext(event);
+    event = this.withEmbeddedFileChangeApprovalContext(event);
+
     if (event.backend === "codex") {
       this.recordTaskMonitorActivity(event.notification);
     }

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -1,5 +1,6 @@
 import {
   buildPendingRequestActions,
+  buildPendingRequestApprovalContext,
   type AppServerPendingRequestNotification,
   type PendingRequestAction,
 } from "@pwragent/shared";
@@ -15,12 +16,16 @@ import {
 export function buildApprovalIntent(params: {
   capabilityProfile?: MessagingCapabilityProfile;
   createdAt: number;
+  directoryPaths?: string[];
   id: string;
   request: AppServerPendingRequestNotification;
 }): MessagingApprovalIntent {
   const prompt = stringField(params.request.params.prompt) ?? "Approve this action?";
   const command = extractCommand(params.request.params);
-  const fileContext = extractFileContext(params.request.params);
+  const context = buildPendingRequestApprovalContext(params.request, {
+    directoryPaths: params.directoryPaths,
+  });
+  const fileContext = approvalContextMarkdown(context);
   const decisions = applyActionCapabilityLimits(
     buildDecisions(params.request),
     params.capabilityProfile,
@@ -32,6 +37,7 @@ export function buildApprovalIntent(params: {
     kind: "approval",
     createdAt: params.createdAt,
     title: titleForRequest(params.request),
+    ...(context ? { context } : {}),
     body: [
       prompt,
       command
@@ -165,15 +171,28 @@ function isGenericShellToolTitle(command: string): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
-function extractFileContext(
-  params: AppServerPendingRequestNotification["params"],
+function approvalContextMarkdown(
+  context: ReturnType<typeof buildPendingRequestApprovalContext>,
 ): string | undefined {
-  const path =
-    stringField(params.path) ??
-    stringField(params.filePath) ??
-    stringField(params.filename);
-  const action = stringField(params.action) ?? stringField(params.operation);
-  return [action, path].filter(Boolean).join(" ").trim() || undefined;
+  if (!context) {
+    return undefined;
+  }
+
+  const lines: string[] = [];
+  if (context.action) {
+    lines.push(`Action: ${context.action}`);
+  }
+  if (context.displayPath) {
+    lines.push(`File: ${context.displayPath}`);
+  }
+  if (context.displayGrantRoot) {
+    lines.push(`Write root: ${context.displayGrantRoot}`);
+  }
+  if (context.diff) {
+    lines.push(["Diff:", "```diff", context.diff, "```"].join("\n"));
+  }
+
+  return lines.join("\n") || undefined;
 }
 
 function stripDisplayShellWrapper(command: string): string {

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -182,17 +182,105 @@ function approvalContextMarkdown(
   if (context.action) {
     lines.push(`Action: ${context.action}`);
   }
-  if (context.displayPath) {
+  const fileContexts = context.files?.length
+    ? context.files
+    : context.displayPath && context.path
+      ? [
+          {
+            action: context.action,
+            additions: undefined,
+            diff: context.diff,
+            displayPath: context.displayPath,
+            path: context.path,
+            removals: undefined,
+          },
+        ]
+      : [];
+
+  if (fileContexts.length === 1) {
+    const file = fileContexts[0]!;
+    if (file.action && file.action !== context.action) {
+      lines.push(`Action: ${file.action}`);
+    }
+    lines.push(`File: ${file.displayPath}`);
+  } else if (fileContexts.length > 1) {
+    lines.push("Files:");
+    for (const file of fileContexts) {
+      lines.push(`- ${file.displayPath}${file.action ? ` (${file.action})` : ""}`);
+    }
+  } else if (context.displayPath) {
     lines.push(`File: ${context.displayPath}`);
   }
   if (context.displayGrantRoot) {
     lines.push(`Write root: ${context.displayGrantRoot}`);
   }
-  if (context.diff) {
-    lines.push(["Diff:", "```diff", context.diff, "```"].join("\n"));
+  const diffSummary = summarizeApprovalDiffs(fileContexts, context.diff);
+  if (diffSummary) {
+    lines.push(`Diff: ${diffSummary}`);
   }
 
   return lines.join("\n") || undefined;
+}
+
+function summarizeApprovalDiffs(
+  files: Array<{
+    additions?: number;
+    diff?: string;
+    diffRef?: unknown;
+    diffRefs?: unknown[];
+    omittedReason?: string;
+    removals?: number;
+  }>,
+  fallbackDiff: string | undefined,
+): string | undefined {
+  if (files.length) {
+    const filesWithDiff = files.filter((file) =>
+      Boolean(file.diff || file.diffRef || file.diffRefs?.length || file.omittedReason),
+    );
+    if (!filesWithDiff.length) {
+      return undefined;
+    }
+    const totals = filesWithDiff.reduce<{ additions: number; removals: number }>(
+      (sum, file) => {
+        const counted = countDiffLines(file.diff);
+        return {
+          additions: sum.additions + (file.additions ?? counted.additions),
+          removals: sum.removals + (file.removals ?? counted.removals),
+        };
+      },
+      { additions: 0, removals: 0 },
+    );
+    return `${filesWithDiff.length.toLocaleString()} file${
+      filesWithDiff.length === 1 ? "" : "s"
+    }, +${totals.additions.toLocaleString()} -${totals.removals.toLocaleString()}`;
+  }
+  if (!fallbackDiff) {
+    return undefined;
+  }
+  const counted = countDiffLines(fallbackDiff);
+  return `+${counted.additions.toLocaleString()} -${counted.removals.toLocaleString()}`;
+}
+
+function countDiffLines(diff: string | undefined): {
+  additions: number;
+  removals: number;
+} {
+  if (!diff) {
+    return { additions: 0, removals: 0 };
+  }
+  let additions = 0;
+  let removals = 0;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith("+++") || line.startsWith("---")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      additions += 1;
+    } else if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+  return { additions, removals };
 }
 
 function stripDisplayShellWrapper(command: string): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -324,6 +324,7 @@ function isGenericShellToolTitle(command: string): boolean {
 
 function pendingRequestPrompt(
   request: AppServerPendingRequestNotification,
+  entries: AppServerThreadEntry[],
   directoryPaths?: string[],
 ): string {
   const prompt =
@@ -332,7 +333,7 @@ function pendingRequestPrompt(
   const command = approvalDisplayCommand(request.params);
   const commandBlock = command ? `Command:\n\n${markdownCodeBlock(command, "sh")}` : "";
   const contextBlock = approvalContextMarkdown(
-    buildPendingRequestApprovalContext(request, { directoryPaths }),
+    buildPendingRequestApprovalContext(request, { directoryPaths, entries }),
   );
 
   if (prompt && commandBlock) {
@@ -370,13 +371,39 @@ function approvalContextMarkdown(
   if (context.action) {
     lines.push(`Action: ${context.action}`);
   }
-  if (context.displayPath) {
+  const fileContexts = context.files?.length
+    ? context.files
+    : context.displayPath && context.path
+      ? [
+          {
+            action: context.action,
+            diff: context.diff,
+            displayPath: context.displayPath,
+            path: context.path,
+          },
+        ]
+      : [];
+
+  if (fileContexts.length === 1) {
+    const file = fileContexts[0]!;
+    if (file.action && file.action !== context.action) {
+      lines.push(`Action: ${file.action}`);
+    }
+    lines.push(`File: ${file.displayPath}`);
+  } else if (fileContexts.length > 1) {
+    lines.push("Files:");
+    for (const file of fileContexts) {
+      lines.push(`- ${file.displayPath}${file.action ? ` (${file.action})` : ""}`);
+    }
+  } else if (context.displayPath) {
     lines.push(`File: ${context.displayPath}`);
   }
   if (context.displayGrantRoot) {
     lines.push(`Write root: ${context.displayGrantRoot}`);
   }
-  if (context.diff) {
+  if (fileContexts.length === 1 && fileContexts[0]?.diff) {
+    lines.push(`Diff:\n\n${markdownCodeBlock(fileContexts[0].diff, "diff")}`);
+  } else if (context.diff) {
     lines.push(`Diff:\n\n${markdownCodeBlock(context.diff, "diff")}`);
   }
 
@@ -1076,6 +1103,7 @@ export function TranscriptList(props: TranscriptListProps) {
                 desktopApi={props.desktopApi}
                 text={pendingRequestPrompt(
                   props.pendingRequest,
+                  transcriptEntries,
                   props.directoryPaths,
                 )}
               />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1,10 +1,12 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type ReactElement,
 } from "react";
 import type {
   AppServerPendingRequestNotification,
@@ -13,11 +15,14 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
+  AppServerThreadFileChangeKind,
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
   AutomationTimelineCard,
   DesktopApplicationsSnapshot,
   PendingRequestAction,
+  PendingRequestApprovalContext,
+  PendingRequestApprovalFileContext,
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
   ThreadTurnFailure,
@@ -44,6 +49,7 @@ import { TranscriptMessage } from "./TranscriptMessage";
 import { TranscriptPlan } from "./TranscriptPlan";
 import { TranscriptReview } from "./TranscriptReview";
 import { TranscriptWorkPhaseGroup } from "./TranscriptWorkPhaseGroup";
+import { TranscriptDiff } from "./TranscriptDiff";
 import type { PendingQuestionnaireState } from "./questionnaire";
 import type { PendingMcpInteractionState } from "./mcp-elicitation";
 import {
@@ -324,17 +330,14 @@ function isGenericShellToolTitle(command: string): boolean {
 
 function pendingRequestPrompt(
   request: AppServerPendingRequestNotification,
-  entries: AppServerThreadEntry[],
-  directoryPaths?: string[],
+  context: PendingRequestApprovalContext | undefined,
 ): string {
   const prompt =
     typeof request.params.prompt === "string" ? request.params.prompt.trim() : "";
   const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
   const command = approvalDisplayCommand(request.params);
   const commandBlock = command ? `Command:\n\n${markdownCodeBlock(command, "sh")}` : "";
-  const contextBlock = approvalContextMarkdown(
-    buildPendingRequestApprovalContext(request, { directoryPaths, entries }),
-  );
+  const contextBlock = approvalContextMarkdown(context);
 
   if (prompt && commandBlock) {
     return [prompt, commandBlock, contextBlock].filter(Boolean).join("\n\n");
@@ -401,13 +404,150 @@ function approvalContextMarkdown(
   if (context.displayGrantRoot) {
     lines.push(`Write root: ${context.displayGrantRoot}`);
   }
-  if (fileContexts.length === 1 && fileContexts[0]?.diff) {
-    lines.push(`Diff:\n\n${markdownCodeBlock(fileContexts[0].diff, "diff")}`);
-  } else if (context.diff) {
-    lines.push(`Diff:\n\n${markdownCodeBlock(context.diff, "diff")}`);
-  }
 
   return lines.join("\n");
+}
+
+const APPROVAL_DIFF_INLINE_MAX_CHARS = 2_000;
+const APPROVAL_DIFF_INLINE_MAX_LINES = 18;
+const APPROVAL_DIFF_INLINE_MAX_LINE_CHARS = 240;
+
+function shouldExpandApprovalDiffByDefault(
+  file: PendingRequestApprovalFileContext,
+): boolean {
+  if (file.omittedReason || file.diffRef || file.diffRefs?.length || !file.diff) {
+    return false;
+  }
+  if (file.diff.length > APPROVAL_DIFF_INLINE_MAX_CHARS) {
+    return false;
+  }
+  const lines = file.diff.split(/\r?\n/);
+  return (
+    lines.length <= APPROVAL_DIFF_INLINE_MAX_LINES &&
+    lines.every((line) => line.length <= APPROVAL_DIFF_INLINE_MAX_LINE_CHARS)
+  );
+}
+
+function countDiffLines(diff: string | undefined): {
+  additions: number;
+  removals: number;
+} {
+  if (!diff) {
+    return { additions: 0, removals: 0 };
+  }
+  let additions = 0;
+  let removals = 0;
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith("+++") || line.startsWith("---")) {
+      continue;
+    }
+    if (line.startsWith("+")) {
+      additions += 1;
+    } else if (line.startsWith("-")) {
+      removals += 1;
+    }
+  }
+  return { additions, removals };
+}
+
+function normalizeFileChangeKind(
+  value: string | undefined,
+): AppServerThreadFileChangeKind {
+  return value === "add" || value === "delete" || value === "update"
+    ? value
+    : "update";
+}
+
+function ApprovalDiffDisclosure(props: {
+  file: PendingRequestApprovalFileContext;
+}): ReactElement | null {
+  const diffId = useId();
+  const defaultExpanded = shouldExpandApprovalDiffByDefault(props.file);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const counts = countDiffLines(props.file.diff);
+  const additions = props.file.additions ?? counts.additions;
+  const removals = props.file.removals ?? counts.removals;
+  const hasDiff = Boolean(
+    props.file.diff ||
+      props.file.diffRef ||
+      props.file.diffRefs?.length ||
+      props.file.omittedReason,
+  );
+  if (!hasDiff) {
+    return null;
+  }
+
+  return (
+    <div className="transcript-request__diff">
+      <button
+        type="button"
+        className="transcript-request__diff-toggle"
+        aria-controls={diffId}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="transcript-request__diff-chev" aria-hidden="true" />
+        <span>{expanded ? "Hide diff" : "Show diff"}</span>
+        <span className="transcript-request__diff-stat">
+          +{additions.toLocaleString()} -{removals.toLocaleString()}
+        </span>
+      </button>
+      <div id={diffId} hidden={!expanded}>
+        {expanded ? (
+          <TranscriptDiff
+            compact
+            detail={{
+              id: `approval-diff:${props.file.path}`,
+              kind: "write",
+              label: props.file.displayPath,
+              path: props.file.path,
+              fileDiff: {
+                kind: normalizeFileChangeKind(props.file.action),
+                diff: props.file.omittedReason ? "" : props.file.diff ?? "",
+                ...(props.file.diffRef ? { diffRef: props.file.diffRef } : {}),
+                ...(props.file.diffRefs ? { diffRefs: props.file.diffRefs } : {}),
+                additions,
+                removals,
+                ...(props.file.omittedReason
+                  ? { omittedReason: props.file.omittedReason }
+                  : {}),
+              },
+            }}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ApprovalDiffDisclosures(props: {
+  context: PendingRequestApprovalContext | undefined;
+}): ReactElement | null {
+  const files = props.context?.files?.length
+    ? props.context.files
+    : props.context?.path && props.context.displayPath
+      ? [
+          {
+            action: props.context.action,
+            diff: props.context.diff,
+            displayPath: props.context.displayPath,
+            path: props.context.path,
+          },
+        ]
+      : [];
+  if (!files.length) {
+    return null;
+  }
+  return (
+    <div className="transcript-request__diffs">
+      {files.map((file) => (
+        <ApprovalDiffDisclosure
+          file={file}
+          key={`${file.path}:${file.diffRef?.key ?? file.diff ?? ""}`}
+        />
+      ))}
+    </div>
+  );
 }
 
 export function TranscriptList(props: TranscriptListProps) {
@@ -532,6 +672,16 @@ export function TranscriptList(props: TranscriptListProps) {
     props.permissionTransitions,
     props.turnFailures,
   ]);
+  const pendingApprovalContext = useMemo(
+    () =>
+      props.pendingRequest
+        ? buildPendingRequestApprovalContext(props.pendingRequest, {
+            directoryPaths: props.directoryPaths,
+            entries: transcriptEntries,
+          })
+        : undefined,
+    [props.directoryPaths, props.pendingRequest, transcriptEntries],
+  );
   const transcriptRenderItems = useMemo(
     () =>
       buildTranscriptRenderItems({
@@ -1103,10 +1253,10 @@ export function TranscriptList(props: TranscriptListProps) {
                 desktopApi={props.desktopApi}
                 text={pendingRequestPrompt(
                   props.pendingRequest,
-                  transcriptEntries,
-                  props.directoryPaths,
+                  pendingApprovalContext,
                 )}
               />
+              <ApprovalDiffDisclosures context={pendingApprovalContext} />
               <div className="transcript-request__actions">
                 {pendingRequestActions.map((action) => (
                   <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -22,7 +22,10 @@ import type {
   ThreadPermissionTransition,
   ThreadTurnFailure,
 } from "@pwragent/shared";
-import { buildPendingRequestActions } from "@pwragent/shared";
+import {
+  buildPendingRequestActions,
+  buildPendingRequestApprovalContext,
+} from "@pwragent/shared";
 import { injectAutomationCards } from "./automation-card-entries";
 import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
@@ -319,30 +322,65 @@ function isGenericShellToolTitle(command: string): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
-function pendingRequestPrompt(request: AppServerPendingRequestNotification): string {
+function pendingRequestPrompt(
+  request: AppServerPendingRequestNotification,
+  directoryPaths?: string[],
+): string {
   const prompt =
     typeof request.params.prompt === "string" ? request.params.prompt.trim() : "";
   const reason = typeof request.params.reason === "string" ? request.params.reason.trim() : "";
   const command = approvalDisplayCommand(request.params);
   const commandBlock = command ? `Command:\n\n${markdownCodeBlock(command, "sh")}` : "";
+  const contextBlock = approvalContextMarkdown(
+    buildPendingRequestApprovalContext(request, { directoryPaths }),
+  );
 
   if (prompt && commandBlock) {
-    return `${prompt}\n\n${commandBlock}`;
+    return [prompt, commandBlock, contextBlock].filter(Boolean).join("\n\n");
   }
   if (prompt) {
-    return prompt;
+    return [prompt, contextBlock].filter(Boolean).join("\n\n");
   }
   if (reason && commandBlock) {
-    return `${reason}\n\n${commandBlock}`;
+    return [reason, commandBlock, contextBlock].filter(Boolean).join("\n\n");
   }
   if (commandBlock) {
-    return commandBlock;
+    return [commandBlock, contextBlock].filter(Boolean).join("\n\n");
   }
   if (reason) {
-    return reason;
+    return [reason, contextBlock].filter(Boolean).join("\n\n");
   }
 
-  return "This turn is waiting for approval before it can continue.";
+  return [
+    "This turn is waiting for approval before it can continue.",
+    contextBlock,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function approvalContextMarkdown(
+  context: ReturnType<typeof buildPendingRequestApprovalContext>,
+): string {
+  if (!context) {
+    return "";
+  }
+
+  const lines: string[] = [];
+  if (context.action) {
+    lines.push(`Action: ${context.action}`);
+  }
+  if (context.displayPath) {
+    lines.push(`File: ${context.displayPath}`);
+  }
+  if (context.displayGrantRoot) {
+    lines.push(`Write root: ${context.displayGrantRoot}`);
+  }
+  if (context.diff) {
+    lines.push(`Diff:\n\n${markdownCodeBlock(context.diff, "diff")}`);
+  }
+
+  return lines.join("\n");
 }
 
 export function TranscriptList(props: TranscriptListProps) {
@@ -1036,7 +1074,10 @@ export function TranscriptList(props: TranscriptListProps) {
                 applications={props.applications}
                 className="transcript-request__prompt"
                 desktopApi={props.desktopApi}
-                text={pendingRequestPrompt(props.pendingRequest)}
+                text={pendingRequestPrompt(
+                  props.pendingRequest,
+                  props.directoryPaths,
+                )}
               />
               <div className="transcript-request__actions">
                 {pendingRequestActions.map((action) => (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3150,12 +3150,12 @@ describe("TranscriptList", () => {
               label: "Add pwragent-pr-refresh-body.md",
               path: "/repo/pwragent/pwragent-pr-refresh-body.md",
               status: "in_progress",
-              fileDiff: {
-                kind: "add",
-                diff: "+Draft PR body",
-                additions: 1,
-                removals: 0,
-              },
+                fileDiff: {
+                  kind: "add",
+                  diff: "@@ -0,0 +1 @@\n+Draft PR body",
+                  additions: 1,
+                  removals: 0,
+                },
             },
           ],
         }}
@@ -3176,7 +3176,62 @@ describe("TranscriptList", () => {
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
     expect(screen.getByText(/Action: add/)).toBeInTheDocument();
     expect(screen.getByText(/File: pwragent-pr-refresh-body\.md/)).toBeInTheDocument();
-    expect(screen.getByText(/\+Draft PR body/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hide diff/ })).toBeInTheDocument();
+    expect(screen.getByText(/Draft PR body/)).toBeInTheDocument();
+  });
+
+  it("keeps large approval diffs collapsed until the user expands them", () => {
+    const longLine = `+${"x".repeat(320)}`;
+
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "activity-call_123",
+          summary: "Updated 1 file, +1, -0",
+          status: "in_progress",
+          turn: { id: "turn-1", status: "in_progress" },
+          details: [
+            {
+              id: "call_123-1",
+              kind: "write",
+              label: "Update pwragent-pr-refresh-body.md",
+              path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+              status: "in_progress",
+              fileDiff: {
+                kind: "update",
+                diff: `@@ -1 +1 @@\n${longLine}`,
+                additions: 1,
+                removals: 0,
+              },
+            },
+          ],
+        }}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            requestId: "approval-1",
+            itemId: "call_123",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Show diff/ })).toBeInTheDocument();
+    expect(screen.queryByText(longLine.slice(1))).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Show diff/ }));
+
+    expect(screen.getByRole("button", { name: /Hide diff/ })).toBeInTheDocument();
+    expect(screen.getByText(longLine.slice(1))).toBeInTheDocument();
   });
 
   it("renders pending user input without approval actions", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3102,6 +3102,34 @@ describe("TranscriptList", () => {
     expect(screen.queryByText(/\/bin\/zsh -lc/)).not.toBeInTheDocument();
   });
 
+  it("shows file-change approval paths relative to the thread directory", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            reason: "Write access is required.",
+            grantRoot: "/repo/pwragent",
+            path: "/repo/pwragent/.github/PULL_REQUEST_TEMPLATE.md",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Write access is required/)).toBeInTheDocument();
+    expect(screen.getByText(/File: \.github\/PULL_REQUEST_TEMPLATE\.md/)).toBeInTheDocument();
+    expect(screen.getByText(/Write root: \./)).toBeInTheDocument();
+  });
+
   it("renders pending user input without approval actions", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3130,6 +3130,55 @@ describe("TranscriptList", () => {
     expect(screen.getByText(/Write root: \./)).toBeInTheDocument();
   });
 
+  it("shows file-change approval context inferred from the matching activity", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingActivityEntry={{
+          type: "activity",
+          id: "activity-call_123",
+          summary: "Added 1 file, +1, -0",
+          status: "in_progress",
+          turn: { id: "turn-1", status: "in_progress" },
+          details: [
+            {
+              id: "call_123-1",
+              kind: "write",
+              label: "Add pwragent-pr-refresh-body.md",
+              path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+              status: "in_progress",
+              fileDiff: {
+                kind: "add",
+                diff: "+Draft PR body",
+                additions: 1,
+                removals: 0,
+              },
+            },
+          ],
+        }}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            requestId: "approval-1",
+            itemId: "call_123",
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/Action: add/)).toBeInTheDocument();
+    expect(screen.getByText(/File: pwragent-pr-refresh-body\.md/)).toBeInTheDocument();
+    expect(screen.getByText(/\+Draft PR body/)).toBeInTheDocument();
+  });
+
   it("renders pending user input without approval actions", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3130,6 +3130,42 @@ describe("TranscriptList", () => {
     expect(screen.getByText(/Write root: \./)).toBeInTheDocument();
   });
 
+  it("shows file-change approval context carried by the request before activity exists", () => {
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/pwragent"]}
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/fileChange/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            prompt: "Approve file edit?",
+            changes: [
+              {
+                path: "/Users/huntharo/huntharo_rocks.txt",
+                kind: {
+                  type: "update",
+                  unified_diff:
+                    "@@ -1 +1 @@\n-old dumb sentence\n+new dumb sentence",
+                },
+              },
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
+    expect(screen.getByText(/File: \/Users\/huntharo\/huntharo_rocks\.txt/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Hide diff/ })).toBeInTheDocument();
+    expect(screen.getByText(/new dumb sentence/)).toBeInTheDocument();
+  });
+
   it("shows file-change approval context inferred from the matching activity", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9881,6 +9881,62 @@ textarea,
   white-space: pre-wrap;
 }
 
+.transcript-request__diffs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.transcript-request__diff {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.transcript-request__diff-toggle {
+  width: fit-content;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.transcript-request__diff-toggle:hover {
+  background: var(--bg-panel-hover);
+}
+
+.transcript-request__diff-toggle:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.transcript-request__diff-chev {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.transcript-request__diff-toggle[aria-expanded="true"] .transcript-request__diff-chev {
+  transform: rotate(45deg);
+}
+
+.transcript-request__diff-stat {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
 .transcript-request__actions,
 .transcript-questionnaire__actions,
 .transcript-mcp__actions {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessagePart,
   AppServerThreadSummary,
+  PendingRequestApprovalContext,
   MessagingBindingTargetKind,
   MessagingDeliveryScope,
   MessagingToolUpdateMode,
@@ -967,6 +968,7 @@ export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {
   kind: "approval";
   title: string;
   body: string;
+  context?: PendingRequestApprovalContext;
   decisions: Array<
     MessagingSurfaceAction & {
       decision: MessagingApprovalDecision;

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -359,4 +359,42 @@ describe("buildPendingRequestApprovalContext", () => {
       diff: "-old\n+new",
     });
   });
+
+  it("reads file-change context from changes on the approval request", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        changes: [
+          {
+            path: "/Users/huntharo/huntharo_rocks.txt",
+            kind: {
+              type: "update",
+              unified_diff: "@@ -1 +1 @@\n-old\n+new",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["/repo/pwragent"],
+      }),
+    ).toMatchObject({
+      action: "update",
+      path: "/Users/huntharo/huntharo_rocks.txt",
+      displayPath: "/Users/huntharo/huntharo_rocks.txt",
+      diff: "@@ -1 +1 @@\n-old\n+new",
+      files: [
+        {
+          action: "update",
+          path: "/Users/huntharo/huntharo_rocks.txt",
+          displayPath: "/Users/huntharo/huntharo_rocks.txt",
+          diff: "@@ -1 +1 @@\n-old\n+new",
+        },
+      ],
+    });
+  });
 });

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -274,4 +274,89 @@ describe("buildPendingRequestApprovalContext", () => {
       "/tmp/PR_DESCRIPTION.md",
     );
   });
+
+  it("infers file-change context from the matching transcript activity item", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-1",
+        itemId: "call_123",
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["/repo/pwragent"],
+        entries: [
+          {
+            type: "activity",
+            id: "activity-call_123",
+            summary: "Added 1 file, +1, -0",
+            status: "in_progress",
+            turn: { id: "turn-1", status: "in_progress" },
+            details: [
+              {
+                id: "call_123-1",
+                kind: "write",
+                label: "Add pwragent-pr-refresh-body.md",
+                path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+                status: "in_progress",
+                fileDiff: {
+                  kind: "add",
+                  diff: "+Draft PR body",
+                  additions: 1,
+                  removals: 0,
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toMatchObject({
+      action: "add",
+      path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+      displayPath: "pwragent-pr-refresh-body.md",
+      diff: "+Draft PR body",
+      files: [
+        {
+          action: "add",
+          path: "/repo/pwragent/pwragent-pr-refresh-body.md",
+          displayPath: "pwragent-pr-refresh-body.md",
+          diff: "+Draft PR body",
+        },
+      ],
+    });
+  });
+
+  it("reads file-change context embedded by the desktop event bus", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        _pwragentApprovalContext: {
+          files: [
+            {
+              action: "update",
+              path: "/repo/pwragent/src/app.ts",
+              diff: "-old\n+new",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["/repo/pwragent"],
+      }),
+    ).toMatchObject({
+      action: "update",
+      path: "/repo/pwragent/src/app.ts",
+      displayPath: "src/app.ts",
+      diff: "-old\n+new",
+    });
+  });
 });

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { AppServerPendingRequestNotification } from "../contracts/normalized-app-server";
 import {
   buildPendingRequestActions,
+  buildPendingRequestApprovalContext,
   buildPendingRequestResponse,
+  formatApprovalPath,
 } from "../pending-request-response";
 
 function createRequest(
@@ -238,5 +240,38 @@ describe("buildPendingRequestResponse", () => {
         style: "danger",
       }),
     ]);
+  });
+});
+
+describe("buildPendingRequestApprovalContext", () => {
+  it("formats file-change paths relative to known thread directories", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        action: "write",
+        path: "/repo/pwragent/apps/desktop/PR_DESCRIPTION.md",
+        grantRoot: "/repo/pwragent",
+      },
+    });
+
+    expect(
+      buildPendingRequestApprovalContext(request, {
+        directoryPaths: ["/repo/pwragent"],
+      }),
+    ).toMatchObject({
+      action: "write",
+      path: "/repo/pwragent/apps/desktop/PR_DESCRIPTION.md",
+      displayPath: "apps/desktop/PR_DESCRIPTION.md",
+      grantRoot: "/repo/pwragent",
+      displayGrantRoot: ".",
+    });
+  });
+
+  it("keeps absolute paths when they are outside known thread directories", () => {
+    expect(formatApprovalPath("/tmp/PR_DESCRIPTION.md", ["/repo/pwragent"])).toBe(
+      "/tmp/PR_DESCRIPTION.md",
+    );
   });
 });

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -53,8 +53,13 @@ export function buildPendingRequestApprovalContext(
 ): PendingRequestApprovalContext | undefined {
   const params = request.params;
   const embeddedFiles = readEmbeddedApprovalFiles(params, options.directoryPaths);
+  const requestFiles = embeddedFiles.length
+    ? []
+    : readRequestApprovalFiles(params, options.directoryPaths);
   const inferredFiles = embeddedFiles.length
     ? embeddedFiles
+    : requestFiles.length
+      ? requestFiles
     : inferFileChangeApprovalFiles(request, options);
   const path = readFirstString(params, [
     "path",
@@ -155,34 +160,112 @@ function readEmbeddedApprovalFiles(
     rawFiles
       .map((entry) => {
         const record = asRecord(entry);
-        const path = readString(record?.path);
-        if (!path) {
-          return undefined;
-        }
-        return {
-          ...(readString(record?.action)
-            ? { action: readString(record?.action) }
-            : {}),
-          ...(readNumber(record?.additions) !== undefined
-            ? { additions: readNumber(record?.additions) }
-            : {}),
-          ...(readString(record?.diff) ? { diff: readString(record?.diff) } : {}),
-          ...readDiffRefFields(record),
-          displayPath: formatApprovalPath(
-            readString(record?.displayPath) ?? path,
-            directoryPaths,
-          ),
-          ...(readString(record?.omittedReason)
-            ? { omittedReason: readString(record?.omittedReason) }
-            : {}),
-          path,
-          ...(readNumber(record?.removals) !== undefined
-            ? { removals: readNumber(record?.removals) }
-            : {}),
-        };
+        return fileContextFromApprovalRecord(record, directoryPaths);
       })
       .filter((file): file is PendingRequestApprovalFileContext => Boolean(file)),
   );
+}
+
+function readRequestApprovalFiles(
+  params: Record<string, unknown>,
+  directoryPaths: string[] | undefined,
+): PendingRequestApprovalFileContext[] {
+  const item = asRecord(params.item);
+  const rawFiles = [
+    params.files,
+    params.fileChanges,
+    params.file_changes,
+    params.changes,
+    item?.changes,
+  ]
+    .filter((entry): entry is unknown[] => Array.isArray(entry))
+    .flat();
+  if (!rawFiles.length) {
+    return [];
+  }
+
+  return dedupeApprovalFiles(
+    rawFiles
+      .map((entry) =>
+        fileContextFromApprovalRecord(asRecord(entry), directoryPaths),
+      )
+      .filter((file): file is PendingRequestApprovalFileContext => Boolean(file)),
+  );
+}
+
+function fileContextFromApprovalRecord(
+  record: Record<string, unknown> | undefined,
+  directoryPaths: string[] | undefined,
+): PendingRequestApprovalFileContext | undefined {
+  const path = readFirstString(record ?? {}, [
+    "path",
+    "filePath",
+    "file_path",
+    "filename",
+    "file",
+    "targetPath",
+    "target_path",
+  ]);
+  if (!record || !path) {
+    return undefined;
+  }
+
+  const kind = asRecord(record.kind);
+  const action =
+    readFirstString(kind ?? {}, ["type", "action", "operation"]) ??
+    readFirstString(record, ["action", "operation", "kind", "type"]);
+  const directDiff =
+    readFirstString(kind ?? {}, ["diff", "patch", "unifiedDiff", "unified_diff"]) ??
+    readFirstString(record, ["diff", "patch", "unifiedDiff", "unified_diff"]);
+  const content =
+    readOptionalString(kind?.content) ?? readOptionalString(record.content);
+  const generatedDiff =
+    directDiff ?? contentDiffForApproval({ action, content, path });
+
+  return {
+    ...(action ? { action } : {}),
+    ...(readNumber(record.additions) !== undefined
+      ? { additions: readNumber(record.additions) }
+      : {}),
+    ...(generatedDiff ? { diff: generatedDiff } : {}),
+    ...readDiffRefFields(record),
+    displayPath: formatApprovalPath(
+      readString(record.displayPath) ?? path,
+      directoryPaths,
+    ),
+    ...(readString(record.omittedReason)
+      ? { omittedReason: readString(record.omittedReason) }
+      : {}),
+    path,
+    ...(readNumber(record.removals) !== undefined
+      ? { removals: readNumber(record.removals) }
+      : {}),
+  };
+}
+
+function contentDiffForApproval(params: {
+  action: string | undefined;
+  content: string | undefined;
+  path: string;
+}): string | undefined {
+  if (
+    params.content === undefined ||
+    (params.action !== "add" && params.action !== "delete")
+  ) {
+    return undefined;
+  }
+  const path = params.path.replace(/^\/+/, "") || "file";
+  const lines = params.content.length ? params.content.split("\n") : [];
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  const hunkLineCount = lines.length;
+  const header =
+    params.action === "add"
+      ? [`--- /dev/null`, `+++ b/${path}`, `@@ -0,0 +1,${hunkLineCount} @@`]
+      : [`--- a/${path}`, `+++ /dev/null`, `@@ -1,${hunkLineCount} +0,0 @@`];
+  const prefix = params.action === "add" ? "+" : "-";
+  return [...header, ...lines.map((line) => `${prefix}${line}`)].join("\n");
 }
 
 function activityMatchesItem(
@@ -679,6 +762,10 @@ function hasNetworkApprovalContext(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
 }
 
 function readNumber(value: unknown): number | undefined {

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -1,4 +1,9 @@
-import type { AppServerPendingRequestNotification } from "./contracts/normalized-app-server";
+import type {
+  AppServerPendingRequestNotification,
+  AppServerThreadActivityDetail,
+  AppServerThreadActivityEntry,
+  AppServerThreadEntry,
+} from "./contracts/normalized-app-server";
 
 export type PendingRequestDecision = "approve" | "decline" | "cancel";
 export type PendingRequestActionDecision =
@@ -24,15 +29,27 @@ export type PendingRequestApprovalContext = {
   diff?: string;
   displayGrantRoot?: string;
   displayPath?: string;
+  files?: PendingRequestApprovalFileContext[];
   grantRoot?: string;
   path?: string;
 };
 
+export type PendingRequestApprovalFileContext = {
+  action?: string;
+  diff?: string;
+  displayPath: string;
+  path: string;
+};
+
 export function buildPendingRequestApprovalContext(
   request: AppServerPendingRequestNotification,
-  options: { directoryPaths?: string[] } = {},
+  options: { directoryPaths?: string[]; entries?: AppServerThreadEntry[] } = {},
 ): PendingRequestApprovalContext | undefined {
   const params = request.params;
+  const embeddedFiles = readEmbeddedApprovalFiles(params, options.directoryPaths);
+  const inferredFiles = embeddedFiles.length
+    ? embeddedFiles
+    : inferFileChangeApprovalFiles(request, options);
   const path = readFirstString(params, [
     "path",
     "filePath",
@@ -50,26 +67,154 @@ export function buildPendingRequestApprovalContext(
   ]);
   const action = readFirstString(params, ["action", "operation"]);
   const diff = readFirstString(params, ["diff", "patch", "unifiedDiff", "unified_diff"]);
-  const hasSubject = Boolean(path || grantRoot || diff);
+  const primaryFile = inferredFiles[0];
+  const resolvedPath = path ?? primaryFile?.path;
+  const resolvedAction = action ?? primaryFile?.action;
+  const resolvedDiff = diff ?? primaryFile?.diff;
+  const hasSubject = Boolean(resolvedPath || grantRoot || resolvedDiff || inferredFiles.length);
 
   const context: PendingRequestApprovalContext = {
-    ...(hasSubject && action ? { action } : {}),
-    ...(path
+    ...(hasSubject && resolvedAction ? { action: resolvedAction } : {}),
+    ...(resolvedPath
       ? {
-          path,
-          displayPath: formatApprovalPath(path, options.directoryPaths),
+          path: resolvedPath,
+          displayPath: formatApprovalPath(resolvedPath, options.directoryPaths),
         }
       : {}),
+    ...(inferredFiles.length ? { files: inferredFiles } : {}),
     ...(grantRoot
       ? {
           grantRoot,
           displayGrantRoot: formatApprovalPath(grantRoot, options.directoryPaths),
         }
       : {}),
-    ...(diff ? { diff } : {}),
+    ...(resolvedDiff ? { diff: resolvedDiff } : {}),
   };
 
   return Object.keys(context).length > 0 ? context : undefined;
+}
+
+function inferFileChangeApprovalFiles(
+  request: AppServerPendingRequestNotification,
+  options: { directoryPaths?: string[]; entries?: AppServerThreadEntry[] },
+): PendingRequestApprovalFileContext[] {
+  if (!request.method.includes("fileChange/requestApproval")) {
+    return [];
+  }
+
+  const entries = options.entries ?? [];
+  if (!entries.length) {
+    return [];
+  }
+
+  const itemId = readFirstString(request.params, ["itemId", "item_id", "callId", "call_id"]);
+  const turnId = readString(request.params.turnId);
+  const activities = entries
+    .filter((entry): entry is AppServerThreadActivityEntry => entry.type === "activity")
+    .filter((entry) => !turnId || entry.turn?.id === turnId);
+  const matchingActivities = itemId
+    ? activities.filter((entry) => activityMatchesItem(entry, itemId))
+    : [];
+  const sourceActivities = matchingActivities.length
+    ? matchingActivities
+    : activities
+        .filter((entry) => entry.details.some((detail) => detail.kind === "write"))
+        .slice(-1);
+
+  const files = sourceActivities.flatMap((entry) =>
+    entry.details
+      .filter((detail) => detail.kind === "write")
+      .filter((detail) => !itemId || detailMatchesItem(detail, itemId) || !matchingActivities.length)
+      .map((detail) => fileContextFromActivityDetail(detail, options.directoryPaths))
+      .filter((file): file is PendingRequestApprovalFileContext => Boolean(file)),
+  );
+
+  return dedupeApprovalFiles(files);
+}
+
+function readEmbeddedApprovalFiles(
+  params: Record<string, unknown>,
+  directoryPaths: string[] | undefined,
+): PendingRequestApprovalFileContext[] {
+  const context =
+    asRecord(params._pwragentApprovalContext) ??
+    asRecord(params.approvalContext) ??
+    asRecord(params.fileChangeContext);
+  const rawFiles = context?.files;
+  if (!Array.isArray(rawFiles)) {
+    return [];
+  }
+
+  return dedupeApprovalFiles(
+    rawFiles
+      .map((entry) => {
+        const record = asRecord(entry);
+        const path = readString(record?.path);
+        if (!path) {
+          return undefined;
+        }
+        return {
+          ...(readString(record?.action)
+            ? { action: readString(record?.action) }
+            : {}),
+          ...(readString(record?.diff) ? { diff: readString(record?.diff) } : {}),
+          displayPath: formatApprovalPath(
+            readString(record?.displayPath) ?? path,
+            directoryPaths,
+          ),
+          path,
+        };
+      })
+      .filter((file): file is PendingRequestApprovalFileContext => Boolean(file)),
+  );
+}
+
+function activityMatchesItem(
+  entry: AppServerThreadActivityEntry,
+  itemId: string,
+): boolean {
+  return entry.id === itemId ||
+    entry.id === `activity-${itemId}` ||
+    entry.details.some((detail) => detailMatchesItem(detail, itemId));
+}
+
+function detailMatchesItem(
+  detail: AppServerThreadActivityDetail,
+  itemId: string,
+): boolean {
+  return detail.id === itemId || detail.id.startsWith(`${itemId}-`);
+}
+
+function fileContextFromActivityDetail(
+  detail: AppServerThreadActivityDetail,
+  directoryPaths: string[] | undefined,
+): PendingRequestApprovalFileContext | undefined {
+  const path = readString(detail.path);
+  if (!path) {
+    return undefined;
+  }
+  return {
+    action: detail.fileDiff?.kind,
+    diff: detail.fileDiff?.diff,
+    displayPath: formatApprovalPath(path, directoryPaths),
+    path,
+  };
+}
+
+function dedupeApprovalFiles(
+  files: PendingRequestApprovalFileContext[],
+): PendingRequestApprovalFileContext[] {
+  const seen = new Set<string>();
+  const result: PendingRequestApprovalFileContext[] = [];
+  for (const file of files) {
+    const key = `${file.path}\0${file.diff ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(file);
+  }
+  return result;
 }
 
 export function formatApprovalPath(
@@ -526,6 +671,12 @@ function readFirstString(
     }
   }
   return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 function normalizePath(value: string): string {

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -3,6 +3,7 @@ import type {
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadEntry,
+  AppServerThreadFileDiffRef,
 } from "./contracts/normalized-app-server";
 
 export type PendingRequestDecision = "approve" | "decline" | "cancel";
@@ -36,9 +37,14 @@ export type PendingRequestApprovalContext = {
 
 export type PendingRequestApprovalFileContext = {
   action?: string;
+  additions?: number;
   diff?: string;
+  diffRef?: AppServerThreadFileDiffRef;
+  diffRefs?: AppServerThreadFileDiffRef[];
   displayPath: string;
+  omittedReason?: string;
   path: string;
+  removals?: number;
 };
 
 export function buildPendingRequestApprovalContext(
@@ -157,12 +163,22 @@ function readEmbeddedApprovalFiles(
           ...(readString(record?.action)
             ? { action: readString(record?.action) }
             : {}),
+          ...(readNumber(record?.additions) !== undefined
+            ? { additions: readNumber(record?.additions) }
+            : {}),
           ...(readString(record?.diff) ? { diff: readString(record?.diff) } : {}),
+          ...readDiffRefFields(record),
           displayPath: formatApprovalPath(
             readString(record?.displayPath) ?? path,
             directoryPaths,
           ),
+          ...(readString(record?.omittedReason)
+            ? { omittedReason: readString(record?.omittedReason) }
+            : {}),
           path,
+          ...(readNumber(record?.removals) !== undefined
+            ? { removals: readNumber(record?.removals) }
+            : {}),
         };
       })
       .filter((file): file is PendingRequestApprovalFileContext => Boolean(file)),
@@ -195,9 +211,14 @@ function fileContextFromActivityDetail(
   }
   return {
     action: detail.fileDiff?.kind,
+    additions: detail.fileDiff?.additions,
     diff: detail.fileDiff?.diff,
+    diffRef: detail.fileDiff?.diffRef,
+    diffRefs: detail.fileDiff?.diffRefs,
     displayPath: formatApprovalPath(path, directoryPaths),
+    omittedReason: detail.fileDiff?.omittedReason,
     path,
+    removals: detail.fileDiff?.removals,
   };
 }
 
@@ -658,6 +679,65 @@ function hasNetworkApprovalContext(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readDiffRefFields(
+  record: Record<string, unknown> | undefined,
+): Pick<PendingRequestApprovalFileContext, "diffRef" | "diffRefs"> {
+  if (!record) {
+    return {};
+  }
+  const diffRef = readDiffRef(record.diffRef);
+  const diffRefs = Array.isArray(record.diffRefs)
+    ? record.diffRefs
+        .map((entry) => readDiffRef(entry))
+        .filter((entry): entry is AppServerThreadFileDiffRef => Boolean(entry))
+    : undefined;
+  return {
+    ...(diffRef ? { diffRef } : {}),
+    ...(diffRefs?.length ? { diffRefs } : {}),
+  };
+}
+
+function readDiffRef(value: unknown): AppServerThreadFileDiffRef | undefined {
+  const record = asRecord(value);
+  const source = readString(record?.source);
+  const key = readString(record?.key);
+  const threadId = readString(record?.threadId);
+  const entryId = readString(record?.entryId);
+  const detailId = readString(record?.detailId);
+  if (
+    (source !== "live" && source !== "thread") ||
+    !key ||
+    !threadId ||
+    !entryId ||
+    !detailId
+  ) {
+    return undefined;
+  }
+  const backend = readDiffRefBackend(record?.backend);
+  return {
+    source,
+    key,
+    threadId,
+    entryId,
+    detailId,
+    ...(backend ? { backend } : {}),
+  };
+}
+
+function readDiffRefBackend(
+  value: unknown,
+): AppServerThreadFileDiffRef["backend"] | undefined {
+  const backend = readString(value);
+  if (backend === "codex" || backend === "grok" || backend?.startsWith("acp:")) {
+    return backend as AppServerThreadFileDiffRef["backend"];
+  }
+  return undefined;
 }
 
 function readFirstString(

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -19,6 +19,86 @@ export type PendingRequestAction = {
   response: { decision: unknown };
 };
 
+export type PendingRequestApprovalContext = {
+  action?: string;
+  diff?: string;
+  displayGrantRoot?: string;
+  displayPath?: string;
+  grantRoot?: string;
+  path?: string;
+};
+
+export function buildPendingRequestApprovalContext(
+  request: AppServerPendingRequestNotification,
+  options: { directoryPaths?: string[] } = {},
+): PendingRequestApprovalContext | undefined {
+  const params = request.params;
+  const path = readFirstString(params, [
+    "path",
+    "filePath",
+    "file_path",
+    "filename",
+    "file",
+    "targetPath",
+    "target_path",
+  ]);
+  const grantRoot = readFirstString(params, [
+    "grantRoot",
+    "grant_root",
+    "writeRoot",
+    "write_root",
+  ]);
+  const action = readFirstString(params, ["action", "operation"]);
+  const diff = readFirstString(params, ["diff", "patch", "unifiedDiff", "unified_diff"]);
+  const hasSubject = Boolean(path || grantRoot || diff);
+
+  const context: PendingRequestApprovalContext = {
+    ...(hasSubject && action ? { action } : {}),
+    ...(path
+      ? {
+          path,
+          displayPath: formatApprovalPath(path, options.directoryPaths),
+        }
+      : {}),
+    ...(grantRoot
+      ? {
+          grantRoot,
+          displayGrantRoot: formatApprovalPath(grantRoot, options.directoryPaths),
+        }
+      : {}),
+    ...(diff ? { diff } : {}),
+  };
+
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+export function formatApprovalPath(
+  value: string,
+  directoryPaths: string[] | undefined,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const roots = [...(directoryPaths ?? [])]
+    .map((root) => normalizePath(root))
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length);
+  const normalizedValue = normalizePath(trimmed);
+
+  for (const root of roots) {
+    if (normalizedValue === root) {
+      return ".";
+    }
+    if (normalizedValue.startsWith(`${root}/`)) {
+      return normalizedValue.slice(root.length + 1) || ".";
+    }
+  }
+
+  return trimmed;
+}
+
 export function buildPendingRequestResponse(
   request: AppServerPendingRequestNotification,
   decision: PendingRequestDecision | PendingRequestAction,
@@ -433,4 +513,22 @@ function hasNetworkApprovalContext(
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readFirstString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = readString(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/");
+  return normalized.length > 1 ? normalized.replace(/\/+$/, "") : normalized;
 }


### PR DESCRIPTION
## Summary

- Add shared extraction and formatting for pending approval file context, including relative path display under known thread directories.
- Render file-change approval context in the desktop transcript card so users can see the file, write root, and diff when provided.
- Carry structured approval context on messaging approval intents while preserving provider body rendering.

## Root Cause

File-change approval requests were treated like generic pending approvals in the renderer and messaging layer. The Codex request params were preserved, but PwrAgent only rendered prompt/reason/command fields, so `grantRoot`, path-like fields, and diff-like fields were invisible to users.

The current Codex protocol for `item/fileChange/requestApproval` defines `grantRoot` but not a required per-file path or diff. This PR renders the protocol data available today and will display path/diff fields if the backend provides them.

## Validation

- `pnpm --filter @pwragent/shared exec tsc --noEmit`
- `pnpm --filter @pwragent/messaging-interface exec tsc --noEmit`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit`
- `pnpm test packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
