### PR TITLE
feat(desktop): estimate context replay pricing

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -778,6 +778,251 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows estimated cold and hot context replay counts on pricing cards", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-context-replays",
+      threadId: "thread-1",
+      turnId: "turn-context-replays",
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 550_000,
+      uncachedInputTokens: 100_000,
+      cachedInputTokens: 450_000,
+      outputTokens: 2_000,
+      reasoningOutputTokens: 500,
+      totalTokens: 552_500,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 500_000,
+      cachedInputCostMicros: 225_000,
+      outputCostMicros: 75_000,
+      totalCostMicros: 800_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [
+          {
+            backend: "codex",
+            cachedInputTokens: 450_000,
+            currency: "USD",
+            inputTokens: 550_000,
+            outputTokens: 2_000,
+            pricedUsageLineCount: 1,
+            provider: "openai",
+            reasoningOutputTokens: 500,
+            threadId: "thread-1",
+            totalCostMicros: 800_000,
+            totalTokens: 552_500,
+            uncachedInputTokens: 100_000,
+            unpricedUsageLineCount: 0,
+            updatedAt: 1_800_000_000_000,
+            usageLineCount: 1,
+          },
+        ],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 1 (100,000 uncached · $0.50)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 5 (~90,000 cached avg; 450,000 cached bucket · $0.23)",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("splits replay estimates that exceed a plausible context window size", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-large-context-replays",
+      threadId: "thread-1",
+      turnId: "turn-large-context-replays",
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 3_714_407,
+      uncachedInputTokens: 453_351,
+      cachedInputTokens: 3_261_056,
+      outputTokens: 13_156,
+      reasoningOutputTokens: 4_891,
+      totalTokens: 3_732_454,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 2_266_755,
+      cachedInputCostMicros: 1_630_528,
+      outputCostMicros: 543_000,
+      totalCostMicros: 4_440_283,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 2 (~226,676 uncached avg; 453,351 uncached bucket · $2.27)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 15 (~217,404 cached avg; 3,261,056 cached bucket · $1.64)",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("honors pricing display options for replay estimate costs", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-replay-display-options",
+      threadId: "thread-1",
+      turnId: "turn-replay-display-options",
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 550_000,
+      uncachedInputTokens: 100_000,
+      cachedInputTokens: 450_000,
+      outputTokens: 2_000,
+      reasoningOutputTokens: 500,
+      totalTokens: 552_500,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 500_000,
+      cachedInputCostMicros: 225_000,
+      outputCostMicros: 75_000,
+      totalCostMicros: 800_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    const { rerender } = renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      pricingDisplayOptions: {
+        codexCredits: true,
+        usd: false,
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 1 (100,000 uncached · 13 Codex Credits)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 5 (~90,000 cached avg; 450,000 cached bucket · 5.6 Codex Credits)",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.50/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.23/)).not.toBeInTheDocument();
+
+    rerender(
+      <ThreadContextPanel
+        activeTab="pricing"
+        backends={[baseBackend]}
+        onActiveTabChange={() => {}}
+        pinned
+        pricing={{
+          lines: [line],
+          summaries: [],
+        }}
+        pricingDisplayOptions={{
+          codexCredits: true,
+          usd: true,
+        }}
+        thread={baseThread}
+        threadPricingSummaryEnabled
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 1 (100,000 uncached · $0.50 · 13 Codex Credits)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 5 (~90,000 cached avg; 450,000 cached bucket · $0.23 · 5.6 Codex Credits)",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not estimate context replays for historical gap rows", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-with-gap",
+      threadId: "thread-1",
+      turnId: "turn-with-gap",
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      model: "gpt-5.5",
+      inputTokens: 150,
+      uncachedInputTokens: 100,
+      cachedInputTokens: 50,
+      outputTokens: 10,
+      reasoningOutputTokens: 0,
+      totalTokens: 160,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeInputTokens: 300_150,
+      cumulativeCachedInputTokens: 200_050,
+      cumulativeUncachedInputTokens: 100_100,
+      cumulativeOutputTokens: 10,
+      cumulativeReasoningOutputTokens: 0,
+      cumulativeTotalTokens: 300_160,
+      uncachedInputCostMicros: 1_000,
+      cachedInputCostMicros: 100,
+      outputCostMicros: 900,
+      totalCostMicros: 2_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("Historical usage estimate")).toBeInTheDocument();
+    expect(screen.queryByText(/cold context replays/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/hot context replays/)).not.toBeInTheDocument();
+  });
+
   it("makes pricing row timestamps scroll the transcript to their turn", () => {
     const onScrollToTurn = vi.fn();
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -32,6 +32,9 @@ const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
   codexCredits: false,
   usd: true,
 };
+// Below this size, uncached input is often the new request/tool payload rather than a full context replay.
+const MIN_CONTEXT_REPLAY_INPUT_TOKENS = 32_000;
+const MAX_ESTIMATED_CONTEXT_REPLAY_TOKENS = 250_000;
 
 export function PricingPanel(props: PricingPanelProps) {
   const summaries = props.pricing?.summaries ?? [];
@@ -129,6 +132,10 @@ export function PricingPanel(props: PricingPanelProps) {
               line,
               lineTotals,
             });
+            const contextReplayLines = formatContextReplayEstimate({
+              displayOptions,
+              line,
+            });
             const runningTokens = formatUsageLineRunningTokens(line);
 
             return (
@@ -156,6 +163,11 @@ export function PricingPanel(props: PricingPanelProps) {
                 {usageLineEstimate ? (
                   <p className="rail-card__usage">{usageLineEstimate}</p>
                 ) : null}
+                {contextReplayLines.map((replayLine) => (
+                  <p key={replayLine} className="rail-card__usage">
+                    {replayLine}
+                  </p>
+                ))}
                 {runningTokens ? (
                   <details className="pricing-running-total">
                     <summary className="pricing-running-total__summary">
@@ -614,6 +626,144 @@ function formatUsageLineRunningTotal(params: {
   return estimates.length > 0
     ? `Running total: ${estimates.join(" · ")}${params.lineTotals?.runningHasEstimate ? " (includes estimates)" : ""}`
     : undefined;
+}
+
+function formatContextReplayEstimate(params: {
+  displayOptions: PricingDisplayOptions;
+  line: PricingUsageLine;
+}): string[] {
+  if (isEstimatedUsageGap(params.line) || isHistoricalUsageSummary(params.line)) {
+    return [];
+  }
+
+  const coldContextReplays = estimateContextReplayBucket(
+    params.line.uncachedInputTokens,
+  );
+  const hotContextReplays = estimateContextReplayBucket(
+    params.line.cachedInputTokens,
+    coldContextReplays?.averageTokens,
+  );
+  const lines: string[] = [];
+  if (coldContextReplays) {
+    lines.push(
+      formatContextReplayBucketLine({
+        bucket: coldContextReplays,
+        displayOptions: params.displayOptions,
+        label: "cold",
+        line: params.line,
+        tokenKind: "uncached",
+      }),
+    );
+  }
+  if (hotContextReplays) {
+    lines.push(
+      formatContextReplayBucketLine({
+        bucket: hotContextReplays,
+        displayOptions: params.displayOptions,
+        label: "hot",
+        line: params.line,
+        tokenKind: "cached",
+      }),
+    );
+  }
+  return lines;
+}
+
+type EstimatedContextReplayBucket = {
+  averageTokens: number;
+  count: number;
+  totalTokens: number;
+};
+
+function estimateContextReplayBucket(
+  totalTokens: number,
+  referenceReplayTokens?: number,
+): EstimatedContextReplayBucket | undefined {
+  if (totalTokens < MIN_CONTEXT_REPLAY_INPUT_TOKENS) {
+    return undefined;
+  }
+  const replaySize =
+    referenceReplayTokens && referenceReplayTokens >= MIN_CONTEXT_REPLAY_INPUT_TOKENS
+      ? Math.min(referenceReplayTokens, MAX_ESTIMATED_CONTEXT_REPLAY_TOKENS)
+      : MAX_ESTIMATED_CONTEXT_REPLAY_TOKENS;
+  const count = Math.max(1, Math.ceil(totalTokens / replaySize));
+  return {
+    averageTokens: Math.round(totalTokens / count),
+    count,
+    totalTokens,
+  };
+}
+
+function formatContextReplayBucketLine(params: {
+  bucket: EstimatedContextReplayBucket;
+  displayOptions: PricingDisplayOptions;
+  label: "cold" | "hot";
+  line: PricingUsageLine;
+  tokenKind: "cached" | "uncached";
+}): string {
+  const replayTokens =
+    params.bucket.count > 1
+      ? `~${formatTokenCount(params.bucket.averageTokens)} ${params.tokenKind} avg; ${formatTokenCount(
+          params.bucket.totalTokens,
+        )} ${params.tokenKind} bucket`
+      : `${formatTokenCount(params.bucket.totalTokens)} ${params.tokenKind}`;
+  return `Estimated ${params.label} context replays: ${params.bucket.count.toLocaleString()} (${replayTokens}${formatReplayCostEstimates(
+    params,
+  )})`;
+}
+
+function formatReplayCostEstimates(params: {
+  bucket: EstimatedContextReplayBucket;
+  displayOptions: PricingDisplayOptions;
+  line: PricingUsageLine;
+  tokenKind: "cached" | "uncached";
+}): string {
+  const estimates: string[] = [];
+  if (params.displayOptions.usd) {
+    const valueMicros =
+      params.tokenKind === "cached"
+        ? params.line.cachedInputCostMicros
+        : params.line.uncachedInputCostMicros;
+    if (valueMicros > 0) {
+      estimates.push(formatMoney(valueMicros, params.line.currency));
+    }
+  }
+  if (params.displayOptions.codexCredits) {
+    const credits = estimateContextReplayCodexCredits({
+      bucket: params.bucket,
+      line: params.line,
+      tokenKind: params.tokenKind,
+    });
+    if (credits !== undefined && credits > 0) {
+      estimates.push(formatCodexCredits(credits));
+    }
+  }
+  if (estimates.length === 0) {
+    return "";
+  }
+  return ` · ${estimates.join(" · ")}`;
+}
+
+function estimateContextReplayCodexCredits(params: {
+  bucket: EstimatedContextReplayBucket;
+  line: PricingUsageLine;
+  tokenKind: "cached" | "uncached";
+}): number | undefined {
+  if (params.line.provider !== "openai") {
+    return undefined;
+  }
+  const estimate = estimateOpenAiCodexCreditUsage({
+    at: params.line.createdAt,
+    cachedInputTokens: params.tokenKind === "cached" ? params.bucket.totalTokens : 0,
+    fastMode: params.line.fastMode,
+    model: params.line.model,
+    outputTokens: 0,
+    reasoningOutputTokens: 0,
+    serviceTier: params.line.serviceTier,
+    uncachedInputTokens:
+      params.tokenKind === "uncached" ? params.bucket.totalTokens : 0,
+  });
+  return estimate?.totalCreditMicros;
 }
 
 function formatUsageLineRunningTokens(line: ThreadUsageLineRecord): string | undefined {


### PR DESCRIPTION
## Summary

Pricing cards now call out estimated cold and hot context replay buckets so large cached or uncached input spikes are easier to interpret. The display keeps the underlying token and cost totals tied to the persisted usage row, skips synthetic historical estimate rows, and labels the replay count as estimated because the ledger does not yet store exact per-request replay counts.

Large turn-level buckets are split into plausible replay-sized buckets using a 250k-token cap, so the UI no longer implies that a single context replay exceeded the model context window. Split rows show the average replay-sized bucket plus the total cached/uncached bucket estimate in whatever units the operator enabled: USD, Codex Credits, both, or neither.

## Test Plan

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test:desktop-e2e apps/desktop/e2e/thread-pricing-panel.spec.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
