### PR TITLE
fix(desktop): clear stale Codex Fast launchpad defaults

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -110,24 +110,45 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
     stateDb.raw
       .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
       .run("fastMode", JSON.stringify(false));
+    stateDb.raw
+      .prepare("INSERT OR REPLACE INTO launchpad_defaults(key, value) VALUES (?, ?)")
+      .run(
+        "providerSettings",
+        JSON.stringify({
+          codex: {
+            executionMode: "default",
+            serviceTier: "priority",
+            fastMode: false,
+          },
+        }),
+      );
 
     const readDefaults = await store.getLaunchpadDefaults();
-    expect(readDefaults.fastMode).toBe(false);
+    expect(readDefaults.fastMode).toBeUndefined();
     expect(readDefaults.serviceTier).toBeUndefined();
-    expect(listDefaultKeys()).toEqual(["backend", "executionMode", "fastMode"]);
+    expect(readDefaults.providerSettings?.codex?.fastMode).toBeUndefined();
+    expect(readDefaults.providerSettings?.codex?.serviceTier).toBeUndefined();
+    expect(listDefaultKeys()).toEqual([
+      "backend",
+      "executionMode",
+      "providerSettings",
+    ]);
+    expect(readDefaultValue("providerSettings")).toEqual({
+      codex: {
+        executionMode: "default",
+      },
+    });
 
     await store.setLaunchpadDefaults({ fastMode: false, serviceTier: undefined });
 
     expect(listDefaultKeys()).toEqual([
       "backend",
       "executionMode",
-      "fastMode",
       "providerSettings",
     ]);
     expect(readDefaultValue("providerSettings")).toEqual({
       codex: {
         executionMode: "default",
-        fastMode: false,
       },
     });
   });
@@ -152,10 +173,12 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
     });
 
     expect(defaults.serviceTier).toBeUndefined();
+    expect(defaults.fastMode).toBeUndefined();
     expect(defaults).toMatchObject({
       futureExperimentalFlag: { enabled: true },
     });
     expect(readDefaultValue("serviceTier")).toBeUndefined();
+    expect(readDefaultValue("fastMode")).toBeUndefined();
     expect(readDefaultValue("futureExperimentalFlag")).toEqual({ enabled: true });
   });
 });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -179,11 +179,44 @@ function normalizeLaunchpadDefaults(
 ): NavigationLaunchpadDefaults {
   const next: NavigationLaunchpadDefaults =
     projectNavigationLaunchpadProviderSettings(defaults);
+  const providerSettings = next.providerSettings
+    ? { ...next.providerSettings }
+    : undefined;
+  const codexProviderSettings = providerSettings?.codex
+    ? { ...providerSettings.codex }
+    : undefined;
+
+  if (codexProviderSettings) {
+    if (
+      codexProviderSettings.serviceTier === "fast" ||
+      codexProviderSettings.serviceTier === "priority"
+    ) {
+      delete codexProviderSettings.serviceTier;
+    }
+    if (codexProviderSettings.fastMode === false) {
+      delete codexProviderSettings.fastMode;
+    }
+    if (Object.keys(codexProviderSettings).length > 0) {
+      providerSettings!.codex = codexProviderSettings;
+    } else {
+      delete providerSettings!.codex;
+    }
+  }
+
+  if (providerSettings && Object.keys(providerSettings).length > 0) {
+    next.providerSettings = providerSettings;
+  } else {
+    delete next.providerSettings;
+  }
+
   if (
     next.backend === "codex" &&
     (next.serviceTier === "fast" || next.serviceTier === "priority")
   ) {
     delete next.serviceTier;
+  }
+  if (next.backend === "codex" && next.fastMode === false) {
+    delete next.fastMode;
   }
   return next;
 }
@@ -1830,10 +1863,7 @@ export class SqliteOverlayStore {
         : { backend: "codex", executionMode: "default" }
     ) as NavigationLaunchpadDefaults;
     const normalized = normalizeLaunchpadDefaults(parsed);
-    if (
-      parsed.backend === "codex" &&
-      (parsed.serviceTier === "fast" || parsed.serviceTier === "priority")
-    ) {
+    if (JSON.stringify(parsed) !== JSON.stringify(normalized)) {
       this.writeLaunchpadDefaults(normalized);
     }
     return normalized;


### PR DESCRIPTION
## Summary
Codex Fast mode can now be toggled reliably from pre-thread launchpads even when an older profile persisted Fast as an explicit `false` value. The launcher normalizes stale Codex `serviceTier` aliases and `fastMode: false` defaults to absence, including nested provider defaults, so old state no longer pins new-thread composers to Fast off.

The sqlite defaults reader also rewrites normalized defaults back to disk whenever it repairs stale shape, so affected profiles clean themselves up on read.

## Test Plan
- `pnpm test apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
