### PR TITLE
feat(messaging): route default Agent control requests

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -209,6 +209,272 @@ describe("MessagingController", () => {
     });
   });
 
+  it("routes /agent requests to the conversation default Agent without rebinding work text", async () => {
+    const harness = await createHarness();
+    const event = buildCommandEvent("/agent fork this and attach it here");
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:codex:work-thread",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 900,
+      targetKind: "thread",
+      threadId: "work-thread",
+      updatedAt: 900,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:chat-1",
+      backend: "codex",
+      channel: event.channel,
+      channelKind: "telegram",
+      createdAt: 950,
+      scopeKind: "conversation",
+      threadId: "agent-thread",
+      updatedAt: 950,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "agent-thread",
+        input: [
+          {
+            type: "text",
+            text: "fork this and attach it here",
+          },
+        ],
+      }),
+    );
+    await expect(harness.store.findActiveBindingForChannel(event.channel)).resolves
+      .toMatchObject({
+        targetKind: "thread",
+        threadId: "work-thread",
+      });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "Attached the fork here.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      [...harness.delivered].reverse().find((intent) => intent.kind === "message"),
+    ).toMatchObject({
+      kind: "message",
+      role: "assistant",
+      parts: [
+        expect.objectContaining({
+          text: "Attached the fork here.",
+        }),
+      ],
+    });
+  });
+
+  it("returns default Agent control responses only to the requesting surface", async () => {
+    const harness = await createHarness();
+    const event = buildCommandEvent("/agent summarize the current work");
+    const agentSurfaceBindingId =
+      "binding:telegram:topic:-1001:200:codex:agent-thread";
+    await harness.store.upsertBinding({
+      id: agentSurfaceBindingId,
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: buildTopicChannel("200"),
+      createdAt: 900,
+      targetKind: "agent_thread",
+      threadId: "agent-thread",
+      updatedAt: 900,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:chat-1",
+      backend: "codex",
+      channel: event.channel,
+      channelKind: "telegram",
+      createdAt: 950,
+      scopeKind: "conversation",
+      threadId: "agent-thread",
+      updatedAt: 950,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "Current work summarized.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const assistantMessages = harness.delivered.filter(
+      (intent) => intent.kind === "message" && intent.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]).toMatchObject({
+      bindingId: expect.stringMatching(/^agent-control:/),
+      parts: [
+        expect.objectContaining({
+          text: "Current work summarized.",
+        }),
+      ],
+    });
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        bindingId: agentSurfaceBindingId,
+      }),
+    );
+  });
+
+  it("returns default Agent control pending requests only to the requesting surface", async () => {
+    const harness = await createHarness();
+    const event = buildCommandEvent("/agent ask the operator");
+    const agentSurfaceBindingId =
+      "binding:telegram:topic:-1001:200:codex:agent-thread";
+    await harness.store.upsertBinding({
+      id: agentSurfaceBindingId,
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: buildTopicChannel("200"),
+      createdAt: 900,
+      targetKind: "agent_thread",
+      threadId: "agent-thread",
+      updatedAt: 900,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:chat-1",
+      backend: "codex",
+      channel: event.channel,
+      channelKind: "telegram",
+      createdAt: 950,
+      scopeKind: "conversation",
+      threadId: "agent-thread",
+      updatedAt: 950,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        requestId: "request-1",
+        questions: [
+          {
+            id: "q1",
+            header: "Mode",
+            question: "How should I proceed?",
+            isOther: true,
+            isSecret: false,
+            options: [
+              {
+                label: "Continue (Recommended)",
+                description: "Continue in this conversation.",
+              },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    const questionnaires = harness.delivered.filter(
+      (intent) => intent.kind === "questionnaire",
+    );
+    expect(questionnaires).toHaveLength(1);
+    expect(questionnaires[0]).toMatchObject({
+      bindingId: expect.stringMatching(/^agent-control:/),
+      requestContext: {
+        requestId: "request-1",
+      },
+    });
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        bindingId: agentSurfaceBindingId,
+      }),
+    );
+  });
+
+  it("preserves a /agent request while choosing the first default Agent", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Inbox Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    const event = buildCommandEvent("/agent fork this");
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "thread_picker",
+      prompt: expect.stringContaining("Choose an Agent thread"),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    await expect(harness.store.findActiveBindingForChannel(event.channel)).resolves
+      .toBeUndefined();
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(event.channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "text",
+            text: "fork this",
+          },
+        ],
+      }),
+    );
+  });
+
   it("starts a new Agent thread from /agent --new and binds it as an Agent target", async () => {
     const harness = await createHarness();
 
@@ -8162,12 +8428,34 @@ describe("MessagingController", () => {
         ],
       }),
     );
-    expect(
-      harness.delivered
-        .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
-        .at(-1),
-    ).toMatchObject({
+    const queuedNotice = harness.delivered
+      .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
+      .at(-1);
+    expect(queuedNotice).toMatchObject({
       body: expect.stringContaining("> follow up from discord"),
+    });
+    const queuedActions =
+      queuedNotice && "actions" in queuedNotice && Array.isArray(queuedNotice.actions)
+        ? queuedNotice.actions
+        : [];
+    const steerAction = queuedActions.find((action) =>
+      action.id.startsWith("queued-turn:steer:"),
+    );
+    expect(steerAction).toMatchObject({
+      disabled: true,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: steerAction!.id,
+        channel: discordChannel,
+      }),
+    );
+    expect(harness.steerTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Steer unavailable",
+      body: expect.stringContaining("started the active Agent turn"),
     });
 
     await harness.controller.handleBackendEvent({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -462,6 +462,108 @@ describe("MessagingController", () => {
     );
   });
 
+  it("preserves an unbound source surface for default Agent control tools", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads.push({
+      id: "thread-2",
+      title: "Escalated task",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:pwragent",
+          kind: "local",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      ],
+      inbox: {
+        inInbox: false,
+      },
+      updatedAt: 1000,
+    });
+    const harness = await createHarness({ navigation });
+    const event = buildTopicCommandEvent("/agent attach it here", "200");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:topic-200",
+      backend: "codex",
+      channel: event.channel,
+      channelKind: "telegram",
+      createdAt: 950,
+      scopeKind: "conversation",
+      threadId: "agent-thread",
+      updatedAt: 950,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+
+    const surfaceResponse = await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "get_current_messaging_surface",
+      context: {
+        backend: "codex",
+        threadId: "agent-thread",
+        turnId: "turn-1",
+      },
+      args: {},
+    });
+    expect(surfaceResponse).toMatchObject({
+      ok: true,
+      data: {
+        location: {
+          actor: {
+            platformUserId: "user-1",
+          },
+          channel: "telegram",
+          conversation: {
+            id: "200",
+            kind: "topic",
+            parentId: "-1001",
+            parentTitle: "Ops",
+          },
+        },
+      },
+    });
+    if (!surfaceResponse.ok) {
+      throw new Error("Expected current messaging surface response");
+    }
+    expect(surfaceResponse.data.location).not.toHaveProperty("binding");
+
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "attach_thread_here",
+        context: {
+          backend: "codex",
+          threadId: "agent-thread",
+          turnId: "turn-1",
+        },
+        args: {
+          backend: "codex",
+          threadId: "thread-2",
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        binding: {
+          backend: "codex",
+          targetKind: "thread",
+          threadId: "thread-2",
+        },
+        conversation: {
+          id: "200",
+          kind: "topic",
+        },
+        placement: "current_conversation",
+      },
+    });
+    await expect(harness.store.findActiveBindingForChannel(event.channel)).resolves
+      .toMatchObject({
+        backend: "codex",
+        targetKind: "thread",
+        threadId: "thread-2",
+      });
+  });
+
   it("returns default Agent control pending requests only to the requesting surface", async () => {
     const harness = await createHarness();
     const event = buildCommandEvent("/agent ask the operator");

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -235,18 +235,30 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(event);
 
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "codex",
-        threadId: "agent-thread",
-        input: [
-          {
-            type: "text",
-            text: "fork this and attach it here",
-          },
-        ],
-      }),
+    const startRequest = harness.startTurn.mock.calls[0]?.[0];
+    expect(startRequest).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    const inputItem = startRequest?.input[0];
+    if (!inputItem || inputItem.type !== "text") {
+      throw new Error("Expected default Agent control request text input");
+    }
+    expect(inputItem.text).toContain("PwrAgent operator request");
+    expect(inputItem.text).toContain(
+      "This is a one-off `/agent` request from a messaging surface.",
     );
+    expect(inputItem.text).toContain(
+      "Do not assume the source surface is now bound to this Agent thread.",
+    );
+    expect(inputItem.text).toContain(
+      "use `pwragent.get_current_messaging_surface` to inspect the origin surface",
+    );
+    expect(inputItem.text).toContain(
+      "- Active binding at source: codex/work-thread (thread)",
+    );
+    expect(inputItem.text).toContain("- Default Agent target: codex/agent-thread");
+    expect(inputItem.text).toContain("User request:\nfork this and attach it here");
     await expect(harness.store.findActiveBindingForChannel(event.channel)).resolves
       .toMatchObject({
         targetKind: "thread",
@@ -388,6 +400,15 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(event);
+    const startRequest = harness.startTurn.mock.calls[0]?.[0];
+    const inputItem = startRequest?.input[0];
+    if (!inputItem || inputItem.type !== "text") {
+      throw new Error("Expected queued default Agent control request text input");
+    }
+    expect(inputItem.text).toContain("PwrAgent operator request");
+    expect(inputItem.text).toContain(
+      "User request:\nsummarize after the active turn",
+    );
     await harness.controller.handleBackendEvent({
       backend: "codex",
       notification: {
@@ -548,18 +569,19 @@ describe("MessagingController", () => {
       backend: "codex",
       threadId: "thread-1",
     });
-    expect(harness.startTurn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        backend: "codex",
-        threadId: "thread-1",
-        input: [
-          {
-            type: "text",
-            text: "fork this",
-          },
-        ],
-      }),
-    );
+    const startRequest = harness.startTurn.mock.calls[0]?.[0];
+    expect(startRequest).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const inputItem = startRequest?.input[0];
+    if (!inputItem || inputItem.type !== "text") {
+      throw new Error("Expected default Agent picker request text input");
+    }
+    expect(inputItem.text).toContain("PwrAgent operator request");
+    expect(inputItem.text).toContain("- Active binding at source: none");
+    expect(inputItem.text).toContain("- Default Agent target: codex/thread-1");
+    expect(inputItem.text).toContain("User request:\nfork this");
   });
 
   it("starts a new Agent thread from /agent --new and binds it as an Agent target", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -354,6 +354,93 @@ describe("MessagingController", () => {
     );
   });
 
+  it("preserves default Agent control routing when the backend queues the turn", async () => {
+    const harness = await createHarness();
+    const event = buildCommandEvent("/agent summarize after the active turn");
+    const agentSurfaceBindingId =
+      "binding:telegram:topic:-1001:200:codex:agent-thread";
+    harness.startTurn.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "agent-thread",
+      turnId: "queue-1",
+      queueStatus: "queued",
+      queueEntryId: "queue-1",
+    });
+    await harness.store.upsertBinding({
+      id: agentSurfaceBindingId,
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: buildTopicChannel("200"),
+      createdAt: 900,
+      targetKind: "agent_thread",
+      threadId: "agent-thread",
+      updatedAt: 900,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:chat-1",
+      backend: "codex",
+      channel: event.channel,
+      channelKind: "telegram",
+      createdAt: 950,
+      scopeKind: "conversation",
+      threadId: "agent-thread",
+      updatedAt: 950,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/turnQueue/updated",
+        params: {
+          threadId: "agent-thread",
+          queueEntryId: "queue-1",
+          origin: "messaging",
+          status: "started",
+          turnId: "turn-from-queue",
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-from-queue",
+          turn: {
+            id: "turn-from-queue",
+            status: "completed",
+            output: [
+              {
+                type: "text",
+                text: "Queued Agent answer.",
+              },
+            ],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const assistantMessages = harness.delivered.filter(
+      (intent) => intent.kind === "message" && intent.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]).toMatchObject({
+      bindingId: expect.stringMatching(/^agent-control:/),
+      parts: [
+        expect.objectContaining({
+          text: "Queued Agent answer.",
+        }),
+      ],
+    });
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        bindingId: agentSurfaceBindingId,
+      }),
+    );
+  });
+
   it("returns default Agent control pending requests only to the requesting surface", async () => {
     const harness = await createHarness();
     const event = buildCommandEvent("/agent ask the operator");

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type {
   MessagingBindingRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
@@ -40,6 +41,21 @@ function buildBinding(
     backend: "codex",
     threadId: "thread-1",
     authorizedActorIds: ["user-1"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildDefaultAgentAssignment(
+  overrides: Partial<MessagingDefaultAgentAssignmentRecord> = {},
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    id: "default-agent-1",
+    scopeKind: "conversation",
+    channel: buildBinding().channel,
+    backend: "codex",
+    threadId: "agent-thread-1",
     createdAt: 1000,
     updatedAt: 1000,
     ...overrides,
@@ -194,6 +210,99 @@ describe("SqliteMessagingStore", () => {
       id: "binding-1",
       targetKind: "agent_thread",
     });
+  });
+
+  it("keeps default Agent assignments separate from active bindings", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding({ threadId: "work-thread-1" }));
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+
+    await expect(store.findActiveBindingForChannel(buildBinding().channel)).resolves
+      .toMatchObject({
+        id: "binding-1",
+        threadId: "work-thread-1",
+      });
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-1",
+      threadId: "agent-thread-1",
+    });
+  });
+
+  it("resolves the most specific active default Agent assignment", async () => {
+    const store = await createStore();
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "profile-default",
+        scopeKind: "profile",
+        channel: undefined,
+        channelKind: undefined,
+        threadId: "profile-agent",
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "provider-default",
+        scopeKind: "provider",
+        channel: undefined,
+        channelKind: "telegram",
+        threadId: "provider-agent",
+        createdAt: 1100,
+        updatedAt: 1100,
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "conversation-default",
+        threadId: "conversation-agent",
+        createdAt: 1200,
+        updatedAt: 1200,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "conversation-default",
+      threadId: "conversation-agent",
+    });
+
+    await store.revokeDefaultAgentAssignment({
+      assignmentId: "conversation-default",
+      revokedAt: 1300,
+    });
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "provider-default",
+      threadId: "provider-agent",
+    });
+  });
+
+  it("replaces active default Agent assignments within the same scope", async () => {
+    const store = await createStore();
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "default-agent-2",
+        threadId: "agent-thread-2",
+        createdAt: 2000,
+        updatedAt: 2000,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-2",
+      threadId: "agent-thread-2",
+    });
+    await expect(store.getDefaultAgentAssignment("default-agent-1")).resolves
+      .toMatchObject({
+        revokedAt: 2000,
+      });
   });
 
   it("persists pending skill selections on bindings", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -6,6 +6,7 @@ import type {
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingManagedTopicRecord,
   MessagingPendingIntentRecord,
   MessagingThreadTopicLinkRecord,
@@ -40,6 +41,21 @@ function buildBinding(
     backend: "codex",
     threadId: "thread-1",
     authorizedActorIds: ["user-1"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildDefaultAgentAssignment(
+  overrides: Partial<MessagingDefaultAgentAssignmentRecord> = {},
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    id: "default-agent-1",
+    scopeKind: "conversation",
+    channel: buildBinding().channel,
+    backend: "codex",
+    threadId: "agent-thread-1",
     createdAt: 1000,
     updatedAt: 1000,
     ...overrides,
@@ -403,6 +419,99 @@ describe("MessagingStore", () => {
     await expect(store.getBinding("binding-old")).resolves.toMatchObject({
       revokedAt: 2000,
     });
+  });
+
+  it("keeps default Agent assignments separate from active bindings", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({ threadId: "work-thread-1" }));
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+
+    await expect(store.findActiveBindingForChannel(buildBinding().channel)).resolves
+      .toMatchObject({
+        id: "binding-1",
+        threadId: "work-thread-1",
+      });
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-1",
+      threadId: "agent-thread-1",
+    });
+  });
+
+  it("resolves the most specific active default Agent assignment", async () => {
+    const { store } = await createStore();
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "profile-default",
+        scopeKind: "profile",
+        channel: undefined,
+        channelKind: undefined,
+        threadId: "profile-agent",
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "provider-default",
+        scopeKind: "provider",
+        channel: undefined,
+        channelKind: "telegram",
+        threadId: "provider-agent",
+        createdAt: 1100,
+        updatedAt: 1100,
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "conversation-default",
+        threadId: "conversation-agent",
+        createdAt: 1200,
+        updatedAt: 1200,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "conversation-default",
+      threadId: "conversation-agent",
+    });
+
+    await store.revokeDefaultAgentAssignment({
+      assignmentId: "conversation-default",
+      revokedAt: 1300,
+    });
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "provider-default",
+      threadId: "provider-agent",
+    });
+  });
+
+  it("replaces active default Agent assignments within the same scope", async () => {
+    const { store } = await createStore();
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "default-agent-2",
+        threadId: "agent-thread-2",
+        createdAt: 2000,
+        updatedAt: 2000,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-2",
+      threadId: "agent-thread-2",
+    });
+    await expect(store.getDefaultAgentAssignment("default-agent-1")).resolves
+      .toMatchObject({
+        revokedAt: 2000,
+      });
   });
 
   it("sweeps binding and channel state when a binding is revoked", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
@@ -78,7 +78,7 @@ export const MESSAGING_COMMAND_CATALOG: readonly MessagingCommandSpec[] = [
   },
   {
     verb: "agent",
-    description: "choose an Agent thread to control from this conversation",
+    description: "ask or choose the default Agent for this conversation",
   },
   {
     verb: "new",

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -631,6 +631,10 @@ export class MessagingController {
     string,
     ActiveAgentMessagingOrigin
   >();
+  private readonly queuedAgentMessagingOriginsByQueueKey = new Map<
+    string,
+    ActiveAgentMessagingOrigin
+  >();
   private readonly deliveredAutomationStartKeys = new Set<string>();
   private readonly deliveredAutomationFinalKeys = new Set<string>();
   private readonly now: () => number;
@@ -1053,6 +1057,31 @@ export class MessagingController {
     }
     const turnQueueUpdate = turnQueueUpdateForBackendEvent(event);
     if (turnQueueUpdate) {
+      if (
+        turnQueueUpdate.origin === "messaging" &&
+        turnQueueUpdate.queueEntryId
+      ) {
+        if (
+          turnQueueUpdate.status === "started" &&
+          turnQueueUpdate.turnId
+        ) {
+          this.promoteQueuedAgentMessagingOrigin({
+            backend: event.backend,
+            queueEntryId: turnQueueUpdate.queueEntryId,
+            threadId,
+            turnId: turnQueueUpdate.turnId,
+          });
+        } else if (
+          turnQueueUpdate.status === "failed" ||
+          turnQueueUpdate.status === "cancelled"
+        ) {
+          this.forgetQueuedAgentMessagingOrigin(
+            event.backend,
+            threadId,
+            turnQueueUpdate.queueEntryId,
+          );
+        }
+      }
       if (
         turnQueueUpdate.origin === "automation" &&
         turnQueueUpdate.status === "started" &&
@@ -2187,6 +2216,12 @@ export class MessagingController {
           threadId: params.binding.threadId,
           queueEntryId: started.queueEntryId ?? started.turnId,
           requestedExecutionMode: turnSettings.executionMode ?? "unset",
+        });
+        this.rememberQueuedAgentMessagingOrigin({
+          binding: params.binding,
+          event: params.event,
+          originBinding: params.originBinding,
+          queueEntryId: started.queueEntryId ?? started.turnId,
         });
         return "queued";
       }
@@ -11118,6 +11153,51 @@ export class MessagingController {
     );
   }
 
+  private rememberQueuedAgentMessagingOrigin(params: {
+    binding: MessagingBindingRecord;
+    event?: MessagingInboundEvent;
+    originBinding?: MessagingBindingRecord;
+    queueEntryId: string;
+  }): void {
+    if (!params.event || params.binding.targetKind !== "agent_thread") {
+      return;
+    }
+    this.queuedAgentMessagingOriginsByQueueKey.set(
+      agentMessagingQueueKey(
+        params.binding.backend,
+        params.binding.threadId,
+        params.queueEntryId,
+      ),
+      {
+        binding: params.originBinding ?? params.binding,
+        controlBinding: params.originBinding ? params.binding : undefined,
+        event: params.event,
+      },
+    );
+  }
+
+  private promoteQueuedAgentMessagingOrigin(params: {
+    backend: AppServerBackendKind;
+    queueEntryId: string;
+    threadId: ThreadIdentifier;
+    turnId: string;
+  }): void {
+    const queueKey = agentMessagingQueueKey(
+      params.backend,
+      params.threadId,
+      params.queueEntryId,
+    );
+    const origin = this.queuedAgentMessagingOriginsByQueueKey.get(queueKey);
+    if (!origin) {
+      return;
+    }
+    this.queuedAgentMessagingOriginsByQueueKey.delete(queueKey);
+    this.activeAgentMessagingOriginsByTurnKey.set(
+      agentMessagingTurnKey(params.backend, params.threadId, params.turnId),
+      origin,
+    );
+  }
+
   private deliveryBindingsForAgentTurn(params: {
     bindings: MessagingBindingRecord[];
     backend: AppServerBackendKind;
@@ -11148,6 +11228,16 @@ export class MessagingController {
   ): void {
     this.activeAgentMessagingOriginsByTurnKey.delete(
       agentMessagingTurnKey(backend, threadId, turnId),
+    );
+  }
+
+  private forgetQueuedAgentMessagingOrigin(
+    backend: AppServerBackendKind,
+    threadId: ThreadIdentifier,
+    queueEntryId: string,
+  ): void {
+    this.queuedAgentMessagingOriginsByQueueKey.delete(
+      agentMessagingQueueKey(backend, threadId, queueEntryId),
     );
   }
 
@@ -14123,6 +14213,14 @@ function agentMessagingTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function agentMessagingQueueKey(
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+  queueEntryId: string,
+): string {
+  return `${backend}:${threadId}:${queueEntryId}`;
+}
+
 function summarizeMessagingConversation(
   conversation: MessagingChannelRef["conversation"],
 ): PwrAgentMessagingLocationSummary["conversation"] {
@@ -14240,6 +14338,7 @@ function turnQueueUpdateForBackendEvent(event: AgentEvent): {
   automationRunId?: string;
   finalText?: string;
   origin?: string;
+  queueEntryId?: string;
   status?: string;
   suppressBindingBroadcast?: boolean;
   turnId?: string;
@@ -14252,6 +14351,7 @@ function turnQueueUpdateForBackendEvent(event: AgentEvent): {
     automationRunId?: unknown;
     finalText?: unknown;
     origin?: unknown;
+    queueEntryId?: unknown;
     status?: unknown;
     suppressBindingBroadcast?: unknown;
     turnId?: unknown;
@@ -14263,6 +14363,8 @@ function turnQueueUpdateForBackendEvent(event: AgentEvent): {
       typeof params.automationRunId === "string" ? params.automationRunId : undefined,
     finalText: typeof params.finalText === "string" ? params.finalText : undefined,
     origin: typeof params.origin === "string" ? params.origin : undefined,
+    queueEntryId:
+      typeof params.queueEntryId === "string" ? params.queueEntryId : undefined,
     status: typeof params.status === "string" ? params.status : undefined,
     suppressBindingBroadcast: params.suppressBindingBroadcast === true,
     turnId: typeof params.turnId === "string" ? params.turnId : undefined,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -57,6 +57,7 @@ import type {
   MessagingChannelKind,
   MessagingChannelRef,
   MessagingConfirmationIntent,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingDeliveryScope,
   MessagingDeliveryResult,
   MessagingInboundCallbackEvent,
@@ -317,6 +318,7 @@ type AutomationTurnMessagingContext = {
 
 type ActiveAgentMessagingOrigin = {
   binding: MessagingBindingRecord;
+  controlBinding?: MessagingBindingRecord;
   event: MessagingInboundEvent;
 };
 
@@ -1030,7 +1032,7 @@ export class MessagingController {
       return;
     }
 
-    const bindings = this.filterBindingsForChannel(
+    let bindings = this.filterBindingsForChannel(
       await this.options.store.findActiveBindingsForThread({
         backend: event.backend,
         threadId,
@@ -1095,10 +1097,17 @@ export class MessagingController {
     const markdownFileArtifactSelection =
       this.markdownFileAttachmentSelector.selectFromBackendEvent(event);
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
+    bindings = this.deliveryBindingsForAgentTurn({
+      bindings,
+      backend: event.backend,
+      threadId,
+      turnId: turnIdForBackendEvent(event) ?? lifecycle?.turnId,
+    });
     const completedPlan = lifecycle && isTerminalTurnLifecycle(lifecycle)
       ? this.planArtifactsByTurnKey.get(artifactTurnKey(event.backend, threadId, lifecycle.turnId))
       : undefined;
     for (const binding of bindings) {
+      const isControlBinding = this.isEphemeralAgentControlBinding(binding);
       let activeTurn = this.getActiveTurn(binding);
       let turnStateChanged = false;
       const eventTurnId = turnIdForBackendEvent(event);
@@ -1240,6 +1249,9 @@ export class MessagingController {
       }
 
       if (isThreadNameUpdatedEvent(event)) {
+        if (isControlBinding) {
+          continue;
+        }
         await this.renderBindingStatus(
           binding,
           undefined,
@@ -1249,6 +1261,10 @@ export class MessagingController {
       }
 
       if (turnStateChanged && (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn))) {
+        if (isControlBinding) {
+          await this.startNextQueuedTurn(binding);
+          continue;
+        }
         await this.signalTurnActivity(binding, activeTurn!, {
           reason: event.notification.method,
           force: true,
@@ -1331,12 +1347,18 @@ export class MessagingController {
     backend: AppServerBackendKind,
     request: AppServerPendingRequestNotification,
   ): Promise<void> {
-    const bindings = this.filterBindingsForChannel(
+    let bindings = this.filterBindingsForChannel(
       await this.options.store.findActiveBindingsForThread({
         backend,
         threadId: request.params.threadId,
       }),
     );
+    bindings = this.deliveryBindingsForAgentTurn({
+      bindings,
+      backend,
+      threadId: request.params.threadId,
+      turnId: request.params.turnId ?? undefined,
+    });
 
     for (const binding of bindings) {
       const intent = this.intentForPendingRequest(request);
@@ -1504,6 +1526,11 @@ export class MessagingController {
       return;
     }
     if (verb === "agent") {
+      const controlRequest = parseAgentControlRequest(event.args);
+      if (controlRequest) {
+        await this.handleAgentControlRequest(event, controlRequest);
+        return;
+      }
       await this.presentAgentBrowser(event);
       return;
     }
@@ -2098,8 +2125,10 @@ export class MessagingController {
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
     navigation?: NavigationSnapshot;
+    originBinding?: MessagingBindingRecord;
     preview: string;
     queueOnConcurrentStart?: boolean;
+    renderStatus?: boolean;
     threadKey: string;
   }): Promise<PreparedInputStartResult> {
     this.turnAdmission.markStarting(params.threadKey);
@@ -2179,12 +2208,15 @@ export class MessagingController {
         binding: params.binding,
         event: params.event,
         navigation,
+        originBinding: params.originBinding,
         turnId: started.turnId,
       });
-      await this.signalTurnActivity(params.binding, activeTurn, {
-        force: true,
-      });
-      await this.renderBindingStatus(params.binding, undefined, navigation);
+      if (params.renderStatus !== false) {
+        await this.signalTurnActivity(params.binding, activeTurn, {
+          force: true,
+        });
+        await this.renderBindingStatus(params.binding, undefined, navigation);
+      }
       return "started";
     } catch (error) {
       if (turnStarted) {
@@ -2200,7 +2232,9 @@ export class MessagingController {
             binding: params.binding,
             event: params.event,
             input: params.input,
+            originBinding: params.originBinding,
             preview: params.preview,
+            renderStatus: params.renderStatus,
             threadKey: params.threadKey,
           });
           return "queued";
@@ -2281,7 +2315,9 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
+    originBinding?: MessagingBindingRecord;
     preview: string;
+    renderStatus?: boolean;
     threadKey: string;
   }): Promise<void> {
     const queued = this.turnAdmission.enqueue(params);
@@ -2328,8 +2364,32 @@ export class MessagingController {
     return Boolean(
       this.options.backend.steerTurn &&
         activeTurn &&
-        ["working", "waiting"].includes(activeTurn.status),
+        ["working", "waiting"].includes(activeTurn.status) &&
+        this.canQueuedEntrySteerActiveTurn(entry, activeTurn.turnId),
     );
+  }
+
+  private canQueuedEntrySteerActiveTurn(
+    entry: MessagingQueuedTurnEntry,
+    turnId: string,
+  ): boolean {
+    if (entry.binding.targetKind !== "agent_thread") {
+      return true;
+    }
+    if (!entry.event) {
+      return false;
+    }
+    const origin = this.activeAgentMessagingOriginsByTurnKey.get(
+      agentMessagingTurnKey(
+        entry.binding.backend,
+        entry.binding.threadId,
+        turnId,
+      ),
+    );
+    if (!origin) {
+      return false;
+    }
+    return sameMessagingTurnOwner(entry.event, origin.event);
   }
 
   private async retireQueuedTurnNotice(
@@ -2422,6 +2482,20 @@ export class MessagingController {
       );
       return;
     }
+    if (!this.canQueuedEntrySteerActiveTurn(entry, activeTurn.turnId)) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("queued-turn-steer-owner-mismatch"),
+          createdAt: this.now(),
+          title: "Steer unavailable",
+          body: "Only the messaging surface that started the active Agent turn can steer it. The message is still queued.",
+          recoverable: true,
+        }),
+        entry.binding,
+        event,
+      );
+      return;
+    }
 
     try {
       await this.options.backend.steerTurn({
@@ -2471,8 +2545,10 @@ export class MessagingController {
       binding: entry.binding,
       event: entry.event,
       input: entry.input,
+      originBinding: entry.originBinding,
       preview: entry.preview,
       queueOnConcurrentStart: false,
+      renderStatus: entry.renderStatus,
       threadKey,
     });
     if (startResult !== "started") {
@@ -3866,7 +3942,120 @@ export class MessagingController {
     await this.renderResumeBrowser(session, navigation, event);
   }
 
-  private async presentAgentBrowser(event: MessagingInboundCommandEvent): Promise<void> {
+  private async handleAgentControlRequest(
+    event: MessagingInboundCommandEvent,
+    prompt: string,
+  ): Promise<void> {
+    const assignment =
+      await this.options.store.findActiveDefaultAgentAssignmentForChannel(
+        event.channel,
+      );
+    if (!assignment) {
+      await this.presentAgentBrowser({
+        ...event,
+        args: [],
+        rawText: "/agent",
+      }, {
+        agentPrompt: prompt,
+        agentSelectionMode: "default_control",
+      });
+      return;
+    }
+
+    await this.submitAgentControlRequest({ assignment, event, prompt });
+  }
+
+  private async submitAgentControlRequest(params: {
+    assignment: MessagingDefaultAgentAssignmentRecord;
+    event: MessagingInboundCommandEvent | MessagingInboundCallbackEvent;
+    prompt: string;
+  }): Promise<void> {
+    const text = params.prompt.trim();
+    if (!text) {
+      await this.presentAgentBrowser(params.event as MessagingInboundCommandEvent);
+      return;
+    }
+
+    const controlEvent: MessagingInboundTextEvent = {
+      ...params.event,
+      id: `${params.event.id}:agent-control`,
+      kind: "text",
+      receivedAt: params.event.receivedAt,
+      text,
+    };
+    const binding = this.defaultAgentControlBinding(params.assignment, controlEvent);
+    const originBinding =
+      await this.options.store.findActiveBindingForChannel(params.event.channel);
+    const prepared = await this.prepareTurnInput([controlEvent], binding, controlEvent);
+    if (!prepared) {
+      return;
+    }
+    const threadKey = this.threadKeyForBinding(binding);
+    if (await this.isTurnOccupied(binding, threadKey)) {
+      await this.queuePreparedInput({
+        binding,
+        event: controlEvent,
+        input: prepared.input,
+        originBinding: originBinding ?? binding,
+        preview: prepared.preview,
+        renderStatus: false,
+        threadKey,
+      });
+      return;
+    }
+
+    await this.startPreparedInput({
+      binding,
+      event: controlEvent,
+      input: prepared.input,
+      originBinding: originBinding ?? binding,
+      preview: prepared.preview,
+      renderStatus: false,
+      threadKey,
+    });
+  }
+
+  private defaultAgentControlBinding(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+    event: MessagingInboundEvent,
+  ): MessagingBindingRecord {
+    return {
+      id: `agent-control:${assignment.id}:${event.id}`,
+      authorizedActorIds: [event.actor.platformUserId],
+      backend: assignment.backend,
+      channel: event.channel,
+      createdAt: this.now(),
+      routingState: event.routingState ?? assignment.routingState,
+      targetKind: "agent_thread",
+      threadId: assignment.threadId,
+      updatedAt: this.now(),
+    };
+  }
+
+  private async setDefaultAgentAssignmentForSelection(params: {
+    event: MessagingInboundEvent;
+    target: { backend: AppServerBackendKind; threadId: ThreadIdentifier };
+  }): Promise<MessagingDefaultAgentAssignmentRecord> {
+    return await this.options.store.upsertDefaultAgentAssignment({
+      id: this.newIntentId("default-agent"),
+      backend: params.target.backend,
+      channel: params.event.channel,
+      channelKind: params.event.channel.channel,
+      createdAt: this.now(),
+      routingState: params.event.routingState,
+      scopeKind: "conversation",
+      threadId: params.target.threadId,
+      updatedAt: this.now(),
+    });
+  }
+
+  private async presentAgentBrowser(
+    event: MessagingInboundCommandEvent,
+    options?: {
+      agentPrompt?: string;
+      agentSelectionMode?: MessagingBrowseSessionRecord["agentSelectionMode"];
+    },
+  ): Promise<void> {
     const parsed = parseResumeCommandArgs(event.args);
     if (parsed.error) {
       await this.deliver(
@@ -3906,6 +4095,8 @@ export class MessagingController {
       : undefined;
     const session: MessagingBrowseSessionRecord = {
       id: this.newIntentId("browse"),
+      agentPrompt: options?.agentPrompt,
+      agentSelectionMode: options?.agentSelectionMode,
       allowedActorIds: [event.actor.platformUserId],
       backend: selectedBackend?.kind,
       channel: event.channel,
@@ -4563,6 +4754,43 @@ export class MessagingController {
       );
       if (session.mode === "agents" && !targetThread?.agent) {
         await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      if (
+        session.mode === "agents" &&
+        session.agentSelectionMode === "default_control"
+      ) {
+        const assignment = await this.setDefaultAgentAssignmentForSelection({
+          event,
+          target,
+        });
+        await this.options.store.deleteBrowseSession(session.id);
+        if (session.agentPrompt?.trim()) {
+          await this.submitAgentControlRequest({
+            assignment,
+            event,
+            prompt: session.agentPrompt,
+          });
+        } else {
+          await this.deliver(
+            buildConfirmationIntent({
+              id: this.newIntentId("default-agent-set"),
+              capabilityProfile: this.capabilityProfile,
+              createdAt: this.now(),
+              delivery: session.surface
+                ? {
+                    mode: "update",
+                    replaceMarkup: true,
+                  }
+                : undefined,
+              title: "Default Agent set",
+              body: "Future /agent requests from this conversation will use the selected Agent.",
+              targetSurface: session.surface,
+            }),
+            undefined,
+            event,
+          );
+        }
         return;
       }
       if (
@@ -10867,6 +11095,7 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     navigation: NavigationSnapshot;
+    originBinding?: MessagingBindingRecord;
     turnId: string;
   }): void {
     if (
@@ -10882,10 +11111,34 @@ export class MessagingController {
         params.turnId,
       ),
       {
-        binding: params.binding,
+        binding: params.originBinding ?? params.binding,
+        controlBinding: params.originBinding ? params.binding : undefined,
         event: params.event,
       },
     );
+  }
+
+  private deliveryBindingsForAgentTurn(params: {
+    bindings: MessagingBindingRecord[];
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    turnId?: string;
+  }): MessagingBindingRecord[] {
+    if (!params.turnId) {
+      return params.bindings;
+    }
+    const origin = this.activeAgentMessagingOriginsByTurnKey.get(
+      agentMessagingTurnKey(params.backend, params.threadId, params.turnId),
+    );
+    const controlBinding = origin?.controlBinding;
+    if (!controlBinding) {
+      return params.bindings;
+    }
+    return this.isChannelInScope(controlBinding.channel) ? [controlBinding] : [];
+  }
+
+  private isEphemeralAgentControlBinding(binding: MessagingBindingRecord): boolean {
+    return binding.id.startsWith("agent-control:");
   }
 
   private forgetAgentMessagingOrigin(
@@ -12629,6 +12882,25 @@ function parseMonitorBooleanArg(arg: string | undefined): boolean | undefined {
     return false;
   }
   return undefined;
+}
+
+function parseAgentControlRequest(args: readonly string[]): string | undefined {
+  if (args.length === 0 || args[0]?.startsWith("-")) {
+    return undefined;
+  }
+  const prompt = args.join(" ").trim();
+  return prompt.length > 0 ? prompt : undefined;
+}
+
+function sameMessagingTurnOwner(
+  left: MessagingInboundEvent,
+  right: MessagingInboundEvent,
+): boolean {
+  return (
+    left.actor.platformUserId === right.actor.platformUserId &&
+    buildMessagingConversationKey(left.channel) ===
+      buildMessagingConversationKey(right.channel)
+  );
 }
 
 function buildMonitorSubscriptionId(channel: MessagingChannelRef): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4025,12 +4025,19 @@ export class MessagingController {
     if (!prepared) {
       return;
     }
+    const input = buildDefaultAgentControlInput({
+      assignment: params.assignment,
+      event: controlEvent,
+      input: prepared.input,
+      originBinding,
+      request: text,
+    });
     const threadKey = this.threadKeyForBinding(binding);
     if (await this.isTurnOccupied(binding, threadKey)) {
       await this.queuePreparedInput({
         binding,
         event: controlEvent,
-        input: prepared.input,
+        input,
         originBinding: originBinding ?? binding,
         preview: prepared.preview,
         renderStatus: false,
@@ -4042,7 +4049,7 @@ export class MessagingController {
     await this.startPreparedInput({
       binding,
       event: controlEvent,
-      input: prepared.input,
+      input,
       originBinding: originBinding ?? binding,
       preview: prepared.preview,
       renderStatus: false,
@@ -14859,6 +14866,82 @@ function buildQueuedTurnNoticeBody(preview: string, canSteer: boolean): string {
     ? " To submit it as a steering message, click Steer."
     : "";
   return `${quotedPreview}\n\nI got your message, but there is a turn in progress. I've queued it to be sent when the turn completes.${steeringSentence} You can cancel if you don't want this queued.`;
+}
+
+function buildDefaultAgentControlInput(params: {
+  assignment: MessagingDefaultAgentAssignmentRecord;
+  event: MessagingInboundEvent;
+  input: AppServerTurnInputItem[];
+  originBinding?: MessagingBindingRecord;
+  request: string;
+}): AppServerTurnInputItem[] {
+  const envelope = buildDefaultAgentControlPrompt(params);
+  const firstTextIndex = params.input.findIndex((item) => item.type === "text");
+  if (firstTextIndex < 0) {
+    return [{ type: "text", text: envelope }, ...params.input];
+  }
+  return params.input.map((item, index) =>
+    index === firstTextIndex && item.type === "text"
+      ? { ...item, text: envelope }
+      : item
+  );
+}
+
+function buildDefaultAgentControlPrompt(params: {
+  assignment: MessagingDefaultAgentAssignmentRecord;
+  event: MessagingInboundEvent;
+  originBinding?: MessagingBindingRecord;
+  request: string;
+}): string {
+  return [
+    "PwrAgent operator request",
+    "",
+    "This is a one-off `/agent` request from a messaging surface. It may be an escalation from a surface currently bound to a different PwrAgent thread.",
+    "Do not assume the source surface is now bound to this Agent thread. Reply normally; PwrAgent will route the response back to the requesting surface.",
+    "",
+    "If the user says \"here\", \"this thread\", \"this topic\", or asks to attach, fork, or hand off work, use `pwragent.get_current_messaging_surface` to inspect the origin surface before acting.",
+    "",
+    "Source surface:",
+    `- Provider: ${params.event.channel.channel}`,
+    `- Conversation: ${formatDefaultAgentControlConversation(params.event.channel.conversation)}`,
+    `- Actor: ${formatDefaultAgentControlActor(params.event.actor)}`,
+    params.originBinding
+      ? `- Active binding at source: ${params.originBinding.backend}/${params.originBinding.threadId} (${params.originBinding.targetKind})`
+      : "- Active binding at source: none",
+    `- Default Agent target: ${params.assignment.backend}/${params.assignment.threadId}`,
+    "",
+    "User request:",
+    params.request,
+  ].join("\n");
+}
+
+function formatDefaultAgentControlConversation(
+  conversation: MessagingChannelRef["conversation"],
+): string {
+  return [
+    `${conversation.kind} ${conversation.id}`,
+    conversation.title ? `title "${oneLine(conversation.title)}"` : undefined,
+    conversation.parentTitle
+      ? `parent "${oneLine(conversation.parentTitle)}"`
+      : undefined,
+    conversation.ancestorTitle
+      ? `ancestor "${oneLine(conversation.ancestorTitle)}"`
+      : undefined,
+  ].filter(Boolean).join(", ");
+}
+
+function formatDefaultAgentControlActor(
+  actor: MessagingInboundEvent["actor"],
+): string {
+  return [
+    actor.displayName ? oneLine(actor.displayName) : undefined,
+    actor.username ? `@${oneLine(actor.username)}` : undefined,
+    actor.platformUserId,
+  ].filter(Boolean).join(" ");
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
 }
 
 function truncateText(text: string, limit: number): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2364,7 +2364,7 @@ export class MessagingController {
       entry.binding,
       "queued_turn_notice",
     );
-    const canSteer = this.canSteerQueuedTurn(activeTurn);
+    const canSteer = this.canSteerQueuedTurn(entry, activeTurn);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("queued-turn"),
       capabilityProfile: this.capabilityProfile,
@@ -2394,6 +2394,7 @@ export class MessagingController {
   }
 
   private canSteerQueuedTurn(
+    entry: MessagingQueuedTurnEntry,
     activeTurn: MessagingActiveTurnSummary | undefined,
   ): boolean {
     return Boolean(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -317,7 +317,7 @@ type AutomationTurnMessagingContext = {
 };
 
 type ActiveAgentMessagingOrigin = {
-  binding: MessagingBindingRecord;
+  binding?: MessagingBindingRecord;
   controlBinding?: MessagingBindingRecord;
   event: MessagingInboundEvent;
 };
@@ -2154,7 +2154,7 @@ export class MessagingController {
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
     navigation?: NavigationSnapshot;
-    originBinding?: MessagingBindingRecord;
+    originBinding?: MessagingBindingRecord | null;
     preview: string;
     queueOnConcurrentStart?: boolean;
     renderStatus?: boolean;
@@ -2350,7 +2350,7 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
-    originBinding?: MessagingBindingRecord;
+    originBinding?: MessagingBindingRecord | null;
     preview: string;
     renderStatus?: boolean;
     threadKey: string;
@@ -4038,7 +4038,7 @@ export class MessagingController {
         binding,
         event: controlEvent,
         input,
-        originBinding: originBinding ?? binding,
+        originBinding: originBinding ?? null,
         preview: prepared.preview,
         renderStatus: false,
         threadKey,
@@ -4050,7 +4050,7 @@ export class MessagingController {
       binding,
       event: controlEvent,
       input,
-      originBinding: originBinding ?? binding,
+      originBinding: originBinding ?? null,
       preview: prepared.preview,
       renderStatus: false,
       threadKey,
@@ -11137,7 +11137,7 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     navigation: NavigationSnapshot;
-    originBinding?: MessagingBindingRecord;
+    originBinding?: MessagingBindingRecord | null;
     turnId: string;
   }): void {
     if (
@@ -11153,8 +11153,10 @@ export class MessagingController {
         params.turnId,
       ),
       {
-        binding: params.originBinding ?? params.binding,
-        controlBinding: params.originBinding ? params.binding : undefined,
+        binding: params.originBinding === undefined
+          ? params.binding
+          : params.originBinding ?? undefined,
+        controlBinding: params.originBinding !== undefined ? params.binding : undefined,
         event: params.event,
       },
     );
@@ -11163,7 +11165,7 @@ export class MessagingController {
   private rememberQueuedAgentMessagingOrigin(params: {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
-    originBinding?: MessagingBindingRecord;
+    originBinding?: MessagingBindingRecord | null;
     queueEntryId: string;
   }): void {
     if (!params.event || params.binding.targetKind !== "agent_thread") {
@@ -11176,8 +11178,10 @@ export class MessagingController {
         params.queueEntryId,
       ),
       {
-        binding: params.originBinding ?? params.binding,
-        controlBinding: params.originBinding ? params.binding : undefined,
+        binding: params.originBinding === undefined
+          ? params.binding
+          : params.originBinding ?? undefined,
+        controlBinding: params.originBinding !== undefined ? params.binding : undefined,
         event: params.event,
       },
     );
@@ -12334,11 +12338,17 @@ export class MessagingController {
       return { ok: true, placement: "new_child" };
     }
 
-    if (
-      params.origin.binding.targetKind !== "agent_thread" &&
-      (params.origin.event.channel.conversation.kind === "thread" ||
-        params.origin.event.channel.conversation.kind === "topic")
-    ) {
+    const sourceConversationKind = params.origin.event.channel.conversation.kind;
+    const canAttachToCurrentUnboundConversation =
+      !params.origin.binding &&
+      (sourceConversationKind === "dm" ||
+        sourceConversationKind === "thread" ||
+        sourceConversationKind === "topic");
+    const canReplaceCurrentThreadOrTopicBinding =
+      Boolean(params.origin.binding) &&
+      params.origin.binding?.targetKind !== "agent_thread" &&
+      (sourceConversationKind === "thread" || sourceConversationKind === "topic");
+    if (canAttachToCurrentUnboundConversation || canReplaceCurrentThreadOrTopicBinding) {
       return { ok: true, placement: "current_conversation" };
     }
 
@@ -12361,7 +12371,10 @@ export class MessagingController {
       const origin = this.activeAgentMessagingOriginsByTurnKey.get(
         agentMessagingTurnKey(context.backend, context.threadId, context.turnId),
       );
-      if (!origin || !this.isChannelInScope(origin.binding.channel)) {
+      if (
+        !origin ||
+        !this.isChannelInScope(origin.binding?.channel ?? origin.event.channel)
+      ) {
         return {
           ok: false,
           error: {
@@ -12427,13 +12440,17 @@ export class MessagingController {
   ): Promise<PwrAgentMessagingLocationSummary> {
     return {
       actor: summarizeMessagingActor(origin.event.actor),
-      binding: summarizeMessagingBinding(
-        origin.binding,
-        await this.resolveBoundThreadSummary(
-          origin.binding,
-          options.navigation,
-        ),
-      ),
+      ...(origin.binding
+        ? {
+            binding: summarizeMessagingBinding(
+              origin.binding,
+              await this.resolveBoundThreadSummary(
+                origin.binding,
+                options.navigation,
+              ),
+            ),
+          }
+        : {}),
       channel: origin.event.channel.channel,
       conversation: summarizeMessagingConversation(origin.event.channel.conversation),
       managedConversation: await this.resolveManagedConversationSummary(origin),

--- a/apps/desktop/src/main/messaging/core/messaging-migrations.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-migrations.ts
@@ -2,6 +2,7 @@ import type {
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingDeliveryResult,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -32,6 +33,7 @@ export type MessagingStoreData = {
   version: number;
   browseSessions: Record<string, MessagingBrowseSessionRecord>;
   bindings: Record<string, MessagingBindingRecord>;
+  defaultAgentAssignments: Record<string, MessagingDefaultAgentAssignmentRecord>;
   callbackHandles: Record<string, MessagingCallbackHandleRecord>;
   monitorSubscriptions: Record<string, MessagingMonitorSubscriptionRecord>;
   topicCleanupProposals: Record<string, MessagingTopicCleanupProposalRecord>;
@@ -45,6 +47,7 @@ const EMPTY_MESSAGING_STORE_DATA: MessagingStoreData = {
   version: CURRENT_MESSAGING_STORE_VERSION,
   browseSessions: {},
   bindings: {},
+  defaultAgentAssignments: {},
   callbackHandles: {},
   monitorSubscriptions: {},
   topicCleanupProposals: {},
@@ -64,6 +67,10 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
     version: CURRENT_MESSAGING_STORE_VERSION,
     browseSessions: migrateRecord(record.browseSessions, isMessagingBrowseSessionRecord),
     bindings: migrateBindingRecords(record.bindings),
+    defaultAgentAssignments: migrateRecord(
+      record.defaultAgentAssignments,
+      isMessagingDefaultAgentAssignmentRecord,
+    ),
     callbackHandles: migrateRecord(record.callbackHandles, isMessagingCallbackHandleRecord),
     monitorSubscriptions: migrateRecord(
       record.monitorSubscriptions,
@@ -78,6 +85,27 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
     pendingIntents: migrateRecord(record.pendingIntents, isMessagingPendingIntentRecord),
     deliveries: migrateRecord(record.deliveries, isMessagingDeliveryRecord),
   };
+}
+
+function isMessagingDefaultAgentAssignmentRecord(
+  value: unknown,
+): value is MessagingDefaultAgentAssignmentRecord {
+  const record = asRecord(value);
+  const channel = asRecord(record?.channel);
+  const conversation = asRecord(channel?.conversation);
+  return Boolean(
+    record &&
+      typeof record.id === "string" &&
+      typeof record.scopeKind === "string" &&
+      typeof record.backend === "string" &&
+      typeof record.threadId === "string" &&
+      typeof record.createdAt === "number" &&
+      typeof record.updatedAt === "number" &&
+      (!record.channel ||
+        (typeof channel?.channel === "string" &&
+          typeof conversation?.id === "string" &&
+          typeof conversation?.kind === "string")),
+  );
 }
 
 function migrateBindingRecords(value: unknown): Record<string, MessagingBindingRecord> {

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -7,6 +7,7 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingJsonValue,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -52,6 +53,81 @@ export class MessagingStore {
 
   async getBinding(id: string): Promise<MessagingBindingRecord | undefined> {
     return await this.withReadData((data) => cloneOptional(data.bindings[id]));
+  }
+
+  async upsertDefaultAgentAssignment(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+  ): Promise<MessagingDefaultAgentAssignmentRecord> {
+    const sanitized = sanitizeDefaultAgentAssignment(assignment);
+    const scopeKey = buildMessagingDefaultAgentScopeKey(sanitized);
+    return await this.withData((data) => {
+      for (const existing of Object.values(data.defaultAgentAssignments)) {
+        if (
+          existing.id !== sanitized.id &&
+          !existing.revokedAt &&
+          buildMessagingDefaultAgentScopeKey(existing) === scopeKey
+        ) {
+          const revoked: MessagingDefaultAgentAssignmentRecord = {
+            ...existing,
+            revokedAt: sanitized.updatedAt,
+            updatedAt: sanitized.updatedAt,
+          };
+          data.defaultAgentAssignments[existing.id] = revoked;
+        }
+      }
+
+      data.defaultAgentAssignments[sanitized.id] = sanitized;
+      return structuredClone(sanitized);
+    });
+  }
+
+  async getDefaultAgentAssignment(
+    id: string,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return await this.withReadData((data) =>
+      cloneOptional(data.defaultAgentAssignments[id]),
+    );
+  }
+
+  async findActiveDefaultAgentAssignmentForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const scopeKeys = buildDefaultAgentScopeLookupKeys(channel);
+    return await this.withReadData((data) => {
+      const active = Object.values(data.defaultAgentAssignments).filter(
+        (assignment) => !assignment.revokedAt,
+      );
+      for (const scopeKey of scopeKeys) {
+        const match = active
+          .filter(
+            (assignment) =>
+              buildMessagingDefaultAgentScopeKey(assignment) === scopeKey,
+          )
+          .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)[0];
+        if (match) {
+          return structuredClone(match);
+        }
+      }
+      return undefined;
+    });
+  }
+
+  async revokeDefaultAgentAssignment(params: {
+    assignmentId: string;
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return await this.withData((data) => {
+      const current = data.defaultAgentAssignments[params.assignmentId];
+      if (!current) return undefined;
+      const revokedAt = params.revokedAt ?? Date.now();
+      const revoked: MessagingDefaultAgentAssignmentRecord = {
+        ...current,
+        revokedAt,
+        updatedAt: revokedAt,
+      };
+      data.defaultAgentAssignments[params.assignmentId] = revoked;
+      return structuredClone(revoked);
+    });
   }
 
   async findActiveBindingForChannel(
@@ -638,6 +714,7 @@ export class MessagingStore {
           callbackHandles: {},
           pendingIntents: {},
           deliveries: {},
+          defaultAgentAssignments: {},
         });
       }
 
@@ -660,6 +737,47 @@ export function buildMessagingConversationKey(channel: MessagingChannelRef): str
     channel.conversation.parentId ?? "",
     channel.conversation.id,
   ].join(":");
+}
+
+export function buildMessagingDefaultAgentScopeKey(
+  assignment: Pick<
+    MessagingDefaultAgentAssignmentRecord,
+    "scopeKind" | "channel" | "channelKind"
+  >,
+): string {
+  if (assignment.scopeKind === "conversation" && assignment.channel) {
+    return `conversation:${buildMessagingConversationKey(assignment.channel)}`;
+  }
+  if (assignment.scopeKind === "provider" && assignment.channelKind) {
+    return `provider:${assignment.channelKind}`;
+  }
+  return "profile";
+}
+
+export function buildDefaultAgentScopeLookupKeys(
+  channel: MessagingChannelRef,
+): string[] {
+  return [
+    `conversation:${buildMessagingConversationKey(channel)}`,
+    `provider:${channel.channel}`,
+    "profile",
+  ];
+}
+
+function sanitizeDefaultAgentAssignment(
+  assignment: MessagingDefaultAgentAssignmentRecord,
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    ...assignment,
+    channel: assignment.channel
+      ? {
+          ...assignment.channel,
+          conversation: { ...assignment.channel.conversation },
+        }
+      : undefined,
+    channelKind: assignment.channelKind ?? assignment.channel?.channel,
+    routingState: sanitizeAdapterState(assignment.routingState),
+  };
 }
 
 function sanitizeBinding(binding: MessagingBindingRecord): MessagingBindingRecord {

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -27,7 +27,9 @@ export type MessagingQueuedTurnEntry = {
   event?: MessagingInboundEvent;
   id: string;
   input: AppServerTurnInputItem[];
+  originBinding?: MessagingBindingRecord;
   preview: string;
+  renderStatus?: boolean;
   status: "queued" | "steered" | "cancelled" | "submitted" | "failed";
   surface?: MessagingSurfaceRef;
   threadKey: string;

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -27,7 +27,7 @@ export type MessagingQueuedTurnEntry = {
   event?: MessagingInboundEvent;
   id: string;
   input: AppServerTurnInputItem[];
-  originBinding?: MessagingBindingRecord;
+  originBinding?: MessagingBindingRecord | null;
   preview: string;
   renderStatus?: boolean;
   status: "queued" | "steered" | "cancelled" | "submitted" | "failed";

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -4,6 +4,7 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingJsonValue,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -53,6 +54,118 @@ export class SqliteMessagingStore {
       .prepare("SELECT payload FROM bindings WHERE binding_id = ?")
       .get(id) as { payload: string } | undefined;
     return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async upsertDefaultAgentAssignment(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+  ): Promise<MessagingDefaultAgentAssignmentRecord> {
+    const sanitized = sanitizeDefaultAgentAssignment(assignment);
+    const scopeKey = buildMessagingDefaultAgentScopeKey(sanitized);
+    const now = sanitized.updatedAt;
+    const rowsToRevoke = this.stateDb.raw
+      .prepare(
+        "SELECT assignment_id, payload FROM messaging_default_agent_assignments WHERE status = 'active' AND scope_key = ? AND assignment_id != ?",
+      )
+      .all(scopeKey, sanitized.id) as { assignment_id: string; payload: string }[];
+
+    const upsertAssignment = this.stateDb.raw.prepare(
+      `INSERT OR REPLACE INTO messaging_default_agent_assignments(assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, revoked_at, payload)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const upsert = this.stateDb.raw.transaction(() => {
+      for (const row of rowsToRevoke) {
+        try {
+          const current = JSON.parse(
+            row.payload,
+          ) as MessagingDefaultAgentAssignmentRecord;
+          const revoked: MessagingDefaultAgentAssignmentRecord = {
+            ...current,
+            revokedAt: now,
+            updatedAt: now,
+          };
+          upsertAssignment.run(
+            revoked.id,
+            revoked.scopeKind,
+            buildMessagingDefaultAgentScopeKey(revoked),
+            revoked.channelKind ?? revoked.channel?.channel ?? null,
+            revoked.backend,
+            revoked.threadId,
+            "revoked",
+            revoked.createdAt,
+            revoked.updatedAt,
+            revoked.revokedAt ?? null,
+            JSON.stringify(revoked),
+          );
+        } catch {
+          this.stateDb.raw
+            .prepare(
+              "UPDATE messaging_default_agent_assignments SET status = 'revoked', revoked_at = ?, updated_at = ? WHERE assignment_id = ?",
+            )
+            .run(now, now, row.assignment_id);
+        }
+      }
+
+      upsertAssignment.run(
+        sanitized.id,
+        sanitized.scopeKind,
+        scopeKey,
+        sanitized.channelKind ?? sanitized.channel?.channel ?? null,
+        sanitized.backend,
+        sanitized.threadId,
+        sanitized.revokedAt ? "revoked" : "active",
+        sanitized.createdAt,
+        sanitized.updatedAt,
+        sanitized.revokedAt ?? null,
+        JSON.stringify(sanitized),
+      );
+    });
+    upsert();
+
+    return structuredClone(sanitized);
+  }
+
+  async getDefaultAgentAssignment(
+    id: string,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_default_agent_assignments WHERE assignment_id = ?",
+      )
+      .get(id) as { payload: string } | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async findActiveDefaultAgentAssignmentForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    for (const scopeKey of buildDefaultAgentScopeLookupKeys(channel)) {
+      const rows = this.stateDb.raw
+        .prepare(
+          "SELECT payload FROM messaging_default_agent_assignments WHERE status = 'active' AND scope_key = ? ORDER BY updated_at DESC, created_at DESC",
+        )
+        .all(scopeKey) as { payload: string }[];
+      const match = rows
+        .map((row) => JSON.parse(row.payload) as MessagingDefaultAgentAssignmentRecord)
+        .find((assignment) => !assignment.revokedAt);
+      if (match) return match;
+    }
+    return undefined;
+  }
+
+  async revokeDefaultAgentAssignment(params: {
+    assignmentId: string;
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const current = await this.getDefaultAgentAssignment(params.assignmentId);
+    if (!current) return undefined;
+    const revokedAt = params.revokedAt ?? Date.now();
+    const revoked: MessagingDefaultAgentAssignmentRecord = {
+      ...current,
+      revokedAt,
+      updatedAt: revokedAt,
+    };
+    await this.upsertDefaultAgentAssignment(revoked);
+    return structuredClone(revoked);
   }
 
   async findActiveBindingForChannel(
@@ -785,6 +898,10 @@ export class SqliteMessagingStore {
 
   async readSnapshot(): Promise<MessagingStoreData> {
     const bindings: Record<string, MessagingBindingRecord> = {};
+    const defaultAgentAssignments: Record<
+      string,
+      MessagingDefaultAgentAssignmentRecord
+    > = {};
     const monitorSubscriptions: Record<string, MessagingMonitorSubscriptionRecord> = {};
     const pendingIntents: Record<string, MessagingPendingIntentRecord> = {};
     const browseSessions: Record<string, MessagingBrowseSessionRecord> = {};
@@ -798,6 +915,13 @@ export class SqliteMessagingStore {
       .prepare("SELECT binding_id, payload FROM bindings")
       .all() as { binding_id: string; payload: string }[]) {
       bindings[row.binding_id] = JSON.parse(row.payload);
+    }
+    for (const row of this.stateDb.raw
+      .prepare(
+        "SELECT assignment_id, payload FROM messaging_default_agent_assignments",
+      )
+      .all() as { assignment_id: string; payload: string }[]) {
+      defaultAgentAssignments[row.assignment_id] = JSON.parse(row.payload);
     }
     for (const row of this.stateDb.raw
       .prepare("SELECT subscription_id, payload FROM monitor_subscriptions")
@@ -843,6 +967,7 @@ export class SqliteMessagingStore {
     return {
       version: CURRENT_MESSAGING_STORE_VERSION,
       bindings,
+      defaultAgentAssignments,
       monitorSubscriptions,
       topicCleanupProposals,
       topicLinks,
@@ -866,6 +991,31 @@ export function buildMessagingConversationKey(
   ].join(":");
 }
 
+export function buildMessagingDefaultAgentScopeKey(
+  assignment: Pick<
+    MessagingDefaultAgentAssignmentRecord,
+    "scopeKind" | "channel" | "channelKind"
+  >,
+): string {
+  if (assignment.scopeKind === "conversation" && assignment.channel) {
+    return `conversation:${buildMessagingConversationKey(assignment.channel)}`;
+  }
+  if (assignment.scopeKind === "provider" && assignment.channelKind) {
+    return `provider:${assignment.channelKind}`;
+  }
+  return "profile";
+}
+
+export function buildDefaultAgentScopeLookupKeys(
+  channel: MessagingChannelRef,
+): string[] {
+  return [
+    `conversation:${buildMessagingConversationKey(channel)}`,
+    `provider:${channel.channel}`,
+    "profile",
+  ];
+}
+
 function buildChannelId(channel: MessagingChannelRef): string {
   return [
     channel.conversation.kind,
@@ -887,6 +1037,22 @@ function sanitizeBinding(
     routingState: sanitizeAdapterState(binding.routingState),
     statusSurface: sanitizeSurfaceRef(binding.statusSurface),
     targetKind: normalizeMessagingBindingTargetKind(binding.targetKind),
+  };
+}
+
+function sanitizeDefaultAgentAssignment(
+  assignment: MessagingDefaultAgentAssignmentRecord,
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    ...assignment,
+    channel: assignment.channel
+      ? {
+          ...assignment.channel,
+          conversation: { ...assignment.channel.conversation },
+        }
+      : undefined,
+    channelKind: assignment.channelKind ?? assignment.channel?.channel,
+    routingState: sanitizeAdapterState(assignment.routingState),
   };
 }
 
@@ -993,6 +1159,10 @@ export type MessagingStoreLike = Pick<
   SqliteMessagingStore,
   | "upsertBinding"
   | "getBinding"
+  | "upsertDefaultAgentAssignment"
+  | "getDefaultAgentAssignment"
+  | "findActiveDefaultAgentAssignmentForChannel"
+  | "revokeDefaultAgentAssignment"
   | "findActiveBindingForChannel"
   | "findActiveBindingsForBackend"
   | "findActiveBindingsForThread"

--- a/apps/desktop/src/main/state/migration.ts
+++ b/apps/desktop/src/main/state/migration.ts
@@ -156,6 +156,10 @@ export function migrateIfNeeded(options?: {
         migrated.callbackHandles,
       );
       counts.deliveries = migrateDeliveries(stateDb.raw, migrated.deliveries);
+      counts.default_agent_assignments = migrateDefaultAgentAssignments(
+        stateDb.raw,
+        migrated.defaultAgentAssignments,
+      );
     }
 
     if (overlayData) {
@@ -347,6 +351,43 @@ function migrateDeliveries(
   return count;
 }
 
+function migrateDefaultAgentAssignments(
+  db: BetterSqlite3.Database,
+  assignments: Record<string, unknown>,
+): number {
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO messaging_default_agent_assignments(assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, revoked_at, payload)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  let count = 0;
+  const insert = db.transaction(() => {
+    for (const [id, raw] of Object.entries(assignments)) {
+      const assignment = raw as Record<string, unknown>;
+      const channel = assignment.channel as Record<string, unknown> | undefined;
+      const scopeKind = (assignment.scopeKind as string | undefined) ?? "profile";
+      const channelKind =
+        (assignment.channelKind as string | undefined) ??
+        (channel?.channel as string | undefined);
+      stmt.run(
+        id,
+        scopeKind,
+        defaultAgentScopeKey(scopeKind, channel, channelKind),
+        channelKind ?? null,
+        (assignment.backend as string) ?? "",
+        (assignment.threadId as string) ?? "",
+        assignment.revokedAt ? "revoked" : "active",
+        assignment.createdAt ?? Date.now(),
+        assignment.updatedAt ?? Date.now(),
+        assignment.revokedAt ?? null,
+        JSON.stringify(assignment),
+      );
+      count++;
+    }
+  });
+  insert();
+  return count;
+}
+
 function migrateBackends(
   db: BetterSqlite3.Database,
   backends: unknown,
@@ -486,6 +527,20 @@ function channelId(channel: Record<string, unknown> | undefined): string {
   return [conv.kind ?? "", conv.parentId ?? "", conv.id ?? ""].join(":");
 }
 
+function defaultAgentScopeKey(
+  scopeKind: string,
+  channel: Record<string, unknown> | undefined,
+  channelKind: string | undefined,
+): string {
+  if (scopeKind === "conversation" && channel) {
+    return `conversation:${channel.channel ?? ""}:${channelId(channel)}`;
+  }
+  if (scopeKind === "provider" && channelKind) {
+    return `provider:${channelKind}`;
+  }
+  return "profile";
+}
+
 function copyConfig(
   srcPath: string | undefined,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string; cliProfile?: string },
@@ -522,6 +577,10 @@ function verifyCounts(dbPath: string): Record<string, number> {
   try {
     const tableCountQueries = [
       ["bindings", "SELECT COUNT(*) as count FROM bindings"],
+      [
+        "default_agent_assignments",
+        "SELECT COUNT(*) as count FROM messaging_default_agent_assignments",
+      ],
       ["pending_intents", "SELECT COUNT(*) as count FROM pending_intents"],
       ["browse_sessions", "SELECT COUNT(*) as count FROM browse_sessions"],
       ["callback_handles", "SELECT COUNT(*) as count FROM callback_handles"],

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 28;
+export const CURRENT_STATE_DB_USER_VERSION = 29;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -417,6 +417,26 @@ CREATE TABLE IF NOT EXISTS messaging_activity_summary (
   last_response_at INTEGER,
   updated_at       INTEGER NOT NULL
 );
+`;
+
+const MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA = `
+CREATE TABLE IF NOT EXISTS messaging_default_agent_assignments (
+  assignment_id TEXT PRIMARY KEY,
+  scope_kind    TEXT NOT NULL,
+  scope_key     TEXT NOT NULL,
+  channel_kind  TEXT,
+  backend       TEXT NOT NULL,
+  thread_id     TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  revoked_at    INTEGER,
+  payload       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messaging_default_agent_assignments_scope
+  ON messaging_default_agent_assignments(scope_key, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messaging_default_agent_assignments_thread
+  ON messaging_default_agent_assignments(backend, thread_id, status);
 `;
 
 const THREAD_SEARCH_SCHEMA = `
@@ -933,6 +953,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 28) {
       db.transaction(() => {
         repairOpenAiThreadUsagePricing(db);
+        db.pragma("user_version = 28");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 29) {
+      db.transaction(() => {
+        db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1081,6 +1107,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(ACP_SESSION_SCHEMA);
     db.exec(AUTOMATION_SCHEMA);
     db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
+    db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -49,6 +49,14 @@ turn admission policy that coalesces split input, prevents overlapping
 `turn/start` calls, queues follow-ups during active turns, and maps queued
 input to `turn/steer` or a later `turn/start`.
 
+Explicit Agent control routing is also controller-owned. Adapters should
+normalize `/agent <request>` as a `command` event with `command: "agent"` and
+the remaining tokens in `args`; they must not decide whether the request goes
+to a work thread, an Agent thread, or a default Agent assignment. Mention-based
+Agent routing is not part of the generic adapter contract yet. Providers should
+continue to normalize mentions according to their existing command/text rules
+until a provider-specific mention policy is added.
+
 The `actor.platformUserId` must be the stable platform ID used for
 authorization. Mutable usernames and display names may be included for audit or
 operator visibility only.
@@ -91,6 +99,11 @@ long-lived sqlite records:
   conversation, the full `allowedActorIds` set, and
   `intent.audit?.bindingId ?? intent.bindingId`; a single intent/action may be
   delivered to multiple bindings with the same platform handle.
+
+Default Agent assignment state follows the same opaque-state rule as bindings:
+workflow code may persist and echo `MessagingChannelRef` plus adapter-owned
+routing state, but only the adapter may parse platform-native workspace,
+channel, topic, thread, or message IDs.
 
 ## Rendering Policy
 

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -105,6 +105,35 @@ is intentionally separate from bound-thread user input: a Datadog Slack post can
 start or queue work in one Agent thread without requiring that Slack channel to
 be bound to the thread as a normal conversation.
 
+### Default Agent control routing
+
+Messaging conversations may have two independent routing facts:
+
+- the active thread binding, which decides where ordinary text and media go
+- the default Agent assignment, which decides where explicit `/agent <request>`
+  control-plane requests go
+
+The default Agent assignment is deliberately not a second active
+`MessagingBinding`. One conversation still has at most one active binding, so a
+work-bound channel can keep sending ordinary text to its work thread while
+`/agent fork this and attach it here` starts an Agent-thread turn. The
+assignment is stored separately and resolves from the most specific known scope
+to broader fallbacks: conversation, provider, then profile default.
+
+When `/agent <request>` starts a side-channel Agent turn, the controller uses an
+ephemeral Agent-thread binding for turn admission and response delivery. The
+recorded Agent origin still points at the originating messaging event and the
+conversation's real binding, if one exists, so Agent tools such as
+`pwragent_messaging.get_current_location` and
+`pwragent_messaging.attach_thread_here` interpret "here" as the surface that
+asked the Agent.
+
+Multiple surfaces can target the same Agent thread. The surface and actor that
+started the active Agent turn own steering for that turn. Other surfaces may
+queue follow-up Agent input, but they cannot steer a turn they did not start.
+Mention-based natural-language Agent routing remains provider-specific follow-up
+work; the portable control-plane route is the explicit `/agent` command.
+
 ### Outbound (agent produces output)
 
 ```mermaid
@@ -163,7 +192,9 @@ graph LR
 Why this shape:
 - Each controller owns one capability profile, so producers can adapt deterministically.
 - A thread bound to both Telegram and Discord renders independently per channel — Discord users see Discord-native buttons, Telegram users see Telegram-native buttons. No cross-channel contamination.
-- Shared state lives only in the sqlite `MessagingStore` (bindings, browse sessions, callback handles). Both controllers read/write the same store but never reach into each other's runtime state.
+- Shared state lives only in the sqlite `MessagingStore` (bindings, default
+  Agent assignments, browse sessions, callback handles). Both controllers
+  read/write the same store but never reach into each other's runtime state.
 
 ## Callback delivery models
 
@@ -394,7 +425,9 @@ This is enforced by package boundaries (`pnpm lint:boundaries`) and reinforced i
 
 ## Canonical command catalog
 
-The channel-neutral command surface — `resume`, `new`, `status`, `detach`, `monitor`, `help` — is defined in a single catalog at [`apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`](../apps/desktop/src/main/messaging/core/messaging-command-catalog.ts).
+The channel-neutral command surface — `resume`, `agent`, `new`, `status`,
+`detach`, `monitor`, `help` — is defined in a single catalog at
+[`apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`](../apps/desktop/src/main/messaging/core/messaging-command-catalog.ts).
 
 Four things consume the catalog:
 
@@ -411,6 +444,12 @@ To add a new canonical verb:
 4. For each provider adapter that registers native slash commands, add the verb to its own canonical-bases array (Discord's `DISCORD_APPLICATION_COMMANDS`, Mattermost's `CANONICAL_COMMAND_BASES`, etc.).
 
 The help surface and unknown-command fallback automatically pick up the new verb from the catalog — no string-list to update separately.
+
+`/agent` has two controller paths. With no free-form request, it opens the
+existing Agent picker/binding flow. With free-form text, `/agent <request>`
+routes that text to the conversation's default Agent without changing the
+conversation's active work-thread binding. Option-style invocations such as
+`/agent --new` remain picker/start flows rather than Agent prompts.
 
 ## How to add a provider
 
@@ -445,7 +484,7 @@ The full hands-on walkthrough — including a capability-profile workshop, the i
 | `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts` | Producer for resume browser (`/resume`) — picker pagination, project/thread filtering |
 | `apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts` | Producer for approval prompts |
 | `apps/desktop/src/main/messaging/core/messaging-attachment-processor.ts` | Inbound attachment normalization (size caps, MIME sniffing, image conversion) |
-| `apps/desktop/src/main/messaging/core/messaging-store.ts` | Persistence interface (bindings, browse sessions, callback handles, pending intents) |
+| `apps/desktop/src/main/messaging/core/messaging-store.ts` | Persistence interface (bindings, default Agent assignments, browse sessions, callback handles, pending intents) |
 | `apps/desktop/src/main/state/messaging-store-sqlite.ts` | Sqlite implementation of the store |
 
 ## Cross-references

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -124,8 +124,8 @@ When `/agent <request>` starts a side-channel Agent turn, the controller uses an
 ephemeral Agent-thread binding for turn admission and response delivery. The
 recorded Agent origin still points at the originating messaging event and the
 conversation's real binding, if one exists, so Agent tools such as
-`pwragent_messaging.get_current_location` and
-`pwragent_messaging.attach_thread_here` interpret "here" as the surface that
+`pwragent.get_current_messaging_surface` and
+`pwragent.attach_thread_here` interpret "here" as the surface that
 asked the Agent.
 
 Multiple surfaces can target the same Agent thread. The surface and actor that

--- a/docs/messaging-platform-integration.md
+++ b/docs/messaging-platform-integration.md
@@ -64,6 +64,22 @@ should keep these checks in sync with tests:
   After binding, the status card reports the backend identity and does
   not offer a Provider switch.
 
+## Default Agent control smoke
+
+Contributor checks for `/agent` routing:
+
+- `/agent` with no free-form request opens the Agent picker/binding flow.
+- `/agent --new` still starts the existing new-Agent picker flow.
+- `/agent <request>` routes the request to the conversation's default
+  Agent assignment without replacing any active work-thread binding.
+- If no default Agent is configured, `/agent <request>` opens the Agent
+  picker, preserves the request, stores the selected Agent as the
+  conversation default, and submits the preserved request.
+- Ordinary text in a work-bound conversation still routes to the work
+  thread. Mention-only Agent routing is deferred and provider-specific.
+- When two surfaces target the same Agent thread, the surface that
+  started the active Agent turn may steer it; other surfaces queue.
+
 ## Chat SDK decision (contributor context)
 
 Vercel Chat SDK is not the runtime boundary for PwrAgent. The current

--- a/docs/plans/2026-06-17-002-feat-default-agent-control-routing-plan.md
+++ b/docs/plans/2026-06-17-002-feat-default-agent-control-routing-plan.md
@@ -31,7 +31,7 @@ The plan builds on these existing repo capabilities:
 - `MessagingController` already parses commands before bound-thread input, so `/agent` can bypass the work binding without replacing it.
 - `MessagingBindingTargetKind` already includes `agent_thread`.
 - The Agent browse flow already supports `MessagingBrowseMode = "agents"` and creating new Agent threads.
-- Agent turns already remember messaging origin for `agent_thread` bindings and expose `pwragent_messaging.get_current_location` plus `pwragent_messaging.attach_thread_here`.
+- Agent turns already remember messaging origin for `agent_thread` bindings and expose `pwragent.get_current_messaging_surface` plus `pwragent.attach_thread_here`.
 - Turn admission already queues concurrent messages and renders steer/cancel actions.
 - Adapter contracts already require providers to emit normalized inbound events and keep workflow semantics in the desktop messaging core.
 
@@ -88,7 +88,7 @@ sequenceDiagram
   participant Controller as MessagingController
   participant Store as Messaging Store
   participant Agent as Agent Thread
-  participant Tools as pwragent_messaging tools
+  participant Tools as pwragent tools
 
   User->>Surface: /agent fork this and attach it here
   Surface->>Adapter: provider event
@@ -96,7 +96,7 @@ sequenceDiagram
   Controller->>Store: resolveDefaultAgent(origin surface)
   Store-->>Controller: Agent thread id
   Controller->>Agent: start or queue turn with origin owner
-  Agent->>Tools: get_current_location / attach_thread_here
+  Agent->>Tools: get_current_messaging_surface / attach_thread_here
   Tools->>Controller: request using turn origin
   Controller->>Store: attach work thread at origin surface
   Controller-->>Surface: Agent response for this request
@@ -145,7 +145,7 @@ Do not represent a work surface plus default Agent as two active bindings for th
 
 ### Agent tools remain the action surface
 
-The control request should be plain Agent input. We should not build a large bespoke parser for phrases like "fork this and attach it here." Instead, the Agent uses dynamic messaging tools, starting with the existing `get_current_location` and `attach_thread_here` operations.
+The control request should be plain Agent input. We should not build a large bespoke parser for phrases like "fork this and attach it here." Instead, the Agent uses dynamic messaging tools, starting with the advertised `get_current_messaging_surface` and `attach_thread_here` operations.
 
 Follow-up slices can add tools for preferences such as "fast mode" once the routing and origin model is stable.
 
@@ -216,7 +216,7 @@ Likely files:
 
 Behavior:
 
-- `get_current_location` reports the origin surface, actor, managed conversation capability, and current work binding if one exists.
+- `get_current_messaging_surface` reports the origin surface, actor, managed conversation capability, and current work binding if one exists.
 - `attach_thread_here` attaches at the origin surface, not at an Agent-bound shadow conversation.
 - Tool responses remain clear when the origin has no managed native child conversation support.
 

--- a/docs/plans/2026-06-17-002-feat-default-agent-control-routing-plan.md
+++ b/docs/plans/2026-06-17-002-feat-default-agent-control-routing-plan.md
@@ -1,0 +1,350 @@
+---
+title: "feat: Add default Agent control routing from messaging"
+type: feat
+date: 2026-06-17
+---
+
+# feat: Add default Agent control routing from messaging
+
+## Summary
+
+Let a user in any messaging surface talk to the surface's configured/default PwrAgent Agent without breaking the existing binding for that surface.
+
+The first implementation slice should be command-first: `/agent <request>` is the universal escape hatch from a work-bound conversation into the Agent control plane. It should work from Telegram groups/topics, Discord servers/channels/threads, Slack channels/threads, and future adapters through the existing provider-neutral inbound event model. Mention-based routing, inbound automation triggers, and source-message reply behavior are intentionally deferred so this work can land around PR #847 with limited overlap.
+
+The Agent turn that starts from a messaging surface owns its response route. Other surfaces may enqueue additional messages to the same Agent thread, but they should not steer a turn they did not start.
+
+## Problem Frame
+
+PwrAgent messaging already supports binding a platform conversation to either a normal work thread or an Agent thread. That gives us the core mechanics for Agent-driven messaging tools, but it leaves an important interaction unresolved:
+
+- A bound work conversation needs a way to ask the default Agent to do control-plane work like "fork this and attach it here" without sending that sentence to the work thread.
+- The default Agent can exist at different scopes: whole PwrAgent instance, provider/platform, server/group/workspace, channel/topic/thread, or an explicit surface-level override.
+- Platform affordances differ. Telegram bot commands behave differently from Discord slash commands, Slack mentions, Slack thread replies, and button callbacks.
+- Multiple messaging surfaces can target the same Agent. Turn ownership needs to remain deterministic so one surface cannot unexpectedly steer another surface's active turn.
+- PR #847 adds inbound-triggered automation behavior in nearby code. This feature should avoid automation handlers and provider adapter changes until #847 has landed.
+
+## Existing Anchors
+
+The plan builds on these existing repo capabilities:
+
+- `MessagingController` already parses commands before bound-thread input, so `/agent` can bypass the work binding without replacing it.
+- `MessagingBindingTargetKind` already includes `agent_thread`.
+- The Agent browse flow already supports `MessagingBrowseMode = "agents"` and creating new Agent threads.
+- Agent turns already remember messaging origin for `agent_thread` bindings and expose `pwragent_messaging.get_current_location` plus `pwragent_messaging.attach_thread_here`.
+- Turn admission already queues concurrent messages and renders steer/cancel actions.
+- Adapter contracts already require providers to emit normalized inbound events and keep workflow semantics in the desktop messaging core.
+
+## Requirements
+
+### Addressing and Routing
+
+1. `/agent <request>` from any messaging conversation MUST route the request to the resolved default Agent, not to the conversation's current work binding.
+2. `/agent` with no request MUST open the existing Agent picker/browse flow.
+3. If `/agent <request>` has no resolvable default Agent, the user MUST be prompted to choose or create an Agent, and the original request MUST be preserved for submission after selection.
+4. Choosing an Agent for a surface MUST NOT replace an existing work-thread binding for that surface.
+5. Ordinary text in a work-bound conversation MUST continue to route to the work thread unless it is explicitly addressed to the Agent.
+
+### Default Agent Scope
+
+6. The implementation MUST model default Agent assignment as a side-channel association, not as a second active `MessagingBinding` for the same platform conversation.
+7. Resolution MUST prefer the most specific matching default:
+   - conversation surface, including topic/thread when available
+   - parent channel/group/server/workspace when the adapter exposes that shape
+   - provider/platform profile
+   - PwrAgent profile default
+8. The first slice MAY implement only surface-level assignment plus profile-level fallback if the data model can expand to the full hierarchy without migration churn.
+9. Default assignment state MUST use provider-neutral `MessagingChannelRef` and adapter-owned opaque routing state. The desktop core must not parse provider-native IDs.
+
+### Agent Turn Ownership
+
+10. Every `/agent <request>` MUST start or queue one Agent turn owned by the actor and origin surface that submitted it.
+11. Responses for that request MUST return to the origin surface.
+12. If another surface sends a message to the same Agent while a turn is active, it MAY queue a follow-up, but it MUST NOT steer the active turn unless it is the same actor and same origin surface.
+13. The origin surface that started the turn MAY be offered steer/cancel controls when the backend supports them.
+14. Status/audit updates to affected surfaces are allowed only when an Agent action changes those surfaces, for example after attaching a thread.
+
+### Platform Behavior
+
+15. Telegram: `/agent` MUST work in DMs, groups, and topics. Topic-originated requests should prefer the topic default before group fallback.
+16. Discord: slash command or text command handling MUST preserve channel/thread origin so the default can be scoped at the right surface.
+17. Slack: the first slice SHOULD rely on explicit `/agent` command events and existing normalized command handling. Mention and bot-message routing should wait until after PR #847.
+18. Button/callback surfaces MAY invoke the same default-Agent routing path when slash commands are awkward or unavailable.
+
+### PR #847 Boundary
+
+19. This work MUST NOT implement inbound-triggered automations.
+20. This work MUST NOT modify Slack adapter mention routing or source-message reply behavior.
+21. This work SHOULD avoid files introduced mainly for PR #847 automation orchestration.
+22. Any `MessagingController` changes SHOULD remain localized to command handling, Agent default resolution, turn origin capture, and queue ownership.
+
+## High-Level Design
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Surface as Messaging Surface
+  participant Adapter
+  participant Controller as MessagingController
+  participant Store as Messaging Store
+  participant Agent as Agent Thread
+  participant Tools as pwragent_messaging tools
+
+  User->>Surface: /agent fork this and attach it here
+  Surface->>Adapter: provider event
+  Adapter->>Controller: MessagingInboundEvent(command)
+  Controller->>Store: resolveDefaultAgent(origin surface)
+  Store-->>Controller: Agent thread id
+  Controller->>Agent: start or queue turn with origin owner
+  Agent->>Tools: get_current_location / attach_thread_here
+  Tools->>Controller: request using turn origin
+  Controller->>Store: attach work thread at origin surface
+  Controller-->>Surface: Agent response for this request
+```
+
+```mermaid
+flowchart TD
+  A["Inbound /agent request"] --> B{"Surface default Agent?"}
+  B -- yes --> G["Use surface Agent"]
+  B -- no --> C{"Parent channel/group default?"}
+  C -- yes --> G
+  C -- no --> D{"Provider default?"}
+  D -- yes --> G
+  D -- no --> E{"Profile default?"}
+  E -- yes --> G
+  E -- no --> F["Open Agent picker and preserve request"]
+  F --> H["User selects or creates Agent"]
+  H --> I["Persist default association if user confirms"]
+  I --> G
+  G --> J["Start or queue Agent turn"]
+```
+
+```mermaid
+flowchart TD
+  A["Message targets Agent thread"] --> B{"Agent turn active?"}
+  B -- no --> C["Start turn; owner = actor + origin surface"]
+  B -- yes --> D{"Same actor and same origin surface?"}
+  D -- yes --> E["Allow steer when backend supports steer"]
+  D -- no --> F["Queue message; do not steer active turn"]
+  C --> G["Respond to origin surface"]
+  E --> G
+  F --> H["Queued notice to submitting surface"]
+```
+
+## Key Technical Decisions
+
+### Command-first control plane
+
+Use `/agent` as the reliable cross-platform escape hatch. It is explicit, provider-neutral, and already sits before bound-thread input in the controller. This avoids changing the meaning of ordinary text and avoids the platform-specific ambiguity of bot mentions.
+
+Mention-based routing can still become a provider-specific affordance later, but it should be designed after PR #847 lands because Slack inbound handling and source-message context are moving there.
+
+### Default Agent assignment is not a binding
+
+Do not represent a work surface plus default Agent as two active bindings for the same channel. The stores currently assume one active binding per channel, and the sqlite store and test store differ in how aggressively they enforce that invariant. A separate default-Agent association avoids ambiguous binding lookup and keeps "where work text goes" independent from "where control-plane text goes."
+
+### Agent tools remain the action surface
+
+The control request should be plain Agent input. We should not build a large bespoke parser for phrases like "fork this and attach it here." Instead, the Agent uses dynamic messaging tools, starting with the existing `get_current_location` and `attach_thread_here` operations.
+
+Follow-up slices can add tools for preferences such as "fast mode" once the routing and origin model is stable.
+
+### Origin is actor plus surface
+
+The active Agent turn must carry the exact origin that submitted it, including actor identity and provider-normalized conversation reference. Tool calls should resolve "here" from that origin, even when the surface is bound to a normal work thread rather than directly bound to the Agent thread.
+
+### Provider-neutral core, provider-aware behavior
+
+Platform quirks should be expressed through normalized events, capabilities, and opaque routing state. The desktop messaging core can choose different behavior based on available capabilities, but it should not branch on provider IDs to parse native channel semantics.
+
+## Implementation Units
+
+### 1. Default Agent Assignment Contract and Store
+
+Add a persistent default-Agent association separate from `MessagingBinding`.
+
+Likely files:
+
+- `packages/shared/src/contracts/messaging.ts`
+- `apps/desktop/src/main/messaging/core/messaging-store.ts`
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- `apps/desktop/src/main/__tests__/messaging-store.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts`
+
+Shape:
+
+- assignment id
+- scope kind: `profile`, `provider`, `conversation`
+- provider id/profile id where applicable
+- optional `MessagingChannelRef` for conversation scope
+- optional opaque routing state for adapter-managed placement
+- target Agent backend/thread id
+- created/updated timestamps
+- active/revoked status
+
+The first implementation can store only `profile` and `conversation` scopes if the schema leaves room for provider and parent-surface scopes.
+
+### 2. `/agent <request>` Control Routing
+
+Extend command handling so `/agent` can submit a request to the resolved default Agent without changing the current work binding.
+
+Likely files:
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+Behavior:
+
+- `/agent` with no args keeps the current browse/picker behavior.
+- `/agent <request>` resolves the default Agent for the origin surface.
+- If a default exists, submit the request to that Agent.
+- If no default exists, open the Agent picker and preserve the request as pending input.
+- After selection, offer or apply a default assignment for that surface, then submit the preserved request.
+
+### 3. Origin Context for Side-channel Agent Turns
+
+Generalize the current Agent messaging origin capture so side-channel `/agent <request>` turns have a valid origin even when the surface's active binding is a work thread.
+
+Likely files:
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts`
+- `packages/shared/src/contracts/messaging-tools.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+Behavior:
+
+- `get_current_location` reports the origin surface, actor, managed conversation capability, and current work binding if one exists.
+- `attach_thread_here` attaches at the origin surface, not at an Agent-bound shadow conversation.
+- Tool responses remain clear when the origin has no managed native child conversation support.
+
+### 4. Queue and Steer Ownership
+
+Tighten queue/steer rules for Agent turns shared across surfaces.
+
+Likely files:
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/core/messaging-turn-admission.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+Behavior:
+
+- Active Agent turn ownership is `actor + origin surface`.
+- Same owner may steer when backend support exists.
+- Different owner or different surface queues a message.
+- Queued notices go only to the surface that submitted the queued request.
+- Existing multi-surface queue tests should be extended to prove the second surface cannot steer the first surface's turn.
+
+### 5. Picker, Status, and Help Copy
+
+Make the command discoverable without introducing provider-specific mention behavior.
+
+Likely files:
+
+- `apps/desktop/src/main/messaging/core/messaging-command-catalog.ts`
+- `apps/desktop/src/main/messaging/core/messaging-resume-browser.ts`
+- `apps/desktop/src/main/messaging/core/messaging-status-card.ts`
+- `apps/desktop/src/main/__tests__/messaging-controller.test.ts`
+
+Behavior:
+
+- Help copy says `/agent <request>` asks the default Agent from this conversation.
+- Agent picker copy distinguishes "bind this conversation to an Agent" from "set this conversation's default Agent."
+- Status card actions can include an Agent control button where the adapter supports callbacks.
+
+### 6. Contributor Documentation
+
+Document the model and platform-specific behavior in repo docs.
+
+Likely files:
+
+- `docs/messaging-architecture.md`
+- `docs/messaging-adapter-contract.md`
+- `docs/messaging-platform-integration.md`
+
+Content:
+
+- `/agent` is the portable explicit control-plane route.
+- Default Agent assignment is separate from the active work binding.
+- Mention routing is deferred and provider-specific.
+- Other surfaces can queue to an Agent but cannot steer turns they did not start.
+- Adapter authors should emit normalized command/callback events and avoid workflow logic in provider packages.
+
+## Acceptance Criteria
+
+1. A Telegram topic bound to a work thread can send `/agent fork this and attach it here`; the request goes to the configured Agent, the work binding remains active, and the Agent can attach a thread back to that topic.
+2. A Discord channel bound to a work thread can send `/agent <request>` and receive the Agent response in that channel without creating a shadow work thread.
+3. `/agent <request>` with no configured default opens the Agent picker, preserves the request, and submits it after the user selects or creates an Agent.
+4. Two messaging surfaces targeting the same Agent cannot both steer one active turn. The second surface queues and receives its own queued notice.
+5. Help/status copy makes the explicit `/agent` route discoverable.
+6. Slack mention text without `/agent` retains current behavior in this slice.
+7. Existing Agent binding, Agent picker, and `attach_thread_here` tests continue to pass.
+8. Store tests prove default Agent assignments do not create multiple active bindings for one conversation.
+
+## Test Plan
+
+Run focused tests first:
+
+```bash
+pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts
+pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts
+pnpm test apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts
+```
+
+Then run boundary and package checks:
+
+```bash
+pnpm lint:boundaries
+pnpm --filter @pwragent/messaging-interface test
+pnpm --filter @pwragent/messaging-provider-telegram test
+pnpm --filter @pwragent/messaging-provider-discord test
+pnpm --filter @pwragent/messaging-provider-slack test
+```
+
+If renderer/status-card behavior changes, add the relevant desktop UI tests and run the desktop package test suite.
+
+## PR #847 Conflict Avoidance
+
+Avoid these areas in the first slice:
+
+- `apps/desktop/src/main/automations/*`
+- `apps/desktop/src/renderer/src/features/automations/*`
+- inbound automation matching or scheduling docs
+- Slack adapter mention/bot-message routing
+- source-message reply delivery
+- automation launch-profile override behavior
+
+Expected overlap:
+
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/messaging/messaging-runtime.ts` only if necessary for tool request plumbing
+- shared messaging types if a default-assignment contract is added
+
+Keep the controller change near command handling and Agent turn routing. PR #847's likely overlap is early inbound automation dispatch and source-relative delivery, so keeping this feature on the `/agent` path should make the eventual merge mechanical.
+
+## Deferred Follow-up Work
+
+- Mention-based Agent routing, including `@bot` in Discord/Slack and Telegram mention text.
+- Inbound-triggered automation rules and default-Agent actions that run without explicit `/agent`.
+- Full Settings UI for instance, provider, workspace/server/group, channel/topic/thread defaults.
+- Richer Agent tools for preference changes such as model mode, launch profile, queue policy, or channel notification settings.
+- Cross-surface audit feed for Agent actions that affect multiple messaging conversations.
+- Operator-facing docs site updates in the separate `docs.pwragent.ai` repo.
+
+## Sources and Research
+
+- `docs/messaging-architecture.md`
+- `docs/messaging-adapter-contract.md`
+- `packages/messaging/AGENTS.md`
+- `apps/desktop/AGENTS.md`
+- `docs/brainstorms/2026-05-13-codex-via-messaging-docs-requirements.md`
+- `docs/brainstorms/2026-05-22-agent-thread-attached-automations-requirements.md`
+- `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts`
+- `packages/shared/src/contracts/messaging-tools.ts`
+- `apps/desktop/src/main/state/messaging-store-sqlite.ts`
+- PR #847: `feat(automations): support inbound message triggers`

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1408,6 +1408,24 @@ export type MessagingBindingRecord = {
   threadDisplay?: MessagingThreadDisplaySummary;
 };
 
+export type MessagingDefaultAgentAssignmentScopeKind =
+  | "profile"
+  | "provider"
+  | "conversation";
+
+export type MessagingDefaultAgentAssignmentRecord = {
+  id: string;
+  scopeKind: MessagingDefaultAgentAssignmentScopeKind;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  createdAt: number;
+  updatedAt: number;
+  revokedAt?: number;
+  channelKind?: MessagingChannelKind;
+  channel?: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+};
+
 export type MessagingPendingIntentRecord = {
   id: string;
   bindingId?: string;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1467,6 +1467,8 @@ export type MessagingBrowseReturnTarget = {
 
 export type MessagingBrowseSessionRecord = {
   id: string;
+  agentSelectionMode?: "bind" | "default_control";
+  agentPrompt?: string;
   allowedActorIds: string[];
   backend?: AppServerBackendKind;
   bindingId?: string;

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -106,7 +106,7 @@ export type PwrAgentMessagingManagedConversationSummary = {
 
 export type PwrAgentMessagingLocationSummary = {
   actor?: PwrAgentMessagingActorSummary;
-  binding: PwrAgentMessagingBindingSummary;
+  binding?: PwrAgentMessagingBindingSummary;
   channel: MessagingChannelKind;
   conversation: PwrAgentMessagingConversationSummary;
   managedConversation: PwrAgentMessagingManagedConversationSummary;


### PR DESCRIPTION
## Summary

- Work-bound messaging conversations can now send `/agent <request>` to their default Agent without rebinding ordinary text away from the active work thread.
- Default Agent assignment is persisted separately from active bindings, with conversation/provider/profile lookup support and sqlite migration coverage.
- Agent-control turns now preserve their requesting surface for responses, pending-request buttons, queued follow-ups, and backend FIFO queue promotion, so other Agent-bound surfaces do not receive or steer a turn they did not start.
- Contributor docs now define the controller-owned `/agent` behavior and platform smoke checks while leaving provider-specific mention routing for later.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- This avoids the PR 847 automation/Slack surfaces; the new work is scoped to messaging store/controller contracts and contributor docs.
- The final focused verification passed with 4 files and 559 tests, plus dependency-cruiser clean.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
