### PR TITLE
chore(desktop): shorten preload bridge log

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1420,7 +1420,7 @@ if (process.contextIsolated) {
   );
   contextBridge.exposeInMainWorld("__pwragentHomeDir", bootstrapHomeDir);
   recordPreloadLog("info", "exposed context bridge", {
-    keys: Object.keys(desktopApi)
+    keyCount: Object.keys(desktopApi).length
   });
 } else {
   recordPreloadLog("warn", "context isolation disabled; bridge not exposed");


### PR DESCRIPTION
## Summary

- Preload startup logging now reports the renderer bridge API size instead of dumping every exposed method name into one very long log line.
- The log remains useful for confirming that the Electron context bridge was exposed, without flooding the app log with the full `window.pwragent` API inventory.

## Verification

- `pnpm --filter @pwragent/desktop typecheck`

## Notes

- This is not PwrAgent protocol or App Server protocol logging. It is the Electron preload context bridge surface exposed to the renderer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex_GPT--5](https://img.shields.io/badge/Codex_GPT--5-000000)
