### PR TITLE
feat(federation): remote-window UX guardrails + encrypted-transport & messaging plans

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/RemoteWindowBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RemoteWindowBadge.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import type { ReactElement } from "react";
+import type { FederationConnectionState } from "@pwragent/shared";
+import { useDesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+
+// A remote window targets another PwrAgent instance over federation. The
+// federation target injected into the window carries only an instanceId, so we
+// poll federation health to resolve the peer's human label and live connection
+// state. Health is snapshot-on-read with no push channel, so a light poll is
+// the pragmatic way to keep the badge fresh.
+const POLL_INTERVAL_MS = 8000;
+
+type RemotePeerState = {
+  label: string;
+  status: FederationConnectionState;
+};
+
+function dotModifier(
+  status: FederationConnectionState,
+): "connected" | "pending" | "down" {
+  switch (status) {
+    case "connected":
+      return "connected";
+    case "connecting":
+    case "handshaking":
+    case "listening":
+    case "degraded":
+      return "pending";
+    default:
+      return "down";
+  }
+}
+
+function statusLabel(status: FederationConnectionState): string {
+  switch (status) {
+    case "connected":
+      return "Connected";
+    case "connecting":
+    case "handshaking":
+      return "Connecting";
+    case "degraded":
+      return "Degraded";
+    case "listening":
+      return "Listening";
+    case "rejected":
+      return "Rejected";
+    case "revoked":
+      return "Revoked";
+    default:
+      return "Offline";
+  }
+}
+
+export function RemoteWindowBadge(): ReactElement | null {
+  const desktopApi = useDesktopApi();
+  const target = readRendererFederationTarget();
+  const instanceId = target?.instanceId;
+  const [peer, setPeer] = useState<RemotePeerState | undefined>(undefined);
+
+  useEffect(() => {
+    if (!instanceId) {
+      setPeer(undefined);
+      return;
+    }
+    const shortId = instanceId.slice(0, 8);
+    const read = desktopApi?.readFederationHealth;
+    let cancelled = false;
+
+    async function poll(): Promise<void> {
+      if (!read) {
+        if (!cancelled) setPeer({ label: shortId, status: "disconnected" });
+        return;
+      }
+      try {
+        const { health } = await read();
+        if (cancelled) return;
+        const match = health.peers.find(
+          (candidate) => candidate.id === instanceId,
+        );
+        setPeer(
+          match
+            ? { label: match.label || shortId, status: match.status }
+            : { label: shortId, status: "disconnected" },
+        );
+      } catch {
+        if (!cancelled) setPeer({ label: shortId, status: "disconnected" });
+      }
+    }
+
+    void poll();
+    const timer = window.setInterval(() => void poll(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [desktopApi, instanceId]);
+
+  if (!instanceId) return null;
+
+  const status = peer?.status ?? "connecting";
+  const label = peer?.label ?? instanceId.slice(0, 8);
+
+  return (
+    <span
+      className="remote-window-badge"
+      title={`Remote instance · ${statusLabel(status)}`}
+      aria-label={`Remote instance ${label}, ${statusLabel(status)}`}
+    >
+      <span
+        className={`remote-window-badge__dot remote-window-badge__dot--${dotModifier(status)}`}
+        aria-hidden
+      />
+      <span className="remote-window-badge__kind">Remote</span>
+      <span className="remote-window-badge__label">{label}</span>
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../lib/backend-status-format";
 import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
+import { RemoteWindowBadge } from "./RemoteWindowBadge";
 
 type ThreadContextMenuPosition = {
   x: number;
@@ -742,6 +743,7 @@ export function Sidebar(props: SidebarProps) {
       />
       <header className="sidebar__masthead">
         <p className="sidebar__brand">Pwr<span className="sidebar__brand-accent">Agent</span></p>
+        <RemoteWindowBadge />
 
         <div className="sidebar__masthead-actions">
           <MastheadActionButton

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/RemoteWindowBadge.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/RemoteWindowBadge.test.tsx
@@ -1,0 +1,119 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  FederationHealthStatus,
+  FederationPeerSummary,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { RemoteWindowBadge } from "../RemoteWindowBadge";
+
+type TestWindow = typeof window & {
+  __pwragentFederationTarget?: { scope: "remote"; instanceId: string };
+  pwragent?: DesktopApi;
+};
+
+function setRemoteTarget(instanceId: string | undefined): void {
+  const testWindow = window as TestWindow;
+  if (instanceId === undefined) {
+    delete testWindow.__pwragentFederationTarget;
+    return;
+  }
+  testWindow.__pwragentFederationTarget = { scope: "remote", instanceId };
+}
+
+function setDesktopApi(api: DesktopApi | undefined): void {
+  (window as TestWindow).pwragent = api;
+}
+
+function healthWithPeer(peer: FederationPeerSummary): FederationHealthStatus {
+  return {
+    enabled: true,
+    role: "gateway",
+    status: "listening",
+    peers: [peer],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  setRemoteTarget(undefined);
+  setDesktopApi(undefined);
+});
+
+describe("RemoteWindowBadge", () => {
+  it("renders nothing in a local window (no federation target)", () => {
+    setRemoteTarget(undefined);
+    setDesktopApi({ readFederationHealth: vi.fn() });
+
+    const { container } = render(<RemoteWindowBadge />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the peer label and a connected status dot for a healthy peer", async () => {
+    setRemoteTarget("client_studio_mac_01");
+    setDesktopApi({
+      readFederationHealth: vi.fn(async () => ({
+        health: healthWithPeer({
+          id: "client_studio_mac_01",
+          label: "Studio Mac",
+          role: "client",
+          status: "connected",
+          capabilities: ["thread_navigation"],
+        }),
+      })),
+    });
+
+    render(<RemoteWindowBadge />);
+
+    expect(await screen.findByText("Studio Mac")).toBeInTheDocument();
+    expect(screen.getByText("Remote")).toBeInTheDocument();
+    const dot = document.querySelector(".remote-window-badge__dot");
+    await waitFor(() =>
+      expect(dot).toHaveClass("remote-window-badge__dot--connected"),
+    );
+  });
+
+  it("falls back to a down dot and short id when the peer is absent from health", async () => {
+    setRemoteTarget("client_absent_peer_0123456789");
+    setDesktopApi({
+      readFederationHealth: vi.fn(async () => ({
+        health: healthWithPeer({
+          id: "some_other_peer",
+          label: "Other",
+          role: "client",
+          status: "connected",
+          capabilities: [],
+        }),
+      })),
+    });
+
+    render(<RemoteWindowBadge />);
+
+    // Short id fallback is the first 8 chars of the instance id.
+    expect(await screen.findByText("client_a")).toBeInTheDocument();
+    const dot = document.querySelector(".remote-window-badge__dot");
+    await waitFor(() =>
+      expect(dot).toHaveClass("remote-window-badge__dot--down"),
+    );
+  });
+
+  it("falls back to a down dot when health diagnostics throw", async () => {
+    setRemoteTarget("client_unreachable_abcdef");
+    setDesktopApi({
+      readFederationHealth: vi.fn(async () => {
+        throw new Error("federation unavailable");
+      }),
+    });
+
+    render(<RemoteWindowBadge />);
+
+    const dot = await waitFor(() => {
+      const node = document.querySelector(".remote-window-badge__dot");
+      expect(node).toHaveClass("remote-window-badge__dot--down");
+      return node;
+    });
+    expect(dot).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/RemoteWindowBadge.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/RemoteWindowBadge.test.tsx
@@ -75,6 +75,29 @@ describe("RemoteWindowBadge", () => {
     );
   });
 
+  it("shows a pending status dot while the peer is connecting", async () => {
+    setRemoteTarget("client_connecting_01");
+    setDesktopApi({
+      readFederationHealth: vi.fn(async () => ({
+        health: healthWithPeer({
+          id: "client_connecting_01",
+          label: "Laptop",
+          role: "client",
+          status: "connecting",
+          capabilities: [],
+        }),
+      })),
+    });
+
+    render(<RemoteWindowBadge />);
+
+    expect(await screen.findByText("Laptop")).toBeInTheDocument();
+    const dot = document.querySelector(".remote-window-badge__dot");
+    await waitFor(() =>
+      expect(dot).toHaveClass("remote-window-badge__dot--pending"),
+    );
+  });
+
   it("falls back to a down dot and short id when the peer is absent from health", async () => {
     setRemoteTarget("client_absent_peer_0123456789");
     setDesktopApi({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2193,6 +2193,72 @@ describe("useThreadNavigation", () => {
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
   });
 
+  describe("remote federation window guards", () => {
+    function setRemoteFederationWindow(instanceId: string): void {
+      (
+        window as unknown as {
+          __pwragentFederationTarget?: { scope: "remote"; instanceId: string };
+        }
+      ).__pwragentFederationTarget = { scope: "remote", instanceId };
+    }
+
+    afterEach(() => {
+      delete (
+        window as unknown as { __pwragentFederationTarget?: unknown }
+      ).__pwragentFederationTarget;
+    });
+
+    const emptySnapshot = async (): Promise<NavigationSnapshot> => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [],
+      launchpadDefaults: { backend: "codex", executionMode: "default" },
+    });
+
+    it("blocks createThread in a remote window without touching the local backend", async () => {
+      setRemoteFederationWindow("client_remote_01");
+      const ensureDirectoryLaunchpad = vi.fn();
+      const desktopApi: DesktopApi = {
+        getNavigationSnapshot: vi.fn(emptySnapshot),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      };
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+      await act(async () => {
+        await result.current.createThread();
+      });
+
+      expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
+      expect(result.current.createThreadError).toMatch(/remote window/i);
+    });
+
+    it("rejects materializeDirectoryLaunchpad in a remote window without touching the local backend", async () => {
+      setRemoteFederationWindow("client_remote_02");
+      const materializeDirectoryLaunchpad = vi.fn();
+      const desktopApi: DesktopApi = {
+        getNavigationSnapshot: vi.fn(emptySnapshot),
+        materializeDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      };
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+      await act(async () => {
+        await expect(
+          result.current.materializeDirectoryLaunchpad("directory:/tmp/whatever"),
+        ).rejects.toThrow(/remote window/i);
+      });
+
+      expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+      expect(result.current.launchpadError).toMatch(/remote window/i);
+    });
+  });
+
   it("carries the started review turn from launchpad materialization", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3475,6 +3475,12 @@ export function useThreadNavigation(
       executionMode: ThreadExecutionMode = "default",
       options?: { forceWorkspace?: boolean }
     ): Promise<void> => {
+      if (readRendererFederationTarget()) {
+        setCreateThreadError(
+          "New threads can't be created in a remote window. Create it on the remote instance, then open it here.",
+        );
+        return;
+      }
       if (!desktopApi?.ensureDirectoryLaunchpad) {
         setCreateThreadError("Desktop bridge is missing ensureDirectoryLaunchpad().");
         return;
@@ -4174,6 +4180,12 @@ export function useThreadNavigation(
       reviewTarget?: AppServerReviewTarget,
       parentThreadId?: string,
     ): Promise<void> => {
+      if (readRendererFederationTarget()) {
+        const message =
+          "New threads can't be created in a remote window. Create it on the remote instance, then open it here.";
+        setLaunchpadError(message);
+        throw new Error(message);
+      }
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
         return;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2426,6 +2426,55 @@ textarea,
   color: var(--accent);
 }
 
+/* Remote federation window badge. Only mounted in windows that operate a
+   remote PwrAgent instance, so local windows are unaffected. Sits next to the
+   brand and pushes the masthead action cluster to the trailing edge. */
+.remote-window-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: auto;
+  min-width: 0;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.remote-window-badge__dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+.remote-window-badge__dot--connected {
+  background: var(--success-text);
+}
+
+.remote-window-badge__dot--pending {
+  background: var(--status-warning);
+}
+
+.remote-window-badge__dot--down {
+  background: var(--danger-text);
+}
+
+.remote-window-badge__kind {
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.remote-window-badge__label {
+  min-width: 0;
+  max-width: 140px;
+  overflow: hidden;
+  color: var(--text-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .runtime-identity {
   display: flex;
   position: relative;

--- a/docs/plans/2026-06-21-001-feat-federation-encrypted-lan-transport-plan.md
+++ b/docs/plans/2026-06-21-001-feat-federation-encrypted-lan-transport-plan.md
@@ -1,0 +1,336 @@
+---
+title: "feat: encrypted, identity-bound federation transport for direct/LAN mode"
+type: feat
+date: 2026-06-21
+status: proposed
+builds-on: docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md
+---
+
+# feat: encrypted, identity-bound federation transport for direct/LAN mode
+
+## Summary
+
+The federation MVP (PR #735) ships a working authenticated control plane, but the
+transport channel is only secured at the *handshake*, not per message, and the
+listener is plain `ws://`. Confidentiality and integrity are delegated wholesale
+to an external Cloudflare Tunnel. That is fine for the WAN/tunnel posture, but it
+leaves the **direct same-machine / same-LAN / cross-machine-without-tunnel**
+posture exposed: an on-path attacker can read every envelope in cleartext and
+inject forged agent-control envelopes (`startTurn`, `runCodexEnvironmentAction`,
+`submitServerRequest`, `handoffThreadWorkspace`) into an already-authenticated
+socket.
+
+This plan adds an **ssh-like encrypted, mutually-authenticated, identity-bound
+channel** that works without Cloudflare, reusing the existing pinned per-instance
+identity as the trust anchor. After this change, crossing machines on a LAN is
+safe by default and no agent control surface is reachable in cleartext.
+
+This is the "polished local-only transport that does not assume Cloudflare or a
+stable DNS hostname" that the original plan explicitly
+[deferred to follow-up work](2026-06-10-001-feat-pwragent-instance-federation-plan.md).
+
+---
+
+## Problem Frame
+
+The current transport
+([`federation-transport.ts`](../../apps/desktop/src/main/federation/federation-transport.ts)):
+
+- Binds a plain `http.createServer()` + `ws` `WebSocketServer` — there is **no
+  TLS in the listener** (`federation-transport.ts:113`). The advertised URL is
+  hard-coded `ws://`.
+- Authenticates the peer **once** at connection time: a server-fresh nonce
+  challenge, signed by the peer's pinned Ed25519 key
+  (`federation-transport.ts:151`, `federation-enrollment.ts`). This part is
+  sound — genuine TOFU host identity.
+- After `auth.accepted`, sends every application `envelope` as raw
+  `JSON.stringify(...)` (`federation-transport.ts:402-405`) with **no
+  per-message signature, MAC, encryption, or session-binding**. The envelope
+  type (`packages/shared/src/contracts/federation.ts`) has no signature field.
+
+Consequences for the non-tunneled path:
+
+- **Confidentiality:** all thread contents, prompts, transcripts, skills, and
+  environment actions travel in cleartext.
+- **Integrity / injection:** an on-path attacker can inject or modify envelopes
+  on the live socket; the gateway trusts any frame arriving on an
+  already-authenticated connection (the `sessionId` is never echoed/checked on
+  inbound frames).
+- **Default is loopback** (`listen_host = 127.0.0.1`,
+  `desktop-settings-service.ts`), which is safe — but flipping `listen_host` to
+  `0.0.0.0` for LAN use is one undefended config line away, and nothing warns or
+  blocks it.
+
+The crypto fundamentals that already exist (Ed25519 identity, fresh-nonce replay
+protection, TOFU pinning enforced on reconnect, HMAC-hashed invite tokens,
+secret/key redaction) are good and should be **kept**. The gap is specifically
+the **channel** after authentication.
+
+---
+
+## Goals / Non-Goals
+
+### Goals
+
+- G1. Confidentiality + integrity + replay resistance for **every** federation
+  message on direct/LAN connections, not just the handshake.
+- G2. Mutual authentication bound to the **channel**, so a man-in-the-middle
+  cannot splice an authenticated identity onto a channel it controls.
+- G3. Reuse the existing pinned per-instance identity as the trust anchor (no
+  CA, no cert lifecycle) — the ssh "known_hosts" model the operator asked for.
+- G4. Safe-by-default: refuse non-loopback binds unless the encrypted channel is
+  active; never silently downgrade to plaintext.
+- G5. Preserve the Cloudflare-tunnel posture as a supported option (TLS already
+  provided at the edge), with explicit, not implicit, configuration.
+
+### Non-Goals
+
+- Multi-gateway mesh, quorum, or peer discovery beyond what MVP already has.
+- Automated Cloudflare provisioning.
+- Replacing the existing Ed25519 identity model — we extend it, not rip it out.
+- mDNS/zeroconf LAN auto-discovery (tracked separately; see Deferred).
+
+---
+
+## Key Technical Decisions
+
+- **KTD1. Use the Noise Protocol Framework for the channel, not bolt-on TLS.**
+  Noise (`Noise_IK_25519_ChaChaPoly_BLAKE2s` or `_SHA256`) gives mutual static-key
+  authentication, forward secrecy, per-message AEAD, and built-in nonce counters
+  (replay resistance) in a tiny dependency, using raw public keys as the trust
+  anchor — exactly the ssh model. `wss://` + self-signed pinned certs is the
+  considered alternative (see Alternatives); it works but drags in X.509/cert
+  lifecycle and a *second* identity object next to the Ed25519 key, for no
+  security gain over Noise in a no-CA, pinned-key world.
+
+- **KTD2. Add an X25519 static channel key alongside the Ed25519 identity; bind
+  the two.** Ed25519 is a signing key, not a DH key. Rather than convert the
+  Ed25519 key to X25519 (cross-primitive key reuse — discouraged), generate a
+  separate per-instance X25519 static, store it in the secret store next to the
+  Ed25519 private key, and **bind it to the canonical identity** by including the
+  X25519 static public key inside the Ed25519-signed enrollment/reconnect proof.
+  The Ed25519 key stays the canonical pinned identity; the X25519 key is the
+  channel key, authenticated by it.
+
+- **KTD3. Run identity auth *inside* the encrypted channel and channel-bind the
+  proof.** Sequence: (1) Noise IK handshake establishes the encrypted tunnel
+  using the pinned static X25519 keys; (2) the existing Ed25519 challenge/proof
+  runs *inside* that tunnel; (3) the signed proof includes the Noise **handshake
+  hash** so the identity assertion is cryptographically bound to this specific
+  channel. This kills the post-auth injection/splice problem (G2).
+
+- **KTD4. Make transport security an explicit mode with a fail-closed guard.**
+  Add `[federation] transport_security`: `encrypted` (Noise required, the new
+  default for direct binds) or `tunnel` (plaintext to loopback, relies on
+  Cloudflare TLS — only valid with a loopback `listen_host`). Refuse to start a
+  non-loopback listener in `tunnel` mode. No silent fallback (follows the
+  no-silent-security-fallback guidance in
+  `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`).
+
+- **KTD5. Prevent downgrade.** The protocol version is bumped and the required
+  `transport_security` posture is part of the enrollment record, so a peer
+  enrolled as `encrypted` cannot be tricked into a plaintext reconnect. A
+  `tunnel`-mode peer is only honored on a loopback bind.
+
+---
+
+## High-Level Design
+
+```
+WebSocket upgrade (ws:// to loopback, or wss:// via Cloudflare at the edge)
+        │
+        ▼
+[Noise_IK handshake]  ── static X25519 keys, pinned TOFU like the Ed25519 key
+        │   establishes encrypted, mutually-authenticated tunnel
+        ▼
+[Ed25519 identity auth]  ── existing challenge/proof, now sent INSIDE the tunnel,
+        │                    proof includes Noise handshake hash (channel binding)
+        ▼
+[Encrypted envelope transport]  ── every envelope is a Noise transport message
+                                   (AEAD, monotonic nonce); no cleartext frames
+```
+
+- The Noise layer is a thin wrapper (`encrypt(plaintext) -> ciphertext`,
+  `decrypt(ciphertext) -> plaintext`) around the existing `socket.send` /
+  `message` handlers in `federation-transport.ts`. The `FederationSocketMessage`
+  JSON shapes are unchanged; they are just carried as Noise transport payloads
+  after the handshake.
+- In `tunnel` mode, the Noise layer is skipped and behavior is identical to
+  today (loopback only), so Cloudflare-fronted deployments keep working.
+
+---
+
+## Implementation Units
+
+### U1. X25519 channel identity, bound to the Ed25519 identity
+
+**Goal:** Each instance has a persistent X25519 static keypair, stored in the
+secret store, authenticated by the canonical Ed25519 identity and pinned at
+enrollment.
+
+**Files:**
+- `apps/desktop/src/main/federation/federation-identity.ts` (generate/load X25519
+  static; helper to sign/verify the X25519 pubkey under the Ed25519 key)
+- `apps/desktop/src/main/federation/federation-enrollment.ts` (include the
+  X25519 static pubkey in the proof message; pin it on the peer record)
+- `apps/desktop/src/main/federation/federation-store.ts` (persist
+  `pinnedChannelPublicKey` next to `pinnedPublicKeyPem`)
+- `packages/shared/src/contracts/federation.ts` (proof/peer contract fields)
+- Tests: `federation-identity.test.ts`, `federation-enrollment.test.ts`,
+  `federation-store.test.ts`
+
+**Test scenarios:** happy-path enroll pins both keys; reconnect verifies the
+channel key matches the pinned one; an X25519 static not signed by the pinned
+Ed25519 key is rejected; missing channel key on a pre-existing peer fails closed
+with a redacted error.
+
+### U2. Noise secure-channel module
+
+**Goal:** A self-contained, dependency-vetted Noise IK implementation wrapping a
+duplex byte stream.
+
+**Files:**
+- `apps/desktop/src/main/federation/federation-secure-channel.ts` (new)
+- `apps/desktop/package.json` (add a vetted Noise dependency — evaluate
+  `@noble/ciphers` + `@noble/curves` hand-rolled IK, or an audited
+  `noise-protocol` lib; record the choice + license in `THIRD_PARTY_LICENSES`)
+- Tests: `apps/desktop/src/main/__tests__/federation-secure-channel.test.ts`
+
+**Approach:** Expose `createInitiatorChannel({ staticPriv, remoteStaticPub })`
+and `createResponderChannel({ staticPriv })` returning
+`{ writeHandshake(), readHandshake(), encrypt(buf), decrypt(buf), handshakeHash }`.
+Keep it transport-agnostic (operate on buffers) so it is unit-testable without
+sockets.
+
+**Test scenarios:** initiator/responder complete a handshake and exchange
+encrypted round-trips; a tampered ciphertext fails the AEAD tag; a replayed frame
+is rejected by the nonce counter; mismatched static keys fail the handshake;
+`handshakeHash` is identical on both ends and unique per session.
+
+### U3. Integrate the channel into the transport
+
+**Goal:** Run Noise → identity auth → encrypted envelopes on both gateway and
+client sides, channel-binding the Ed25519 proof.
+
+**Files:**
+- `apps/desktop/src/main/federation/federation-transport.ts`
+- `apps/desktop/src/main/federation/federation-enrollment.ts`
+  (`buildFederationProofMessage` gains a `channelBinding` field = Noise
+  handshake hash; verify it on the server)
+- `packages/shared/src/contracts/federation.ts`
+  (`FEDERATION_PROTOCOL_VERSION` bump)
+- Tests: `federation-transport.test.ts` (extend the existing real-socket test to
+  run end-to-end encrypted)
+
+**Approach:** On `connection`/`open`, perform the Noise handshake first. After it
+completes, send the existing `auth.challenge` / `auth` / `auth.accepted` messages
+as Noise-encrypted payloads, with the proof binding the handshake hash. Then wrap
+`sendSocketMessage`/`parseSocketMessage` so envelopes are encrypted/decrypted. In
+`tunnel` mode, skip Noise entirely (current code path).
+
+**Test scenarios:** end-to-end encrypted handshake + request/response over a real
+in-process socket; a passive observer of the raw socket bytes cannot recover
+plaintext envelope contents; an injected raw-JSON envelope on the socket is
+rejected (not decryptable); a proof with a stale/mismatched channel binding is
+rejected (`policy_denied`); `tunnel` mode still interoperates on loopback.
+
+### U4. Config, fail-closed guard, and Settings surface
+
+**Goal:** Operator picks transport security; non-loopback plaintext is refused.
+
+**Files:**
+- `apps/desktop/src/main/settings/desktop-config.ts`
+- `apps/desktop/src/main/settings/desktop-settings-service.ts`
+- `packages/shared/src/contracts/settings.ts` (`transport_security` enum,
+  default `encrypted`)
+- `apps/desktop/src/main/federation/federation-runtime.ts` (refuse to bind
+  non-loopback `listen_host` when `transport_security !== "encrypted"`; log a
+  redacted, actionable error)
+- `apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx`
+  (mode control + inline warning when a non-loopback host is set without
+  encryption)
+- Tests: `desktop-config-federation.test.ts`,
+  `desktop-settings-service.test.ts`, `federation-runtime.test.ts`,
+  `FederationSettings.test.tsx`
+
+**Config evolution:** new key is additive with a safe default; follow
+`docs/config-file-evolution.md` read-fallback/comment rules. Existing configs
+(no `transport_security`) default to `encrypted` for direct binds; a loopback-only
+`tunnel` deployment must opt in explicitly.
+
+### U5. Transport hardening (lands with the above)
+
+- Set `maxPayload` on the `WebSocketServer` (currently unbounded → ws default
+  100 MB) — `federation-transport.ts:114`.
+- Validate envelope shape (not just `parsed.envelope` truthy) before routing —
+  `federation-transport.ts:416`.
+- Reconcile the relay hop cap inconsistency surfaced in review
+  (`relayRemoteBackendEvent` cap `1` vs router `maxHopCount` `4`).
+
+### U6. Threat-model docs
+
+- Update `docs/federation-architecture.md`: document the encrypted direct mode,
+  the `tunnel` mode, the channel-binding property, and the explicit statement
+  that no agent control surface is reachable in cleartext in `encrypted` mode.
+
+---
+
+## Alternatives Considered
+
+- **`wss://` with pinned self-signed certs (TOFU on the cert fingerprint).**
+  Works and is "standard," but: (a) introduces a second identity object (the
+  cert) alongside the Ed25519 key, needing its own generation/rotation/expiry
+  handling; (b) X.509 parsing surface; (c) channel binding to the *Ed25519*
+  identity still has to be added on top. Rejected as more moving parts for no
+  security gain over Noise in a no-CA, pinned-key deployment.
+- **Convert Ed25519 → X25519 and reuse one key.** Cryptographically possible but
+  reuses a key across signing and DH primitives, which is discouraged; KTD2's
+  separate-but-bound key avoids the foot-gun.
+- **Per-message Ed25519 signatures over the existing plaintext channel.** Adds
+  integrity but not confidentiality, and is slower than AEAD. Insufficient for G1.
+
+---
+
+## Acceptance Examples
+
+- AE1. Two instances on different machines on the same LAN (no Cloudflare),
+  `transport_security = encrypted`, `listen_host = 0.0.0.0`: enrollment +
+  remote thread operation succeed, and a packet capture of the link shows no
+  cleartext thread/prompt content.
+- AE2. With an active encrypted session, an attacker who injects a well-formed
+  raw-JSON `startTurn` envelope onto the TCP stream is ignored (fails AEAD), and
+  the session is unaffected or closed — the remote agent does not run the
+  injected turn.
+- AE3. Operator sets `listen_host = 0.0.0.0` with `transport_security = tunnel`:
+  the gateway refuses to start the listener and Settings shows an actionable
+  error explaining encryption is required for non-loopback binds.
+- AE4. A peer enrolled in `encrypted` mode cannot complete a plaintext reconnect
+  (downgrade attempt is rejected).
+- AE5. Existing Cloudflare-tunnel deployments (`tunnel` mode, loopback bind)
+  continue to work unchanged.
+
+---
+
+## Risks and Dependencies
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Noise library choice is unvetted / unmaintained | Crypto bugs, supply-chain risk | Prefer audited primitives (`@noble/*`); keep the IK state machine small and unit-tested; record license in `THIRD_PARTY_LICENSES`; pin version |
+| Cross-primitive key handling done wrong | Identity/channel keys become forgeable | KTD2 separate X25519 bound by Ed25519 signature; tests reject unsigned/ mismatched channel keys |
+| Downgrade to plaintext | LAN exposure persists despite the feature | KTD5: posture in enrollment record + protocol-version bump + non-loopback guard; no silent fallback |
+| Channel established but identity not bound to it | MITM splices a valid identity onto its own channel | KTD3 channel-binding the Ed25519 proof to the Noise handshake hash; AE2/AE4 tests |
+| Performance overhead of AEAD per envelope | Sluggish remote streaming | ChaCha20-Poly1305 is fast; benchmark transcript streaming; envelopes are small JSON |
+| Added handshake round-trips | Slower connect | IK is 1-RTT for the initiator; acceptable for long-lived sessions |
+
+---
+
+## Sources
+
+- Original plan & deferral:
+  `docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md`
+- Current transport gaps:
+  `apps/desktop/src/main/federation/federation-transport.ts`,
+  `packages/shared/src/contracts/federation.ts`
+- No-silent-security-fallback guidance:
+  `docs/solutions/2026-05-07-codex-permission-mode-state-machine.md`
+- Noise Protocol Framework spec: https://noiseprotocol.org/noise.html

--- a/docs/plans/2026-06-21-002-feat-federation-messaging-routing-plan.md
+++ b/docs/plans/2026-06-21-002-feat-federation-messaging-routing-plan.md
@@ -1,0 +1,229 @@
+---
+title: "feat: route messaging to federated remote threads"
+type: feat
+date: 2026-06-21
+status: proposed
+builds-on: docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md
+---
+
+# feat: route messaging to federated remote threads
+
+## Summary
+
+The federation MVP (PR #735) added helpers to route messaging (Telegram/Discord/
+etc.) to threads that live on remote PwrAgent instances, but they are **dead
+code**: `federatedThreadRefForMessagingBinding`,
+`messagingBindingTargetsRemoteInstance`, and
+`findActiveBindingsForFederatedThread` have unit tests but **zero production
+callers**. This plan wires them into a working end-to-end path so a gateway's
+messaging surface can browse, bind, steer, and receive live updates from a remote
+child instance's threads — fulfilling requirement R14 of the original plan.
+
+Critically, "wire the helpers" is **not** sufficient on its own. Investigation
+confirmed two missing pieces that make the helpers unreachable today, plus one
+security decision:
+
+1. **No remote threads in the browse list.** Messaging `/resume`-style browse is
+   powered by `DesktopMessagingBackendBridge.getNavigationSnapshot`
+   (`messaging-controller.ts:1810`, `:2252`, `:4551`), which is local-only. An
+   operator can never *select* a remote thread to bind, so nothing ever creates a
+   remote binding.
+2. **Bindings never record the remote target.** `federatedThread` is never
+   assigned anywhere in `apps/desktop/src/main/messaging/` (confirmed by grep);
+   `bindChannelToThread` (`messaging-controller.ts:10452`) does not stamp it. So
+   even a hypothetical remote binding would have `federatedThread === undefined`
+   and `findActiveBindingsForFederatedThread` would return empty.
+3. **Remote-agent control via messaging needs explicit authorization.** Routing a
+   Telegram message to a child instance lets a messaging actor drive a coding
+   agent on another machine. The original plan's System-Wide Impact note is
+   explicit: existing actor allowlists are necessary but **not sufficient**; the
+   remote peer must also allow messaging-originated operations.
+
+---
+
+## Problem Frame
+
+Today, for a LOCAL bound thread, the flow is:
+
+inbound platform event → `MessagingController` (`handleText`,
+`messaging-controller.ts:1345`) → resolve binding by channel
+(`findActiveBindingForChannel`) → `startPreparedInput` → `this.options.backend.*`
+(the `DesktopMessagingBackendBridge`) → `BackendRegistry`.
+
+Backend events flow back via `registry.onEvent` →
+`messaging-runtime.ts:1166` → `controller.handleBackendEvent`
+(`messaging-controller.ts:766`) → binding lookup by
+`findActiveBindingsForThread` → status-surface refresh.
+
+For a REMOTE thread, three things must change without leaking federation into
+provider packages or `messaging/core/` (dependency-cruiser forbids both):
+
+- The browse list must include remote threads (so a binding can be created).
+- The binding must persist its `federatedThread` (so routing can target the peer).
+- Outbound calls and inbound events must branch local-vs-remote.
+
+The single legal seam for federation calls is
+`apps/desktop/src/main/messaging/desktop-backend-bridge.ts` (lives in
+`messaging/`, not `messaging/core/`; already imports `../app-server/*`, so it may
+import `../federation/federation-runtime`). The renderer-facing IPC layer
+(`agent-ipc.ts:362-369`) already implements the exact branch pattern to mirror:
+`if (isRemoteFederationTarget(target)) return
+getDesktopFederationRuntime().remoteBackend(target).<method>(...)`.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1. Branch in the bridge, stamp in the controller.** `MessagingController`
+  (in `messaging/core/`) may only use `@pwragent/shared` +
+  `@pwragent/messaging-interface` helpers, so it stamps `request.federationTarget`
+  from `binding.federatedThread` but never calls federation runtime. The bridge
+  (in `messaging/`) does the actual local-vs-remote dispatch. Keeps the
+  dependency boundary intact.
+
+- **KTD2. Reuse existing federation primitives, do not invent new transport.**
+  Browse surfacing uses the already-built `remoteNavigationSnapshot`
+  (`federation-runtime.ts:237`) / `FederatedSearchService` (currently dead). Each
+  backend op maps 1:1 to a `FederationBackendOperations` method
+  (`federation-backend-bridge.ts:91-132`) — `startTurn`, `steerTurn`,
+  `interruptTurn`, `compactThread`, `submitServerRequest`, `readThread`,
+  `listSkills`, etc. `readThreadStatus`/`readThreadLastAssistantReply` call remote
+  `readThread` then reuse the local `findLastAssistant*` extraction.
+
+- **KTD3. Fail-closed remote messaging authorization (the security fork).** Add a
+  `messaging_route` federation capability that defaults **OFF**. A gateway only
+  routes messaging to a child peer that was enrolled with `messaging_route`
+  granted. With the capability absent, remote browse hides the peer's threads and
+  any attempted remote route returns a safe "not authorized" surface. This gives
+  a conservative default without a full multi-tenant policy engine, and keeps
+  remote agent control opt-in per peer. (A richer per-actor/per-peer policy is a
+  later refinement; default-off is the safe MVP.)
+
+- **KTD4. Remote backend events reach messaging without polluting the local
+  registry.** Remote events currently terminate at the renderer
+  (`DesktopFederationRuntime.publishAgentEvent` → `broadcastAgentEvent`,
+  `agent-ipc.ts:300`). Add a *second* federation-event consumer for messaging
+  rather than funneling remote events through `registry.emit` (which would
+  corrupt local registry semantics). The controller's event lookup branches to
+  `findActiveBindingsForFederatedThread` when `event.federationTarget` is remote.
+
+---
+
+## Implementation Units
+
+### U1. Request contracts carry a federation target
+
+**Files:** `packages/shared/src/contracts/normalized-app-server.ts`
+**Goal:** Ensure `StartTurnRequest`, `SteerTurnRequest`, `InterruptTurnRequest`,
+`CompactThreadRequest`, and the other turn-control requests the bridge forwards
+carry `federationTarget?: FederationTarget` (the pattern already exists on list/
+handoff requests at `:491`, `:578`, `:641`, `:677`). Leaf package — boundary-safe.
+
+### U2. `messaging_route` capability (fail-closed authorization)
+
+**Files:** `packages/shared/src/contracts/federation.ts` (capability enum),
+`apps/desktop/src/main/federation/federation-runtime.ts` (do **not** add to
+`DEFAULT_CAPABILITIES`), `FederationSettings.tsx` (per-peer grant control).
+**Goal:** New opt-in capability gating all messaging→remote routing. Enrollment
+must be able to grant it explicitly; reconnect policy enforces it.
+
+### U3. Surface remote threads in messaging browse
+
+**Files:** `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+(`getNavigationSnapshot`, `:58`), reuse `remoteNavigationSnapshot` /
+`FederatedSearchService`.
+**Goal:** When the local instance is a gateway with `messaging_route`-granted
+connected peers, merge their threads into the browse snapshot, each labeled with
+the source instance (`NavigationThreadSummary.federation.instanceLabel`, already
+in the contract). Per-peer deadlines; partial-failure visible; local results
+always render.
+
+### U4. Stamp `federatedThread` at bind time
+
+**Files:** `apps/desktop/src/main/messaging/core/messaging-controller.ts`
+(`bindChannelToThread`, `:10452`; callers `:2271`, `:4158`, `:5612`, `:8609`,
+`:11061`).
+**Goal:** When the chosen browse result is remote (carries a `FederatedThreadRef`),
+persist `federatedThread` on the binding. The sqlite store already serializes the
+whole binding to the `payload` column, so no schema change is needed
+(`messaging-store-sqlite.ts:36-51`); `sanitizeBinding` already preserves it.
+
+### U5. Bridge routes local-vs-remote
+
+**Files:** `apps/desktop/src/main/messaging/desktop-backend-bridge.ts`
+**Goal:** Mirror `agent-ipc.ts:362-369` in each forwarded method
+(`startTurn` `:177`, `steerTurn` `:199`, `interruptTurn` `:211`, `compactThread`
+`:207`, `submitServerRequest` `:257`, exec-mode/model/skills/handoff): if
+`isRemoteFederationTarget(request.federationTarget)`, dispatch to
+`getDesktopFederationRuntime().remoteBackend(target).<method>(...)`. Controller
+stamps the target from `binding.federatedThread` (KTD1).
+
+### U6. Remote events reach messaging controllers
+
+**Files:** `apps/desktop/src/main/messaging/messaging-runtime.ts` /
+`desktop-backend-bridge.ts` (`onEvent`, `:263`),
+`apps/desktop/src/main/messaging/core/messaging-controller.ts`
+(`handleBackendEvent` lookup, `:830`).
+**Goal:** Add a federation-event subscription that fans remote backend events to
+controllers (KTD4); branch the controller's binding lookup to
+`findActiveBindingsForFederatedThread(buildFederatedThreadRef({ backend,
+instanceId, threadId }))` when `event.federationTarget` is remote.
+`federatedThreadIdentityKey` namespaces by `remote:<instanceId>:<backend>:
+<threadId>`, so local/remote threadId collisions don't cross-match.
+
+### U7. Tests
+
+Mirror existing patterns: bridge local-vs-remote routing (fake federation
+runtime), controller stamping + remote event lookup, capability fail-closed
+(ungranted peer routes nothing), browse merge with source labels and partial
+failure, degraded remote binding remains visible on disconnect. Provider package
+tests must remain unchanged (callbacks stay opaque).
+
+---
+
+## Scope / Deferred
+
+**In scope:** the full vertical above, with `messaging_route` default-off.
+**Deferred:** per-actor (not just per-peer) remote authorization; remote
+new-thread creation from messaging (no remote `startThread` protocol method
+exists — see the local-only gap also reflected in the remote-window UX);
+federated *content* search within messaging (this surfaces threads, not
+transcript bodies).
+
+---
+
+## Acceptance Examples
+
+- AE1. Operator grants `messaging_route` to child "Studio Mac", runs `/resume`
+  from Telegram on the gateway, sees Studio Mac's threads labeled by source,
+  binds one; the binding persists `federatedThread`.
+- AE2. Sending a message to that channel steers the turn on Studio Mac, and the
+  child's assistant deltas / turn status stream back to the Telegram surface.
+- AE3. A child WITHOUT `messaging_route` never appears in browse and any forced
+  remote route fails closed with a safe message.
+- AE4. The child disconnects mid-binding: the binding stays visible but degraded;
+  callbacks fail closed, not silently to a local thread.
+- AE5. Provider package tests are untouched — callbacks remain opaque handles.
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Remote agent control granted too broadly | Messaging actor drives another machine's agent unexpectedly | `messaging_route` default-off, per-peer, fail-closed (KTD3) |
+| Federation leaks into `messaging/core/` or providers | Boundary regression | Branch only in the bridge; controller uses shared helpers only (KTD1); run `pnpm lint:boundaries` |
+| Remote events corrupt local registry | Local thread state desync | Separate federation-event consumer, never `registry.emit` (KTD4) |
+| Bindings created before this change have no `federatedThread` | Silent no-op routing | They are local bindings by definition; only new remote binds get stamped |
+
+---
+
+## Sources
+
+- Recon of the dead helpers, bind path, and event flow (this branch).
+- `apps/desktop/src/main/messaging/desktop-backend-bridge.ts` (the seam).
+- `apps/desktop/src/main/ipc/agent-ipc.ts:362-369` (the branch pattern to mirror).
+- `apps/desktop/src/main/federation/federation-runtime.ts` (`remoteBackend`,
+  `remoteNavigationSnapshot`, `publishAgentEvent`).
+- Original plan R14 + System-Wide Impact:
+  `docs/plans/2026-06-10-001-feat-pwragent-instance-federation-plan.md`.


### PR DESCRIPTION
## Summary

Follow-up stacked on #735 (instance federation MVP). Ships verified dogfood UX guardrails for remote windows and lands two follow-up plans. Targets the federation feature branch so it stacks cleanly.

## Shipped (code, verified)

- **Remote new-thread guard.** A remote window no longer *silently* creates a LOCAL thread on the client instance. `createThread` and `materializeDirectoryLaunchpad` bail with a clear message when a renderer federation target is active; the launchpad path throws so the composer preserves the typed prompt.
- **Remote window badge.** New `RemoteWindowBadge` in the sidebar masthead makes remote windows visually distinct (`● Remote · <peer label>`).
- **Peer reachability.** Folded into the same badge as a connection-status dot (connected / pending / offline), polling federation health — covers both "which window is this" and "is the peer up" in one always-visible element.

All using existing theme tokens; the brand-token contract test still passes.

## Plans (docs)

- **Encrypted LAN transport** — `docs/plans/2026-06-21-001-feat-federation-encrypted-lan-transport-plan.md`. ssh-like Noise_IK channel over the existing WebSocket, reusing the pinned identity, closing the post-auth cleartext read/inject exposure when not behind a Cloudflare tunnel. This is the deferred "local-only transport" from the original plan.
- **Messaging → remote routing** — `docs/plans/2026-06-21-002-feat-federation-messaging-routing-plan.md`. Wires the currently-dead federated messaging helpers into a reachable end-to-end path behind a default-off `messaging_route` capability.

## Why these UX fixes

#735 is a genuinely working remote-thread control plane (auth handshake, real backend data, startTurn/steer over the wire). The gaps that made it unpleasant to dogfood were: silent wrong-instance thread creation, no way to tell a remote window apart, and no peer-offline signal. These three fixes address exactly those.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean
- theme-contract test — 42/42
- `pnpm lint:boundaries` — 0 violations
- app-shell render — 20/20
- new `RemoteWindowBadge` tests — 4/4

## Not included (deliberately)

The messaging→remote routing *implementation* is held for its own PR — recon showed it's a feature, not a wiring (bindings never stamp `federatedThread`, browse never surfaces remote threads), with a security fork (remote agent control via messaging). It's fully specced in the plan doc above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)