### PR TITLE
fix(desktop): clear unread after delayed seen writes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import {
   buildPullRequestStatusKey,
   shortenDerivedThreadTitle,
@@ -467,7 +468,9 @@ describe("useThreadNavigation", () => {
       },
     };
 
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    const { result } = renderHook(() => useThreadNavigation(desktopApi), {
+      wrapper: StrictMode,
+    });
 
     await waitFor(() => {
       expect(result.current.selectedThread?.id).toBe("thread-read");

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -386,6 +386,150 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("clears a selected-thread unread update when the seen write resolves after selecting away", async () => {
+    const listeners = new Set<(event: any) => void>();
+    const delayedSeen = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      seenAt: number;
+      seenUpdatedAt?: number;
+    }>();
+    const markThreadSeen = vi.fn(
+      (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0]
+      ) => {
+        const response = {
+          backend: request.backend,
+          threadId: request.threadId,
+          seenAt: Date.now(),
+          seenUpdatedAt: request.seenUpdatedAt,
+        } as const;
+
+        return request.seenUpdatedAt === 2_000
+          ? delayedSeen.promise
+          : Promise.resolve(response);
+      }
+    );
+    let refreshed = false;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: refreshed ? ["codex:thread-read"] : [],
+      threads: [
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: refreshed
+            ? {
+                inInbox: true,
+                reason: "updated-since-seen" as const,
+                lastSeenUpdatedAt: 1_000,
+              }
+            : {
+                inInbox: false,
+                lastSeenUpdatedAt: 1_000,
+              },
+          updatedAt: refreshed ? 2_000 : 1_000,
+        },
+        {
+          id: "thread-other",
+          title: "Other thread",
+          titleSource: "explicit" as const,
+          summary: "Other thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 900,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-read");
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 1_000,
+      });
+    });
+
+    refreshed = true;
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-other",
+              turnId: "turn-other",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 2_000,
+      });
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+    });
+
+    act(() => {
+      result.current.selectThread(result.current.threads[1]!);
+    });
+
+    await act(async () => {
+      delayedSeen.resolve({
+        backend: "codex",
+        threadId: "thread-read",
+        seenAt: Date.now(),
+        seenUpdatedAt: 2_000,
+      });
+      await delayedSeen.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-other");
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    });
+  });
+
   it("keeps selected refreshes unread while the window is backgrounded", async () => {
     const listeners = new Set<(event: any) => void>();
     const markThreadSeen = vi.fn(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2199,6 +2199,7 @@ export function useThreadNavigation(
   stateRef.current = state;
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1059,6 +1059,14 @@ function markThreadSeenInSnapshot(
       return thread;
     }
 
+    if (
+      params.seenUpdatedAt !== undefined &&
+      thread.updatedAt !== undefined &&
+      thread.updatedAt > params.seenUpdatedAt
+    ) {
+      return thread;
+    }
+
     if (!thread.inbox.inInbox && thread.inbox.lastSeenUpdatedAt === params.seenUpdatedAt) {
       return thread;
     }
@@ -2167,6 +2175,7 @@ export function useThreadNavigation(
   const manuallySelectedThreadKeysRef = useRef(new Set<string>());
   const submittedSeenUpdatedAtByThreadKeyRef = useRef(new Map<string, number | undefined>());
   const refreshInFlightRef = useRef(false);
+  const mountedRef = useRef(true);
   const queuedRefreshRef = useRef<
     | {
         forceRefresh?: boolean;
@@ -2188,6 +2197,12 @@ export function useThreadNavigation(
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
   stateRef.current = state;
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     setNavigationBrowseModeRequestRef.current = setNavigationBrowseModeRequest;
@@ -3197,7 +3212,6 @@ export function useThreadNavigation(
 
     const markThreadSeenRequest = submitMarkThreadSeen;
     const threadToMarkSeen = selectedThread;
-    let cancelled = false;
 
     async function markSeen(): Promise<void> {
       const threadKey = buildThreadIdentityKey(
@@ -3215,10 +3229,11 @@ export function useThreadNavigation(
           threadId: threadToMarkSeen.id,
           seenUpdatedAt: threadToMarkSeen.updatedAt,
         });
-        if (!cancelled) {
+        if (mountedRef.current) {
+          const retainedThread = retainedUnreadThreadRef.current;
           if (
-            !retainedUnreadThread ||
-            buildThreadIdentityKey(retainedUnreadThread.source, retainedUnreadThread.id) !==
+            !retainedThread ||
+            buildThreadIdentityKey(retainedThread.source, retainedThread.id) !==
               threadKey
           ) {
             setState((current) => ({
@@ -3232,18 +3247,16 @@ export function useThreadNavigation(
           }
         }
       } finally {
-        if (!cancelled) {
-          setPendingSeenThreadKey(undefined);
+        if (mountedRef.current) {
+          setPendingSeenThreadKey((current) =>
+            current === threadKey ? undefined : current
+          );
         }
       }
     }
 
     void markSeen();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [markThreadSeen, pendingSeenThreadKey, retainedUnreadThread, selectedThread]);
+  }, [markThreadSeen, pendingSeenThreadKey, selectedThread]);
 
   const refreshThreadDirectoryGitStatuses = useCallback(
     (threadKey: string): void => {


### PR DESCRIPTION
## Summary

- I fixed the unread marker race where a selected thread could stay unread after I clicked away while its `markThreadSeen` write was still resolving.
- Seen-write completions now reconcile the local navigation snapshot by thread identity after selection changes, while stale completions cannot clear a newer update.
- I added a regression test for the delayed seen-write sequence so clicking away from the updated thread clears the marker as soon as the seen write lands.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx -- --runInBand`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- I did not include a screenshot because the fix is an async navigation-state race; the regression test is the meaningful proof.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
