### PR TITLE
fix(desktop): honor credits-only subagent costs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11693,6 +11693,15 @@ command = "pnpm dev"
   it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },
+      models: [
+        {
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+          current: true,
+          supportsFast: true,
+          supportsReasoning: true,
+        },
+      ],
       startReviewResult: {
         threadId: "thread-1",
         reviewThreadId: "thread-1",
@@ -11739,10 +11748,12 @@ command = "pnpm dev"
         model: "gpt-5.5",
         tokenUsage: {
           total: {
+            fastMode: true,
             inputTokens: 1_000,
             cachedInputTokens: 200,
             outputTokens: 50,
             reasoningOutputTokens: 10,
+            serviceTier: "priority",
           },
         },
       },
@@ -11757,6 +11768,8 @@ command = "pnpm dev"
         return overlay?.subAgents?.[0]?.monitorUsage;
       })
       .toMatchObject({
+        fastMode: true,
+        serviceTier: "priority",
         summary: expect.stringContaining(
           "800 uncached in · 200 cached · 50 out (10 reasoning)"
         ),
@@ -11775,10 +11788,12 @@ command = "pnpm dev"
     });
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({
+      fastMode: true,
       model: "gpt-5.5",
       parentThreadId: "thread-1",
       priceStatus: "priced",
       scope: "monitor",
+      serviceTier: "priority",
       threadId: "thread-1",
       turnId: "turn-review-1",
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2345,7 +2345,9 @@ function buildTaskMonitorUsageSnapshot(params: {
 
   return {
     ...(cost ? { cost } : {}),
+    ...(params.fastMode !== undefined ? { fastMode: params.fastMode } : {}),
     ...(params.model ? { model: params.model } : {}),
+    ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
     summary,
     tokenUsage: {
       cachedInputTokens,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -688,7 +688,12 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "subagents":
-        return <SubAgentsPanel thread={props.thread} />;
+        return (
+          <SubAgentsPanel
+            pricingDisplayOptions={props.pricingDisplayOptions}
+            thread={props.thread}
+          />
+        );
       case "automations":
         return (
           <ThreadAutomationsPanel

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -326,9 +326,11 @@ describe("ThreadContextPanel", () => {
             completedAt: 2600,
             preferredModel: "gpt-5.5",
             monitorUsage: {
+              fastMode: true,
               model: "gpt-5.5",
+              serviceTier: "priority",
               summary:
-                "1,500 uncached in · 500 cached · 300 out (120 reasoning) · $0.010 list price",
+                "1,500 uncached in · 500 cached · 300 out (120 reasoning) · $0.024 list price",
               tokenUsage: {
                 inputTokens: 2000,
                 cachedInputTokens: 500,
@@ -339,7 +341,7 @@ describe("ThreadContextPanel", () => {
               },
               cost: {
                 model: "gpt-5.5",
-                totalUsd: 0.0095,
+                totalUsd: 0.02375,
               },
             },
           },
@@ -349,21 +351,21 @@ describe("ThreadContextPanel", () => {
 
     expect(
       screen.getByText(
-        "Monitor usage: 1,500 uncached in · 500 cached · 300 out (120 reasoning) · 0.5 Codex Credits",
+        "Monitor usage: 1,500 uncached in · 500 cached · 300 out (120 reasoning) · 1.3 Codex Credits",
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/\$0\.010 list price/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.024 list price/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     const modal = within(screen.getByRole("dialog"));
     expect(modal.getByText("Cost")).toBeInTheDocument();
-    expect(modal.getByText("0.5 Codex Credits")).toBeInTheDocument();
+    expect(modal.getByText("1.3 Codex Credits")).toBeInTheDocument();
     expect(
       modal.getByText(
-        "1,500 uncached in · 500 cached · 300 out (120 reasoning) · 0.5 Codex Credits",
+        "1,500 uncached in · 500 cached · 300 out (120 reasoning) · 1.3 Codex Credits",
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/\$0\.010 list price/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.024 list price/)).not.toBeInTheDocument();
   });
 
   it("labels review sub-agent usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -306,6 +306,66 @@ describe("ThreadContextPanel", () => {
     expect(detailsButtons[0]).toHaveFocus();
   });
 
+  it("honors Credits-only pricing display options for sub-agent usage", () => {
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      pricingDisplayOptions: {
+        codexCredits: true,
+        usd: false,
+      },
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "monitor-credits",
+            task: "Watch PR #274 CI after pushed review-fix commit",
+            status: "success",
+            createdAt: 2000,
+            updatedAt: 2500,
+            completedAt: 2600,
+            preferredModel: "gpt-5.5",
+            monitorUsage: {
+              model: "gpt-5.5",
+              summary:
+                "1,500 uncached in · 500 cached · 300 out (120 reasoning) · $0.010 list price",
+              tokenUsage: {
+                inputTokens: 2000,
+                cachedInputTokens: 500,
+                uncachedInputTokens: 1500,
+                outputTokens: 300,
+                reasoningOutputTokens: 120,
+                totalTokens: 2420,
+              },
+              cost: {
+                model: "gpt-5.5",
+                totalUsd: 0.0095,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByText(
+        "Monitor usage: 1,500 uncached in · 500 cached · 300 out (120 reasoning) · 0.5 Codex Credits",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.010 list price/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const modal = within(screen.getByRole("dialog"));
+    expect(modal.getByText("Cost")).toBeInTheDocument();
+    expect(modal.getByText("0.5 Codex Credits")).toBeInTheDocument();
+    expect(
+      modal.getByText(
+        "1,500 uncached in · 500 cached · 300 out (120 reasoning) · 0.5 Codex Credits",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.010 list price/)).not.toBeInTheDocument();
+  });
+
   it("labels review sub-agent usage separately from monitor usage", () => {
     renderPanel({
       activeTab: "subagents",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -3,8 +3,10 @@ import { createPortal } from "react-dom";
 import type { ThreadSubAgentSummary } from "@pwragent/shared";
 import { formatTimestamp } from "./context-rail-shared";
 import {
+  formatSubAgentUsageEstimates,
+  formatSubAgentUsageSummary,
   formatTokenCount,
-  formatUsd,
+  type PricingDisplayOptions,
   subAgentStatusLabel,
   subAgentTone,
 } from "./subagent-format";
@@ -12,6 +14,7 @@ import { RailStatusChip } from "./RailStatusChip";
 import { subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
+  pricingDisplayOptions?: PricingDisplayOptions;
   subAgent: ThreadSubAgentSummary;
   onClose: () => void;
 };
@@ -79,6 +82,13 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
+  const usageEstimates = usage
+    ? formatSubAgentUsageEstimates({
+        displayOptions: props.pricingDisplayOptions,
+        model,
+        usage,
+      })
+    : undefined;
   const originLabel = subAgentOriginLabel(subAgent);
   const ariaLabel = subAgent.agentName
     ? `${subAgent.agentName}: ${subAgent.task}`
@@ -188,15 +198,21 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
                   <dd>{formatTokenCount(usage.tokenUsage.totalTokens)}</dd>
                 </div>
               ) : null}
-              {usage.cost ? (
+              {usageEstimates ? (
                 <div>
                   <dt>Cost</dt>
-                  <dd>{formatUsd(usage.cost.totalUsd)}</dd>
+                  <dd>{usageEstimates}</dd>
                 </div>
               ) : null}
             </dl>
             {usage.summary ? (
-              <p className="subagent-modal__usage-summary">{usage.summary}</p>
+              <p className="subagent-modal__usage-summary">
+                {formatSubAgentUsageSummary({
+                  displayOptions: props.pricingDisplayOptions,
+                  model,
+                  usage,
+                })}
+              </p>
             ) : null}
           </section>
         ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -5,7 +5,12 @@ import type {
 } from "@pwragent/shared";
 import { useSubAgents } from "./useSubAgents";
 import { formatTimestamp } from "./context-rail-shared";
-import { subAgentStatusLabel, subAgentTone } from "./subagent-format";
+import {
+  formatSubAgentUsageSummary,
+  type PricingDisplayOptions,
+  subAgentStatusLabel,
+  subAgentTone,
+} from "./subagent-format";
 import { RailStatusChip } from "./RailStatusChip";
 import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
 import {
@@ -14,6 +19,7 @@ import {
 } from "./subagent-kind";
 
 type SubAgentsPanelProps = {
+  pricingDisplayOptions?: PricingDisplayOptions;
   thread: NavigationThreadSummary;
 };
 
@@ -76,7 +82,11 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 {subAgent.monitorUsage?.summary ? (
                   <p className="rail-card__usage">
                     {subAgentUsageLabel(subAgent)} usage:{" "}
-                    {subAgent.monitorUsage.summary}
+                    {formatSubAgentUsageSummary({
+                      displayOptions: props.pricingDisplayOptions,
+                      model: subAgent.preferredModel,
+                      usage: subAgent.monitorUsage,
+                    })}
                   </p>
                 ) : null}
                 <button
@@ -98,6 +108,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
       )}
       {detailsFor ? (
         <SubAgentDetailsModal
+          pricingDisplayOptions={props.pricingDisplayOptions}
           subAgent={detailsFor}
           onClose={() => setDetailsFor(null)}
         />

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
@@ -1,5 +1,22 @@
-import type { ThreadSubAgentStatus } from "@pwragent/shared";
+import type {
+  TaskMonitorUsageSnapshot,
+  ThreadSubAgentStatus,
+} from "@pwragent/shared";
+import {
+  estimateOpenAiCodexCreditUsage,
+  formatTokenUsageUsd,
+} from "@pwragent/shared";
 import type { RailChipTone } from "./RailStatusChip";
+
+export type PricingDisplayOptions = {
+  codexCredits: boolean;
+  usd: boolean;
+};
+
+const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
+  codexCredits: false,
+  usd: true,
+};
 
 /** Maps a sub-agent status onto a shared status-chip tone. */
 export function subAgentTone(status: ThreadSubAgentStatus): RailChipTone {
@@ -41,6 +58,101 @@ export function subAgentStatusLabel(status: ThreadSubAgentStatus): string {
 /** Compact, locale-grouped token count (e.g. `303,488`). */
 export function formatTokenCount(value: number): string {
   return value.toLocaleString();
+}
+
+export function formatSubAgentUsageSummary(params: {
+  displayOptions?: PricingDisplayOptions;
+  model?: string;
+  usage: TaskMonitorUsageSnapshot;
+}): string {
+  const displayOptions = params.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
+  const tokenUsage = params.usage.tokenUsage;
+  const inputTokens = Math.max(0, tokenUsage.inputTokens ?? 0);
+  const cachedInputTokens = Math.min(
+    inputTokens,
+    Math.max(0, tokenUsage.cachedInputTokens ?? 0),
+  );
+  const uncachedInputTokens = Math.max(
+    0,
+    tokenUsage.uncachedInputTokens ?? inputTokens - cachedInputTokens,
+  );
+  const outputTokens = Math.max(0, tokenUsage.outputTokens ?? 0);
+  const reasoningOutputTokens = Math.max(
+    0,
+    tokenUsage.reasoningOutputTokens ?? 0,
+  );
+  const estimates = formatSubAgentUsageEstimates({
+    displayOptions,
+    model: params.model ?? params.usage.model ?? params.usage.cost?.model,
+    usage: params.usage,
+  });
+
+  return [
+    `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    `${formatTokenCount(cachedInputTokens)} cached`,
+    reasoningOutputTokens > 0
+      ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(
+          reasoningOutputTokens,
+        )} reasoning)`
+      : `${formatTokenCount(outputTokens)} out`,
+    estimates,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function formatSubAgentUsageEstimates(params: {
+  displayOptions?: PricingDisplayOptions;
+  model?: string;
+  usage: TaskMonitorUsageSnapshot;
+}): string | undefined {
+  const displayOptions = params.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
+  const estimates: string[] = [];
+  if (displayOptions.usd && params.usage.cost) {
+    estimates.push(`${formatTokenUsageUsd(params.usage.cost.totalUsd)} list price`);
+  }
+  if (displayOptions.codexCredits) {
+    const credits = estimateOpenAiCodexCreditUsage({
+      cachedInputTokens: Math.max(
+        0,
+        params.usage.tokenUsage.cachedInputTokens ?? 0,
+      ),
+      model: params.model ?? params.usage.model ?? params.usage.cost?.model,
+      outputTokens: Math.max(0, params.usage.tokenUsage.outputTokens ?? 0),
+      reasoningOutputTokens: Math.max(
+        0,
+        params.usage.tokenUsage.reasoningOutputTokens ?? 0,
+      ),
+      uncachedInputTokens: Math.max(
+        0,
+        params.usage.tokenUsage.uncachedInputTokens ??
+          Math.max(0, params.usage.tokenUsage.inputTokens ?? 0) -
+            Math.max(0, params.usage.tokenUsage.cachedInputTokens ?? 0),
+      ),
+    });
+    if (credits && credits.totalCreditMicros > 0) {
+      estimates.push(formatCodexCredits(credits.totalCreditMicros));
+    }
+  }
+  return estimates.length > 0 ? estimates.join(" · ") : undefined;
+}
+
+export function formatCodexCredits(valueMicros: number): string {
+  if (valueMicros <= 0) {
+    return "0 Codex Credits";
+  }
+  const value = valueMicros / 1_000_000;
+  if (value < 0.05) {
+    return "<0.1 Codex Credits";
+  }
+  if (value >= 10) {
+    return `${new Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 0,
+    }).format(value)} Codex Credits`;
+  }
+  return `${new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 1,
+  }).format(value)} Codex Credits`;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
@@ -117,12 +117,14 @@ export function formatSubAgentUsageEstimates(params: {
         0,
         params.usage.tokenUsage.cachedInputTokens ?? 0,
       ),
+      fastMode: params.usage.fastMode,
       model: params.model ?? params.usage.model ?? params.usage.cost?.model,
       outputTokens: Math.max(0, params.usage.tokenUsage.outputTokens ?? 0),
       reasoningOutputTokens: Math.max(
         0,
         params.usage.tokenUsage.reasoningOutputTokens ?? 0,
       ),
+      serviceTier: params.usage.serviceTier,
       uncachedInputTokens: Math.max(
         0,
         params.usage.tokenUsage.uncachedInputTokens ??

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -54,7 +54,9 @@ export type TaskMonitorUsageSnapshot = {
     model: string;
     totalUsd: number;
   };
+  fastMode?: boolean;
   model?: string;
+  serviceTier?: string;
   summary: string;
   tokenUsage: {
     cachedInputTokens?: number;


### PR DESCRIPTION
## Summary
Sub-agent cost rows now follow the operator's selected pricing units. When USD is off and Codex Credits is on, the Sub-agents tab and details modal show only Credits instead of leaking the persisted USD list-price summary.

The UI now formats sub-agent usage from structured token data, so saved monitor summaries remain untouched while the renderer applies the same display preference shape used by the Pricing tab.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-format.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
