### PR TITLE
fix(desktop): reject ungrouped same-workspace handoffs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -44,6 +44,7 @@ import {
   CodexEnvironmentCommandError,
   type CodexEnvironmentCommandRunner,
 } from "../app-server/codex-environment-runtime";
+import { GitDirectoryService } from "../app-server/git-directory-service";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
@@ -13650,6 +13651,9 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      gitDirectoryService: new GitDirectoryService({
+        resolveWorktreeStorage: () => "in-repo",
+      }),
       overlayStore,
       threadTitleGenerationService: null,
     });
@@ -13733,6 +13737,7 @@ command = "pnpm dev"
           task: "Investigate issue XYZ and report back.",
           title: "Investigate issue XYZ",
           context: "Parent already checked the latest CI run.",
+          workspaceMode: "new_worktree",
           messagingAttachment: "new_child",
         },
       },
@@ -13742,7 +13747,6 @@ command = "pnpm dev"
     const payload = JSON.parse(
       (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
     );
-    const normalizedRoot = expectedDir(root);
     expect(payload).toMatchObject({
       backend: "codex",
       threadId: "thread-1",
@@ -13761,11 +13765,11 @@ command = "pnpm dev"
         sandbox: "danger-full-access",
       },
       workspace: {
-        mode: "same",
-        cwd: normalizedRoot,
-        branch: "main",
+        mode: "new_worktree",
+        cwd: expect.stringContaining("handoff"),
+        branch: "HEAD",
         git: {
-          kind: "git_local",
+          kind: "git_worktree",
           worktreeCreationAvailable: true,
         },
       },
@@ -13803,7 +13807,7 @@ command = "pnpm dev"
       },
     ]);
     expect(codexClient.lastStartThreadParams).toMatchObject({
-      cwd: normalizedRoot,
+      cwd: expect.stringContaining("handoff"),
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",
@@ -13817,7 +13821,7 @@ command = "pnpm dev"
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
-      cwd: normalizedRoot,
+      cwd: expect.stringContaining("handoff"),
       model: "gpt-5.4",
       reasoningEffort: "high",
       serviceTier: "priority",
@@ -13832,7 +13836,7 @@ command = "pnpm dev"
     expect(prompt).toContain("Task:\nInvestigate issue XYZ and report back.");
     expect(prompt).toContain("- Thread ID: ordinary-thread");
     expect(prompt).toContain("- Turn ID: turn-1");
-    expect(prompt).toContain(`- CWD: ${normalizedRoot}`);
+    expect(prompt).toContain("- CWD: ");
     expect(prompt).toContain("Additional context from parent:");
     expect(prompt).toContain("Parent already checked the latest CI run.");
     await expect(
@@ -13853,15 +13857,77 @@ command = "pnpm dev"
         seedMode: "clean",
         groupingMode: "none",
         workspace: {
-          mode: "same",
-          cwd: normalizedRoot,
-          branch: "main",
+          mode: "new_worktree",
+          cwd: expect.stringContaining("handoff"),
+          branch: "HEAD",
         },
       },
     });
 
     await registry.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it("rejects ungrouped same-workspace thread handoff dynamic tool calls", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate issue XYZ and report back.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "invalid_arguments",
+              message:
+                'workspaceMode="same" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for an ungrouped delegated thread with an isolated worktree, or workspaceMode="none" for an unscoped local thread.',
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
+    expect(codexClient.lastStartTurnParams).toBeUndefined();
+
+    await registry.close();
   });
 
   it("sends a follow-up prompt to another thread from an active turn", async () => {

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -94,7 +94,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread, and groupingMode=subthread only when the user asks for a sub-thread.";
+      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread, and groupingMode=subthread only when the user asks for a sub-thread. For ungrouped handoffs, explicitly choose workspaceMode=new_worktree or workspaceMode=none.";
     case "send_message_to_thread":
       return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead.";
   }
@@ -141,7 +141,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: HANDOFF_TASK_WORKSPACE_MODES,
             description:
-              "`same` inherits the current workspace and is the default. `new_worktree` requests an isolated Git worktree. `none` allows a no-workspace thread.",
+              "`same` inherits the current workspace and is valid only with groupingMode=subthread. `new_worktree` requests an isolated Git worktree. `none` allows a no-workspace thread.",
           },
           messagingAttachment: {
             type: "string",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14040,6 +14040,12 @@ export class DesktopBackendRegistry {
       request.args.groupingMode ?? "none";
     const workspaceMode: HandoffTaskWorkspaceMode =
       request.args.workspaceMode ?? "same";
+    if (workspaceMode === "same" && groupingMode !== "subthread") {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        'workspaceMode="same" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for an ungrouped delegated thread with an isolated worktree, or workspaceMode="none" for an unscoped local thread.',
+      );
+    }
     const sourceThread = await this.findThreadForWorkspaceHandoff({
       backend: sourceBackend,
       callerReason: "agent-handoff",


### PR DESCRIPTION
## Summary

Agent-created handoffs can no longer create the hidden mode where an ungrouped delegated thread silently inherits the caller's worktree. Ungrouped handoffs now have to choose an isolated worktree or no workspace, matching the modes exposed by the desktop UI.

The agent-facing tool text now documents that `workspaceMode="same"` is reserved for grouped subthreads, and the backend rejects the invalid combination before creating a thread or starting a turn.

## Test Plan

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
