### PR TITLE
fix(desktop): align sidebar masthead and lanes to a shared 8px inset

### DIFF
--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -180,6 +180,10 @@ describe("Tangerine Terminal theme contract", () => {
       "thinking-scanner-beam-width",
       "thinking-scanner-delay",
       "thinking-scanner-travel",
+      // Sidebar rail/lane inset system — defined on `.sidebar`, not `:root`.
+      "sidebar-rail-inset",
+      "sidebar-lane-inset",
+      "sidebar-masthead-pull",
     ]);
     const tokenReferences = [...css.matchAll(/var\(--([a-z0-9-]+)\)/g)].map(
       ([, token]) => token
@@ -887,6 +891,62 @@ describe("Tangerine Terminal theme contract", () => {
     }
     expect(css).not.toMatch(
       /\.(?:sidebar-list--dense|directory-groups)::-webkit-scrollbar/
+    );
+  });
+
+  it("aligns the sidebar masthead and lanes to one shared inset system", () => {
+    // Regression guard. The thread/directory lanes bleed to the rail walls
+    // and re-inset to `--sidebar-lane-inset`, while the masthead chrome
+    // (pills + lens switch) pulls out from the wider `--sidebar-rail-inset`
+    // to the same lane edge via the derived `--sidebar-masthead-pull`. The
+    // tabs/pills once sat at the rail inset while the cards sat narrower, so
+    // they read as misaligned; the Directories lane separately drifted to a
+    // 4px left gutter while the Recents lane was at 8px. Both classes of
+    // drift were silent because no test pinned the relationship — so pin it
+    // here by asserting every consumer reads the shared tokens, not a
+    // hand-tuned literal.
+    const sidebarBody = extractRuleBody(css, ".sidebar");
+    expect(sidebarBody).toMatch(/--sidebar-rail-inset:\s*16px;/);
+    expect(sidebarBody).toMatch(/--sidebar-lane-inset:\s*8px;/);
+    // The masthead pull is always derived from the two insets, never set
+    // by hand — that's what keeps the chrome glued to the lane edge.
+    expect(sidebarBody).toMatch(
+      /--sidebar-masthead-pull:\s*calc\(\s*var\(--sidebar-lane-inset\)\s*-\s*var\(--sidebar-rail-inset\)\s*\)/
+    );
+
+    // Both lanes inset to the same lane token (no recurrence of the
+    // 4px-left / 8px-left split between Directories and Recents). Each
+    // selector has more than one base rule (a layout rule plus the scroll
+    // rule), so collect every body and assert the inset lives in one of
+    // them — mirroring the scrollbar guard above.
+    for (const selector of [".sidebar-list--dense", ".directory-groups"]) {
+      const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const bodies = [
+        ...css.matchAll(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`, "g")),
+      ].map((match) => match[1]);
+      expect(
+        bodies.some((body) =>
+          /padding-inline:\s*var\(--sidebar-lane-inset\);/.test(body)
+        )
+      ).toBe(true);
+    }
+
+    // Both masthead rows pull out to the lane edge via the shared token.
+    for (const selector of [".runtime-identity", ".lens-switch"]) {
+      expect(extractRuleBody(css, selector)).toMatch(
+        /margin-inline:\s*var\(--sidebar-masthead-pull\)/
+      );
+    }
+    // The lens switch is an inline-grid that can't stretch, so it also
+    // grows its explicit width by twice the pull to reach both lane edges.
+    expect(extractRuleBody(css, ".lens-switch")).toMatch(
+      /width:\s*calc\(\s*100%\s*-\s*2\s*\*\s*var\(--sidebar-masthead-pull\)\s*\)/
+    );
+
+    // The scroll region cancels exactly the rail padding to bleed to the
+    // walls — kept in lockstep with the padding via the same token.
+    expect(extractRuleBody(css, ".sidebar__scroll-region")).toMatch(
+      /margin-inline:\s*calc\(\s*-1\s*\*\s*var\(--sidebar-rail-inset\)\s*\)/
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -802,7 +802,21 @@ textarea,
   flex-direction: column;
   height: 100%;
   min-height: 0;
-  padding: 0 16px;
+  /* Horizontal inset system for the rail — single source of truth.
+     `--sidebar-rail-inset` is the default chrome inset (the rail's side
+     padding, applied just below). The thread/directory lanes bleed past it
+     and re-inset to the narrower `--sidebar-lane-inset` (see
+     `.sidebar-list--dense`). Masthead rows (`.runtime-identity`,
+     `.lens-switch`) pull from rail to lane via the negative
+     `--sidebar-masthead-pull` margin, so the pills, tabs, and cards all
+     line up on both edges. Change an inset here once and every consumer
+     below follows. */
+  --sidebar-rail-inset: 16px;
+  --sidebar-lane-inset: 8px;
+  --sidebar-masthead-pull: calc(
+    var(--sidebar-lane-inset) - var(--sidebar-rail-inset)
+  );
+  padding: 0 var(--sidebar-rail-inset);
   overflow: hidden;
   background: var(--bg-sidebar);
   border-right: 1px solid var(--border-subtle);
@@ -2433,11 +2447,12 @@ textarea,
   align-items: center;
   gap: 6px;
   padding: 6px 0;
-  /* Pull out to the 8px lane inset (see `.sidebar-list--dense`) so the
-     pills and their divider line up with the thread/directory cards
-     below instead of sitting 8px narrower at the parent's 16px rail
-     padding. */
-  margin-inline: -8px;
+  /* Pull out to the lane inset so the pills and their divider line up with
+     the thread/directory cards below instead of sitting at the wider rail
+     inset. This is an auto-width flex row, so the negative margin simply
+     shrinks it onto the lane edges (cf. `.lens-switch`, which needs an
+     explicit width). See `--sidebar-masthead-pull` on `.sidebar`. */
+  margin-inline: var(--sidebar-masthead-pull);
   border-bottom: 1px solid var(--border-subtle);
   -webkit-app-region: no-drag;
 }
@@ -2516,16 +2531,16 @@ textarea,
   flex: 1;
   flex-direction: column;
   min-height: 0;
-  /* Cancel the sidebar's 16px side padding so the thread lanes span
+  /* Cancel the sidebar's rail padding so the thread lanes span
      wall-to-wall and the reserved scrollbar gutter parks the thumb at
      the right edge — out from under the lens-switch header, which keeps
      its inset as a sibling above. The bleed clips cleanly at the sidebar
      walls (`.sidebar` is `overflow: hidden`); the only intervening
      ancestor (`.sidebar__section--fill`) is `overflow: visible`, so the
-     -16px reaches the walls instead of being clipped early. Transient
-     empty / loading / error messages that render directly here (no lane
-     wrapper) are re-inset just below. */
-  margin-inline: -16px;
+     negative margin reaches the walls instead of being clipped early.
+     Transient empty / loading / error messages that render directly here
+     (no lane wrapper) are re-inset just below. */
+  margin-inline: calc(-1 * var(--sidebar-rail-inset));
   overflow: hidden;
 }
 
@@ -2536,7 +2551,7 @@ textarea,
    (a `.sidebar` child, not a region child) are untouched. */
 .sidebar__scroll-region > .sidebar-empty,
 .sidebar__scroll-region > .sidebar-error {
-  margin-inline: 16px;
+  margin-inline: var(--sidebar-rail-inset);
 }
 
 .context-panel h3 {
@@ -2570,13 +2585,15 @@ textarea,
 
 .lens-switch {
   display: inline-grid;
-  /* Span the 8px lane inset (see `.sidebar-list--dense`) so the segmented
-     control's edges line up with the thread/directory cards below. The
-     parent (`.sidebar__section--fill`) carries no horizontal padding, so it
-     sits at the sidebar's 16px rail padding; `calc(100% + 16px)` + the
-     symmetric -8px margin widens it 8px on each side down to the 8px inset. */
-  width: calc(100% + 16px);
-  margin-inline: -8px;
+  /* Pull out to the lane inset so the segmented control's edges line up
+     with the thread/directory cards below. Unlike `.runtime-identity` (an
+     auto-width flex row that just shrinks under the negative margin), this
+     is an inline-grid that won't stretch to fill its parent, so it needs an
+     explicit width: the negative `--sidebar-masthead-pull` margin on each
+     side, plus a width grown by twice that pull, lands both edges on the
+     lane inset. See `--sidebar-masthead-pull` on `.sidebar`. */
+  width: calc(100% - 2 * var(--sidebar-masthead-pull));
+  margin-inline: var(--sidebar-masthead-pull);
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 3px;
   padding: 3px;
@@ -2586,7 +2603,8 @@ textarea,
   /* Width-query container so the longest label ("Directories") can swap to
      a short form once the (resizable) sidebar narrows past the point where it
      would otherwise spill past the segmented control. The width is extrinsic
-     (`width: calc(100% + 16px)`), so inline-size containment is safe here. */
+     (set above from `--sidebar-masthead-pull`), so inline-size containment is
+     safe here. */
   container-type: inline-size;
 }
 
@@ -2750,8 +2768,10 @@ textarea,
      (2px @ 2px offset → 4px outside the row box) off the now-reachable
      left wall; 8px right holds row content — and the per-directory
      launchpad (+) button on directory headers — clear of the thumb in
-     the reserved gutter. */
-  padding-inline: 8px;
+     the reserved gutter. This `8px` is the canonical lane inset; the
+     `--sidebar-lane-inset` token on `.sidebar` carries the value so the
+     masthead chrome can line up with it. */
+  padding-inline: var(--sidebar-lane-inset);
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   /* Reserve a stable gutter so the thin auto-hiding scrollbar never
@@ -2776,9 +2796,9 @@ textarea,
   overflow-y: auto;
   padding-top: 0;
   /* Mirrors `.sidebar-list--dense` — see that block for the gutter
-     rationale (8px left keeps the focus-visible outline off the wall;
-     8px right clears the reserved scrollbar thumb). */
-  padding-inline: 8px;
+     rationale (lane inset keeps the focus-visible outline off the wall on
+     the left and clears the reserved scrollbar thumb on the right). */
+  padding-inline: var(--sidebar-lane-inset);
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   scrollbar-gutter: stable;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2433,6 +2433,11 @@ textarea,
   align-items: center;
   gap: 6px;
   padding: 6px 0;
+  /* Pull out to the 8px lane inset (see `.sidebar-list--dense`) so the
+     pills and their divider line up with the thread/directory cards
+     below instead of sitting 8px narrower at the parent's 16px rail
+     padding. */
+  margin-inline: -8px;
   border-bottom: 1px solid var(--border-subtle);
   -webkit-app-region: no-drag;
 }
@@ -2565,7 +2570,13 @@ textarea,
 
 .lens-switch {
   display: inline-grid;
-  width: 100%;
+  /* Span the 8px lane inset (see `.sidebar-list--dense`) so the segmented
+     control's edges line up with the thread/directory cards below. The
+     parent (`.sidebar__section--fill`) carries no horizontal padding, so it
+     sits at the sidebar's 16px rail padding; `calc(100% + 16px)` + the
+     symmetric -8px margin widens it 8px on each side down to the 8px inset. */
+  width: calc(100% + 16px);
+  margin-inline: -8px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 3px;
   padding: 3px;
@@ -2575,7 +2586,7 @@ textarea,
   /* Width-query container so the longest label ("Directories") can swap to
      a short form once the (resizable) sidebar narrows past the point where it
      would otherwise spill past the segmented control. The width is extrinsic
-     (`width: 100%`), so inline-size containment is safe here. */
+     (`width: calc(100% + 16px)`), so inline-size containment is safe here. */
   container-type: inline-size;
 }
 
@@ -2764,9 +2775,10 @@ textarea,
   min-height: 0;
   overflow-y: auto;
   padding-top: 0;
-  /* Mirrors `.sidebar-list--dense` — see that block for the asymmetric
-     gutter rationale (4px left / 8px right for scrollbar clearance). */
-  padding-inline: 4px 8px;
+  /* Mirrors `.sidebar-list--dense` — see that block for the gutter
+     rationale (8px left keeps the focus-visible outline off the wall;
+     8px right clears the reserved scrollbar thumb). */
+  padding-inline: 8px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
   scrollbar-gutter: stable;


### PR DESCRIPTION
## What

Aligns the left sidebar's masthead (the directory/branch and profile pills, plus the Updated/Created/Directories lens-switch tabs) with the thread and directory lanes below them. Everything from the runtime-identity pills down now sits at a single **8px** rail inset and lines up on both edges.

## Why

The gutter-reclaim pass (#780) deliberately pulled the thread/directory **lanes** out to a narrow inset so they span nearly wall-to-wall and reclaim the scrollbar gutter — but it left the masthead pills and the lens-switch tabs at the sidebar's original **16px** rail padding (`.sidebar { padding: 0 16px }`). The result: the tabs and pills read as visibly narrower than the cards beneath them.

There was also a second, smaller drift between the two lane modes themselves: the Directories lane (`.directory-groups`) was at `4px` on the left while the Recents lane (`.sidebar-list--dense`) had already moved to `8px`. Its comment claimed to "mirror" the dense lane but no longer did.

## Changes

All in `apps/desktop/src/renderer/src/styles/app.css`:

- `.runtime-identity` — `margin-inline: -8px` so both pill rows (and their divider) pull from 16px out to the 8px lane inset.
- `.lens-switch` — `width: calc(100% + 16px)` + `margin-inline: -8px` so the segmented control spans to 8px on both sides (the parent carries no horizontal padding, so it inherited the 16px rail).
- `.directory-groups` — `padding-inline: 4px 8px` → `8px`, unifying the Directories lane with the Recents lane and correcting the now-accurate "mirrors" comment.

8px is the value the dense-lane rationale documents as the focus-outline-safe minimum (a 2px focus ring at 2px offset clears the wall); 4px let the outline touch it.

## Notes for reviewer

- The **brand/titlebar row** ("PwrAgent" + window controls) is intentionally left at 16px — it reads as a distinct titlebar zone aligned to the macOS traffic-light spacing. Easy to drop to 8px too if we want a fully flush left rail.
- `box-sizing: border-box` is global, which the `.lens-switch` `calc(100% + 16px)` width relies on.
- `theme-contract.test.tsx` (which guards the sidebar lanes) passes — 42/42.

## Test plan

- [x] `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` — 42 passing
- [ ] Visual check: open the desktop app, confirm pills/tabs/cards line up on left and right edges across all three lenses (Updated, Created, Directories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)