### PR TITLE
chore(deps): apply production dependency updates

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -58,14 +58,12 @@ MIT
 - @floating-ui/core@1.7.5 | https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.7.6 | https://github.com/floating-ui/floating-ui
 - @floating-ui/utils@0.2.11 | https://github.com/floating-ui/floating-ui
-- @pwrdrvr/agent-acp@0.12.0 | https://github.com/pwrdrvr/agent-kit
+- @pwrdrvr/agent-acp@0.12.2 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-client@0.6.1 | https://github.com/pwrdrvr/agent-kit
-- @pwrdrvr/agent-core@0.1.3 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-core@0.2.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-transport@0.1.6 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/codex-app-server-protocol@0.133.0 | https://github.com/pwrdrvr/codex-app-server-protocol
 - @pwrdrvr/codex-app-server-protocol@0.135.0 | https://github.com/pwrdrvr/codex-app-server-protocol
-- @pwrdrvr/codex-discovery@0.1.2 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/codex-discovery@0.1.3 | https://github.com/pwrdrvr/agent-kit
 - @shutterstock/p-map-iterable@1.1.2 | https://github.com/shutterstock/p-map-iterable
 - @tiptap/core@3.26.0 | https://github.com/ueberdosis/tiptap
@@ -104,7 +102,7 @@ MIT
 - @types/hast@3.0.4 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 | https://github.com/DefinitelyTyped/DefinitelyTyped
-- @types/react@19.2.15 | https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/react@19.2.17 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/react-dom@19.2.3 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@2.0.11 | https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@3.0.3 | https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -238,8 +236,8 @@ MIT
 - prosemirror-transform@1.12.0 | https://github.com/prosemirror/prosemirror-transform
 - prosemirror-view@1.41.8 | https://code.haverbeke.berlin/prosemirror/prosemirror-view
 - pump@3.0.4 | https://github.com/mafintosh/pump
-- react@19.2.6 | https://github.com/facebook/react
-- react-dom@19.2.6 | https://github.com/facebook/react
+- react@19.2.7 | https://github.com/facebook/react
+- react-dom@19.2.7 | https://github.com/facebook/react
 - react-markdown@10.1.0 | remarkjs/react-markdown
 - readable-stream@3.6.2 | https://github.com/nodejs/readable-stream
 - remark-breaks@4.0.0 | remarkjs/remark-breaks
@@ -320,21 +318,19 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@pwrdrvr/agent-acp@0.12.0 (MIT)
+@pwrdrvr/agent-acp@0.12.2 (MIT)
 -------------------------------
 
 Applies to:
-- @pwrdrvr/agent-acp@0.12.0 (MIT)
+- @pwrdrvr/agent-acp@0.12.2 (MIT)
 - @pwrdrvr/agent-client@0.6.1 (MIT)
-- @pwrdrvr/agent-core@0.1.3 (MIT)
 - @pwrdrvr/agent-core@0.2.0 (MIT)
 - @pwrdrvr/agent-transport@0.1.6 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.133.0 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.135.0 (MIT)
-- @pwrdrvr/codex-discovery@0.1.2 (MIT)
 - @pwrdrvr/codex-discovery@0.1.3 (MIT)
 
-Representative file: @pwrdrvr/agent-acp@0.12.0/LICENSE
+Representative file: @pwrdrvr/agent-acp@0.12.2/LICENSE
 
 MIT License
 
@@ -457,7 +453,7 @@ Applies to:
 - @types/hast@3.0.4 (MIT)
 - @types/mdast@4.0.4 (MIT)
 - @types/ms@2.1.0 (MIT)
-- @types/react@19.2.15 (MIT)
+- @types/react@19.2.17 (MIT)
 - @types/react-dom@19.2.3 (MIT)
 - @types/unist@2.0.11 (MIT)
 - @types/unist@3.0.3 (MIT)
@@ -3183,16 +3179,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-react@19.2.6 (MIT)
+react@19.2.7 (MIT)
 ------------------
 
 Applies to:
-- react@19.2.6 (MIT)
-- react-dom@19.2.6 (MIT)
+- react@19.2.7 (MIT)
+- react-dom@19.2.7 (MIT)
 - scheduler@0.27.0 (MIT)
 - use-sync-external-store@1.6.0 (MIT)
 
-Representative file: react@19.2.6/LICENSE
+Representative file: react@19.2.7/LICENSE
 
 MIT License
 

--- a/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
@@ -22,6 +22,7 @@ type StreamToolCall = {
 
 function createStreamTextMock(params: {
   text?: string;
+  reasoningText?: string;
   responseId?: string;
   toolCalls?: StreamToolCall[];
   sources?: unknown[];
@@ -44,6 +45,7 @@ function createStreamTextMock(params: {
     const text = run();
     return {
       text,
+      reasoningText: text.then(() => params.reasoningText),
       response: text.then(() => ({ id: params.responseId ?? "resp_123" })),
       sources: Promise.resolve(params.sources ?? []),
       providerMetadata: Promise.resolve(undefined),
@@ -236,6 +238,37 @@ describe("GrokProvider tool loop", () => {
         }),
       }),
     );
+  });
+
+  it("falls back to final reasoning text when xAI returns no text after tool use", async () => {
+    const streamTextImpl = createStreamTextMock({
+      text: "",
+      reasoningText: "Needle located.",
+      responseId: "resp_reasoning_final",
+      toolCalls: [{ id: "call_search", name: "search_code", input: { query: "needle" } }],
+    });
+    const { executor } = createStubToolExecutor();
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      streamTextImpl,
+    });
+
+    const activeTurn = provider.startTurn({
+      thread: {
+        threadId: "thread-123",
+        cwd: "/repo/workspace",
+        model: "grok-4.20-reasoning",
+      },
+      input: [{ type: "text", text: "Find the needle." }],
+      tools: executor,
+    });
+
+    await expect(activeTurn.result).resolves.toEqual({
+      assistantText: "Needle located.",
+      providerResponseId: "resp_reasoning_final",
+      sources: [],
+      providerMetadata: undefined,
+    });
   });
 
   it("includes thread history when starting a chat-model turn", async () => {

--- a/packages/agent-core/src/providers/grok-provider.ts
+++ b/packages/agent-core/src/providers/grok-provider.ts
@@ -99,20 +99,22 @@ async function runAiSdkTurn(params: {
     }),
   }) as {
     text: PromiseLike<string>;
+    reasoningText?: PromiseLike<string | undefined>;
     response: PromiseLike<{ id?: string }>;
     sources?: PromiseLike<unknown[]>;
     providerMetadata?: PromiseLike<unknown>;
   };
 
-  const [assistantText, response, sources, providerMetadata] = await Promise.all([
+  const [assistantText, reasoningText, response, sources, providerMetadata] = await Promise.all([
     result.text,
+    result.reasoningText ?? Promise.resolve(undefined),
     result.response,
     result.sources ?? Promise.resolve([]),
     result.providerMetadata ?? Promise.resolve(undefined),
   ]);
 
   return {
-    assistantText,
+    assistantText: assistantText.trim() ? assistantText : (reasoningText ?? assistantText),
     providerResponseId: response.id,
     sources: normalizeAiSdkSources(sources),
     providerMetadata: normalizeProviderMetadata(providerMetadata),

--- a/packages/messaging/providers/feishu/package.json
+++ b/packages/messaging/providers/feishu/package.json
@@ -8,7 +8,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@larksuiteoapi/node-sdk": "1.66.1",
+    "@larksuiteoapi/node-sdk": "1.67.0",
     "@pwragent/messaging-interface": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: link:../../packages/shared
       '@pwrdrvr/agent-acp':
         specifier: ^0.12.0
-        version: 0.12.0
+        version: 0.12.2
       '@pwrdrvr/agent-client':
         specifier: ^0.6.1
         version: 0.6.1
@@ -84,7 +84,7 @@ importers:
         version: 0.135.0
       '@pwrdrvr/codex-discovery':
         specifier: ^0.1.2
-        version: 0.1.2
+        version: 0.1.3
       '@shutterstock/p-map-iterable':
         specifier: ^1.1.2
         version: 1.1.2(aggregate-error@3.1.0)
@@ -93,7 +93,7 @@ importers:
         version: 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@tiptap/suggestion@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))
       '@tiptap/react':
         specifier: ^3.22.5
-        version: 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tiptap/starter-kit':
         specifier: ^3.22.5
         version: 3.26.0
@@ -129,13 +129,13 @@ importers:
         version: 1.5.0
       react:
         specifier: ^19.2.0
-        version: 19.2.6
+        version: 19.2.7
       react-dom:
         specifier: ^19.2.0
-        version: 19.2.6(react@19.2.6)
+        version: 19.2.7(react@19.2.7)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.15)(react@19.2.6)
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
@@ -157,16 +157,16 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
       '@types/react':
         specifier: ^19.2.14
-        version: 19.2.15
+        version: 19.2.17
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.15)
+        version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
@@ -193,13 +193,13 @@ importers:
     dependencies:
       '@ai-sdk/xai':
         specifier: ^3.0.83
-        version: 3.0.93(zod@4.3.6)
+        version: 3.0.95(zod@4.3.6)
       '@pwragent/shared':
         specifier: workspace:*
         version: link:../shared
       ai:
         specifier: ^6.0.168
-        version: 6.0.193(zod@4.3.6)
+        version: 6.0.205(zod@4.3.6)
 
   packages/messaging/interface:
     dependencies:
@@ -223,8 +223,8 @@ importers:
   packages/messaging/providers/feishu:
     dependencies:
       '@larksuiteoapi/node-sdk':
-        specifier: 1.66.1
-        version: 1.66.1
+        specifier: 1.67.0
+        version: 1.67.0
       '@pwragent/messaging-interface':
         specifier: workspace:*
         version: link:../../interface
@@ -250,7 +250,7 @@ importers:
     dependencies:
       '@mattermost/client':
         specifier: ^11.4.0
-        version: 11.6.0(@mattermost/types@11.6.0(typescript@6.0.3))(typescript@6.0.3)
+        version: 11.7.0(@mattermost/types@11.7.0(typescript@6.0.3))(typescript@6.0.3)
       '@pwragent/messaging-interface':
         specifier: workspace:*
         version: link:../../interface
@@ -269,7 +269,7 @@ importers:
         version: 2.0.7
       '@slack/web-api':
         specifier: ^7.15.2
-        version: 7.16.0
+        version: 7.17.0
     devDependencies:
       vitest:
         specifier: ^4.1.4
@@ -282,7 +282,7 @@ importers:
         version: link:../../interface
       grammy:
         specifier: ^1.42.0
-        version: 1.43.0(encoding@0.1.13)
+        version: 1.44.0(encoding@0.1.13)
     devDependencies:
       vitest:
         specifier: ^4.1.4
@@ -300,20 +300,20 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@3.0.121':
-    resolution: {integrity: sha512-uY248djJRxa5W68MHiyqO8WLdOeKQoRClGg7PVX/VPhVW8SJNM7/l5DcrA5WAM3YfQrLyNkgZa2VOu8T0t8LUw==}
+  '@ai-sdk/gateway@3.0.131':
+    resolution: {integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@2.0.48':
-    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
+  '@ai-sdk/openai-compatible@2.0.50':
+    resolution: {integrity: sha512-HyuxddF2Yv5G8qxK/0uksAINjQ4h6TpwOqHuqzsCM0u78/JWAW2OXcIplQeB44PIAORgPjbMzrw9DhnPYHMskA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+  '@ai-sdk/provider-utils@4.0.29':
+    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -322,8 +322,8 @@ packages:
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/xai@3.0.93':
-    resolution: {integrity: sha512-HxazLIcSTgI0UQoq6ua0rcSR8+eXuNy0Qh4jkCY9EAWedYn6CQ0XD/j34U4/JYtO738xJdY+tE95okdqWqXkHA==}
+  '@ai-sdk/xai@3.0.95':
+    resolution: {integrity: sha512-8pN/bekiBy4Nf0h9G934mpNg+izj+sAgKjqd3GcoGZKhj2I7d40khQlFxgzoA2xOQNzMfcKKNAUQb22EulB8OQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -758,8 +758,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@grammyjs/types@3.27.3':
-    resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
+  '@grammyjs/types@3.28.0':
+    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -785,8 +785,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@larksuiteoapi/node-sdk@1.66.1':
-    resolution: {integrity: sha512-W1rIAs/8Oc/rEYuWc0sxGvR8iLwd8p5D2RS4ODMqs8htIxK8yIa8sb22EDv/OEBqUpKXZaNLydTz7Oq8HOQROg==}
+  '@larksuiteoapi/node-sdk@1.67.0':
+    resolution: {integrity: sha512-pr3iZbK+CkwgwIhUzt86mZGP/wLCzBDRmCy+Vt+/UAWx/KjwxwrRpfAKm4eOmd0uUd8AcG2mWC/ZSUMu7lZIqg==}
 
   '@line/bot-sdk@11.0.1':
     resolution: {integrity: sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==}
@@ -800,17 +800,17 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
-  '@mattermost/client@11.6.0':
-    resolution: {integrity: sha512-2su6eOr8Vj7xeeb9tKaLgpg3a8u2vgmBfK82d61sjKTjKZt7ySy15xhbFFsnLo8fXePQG0zUZP8YtY+/NutD0Q==}
+  '@mattermost/client@11.7.0':
+    resolution: {integrity: sha512-CTwdegHBBtQzfaWWp3s/gkfEE5HCyncuwGv7A/TcuUf+kjDrLQ4CGOxepZ3LaRq2D5vdlA1IkcCSD4CG5IZPcg==}
     peerDependencies:
-      '@mattermost/types': 11.6.0
+      '@mattermost/types': 11.7.0
       typescript: ^4.3.0 || ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  '@mattermost/types@11.6.0':
-    resolution: {integrity: sha512-0sBZaN1QYB+P0qo7ByiMU8Ja2VTepFWfgqFcx7KA9/TT6+dWiemOQav6SHK1fP4oAlWdh2nikaD01I8VPg4ZRQ==}
+  '@mattermost/types@11.7.0':
+    resolution: {integrity: sha512-KPHcgjOMoQTmwUUHF+ygmx85qpzbsHVLEUGKAAn/XXg8U4rEpKwGFcSyOOfH8pk1OHJAG0Ob5sfvHawVzd7wqA==}
     peerDependencies:
       typescript: ^4.3.0 || ^5.0.0
     peerDependenciesMeta:
@@ -877,14 +877,11 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
-  '@pwrdrvr/agent-acp@0.12.0':
-    resolution: {integrity: sha512-79B0dhU6XTitgYEkQjY0t8bEcOTjfvD2wcjoArVB/uxFr9hvUz3KCb4Y7BHOHtOcIC36P6UUfarwlFh+gahDsw==}
+  '@pwrdrvr/agent-acp@0.12.2':
+    resolution: {integrity: sha512-SwBZfk98nStyoK8t2NTYF9d00+MqhemsP6pUDOkVMHXXNkAbiPn0a8VAuFU2GZxMrQf8QesGi6R8utvw1CULig==}
 
   '@pwrdrvr/agent-client@0.6.1':
     resolution: {integrity: sha512-Q8jyGN9c3BfGTW1ba3baFliaF0bWpabV2rYgKmgwZypB3BoPiraZ3qv4X4piHNKVHJ+XK8PdNtyGC78c6sLHNA==}
-
-  '@pwrdrvr/agent-core@0.1.3':
-    resolution: {integrity: sha512-4yN246yJvMvupOd1R3Z/wo2QfpfpP7WWX3RvATklZVWthrjJgmVSoHn0J8emvJdySJAvvG0eE6TkQB7VNAnqVw==}
 
   '@pwrdrvr/agent-core@0.2.0':
     resolution: {integrity: sha512-zTo7vJGekyZX2h9xWYiZfQvt+qKTPhuciWyCouow1shaKgg0Bn6B8S5lTRvMzxvT7feKOZ7zy/To2Cu6+1i1+A==}
@@ -899,9 +896,6 @@ packages:
   '@pwrdrvr/codex-app-server-protocol@0.135.0':
     resolution: {integrity: sha512-lmebPpbmaE7yfe0EDqcT2MPRtKurUc1o9NinHAVdA3lBdF3c8ZK3okiHIw6r6GEQLqOTd+7dpEuPsk4a1dEpkw==}
     engines: {node: '>=20'}
-
-  '@pwrdrvr/codex-discovery@0.1.2':
-    resolution: {integrity: sha512-9jt+tdNcos6q22ObiRqDf94jCO6l/Z7RsELVXRssY3WXPJPAUXpuSpPFj9K1PkFUAXsDIRwr169iGbUBbeKmJw==}
 
   '@pwrdrvr/codex-discovery@0.1.3':
     resolution: {integrity: sha512-9i6ZuDujKougP3JP+KRFf/V/wLmCxd73vLVwld4YTPqihQtlygjFHyqMCopTcDoIhMkSPogFcv5jzBxyAcX8qg==}
@@ -1182,8 +1176,8 @@ packages:
     resolution: {integrity: sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==}
     engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
 
-  '@slack/web-api@7.16.0':
-    resolution: {integrity: sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg==}
+  '@slack/web-api@7.17.0':
+    resolution: {integrity: sha512-jejr34a8B4L5AS713wOAx1LAqNkW16HVMDEa6sYBvFDc/llUBl8hXaiI4BwF+Al+Sug19Vn2O7iokTVIhVvZ1Q==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -1446,8 +1440,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.15':
-    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
@@ -1579,8 +1573,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@6.0.193:
-    resolution: {integrity: sha512-VQOTOse8+X8kMtg61DNSXlYJzwOW4NjMLDJNk/qxClWsFe4oiyFJDHGGG1oezfGcFzuYuQe/8Z7r4kwiZWh2YQ==}
+  ai@6.0.205:
+    resolution: {integrity: sha512-F4akEGF41UdgJO3L4v+D5noVD1/czhJy6x0k9R/i1EXfxqrkBh/PdYSgRSLPiGFvrw76dzI8h4w3NYmLrTb8dw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1667,8 +1661,8 @@ packages:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -2301,8 +2295,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  grammy@1.43.0:
-    resolution: {integrity: sha512-7dYm06A945mXuIk/5HUlSjeyIYChW8vCEiU2dkOKKqJJzwAWxTkCc91Eqbz7TgODh2rtFFKWI/fekowWHOkmjQ==}
+  grammy@1.44.0:
+    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   has-flag@4.0.0:
@@ -3198,10 +3192,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.7
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -3216,8 +3210,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-binary-file-arch@1.0.6:
@@ -3380,8 +3374,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -3942,20 +3936,20 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@3.0.121(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.131(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.3.6)
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/openai-compatible@2.0.48(zod@4.3.6)':
+  '@ai-sdk/openai-compatible@2.0.50(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.27(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.29(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
@@ -3966,11 +3960,11 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/xai@3.0.93(zod@4.3.6)':
+  '@ai-sdk/xai@3.0.95(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.48(zod@4.3.6)
+      '@ai-sdk/openai-compatible': 2.0.50(zod@4.3.6)
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.3.6)
       zod: 4.3.6
 
   '@asamuzakjp/css-color@5.1.11':
@@ -4428,7 +4422,7 @@ snapshots:
   '@floating-ui/utils@0.2.11':
     optional: true
 
-  '@grammyjs/types@3.27.3': {}
+  '@grammyjs/types@3.28.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4462,9 +4456,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@larksuiteoapi/node-sdk@1.66.1':
+  '@larksuiteoapi/node-sdk@1.67.0':
     dependencies:
-      axios: 1.16.1
+      axios: 1.18.0
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -4494,13 +4488,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mattermost/client@11.6.0(@mattermost/types@11.6.0(typescript@6.0.3))(typescript@6.0.3)':
+  '@mattermost/client@11.7.0(@mattermost/types@11.7.0(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@mattermost/types': 11.6.0(typescript@6.0.3)
+      '@mattermost/types': 11.7.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  '@mattermost/types@11.6.0(typescript@6.0.3)':
+  '@mattermost/types@11.7.0(typescript@6.0.3)':
     optionalDependencies:
       typescript: 6.0.3
 
@@ -4558,7 +4552,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
-  '@pwrdrvr/agent-acp@0.12.0':
+  '@pwrdrvr/agent-acp@0.12.2':
     dependencies:
       '@pwrdrvr/agent-core': 0.2.0
       '@pwrdrvr/agent-transport': 0.1.6
@@ -4572,8 +4566,6 @@ snapshots:
       '@pwrdrvr/codex-discovery': 0.1.3
       zod: 4.3.6
 
-  '@pwrdrvr/agent-core@0.1.3': {}
-
   '@pwrdrvr/agent-core@0.2.0': {}
 
   '@pwrdrvr/agent-transport@0.1.6':
@@ -4583,10 +4575,6 @@ snapshots:
   '@pwrdrvr/codex-app-server-protocol@0.133.0': {}
 
   '@pwrdrvr/codex-app-server-protocol@0.135.0': {}
-
-  '@pwrdrvr/codex-discovery@0.1.2':
-    dependencies:
-      '@pwrdrvr/agent-core': 0.1.3
 
   '@pwrdrvr/codex-discovery@0.1.3':
     dependencies:
@@ -4744,7 +4732,7 @@ snapshots:
   '@slack/socket-mode@2.0.7':
     dependencies:
       '@slack/logger': 4.0.1
-      '@slack/web-api': 7.16.0
+      '@slack/web-api': 7.17.0
       '@types/node': 24.13.2
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
@@ -4757,13 +4745,13 @@ snapshots:
 
   '@slack/types@2.21.1': {}
 
-  '@slack/web-api@7.16.0':
+  '@slack/web-api@7.17.0':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
       '@types/node': 24.13.2
       '@types/retry': 0.12.0
-      axios: 1.16.1
+      axios: 1.18.0
       eventemitter3: 5.0.4
       form-data: 4.0.6
       is-electron: 2.2.2
@@ -4801,15 +4789,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 19.2.15
-      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@tiptap/core@3.26.0(@tiptap/pm@3.26.0)':
     dependencies:
@@ -4945,17 +4933,17 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@tiptap/react@3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tiptap/react@3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@tiptap/core': 3.26.0(@tiptap/pm@3.26.0)
       '@tiptap/pm': 3.26.0
-      '@types/react': 19.2.15
-      '@types/react-dom': 19.2.3(@types/react@19.2.15)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.0
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      use-sync-external-store: 1.6.0(react@19.2.6)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
       '@tiptap/extension-floating-menu': 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)
@@ -5080,11 +5068,11 @@ snapshots:
       xmlbuilder: 15.1.1
     optional: true
 
-  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
-      '@types/react': 19.2.15
+      '@types/react': 19.2.17
 
-  '@types/react@19.2.15':
+  '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
 
@@ -5218,11 +5206,11 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@6.0.193(zod@4.3.6):
+  ai@6.0.205(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.121(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.131(zod@4.3.6)
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.3.6)
       '@opentelemetry/api': 1.9.1
       zod: 4.3.6
 
@@ -5322,7 +5310,7 @@ snapshots:
 
   axe-core@4.12.1: {}
 
-  axios@1.16.1:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
@@ -6093,9 +6081,9 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  grammy@1.43.0(encoding@0.1.13):
+  grammy@1.44.0(encoding@0.1.13):
     dependencies:
-      '@grammyjs/types': 3.27.3
+      '@grammyjs/types': 3.28.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -7213,7 +7201,7 @@ snapshots:
 
   qs@6.15.2:
     dependencies:
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   quick-lru@5.1.1: {}
 
@@ -7224,23 +7212,23 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.6(react@19.2.6):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.2.6
+      react: 19.2.7
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
 
-  react-markdown@10.1.0(@types/react@19.2.15)(react@19.2.6):
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      '@types/react': 19.2.15
+      '@types/react': 19.2.17
       devlop: 1.1.0
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
-      react: 19.2.6
+      react: 19.2.7
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
@@ -7251,7 +7239,7 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react@19.2.6: {}
+  react@19.2.7: {}
 
   read-binary-file-arch@1.0.6:
     dependencies:
@@ -7476,7 +7464,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -7784,9 +7772,9 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-sync-external-store@1.6.0(react@19.2.6):
+  use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
-      react: 19.2.6
+      react: 19.2.7
 
   utf8-byte-length@1.0.5: {}
 
@@ -7851,6 +7839,35 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0


### PR DESCRIPTION
## Summary

- apply the npm production dependency updates from the closed Dependabot PR #875
- regenerate `THIRD_PARTY_LICENSES` for the updated production dependency graph
- handle xAI/AI SDK reasoning-only tool responses in the Grok provider

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- GitHub Actions run for the same head commit passed on the original PR branch: https://github.com/pwrdrvr/PwrAgent/actions/runs/28059775592

Dependabot closed #875 after reporting the updates were no longer updatable, so this PR republishes the same tested changes from a human-owned branch.