### PR TITLE
fix(desktop): limit context replay estimates to live turns

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -78,6 +78,7 @@ const CONTEXT_TABS: ContextTab[] = [
 ];
 
 type ThreadContextPanelProps = {
+  activeTurnId?: string;
   backendError?: string;
   backends: BackendSummary[];
   desktopApi?: DesktopApi;
@@ -664,6 +665,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       case "pricing":
         return (
           <PricingPanel
+            activeTurnId={props.activeTurnId}
             pricing={props.pricing}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2591,6 +2591,7 @@ export function ThreadView(props: ThreadViewProps) {
         </div>
 
         <ThreadContextPanel
+          activeTurnId={props.activeTurnId}
           activeTab={activeContextTab}
           backendError={props.backendError}
           backends={props.backends}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -108,6 +108,7 @@ type PanelOverrides = Partial<
   Pick<
     ComponentProps<typeof ThreadContextPanel>,
     | "activeTab"
+    | "activeTurnId"
     | "backends"
     | "desktopApi"
     | "pinned"
@@ -887,6 +888,7 @@ describe("ThreadContextPanel", () => {
 
     renderPanel({
       activeTab: "pricing",
+      activeTurnId: "turn-context-replays",
       pinned: true,
       pricing: {
         lines: [line],
@@ -925,6 +927,106 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides context replay estimates for inactive persisted pricing rows", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-inactive-context-replays",
+      threadId: "thread-1",
+      turnId: "turn-inactive-context-replays",
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      model: "gpt-5.5",
+      inputTokens: 550_000,
+      uncachedInputTokens: 100_000,
+      cachedInputTokens: 450_000,
+      outputTokens: 2_000,
+      reasoningOutputTokens: 500,
+      totalTokens: 552_500,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 500_000,
+      cachedInputCostMicros: 225_000,
+      outputCostMicros: 75_000,
+      totalCostMicros: 800_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.queryByText(/Estimated cold context replays/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Estimated hot context replays/)).not.toBeInTheDocument();
+  });
+
+  it("does not add later uncached tail tokens to a cumulative live cold replay estimate", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-cumulative-live-context-replays",
+      threadId: "thread-1",
+      turnId: "turn-cumulative-live-context-replays",
+      scope: "turn",
+      source: "live",
+      status: "pending",
+      model: "gpt-5.5",
+      inputTokens: 2_014_925,
+      uncachedInputTokens: 205_261,
+      cachedInputTokens: 1_809_664,
+      outputTokens: 2_454,
+      reasoningOutputTokens: 417,
+      totalTokens: 2_017_796,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeInputTokens: 7_633_951,
+      cumulativeCachedInputTokens: 7_219_456,
+      cumulativeUncachedInputTokens: 414_495,
+      cumulativeOutputTokens: 9_000,
+      cumulativeReasoningOutputTokens: 1_200,
+      cumulativeTotalTokens: 7_644_151,
+      uncachedInputCostMicros: 2_570_000,
+      cachedInputCostMicros: 905_000,
+      outputCostMicros: 100_000,
+      totalCostMicros: 3_575_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      activeTurnId: "turn-cumulative-live-context-replays",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 1 (201,074 uncached · $2.52)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 9 (~201,074 cached avg; 1,809,664 cached bucket · $0.91)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Estimated cold context replays: 1 (205,261 uncached · $2.57)",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("splits replay estimates that exceed a plausible context window size", () => {
     const line: ThreadUsageLineRecord = {
       backend: "codex",
@@ -953,6 +1055,7 @@ describe("ThreadContextPanel", () => {
 
     renderPanel({
       activeTab: "pricing",
+      activeTurnId: "turn-large-context-replays",
       pinned: true,
       pricing: {
         lines: [line],
@@ -1001,6 +1104,7 @@ describe("ThreadContextPanel", () => {
 
     const { rerender } = renderPanel({
       activeTab: "pricing",
+      activeTurnId: "turn-replay-display-options",
       pinned: true,
       pricing: {
         lines: [line],
@@ -1028,6 +1132,7 @@ describe("ThreadContextPanel", () => {
 
     rerender(
       <ThreadContextPanel
+        activeTurnId="turn-replay-display-options"
         activeTab="pricing"
         backends={[baseBackend]}
         onActiveTabChange={() => {}}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -11,6 +11,7 @@ import { formatTimestamp } from "./context-rail-shared";
 import { formatTokenCount } from "./subagent-format";
 
 type PricingPanelProps = {
+  activeTurnId?: string;
   displayOptions?: PricingDisplayOptions;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   pricing?: {
@@ -133,6 +134,7 @@ export function PricingPanel(props: PricingPanelProps) {
               lineTotals,
             });
             const contextReplayLines = formatContextReplayEstimate({
+              activeTurnId: props.activeTurnId,
               displayOptions,
               line,
             });
@@ -629,20 +631,33 @@ function formatUsageLineRunningTotal(params: {
 }
 
 function formatContextReplayEstimate(params: {
+  activeTurnId?: string;
   displayOptions: PricingDisplayOptions;
   line: PricingUsageLine;
 }): string[] {
-  if (isEstimatedUsageGap(params.line) || isHistoricalUsageSummary(params.line)) {
+  if (
+    !isActiveLiveTurnUsageLine({
+      activeTurnId: params.activeTurnId,
+      line: params.line,
+    }) ||
+    isEstimatedUsageGap(params.line) ||
+    isHistoricalUsageSummary(params.line)
+  ) {
     return [];
   }
 
-  const coldContextReplays = estimateContextReplayBucket(
+  const unboundedColdContextReplays = estimateContextReplayBucket(
     params.line.uncachedInputTokens,
   );
   const hotContextReplays = estimateContextReplayBucket(
     params.line.cachedInputTokens,
-    coldContextReplays?.averageTokens,
+    unboundedColdContextReplays?.averageTokens,
   );
+  const coldContextReplays = refineColdContextReplayBucket({
+    bucket: unboundedColdContextReplays,
+    hotBucket: hotContextReplays,
+    line: params.line,
+  });
   const lines: string[] = [];
   if (coldContextReplays) {
     lines.push(
@@ -694,6 +709,53 @@ function estimateContextReplayBucket(
   };
 }
 
+function refineColdContextReplayBucket(params: {
+  bucket: EstimatedContextReplayBucket | undefined;
+  hotBucket: EstimatedContextReplayBucket | undefined;
+  line: PricingUsageLine;
+}): EstimatedContextReplayBucket | undefined {
+  if (!params.bucket) {
+    return undefined;
+  }
+  if (
+    !isCumulativeLiveTurnUsageLine(params.line) ||
+    !params.hotBucket ||
+    params.bucket.count !== 1
+  ) {
+    return params.bucket;
+  }
+
+  const replayTokens = Math.min(
+    params.bucket.totalTokens,
+    params.hotBucket.averageTokens,
+  );
+  return {
+    averageTokens: replayTokens,
+    count: 1,
+    totalTokens: replayTokens,
+  };
+}
+
+function isCumulativeLiveTurnUsageLine(line: PricingUsageLine): boolean {
+  return (
+    line.scope === "turn" &&
+    line.source === "live" &&
+    hasCumulativeTokenBreakdown(line)
+  );
+}
+
+function isActiveLiveTurnUsageLine(params: {
+  activeTurnId?: string;
+  line: PricingUsageLine;
+}): boolean {
+  return (
+    params.line.scope === "turn" &&
+    params.line.source === "live" &&
+    Boolean(params.activeTurnId) &&
+    params.line.turnId === params.activeTurnId
+  );
+}
+
 function formatContextReplayBucketLine(params: {
   bucket: EstimatedContextReplayBucket;
   displayOptions: PricingDisplayOptions;
@@ -720,10 +782,7 @@ function formatReplayCostEstimates(params: {
 }): string {
   const estimates: string[] = [];
   if (params.displayOptions.usd) {
-    const valueMicros =
-      params.tokenKind === "cached"
-        ? params.line.cachedInputCostMicros
-        : params.line.uncachedInputCostMicros;
+    const valueMicros = estimateReplayCostMicros(params);
     if (valueMicros > 0) {
       estimates.push(formatMoney(valueMicros, params.line.currency));
     }
@@ -742,6 +801,25 @@ function formatReplayCostEstimates(params: {
     return "";
   }
   return ` · ${estimates.join(" · ")}`;
+}
+
+function estimateReplayCostMicros(params: {
+  bucket: EstimatedContextReplayBucket;
+  line: PricingUsageLine;
+  tokenKind: "cached" | "uncached";
+}): number {
+  const totalTokens =
+    params.tokenKind === "cached"
+      ? params.line.cachedInputTokens
+      : params.line.uncachedInputTokens;
+  const totalMicros =
+    params.tokenKind === "cached"
+      ? params.line.cachedInputCostMicros
+      : params.line.uncachedInputCostMicros;
+  if (totalTokens <= 0 || params.bucket.totalTokens >= totalTokens) {
+    return totalMicros;
+  }
+  return Math.round((totalMicros * params.bucket.totalTokens) / totalTokens);
 }
 
 function estimateContextReplayCodexCredits(params: {


### PR DESCRIPTION
## Summary
Context replay estimates in the Pricing rail now stay live-only, so persisted pricing rows no longer show stale or degraded replay guesses after the turn ends or the app restarts.

While a turn is active, cumulative live rows also stop folding later uncached tail tokens into the cold replay bucket. The estimate uses the inferred replay-sized window from cached context replays and prorates the displayed cost when that bucket is smaller than the full uncached total.

## Tests
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
