### PR TITLE
fix(desktop): clarify automation Agent picker

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -302,6 +302,41 @@ describe("AutomationScheduler", () => {
     ]);
   });
 
+  it("records one skipped summary when many drop_missed windows are due", async () => {
+    createIntervalAutomation({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      backlogPolicy: "drop_missed",
+      schedule: {
+        kind: "interval",
+        every: 5,
+        unit: "minutes",
+        anchorAt: 0,
+      },
+      nextRunAt: 5 * 60 * 1000,
+    });
+    const scheduler = buildScheduler();
+    now = 5 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+
+    now = 60 * 60 * 1000;
+    await scheduler.evaluateDueAutomations();
+
+    expect(queue.submitted).toHaveLength(1);
+    expect(store.listRunsForAutomation("automation-1")).toEqual([
+      expect.objectContaining({
+        status: "skipped",
+        scheduledFor: 10 * 60 * 1000,
+        scheduledWindows: [{ scheduledFor: 10 * 60 * 1000 }],
+        errorMessage:
+          "Dropped 11 missed schedule windows because the automation execution lane was busy.",
+      }),
+      expect.objectContaining({ status: "running", scheduledFor: 5 * 60 * 1000 }),
+    ]);
+  });
+
   it("queues manual run-now without changing the recurring next run", async () => {
     queue.active = true;
     createIntervalAutomation();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7444,6 +7444,36 @@ script = "pnpm install"
     await registry.close();
   });
 
+  it("seeds an idle newly started Agent thread with the Agent name", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/start"] },
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startThread({
+      agent: { name: "Summy Dummy" },
+      backend: "codex",
+      cwd: "/repo-a",
+    });
+
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Summy Dummy",
+        titleSource: "explicit",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("starts requested worktree threads as local when the cwd is not a git repository", async () => {
     const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
     const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -882,4 +882,115 @@ describe("DesktopAutomationService", () => {
       ),
     ).toEqual(Array.from({ length: 55 }, (_, index) => `queue-${55 - index}`));
   });
+
+  it("cancels queued automation turns when pausing an automation", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: { hour: 9, minute: 0 },
+      },
+    });
+    const run = store.createRun({
+      id: "run-1",
+      automationId: created.automation.id,
+      trigger: "scheduled",
+      scheduledFor: 10_000,
+      now: 10_000,
+    });
+    expect(run).toBeDefined();
+    store.markRunQueued({
+      runId: "run-1",
+      queueEntryId: "queue-1",
+      queuedAt: 10_100,
+      now: 10_100,
+    });
+
+    await service.pause({ automationId: created.automation.id });
+
+    expect(registry.cancelQueuedTurn).toHaveBeenCalledWith(
+      "queue-1",
+      "Automation paused before this run started.",
+    );
+    expect(store.listRunsForAutomation(created.automation.id)).toEqual([
+      expect.objectContaining({
+        id: "run-1",
+        status: "cancelled",
+        errorMessage: "Automation paused before this run started.",
+      }),
+    ]);
+    expect(publishedEvents).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "automation/run/updated",
+        params: expect.objectContaining({
+          automationId: created.automation.id,
+          runId: "run-1",
+          status: "cancelled",
+          threadId: "thread-1",
+        }),
+      },
+    });
+  });
+
+  it("cancels queued automation turns when disabling from an update", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    const created = await service.create({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Check email",
+      taskPrompt: "Check mail",
+      schedule: {
+        kind: "weekdays",
+        timeOfDay: { hour: 9, minute: 0 },
+      },
+    });
+    const run = store.createRun({
+      id: "run-1",
+      automationId: created.automation.id,
+      trigger: "scheduled",
+      scheduledFor: 10_000,
+      now: 10_000,
+    });
+    expect(run).toBeDefined();
+    store.markRunQueued({
+      runId: "run-1",
+      queueEntryId: "queue-1",
+      queuedAt: 10_100,
+      now: 10_100,
+    });
+
+    await service.update({
+      automationId: created.automation.id,
+      enabled: false,
+    });
+
+    expect(registry.cancelQueuedTurn).toHaveBeenCalledWith(
+      "queue-1",
+      "Automation paused before this run started.",
+    );
+    expect(store.listRunsForAutomation(created.automation.id)).toEqual([
+      expect.objectContaining({
+        id: "run-1",
+        status: "cancelled",
+        errorMessage: "Automation paused before this run started.",
+      }),
+    ]);
+    expect(publishedEvents).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "automation/run/updated",
+        params: expect.objectContaining({
+          automationId: created.automation.id,
+          runId: "run-1",
+          status: "cancelled",
+          threadId: "thread-1",
+        }),
+      },
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5981,14 +5981,16 @@ export class DesktopBackendRegistry {
           dynamicTools,
         });
     const startedAt = Date.now();
+    const pendingThreadKey = buildThreadIdentityKey(backend, result.threadId);
+    const agentName = request.agent?.name?.trim();
     const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
     this.pendingStartedThreads.set(
-      `${backend}:${result.threadId}`,
+      pendingThreadKey,
       {
         id: result.threadId,
         source: backend,
-        title: "Untitled thread",
-        titleSource: "fallback",
+        title: agentName || "Untitled thread",
+        titleSource: agentName ? "explicit" : "fallback",
         projectKey: cwd,
         createdAt: startedAt,
         updatedAt: startedAt,
@@ -6188,7 +6190,7 @@ export class DesktopBackendRegistry {
     try {
       const forkedAt = Date.now();
       const gitBranch = cwd ? await readCurrentGitBranch(cwd).catch(() => undefined) : undefined;
-      this.pendingStartedThreads.set(`${backend}:${result.threadId}`, {
+      this.pendingStartedThreads.set(buildThreadIdentityKey(backend, result.threadId), {
         id: result.threadId,
         source: backend,
         title: "Forked thread",
@@ -6261,7 +6263,7 @@ export class DesktopBackendRegistry {
       });
       this.invalidateThreadListCache(backend);
     } catch (error) {
-      this.pendingStartedThreads.delete(`${backend}:${result.threadId}`);
+      this.pendingStartedThreads.delete(buildThreadIdentityKey(backend, result.threadId));
       await preparedWorkspace.rollback?.();
       request.onPreparedWorkspaceRollback?.(undefined);
       throw error;
@@ -10359,7 +10361,7 @@ export class DesktopBackendRegistry {
   ): AppServerThreadSummary[] {
     const threadIds = new Set(threads.map((thread) => thread.id));
     for (const threadId of threadIds) {
-      this.pendingStartedThreads.delete(`${backend}:${threadId}`);
+      this.pendingStartedThreads.delete(buildThreadIdentityKey(backend, threadId));
     }
     if (params.archived === true) {
       return threads;
@@ -11252,7 +11254,9 @@ export class DesktopBackendRegistry {
       return overlayCwd.trim();
     }
 
-    const pendingThread = this.pendingStartedThreads.get(`${backend}:${threadId}`);
+    const pendingThread = this.pendingStartedThreads.get(
+      buildThreadIdentityKey(backend, threadId),
+    );
     const pendingCwd = resolveThreadWorkspaceCwd(pendingThread);
     if (pendingCwd?.trim()) {
       return pendingCwd.trim();

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -156,25 +156,25 @@ export class AutomationScheduler {
 
     if (automation.backlogPolicy === "drop_missed") {
       if (this.options.store.findActiveRunForAutomation(automation.id)) {
-        for (const window of windows) {
-          const skipped = this.options.store.createRun({
-            automationId: automation.id,
-            trigger: "scheduled",
+        const skipped = this.options.store.createRun({
+          automationId: automation.id,
+          trigger: "scheduled",
+          status: "skipped",
+          scheduledFor: windows[0]?.scheduledFor,
+          scheduledWindows: windows.slice(0, 1),
+          now,
+        });
+        if (skipped) {
+          this.options.store.markRunTerminal({
+            runId: skipped.id,
             status: "skipped",
-            scheduledFor: window.scheduledFor,
-            scheduledWindows: [window],
+            completedAt: now,
+            errorMessage:
+              windows.length === 1
+                ? "The automation execution lane was busy when this schedule fired."
+                : `Dropped ${windows.length} missed schedule windows because the automation execution lane was busy.`,
             now,
           });
-          if (skipped) {
-            this.options.store.markRunTerminal({
-              runId: skipped.id,
-              status: "skipped",
-              completedAt: now,
-              errorMessage:
-                "The automation execution lane was busy when this schedule fired.",
-              now,
-            });
-          }
         }
         this.options.store.updateAutomation(automation.id, {
           nextRunAt: computeNextAutomationRunAt(automation.schedule, now),

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -250,6 +250,37 @@ export class AutomationStore {
     return record;
   }
 
+  cancelPendingRunsForAutomation(params: {
+    automationId: string;
+    now: number;
+    errorMessage: string;
+  }): void {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND status IN ('pending', 'queued')",
+      )
+      .all(params.automationId) as AutomationRunRow[];
+    for (const row of rows) {
+      const run = this.runFromRow(row);
+      if (!run) continue;
+      this.upsertRun(
+        {
+          ...run,
+          status: "cancelled",
+          completedAt: params.now,
+          errorMessage: params.errorMessage,
+        },
+        {
+          backend: row.backend,
+          threadId: row.thread_id,
+          queueEntryId: row.queue_entry_id ?? undefined,
+          createdAt: row.created_at,
+          updatedAt: params.now,
+        },
+      );
+    }
+  }
+
   getAutomation(
     id: string,
     options: { includeDeleted?: boolean } = {},
@@ -700,37 +731,6 @@ export class AutomationStore {
       updatedAt: now,
     });
     return nextRun;
-  }
-
-  private cancelPendingRunsForAutomation(params: {
-    automationId: string;
-    now: number;
-    errorMessage: string;
-  }): void {
-    const rows = this.stateDb.raw
-      .prepare(
-        "SELECT * FROM automation_runs WHERE automation_id = ? AND status IN ('pending', 'queued')",
-      )
-      .all(params.automationId) as AutomationRunRow[];
-    for (const row of rows) {
-      const run = this.runFromRow(row);
-      if (!run) continue;
-      this.upsertRun(
-        {
-          ...run,
-          status: "cancelled",
-          completedAt: params.now,
-          errorMessage: params.errorMessage,
-        },
-        {
-          backend: row.backend,
-          threadId: row.thread_id,
-          queueEntryId: row.queue_entry_id ?? undefined,
-          createdAt: row.created_at,
-          updatedAt: params.now,
-        },
-      );
-    }
   }
 
   private updateAutomationLastRun(

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -322,6 +322,13 @@ export class DesktopAutomationService {
       now,
     });
     if (!updated) throw new Error("Automation not found.");
+    if (disabling) {
+      await this.cancelPendingRunsForAutomation(
+        request.automationId,
+        now,
+        "Automation paused before this run started.",
+      );
+    }
     if (assignmentChanged) {
       await this.notifyThreadAutomationsUpdated(current);
     }
@@ -331,11 +338,18 @@ export class DesktopAutomationService {
   }
 
   async pause(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
+    const now = Date.now();
     const automation = this.options.store.updateAutomation(request.automationId, {
       status: "paused",
       nextRunAt: null,
+      now,
     });
     if (!automation) throw new Error("Automation not found.");
+    await this.cancelPendingRunsForAutomation(
+      request.automationId,
+      now,
+      "Automation paused before this run started.",
+    );
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
@@ -354,18 +368,12 @@ export class DesktopAutomationService {
   }
 
   async delete(request: AutomationIdRequest): Promise<AutomationMutationResponse> {
-    const pendingQueueEntryIds = this.options.store
-      .listPendingOrQueuedRunsForAutomation(request.automationId)
-      .map((run) => run.queueEntryId)
-      .filter((entryId): entryId is string => Boolean(entryId));
+    this.cancelQueuedTurnsForAutomation(
+      request.automationId,
+      "Automation deleted before the run started.",
+    );
     const automation = this.options.store.deleteAutomation(request.automationId);
     if (!automation) throw new Error("Automation not found.");
-    for (const entryId of pendingQueueEntryIds) {
-      this.options.registry.cancelQueuedTurn(
-        entryId,
-        "Automation deleted before the run started.",
-      );
-    }
     await this.notifyThreadAutomationsUpdated(automation);
     this.startSchedulerIfEnabled();
     return { automation: toAutomationDetail(automation) };
@@ -682,6 +690,53 @@ export class DesktopAutomationService {
   private startSchedulerIfEnabled(): void {
     if (!this.options.runtime?.disabled) {
       this.scheduler.start();
+    }
+  }
+
+  private async cancelPendingRunsForAutomation(
+    automationId: string,
+    now: number,
+    reason: string,
+  ): Promise<void> {
+    const automation = this.options.store.getAutomation(automationId, {
+      includeDeleted: true,
+    });
+    const pendingRuns = this.options.store.listPendingOrQueuedRunsForAutomation(
+      automationId,
+    );
+    this.cancelQueuedTurns(pendingRuns, reason);
+    this.options.store.cancelPendingRunsForAutomation({
+      automationId,
+      errorMessage: reason,
+      now,
+    });
+    if (!automation) {
+      return;
+    }
+    for (const run of pendingRuns) {
+      await this.publishAutomationRunUpdate({
+        backend: automation.backend,
+        runId: run.id,
+        status: "cancelled",
+        threadId: automation.threadId,
+        errorMessage: reason,
+      });
+    }
+  }
+
+  private cancelQueuedTurnsForAutomation(automationId: string, reason: string): void {
+    this.cancelQueuedTurns(
+      this.options.store.listPendingOrQueuedRunsForAutomation(automationId),
+      reason,
+    );
+  }
+
+  private cancelQueuedTurns(runs: AutomationRunSummary[], reason: string): void {
+    const pendingQueueEntryIds = runs
+      .map((run) => run.queueEntryId)
+      .filter((entryId): entryId is string => Boolean(entryId));
+    for (const entryId of pendingQueueEntryIds) {
+      this.options.registry.cancelQueuedTurn(entryId, reason);
     }
   }
 

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
   AutomationBacklogPolicy,
@@ -12,9 +12,12 @@ import type {
 } from "@pwragent/shared";
 import {
   AUTOMATION_WEEKDAYS,
+  buildThreadIdentityKey,
   formatAutomationScheduleSummary,
+  parseThreadIdentityKey,
   validateAutomationScheduleDefinition,
 } from "@pwragent/shared";
+import { HelpCircleIcon } from "../../icons";
 
 type AutomationEditorMode =
   | {
@@ -36,12 +39,28 @@ export type AutomationEditorSubmit =
 type AutomationEditorProps = {
   mode: AutomationEditorMode;
   onCancel: () => void;
+  onPromoteThread?: (
+    thread: NavigationThreadSummary,
+  ) => Promise<{
+    agent?: NavigationThreadSummary["agent"];
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  }>;
   onSubmit: (submission: AutomationEditorSubmit) => Promise<void>;
   saving?: boolean;
   threads?: NavigationThreadSummary[];
 };
 
 type ScheduleFormKind = "interval" | "weekdays" | "weekly";
+type AgentPickerTab = "agents" | "threads";
+
+type AgentThreadOption = {
+  key: string;
+  label: string;
+  meta: string;
+  thread?: NavigationThreadSummary;
+  title: string;
+};
 
 const DAY_LABELS: Record<AutomationWeekday, string> = {
   monday: "Mon",
@@ -52,6 +71,9 @@ const DAY_LABELS: Record<AutomationWeekday, string> = {
   saturday: "Sat",
   sunday: "Sun",
 };
+
+const DEFER_AGENT_KEY = "__defer_agent__";
+const DEFER_AGENT_LABEL = "I'll set this up later...";
 
 export function AutomationEditor(props: AutomationEditorProps) {
   const initialAutomation =
@@ -75,9 +97,16 @@ export function AutomationEditor(props: AutomationEditorProps) {
   const [backlogPolicy, setBacklogPolicy] = useState<AutomationBacklogPolicy>(
     initialAutomation?.backlogPolicy ?? "coalesce",
   );
-  const [threadKey, setThreadKey] = useState(
-    initialThreadKey,
+  const [threadKey, setThreadKey] = useState(initialThreadKey);
+  const [promotedAgentOptions, setPromotedAgentOptions] = useState<AgentThreadOption[]>(
+    [],
   );
+  const [agentPickerOpen, setAgentPickerOpen] = useState(false);
+  const [agentPickerTab, setAgentPickerTab] = useState<AgentPickerTab>("agents");
+  const [agentQuery, setAgentQuery] = useState("");
+  const [agentHelpOpen, setAgentHelpOpen] = useState(false);
+  const [agentPromotionError, setAgentPromotionError] = useState<string>();
+  const [promotingThreadKey, setPromotingThreadKey] = useState<string>();
   const [scheduleKind, setScheduleKind] = useState<ScheduleFormKind>(
     initialSchedule?.kind ?? "interval",
   );
@@ -101,16 +130,20 @@ export function AutomationEditor(props: AutomationEditorProps) {
       : ["monday", "tuesday", "wednesday", "thursday", "friday"],
   );
   const [validationError, setValidationError] = useState<string>();
+  const agentLabelId = useId();
+  const agentHelpId = useId();
+  const canDeferAgent = props.mode.kind === "create";
 
-  const threadOptions = useMemo(
+  const agentOptions = useMemo(
     () => {
-      const options = (props.threads ?? [])
+      const options: AgentThreadOption[] = (props.threads ?? [])
         .filter((thread) => thread.agent)
-        .map((thread) => ({
-          key: buildThreadKey(thread.source, thread.id),
-          label: thread.agent?.name ?? thread.title,
-          title: thread.title,
-        }));
+        .map((thread) => buildAgentOption(thread));
+      for (const promoted of promotedAgentOptions) {
+        if (!options.some((thread) => thread.key === promoted.key)) {
+          options.unshift(promoted);
+        }
+      }
       if (
         initialThreadKey &&
         !options.some((thread) => thread.key === initialThreadKey)
@@ -120,14 +153,45 @@ export function AutomationEditor(props: AutomationEditorProps) {
         );
         options.unshift({
           key: initialThreadKey,
-          label: `${currentThread?.title ?? initialAssignment?.threadId ?? "Current thread"} (current)`,
-          title: currentThread?.title ?? "Current assigned thread",
+          label: `${formatCurrentAssignmentLabel(currentThread)} (current)`,
+          meta: currentThread
+            ? formatAgentThreadMeta(currentThread)
+            : formatCurrentAssignmentMeta(initialAssignment?.threadId),
+          ...(currentThread ? { thread: currentThread } : {}),
+          title: currentThread?.title ?? "Current assigned Agent",
         });
       }
       return options;
     },
-    [initialAssignment?.threadId, initialThreadKey, props.threads],
+    [
+      promotedAgentOptions,
+      initialAssignment?.threadId,
+      initialThreadKey,
+      props.threads,
+    ],
   );
+  const threadOptions = useMemo(
+    () =>
+      (props.threads ?? [])
+        .filter((thread) => !thread.agent)
+        .map((thread) => buildAgentOption(thread)),
+    [props.threads],
+  );
+  const visibleAgentOptions = useMemo(
+    () => filterAgentPickerOptions(agentOptions, agentQuery),
+    [agentOptions, agentQuery],
+  );
+  const visibleThreadOptions = useMemo(
+    () => filterAgentPickerOptions(threadOptions, agentQuery),
+    [agentQuery, threadOptions],
+  );
+  const selectedAgent = agentOptions.find((thread) => thread.key === threadKey);
+  const agentPickerLabel =
+    threadKey === DEFER_AGENT_KEY
+      ? DEFER_AGENT_LABEL
+      : selectedAgent
+        ? selectedAgent.label
+        : "Choose Agent";
   const selectedSchedule = buildSchedule({
     daysOfWeek,
     intervalEvery,
@@ -139,6 +203,34 @@ export function AutomationEditor(props: AutomationEditorProps) {
     selectedSchedule.ok && validateAutomationScheduleDefinition(selectedSchedule.schedule).ok
       ? formatAutomationScheduleSummary(selectedSchedule.schedule)
       : "Invalid schedule";
+
+  const promoteThread = async (option: AgentThreadOption): Promise<void> => {
+    if (!props.onPromoteThread) {
+      setAgentPromotionError("Thread promotion is unavailable from this screen.");
+      return;
+    }
+    setPromotingThreadKey(option.key);
+    setAgentPromotionError(undefined);
+    try {
+      if (!option.thread) {
+        throw new Error("Thread details are unavailable for promotion.");
+      }
+      const assignment = await props.onPromoteThread(option.thread);
+      const promoted = buildPromotedAgentOption(option, assignment);
+      setPromotedAgentOptions((current) => [
+        promoted,
+        ...current.filter((entry) => entry.key !== promoted.key),
+      ]);
+      setThreadKey(promoted.key);
+      setAgentPickerTab("agents");
+      setAgentPickerOpen(false);
+      setValidationError(undefined);
+    } catch (error) {
+      setAgentPromotionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPromotingThreadKey(undefined);
+    }
+  };
 
   const submit = async (): Promise<void> => {
     const trimmedName = name.trim();
@@ -197,7 +289,9 @@ export function AutomationEditor(props: AutomationEditorProps) {
 
     const assignment = readAssignmentFromThreadKey(threadKey);
     if (!assignment) {
-      setValidationError("Choose an Agent for this automation.");
+      setValidationError(
+        "Choose an Agent before saving this automation. You can leave this draft open and set it up later.",
+      );
       return;
     }
 
@@ -236,23 +330,173 @@ export function AutomationEditor(props: AutomationEditorProps) {
       </label>
 
       {shouldShowAgentPicker(props) ? (
-        <label className="automation-field">
-          <span>Agent</span>
-          <select
-            value={threadKey}
-            onChange={(event) => {
-              setThreadKey(event.currentTarget.value);
-              setValidationError(undefined);
-            }}
-          >
-            <option value="">Choose Agent</option>
-            {threadOptions.map((thread) => (
-              <option key={thread.key} title={thread.title} value={thread.key}>
-                {thread.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <div className="automation-field automation-agent-field">
+          <div className="automation-agent-field__label-row">
+            <span id={agentLabelId}>Agent</span>
+            <button
+              aria-controls={agentHelpId}
+              aria-expanded={agentHelpOpen}
+              aria-label="What is an Agent?"
+              className="automation-agent-help"
+              type="button"
+              onClick={() => setAgentHelpOpen((open) => !open)}
+            >
+              <HelpCircleIcon size={14} aria-hidden="true" />
+            </button>
+          </div>
+          {agentHelpOpen ? (
+            <div className="automation-agent-help-popover" id={agentHelpId} role="note">
+              An Agent is a thread that is allowed to receive Automation responses.
+              Typically, you attach one to messaging as a bot's personality
+              thread, where it has context about what it has been doing lately so
+              it can answer questions quickly without too many tool invokes to
+              look up data.
+            </div>
+          ) : null}
+          <div className="automation-agent-picker">
+            <button
+              aria-expanded={agentPickerOpen}
+              aria-haspopup="listbox"
+              aria-labelledby={agentLabelId}
+              className="automation-agent-picker__trigger"
+              type="button"
+              onClick={() => {
+                setAgentPickerOpen((open) => !open);
+                setAgentPromotionError(undefined);
+              }}
+            >
+              <span>{agentPickerLabel}</span>
+              <span aria-hidden="true" className="automation-agent-picker__chevron">
+                v
+              </span>
+            </button>
+            {agentPickerOpen ? (
+              <div className="automation-agent-picker__menu">
+                <div
+                  className="automation-agent-picker__tabs"
+                  role="tablist"
+                  aria-label="Agent source"
+                >
+                  {(["agents", "threads"] as const).map((tab) => (
+                    <button
+                      key={tab}
+                      aria-selected={agentPickerTab === tab}
+                      className={`automation-agent-picker__tab${
+                        agentPickerTab === tab ? " is-active" : ""
+                      }`}
+                      role="tab"
+                      type="button"
+                      onClick={() => {
+                        setAgentPickerTab(tab);
+                        setAgentPromotionError(undefined);
+                      }}
+                    >
+                      {tab === "agents" ? "Agents" : "Threads"}
+                    </button>
+                  ))}
+                </div>
+                <input
+                  aria-label="Filter Agent picker"
+                  className="automation-agent-picker__search"
+                  placeholder={
+                    agentPickerTab === "agents" ? "Find an Agent" : "Find a thread"
+                  }
+                  value={agentQuery}
+                  onChange={(event) => setAgentQuery(event.currentTarget.value)}
+                />
+                {agentPickerTab === "agents" ? (
+                  <div role="listbox" aria-label="Agent threads">
+                    {canDeferAgent ? (
+                      <button
+                        className="automation-agent-picker__option automation-agent-picker__option--muted"
+                        role="option"
+                        type="button"
+                        aria-selected={threadKey === DEFER_AGENT_KEY}
+                        onClick={() => {
+                          setThreadKey(DEFER_AGENT_KEY);
+                          setAgentPickerOpen(false);
+                          setValidationError(undefined);
+                        }}
+                      >
+                        <span className="automation-agent-picker__option-main">
+                          <span>{DEFER_AGENT_LABEL}</span>
+                          <span className="automation-agent-picker__option-meta">
+                            Save the automation after choosing an Agent.
+                          </span>
+                        </span>
+                      </button>
+                    ) : null}
+                    {visibleAgentOptions.length > 0 ? (
+                      visibleAgentOptions.map((thread) => (
+                        <button
+                          key={thread.key}
+                          className="automation-agent-picker__option"
+                          role="option"
+                          title={thread.title}
+                          type="button"
+                          aria-selected={thread.key === threadKey}
+                          onClick={() => {
+                            setThreadKey(thread.key);
+                            setAgentPickerOpen(false);
+                            setValidationError(undefined);
+                          }}
+                        >
+                          <span className="automation-agent-picker__option-main">
+                            <span>{thread.label}</span>
+                            <span className="automation-agent-picker__option-meta">
+                              {thread.meta}
+                            </span>
+                          </span>
+                        </button>
+                      ))
+                    ) : (
+                      <p className="automation-agent-picker__empty">
+                        No Agent threads match.
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <div role="listbox" aria-label="Threads to promote">
+                    {visibleThreadOptions.length > 0 ? (
+                      visibleThreadOptions.map((thread) => (
+                        <button
+                          key={thread.key}
+                          className="automation-agent-picker__option"
+                          disabled={Boolean(promotingThreadKey)}
+                          role="option"
+                          title={thread.title}
+                          type="button"
+                          aria-selected={false}
+                          onClick={() => {
+                            void promoteThread(thread);
+                          }}
+                        >
+                          <span className="automation-agent-picker__option-main">
+                            <span>{thread.label}</span>
+                            <span className="automation-agent-picker__option-meta">
+                              {promotingThreadKey === thread.key
+                                ? "Promoting..."
+                                : `${thread.meta} - promote to Agent`}
+                            </span>
+                          </span>
+                        </button>
+                      ))
+                    ) : (
+                      <p className="automation-agent-picker__empty">
+                        No regular threads match.
+                      </p>
+                    )}
+                  </div>
+                )}
+                {agentPromotionError ? (
+                  <p className="automation-editor__error" role="alert">
+                    {agentPromotionError}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
       ) : null}
 
       <label className="automation-field">
@@ -470,7 +714,7 @@ function buildThreadKey(
   backend: AppServerBackendKind,
   threadId: ThreadIdentifier,
 ): string {
-  return `${backend}:${threadId}`;
+  return buildThreadIdentityKey(backend, threadId);
 }
 
 function readAssignmentFromThreadKey(value: string):
@@ -479,15 +723,83 @@ function readAssignmentFromThreadKey(value: string):
       threadId: ThreadIdentifier;
     }
   | undefined {
-  const separatorIndex = value.indexOf(":");
-  if (separatorIndex <= 0) {
-    return undefined;
-  }
+  return parseThreadIdentityKey(value);
+}
 
+function buildAgentOption(thread: NavigationThreadSummary): AgentThreadOption {
   return {
-    backend: value.slice(0, separatorIndex) as AppServerBackendKind,
-    threadId: value.slice(separatorIndex + 1),
+    key: buildThreadKey(thread.source, thread.id),
+    label: thread.agent?.name ?? thread.title,
+    meta: formatAgentThreadMeta(thread),
+    thread,
+    title: thread.title,
   };
+}
+
+function buildPromotedAgentOption(
+  option: AgentThreadOption,
+  assignment: {
+    agent?: NavigationThreadSummary["agent"];
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+  },
+): AgentThreadOption {
+  const thread = option.thread
+    ? {
+        ...option.thread,
+        agent: assignment.agent ?? {
+          instructionLineCount: 0,
+          instructionsTooLong: false,
+          name: option.thread.title,
+          updatedAt: option.thread.updatedAt ?? 0,
+        },
+      }
+    : undefined;
+  return {
+    ...option,
+    key: buildThreadKey(assignment.backend, assignment.threadId),
+    label: thread?.agent?.name ?? option.label,
+    meta: thread ? formatAgentThreadMeta(thread) : option.meta,
+    ...(thread ? { thread } : {}),
+  };
+}
+
+function formatCurrentAssignmentLabel(
+  thread: NavigationThreadSummary | undefined,
+): string {
+  return thread?.agent?.name ?? thread?.title ?? "Current assigned Agent";
+}
+
+function formatCurrentAssignmentMeta(threadId: ThreadIdentifier | undefined): string {
+  if (!threadId) {
+    return "Current assigned thread";
+  }
+  const suffix = threadId.length > 12 ? threadId.slice(-12) : threadId;
+  return `Current assigned thread ...${suffix}`;
+}
+
+function formatAgentThreadMeta(thread: NavigationThreadSummary): string {
+  const provider = thread.source.startsWith("acp:")
+    ? thread.source.slice("acp:".length)
+    : thread.source;
+  return `${provider} - ${thread.title}`;
+}
+
+function filterAgentPickerOptions(
+  options: AgentThreadOption[],
+  query: string,
+): AgentThreadOption[] {
+  const trimmed = query.trim().toLowerCase();
+  const ordered = [...options].sort(
+    (left, right) => (right.thread?.updatedAt ?? 0) - (left.thread?.updatedAt ?? 0),
+  );
+  if (!trimmed) {
+    return ordered;
+  }
+  return ordered.filter((option) => {
+    const haystack = `${option.label} ${option.meta} ${option.title}`.toLowerCase();
+    return haystack.includes(trimmed);
+  });
 }
 
 function buildSchedule(params: {

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -4,6 +4,7 @@ import type {
   MessagingChannelKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import {
@@ -40,7 +41,7 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
     () =>
       new Map(
         props.threads.map((thread) => [
-          `${thread.source}:${thread.id}`,
+          buildThreadIdentityKey(thread.source, thread.id),
           thread,
         ]),
       ),
@@ -60,6 +61,23 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
     } finally {
       setSaving(false);
     }
+  };
+
+  const promoteThreadToAgent = async (thread: NavigationThreadSummary) => {
+    if (!props.desktopApi?.setThreadAgent) {
+      throw new Error("Desktop bridge is missing setThreadAgent().");
+    }
+    const response = await props.desktopApi.setThreadAgent({
+      agent: { name: thread.title },
+      backend: thread.source,
+      threadId: thread.id,
+    });
+    await props.onRefreshNavigation?.();
+    return {
+      agent: response.agent,
+      backend: response.backend,
+      threadId: response.threadId,
+    };
   };
 
   return (
@@ -125,6 +143,7 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
                 saving={saving}
                 threads={props.threads}
                 onCancel={() => setEditorMode(undefined)}
+                onPromoteThread={promoteThreadToAgent}
                 onSubmit={submitEditor}
               />
             </div>
@@ -151,7 +170,7 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
               </div>
               {automations.automations.map((automation) => {
                 const thread = threadsByKey.get(
-                  `${automation.backend}:${automation.threadId}`,
+                  buildThreadIdentityKey(automation.backend, automation.threadId),
                 );
                 return (
                   <AutomationTableRow
@@ -310,7 +329,15 @@ function formatAutomationAgentLabel(props: {
   automation: AutomationDetail;
   thread?: NavigationThreadSummary;
 }): string {
-  return props.thread?.agent?.name ?? props.thread?.title ?? props.automation.threadId;
+  return (
+    props.thread?.agent?.name ??
+    props.thread?.title ??
+    `Assigned thread ...${formatThreadIdSuffix(props.automation.threadId)}`
+  );
+}
+
+function formatThreadIdSuffix(threadId: string): string {
+  return threadId.length > 12 ? threadId.slice(-12) : threadId;
 }
 
 function formatAutomationLatestRun(automation: AutomationDetail): string {

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -1,7 +1,11 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AutomationDetail, NavigationThreadSummary } from "@pwragent/shared";
+import type {
+  AppServerBackendKind,
+  AutomationDetail,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
 import { AutomationEditor } from "../AutomationEditor";
 
 afterEach(() => {
@@ -54,7 +58,7 @@ describe("AutomationEditor", () => {
     });
   });
 
-  it("only offers Agent threads from the global picker", async () => {
+  it("offers Agents first and regular threads on the Threads tab", async () => {
     const onSubmit = vi.fn(async () => undefined);
 
     render(
@@ -93,9 +97,52 @@ describe("AutomationEditor", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Agent")).toHaveDisplayValue("Choose Agent");
-    expect(screen.getByRole("option", { name: "Inbox Agent" })).toBeInTheDocument();
-    expect(screen.queryByRole("option", { name: "Ordinary work" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Agent")).toHaveTextContent("Choose Agent");
+    fireEvent.click(screen.getByLabelText("Agent"));
+    expect(screen.getByRole("option", { name: /Inbox Agent/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Ordinary work/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Threads" }));
+    expect(screen.getByRole("option", { name: /Ordinary work/ })).toBeInTheDocument();
+  });
+
+  it("explains Agents and supports deferring Agent setup while drafting", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(
+      <AutomationEditor
+        mode={{ kind: "create" }}
+        threads={[]}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "What is an Agent?" }));
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "thread that is allowed to receive Automation responses",
+    );
+
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.click(screen.getByRole("option", { name: /I'll set this up later/ }));
+    expect(screen.getByLabelText("Agent")).toHaveTextContent(
+      "I'll set this up later...",
+    );
+    fireEvent.click(screen.getByLabelText("Agent"));
+    expect(screen.getByRole("option", { name: /I'll set this up later/ }))
+      .toHaveAttribute("aria-selected", "true");
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Draft automation" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Run once I pick the Agent." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Choose an Agent before saving",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("can reassign an existing automation to another Agent", async () => {
@@ -124,10 +171,9 @@ describe("AutomationEditor", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Agent")).toHaveDisplayValue("Old Jarvis");
-    fireEvent.change(screen.getByLabelText("Agent"), {
-      target: { value: "codex:new-thread" },
-    });
+    expect(screen.getByLabelText("Agent")).toHaveTextContent("Old Jarvis");
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.click(screen.getByRole("option", { name: /New Jarvis/ }));
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
@@ -137,6 +183,125 @@ describe("AutomationEditor", () => {
         automationId: "automation-1",
         backend: "codex",
         threadId: "new-thread",
+      }),
+    });
+  });
+
+  it("labels an assigned Agent without exposing the raw thread id as primary text", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+    const automation = buildAutomation({
+      threadId: "019ed770-c7e9-7031-a4d4-87b9f47ec3e9",
+    });
+
+    render(
+      <AutomationEditor
+        mode={{ automation, kind: "edit" }}
+        threads={[]}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(screen.getByLabelText("Agent")).toHaveTextContent(
+      "Current assigned Agent",
+    );
+    expect(screen.getByLabelText("Agent")).not.toHaveTextContent(
+      "019ed770-c7e9-7031-a4d4-87b9f47ec3e9",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      kind: "update",
+      request: expect.objectContaining({
+        backend: "codex",
+        threadId: "019ed770-c7e9-7031-a4d4-87b9f47ec3e9",
+      }),
+    });
+  });
+
+  it("promotes a regular thread to an Agent and selects it", async () => {
+    const onPromoteThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "ordinary-thread",
+    }));
+    const onSubmit = vi.fn(async () => undefined);
+    const ordinaryThread = buildThread({
+      id: "ordinary-thread",
+      title: "Incident triage",
+    });
+
+    render(
+      <AutomationEditor
+        mode={{ kind: "create" }}
+        threads={[ordinaryThread]}
+        onCancel={() => undefined}
+        onPromoteThread={onPromoteThread}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.click(screen.getByRole("tab", { name: "Threads" }));
+    fireEvent.click(screen.getByRole("option", { name: /Incident triage/ }));
+
+    await waitFor(() => expect(onPromoteThread).toHaveBeenCalledTimes(1));
+    expect(onPromoteThread).toHaveBeenCalledWith(ordinaryThread);
+    expect(screen.getByLabelText("Agent")).toHaveTextContent("Incident triage");
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Summarize incidents" },
+    });
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Summarize recent incident context." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      kind: "create",
+      request: expect.objectContaining({
+        backend: "codex",
+        threadId: "ordinary-thread",
+      }),
+    });
+  });
+
+  it("preserves ACP backend ids when selecting an Agent", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+
+    render(
+      <AutomationEditor
+        mode={{ kind: "create" }}
+        threads={[
+          buildThread({
+            agentName: "Qwen Agent",
+            id: "thread-1",
+            source: "acp:qwen",
+            title: "Qwen transcript",
+          }),
+        ]}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Check Qwen" },
+    });
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.click(screen.getByRole("option", { name: /Qwen Agent/ }));
+    fireEvent.change(screen.getByLabelText("Task prompt"), {
+      target: { value: "Run this through Qwen." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      kind: "create",
+      request: expect.objectContaining({
+        backend: "acp:qwen",
+        threadId: "thread-1",
       }),
     });
   });
@@ -243,6 +408,7 @@ function buildAutomation(overrides: Partial<AutomationDetail> = {}): AutomationD
 function buildThread(params: {
   agentName?: string;
   id: string;
+  source?: AppServerBackendKind;
   title: string;
 }): NavigationThreadSummary {
   return {
@@ -258,7 +424,7 @@ function buildThread(params: {
     id: params.id,
     inbox: { inInbox: false },
     linkedDirectories: [],
-    source: "codex",
+    source: params.source ?? "codex",
     title: params.title,
     titleSource: "explicit",
     updatedAt: 1,

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
@@ -27,6 +27,17 @@ const thread: NavigationThreadSummary = {
   updatedAt: 1,
 };
 
+const ordinaryThread: NavigationThreadSummary = {
+  executionMode: "default",
+  id: "ordinary-thread",
+  inbox: { inInbox: false },
+  linkedDirectories: [],
+  source: "codex",
+  title: "Slack helper",
+  titleSource: "explicit",
+  updatedAt: 2,
+};
+
 const automation: AutomationDetail = {
   backend: "codex",
   backlogPolicy: "coalesce",
@@ -114,9 +125,8 @@ describe("AutomationsScreen", () => {
     fireEvent.change(within(editor).getByLabelText("Name"), {
       target: { value: "Check email" },
     });
-    fireEvent.change(within(editor).getByLabelText("Agent"), {
-      target: { value: "codex:thread-1" },
-    });
+    fireEvent.click(within(editor).getByLabelText("Agent"));
+    fireEvent.click(within(editor).getByRole("option", { name: /Email Agent/ }));
     fireEvent.change(within(editor).getByLabelText("Task prompt"), {
       target: { value: "Check email." },
     });
@@ -130,6 +140,76 @@ describe("AutomationsScreen", () => {
         threadId: "thread-1",
       }),
     );
+  });
+
+  it("promotes a regular thread to an Agent before creating an automation", async () => {
+    const promotedAutomation: AutomationDetail = {
+      ...automation,
+      id: "automation-promoted",
+      threadId: "ordinary-thread",
+    };
+    const createAutomation = vi.fn(async () => ({ automation: promotedAutomation }));
+    const setThreadAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "ordinary-thread",
+      agent: {
+        name: "Slack Agent",
+        instructionLineCount: 0,
+        instructionsTooLong: false,
+        updatedAt: 3,
+      },
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+    const desktopApi: DesktopApi = {
+      createAutomation,
+      listAutomations: vi
+        .fn()
+        .mockResolvedValueOnce({ automations: [] })
+        .mockResolvedValue({ automations: [promotedAutomation] }),
+      onAgentEvent: () => () => undefined,
+      setThreadAgent,
+    };
+
+    render(
+      <AutomationsScreen
+        desktopApi={desktopApi}
+        threads={[thread, ordinaryThread]}
+        onClose={() => undefined}
+        onRefreshNavigation={onRefreshNavigation}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "New Automation" }));
+    const editor = screen.getByLabelText("Name").closest("form") as HTMLElement;
+    expect(editor).not.toBeNull();
+    fireEvent.change(within(editor).getByLabelText("Name"), {
+      target: { value: "Slack automation" },
+    });
+    fireEvent.click(within(editor).getByLabelText("Agent"));
+    fireEvent.click(within(editor).getByRole("tab", { name: "Threads" }));
+    fireEvent.click(within(editor).getByRole("option", { name: /Slack helper/ }));
+
+    await waitFor(() => expect(setThreadAgent).toHaveBeenCalledTimes(1));
+    expect(setThreadAgent).toHaveBeenCalledWith({
+      agent: { name: "Slack helper" },
+      backend: "codex",
+      threadId: "ordinary-thread",
+    });
+    expect(within(editor).getByLabelText("Agent")).toHaveTextContent("Slack Agent");
+
+    fireEvent.change(within(editor).getByLabelText("Task prompt"), {
+      target: { value: "Post the latest automation state." },
+    });
+    fireEvent.click(within(editor).getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(createAutomation).toHaveBeenCalledTimes(1));
+    expect(createAutomation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "ordinary-thread",
+      }),
+    );
+    expect(onRefreshNavigation).toHaveBeenCalled();
   });
 
   it("shows rollout replay details for an automation run", async () => {

--- a/apps/desktop/src/renderer/src/icons/HelpCircleIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/HelpCircleIcon.tsx
@@ -1,0 +1,11 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function HelpCircleIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9.8 9a2.4 2.4 0 0 1 4.6 1c0 1.6-1.6 2.1-2.1 3" />
+      <path d="M12 17h.01" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -11,6 +11,7 @@ export { EditsIcon } from "./EditsIcon";
 export { FeishuIcon } from "./FeishuIcon";
 export { FileCodeIcon } from "./FileCodeIcon";
 export { FolderIcon } from "./FolderIcon";
+export { HelpCircleIcon } from "./HelpCircleIcon";
 export { InfoIcon } from "./InfoIcon";
 export { LightningIcon } from "./LightningIcon";
 export { MattermostIcon } from "./MattermostIcon";

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11172,6 +11172,230 @@ textarea,
   outline-offset: 1px;
 }
 
+.automation-agent-field {
+  position: relative;
+}
+
+.automation-agent-field__label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.automation-agent-help {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent-border);
+  border-radius: 999px;
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+  cursor: pointer;
+}
+
+.automation-agent-help:hover,
+.automation-agent-help:focus-visible,
+.automation-agent-help[aria-expanded="true"] {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.automation-agent-picker {
+  position: relative;
+}
+
+.automation-agent-picker__trigger {
+  display: flex;
+  width: 100%;
+  min-height: 32px;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.automation-agent-picker__trigger span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automation-agent-picker__chevron {
+  flex: 0 0 auto;
+  padding: 0 9px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.automation-agent-picker__trigger:focus-visible {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.automation-agent-picker__menu {
+  position: absolute;
+  z-index: 20;
+  right: 0;
+  left: 0;
+  top: calc(100% + 4px);
+  display: flex;
+  max-height: 240px;
+  flex-direction: column;
+  gap: 2px;
+  overflow: auto;
+  padding: 4px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.automation-agent-picker__tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3px;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--bg-panel);
+}
+
+.automation-agent-picker__tab {
+  min-height: 28px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.automation-agent-picker__tab:hover,
+.automation-agent-picker__tab:focus-visible,
+.automation-agent-picker__tab.is-active {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.automation-agent-picker__search {
+  width: 100%;
+  min-height: 30px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-app);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  padding: 0 8px;
+}
+
+.automation-agent-picker__search:focus {
+  border-color: var(--accent-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.automation-agent-picker__option {
+  display: flex;
+  width: 100%;
+  min-height: 30px;
+  align-items: center;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.automation-agent-picker__option:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.automation-agent-picker__option-main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.automation-agent-picker__option-main > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automation-agent-picker__option-meta {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.automation-agent-picker__option:hover,
+.automation-agent-picker__option:focus-visible,
+.automation-agent-picker__option[aria-selected="true"] {
+  background: var(--bg-row-active);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.automation-agent-picker__option--action {
+  color: var(--accent-bright);
+}
+
+.automation-agent-picker__option--muted {
+  color: var(--text-muted);
+}
+
+.automation-agent-picker__empty {
+  margin: 4px 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.automation-agent-help-popover {
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel);
+}
+
+.automation-agent-help-popover {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
 .automation-fieldset {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- replace the Automation Agent select with a custom picker that explains Agents and supports deferring setup while drafting
- add an inline Create Agent flow that starts an Agent thread and selects it for the automation
- add focused coverage for the help popover, defer option, Agent selection, and Agent creation flow

## Tests
- pnpm test apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:colors