### PR TITLE
fix(desktop): surface input-needed threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18676,7 +18676,7 @@ command = "pnpm dev"
       await registry.close();
     });
 
-    it("calls notifyAttention on item/tool/requestUserInput with the question title", async () => {
+    it("calls notifyAttention on item/tool/requestUserInput with input-needed copy", async () => {
       resetNotificationMocks();
       const registry = makeRegistry();
 
@@ -18694,9 +18694,17 @@ command = "pnpm dev"
       const call = desktopNotificationServiceMock.notifyAttention.mock.calls[0]?.[0];
       expect(call).toMatchObject({
         key: "codex:thread-q:req-q",
-        title: "PwrAgent question waiting",
+        title: "PwrAgent input needed",
+        body: "A turn needs your input.",
       });
       expect(call.onDecision).toBeUndefined();
+      expect(typeof call.onShow).toBe("function");
+
+      call.onShow?.();
+      expect(requestShowThreadMock).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-q",
+      });
 
       await registry.close();
     });

--- a/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-notification-service.test.ts
@@ -487,6 +487,26 @@ describe("DesktopNotificationService", () => {
     expect(shownNotifications.at(-1)?.body).toBe("Please approve again");
   });
 
+  it("focuses the relevant thread when clicking an attention notification", () => {
+    const service = new DesktopNotificationService();
+    const onShow = vi.fn();
+    getAllWindows.mockReturnValue([
+      { isDestroyed: () => false, isFocused: () => false, isMinimized: () => false },
+    ]);
+
+    service.notifyAttention({
+      enabled: true,
+      key: "codex:thread-1:req-input",
+      title: "Input needed",
+      body: "A turn needs your input.",
+      onShow,
+    });
+
+    shownNotifications[0]?.instance.emitClick();
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to a passive approval notification when action buttons are unsupported", () => {
     const service = new DesktopNotificationService();
     const onDecision = vi.fn();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13623,7 +13623,7 @@ export class DesktopBackendRegistry {
     const isQuestion =
       event.notification.method === "item/tool/requestUserInput";
     const title = isQuestion
-      ? "PwrAgent question waiting"
+      ? "PwrAgent input needed"
       : "PwrAgent approval needed";
     const threadTitle = this.notificationThreadTitles.get(
       `${event.backend}:${threadId}`,
@@ -13693,7 +13693,7 @@ export class DesktopBackendRegistry {
       return;
     }
     const baseBody = isQuestion
-      ? "waiting for your response"
+      ? "needs your input"
       : "waiting for your approval";
     const body = threadTitle ? `${threadTitle} · ${baseBody}.` : `A turn ${baseBody}.`;
     try {
@@ -13702,6 +13702,12 @@ export class DesktopBackendRegistry {
         key,
         title,
         body,
+        onShow: () => {
+          requestShowThread({
+            backend: event.backend,
+            threadId,
+          });
+        },
       });
     } catch (error) {
       backendRegistryLog.warn("native attention notification failed", {

--- a/apps/desktop/src/main/notifications/desktop-notification-service.ts
+++ b/apps/desktop/src/main/notifications/desktop-notification-service.ts
@@ -54,6 +54,7 @@ export class DesktopNotificationService {
     key: string;
     title: string;
     body: string;
+    onShow?: () => void;
   }): void {
     if (!params.enabled || this.attentionKeys.has(params.key)) {
       return;
@@ -69,6 +70,7 @@ export class DesktopNotificationService {
       attentionKey: params.key,
       title: params.title,
       body: params.body,
+      onClick: params.onShow,
     });
   }
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1054,6 +1054,7 @@ function DesktopAppShell(props: {
           launchpadError={navigation.launchpadError}
           loading={navigation.loading}
           approvalRequestThreadKeys={session.approvalRequestThreadKeys}
+          inputRequestThreadKeys={session.inputRequestThreadKeys}
           composerSourceThreadKey={navigation.composerSourceThreadKey}
           selectedItemKey={navigation.selectedItemKey}
           thinkingThreadKeys={session.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -39,6 +39,7 @@ import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  inputRequestThreadKeys?: Record<string, boolean>;
   composerSourceThreadKey?: string;
   directories: NavigationDirectorySummary[];
   selectedItemKey?: string;
@@ -475,6 +476,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             <ThreadRow
               key={`${directory.key}:${childKey}`}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              inputRequestThreadKeys={props.inputRequestThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               compact
               draggable={reorderable}
@@ -601,6 +603,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
           <ThreadRow
             key={`${directory.key}:${threadKey}`}
             approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+            inputRequestThreadKeys={props.inputRequestThreadKeys}
             composerSourceThreadKey={props.composerSourceThreadKey}
             compact
             draggable={Boolean(props.onReorderThreadPins)}
@@ -904,6 +907,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                        <ThreadRow
 	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                          inputRequestThreadKeys={props.inputRequestThreadKeys}
                           composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
                           dropIndicator={

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -21,6 +21,7 @@ import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  inputRequestThreadKeys?: Record<string, boolean>;
   composerSourceThreadKey?: string;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
@@ -136,6 +137,7 @@ export function RecentsList(props: RecentsListProps) {
             <ThreadRow
               key={childKey}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              inputRequestThreadKeys={props.inputRequestThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               dropIndicator={
                 dropIndicator?.targetKey === rowDropKey
@@ -225,6 +227,7 @@ export function RecentsList(props: RecentsListProps) {
       <div key={key} className="thread-group">
         <ThreadRow
           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+          inputRequestThreadKeys={props.inputRequestThreadKeys}
           composerSourceThreadKey={props.composerSourceThreadKey}
           dropIndicator={
             dropIndicator?.targetKey === key

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -77,6 +77,7 @@ type SidebarProps = {
   threadSearchActive?: boolean;
   settingsActive?: boolean;
   approvalRequestThreadKeys?: Record<string, boolean>;
+  inputRequestThreadKeys?: Record<string, boolean>;
   /** Identity key of the card to highlight as the open composer's source. */
   composerSourceThreadKey?: string;
   selectedItemKey?: string;
@@ -883,6 +884,7 @@ export function Sidebar(props: SidebarProps) {
           ) : props.browseMode === "directories" ? (
             <DirectoriesList
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+              inputRequestThreadKeys={props.inputRequestThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               directories={props.directories}
               selectedItemKey={props.selectedItemKey}
@@ -910,6 +912,7 @@ export function Sidebar(props: SidebarProps) {
             ) : (
               <RecentsList
                 approvalRequestThreadKeys={props.approvalRequestThreadKeys}
+                inputRequestThreadKeys={props.inputRequestThreadKeys}
                 composerSourceThreadKey={props.composerSourceThreadKey}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -8,6 +8,7 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 type ThreadMetaChipsProps = {
   hasApprovalRequest?: boolean;
+  hasInputRequest?: boolean;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   thread: NavigationThreadSummary;
@@ -15,6 +16,7 @@ type ThreadMetaChipsProps = {
 
 export function ThreadMetaChips({
   hasApprovalRequest = false,
+  hasInputRequest = false,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
   thread,
@@ -130,6 +132,16 @@ export function ThreadMetaChips({
           title="Waiting for approval"
         >
           Waiting for approval
+        </span>
+      ) : null}
+
+      {hasInputRequest ? (
+        <span
+          aria-label="Input needed"
+          className="thread-row__chip thread-row__chip--input"
+          title="Input needed"
+        >
+          Input needed
         </span>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -32,6 +32,7 @@ const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
 
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
+  inputRequestThreadKeys?: Record<string, boolean>;
   /**
    * Identity key of the card the open composer was spawned from. When it
    * matches this row, the row renders as the orange "composing" source.
@@ -241,6 +242,7 @@ export function ThreadRow(props: ThreadRowProps) {
         >
           <ThreadMetaChips
             hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
+            hasInputRequest={props.inputRequestThreadKeys?.[threadKey] === true}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}
             thread={props.thread}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1057,6 +1057,38 @@ describe("Sidebar", () => {
     expect(approvalChip).toHaveAttribute("title", "Waiting for approval");
   });
 
+  it("shows an input-needed chip for threads waiting on user input", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        inputRequestThreadKeys={{ "codex:thread-1": true }}
+        selectedItemKey={undefined}
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    const inputChip = within(threadButton).getByTitle("Input needed");
+    expect(inputChip).toHaveTextContent("Input needed");
+    expect(inputChip).not.toHaveTextContent("Approve");
+    expect(inputChip).toHaveAttribute("title", "Input needed");
+  });
+
   it("does not duplicate new-thread inbox membership as an attention marker in recents", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -6177,6 +6177,10 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.pendingStatusText).toBe("Waiting for input");
+    expect(result.current.inputRequestThreadKeys).toEqual({
+      "codex:thread-1": true,
+    });
+    expect(result.current.approvalRequestThreadKeys).toEqual({});
     expect(result.current.pendingRequest).toBeUndefined();
     expect(result.current.pendingUserInput).toMatchObject({
       method: "item/tool/requestUserInput",
@@ -6216,6 +6220,7 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.pendingUserInput).toBeUndefined();
+    expect(result.current.inputRequestThreadKeys).toEqual({});
     expect(result.current.pendingStatusText).toBe("Thinking");
   });
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2855,6 +2855,7 @@ export function useThreadSessionState(params: {
   pendingStatusText?: string;
   runningTurnUsageText?: string;
   approvalRequestThreadKeys: Record<string, boolean>;
+  inputRequestThreadKeys: Record<string, boolean>;
   removeOptimisticMessage: (id: string) => void;
   response?: AppServerReadThreadResponse;
   setActiveTurnId: (turnId?: string) => void;
@@ -4732,6 +4733,15 @@ export function useThreadSessionState(params: {
       ),
     [sessions]
   );
+  const inputRequestThreadKeys = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(sessions)
+          .filter(([, session]) => Boolean(session.pendingUserInput))
+          .map(([sessionThreadKey]) => [sessionThreadKey, true])
+      ),
+    [sessions]
+  );
   const pendingStatusText =
     selectedSession?.pendingStatusText ??
     (selectedSession?.activeTurnId ? "Thinking" : undefined);
@@ -4759,6 +4769,7 @@ export function useThreadSessionState(params: {
       selectedSession?.pendingUsageActivityEntry
     ),
     approvalRequestThreadKeys,
+    inputRequestThreadKeys,
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveTurnId,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3490,14 +3490,16 @@ textarea,
   color: var(--accent-bright);
 }
 
-.thread-row__chip--approval {
+.thread-row__chip--approval,
+.thread-row__chip--input {
   border: 1px solid var(--accent-strong);
   background: var(--accent);
   color: var(--button-text);
   font-weight: 700;
 }
 
-.thread-row__chip--approval:hover {
+.thread-row__chip--approval:hover,
+.thread-row__chip--input:hover {
   background: var(--accent-strong);
 }
 


### PR DESCRIPTION
## Summary

Threads waiting on detailed user input now surface as `Input needed` in the thread list, so they no longer look like a long-running busy turn. The chip uses the same attention lane as approval requests, but keeps the action distinct because questionnaire input cannot be handled by a one-click approve button.

Native notifications for `request_user_input` now explicitly say input is needed and clicking the notification opens the relevant thread. They remain passive notifications with no approve action.

## Tests

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/main/__tests__/desktop-notification-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -t "request_user_input|input-needed|input needed|notifyAttention|attention notification|approval chip|approval requests through|native approval|notification"`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
