### PR TITLE
fix(desktop): quiet shutdown branch drift races

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -995,6 +995,7 @@ class MockBackendClient {
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
       listThreadsError?: Error;
+      listThreadsDelay?: Promise<unknown>;
       archivedThreads?: AppServerThreadSummary[];
       startThreadResult?: { threadId: string };
       startTurnError?: Error;
@@ -1035,6 +1036,9 @@ class MockBackendClient {
     this.listThreadsCalls.push({ diagnostics, params });
     if (this.options.listThreadsError) {
       throw this.options.listThreadsError;
+    }
+    if (this.options.listThreadsDelay) {
+      await this.options.listThreadsDelay;
     }
     if (params?.archived === true && this.options.archivedThreads) {
       return this.options.archivedThreads;
@@ -19087,6 +19091,65 @@ command = "pnpm dev"
     });
 
     await registry.close();
+  });
+
+  it("does not persist branch drift after registry shutdown starts", async () => {
+    let releaseListThreads!: () => void;
+    const listThreadsDelay = new Promise<void>((resolve) => {
+      releaseListThreads = resolve;
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Moved thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      gitBranch: "fix/steering-composer-navigation",
+      observedGitBranch: "fix/steering-composer-navigation",
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "full-access",
+          observedGitBranch: "fix/queued-composer-navigation",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const setThreadObservedBranch = vi.spyOn(overlayStore, "setThreadObservedBranch");
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [thread],
+        listThreadsDelay,
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const responsePromise = registry.checkThreadBranchDrift({
+      backend: "codex",
+      expectedBranch: "fix/queued-composer-navigation",
+      threadId: "thread-1",
+    });
+    await Promise.resolve();
+
+    const closePromise = registry.close();
+    releaseListThreads();
+
+    await expect(responsePromise).resolves.toMatchObject({
+      expectedBranch: "fix/queued-composer-navigation",
+      observedBranch: "fix/steering-composer-navigation",
+      drifted: true,
+    });
+    expect(setThreadObservedBranch).not.toHaveBeenCalled();
+
+    await closePromise;
   });
 
   it("adopts a named branch change from an active turn before notifying listeners", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1018,6 +1018,10 @@ describe("bootstrapApp", () => {
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeAppServerIpcHandlersMock.mock.invocationCallOrder[0]).toBeLessThan(
+      disposeAppStateMock.mock.invocationCallOrder[0],
+    );
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -89,6 +89,23 @@ describe("StdioJsonRpcTransport", () => {
     expect(child.writes).toHaveLength(1);
   });
 
+  it("rejects client requests after an intentional close", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    await transport.connect();
+    await transport.close();
+
+    expect(() =>
+      transport.send(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "thread/list" })),
+    ).toThrow("codex app server stdio not connected");
+    expect(child.writes).toHaveLength(0);
+  });
+
   it("still throws when the app-server exits unexpectedly", async () => {
     const child = new MockCodexChildProcess();
     spawnMock.mockReturnValue(child);

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -1,5 +1,60 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { compareCodexCliVersions } from "@pwrdrvr/codex-discovery";
+import { StdioJsonRpcTransport } from "../codex-app-server/stdio-transport";
+
+const { resolveCodexCommandMock, spawnMock } = vi.hoisted(() => ({
+  resolveCodexCommandMock: vi.fn(async ({ command }: { command: string }) => ({
+    command,
+    source: "path",
+    version: "0.126.0",
+  })),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>(
+    "node:child_process",
+  );
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock("@pwrdrvr/codex-discovery", async () => {
+  const actual = await vi.importActual<typeof import("@pwrdrvr/codex-discovery")>(
+    "@pwrdrvr/codex-discovery",
+  );
+  return {
+    ...actual,
+    resolveCodexCommand: resolveCodexCommandMock,
+  };
+});
+
+class MockCodexChildProcess extends EventEmitter {
+  readonly writes: string[] = [];
+  readonly stdin = new Writable({
+    write: (chunk, _encoding, callback) => {
+      this.writes.push(chunk.toString());
+      callback();
+    },
+  });
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  killCalled = false;
+
+  kill(): void {
+    this.killCalled = true;
+    this.emit("close");
+  }
+}
+
+beforeEach(() => {
+  resolveCodexCommandMock.mockClear();
+  spawnMock.mockReset();
+});
 
 describe("stdio transport Codex CLI resolution", () => {
   it("orders stable Codex CLI releases ahead of prereleases with the same version", () => {
@@ -9,5 +64,44 @@ describe("stdio transport Codex CLI resolution", () => {
 
   it("orders newer Codex.app prereleases ahead of older stable PATH releases", () => {
     expect(compareCodexCliVersions("0.126.0-alpha.1", "0.125.0")).toBeGreaterThan(0);
+  });
+});
+
+describe("StdioJsonRpcTransport", () => {
+  it("drops late sends after an intentional close", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    await transport.connect();
+    transport.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
+    expect(child.writes).toHaveLength(1);
+
+    await transport.close();
+
+    expect(child.killCalled).toBe(true);
+    expect(() =>
+      transport.send(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { ok: true } })),
+    ).not.toThrow();
+    expect(child.writes).toHaveLength(1);
+  });
+
+  it("still throws when the app-server exits unexpectedly", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    await transport.connect();
+    child.emit("close");
+
+    expect(() =>
+      transport.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
+    ).toThrow("codex app server stdio not connected");
   });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4198,6 +4198,7 @@ export class DesktopBackendRegistry {
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly acpBackend: AcpBackendAdapter;
+  private closed = false;
   // Resolves a managed-worktree ACP cwd to its repository checkout so ACP
   // (e.g. Grok) worktree threads group under the same directory row as their
   // repo, exactly like Codex threads do. Codex backends carry a repo-rooted
@@ -8827,10 +8828,26 @@ export class DesktopBackendRegistry {
   async checkThreadBranchDrift(
     params: CheckThreadBranchDriftRequest,
   ): Promise<CheckThreadBranchDriftResponse> {
+    if (this.closed) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        drifted: false,
+        checkedAt: Date.now(),
+      };
+    }
     const overlay = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
       threadId: params.threadId,
     });
+    if (this.closed) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        drifted: false,
+        checkedAt: Date.now(),
+      };
+    }
     const thread = await this.findThreadForWorkspaceHandoff({
       backend: params.backend,
       callerReason: "branch-drift",
@@ -8855,6 +8872,17 @@ export class DesktopBackendRegistry {
     const normalizedObservedBranch = observedBranch?.trim() || undefined;
 
     const drifted = isBranchDrifted(expectedBranch, normalizedObservedBranch);
+
+    if (this.closed) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        expectedBranch,
+        observedBranch: normalizedObservedBranch,
+        drifted,
+        checkedAt: Date.now(),
+      };
+    }
 
     await this.overlayStore.setThreadObservedBranch({
       backend: params.backend,
@@ -10028,6 +10056,7 @@ export class DesktopBackendRegistry {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -31,6 +31,23 @@ export type StdioJsonRpcTransportOptions = {
 
 export { compareCodexCliVersions };
 
+function isJsonRpcResponseEnvelope(message: string): boolean {
+  try {
+    const envelope = JSON.parse(message) as unknown;
+    if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+      return false;
+    }
+    const record = envelope as Record<string, unknown>;
+    return (
+      record.id !== undefined &&
+      typeof record.method !== "string" &&
+      ("result" in record || "error" in record)
+    );
+  } catch {
+    return false;
+  }
+}
+
 export class StdioJsonRpcTransport implements JsonRpcTransport {
   private childProcess: ChildProcessWithoutNullStreams | null = null;
   private messageHandler: (message: string) => void = () => undefined;
@@ -151,7 +168,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   send(message: string): void {
     const child = this.childProcess;
     if (!child?.stdin) {
-      if (this.closeRequested) {
+      if (this.closeRequested && isJsonRpcResponseEnvelope(message)) {
         if (!this.droppedSendAfterCloseLogged) {
           this.droppedSendAfterCloseLogged = true;
           codexTransportLog.info("dropped app-server send after close");

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -35,6 +35,8 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   private childProcess: ChildProcessWithoutNullStreams | null = null;
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
+  private closeRequested = false;
+  private droppedSendAfterCloseLogged = false;
 
   constructor(private readonly options: StdioJsonRpcTransportOptions) {}
 
@@ -50,6 +52,8 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     if (this.childProcess) {
       return;
     }
+    this.closeRequested = false;
+    this.droppedSendAfterCloseLogged = false;
 
     const env = this.options.resolveEnv
       ? await this.options.resolveEnv()
@@ -135,6 +139,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   }
 
   async close(): Promise<void> {
+    this.closeRequested = true;
     const child = this.childProcess;
     this.childProcess = null;
     if (!child) {
@@ -146,6 +151,13 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   send(message: string): void {
     const child = this.childProcess;
     if (!child?.stdin) {
+      if (this.closeRequested) {
+        if (!this.droppedSendAfterCloseLogged) {
+          this.droppedSendAfterCloseLogged = true;
+          codexTransportLog.info("dropped app-server send after close");
+        }
+        return;
+      }
       throw new Error("codex app server stdio not connected");
     }
     child.stdin.write(`${message}\n`);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3052,9 +3052,9 @@ class DesktopAppServerService {
     this.automaticWorktreeWorkingStateRefreshesStarted = 0;
     this.worktreePathByThreadKey.clear();
     this.prRefreshContextByThreadKey.clear();
+    await disposeDesktopBackendRegistry();
     await this.threadMigrationService?.dispose();
     this.threadMigrationService = null;
-    await disposeDesktopBackendRegistry();
   }
 
   private getPrFetcher(): GithubPrFetcher {


### PR DESCRIPTION
## Summary

- I fixed the shutdown race where a late branch-drift check could write to the overlay store after sqlite had already closed, producing `The database connection is not open` during quit.
- I made intentional Codex app-server stdio shutdowns drop late JSON-RPC response writes instead of surfacing `codex app server stdio not connected` as an unhandled rejection.
- I moved backend registry disposal earlier in app-server shutdown so the registry enters its closed state before app state teardown begins.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts`.
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- This is internal shutdown cleanup; there is no useful screenshot or demo artifact.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
