### PR TITLE
fix(ci): install ripgrep from release archives

### DIFF
--- a/.github/actions/install-ripgrep/action.yml
+++ b/.github/actions/install-ripgrep/action.yml
@@ -1,24 +1,55 @@
 name: Install ripgrep
 description: Install a pinned ripgrep binary from the official release archive.
 
+inputs:
+  version:
+    description: ripgrep release version to install.
+    default: "15.1.0"
+    required: false
+
 runs:
   using: composite
   steps:
+    - name: Restore ripgrep cache
+      id: ripgrep-cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ runner.tool_cache }}/ripgrep/${{ inputs.version }}/${{ runner.os }}-${{ runner.arch }}
+        key: ripgrep-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
     - name: Download ripgrep
+      if: steps.ripgrep-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
       shell: bash
       env:
-        RIPGREP_VERSION: "15.1.0"
-        RIPGREP_SHA256: "1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599"
+        RIPGREP_VERSION: ${{ inputs.version }}
+        INSTALL_ROOT: ${{ runner.tool_cache }}/ripgrep/${{ inputs.version }}/${{ runner.os }}-${{ runner.arch }}
       run: |
         set -euo pipefail
 
-        platform="x86_64-unknown-linux-musl"
-        archive="$RUNNER_TEMP/ripgrep.tar.gz"
-        install_root="$RUNNER_TEMP/ripgrep"
+        case "${RUNNER_OS}-${RUNNER_ARCH}" in
+          Linux-X64)
+            platform="x86_64-unknown-linux-musl"
+            sha256="1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599"
+            ;;
+          macOS-X64)
+            platform="x86_64-apple-darwin"
+            sha256="64811cb24e77cac3057d6c40b63ac9becf9082eedd54ca411b475b755d334882"
+            ;;
+          macOS-ARM64)
+            platform="aarch64-apple-darwin"
+            sha256="378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715"
+            ;;
+          *)
+            echo "Unsupported ripgrep platform: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
+            exit 1
+            ;;
+        esac
+
+        archive="$RUNNER_TEMP/ripgrep-${RIPGREP_VERSION}-${platform}.tar.gz"
         url="https://github.com/BurntSushi/ripgrep/releases/download/${RIPGREP_VERSION}/ripgrep-${RIPGREP_VERSION}-${platform}.tar.gz"
 
-        rm -rf "$install_root"
-        mkdir -p "$install_root"
+        rm -rf "$INSTALL_ROOT"
+        mkdir -p "$INSTALL_ROOT"
 
         curl --fail --show-error --location \
           --connect-timeout 15 \
@@ -29,8 +60,78 @@ runs:
           --output "$archive" \
           "$url"
 
-        printf "%s  %s\n" "$RIPGREP_SHA256" "$archive" | sha256sum --check -
-        tar -xzf "$archive" --strip-components=1 --directory "$install_root"
+        if command -v sha256sum >/dev/null 2>&1; then
+          actual_sha256="$(sha256sum "$archive" | awk '{print $1}')"
+        else
+          actual_sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+        fi
 
-        echo "$install_root" >> "$GITHUB_PATH"
-        "$install_root/rg" --version
+        if [[ "$actual_sha256" != "$sha256" ]]; then
+          echo "ripgrep checksum mismatch: expected $sha256, got $actual_sha256" >&2
+          exit 1
+        fi
+
+        tar -xzf "$archive" --strip-components=1 --directory "$INSTALL_ROOT"
+
+    - name: Download ripgrep
+      if: steps.ripgrep-cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      shell: pwsh
+      env:
+        RIPGREP_VERSION: ${{ inputs.version }}
+        INSTALL_ROOT: ${{ runner.tool_cache }}\ripgrep\${{ inputs.version }}\${{ runner.os }}-${{ runner.arch }}
+      run: |
+        if ($env:RUNNER_ARCH -ne "X64") {
+          throw "Unsupported ripgrep platform: $env:RUNNER_OS-$env:RUNNER_ARCH"
+        }
+
+        $platform = "x86_64-pc-windows-msvc"
+        $expectedSha256 = "124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a"
+        $archive = Join-Path $env:RUNNER_TEMP "ripgrep-$env:RIPGREP_VERSION-$platform.zip"
+        $extractRoot = Join-Path $env:RUNNER_TEMP "ripgrep-extract"
+        $url = "https://github.com/BurntSushi/ripgrep/releases/download/$env:RIPGREP_VERSION/ripgrep-$env:RIPGREP_VERSION-$platform.zip"
+
+        Remove-Item -Recurse -Force $env:INSTALL_ROOT -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force $extractRoot -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Force -Path $env:INSTALL_ROOT | Out-Null
+
+        curl.exe --fail --show-error --location `
+          --connect-timeout 15 `
+          --max-time 120 `
+          --retry 3 `
+          --retry-delay 2 `
+          --retry-connrefused `
+          --output $archive `
+          $url
+
+        $actualSha256 = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+        if ($actualSha256 -ne $expectedSha256) {
+          throw "ripgrep checksum mismatch: expected $expectedSha256, got $actualSha256"
+        }
+
+        Expand-Archive -Path $archive -DestinationPath $extractRoot
+        $packageRoot = Get-ChildItem -Path $extractRoot -Directory | Select-Object -First 1
+        if (-not $packageRoot) {
+          throw "ripgrep archive did not contain an extracted package directory"
+        }
+
+        Copy-Item -Path (Join-Path $packageRoot.FullName "*") -Destination $env:INSTALL_ROOT -Recurse -Force
+
+    - name: Add ripgrep to PATH
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        INSTALL_ROOT: ${{ runner.tool_cache }}/ripgrep/${{ inputs.version }}/${{ runner.os }}-${{ runner.arch }}
+      run: |
+        set -euo pipefail
+
+        echo "$INSTALL_ROOT" >> "$GITHUB_PATH"
+        "$INSTALL_ROOT/rg" --version
+
+    - name: Add ripgrep to PATH
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        INSTALL_ROOT: ${{ runner.tool_cache }}\ripgrep\${{ inputs.version }}\${{ runner.os }}-${{ runner.arch }}
+      run: |
+        $env:INSTALL_ROOT >> $env:GITHUB_PATH
+        & (Join-Path $env:INSTALL_ROOT "rg.exe") --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install ripgrep
         timeout-minutes: 5
-        run: choco install ripgrep -y --no-progress
+        uses: ./.github/actions/install-ripgrep
 
       - name: Type check
         timeout-minutes: 10


### PR DESCRIPTION
## Summary

Windows CI no longer has to wait on Chocolatey to install ripgrep, which was timing out during the build + test job. The shared ripgrep action now restores a cached extracted binary when available, otherwise it downloads the pinned official release archive, verifies its SHA-256, extracts it, and adds it to PATH.

The Windows job now uses that shared action instead of `choco install ripgrep`, so Linux and Windows both get the same pinned install path while avoiding package-manager latency.

## Validation

- `ruby` YAML parse for `.github/actions/install-ripgrep/action.yml` and `.github/workflows/ci.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml`
- macOS ripgrep archive download/checksum/extract smoke test
- Windows ripgrep zip download/checksum/layout check, including confirming `rg.exe` exists in the extracted archive
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
