### PR TITLE
fix(desktop): bound sqlite and log churn

### DIFF
--- a/apps/desktop/src/main/__tests__/log.test.ts
+++ b/apps/desktop/src/main/__tests__/log.test.ts
@@ -3,6 +3,7 @@ import electronLog from "electron-log/main.js";
 import {
   compactStructuredLogData,
   isMainLogDebugCollectionEnabled,
+  MAIN_LOG_MAX_SIZE_BYTES,
   resolveMainLogFileNameForProfile,
   resolveMainLogProfileName,
   setMainLogDebugCollectionEnabled,
@@ -25,6 +26,11 @@ describe("main logger compact formatting", () => {
     expect(electronLog.transports.file.level).toBe("debug");
 
     setMainLogDebugCollectionEnabled(false);
+  });
+
+  it("keeps persistent main logs bounded to 1 MiB rotation", () => {
+    expect(MAIN_LOG_MAX_SIZE_BYTES).toBe(1024 * 1024);
+    expect(electronLog.transports.file.maxSize).toBe(MAIN_LOG_MAX_SIZE_BYTES);
   });
 
   it("omits undefined object fields from compact log output", () => {

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -5,7 +5,12 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getNativeBinding } from "../state/native-binding";
-import { CURRENT_STATE_DB_USER_VERSION, StateDb } from "../state/state-db";
+import {
+  CURRENT_STATE_DB_USER_VERSION,
+  STATE_DB_JOURNAL_SIZE_LIMIT_BYTES,
+  STATE_DB_WAL_AUTOCHECKPOINT_PAGES,
+  StateDb,
+} from "../state/state-db";
 
 let stateDb: StateDb;
 let tempDir: string;
@@ -77,6 +82,33 @@ describe("StateDb", () => {
       "thread_pricing_summaries",
       "thread_usage_lines",
       "thread_usage_turns",
+    ]);
+  });
+
+  it("sets explicit WAL checkpoint and journal size bounds", () => {
+    expect(stateDb.raw.pragma("journal_mode", { simple: true })).toBe("wal");
+    expect(stateDb.raw.pragma("wal_autocheckpoint", { simple: true })).toBe(
+      STATE_DB_WAL_AUTOCHECKPOINT_PAGES,
+    );
+    expect(stateDb.raw.pragma("journal_size_limit", { simple: true })).toBe(
+      STATE_DB_JOURNAL_SIZE_LIMIT_BYTES,
+    );
+  });
+
+  it("keeps AUTOINCREMENT limited to existing bounded UI history tables", () => {
+    const rows = stateDb.raw
+      .prepare(
+        `SELECT name
+         FROM sqlite_master
+         WHERE type = 'table'
+           AND upper(sql) LIKE '%AUTOINCREMENT%'
+         ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>;
+
+    expect(rows.map((row) => row.name)).toEqual([
+      "composer_draft_journal",
+      "messaging_activity_log",
     ]);
   });
 

--- a/apps/desktop/src/main/log.ts
+++ b/apps/desktop/src/main/log.ts
@@ -5,6 +5,7 @@ import type { ProfileBootDecision } from "./profile";
 let initialized = false;
 let stdioErrorHandlersInstalled = false;
 let debugCollectionEnabled = false;
+export const MAIN_LOG_MAX_SIZE_BYTES = 1024 * 1024;
 const MAX_COMPACT_STRING_LENGTH = 320;
 const MAX_COMPACT_FIELDS = 24;
 const MAX_COMPACT_DEPTH = 2;
@@ -20,6 +21,7 @@ const electronLogConsoleTransport = electronLog.transports?.console;
 if (process.env.VITEST === "true" && electronLogConsoleTransport) {
   electronLogConsoleTransport.level = false;
 }
+configureFileTransport();
 
 function isClosedStdioError(error: unknown): error is StdioError {
   if (typeof error !== "object" || error === null) {
@@ -81,6 +83,14 @@ function guardConsoleTransport(): void {
   };
 }
 
+function configureFileTransport(): void {
+  const transport = electronLog.transports?.file;
+  if (!transport) {
+    return;
+  }
+  transport.maxSize = MAIN_LOG_MAX_SIZE_BYTES;
+}
+
 export function initializeMainLogger(options?: { profileName?: string }): void {
   if (initialized) {
     return;
@@ -94,6 +104,7 @@ export function initializeMainLogger(options?: { profileName?: string }): void {
       options.profileName,
     );
   }
+  configureFileTransport();
   electronLog.transports.file.level = debugCollectionEnabled ? "debug" : "info";
   electronLog.initialize();
   electronLog.scope.labelPadding = false;

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -10,6 +10,8 @@ import {
 import { getNativeBinding } from "./native-binding.js";
 
 export const CURRENT_STATE_DB_USER_VERSION = 22;
+export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
+export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
 const SCHEMA_V1 = `
 CREATE TABLE meta (
@@ -649,6 +651,8 @@ export class StateDb {
 
     db.pragma("journal_mode = WAL");
     db.pragma("synchronous = NORMAL");
+    db.pragma(`wal_autocheckpoint = ${STATE_DB_WAL_AUTOCHECKPOINT_PAGES}`);
+    db.pragma(`journal_size_limit = ${STATE_DB_JOURNAL_SIZE_LIMIT_BYTES}`);
     db.pragma("busy_timeout = 5000");
     db.pragma("foreign_keys = ON");
 


### PR DESCRIPTION
## Summary

PwrAgent now has explicit write-safety guardrails for the Codex-style SQLite churn failure mode without changing existing database table definitions. The state DB keeps its current schema, including the two existing `AUTOINCREMENT` tables, while tests now fail if another autoincrementing table is added as a future append sink.

SQLite WAL behavior is also bounded explicitly with a 1000-page autocheckpoint and a 16 MiB journal size limit, and persistent main logs pin the existing 1 MiB rotation limit in code instead of relying on the electron-log default.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test apps/desktop/src/main/__tests__/state-db.test.ts apps/desktop/src/main/__tests__/log.test.ts`
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
