### PR TITLE
fix(desktop): tighten env action cards and refine controls

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -373,14 +373,10 @@ function EnvActionStopIcon(): ReactNode {
       width="14"
       height="14"
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.9"
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="currentColor"
       aria-hidden="true"
     >
-      <rect x="7" y="7" width="10" height="10" rx="1.5" />
+      <rect x="7" y="7" width="10" height="10" rx="2" />
     </svg>
   );
 }
@@ -394,14 +390,12 @@ function EnvActionTerminateIcon(): ReactNode {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.9"
+      strokeWidth="2"
       strokeLinecap="round"
-      strokeLinejoin="round"
       aria-hidden="true"
     >
-      <path d="M8.5 3.5h7l5 5v7l-5 5h-7l-5-5v-7z" />
-      <path d="m9 9 6 6" />
-      <path d="m15 9-6 6" />
+      <circle cx="12" cy="12" r="7" />
+      <line x1="7.05" y1="7.05" x2="16.95" y2="16.95" />
     </svg>
   );
 }
@@ -415,14 +409,13 @@ function EnvActionSidebarIcon(): ReactNode {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.9"
+      strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <rect x="4" y="5" width="16" height="14" rx="2" />
-      <path d="M10 5v14" />
-      <path d="m15 10 3 2-3 2" />
+      <rect x="3.5" y="5" width="17" height="14" rx="2.5" />
+      <line x1="14" y1="5" x2="14" y2="19" />
     </svg>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -11,6 +11,16 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 const ENV_ACTION_OUTPUT_MAX_LINES = 500;
 
+// Absolute clock time, matching the transcript-message and edited-files-panel
+// convention (e.g. "Jun 17, 6:31 PM"). Absolute rather than relative ("7h ago")
+// so the sidebar cards never need a re-render tick just to stay accurate.
+const sidebarStartedAtFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
 function tailLines(text: string, maxLines: number): string {
   const lines = text.split("\n");
   if (lines.length <= maxLines) return text;
@@ -113,6 +123,13 @@ export function EnvActionRunsView(props: {
 
   if (props.runs.length === 0) return null;
 
+  // The sidebar Actions panel reads as a scrollable log, so the newest run
+  // (and any live "running" one) belongs on top. actionRuns is append-ordered
+  // (oldest first) — which is what the composer anchors want, newest nearest
+  // the reply box — so only the sidebar flips it.
+  const orderedRuns =
+    props.placement === "sidebar" ? [...props.runs].reverse() : props.runs;
+
   return (
     <>
       {props.placement === "sidebar" ? (
@@ -138,7 +155,7 @@ export function EnvActionRunsView(props: {
       <div
         className={`env-action-runs env-action-runs--${props.placement}`}
       >
-        {props.runs.map((run) => (
+        {orderedRuns.map((run) => (
           <EnvActionRunEntry
             key={run.runId}
             environmentName={props.environmentName}
@@ -226,6 +243,16 @@ export function EnvActionRunEntry(props: {
             {props.environmentName ? ` · ${props.environmentName}` : ""}
             {meta.length > 0 ? ` · ${meta.join(" · ")}` : ""}
           </span>
+          {props.placement === "sidebar" &&
+          typeof run.startedAt === "number" &&
+          run.startedAt > 0 ? (
+            <time
+              className="composer__queued-env-action-time"
+              dateTime={new Date(run.startedAt).toISOString()}
+            >
+              {sidebarStartedAtFormatter.format(run.startedAt)}
+            </time>
+          ) : null}
         </span>
         <span className="composer__queued-env-action-actions">
           {status === "started" ? (

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12417,8 +12417,8 @@ textarea,
 .composer__queued-env-action-summary {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 8px;
+  padding: 5px 8px 5px 10px;
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -12467,8 +12467,17 @@ textarea,
   min-width: 0;
 }
 
-.composer__queued-env-action-dismiss {
+.composer__queued-env-action-actions .composer__queued-env-action-dismiss {
   flex: 0 0 auto;
+  min-height: 26px;
+  height: 26px;
+  padding: 0 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.composer__queued-env-action-actions .composer__queued-env-action-dismiss:hover {
+  color: var(--text-primary);
 }
 
 .composer__queued-env-action-actions {
@@ -12478,11 +12487,11 @@ textarea,
   flex: 0 0 auto;
 }
 
-.composer__queued-env-action-control {
-  width: 30px;
-  min-width: 30px;
-  min-height: 30px;
-  height: 30px;
+.composer__queued-env-action-actions .composer__queued-env-action-control {
+  width: 26px;
+  min-width: 26px;
+  min-height: 26px;
+  height: 26px;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -12507,7 +12516,7 @@ textarea,
   color: var(--text-primary);
 }
 
-.composer__queued-env-action-terminate {
+.composer__queued-env-action-actions .composer__queued-env-action-terminate {
   color: color-mix(in srgb, var(--danger-text) 74%, var(--text-muted));
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9462,6 +9462,12 @@ textarea,
   gap: 10px;
 }
 
+.env-action-runs--composer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .transcript-activity {
   width: min(100%, 760px);
   padding: 12px 0 0;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12563,6 +12563,13 @@ textarea,
   white-space: normal;
 }
 
+.composer__queued-env-action-time {
+  margin-top: 1px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
 .env-action-run--sidebar .composer__queued-env-action-output {
   max-height: 260px;
 }


### PR DESCRIPTION
## Why

The collapsed env-action run cards (above the composer and in the sidebar Actions panel) read as roomy, the **Dismiss** button was an oversized "boulevard boat" (it inherited the composer's primary-button sizing — 34px tall, 12px text), and the three control icons looked clunky at small size. While polishing, two sidebar-panel issues surfaced: the live **running** run was buried at the bottom of the list, and the cards carried no "when did this run" timestamp.

## What changed

**Card chrome (both placements)**
- **Density** — summary padding `8px 10px` → `5px 8px 5px 10px`, and every button in the action row unified to **26px**. Card row height drops from ~52px to ~38px (≈27% shorter). (The icon buttons were also a latent 34px, not the 30px the old CSS implied — they tied the shared `.composer__secondary-action` rule and lost on source order; this fixes that too.)
- **Dismiss button** — shrunk to 26px / `0 10px` / 12px muted text so it sits flush with the icon buttons. The override is scoped under `.composer__queued-env-action-actions` so it wins over the shared `.composer__secondary-action` rule that lives later in the file.
- **Terminate color** — bumped `.composer__queued-env-action-terminate`'s specificity to match the newly-scoped control rule so its danger tint survives.
- **Icons** — replaced all three: **Stop** → solid filled square (was a thin hollow rounded rect); **Terminate** → prohibited circle-slash (was a stop-sign octagon with an internal X — cluttered at 14px), keeps the danger tint; **Move to sidebar** → clean right-docked panel outline (dropped the cramped inner chevron arrow).

**Composer placement**
- **Inter-card gap** — added `gap: 6px` to `.env-action-runs--composer` (it previously had no rule, so stacked cards butted together and the rounded borders nearly touched). Deliberately tighter than the 12px between composer *sections* — proximity grouping signals the runs are one related unit, distinct from the reply box.

**Sidebar Actions panel placement**
- **Newest-first ordering** — `actionRuns` is append-ordered (oldest first), which is right for the composer anchors (newest nearest the reply box) but wrong for a scrollable log where the live **running** run should be on top. `EnvActionRunsView` now reverses the list for `placement === "sidebar"` only.
- **Start timestamp** — each sidebar card now shows when the run started (e.g. `Jun 17, 6:31 PM`) as a muted third line. Uses the **absolute** `Intl.DateTimeFormat` already used by transcript messages and the edited-files panel — absolute rather than relative ("7h ago") so the cards never need a re-render tick to stay accurate. Gated on a real `startedAt > 0` so legacy/zombie rows don't print a 1969 date, and carries a proper `<time dateTime>` attribute. Composer anchors are unchanged (they stay compact).

## Notes

- Renderer-only: CSS + inline SVG + a sidebar-gated `<time>`. No logic/IPC/token changes; colors via `currentColor` + existing tokens.
- `pnpm --filter @pwragent/desktop typecheck` passes. No existing unit/e2e test exercises the sidebar placement or env-action ordering, so the composer path is untouched; the density/icon changes had no test references.
- Verified the composer cards via mockup (live env-action cards are awkward to trigger) and the sidebar restyle via a real running-app screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)