### PR TITLE
fix(desktop): avoid unnecessary keychain prompts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1588,6 +1588,32 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("does not resolve the Grok API key while AgentCore-Grok is disabled", async () => {
+    const previous = process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+    process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "0";
+    const resolveGrokApiKey = vi.fn(() => "xai-stored-key");
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      resolveGrokApiKey,
+      threadTitleGenerationService: null,
+    });
+
+    try {
+      const response = await registry.listBackends({ includeUnavailable: true });
+
+      expect(resolveGrokApiKey).not.toHaveBeenCalled();
+      expect(response.backends.map((backend) => backend.kind)).not.toContain("grok");
+    } finally {
+      await registry.close();
+      if (previous === undefined) {
+        delete process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+      } else {
+        process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = previous;
+      }
+    }
+  });
+
   it("returns ACP provider commands from session metadata", async () => {
     const session: AcpSessionMetadata = {
       backendId: "acp:kimi",

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1218,6 +1218,41 @@ describe("DesktopSettingsService", () => {
     expect(getSecretSync).not.toHaveBeenCalled();
   });
 
+  it("surfaces secret access errors on settings snapshots", async () => {
+    const secretStore: DesktopSecretStore = {
+      describe: () => ({
+        available: true,
+        backend: "safeStorage",
+        encrypted: true,
+      }),
+      getSecretAccessError: vi.fn(
+        (name) =>
+          name === "telegramBotToken"
+            ? "PwrAgent could not unlock secret storage."
+            : undefined,
+      ),
+      hasSecret: vi.fn(async () => false),
+      getSecret: vi.fn(),
+      getSecretSync: vi.fn(),
+      setSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+    };
+    const service = new DesktopSettingsService({
+      configPath: path.join(createTempRoot(), "config.toml"),
+      env: {},
+      secretStore,
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.messaging.telegram.botToken).toMatchObject({
+      configured: false,
+      source: "unset",
+      writable: true,
+      unavailableReason: "PwrAgent could not unlock secret storage.",
+    });
+  });
+
   it("writes non-secret patches without writing plaintext secrets to TOML", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopSettingsService } from "../settings/desktop-settings-service";
-import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
+import {
+  MemoryDesktopSecretStore,
+  type DesktopSecretStore,
+} from "../settings/desktop-secret-store";
 import { readBootstrapAppearance } from "../settings/appearance-bootstrap";
 
 const tempRoots: string[] = [];
@@ -1175,6 +1178,44 @@ describe("DesktopSettingsService", () => {
     expect(await service.resolveGrokApiKey()).toBe("xai-keychain");
     expect(service.resolveCodexCommandPreference()).toBe("codex-env");
     expect(service.resolveGhCommandPreference()).toBe("/custom/bin/gh");
+  });
+
+  it("reads secret metadata without decrypting stored values", async () => {
+    const getSecret = vi.fn(async () => {
+      throw new Error("secret values should not be decrypted for settings snapshots");
+    });
+    const getSecretSync = vi.fn(() => {
+      throw new Error("secret values should not be decrypted for settings snapshots");
+    });
+    const hasSecret = vi.fn(async (name) => name === "grokApiKey");
+    const secretStore: DesktopSecretStore = {
+      describe: () => ({
+        available: true,
+        backend: "safeStorage",
+        encrypted: true,
+      }),
+      hasSecret,
+      getSecret,
+      getSecretSync,
+      setSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+    };
+    const service = new DesktopSettingsService({
+      configPath: path.join(createTempRoot(), "config.toml"),
+      env: {},
+      secretStore,
+    });
+
+    const snapshot = await service.readSettings();
+
+    expect(snapshot.models.grok.apiKey).toMatchObject({
+      configured: true,
+      source: "keychain",
+      writable: true,
+    });
+    expect(hasSecret).toHaveBeenCalledWith("grokApiKey");
+    expect(getSecret).not.toHaveBeenCalled();
+    expect(getSecretSync).not.toHaveBeenCalled();
   });
 
   it("writes non-secret patches without writing plaintext secrets to TOML", async () => {

--- a/apps/desktop/src/main/__tests__/secret-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/secret-store-sqlite.test.ts
@@ -25,13 +25,16 @@ describe("DbBackedSafeStorageSecretStore", () => {
     expect(await store.hasSecret("grokApiKey")).toBe(true);
     expect(store.getSecretSync("grokApiKey")).toBeUndefined();
     expect(await store.hasSecret("grokApiKey")).toBe(false);
+    expect(store.getSecretAccessError("grokApiKey")).toContain(
+      "could not unlock secret storage",
+    );
   });
 
-  it("clears the unusable marker after replacing the secret", async () => {
+  it("clears the secret access error after replacing the secret", async () => {
     let ciphertext: Buffer<ArrayBufferLike> = Buffer.from("old");
     const stateDb = {
       getSecret: vi.fn(() => ciphertext),
-      setSecret: vi.fn((_name: string, nextCiphertext: Buffer) => {
+      setSecret: vi.fn((_name: string, nextCiphertext: Buffer<ArrayBufferLike>) => {
         ciphertext = nextCiphertext;
       }),
       deleteSecret: vi.fn(),
@@ -55,5 +58,35 @@ describe("DbBackedSafeStorageSecretStore", () => {
     await store.setSecret("grokApiKey", "replacement");
 
     expect(await store.hasSecret("grokApiKey")).toBe(true);
+    expect(store.getSecretAccessError("grokApiKey")).toBeUndefined();
+  });
+
+  it("throws a clear error and does not write when encryption is denied", async () => {
+    const stateDb = {
+      getSecret: vi.fn(() => undefined),
+      setSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+    };
+    const safeStorage = {
+      encryptString: vi.fn(() => {
+        throw new Error("user denied keychain access");
+      }),
+      decryptString: vi.fn(),
+      isEncryptionAvailable: vi.fn(() => true),
+      getSelectedStorageBackend: vi.fn(() => "keychain"),
+    };
+    const store = new DbBackedSafeStorageSecretStore(
+      safeStorage,
+      stateDb as never,
+    );
+
+    await expect(store.setSecret("grokApiKey", "replacement")).rejects.toThrow(
+      "could not unlock secret storage",
+    );
+
+    expect(stateDb.setSecret).not.toHaveBeenCalled();
+    expect(store.getSecretAccessError("grokApiKey")).toContain(
+      "could not unlock secret storage",
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/secret-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/secret-store-sqlite.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { DbBackedSafeStorageSecretStore } from "../state/secret-store-sqlite";
+
+describe("DbBackedSafeStorageSecretStore", () => {
+  it("does not report a stored row as configured after decryption fails", async () => {
+    const ciphertext = Buffer.from("encrypted");
+    const stateDb = {
+      getSecret: vi.fn(() => ciphertext),
+      setSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+    };
+    const safeStorage = {
+      encryptString: vi.fn((value: string) => Buffer.from(value)),
+      decryptString: vi.fn(() => {
+        throw new Error("cannot decrypt");
+      }),
+      isEncryptionAvailable: vi.fn(() => true),
+      getSelectedStorageBackend: vi.fn(() => "keychain"),
+    };
+    const store = new DbBackedSafeStorageSecretStore(
+      safeStorage,
+      stateDb as never,
+    );
+
+    expect(await store.hasSecret("grokApiKey")).toBe(true);
+    expect(store.getSecretSync("grokApiKey")).toBeUndefined();
+    expect(await store.hasSecret("grokApiKey")).toBe(false);
+  });
+
+  it("clears the unusable marker after replacing the secret", async () => {
+    let ciphertext: Buffer<ArrayBufferLike> = Buffer.from("old");
+    const stateDb = {
+      getSecret: vi.fn(() => ciphertext),
+      setSecret: vi.fn((_name: string, nextCiphertext: Buffer) => {
+        ciphertext = nextCiphertext;
+      }),
+      deleteSecret: vi.fn(),
+    };
+    const safeStorage = {
+      encryptString: vi.fn((value: string) => Buffer.from(`enc:${value}`)),
+      decryptString: vi.fn(() => {
+        throw new Error("cannot decrypt");
+      }),
+      isEncryptionAvailable: vi.fn(() => true),
+      getSelectedStorageBackend: vi.fn(() => "keychain"),
+    };
+    const store = new DbBackedSafeStorageSecretStore(
+      safeStorage,
+      stateDb as never,
+    );
+
+    expect(store.getSecretSync("grokApiKey")).toBeUndefined();
+    expect(await store.hasSecret("grokApiKey")).toBe(false);
+
+    await store.setSecret("grokApiKey", "replacement");
+
+    expect(await store.hasSecret("grokApiKey")).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4288,6 +4288,7 @@ export class DesktopBackendRegistry {
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
     resolveCodexDefaultModeRequestUserInput?: () => boolean;
+    resolveGrokApiKey?: () => string | undefined;
     acpWorktreeRepositoryResolver?: (
       cwd: string,
     ) => Promise<LinkedDirectorySummary | undefined>;
@@ -4359,9 +4360,12 @@ export class DesktopBackendRegistry {
       createDefaultCodexEnvironmentHydrationStore();
     const codexHome = codexEnv?.CODEX_HOME?.trim() || undefined;
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
-    const grokApiKey = createsLiveGrokClient
-      ? resolveGrokApiKeyForLiveClient()
-      : undefined;
+    const resolveLiveGrokApiKey = (): string | undefined => {
+      if (!resolveAgentCoreGrokEnabled()) {
+        return undefined;
+      }
+      return (options?.resolveGrokApiKey ?? resolveGrokApiKeyForLiveClient)();
+    };
 
     const clientVersion =
       typeof app?.getVersion === "function" ? app.getVersion() : "0.0.0";
@@ -4395,7 +4399,7 @@ export class DesktopBackendRegistry {
       options?.grokClient ??
       replayClients?.grokClient ??
       new GrokAppServerClient({
-        apiKey: grokApiKey,
+        resolveApiKey: resolveLiveGrokApiKey,
         connectionObserver: grokObserver,
       });
     this.acpWorktreeRepositoryResolver =
@@ -4457,7 +4461,7 @@ export class DesktopBackendRegistry {
                     : undefined,
                   grok: createsLiveGrokClient
                     ? new GrokThreadTitleGenerator({
-                        apiKey: grokApiKey,
+                        resolveApiKey: resolveLiveGrokApiKey,
                       })
                     : undefined,
                 },

--- a/apps/desktop/src/main/app-server/ephemeral-object-call.ts
+++ b/apps/desktop/src/main/app-server/ephemeral-object-call.ts
@@ -34,6 +34,7 @@ export type XaiEphemeralObjectCallResult =
 
 export type XaiEphemeralObjectCallerOptions = {
   apiKey?: string;
+  resolveApiKey?: () => string | undefined;
   baseUrl?: string;
   client?: XaiObjectClientLike;
   model?: string;
@@ -42,6 +43,7 @@ export type XaiEphemeralObjectCallerOptions = {
 
 export class XaiEphemeralObjectCaller {
   private readonly configuredApiKey?: string;
+  private readonly resolveApiKey?: () => string | undefined;
   private readonly configuredBaseUrl?: string;
   private readonly configuredClient?: XaiObjectClientLike;
   private readonly configuredModel?: string;
@@ -51,6 +53,7 @@ export class XaiEphemeralObjectCaller {
 
   constructor(options: XaiEphemeralObjectCallerOptions = {}) {
     this.configuredApiKey = options.apiKey?.trim() || undefined;
+    this.resolveApiKey = options.resolveApiKey;
     this.configuredBaseUrl = options.baseUrl?.trim() || undefined;
     this.configuredClient = options.client;
     this.configuredModel = options.model?.trim() || undefined;
@@ -113,8 +116,12 @@ export class XaiEphemeralObjectCaller {
     }
 
     const runtimeConfig = this.getRuntimeConfig();
-    const apiKey = this.configuredApiKey;
+    const apiKey =
+      this.configuredApiKey || this.resolveApiKey?.()?.trim() || undefined;
     if (!apiKey) {
+      if (this.resolveApiKey) {
+        return null;
+      }
       this.envClient = null;
       return this.envClient;
     }

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -66,6 +66,7 @@ export type ThreadTitleGenerationServiceOptions = {
 
 export type GrokThreadTitleGeneratorOptions = {
   apiKey?: string;
+  resolveApiKey?: () => string | undefined;
   baseUrl?: string;
   client?: XaiObjectClientLike;
   model?: string;
@@ -141,6 +142,7 @@ export class GrokThreadTitleGenerator implements ThreadTitleGenerator {
     this.timeoutMs = options.timeoutMs;
     this.caller = new XaiEphemeralObjectCaller({
       apiKey: options.apiKey,
+      resolveApiKey: options.resolveApiKey,
       baseUrl: options.baseUrl,
       client: options.client,
       model: this.model,

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -66,6 +66,7 @@ type GrokServerLike = {
 
 type GrokClientOptions = {
   apiKey?: string;
+  resolveApiKey?: () => string | undefined;
   baseUrl?: string;
   connectionObserver?: JsonRpcObserver;
   model?: string;
@@ -1173,7 +1174,8 @@ export class GrokAppServerClient {
 
     loadLocalEnv({ override: false });
     const runtimeConfig = resolveGrokAppServerRuntimeConfig();
-    const apiKey = this.options.apiKey?.trim();
+    const apiKey =
+      this.options.apiKey?.trim() || this.options.resolveApiKey?.()?.trim();
     if (!apiKey) {
       throw new Error("grok app server unavailable: Grok API key is not set");
     }

--- a/apps/desktop/src/main/settings/desktop-secret-store.ts
+++ b/apps/desktop/src/main/settings/desktop-secret-store.ts
@@ -31,6 +31,7 @@ export function isSecretStorageDisabledByEnv(
 
 export interface DesktopSecretStore {
   describe(): DesktopSettingsSecretStorageState;
+  getSecretAccessError?(name: DesktopSettingsSecretName): string | undefined;
   hasSecret(name: DesktopSettingsSecretName): Promise<boolean>;
   getSecretSync?(name: DesktopSettingsSecretName): string | undefined;
   getSecret(name: DesktopSettingsSecretName): Promise<string | undefined>;
@@ -51,6 +52,10 @@ export class MemoryDesktopSecretStore implements DesktopSecretStore {
 
   describe(): DesktopSettingsSecretStorageState {
     return this.state;
+  }
+
+  getSecretAccessError(_name: DesktopSettingsSecretName): string | undefined {
+    return undefined;
   }
 
   async hasSecret(name: DesktopSettingsSecretName): Promise<boolean> {

--- a/apps/desktop/src/main/settings/desktop-secret-store.ts
+++ b/apps/desktop/src/main/settings/desktop-secret-store.ts
@@ -31,6 +31,7 @@ export function isSecretStorageDisabledByEnv(
 
 export interface DesktopSecretStore {
   describe(): DesktopSettingsSecretStorageState;
+  hasSecret(name: DesktopSettingsSecretName): Promise<boolean>;
   getSecretSync?(name: DesktopSettingsSecretName): string | undefined;
   getSecret(name: DesktopSettingsSecretName): Promise<string | undefined>;
   setSecret(name: DesktopSettingsSecretName, value: string): Promise<void>;
@@ -50,6 +51,10 @@ export class MemoryDesktopSecretStore implements DesktopSecretStore {
 
   describe(): DesktopSettingsSecretStorageState {
     return this.state;
+  }
+
+  async hasSecret(name: DesktopSettingsSecretName): Promise<boolean> {
+    return this.values.has(name);
   }
 
   getSecretSync(name: DesktopSettingsSecretName): string | undefined {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1916,10 +1916,10 @@ export class DesktopSettingsService {
     }
 
     try {
-      const value = await this.options.secretStore.getSecret(secret);
+      const configured = await this.options.secretStore.hasSecret(secret);
       return {
-        configured: Boolean(value),
-        source: value ? "keychain" : "unset",
+        configured,
+        source: configured ? "keychain" : "unset",
         writable: true,
       };
     } catch (error) {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1917,10 +1917,12 @@ export class DesktopSettingsService {
 
     try {
       const configured = await this.options.secretStore.hasSecret(secret);
+      const accessError = this.options.secretStore.getSecretAccessError?.(secret);
       return {
         configured,
         source: configured ? "keychain" : "unset",
         writable: true,
+        ...(accessError ? { unavailableReason: accessError } : {}),
       };
     } catch (error) {
       return {

--- a/apps/desktop/src/main/state/secret-store-sqlite.ts
+++ b/apps/desktop/src/main/state/secret-store-sqlite.ts
@@ -64,6 +64,10 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
     };
   }
 
+  async hasSecret(name: DesktopSettingsSecretName): Promise<boolean> {
+    return Boolean(this.stateDb.getSecret(name));
+  }
+
   getSecretSync(name: DesktopSettingsSecretName): string | undefined {
     const ciphertext = this.stateDb.getSecret(name);
     if (!ciphertext) return undefined;

--- a/apps/desktop/src/main/state/secret-store-sqlite.ts
+++ b/apps/desktop/src/main/state/secret-store-sqlite.ts
@@ -16,6 +16,8 @@ type SafeStorageLike = {
 };
 
 export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
+  private readonly unusableSecrets = new Set<DesktopSettingsSecretName>();
+
   constructor(
     private readonly safeStorage: SafeStorageLike,
     private readonly stateDb: StateDb,
@@ -65,18 +67,27 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
   }
 
   async hasSecret(name: DesktopSettingsSecretName): Promise<boolean> {
+    if (this.unusableSecrets.has(name)) {
+      return false;
+    }
     return Boolean(this.stateDb.getSecret(name));
   }
 
   getSecretSync(name: DesktopSettingsSecretName): string | undefined {
     const ciphertext = this.stateDb.getSecret(name);
-    if (!ciphertext) return undefined;
+    if (!ciphertext) {
+      this.unusableSecrets.delete(name);
+      return undefined;
+    }
     try {
-      return this.safeStorage.decryptString(ciphertext);
+      const value = this.safeStorage.decryptString(ciphertext);
+      this.unusableSecrets.delete(name);
+      return value;
     } catch {
       // Decryption fails when the ciphertext was encrypted under a different
       // signing identity (e.g. dev build vs signed release). Return undefined
       // so callers treat it as "secret not set" and prompt re-entry.
+      this.unusableSecrets.add(name);
       return undefined;
     }
   }
@@ -102,10 +113,12 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
     this.assertWritable();
     const ciphertext = this.safeStorage.encryptString(value);
     this.stateDb.setSecret(name, ciphertext);
+    this.unusableSecrets.delete(name);
   }
 
   async deleteSecret(name: DesktopSettingsSecretName): Promise<void> {
     this.stateDb.deleteSecret(name);
+    this.unusableSecrets.delete(name);
   }
 
   private assertWritable(): void {

--- a/apps/desktop/src/main/state/secret-store-sqlite.ts
+++ b/apps/desktop/src/main/state/secret-store-sqlite.ts
@@ -15,8 +15,14 @@ type SafeStorageLike = {
   getSelectedStorageBackend?: () => string;
 };
 
+const KEYCHAIN_ACCESS_ERROR =
+  "PwrAgent could not unlock secret storage. Choose Allow in the macOS Keychain prompt to read or save secrets.";
+
 export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
-  private readonly unusableSecrets = new Set<DesktopSettingsSecretName>();
+  private readonly secretAccessErrors = new Map<
+    DesktopSettingsSecretName,
+    string
+  >();
 
   constructor(
     private readonly safeStorage: SafeStorageLike,
@@ -66,8 +72,12 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
     };
   }
 
+  getSecretAccessError(name: DesktopSettingsSecretName): string | undefined {
+    return this.secretAccessErrors.get(name);
+  }
+
   async hasSecret(name: DesktopSettingsSecretName): Promise<boolean> {
-    if (this.unusableSecrets.has(name)) {
+    if (this.secretAccessErrors.has(name)) {
       return false;
     }
     return Boolean(this.stateDb.getSecret(name));
@@ -76,18 +86,18 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
   getSecretSync(name: DesktopSettingsSecretName): string | undefined {
     const ciphertext = this.stateDb.getSecret(name);
     if (!ciphertext) {
-      this.unusableSecrets.delete(name);
+      this.secretAccessErrors.delete(name);
       return undefined;
     }
     try {
       const value = this.safeStorage.decryptString(ciphertext);
-      this.unusableSecrets.delete(name);
+      this.secretAccessErrors.delete(name);
       return value;
     } catch {
       // Decryption fails when the ciphertext was encrypted under a different
       // signing identity (e.g. dev build vs signed release). Return undefined
       // so callers treat it as "secret not set" and prompt re-entry.
-      this.unusableSecrets.add(name);
+      this.secretAccessErrors.set(name, KEYCHAIN_ACCESS_ERROR);
       return undefined;
     }
   }
@@ -111,14 +121,20 @@ export class DbBackedSafeStorageSecretStore implements DesktopSecretStore {
       return;
     }
     this.assertWritable();
-    const ciphertext = this.safeStorage.encryptString(value);
+    let ciphertext: Buffer;
+    try {
+      ciphertext = this.safeStorage.encryptString(value);
+    } catch (error) {
+      this.secretAccessErrors.set(name, KEYCHAIN_ACCESS_ERROR);
+      throw new Error(KEYCHAIN_ACCESS_ERROR, { cause: error });
+    }
     this.stateDb.setSecret(name, ciphertext);
-    this.unusableSecrets.delete(name);
+    this.secretAccessErrors.delete(name);
   }
 
   async deleteSecret(name: DesktopSettingsSecretName): Promise<void> {
     this.stateDb.deleteSecret(name);
-    this.unusableSecrets.delete(name);
+    this.secretAccessErrors.delete(name);
   }
 
   private assertWritable(): void {

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -73,6 +73,14 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         return true;
       } catch (writeError) {
         setError(writeError instanceof Error ? writeError.message : String(writeError));
+        try {
+          const response = await desktopApi.readSettings?.({});
+          if (response) {
+            setSnapshot(response.snapshot);
+          }
+        } catch {
+          // Keep the original write error visible.
+        }
         return false;
       } finally {
         setSaving(false);


### PR DESCRIPTION
## Summary
PwrAgent no longer asks macOS Keychain for the “PwrAgent Safe Storage” item just because a stored Grok API key exists. Settings snapshots now report whether secrets are configured without decrypting them, and the direct AgentCore-Grok backend only resolves the xAI key after that experimental feature is enabled.

This keeps normal startup, shell environment hydration, and settings metadata reads from surfacing a scary password prompt. The Grok key is still decrypted when a feature that actually needs it runs.

## Tests
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
