### PR TITLE
feat(desktop): enable cost reporting by default

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1755,7 +1755,7 @@ describe("DesktopSettingsService", () => {
     );
   });
 
-  it("defaults thread pricing summary to false and persists it", async () => {
+  it("defaults thread pricing summary to true and persists it", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     const service = new DesktopSettingsService({
@@ -1766,7 +1766,7 @@ describe("DesktopSettingsService", () => {
 
     const initial = await service.readSettings();
     expect(initial.experimental.threadPricingSummary).toEqual({
-      value: false,
+      value: true,
       source: "default",
     });
     expect(initial.experimental.threadPricingDisplayUsd).toEqual({
@@ -1780,7 +1780,7 @@ describe("DesktopSettingsService", () => {
 
     await service.writeConfigPatch({
       experimental: {
-        threadPricingSummary: true,
+        threadPricingSummary: false,
         threadPricingDisplayUsd: false,
         threadPricingDisplayCodexCredits: true,
       },
@@ -1788,7 +1788,7 @@ describe("DesktopSettingsService", () => {
 
     const updated = await service.readSettings();
     expect(updated.experimental.threadPricingSummary).toEqual({
-      value: true,
+      value: false,
       source: "config",
     });
     expect(updated.experimental.threadPricingDisplayUsd).toEqual({
@@ -1800,7 +1800,7 @@ describe("DesktopSettingsService", () => {
       source: "config",
     });
     expect(fs.readFileSync(configPath, "utf8")).toContain(
-      "thread_pricing_summary = true",
+      "thread_pricing_summary = false",
     );
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "thread_pricing_display_usd = false",

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -561,7 +561,7 @@ export class DesktopSettingsService {
         ),
         threadPricingSummary: this.resolveConfigBoolean(
           config.experimental?.threadPricingSummary,
-          false,
+          true,
         ),
         threadPricingDisplayUsd: this.resolveConfigBoolean(
           config.experimental?.threadPricingDisplayUsd,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -821,7 +821,7 @@ function DesktopAppShell(props: {
     contextWindow: session.contextWindow,
     pricing: session.response?.pricing,
     threadPricingSummaryEnabled:
-      settings.snapshot?.experimental.threadPricingSummary?.value ?? false,
+      settings.snapshot?.experimental.threadPricingSummary?.value ?? true,
     pricingDisplayOptions: {
       codexCredits:
         settings.snapshot?.experimental.threadPricingDisplayCodexCredits?.value ??

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -111,13 +111,13 @@ export function ExperimentalSettings(props: {
       <SettingsPanelHead
         eyebrow="Experimental"
         title="Experimental features"
-        help="Opt-in features that may change shape or be removed without notice."
+        help="Features that may change shape or be removed without notice."
       />
 
       <SettingsSection
         eyebrow="Experimental"
         title="Thread Pricing Summary"
-        description="Show list-price usage totals in the thread context rail. Disabled by default while pricing reconstruction and provider coverage are being validated."
+        description="Show list-price usage totals in the thread context rail. Enabled by default while pricing reconstruction and provider coverage continue to be validated."
         chip={threadPricingSummary.value ? "On" : "Off"}
         chipKind={threadPricingSummary.value ? "ok" : "default"}
       >

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -48,7 +48,7 @@ const DEFAULT_AGENT_CORE_GROK = {
 };
 
 const DEFAULT_THREAD_PRICING_SUMMARY = {
-  value: false,
+  value: true,
   source: "default" as const,
 };
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -146,7 +146,7 @@ function createSnapshot(
         source: "default",
       },
       threadPricingSummary: {
-        value: false,
+        value: true,
         source: "default",
       },
       threadPricingDisplayUsd: {
@@ -650,15 +650,15 @@ describe("SettingsScreen", () => {
     );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
-        experimental: { threadPricingSummary: true },
+        experimental: { threadPricingSummary: false },
       });
     });
     expect(
       screen.getByRole("switch", { name: "Display USD" }),
-    ).toBeDisabled();
+    ).not.toBeDisabled();
     expect(
       screen.getByRole("switch", { name: "Display Codex Credits" }),
-    ).toBeDisabled();
+    ).not.toBeDisabled();
 
     fireEvent.click(
       screen.getByRole("switch", {
@@ -888,6 +888,29 @@ describe("SettingsScreen", () => {
         experimental: { threadPricingDisplayCodexCredits: true },
       });
     });
+  });
+
+  it("disables thread pricing display unit toggles when summary is off", () => {
+    const baseSnapshot = createSnapshot();
+    const settings = createSettingsState(
+      createSnapshot({
+        experimental: {
+          ...baseSnapshot.experimental,
+          threadPricingSummary: { value: false, source: "config" },
+          threadPricingDisplayUsd: { value: true, source: "default" },
+          threadPricingDisplayCodexCredits: { value: false, source: "default" },
+        },
+      }),
+    );
+
+    render(<SettingsScreen settings={settings} onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Experimental" }));
+
+    expect(screen.getByRole("switch", { name: "Display USD" })).toBeDisabled();
+    expect(
+      screen.getByRole("switch", { name: "Display Codex Credits" }),
+    ).toBeDisabled();
   });
 
   it("saves hot CPU profiling delay and trigger mode presets", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -169,13 +169,14 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const revealIntentRef = useRef(0);
   const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
+  const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
 
   const activeTab =
-    props.activeTab === "pricing" && !props.threadPricingSummaryEnabled
+    props.activeTab === "pricing" && !threadPricingSummaryEnabled
       ? "info"
       : props.activeTab;
   const visibleTabs = CONTEXT_TABS.filter(
-    (tab) => tab.id !== "pricing" || props.threadPricingSummaryEnabled,
+    (tab) => tab.id !== "pricing" || threadPricingSummaryEnabled,
   );
   const topTabs = visibleTabs.filter((tab) => !tab.bottom);
   const bottomTabs = visibleTabs.filter((tab) => tab.bottom);

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -966,7 +966,7 @@ export function ThreadView(props: ThreadViewProps) {
   // Defaults to pinned-open (matches the persisted default) when App hasn't
   // threaded a value through yet, so the rail is discoverable.
   const contextRailPinned = props.contextRailPinned ?? true;
-  const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? false;
+  const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
   const activeContextTab =
     !threadPricingSummaryEnabled && props.activeContextTab === "pricing"
       ? DEFAULT_CONTEXT_TAB

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -438,14 +438,29 @@ describe("ThreadContextPanel", () => {
     );
   });
 
-  it("hides the Pricing tab by default while the experimental flag is off", () => {
+  it("shows the Pricing tab by default", () => {
     renderPanel({
       activeTab: "pricing",
       pinned: true,
     });
 
+    expect(screen.getByRole("tab", { name: "Pricing" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Pricing" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Pricing tab while the experimental flag is off", () => {
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      threadPricingSummaryEnabled: false,
+    });
+
     expect(screen.queryByRole("tab", { name: "Pricing" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("heading", { level: 3, name: "Pricing" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { level: 3, name: "Pricing" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Thread info" })).toBeInTheDocument();
   });
 

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -84,7 +84,7 @@ describe("desktop settings contracts", () => {
           source: "default",
         },
         threadPricingSummary: {
-          value: false,
+          value: true,
           source: "default",
         },
         threadPricingDisplayUsd: {


### PR DESCRIPTION
## Summary

- I enabled cost reporting by default so new profiles and missing/stale renderer snapshots show the Pricing tab without requiring the experimental opt-in first.
- I kept the explicit opt-out path intact: setting `experimental.thread_pricing_summary = false` still hides the Pricing tab and disables the display-unit toggles.
- I updated the settings, renderer fallback, and contract tests to lock in both the default-on and explicit-off behavior.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/main/__tests__/desktop-settings-service.test.ts packages/shared/src/contracts/__tests__/settings.test.ts`
- `pnpm lint`
- `pnpm test`

## Post-Deploy Monitoring & Validation

- Log queries/search terms: watch desktop logs for `pricing`, `thread_pricing_summary`, and renderer errors around `ThreadContextPanel` or settings snapshot reads.
- Healthy signals: fresh profiles show the Pricing tab by default, Settings -> Experimental shows thread pricing summary enabled, and operators can still turn it off.
- Failure signals: renderer exceptions in the thread context rail, settings writes failing for `[experimental] thread_pricing_summary`, or reports that Pricing remains hidden on fresh/default config.
- Rollback trigger: revert this default flip if enabling the pricing rail causes thread view crashes, materially noisy logs, or incorrect pricing summaries in normal use.
- Validation window and owner: monitor the next desktop dogfood/release validation pass; owner is PwrDrvr desktop maintainers.

## Notes

- This changes only the default and fallback behavior; existing configs with `thread_pricing_summary = false` remain honored.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
