### PR TITLE
fix(desktop): scope edit status badges

### DIFF
--- a/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
+++ b/apps/desktop/e2e/live-work-rail-sticky-gap.spec.ts
@@ -5,14 +5,13 @@ import { launchElectronApp } from "./fixtures/electron-app";
 
 const specDir = path.dirname(fileURLToPath(import.meta.url));
 
-// Asserts the sticky file-toggle pins flush with the rail body's top
-// edge (no leftover padding gap). Before this fix, `.live-work-rail__body`
-// had `padding: 8px`, so `position: sticky; top: 0` engaged at the
-// content-edge top — 8px below the rail header's border-bottom. Visually
-// that produced a strip of empty rail-card background between the
-// header divider and the sticky toggle when scrolling through a long
-// diff.
-test("LiveWorkRail sticky file-toggle pins flush with the rail body's top edge", async () => {
+// Asserts the sticky edit-group header pins flush with the rail body's top
+// edge, and the sticky file-toggle pins flush beneath that group header (no
+// leftover padding gap). Before #510, `.live-work-rail__body` had
+// `padding: 8px`, so sticky children engaged 8px below the rail header's
+// border-bottom and left a strip of empty rail-card background while
+// scrolling through a long diff.
+test("LiveWorkRail sticky edit header and file-toggle pin without a gap", async () => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
       specDir,
@@ -56,19 +55,27 @@ test("LiveWorkRail sticky file-toggle pins flush with the rail body's top edge",
       el.scrollTop = 200;
     });
 
-    // After scrolling, the toggle should pin at the same top
-    // coordinate as the body's content area's top edge (= the body's
-    // border-edge top, since we removed the body's padding-top in
-    // the fix). Before the fix the toggle would pin 8px below.
+    // After scrolling, the edit-group header should pin at the rail body's
+    // top edge, and the file toggle should pin flush beneath that header. The
+    // no-gap assertion now targets the header->row seam because the transcript
+    // rail keeps the edit-group header even for a single group.
+    const groupHeader = rail.locator("css=.edited-file-groups__group-header");
     const toggleTop = await fileToggle.evaluate(
       (el) => el.getBoundingClientRect().top,
     );
     const bodyTop = await railBody.evaluate(
       (el) => el.getBoundingClientRect().top,
     );
+    const headerTop = await groupHeader.evaluate(
+      (el) => el.getBoundingClientRect().top,
+    );
+    const headerBottom = await groupHeader.evaluate(
+      (el) => el.getBoundingClientRect().bottom,
+    );
 
     // Allow 1px slack for sub-pixel rounding.
-    expect(Math.abs(toggleTop - bodyTop)).toBeLessThanOrEqual(1);
+    expect(Math.abs(headerTop - bodyTop)).toBeLessThanOrEqual(1);
+    expect(Math.abs(toggleTop - headerBottom)).toBeLessThanOrEqual(1);
   } finally {
     await app.close();
   }

--- a/apps/desktop/e2e/live-work-rail-toggle.spec.ts
+++ b/apps/desktop/e2e/live-work-rail-toggle.spec.ts
@@ -58,11 +58,10 @@ test("LiveWorkRail chevron actually collapses the body in a real CSS engine", as
     // click flipped the React state and the [hidden] attribute, but
     // `.live-work-rail__body { display: flex }` silently overrode the
     // UA `[hidden] { display: none }` so the body kept rendering.
-    // The collapse button's accessible name is the rail title
-    // ("Edited 2 files, ..."); the file-row toggles are named after
-    // their files ("Update AGENTS.md", "Update README.md") so this
-    // role+name match is unambiguous.
-    const chevron = rail.getByRole("button", { name: /^Edited 2 files/ });
+    // The rail-level collapse button shares the same summary text as the
+    // per-turn edit-group toggle when the body keeps its group header, so use
+    // the rail chrome class to target the outer chevron specifically.
+    const chevron = rail.locator("css=.live-work-rail__collapse");
     await chevron.click();
 
     // Body actually disappears now — in real CSS, [hidden] resolves

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx
@@ -1,39 +1,75 @@
 import type { EditGroupCommitState } from "@pwragent/shared";
-import { copyText, formatCopyTooltip } from "../../lib/copy-text";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
+type CommitBadgeStatus = {
+  variant: "uncommitted" | "committed" | "pushed";
+  label: string;
+  tooltip: string;
+};
+
+function resolveStatus(state: EditGroupCommitState): CommitBadgeStatus {
+  if (!state.committed) {
+    return {
+      variant: "uncommitted",
+      label: "Uncommitted",
+      tooltip:
+        "Files in this set have uncommitted changes. Changes may be unrelated to this turn's edits.",
+    };
+  }
+
+  if (state.pushed === true) {
+    return {
+      variant: "pushed",
+      label: "Pushed",
+      tooltip: "Most recent commit touching some files in this set was pushed.",
+    };
+  }
+
+  return {
+    variant: "committed",
+    label: "Committed",
+    tooltip:
+      "Files in this set currently have no uncommitted changes. Verify that changes from this turn were committed.",
+  };
+}
+
 /**
- * Git lifecycle badge for an accumulated edited-file group, as a single status
- * pill plus a copyable short-SHA chip: uncommitted (the "unread"/active state)
- * → committed (local) → pushed. Pushed implies committed, so "Pushed" REPLACES
- * "Committed" rather than stacking both. A trailing "N ignored" hint flags any
- * gitignored files in the group (never part of a commit). Renders nothing until
- * the commit state resolves, so a freshly committed group doesn't flash
- * "uncommitted" first.
+ * Current worktree-state hint for an edited-file group. Lifecycle status is
+ * shown only for the newest group; ignored-file counts stay visible for any
+ * resolved group so collapsed historical groups still surface gitignored edits.
  */
-export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
-  const { state } = props;
+export function EditGroupCommitBadge(props: {
+  state?: EditGroupCommitState;
+  showStatus?: boolean;
+}) {
+  const { state, showStatus = true } = props;
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
   if (!state) {
     return null;
   }
 
-  const status: { variant: "uncommitted" | "committed" | "pushed"; label: string } =
-    !state.committed
-      ? { variant: "uncommitted", label: "Uncommitted" }
-      : state.pushed === true
-        ? { variant: "pushed", label: "Pushed" }
-        : { variant: "committed", label: "Committed" };
+  const status = resolveStatus(state);
   const ignoredCount = state.ignoredPaths?.length ?? 0;
+  if (!showStatus && ignoredCount === 0) {
+    return null;
+  }
 
   return (
     <span className="edit-commit-badge">
-      <span
-        className={`edit-commit-badge__status edit-commit-badge__status--${status.variant}`}
-      >
-        {status.label}
-      </span>
-      {state.committed && state.commitSha && state.shortSha ? (
-        <CommitShaChip sha={state.commitSha} shortSha={state.shortSha} />
+      {showStatus ? (
+        <span
+          className={`edit-commit-badge__status edit-commit-badge__status--${status.variant}`}
+          tabIndex={0}
+          aria-label={`${status.label}: ${status.tooltip}`}
+          onBlur={tooltip.hide}
+          onFocus={(event) => tooltip.show(event.currentTarget, status.tooltip)}
+          onMouseEnter={(event) =>
+            tooltip.show(event.currentTarget, status.tooltip)
+          }
+          onMouseLeave={tooltip.hide}
+        >
+          {status.label}
+        </span>
       ) : null}
       {ignoredCount > 0 ? (
         <span
@@ -43,53 +79,7 @@ export function EditGroupCommitBadge(props: { state?: EditGroupCommitState }) {
           {ignoredCount} ignored
         </span>
       ) : null}
-    </span>
-  );
-}
-
-/**
- * Copyable commit-SHA chip. Matches the context rail's own copy affordance
- * (`context-rail-shared`): a viewport tooltip with the full SHA + "Click to
- * copy to clipboard", and click/Enter to copy — copies silently, no "Copied"
- * flip (the thread-row chips flip; the context rail, where this lives, does
- * not — match the surface).
- */
-function CommitShaChip(props: { sha: string; shortSha: string }) {
-  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const tooltipText = formatCopyTooltip(props.sha);
-
-  const copy = (): void => {
-    void copyText(props.sha);
-  };
-
-  return (
-    <>
-      <span
-        className="edit-commit-badge__sha"
-        role="button"
-        tabIndex={0}
-        aria-label={`Copy commit ${props.sha}`}
-        onBlur={tooltip.hide}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          copy();
-        }}
-        onFocus={(event) => tooltip.show(event.currentTarget, tooltipText)}
-        onKeyDown={(event) => {
-          if (event.key !== "Enter" && event.key !== " ") {
-            return;
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          copy();
-        }}
-        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
-        onMouseLeave={tooltip.hide}
-      >
-        <code className="edit-commit-badge__sha-value">{props.shortSha}</code>
-      </span>
       {tooltip.tooltipNode}
-    </>
+    </span>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -219,6 +219,7 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
                   key={group.key}
                   group={group}
                   commitState={props.commitStatesByKey?.[group.key]}
+                  showCommitStatus={index === 0}
                   defaultExpanded={index === 0}
                   onScrollToTurn={props.onScrollToTurn}
                 />
@@ -313,6 +314,7 @@ function useMeasuredHeight(ref: RefObject<HTMLElement | null>): number | undefin
 function EditedFileGroupSection(props: {
   group: EditedFileGroup;
   commitState?: EditGroupCommitState;
+  showCommitStatus: boolean;
   defaultExpanded: boolean;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
 }) {
@@ -363,7 +365,10 @@ function EditedFileGroupSection(props: {
               This turn
             </span>
           ) : (
-            <EditGroupCommitBadge state={props.commitState} />
+            <EditGroupCommitBadge
+              state={props.commitState}
+              showStatus={props.showCommitStatus}
+            />
           )}
         </div>
         <DiffStat

--- a/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx
@@ -74,7 +74,8 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
 
   // Title carries the full summary for each present section (e.g.
   // "Edited 2 files, +5, -2 · Changed 1 file") joined by a midline
-  // dot so there's no redundant section heading inside the body.
+  // dot. The edited-files body may still keep its per-turn group header
+  // so the newest group can show live worktree status metadata.
   // Plan delegates to TranscriptPlan's own header rendering — its
   // contribution here is just the word "Plan" since the detail lives
   // inside the section.
@@ -148,6 +149,7 @@ export function LiveWorkRail(props: LiveWorkRailProps) {
               groups={editedFileGroups}
               commitStatesByKey={props.editedFileCommitStates}
               view={editedView}
+              showSingleGroupHeader={true}
               worktreeRoot={props.editedFilesWorktreeRoot}
               onOpenFile={props.onOpenEditedFile}
               preferredEditor={resolvePreferredEditor(props.applications)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -110,7 +110,7 @@ describe("EditedFileGroupList Show more / Show less", () => {
     expect(screen.getByLabelText("+5 -4")).toBeInTheDocument();
   });
 
-  it("renders the git commit badge per group from the resolved states", () => {
+  it("renders the git status badge only for the newest turn group", () => {
     render(
       <EditedFileGroupList
         groups={groups(2)}
@@ -121,27 +121,28 @@ describe("EditedFileGroupList Show more / Show less", () => {
             commitSha: "a".repeat(40),
             shortSha: "aaaaaaa",
             pushed: true,
+            ignoredPaths: ["src/file-1.ts"],
           },
         }}
       />,
     );
 
     expect(screen.getByText("Uncommitted")).toBeInTheDocument();
-    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
-    expect(screen.getByText("Pushed")).toBeInTheDocument();
-    // Pushed implies committed, so "Pushed" replaces "Committed" — never both.
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pushed")).not.toBeInTheDocument();
     expect(screen.queryByText("Committed")).not.toBeInTheDocument();
+    expect(screen.getByText("1 ignored")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: `Copy commit ${"a".repeat(40)}` }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: `Copy commit ${"a".repeat(40)}` }),
+    ).not.toBeInTheDocument();
   });
 
-  it("shows a plain Committed badge for an unpushed commit", () => {
+  it("shows a plain Committed badge for an unpushed newest group", () => {
     render(
       <EditedFileGroupList
         groups={groups(2)}
         commitStatesByKey={{
-          "turn-1": {
+          "turn-2": {
             committed: true,
             commitSha: "f".repeat(40),
             shortSha: "fffffff",
@@ -155,8 +156,93 @@ describe("EditedFileGroupList Show more / Show less", () => {
     // No "Pushed" for a local-only commit, and no separate "Local" pill.
     expect(screen.queryByText("Pushed")).not.toBeInTheDocument();
     expect(screen.queryByText("Local")).not.toBeInTheDocument();
-    // turn-2 has no resolved state yet → no badge (avoids a wrong flash).
+    expect(screen.queryByText("fffffff")).not.toBeInTheDocument();
+  });
+
+  it("shows no git status badge in the All files view", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(2)}
+        view="files"
+        commitStatesByKey={{
+          "turn-2": { committed: false },
+          "turn-1": {
+            committed: true,
+            commitSha: "a".repeat(40),
+            shortSha: "aaaaaaa",
+            pushed: true,
+          },
+        }}
+      />,
+    );
+
     expect(screen.queryByText("Uncommitted")).not.toBeInTheDocument();
+    expect(screen.queryByText("Pushed")).not.toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
+  });
+
+  it("explains the Uncommitted status on focus", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(1)}
+        showSingleGroupHeader={true}
+        commitStatesByKey={{
+          "turn-1": { committed: false },
+        }}
+      />,
+    );
+
+    fireEvent.focus(screen.getByText("Uncommitted"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Files in this set have uncommitted changes. Changes may be unrelated to this turn's edits.",
+    );
+  });
+
+  it("explains the Committed status on focus", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(1)}
+        showSingleGroupHeader={true}
+        commitStatesByKey={{
+          "turn-1": {
+            committed: true,
+            commitSha: "f".repeat(40),
+            shortSha: "fffffff",
+            pushed: false,
+          },
+        }}
+      />,
+    );
+
+    fireEvent.focus(screen.getByText("Committed"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Files in this set currently have no uncommitted changes. Verify that changes from this turn were committed.",
+    );
+  });
+
+  it("explains the Pushed status on focus", () => {
+    render(
+      <EditedFileGroupList
+        groups={groups(1)}
+        showSingleGroupHeader={true}
+        commitStatesByKey={{
+          "turn-1": {
+            committed: true,
+            commitSha: "a".repeat(40),
+            shortSha: "aaaaaaa",
+            pushed: true,
+          },
+        }}
+      />,
+    );
+
+    fireEvent.focus(screen.getByText("Pushed"));
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Most recent commit touching some files in this set was pushed.",
+    );
   });
 
   it("does not show the turn-overflow toggle in the All files view", () => {
@@ -188,6 +274,7 @@ describe("EditedFileGroupList Show more / Show less", () => {
 
     // Group-level hint on the badge ("· 1 ignored" — the dot is CSS).
     expect(screen.getByText("1 ignored")).toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
     // Per-file chip on the ignored row.
     expect(screen.getByText("Ignored")).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type {
   AppServerThreadActivityEntry,
   AppServerThreadPlanEntry,
+  EditGroupCommitState,
 } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
 import { LiveWorkRail } from "../LiveWorkRail";
@@ -130,6 +131,33 @@ describe("LiveWorkRail", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows the newest group's live worktree status in the transcript rail", () => {
+    const groups = buildEditedFileGroups();
+    const firstGroup = groups[0];
+    if (!firstGroup) {
+      throw new Error("expected edited-file test fixture to build a group");
+    }
+    const commitStates: Record<string, EditGroupCommitState> = {
+      [firstGroup.key]: {
+        committed: true,
+        commitSha: "a".repeat(40),
+        shortSha: "aaaaaaa",
+        pushed: true,
+      },
+    };
+
+    render(
+      <LiveWorkRail
+        pinned={false}
+        editedFileGroups={groups}
+        editedFileCommitStates={commitStates}
+      />,
+    );
+
+    expect(screen.getByText("Pushed")).toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
+  });
+
   it("suffixes the aria label with (last turn) when pinned but keeps the same summary text in the visible title", () => {
     render(
       <LiveWorkRail pinned={true} editedFileGroups={buildEditedFileGroups()} />,
@@ -161,8 +189,8 @@ describe("LiveWorkRail", () => {
     render(
       <LiveWorkRail pinned={false} editedFileGroups={buildEditedFileGroups()} />,
     );
-    // Section heading is gone — the rail title carries the summary
-    // (see "uses the section summary as the rail title" above).
+    // There is no separate section heading; the rail title carries the
+    // summary while the body keeps the per-turn group header metadata.
     expect(
       screen.queryByRole("heading", { level: 3, name: /Edited 2 files/i }),
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2316,12 +2316,16 @@ describe("ThreadView", () => {
 
     // Replay caught up: the pending live entry clears (no dupe), but the
     // rail keeps rendering the persisted entry's edits — accumulated
-    // edited files rehydrate from the replay instead of vanishing. Two
-    // matches: the transcript work-group row and the rail title button.
-    expect(screen.getAllByRole("button", { name: /Edited 1 file/i })).toHaveLength(2);
+    // edited files rehydrate from the replay instead of vanishing. The rail
+    // summary stays at one edited file; if the pending live entry remained,
+    // this would double-count into a two-file rail summary instead.
+    const rail = screen.getByRole("complementary", {
+      name: /Edited 1 file, \+1, -2/,
+    });
+    expect(rail).toBeInTheDocument();
     expect(
-      screen.getByRole("complementary", { name: /Edited 1 file, \+1, -2/ }),
-    ).toBeInTheDocument();
+      within(rail).getAllByRole("button", { name: /Edited 1 file/i }),
+    ).toHaveLength(2);
   });
 
   it("renders Codex warning notifications inline", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -62,7 +62,7 @@ describe("EditsPanel", () => {
         name: /Scroll the transcript to this turn/,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
     expect(screen.getByText("Pushed")).toBeInTheDocument();
   });
 
@@ -80,7 +80,7 @@ describe("EditsPanel", () => {
         name: /Scroll the transcript to this turn/,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText("aaaaaaa")).toBeInTheDocument();
+    expect(screen.queryByText("aaaaaaa")).not.toBeInTheDocument();
     expect(screen.getByText("Pushed")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts
@@ -11,13 +11,12 @@ import { editGroupPaths, type EditedFileGroup } from "./edited-file-groups";
 const RESOLVE_DEBOUNCE_MS = 300;
 
 /**
- * Resolve the git commit lifecycle (uncommitted → committed → pushed/local)
- * of a thread's edited-file groups against the live worktree, via the main
- * process. Re-resolves (debounced) when the group set changes or the
- * worktree's working state shifts (`refreshKey` — pass a signature of the
- * thread's `gitWorkingState` so a commit/push flips the badges). Pass an empty
- * `groups` array when the edits surface isn't shown to skip resolution
- * entirely. Returns an empty map until the first resolution lands.
+ * Resolve current Git file state for edited-file groups against the live
+ * worktree, via the main process. Re-resolves (debounced) when the group set
+ * changes or the worktree's working state shifts (`refreshKey` — pass a
+ * signature of the thread's `gitWorkingState` so status badges can update).
+ * Pass an empty `groups` array when the edits surface isn't shown to skip
+ * resolution entirely. Returns an empty map until the first resolution lands.
  */
 export function useEditCommitStates(params: {
   desktopApi?: Pick<DesktopApi, "resolveEditCommitStates">;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9193,9 +9193,8 @@ textarea,
   color: var(--accent-bright);
 }
 
-/* Per-group git lifecycle: uncommitted → committed (with copyable SHA chip)
-   → pushed, plus a "N ignored" hint for gitignored files. Mirrors the
-   group-tag pill scale. */
+/* Current worktree-state hint for the newest edited-file group, plus a
+   "N ignored" hint for gitignored files. Mirrors the group-tag pill scale. */
 .edit-commit-badge {
   flex: 0 0 auto;
   display: inline-flex;
@@ -9214,6 +9213,7 @@ textarea,
   border-radius: 999px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  cursor: help;
 }
 
 .edit-commit-badge__status--uncommitted {
@@ -9244,40 +9244,13 @@ textarea,
   letter-spacing: 0;
 }
 
-.edit-commit-badge__ignored::before {
+.edit-commit-badge__ignored:not(:first-child)::before {
   content: "· ";
 }
 
-.edit-commit-badge__sha {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 1px 6px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 4px;
-  background: var(--bg-panel-elevated);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font: inherit;
-  font-size: 10px;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease;
-}
-
-.edit-commit-badge__sha:hover {
-  background: var(--bg-panel-hover);
-  color: var(--text-primary);
-}
-
-.edit-commit-badge__sha:focus-visible {
+.edit-commit-badge__status:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 1px;
-}
-
-.edit-commit-badge__sha-value {
-  font-family: var(--font-mono);
-  letter-spacing: 0.02em;
 }
 
 .edited-file-groups__group-time {

--- a/docs/brainstorms/2026-06-17-edits-status-badge-scope-requirements.md
+++ b/docs/brainstorms/2026-06-17-edits-status-badge-scope-requirements.md
@@ -1,0 +1,92 @@
+---
+date: 2026-06-17
+topic: edits-status-badge-scope
+---
+
+# Edits Status Badge Scope Requirements
+
+## Summary
+
+The Edits surfaces should stop implying historical turn edits have reliable commit or push attribution. Keep one live file-state badge only on the newest `By turn` edit group, remove SHA display from edit groups, and make the remaining badge explain that it is a current worktree hint rather than proof of turn provenance.
+
+---
+
+## Problem Frame
+
+The current Edits UI resolves `UNCOMMITTED`, `COMMITTED`, `PUSHED`, and a SHA from live Git path state, then attaches that result to turn edit groups. That can look like a turn-to-commit relationship, but the underlying state answers a narrower question: whether the files are currently dirty, which recent commit touched some of those paths, and whether that chosen commit is pushed.
+
+Historical edit groups drift as the worktree changes. A later edit, commit, push, rebase, detached-head reset, or worktree-path mismatch can make an older turn display a status that is unrelated to what happened during that turn. This creates noise in the Edits sidebar and transcript float-over, and it can falsely suggest that a commit SHA contains hunks that were only transient turn activity.
+
+---
+
+## Key Decisions
+
+- **Status is a current hint, not provenance.** The remaining badge should describe current file/worktree state and avoid claiming that the turn's edits were committed or pushed.
+- **Only the newest turn gets a badge.** Older turn groups should not show commit lifecycle badges because their live path state becomes less trustworthy over time.
+- **No SHA chip in edit groups.** A SHA next to a turn edit group reads as commit attribution, so it should be removed from this surface.
+
+---
+
+## Requirements
+
+**Badge visibility**
+
+- R1. Show `UNCOMMITTED`, `COMMITTED`, or `PUSHED` only for the first visible edit group in the `By turn` view.
+- R2. Do not show commit lifecycle badges on older `By turn` groups.
+- R3. Do not show commit lifecycle badges in the `All files` view.
+- R4. Do not show a commit SHA or short-SHA chip on any edit group.
+
+**Badge meaning**
+
+- R5. `UNCOMMITTED` means files in the newest edit set currently have uncommitted changes.
+- R6. `COMMITTED` means files in the newest edit set currently have no uncommitted changes.
+- R7. `PUSHED` means the most recent commit touching some files in the newest edit set was pushed.
+- R8. The UI must not imply that any status badge proves the turn's exact edits were committed or pushed.
+
+**Tooltip copy**
+
+- R9. The `UNCOMMITTED` tooltip should say: "Files in this set have uncommitted changes. Changes may be unrelated to this turn's edits."
+- R10. The `COMMITTED` tooltip should say: "Files in this set currently have no uncommitted changes. Verify that changes from this turn were committed."
+- R11. The `PUSHED` tooltip should say: "Most recent commit touching some files in this set was pushed."
+
+**Surface coverage**
+
+- R12. Apply the same badge visibility rules in the Edits sidebar and the transcript float-over.
+- R13. Preserve existing edit group summaries, timestamps, file rows, and diff stats when badges are hidden.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R4.** Given the `By turn` Edits view shows four historical edit groups, when no turn is currently streaming, then only the top group may show a lifecycle badge and none of the groups show a SHA.
+- AE2. **Covers R3, R4.** Given the user switches to `All files`, when the merged file list renders, then no lifecycle badge or SHA appears for that merged view.
+- AE3. **Covers R5, R9.** Given the newest edit group's files currently have uncommitted changes, when the badge renders, then it says `UNCOMMITTED` and the tooltip explains that changes may be unrelated to this turn's edits.
+- AE4. **Covers R7, R11.** Given the newest edit group's displayed status resolves to `PUSHED`, when the user inspects the badge, then the UI describes only the pushed state of the most recent commit touching some files in the set.
+- AE5. **Covers R12, R13.** Given the transcript float-over and the Edits sidebar show the same edit groups, when older groups render in either surface, then their file summaries, timestamps, and diff stats remain visible without lifecycle badges.
+
+---
+
+## Scope Boundaries
+
+- Exact turn-to-commit provenance is out of scope for this slice.
+- Fetching and rendering exact commit diffs is out of scope for this slice.
+- Replacing live Git path-state resolution is out of scope unless needed to keep the newest badge from showing stale or mismatched worktree data.
+- Existing live-diff and file-row rendering behavior should not be redesigned as part of this cleanup.
+
+---
+
+## Dependencies / Assumptions
+
+- The remaining top-group badge depends on live Git path-state resolution, not timestamps from the transcript.
+- The resolver must receive paths and a worktree root that refer to the same checkout; stale absolute paths or mismatched worktree identity can make even the newest badge misleading.
+- `PUSHED` remains a statement about the selected commit's remote reachability, not proof that every file or hunk in the edit set was pushed.
+
+---
+
+## Sources / Research
+
+- `apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx` currently renders lifecycle labels and a copyable SHA chip.
+- `apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx` attaches the badge to each grouped edit section.
+- `apps/desktop/src/renderer/src/features/thread-detail/useEditCommitStates.ts` resolves edit group state only when an Edits surface is visible.
+- `apps/desktop/src/main/app-server/git-working-state-service.ts` resolves commit state from live Git path status and recent path history.
+- `packages/shared/src/contracts/navigation.ts` defines `EditGroupCommitState` as live worktree metadata rather than transcript provenance.

--- a/docs/plans/2026-06-17-001-fix-edits-status-badges-plan.md
+++ b/docs/plans/2026-06-17-001-fix-edits-status-badges-plan.md
@@ -1,0 +1,143 @@
+---
+title: Fix Edits Status Badges
+type: fix
+date: 2026-06-17
+origin: docs/brainstorms/2026-06-17-edits-status-badge-scope-requirements.md
+---
+
+# Fix Edits Status Badges
+
+## Summary
+
+Limit Edits lifecycle status to one live file-state hint on the newest `By turn` group. Remove SHA chips from edit groups, hide lifecycle badges from historical and `All files` views, and add tooltips that describe the current-worktree semantics without implying turn-to-commit provenance.
+
+## Problem Frame
+
+The Edits UI currently attaches live Git path-state metadata to every historical turn group. That makes older turn diffs look tied to a current commit or push state even though later worktree changes, rebases, and path mismatches can make that metadata unrelated to the original turn.
+
+## Requirements
+
+**Badge visibility**
+
+- R1. Show a lifecycle badge only on the first visible edit group in the `By turn` view.
+- R2. Hide lifecycle badges on older `By turn` groups.
+- R3. Hide lifecycle badges in the `All files` view.
+- R4. Remove commit SHA and short-SHA display from edit groups.
+
+**Badge meaning and copy**
+
+- R5. Keep `UNCOMMITTED`, `COMMITTED`, and `PUSHED` labels as live file-state hints for the newest group only.
+- R6. Add tooltip copy for each status that matches the origin requirements.
+- R7. Preserve the `This turn` live badge behavior for active live groups.
+- R8. Preserve group-level ignored-file hints and per-row ignored-file chips.
+
+**Surface coverage**
+
+- R9. Apply the same behavior in the sidebar Edits panel and above-composer transcript float-over.
+- R10. Preserve group summaries, timestamps, diff stats, file rows, expansion behavior, and view toggles.
+
+---
+
+## Key Technical Decisions
+
+- **Gate status at the group-list level:** `EditedFileGroupList` already knows view mode and group order, so it should decide whether a group may receive a lifecycle state instead of pushing that decision into the Git resolver.
+- **Keep the resolver unchanged:** `resolveEditCommitStates` remains useful for the newest group and ignored-file metadata; changing its Git semantics would exceed the origin scope.
+- **Simplify the badge component:** `EditGroupCommitBadge` should render only the status pill and ignored-file hint. The SHA copy affordance should be removed from this surface because it reads as commit attribution.
+- **Use the existing viewport tooltip pattern:** The status pill should use `useViewportTooltip`, matching existing clipped-surface tooltip behavior in the Edits rail instead of relying on native `title` text.
+
+---
+
+## Implementation Units
+
+### U1. Gate Badge Visibility by View and Group Position
+
+- **Goal:** Ensure only the newest `By turn` group can receive lifecycle status while older groups and `All files` render without status badges.
+- **Requirements:** R1, R2, R3, R7, R9, R10; covers AE1, AE2, AE5 from the origin.
+- **Dependencies:** None.
+- **Files:**
+  - `apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx`
+  - `apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
+  - `apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx`
+- **Approach:** In the grouped rendering path, pass a commit state only to the first visible group when the effective view is `turns`. Leave live groups on their existing `This turn` tag path, and leave `EditedFileFlatSection` without badge props.
+- **Patterns to follow:** Preserve the existing `visibleGroups.map((group, index) => ...)` structure and the current `showSingleGroupHeader` behavior used by the sidebar.
+- **Test scenarios:**
+  - Covers AE1. Render two historical groups with states for both; expect only the newest visible group to show a lifecycle label.
+  - Covers AE2. Render multiple groups in `files` view; expect no lifecycle label and no SHA text.
+  - Covers AE5. Render the sidebar panel with a single group; expect the single header, timestamp affordance, and top-group badge to remain visible.
+  - Expand hidden groups through the "Show more" affordance; expect newly visible older groups not to receive lifecycle labels even when states exist.
+- **Verification:** Renderer tests prove badge visibility is tied to top `By turn` position and that existing grouping, timestamps, and file rows still render.
+
+### U2. Remove SHA Display and Add Status Tooltips
+
+- **Goal:** Make the remaining lifecycle badge describe live state without exposing a SHA chip or copy action.
+- **Requirements:** R4, R5, R6, R8; covers AE3 and AE4 from the origin.
+- **Dependencies:** U1.
+- **Files:**
+  - `apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx`
+  - `apps/desktop/src/renderer/src/styles/app.css`
+  - `apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
+- **Approach:** Remove the copyable SHA element and its copy-text dependency from `EditGroupCommitBadge`. Attach a viewport tooltip to the status pill with status-specific copy from the origin document. Keep the ignored-file hint after the status pill.
+- **Patterns to follow:** Reuse `useViewportTooltip({ className: "viewport-tooltip" })`, as used by nearby chrome and context-rail controls. Keep the existing status color classes.
+- **Test scenarios:**
+  - Covers AE3. Render an uncommitted top group, focus or hover the status pill, and expect the tooltip to explain that changes may be unrelated to the turn.
+  - Covers AE4. Render a pushed top group, focus or hover the status pill, and expect the tooltip to describe only the most recent pushed commit touching some files in the set.
+  - Render a committed-but-not-pushed top group and expect the committed tooltip copy from the origin.
+  - Render a state with `commitSha` and `shortSha`; expect no SHA text and no "Copy commit" role.
+  - Render ignored paths; expect the group-level ignored count and per-row ignored chip to remain.
+- **Verification:** Renderer tests prove the status pill is explanatory, keyboard-visible, and no longer exposes commit copying.
+
+### U3. Align Context Panel Expectations and Type Comments
+
+- **Goal:** Keep tests and developer-facing comments aligned with the reduced status semantics.
+- **Requirements:** R8, R9, R10.
+- **Dependencies:** U1, U2.
+- **Files:**
+  - `apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx`
+  - `apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
+  - `apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx`
+  - `packages/shared/src/contracts/navigation.ts`
+- **Approach:** Update tests that currently expect SHA text in the sidebar and update comments that describe the badge as a commit lifecycle plus SHA chip. Keep the shared contract honest that the state is live worktree metadata rather than provenance.
+- **Patterns to follow:** Preserve repo-relative references and avoid changing shared type shape unless implementation reveals a real type mismatch.
+- **Test scenarios:**
+  - Sidebar single-group tests should expect the status badge but no SHA.
+  - View-toggle regression tests should cover that moving from `All files` back to a single visible group does not reintroduce historical badges.
+  - Existing ignored-file tests should continue to pass after comments and component simplification.
+- **Verification:** Focused renderer tests pass and comments no longer describe removed SHA behavior.
+
+---
+
+## Scope Boundaries
+
+- Exact turn-to-commit provenance stays out of scope.
+- Exact commit diff fetching or rendering stays out of scope.
+- Main-process Git resolution stays out of scope unless implementation reveals that renderer gating cannot preserve ignored-file behavior.
+- Live diff parsing, row rendering, and file diff expansion stay out of scope.
+
+---
+
+## Risks & Dependencies
+
+- **Tooltip test fragility:** Portal-rendered viewport tooltips require hover/focus events and document-body queries; tests should assert visible tooltip text without over-specifying pixel placement.
+- **Ignored-file metadata coupling:** Hiding old group badges must not hide ignored-file row chips, because row chips rely on the union of `ignoredPaths` across resolved states.
+- **Single-group sidebar behavior:** The sidebar intentionally preserves a group header for one group; this remains the only historical case where a badge may appear because that one group is also the newest group.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given the `By turn` view shows multiple historical edit groups, only the top group may show `UNCOMMITTED`, `COMMITTED`, or `PUSHED`.
+- AE2. Given the user switches to `All files`, the merged view shows no lifecycle badge and no SHA.
+- AE3. Given the top group is uncommitted, the status tooltip says files in the set have uncommitted changes and that changes may be unrelated to this turn's edits.
+- AE4. Given the top group is pushed, the status tooltip says the most recent commit touching some files in the set was pushed.
+- AE5. Given the same groups render in the sidebar and above-composer rail, older groups retain summaries, timestamps, diff stats, and rows without lifecycle badges.
+
+---
+
+## Sources & Research
+
+- `docs/brainstorms/2026-06-17-edits-status-badge-scope-requirements.md` is the origin document for user-facing behavior and scope boundaries.
+- `apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx` owns view mode, group order, and the current per-group badge attachment point.
+- `apps/desktop/src/renderer/src/features/thread-detail/EditGroupCommitBadge.tsx` owns current lifecycle label and SHA rendering.
+- `apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx` and `apps/desktop/src/renderer/src/features/thread-detail/LiveWorkRail.tsx` share `EditedFileGroupList`, so the shared component is the right surface for parity.
+- `apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx` and `apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx` already cover the affected renderer behavior.
+- `apps/desktop/src/main/app-server/git-working-state-service.ts` confirms that commit state is live Git path state; this plan does not change that resolver.

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -579,11 +579,12 @@ export type EditGroupCommitInput = {
 };
 
 /**
- * Git lifecycle of an edited-file group, resolved against the live worktree
- * (not the agent's command transcript). A group is `committed` when none of
- * its files still have uncommitted working-tree changes; `commitSha` is the
+ * Live Git state for an edited-file group, resolved against the worktree
+ * rather than the agent's command transcript. A group is `committed` when none
+ * of its files still have uncommitted working-tree changes; `commitSha` is the
  * most recent commit touching those files, and `pushed` reflects whether that
  * commit is reachable from any remote ref (omitted when it can't be told).
+ * This is a current file-state hint, not turn-to-commit provenance.
  */
 export type EditGroupCommitState = {
   committed: boolean;


### PR DESCRIPTION
## Summary

Edit status badges now behave as live worktree hints instead of historical turn attribution. Only the newest `By turn` edit group can show `Uncommitted`, `Committed`, or `Pushed`; older groups and `All files` stay badge-free, and SHA chips no longer appear in Edits surfaces.

The remaining status pill explains its limited meaning through tooltips, including that uncommitted changes may be unrelated to the turn's exact edits. The transcript rail keeps the single-group edit header too, so the above-composer float-over follows the same newest-group rule as the sidebar.

## Testing

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/LiveWorkRail.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx -- --runInBand`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
