### PR TITLE
fix(agent-core): retry empty Grok tool responses

### DIFF
--- a/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
+++ b/packages/agent-core/src/__tests__/grok-provider-tools.test.ts
@@ -20,12 +20,19 @@ type StreamToolCall = {
   input: Record<string, unknown>;
 };
 
+type StreamStep = {
+  toolResults?: Array<{
+    output?: unknown;
+  }>;
+};
+
 function createStreamTextMock(params: {
   text?: string;
   reasoningText?: string;
   responseId?: string;
   toolCalls?: StreamToolCall[];
   sources?: unknown[];
+  steps?: StreamStep[];
 }) {
   return vi.fn((options: any) => {
     const run = async () => {
@@ -49,6 +56,7 @@ function createStreamTextMock(params: {
       response: text.then(() => ({ id: params.responseId ?? "resp_123" })),
       sources: Promise.resolve(params.sources ?? []),
       providerMetadata: Promise.resolve(undefined),
+      steps: text.then(() => params.steps ?? []),
     };
   });
 }
@@ -240,17 +248,37 @@ describe("GrokProvider tool loop", () => {
     );
   });
 
-  it("falls back to final reasoning text when xAI returns no text after tool use", async () => {
+  it("retries for final text when xAI returns reasoning-only output after tool use", async () => {
     const streamTextImpl = createStreamTextMock({
       text: "",
       reasoningText: "Needle located.",
       responseId: "resp_reasoning_final",
       toolCalls: [{ id: "call_search", name: "search_code", input: { query: "needle" } }],
+      steps: [
+        {
+          toolResults: [
+            {
+              output: {
+                toolName: "search_code",
+                success: true,
+                output: "Found needle.",
+              },
+            },
+          ],
+        },
+      ],
     });
+    const generateTextImpl = vi.fn(async (_params: Record<string, unknown>) => ({
+      text: "Needle located.",
+      response: { id: "resp_retry_final" },
+      sources: [],
+      providerMetadata: undefined,
+    }));
     const { executor } = createStubToolExecutor();
     const provider = new GrokProvider({
       apiKey: "test-key",
       streamTextImpl,
+      generateTextImpl,
     });
 
     const activeTurn = provider.startTurn({
@@ -265,10 +293,22 @@ describe("GrokProvider tool loop", () => {
 
     await expect(activeTurn.result).resolves.toEqual({
       assistantText: "Needle located.",
-      providerResponseId: "resp_reasoning_final",
+      providerResponseId: "resp_retry_final",
       sources: [],
       providerMetadata: undefined,
     });
+    const retryParams = generateTextImpl.mock.calls[0]?.[0] as any;
+    expect(retryParams.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Find the needle." }],
+      },
+      {
+        role: "user",
+        content: expect.stringContaining("Found needle."),
+      },
+    ]);
+    expect(retryParams).not.toHaveProperty("tools");
   });
 
   it("includes thread history when starting a chat-model turn", async () => {

--- a/packages/agent-core/src/providers/grok-provider.ts
+++ b/packages/agent-core/src/providers/grok-provider.ts
@@ -10,6 +10,21 @@ export type GrokProviderOptions = XaiAiSdkRuntimeOptions & {
 };
 
 const DEFAULT_MAX_TOOL_ROUNDS = 12;
+const MAX_RETRY_TOOL_OUTPUT_CHARS = 8_000;
+
+type AiSdkStreamTextResult = {
+  text: PromiseLike<string>;
+  response: PromiseLike<{ id?: string }>;
+  sources?: PromiseLike<unknown[]>;
+  providerMetadata?: PromiseLike<unknown>;
+  steps?: PromiseLike<AiSdkStep[]>;
+};
+
+type AiSdkStep = {
+  toolResults?: Array<{
+    output?: unknown;
+  }>;
+};
 
 export class GrokProvider implements AppServerProvider {
   private readonly runtime: XaiAiSdkRuntime;
@@ -97,26 +112,146 @@ async function runAiSdkTurn(params: {
       reasoningEffort: params.params.thread.reasoningEffort,
       previousResponseId: params.params.previousResponseId,
     }),
-  }) as {
-    text: PromiseLike<string>;
-    reasoningText?: PromiseLike<string | undefined>;
-    response: PromiseLike<{ id?: string }>;
-    sources?: PromiseLike<unknown[]>;
-    providerMetadata?: PromiseLike<unknown>;
-  };
+  }) as AiSdkStreamTextResult;
 
-  const [assistantText, reasoningText, response, sources, providerMetadata] = await Promise.all([
+  const [assistantText, response, sources, providerMetadata, steps] = await Promise.all([
     result.text,
-    result.reasoningText ?? Promise.resolve(undefined),
     result.response,
     result.sources ?? Promise.resolve([]),
     result.providerMetadata ?? Promise.resolve(undefined),
+    result.steps ?? Promise.resolve([]),
   ]);
+  const finalResult = assistantText.trim()
+    ? { assistantText, response, sources, providerMetadata }
+    : await retryFinalText({
+        runtime: params.runtime,
+        params: params.params,
+        signal: params.signal,
+        messages,
+        toolOutputs: collectToolOutputs(steps),
+      });
 
   return {
-    assistantText: assistantText.trim() ? assistantText : (reasoningText ?? assistantText),
-    providerResponseId: response.id,
-    sources: normalizeAiSdkSources(sources),
-    providerMetadata: normalizeProviderMetadata(providerMetadata),
+    assistantText: finalResult.assistantText,
+    providerResponseId: finalResult.response.id,
+    sources: normalizeAiSdkSources(finalResult.sources),
+    providerMetadata: normalizeProviderMetadata(finalResult.providerMetadata),
   };
+}
+
+async function retryFinalText(params: {
+  runtime: XaiAiSdkRuntime;
+  params: ProviderTurnParams;
+  signal: AbortSignal;
+  messages: unknown[];
+  toolOutputs: string[];
+}): Promise<{
+  assistantText: string;
+  response: { id?: string };
+  sources: unknown[];
+  providerMetadata: unknown;
+}> {
+  const result = await params.runtime.generateText({
+    model: params.runtime.model({ model: params.params.thread.model }),
+    messages: [
+      ...params.messages,
+      {
+        role: "user",
+        content: buildRetryPrompt(params.toolOutputs),
+      },
+    ],
+    abortSignal: params.signal,
+    providerOptions: buildXaiProviderOptions({
+      model: params.params.thread.model,
+      reasoningEffort: params.params.thread.reasoningEffort,
+      previousResponseId: params.params.previousResponseId,
+    }),
+  });
+
+  return {
+    assistantText: readTextResult(result),
+    response: readResponseResult(result),
+    sources: readArrayResult(result, "sources"),
+    providerMetadata: readRecordResult(result, "providerMetadata"),
+  };
+}
+
+function buildRetryPrompt(toolOutputs: string[]): string {
+  if (toolOutputs.length === 0) {
+    return [
+      "The previous response did not include user-visible assistant text.",
+      "Produce the final answer requested by the user.",
+      "Do not include reasoning or hidden deliberation.",
+    ].join(" ");
+  }
+
+  return [
+    "The previous tool call completed, but no user-visible assistant text was emitted.",
+    "Produce the final answer requested by the user using only the tool results below.",
+    "Do not include reasoning or hidden deliberation.",
+    "",
+    "Tool results:",
+    toolOutputs.map((output, index) => `Result ${index + 1}:\n${output}`).join("\n\n"),
+  ].join("\n");
+}
+
+function collectToolOutputs(steps: AiSdkStep[]): string[] {
+  return steps
+    .flatMap((step) => step.toolResults ?? [])
+    .map((result) => formatToolOutput(result.output))
+    .filter((output): output is string => Boolean(output?.trim()))
+    .map((output) => truncate(output, MAX_RETRY_TOOL_OUTPUT_CHARS));
+}
+
+function formatToolOutput(output: unknown): string | undefined {
+  if (typeof output === "string") {
+    return output;
+  }
+  if (output && typeof output === "object" && "output" in output) {
+    const nested = (output as { output?: unknown }).output;
+    if (typeof nested === "string") {
+      return nested;
+    }
+  }
+  if (!output) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
+function truncate(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars)}\n[truncated]`;
+}
+
+function readTextResult(value: unknown): string {
+  return value && typeof value === "object" && "text" in value
+    ? String((value as { text?: unknown }).text ?? "")
+    : "";
+}
+
+function readResponseResult(value: unknown): { id?: string } {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const response = (value as { response?: unknown }).response;
+  return response && typeof response === "object" ? (response as { id?: string }) : {};
+}
+
+function readArrayResult(value: unknown, key: string): unknown[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const array = (value as Record<string, unknown>)[key];
+  return Array.isArray(array) ? array : [];
+}
+
+function readRecordResult(value: unknown, key: string): unknown {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[key];
 }


### PR DESCRIPTION
## Summary

- stop treating xAI/AI SDK `reasoningText` as user-visible assistant output
- when a Grok tool turn finishes with empty text, retry once for an actual text response using sanitized tool-result output as context
- cover the reasoning-only tool-response edge with a focused provider test

## Validation

- `pnpm test packages/agent-core/src/__tests__/grok-provider-tools.test.ts packages/agent-core/src/__tests__/grok-live.test.ts`
- `pnpm --filter @pwragent/agent-core typecheck`

This resolves the review finding from #881: reasoning text is no longer surfaced as the assistant reply.