### PR TITLE
fix(desktop): stop settings toggles spanning full width; split Experimental copy

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -115,7 +115,8 @@ export function ExperimentalSettings(props: {
         <div className="settings-fields">
           <SettingsField
             label="Enable thread pricing summary"
-            sub="When on, the Pricing tab appears in the thread context rail with list-price totals and per-turn usage rows."
+            sub="Show the Pricing tab in the thread context rail."
+            help="Surfaces list-price totals and per-turn usage rows for the thread."
             source={sourceBadge(threadPricingSummary)}
             control={
               <SettingsSwitch
@@ -130,7 +131,8 @@ export function ExperimentalSettings(props: {
           />
           <SettingsField
             label="Display USD"
-            sub="Show OpenAI API list-price estimates in USD."
+            sub="Show list-price estimates in USD."
+            help="Estimated from OpenAI API list prices."
             source={sourceBadge(threadPricingDisplayUsd)}
             control={
               <SettingsSwitch
@@ -145,7 +147,8 @@ export function ExperimentalSettings(props: {
           />
           <SettingsField
             label="Display Codex Credits"
-            sub="Show Codex Credits estimates from Codex's token-based credit rate card."
+            sub="Show Codex Credits estimates."
+            help="Estimated from Codex's token-based credit rate card."
             source={sourceBadge(threadPricingDisplayCodexCredits)}
             control={
               <SettingsSwitch
@@ -171,7 +174,8 @@ export function ExperimentalSettings(props: {
         <div className="settings-fields">
           <SettingsField
             label="Enable Codex skill questions"
-            sub="When on, PwrAgent enables Codex's default-mode request_user_input feature for Codex threads."
+            sub="Let Codex skills pause turns to ask questions."
+            help="Enables Codex's default-mode request_user_input feature for Codex threads."
             source={sourceBadge(codexDefaultModeRequestUserInput)}
             control={
               <SettingsSwitch
@@ -207,7 +211,8 @@ export function ExperimentalSettings(props: {
           <div className="settings-fields">
             <SettingsField
               label="Enable diff condensation"
-              sub="When on, focused-diff requests fire an xAI judgment call to decide which hunks to elide."
+              sub="Use an xAI call to hide diff hunks."
+              help="Each focused-diff request fires an xAI judgment call to decide which hunks to elide."
               source={sourceBadge(condensation.enabled)}
               control={
                 <SettingsSwitch
@@ -276,7 +281,8 @@ export function ExperimentalSettings(props: {
           <div className="settings-fields">
             <SettingsField
               label="Enable AgentCore - Grok"
-              sub="When on, the legacy agent-core Grok backend appears in the backend picker. Uses the Grok API key from Settings → Models → Grok."
+              sub="Add the legacy Grok backend to the picker."
+              help="Uses the Grok API key from Settings → Models → Grok."
               source={sourceBadge(agentCoreGrok)}
               control={
                 <SettingsSwitch
@@ -302,7 +308,8 @@ export function ExperimentalSettings(props: {
           <div className="settings-fields">
             <SettingsField
               label="Enable live transcript event filtering"
-              sub="When on, live transcript notifications for other threads no longer update the focused thread view."
+              sub="Ignore unrelated live transcript events."
+              help="Live transcript notifications for other threads no longer update the focused thread view."
               source={sourceBadge(liveTranscriptEventFiltering)}
               control={
                 <SettingsSwitch

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6091,6 +6091,10 @@ textarea,
 /* Switch — track + thumb + word, replaces native checkbox. */
 .settings-switch {
   display: inline-flex;
+  /* Opt out of `.settings-field__control`'s default `align-items: stretch`
+     (column flex) so the pill stays its natural width instead of spanning
+     the control column edge-to-edge — matches `.settings-segmented`. */
+  align-self: flex-start;
   align-items: center;
   gap: 8px;
   height: 28px;


### PR DESCRIPTION
## Summary

- **Settings toggles no longer span the full control column.** The `.settings-switch` pill sits inside `.settings-field__control`, a column flexbox with the default `align-items: stretch`. With no `align-self` of its own, the switch was stretched edge-to-edge, leaving the pill hugging the left with a large empty expanse to its right. Added `align-self: flex-start` so it keeps its natural width — matching `.settings-segmented`, which already opts out of the stretch the same way.
- **Split the Experimental toggle copy into `sub` + `help`.** The long per-toggle descriptions previously lived in the narrow `sub` slot (capped at 28ch under the label), reading as squished paragraphs. Moved the detail into the full-width `help` slot below the control — following the existing "Eliding model" row — so each toggle now shows a short framing line under its label and the operational detail beneath the (now compact) toggle.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` (tsc `--noEmit`) — clean.
- Manually verified in `pnpm dev`: Experimental toggles render compact and left-aligned, with the short `sub` under the label and the detail in the full-width `help` slot below each toggle.
- Confirmed no test snapshots referenced the old `sub` strings; the theme-contract test only locks brand/breadcrumb tokens, which are untouched.

## Notes

- CSS change touches one shared primitive (`.settings-switch`), so **every** toggle across Settings becomes compact, not just Experimental.
- The Experimental copy is a **structural first pass** — wording is intended to be refined later. Only the Experimental panel's toggle rows were reworded; other panels still carry their original `sub` text.
- `sub` (12px) and `help` (11.5px) are both `--text-muted`, so a converted row reads as a short caption + smaller detail line rather than one paragraph. Type tokens were left as-is.
- Two commits, intentionally separable: `2a9c830` (CSS width fix) and `fe89bc6` (Experimental copy split).