### PR TITLE
fix(desktop): preserve mixed blockquote paste content

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -381,6 +381,48 @@ function parseHtmlInlineContent(
   );
 }
 
+function isHtmlStructuredBlockElement(element: HTMLElement): boolean {
+  const tagName = element.tagName.toLowerCase();
+  return (
+    isHtmlListElement(element) ||
+    tagName === "blockquote" ||
+    tagName === "pre" ||
+    tagName === "p" ||
+    tagName === "div" ||
+    tagName === "section" ||
+    tagName === "article" ||
+    tagName === "main" ||
+    tagName === "header" ||
+    tagName === "footer" ||
+    /^h[1-6]$/.test(tagName)
+  );
+}
+
+function hasDirectHtmlStructuredBlockChild(element: HTMLElement): boolean {
+  return Array.from(element.children).some(
+    (child) => child instanceof HTMLElement && isHtmlStructuredBlockElement(child),
+  );
+}
+
+function htmlInlineContentHasText(nodes: Node[]): boolean {
+  return nodes.some((node) => (node.textContent ?? "").trim().length > 0);
+}
+
+function parseHtmlParagraphContent(element: HTMLElement): JSONContent | undefined {
+  const content = Array.from(element.childNodes).flatMap((child) =>
+    child instanceof HTMLElement && isHtmlStructuredBlockElement(child)
+      ? []
+      : parseHtmlInlineContent(child),
+  );
+  if (content.length === 0) {
+    return undefined;
+  }
+  return {
+    type: "paragraph",
+    content,
+  };
+}
+
 function parseHtmlListItemContent(listItem: HTMLElement): JSONContent[] {
   const inlineNodes = Array.from(listItem.childNodes).flatMap((child) =>
     child instanceof HTMLElement && isHtmlListElement(child)
@@ -437,6 +479,82 @@ function parseHtmlListElement(listElement: HTMLElement): JSONContent | undefined
   };
 }
 
+function parseHtmlStructuredBlockElement(element: HTMLElement): JSONContent[] {
+  const tagName = element.tagName.toLowerCase();
+
+  if (isHtmlListElement(element)) {
+    const list = parseHtmlListElement(element);
+    return list ? [list] : [];
+  }
+
+  if (tagName === "blockquote") {
+    return parseHtmlStructuredContent(element.childNodes);
+  }
+
+  if (/^h[1-6]$/.test(tagName)) {
+    const level = Number.parseInt(tagName.slice(1), 10);
+    const content = Array.from(element.childNodes).flatMap((child) =>
+      parseHtmlInlineContent(child),
+    );
+    return [
+      {
+        type: "heading",
+        attrs: { level: Number.isFinite(level) ? level : 1 },
+        content: content.length > 0 ? content : undefined,
+      },
+    ];
+  }
+
+  if (tagName === "pre") {
+    const text = (element.textContent ?? "").replace(/\n$/, "");
+    return [
+      {
+        type: "codeBlock",
+        content: text ? [{ type: "text", text }] : undefined,
+      },
+    ];
+  }
+
+  if (tagName === "p" || !hasDirectHtmlStructuredBlockChild(element)) {
+    const paragraph = parseHtmlParagraphContent(element);
+    return paragraph ? [paragraph] : [];
+  }
+
+  return parseHtmlStructuredContent(element.childNodes);
+}
+
+function parseHtmlStructuredContent(nodes: Iterable<Node>): JSONContent[] {
+  const content: JSONContent[] = [];
+  let inlineNodes: Node[] = [];
+
+  const flushInlineNodes = (): void => {
+    if (!htmlInlineContentHasText(inlineNodes)) {
+      inlineNodes = [];
+      return;
+    }
+    const inlineContent = inlineNodes.flatMap((node) => parseHtmlInlineContent(node));
+    if (inlineContent.length > 0) {
+      content.push({
+        type: "paragraph",
+        content: inlineContent,
+      });
+    }
+    inlineNodes = [];
+  };
+
+  Array.from(nodes).forEach((node) => {
+    if (node instanceof HTMLElement && isHtmlStructuredBlockElement(node)) {
+      flushInlineNodes();
+      content.push(...parseHtmlStructuredBlockElement(node));
+      return;
+    }
+    inlineNodes.push(node);
+  });
+
+  flushInlineNodes();
+  return content;
+}
+
 function parseClipboardHtmlStructuredContent(
   event: ClipboardEvent<HTMLDivElement>,
 ): JSONContent[] {
@@ -446,11 +564,7 @@ function parseClipboardHtmlStructuredContent(
   }
 
   const doc = new DOMParser().parseFromString(html, "text/html");
-  return Array.from(doc.body.querySelectorAll("ul, ol"))
-    .filter((child): child is HTMLElement => child instanceof HTMLElement)
-    .filter((child) => !child.parentElement?.closest("li"))
-    .map(parseHtmlListElement)
-    .filter((child): child is JSONContent => child !== undefined);
+  return parseHtmlStructuredContent(doc.body.childNodes);
 }
 
 function buildTiptapContent(

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -398,6 +398,23 @@ function isHtmlStructuredBlockElement(element: HTMLElement): boolean {
   );
 }
 
+function hasUnsupportedHtmlStructuredBlocks(element: HTMLElement): boolean {
+  return element.querySelector(
+    [
+      "table",
+      "thead",
+      "tbody",
+      "tfoot",
+      "tr",
+      "th",
+      "td",
+      "dl",
+      "dt",
+      "dd",
+    ].join(","),
+  ) !== null;
+}
+
 function hasDirectHtmlStructuredBlockChild(element: HTMLElement): boolean {
   return Array.from(element.children).some(
     (child) => child instanceof HTMLElement && isHtmlStructuredBlockElement(child),
@@ -564,6 +581,9 @@ function parseClipboardHtmlStructuredContent(
   }
 
   const doc = new DOMParser().parseFromString(html, "text/html");
+  if (hasUnsupportedHtmlStructuredBlocks(doc.body)) {
+    return [];
+  }
   return parseHtmlStructuredContent(doc.body.childNodes);
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -475,6 +475,114 @@ describe("ComposerTiptapInput", () => {
     expect(nestedItem).toHaveTextContent("Nested task");
   });
 
+  it("preserves prose and rich lists pasted together inside a blockquote", async () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Source:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Source:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Source:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return [
+              "<p>I’ll retry discovery now that the thread setup changed, then call the PwrAgent management tool if it’s exposed.</p>",
+              "<p><strong>AssistantJun 18, 8:27 AM</strong></p>",
+              "<p>No separate lazy-loaded PwrAgent app tool appeared.</p>",
+              "<p><strong>AssistantJun 18, 8:28 AM</strong></p>",
+              "<p>Current PwrAgent status:</p>",
+              "<ul>",
+              "<li>No active goal is set for this thread.</li>",
+              "<li>No token budget is active.</li>",
+              "<li>No completion budget report is available.</li>",
+              "</ul>",
+              "<p>I also retried app-tool discovery.</p>",
+            ].join("");
+          }
+          if (type === "text/plain") {
+            return [
+              "I’ll retry discovery now that the thread setup changed, then call the PwrAgent management tool if it’s exposed.",
+              "",
+              "AssistantJun 18, 8:27 AM",
+              "",
+              "No separate lazy-loaded PwrAgent app tool appeared.",
+              "",
+              "AssistantJun 18, 8:28 AM",
+              "",
+              "Current PwrAgent status:",
+              "",
+              "No active goal is set for this thread.",
+              "No token budget is active.",
+              "No completion budget report is available.",
+              "",
+              "I also retried app-tool discovery.",
+            ].join("\n");
+          }
+          return "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        [
+          "> Source:",
+          "> ",
+          "> I’ll retry discovery now that the thread setup changed, then call the PwrAgent management tool if it’s exposed.",
+          "> ",
+          "> **AssistantJun 18, 8:27 AM**",
+          "> ",
+          "> No separate lazy-loaded PwrAgent app tool appeared.",
+          "> ",
+          "> **AssistantJun 18, 8:28 AM**",
+          "> ",
+          "> Current PwrAgent status:",
+          "> ",
+          "> - No active goal is set for this thread.",
+          "> - No token budget is active.",
+          "> - No completion budget report is available.",
+          "> ",
+          "> I also retried app-tool discovery.",
+        ].join("\n"),
+        [],
+        expect.any(Object),
+      );
+    });
+
+    expect(container.querySelectorAll("blockquote > p")).toHaveLength(7);
+    expect(container.querySelectorAll("blockquote ul > li")).toHaveLength(3);
+    expect(container.querySelector("blockquote strong")).toHaveTextContent(
+      "AssistantJun 18, 8:27 AM",
+    );
+  });
+
   it("preserves paragraph separators when pasting a handoff prefix without a code block", async () => {
     const { onChange } = renderTiptapInput();
     const textbox = await screen.findByRole("textbox", { name: "Reply" });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -583,6 +583,62 @@ describe("ComposerTiptapInput", () => {
     );
   });
 
+  it("falls back to plain text for unsupported rich blocks pasted inside a blockquote", async () => {
+    const onChange = vi.fn();
+    render(
+      <ComposerTiptapInput
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "blockquote",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Table:" }],
+                },
+              ],
+            },
+          ],
+        }}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="> Table:"
+      />,
+    );
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    setComposerSelection(textbox, "Table:".length);
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => {
+          if (type === "text/html") {
+            return "<table><tr><td>A</td><td>B</td></tr></table>";
+          }
+          if (type === "text/plain") {
+            return "A\tB";
+          }
+          return "";
+        },
+        items: [],
+        types: ["text/html", "text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenLastCalledWith(
+        "> Table:A\tB",
+        [],
+        expect.any(Object),
+      );
+    });
+  });
+
   it("preserves paragraph separators when pasting a handoff prefix without a code block", async () => {
     const { onChange } = renderTiptapInput();
     const textbox = await screen.findByRole("textbox", { name: "Reply" });


### PR DESCRIPTION
## Summary

- I fixed blockquote pastes from rich HTML so mixed prose, bold transcript labels, and lists all survive instead of only the list items being inserted.
- The composer now walks structured clipboard blocks in order when pasting inside an existing blockquote, preserving paragraphs, headings, code blocks, lists, and inline marks.
- I added a regression test based on the reported PwrAgent transcript fragment so this path keeps full blockquote formatting going forward.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`

## Notes

- This branch is a single signed checkpoint commit: `c00704e59 fix(desktop): preserve mixed blockquote paste content`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
