### PR TITLE
fix(release): pin Windows packaging to VS 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,10 @@ jobs:
     # Windows NSIS installer build. Off by default — never runs on normal
     # PRs/pushes, so the ~15-minute packaging cost is paid only on demand.
     if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:windows-package') }}
-    runs-on: windows-latest
+    # node-pty's Electron rebuild currently pulls node-gyp 11.x, which does
+    # not recognize Visual Studio 2026 on windows-latest/windows-2025.
+    # Keep installer packaging on VS 2022 until that toolchain catches up.
+    runs-on: windows-2022
     timeout-minutes: 45
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,10 @@ jobs:
 
   windows-package:
     name: Package Windows installer (unsigned)
-    runs-on: windows-latest
+    # node-pty's Electron rebuild currently pulls node-gyp 11.x, which does
+    # not recognize Visual Studio 2026 on windows-latest/windows-2025.
+    # Keep installer packaging on VS 2022 until that toolchain catches up.
+    runs-on: windows-2022
     needs: prepare
     timeout-minutes: 45
     permissions:

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -49,8 +49,13 @@ function assertWorkflowJobRunner(workflow, workflowPath, jobName, expectedRunner
   const bodyStart = match.index + match[0].length;
   const remainder = workflow.slice(bodyStart);
   const nextJobOffset = remainder.search(/^  [A-Za-z0-9_-]+:/m);
-  const jobBody = nextJobOffset === -1 ? remainder : remainder.slice(0, nextJobOffset);
-  const runnerPattern = new RegExp(`^    runs-on:\\s+${escapeRegex(expectedRunner)}\\s*$`, "m");
+  const jobBody = nextJobOffset === -1
+    ? remainder
+    : remainder.slice(0, nextJobOffset);
+  const runnerPattern = new RegExp(
+    `^    runs-on:\\s+${escapeRegex(expectedRunner)}\\s*$`,
+    "m",
+  );
   if (!runnerPattern.test(jobBody)) {
     fail(`${workflowPath} ${jobName} must run on ${expectedRunner}`);
   }
@@ -152,7 +157,12 @@ for (const expected of [
     fail(`.github/workflows/ci.yml must contain ${JSON.stringify(expected)}`);
   }
 }
-assertWorkflowJobRunner(ciWorkflow, ".github/workflows/ci.yml", "windows-package", "windows-2022");
+assertWorkflowJobRunner(
+  ciWorkflow,
+  ".github/workflows/ci.yml",
+  "windows-package",
+  "windows-2022",
+);
 
 for (const expected of [
   "ubuntu-24.04-arm",

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -39,6 +39,23 @@ function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function assertWorkflowJobRunner(workflow, workflowPath, jobName, expectedRunner) {
+  const jobPattern = new RegExp(`^  ${escapeRegex(jobName)}:\\n`, "m");
+  const match = workflow.match(jobPattern);
+  if (!match) {
+    fail(`${workflowPath} must contain a ${jobName} job`);
+    return;
+  }
+  const bodyStart = match.index + match[0].length;
+  const remainder = workflow.slice(bodyStart);
+  const nextJobOffset = remainder.search(/^  [A-Za-z0-9_-]+:/m);
+  const jobBody = nextJobOffset === -1 ? remainder : remainder.slice(0, nextJobOffset);
+  const runnerPattern = new RegExp(`^    runs-on:\\s+${escapeRegex(expectedRunner)}\\s*$`, "m");
+  if (!runnerPattern.test(jobBody)) {
+    fail(`${workflowPath} ${jobName} must run on ${expectedRunner}`);
+  }
+}
+
 const tag = parseTagArg(process.argv.slice(2));
 if (!tag) {
   usage();
@@ -135,6 +152,7 @@ for (const expected of [
     fail(`.github/workflows/ci.yml must contain ${JSON.stringify(expected)}`);
   }
 }
+assertWorkflowJobRunner(ciWorkflow, ".github/workflows/ci.yml", "windows-package", "windows-2022");
 
 for (const expected of [
   "ubuntu-24.04-arm",
@@ -147,6 +165,12 @@ for (const expected of [
     fail(`.github/workflows/release.yml must contain ${JSON.stringify(expected)}`);
   }
 }
+assertWorkflowJobRunner(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "windows-package",
+  "windows-2022",
+);
 
 for (const expected of [
   "PwrAgent-linux-x64.deb",


### PR DESCRIPTION
## Summary

- I pinned the Windows installer packaging jobs to `windows-2022` while leaving the regular Windows build/test job on `windows-latest`.
- I added comments documenting the node-pty/node-gyp/Visual Studio 2026 compatibility issue in both CI and release workflows.
- I extended `pnpm release:check` so the label-gated CI packaging job and release packaging job must stay on `windows-2022` until the native rebuild toolchain catches up.

## Verification

- I verified `pnpm release:check --tag v1.0.0-beta.37` passes.
- I checked the failed release run logs for `v1.0.0-beta.37`: Windows packaging ran on Windows Server 2025 / `windows-2025-vs2026`, then `@electron/rebuild` failed while rebuilding `node-pty` because `node-gyp` could not find a usable Visual Studio installation.
- I compared an earlier successful Windows package run and confirmed the runner image had already moved to Windows Server 2025 / VS 2026 before `node-pty` was added, so the regression is the new native rebuild path rather than the image change alone.

## Notes

- I did not change the already-pushed `v1.0.0-beta.37` release tag.
- Windows installer artifacts are still unsigned and uploaded as workflow artifacts only; this keeps that policy unchanged.
