### PR TITLE
fix(desktop): require requested handoff worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9766,6 +9766,43 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("rejects Codex forks when requested worktree preparation falls back to local", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/fork"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: "/repo/app",
+          workMode: "local" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+    });
+
+    await expect(
+      registry.forkThread({
+        backend: "codex",
+        sourceThreadId: "thread-parent",
+        parentThreadId: "thread-parent",
+        executionMode: "default",
+        directoryKind: "directory",
+        directoryLabel: "app",
+        directoryPath: "/repo/app",
+        workMode: "worktree",
+        branchName: "missing-base-ref",
+      }),
+    ).rejects.toThrow("Requested worktree workspace");
+    expect(codexClient.lastForkThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("keeps failed environment setup worktree threads registered without starting the turn", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-failure-"));
     const repoPath = path.join(root, "repo");
@@ -13887,6 +13924,221 @@ command = "pnpm dev"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("rehydrates inherited Codex environment runtime for clean new-worktree handoffs", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-env-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+    } catch {
+      await git(repoPath, ["init"]);
+      await git(repoPath, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+    await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(worktreePath, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "GifGrabber"
+
+[setup]
+script = "printf setup"
+
+[[actions]]
+name = "Dev"
+command = "pnpm dev"
+`,
+      "utf8",
+    );
+
+    const sourceRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "environment",
+      environmentName: "GifGrabber",
+      executionTarget: "local",
+      cwd: repoPath,
+      setupEnabled: true,
+      setupStatus: "completed",
+      setupCommand: "printf setup",
+      shellEnvironment: {
+        PATH: `${repoPath}/.venv/bin:/usr/bin`,
+        VIRTUAL_ENV: `${repoPath}/.venv`,
+      },
+      selectedActionIdByEnvironmentId: {
+        environment: "dev",
+      },
+      actions: [
+        {
+          id: "dev",
+          name: "Dev",
+          command: "pnpm dev",
+        },
+      ],
+    };
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: worktreePath,
+      repositoryPath: repoPath,
+      workMode: "worktree" as const,
+    }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async (params) => {
+      expect(params).toMatchObject({
+        cwd: worktreePath,
+        command: "printf setup",
+        mode: "wait",
+        captureShellEnvironment: true,
+      });
+      return {
+        durationMs: 5,
+        exitCode: 0,
+        output: "setup",
+        shellEnvironment: {
+          PATH: `${worktreePath}/.venv/bin:/usr/bin`,
+          VIRTUAL_ENV: `${worktreePath}/.venv`,
+        },
+      };
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:ordinary-thread": {
+          backend: "codex",
+          threadId: "ordinary-thread",
+          executionMode: "full-access",
+          codexEnvironmentRuntime: sourceRuntime,
+          extraLinkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      codexEnvironmentCommandRunner: commandRunner,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread,
+      } as never,
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Implement the export failure alert on master.",
+          title: "Swift export alert",
+          workspaceMode: "new_worktree",
+          branchName: "origin/master",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    expect(prepareLaunchpadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      branchName: "origin/master",
+      directoryKind: "directory",
+      directoryLabel: "repo",
+      directoryPath: expectedDir(repoPath),
+      workMode: "worktree",
+    });
+    expect(commandRunner).toHaveBeenCalledTimes(1);
+    expect(codexClient.lastStartThreadParams?.codexEnvironmentRuntime).toMatchObject({
+      environmentId: "environment",
+      cwd: worktreePath,
+      setupStatus: "completed",
+      shellEnvironment: {
+        PATH: `${worktreePath}/.venv/bin:/usr/bin`,
+        VIRTUAL_ENV: `${worktreePath}/.venv`,
+      },
+      selectedActionIdByEnvironmentId: {
+        environment: "dev",
+      },
+    });
+    expect(
+      codexClient.lastStartThreadParams?.codexEnvironmentRuntime?.shellEnvironment
+        ?.VIRTUAL_ENV,
+    ).not.toBe(`${repoPath}/.venv`);
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.inheritedSettings.codexEnvironmentRuntime).toMatchObject({
+      environmentId: "environment",
+      cwd: worktreePath,
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        cwd: worktreePath,
+      },
+    });
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("rejects ungrouped same-workspace thread handoff dynamic tool calls", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
@@ -13922,6 +14174,7 @@ command = "pnpm dev"
         tool: "handoff_task",
         arguments: {
           task: "Investigate issue XYZ and report back.",
+          workspaceMode: "same_workspace",
         },
       },
     } as AppServerPendingRequestNotification);
@@ -13935,7 +14188,7 @@ command = "pnpm dev"
             {
               code: "invalid_arguments",
               message:
-                'workspaceMode="same" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for an ungrouped delegated thread with an isolated worktree, or workspaceMode="none" for an unscoped local thread.',
+                'workspaceMode="same_workspace" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for a delegated thread with an isolated worktree, workspaceMode="project_local" for the project checkout, or workspaceMode="none" for an unscoped local thread.',
             },
             null,
             2,
@@ -13947,6 +14200,234 @@ command = "pnpm dev"
     expect(codexClient.lastStartTurnParams).toBeUndefined();
 
     await registry.close();
+  });
+
+  it("starts project-local handoffs in the primary repo checkout instead of the caller worktree", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-project-local-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+    } catch {
+      await git(repoPath, ["init"]);
+      await git(repoPath, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+    await git(repoPath, ["worktree", "add", "--detach", worktreePath, "main"]);
+
+    const linkedDirectory = {
+      id: expectedDir(repoPath),
+      kind: "worktree" as const,
+      label: "repo",
+      path: expectedDir(repoPath),
+      worktreePath: expectedDir(worktreePath),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: new GitDirectoryService({
+        resolveWorktreeStorage: () => "in-repo",
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "full-access",
+            extraLinkedDirectories: [linkedDirectory],
+          },
+        },
+      }),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate issue XYZ from the project checkout.",
+          title: "Project local handoff",
+          workspaceMode: "project_local",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const realRepoPath = expectedDir(await realpath(repoPath));
+    const realWorktreePath = expectedDir(await realpath(worktreePath));
+    expect(codexClient.lastStartThreadParams?.cwd).toBe(realRepoPath);
+    expect(codexClient.lastStartThreadParams?.cwd).not.toBe(realWorktreePath);
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.workspace).toMatchObject({
+      mode: "project_local",
+      cwd: realRepoPath,
+      branch: "main",
+      git: {
+        kind: "git_local",
+        worktreeCreationAvailable: true,
+      },
+    });
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("rejects new-worktree handoffs when workspace preparation falls back to the source cwd", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-fallback-"));
+    try {
+      await git(root, ["init", "-b", "main"]);
+    } catch {
+      await git(root, ["init"]);
+      await git(root, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(root, "README.md"), "handoff\n", "utf8");
+    await git(root, ["add", "README.md"]);
+    await git(root, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir(root),
+              kind: "local",
+              label: "handoff",
+              path: expectedDir(root),
+            },
+          ],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: new GitDirectoryService({
+        resolveWorktreeStorage: () => "in-repo",
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "full-access",
+            extraLinkedDirectories: [
+              {
+                id: expectedDir(root),
+                kind: "local",
+                label: "handoff",
+                path: expectedDir(root),
+              },
+            ],
+          },
+        },
+      }),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate issue XYZ and report back.",
+          title: "Investigate issue XYZ",
+          workspaceMode: "new_worktree",
+          branchName: "codex/agent-intended-child-branch",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining("unsupported_workspace"),
+        },
+      ],
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
+    expect(codexClient.lastStartTurnParams).toBeUndefined();
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
   });
 
   it("sends a follow-up prompt to another thread from an active turn", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14139,6 +14139,185 @@ command = "pnpm dev"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("creates new-worktree handoff threads when inherited environment setup is unavailable", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-env-missing-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+    } catch {
+      await git(repoPath, ["init"]);
+      await git(repoPath, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+    await mkdir(worktreePath, { recursive: true });
+    const sourceRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "environment",
+      environmentName: "GifGrabber",
+      executionTarget: "local",
+      cwd: repoPath,
+      setupEnabled: true,
+      setupStatus: "completed",
+      setupCommand: "printf setup",
+      selectedActionIdByEnvironmentId: {
+        environment: "dev",
+      },
+      actions: [
+        {
+          id: "dev",
+          name: "Dev",
+          command: "pnpm dev",
+        },
+      ],
+    };
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: worktreePath,
+      repositoryPath: repoPath,
+      workMode: "worktree" as const,
+      rollback: vi.fn(async () => {}),
+    }));
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async () => {
+      throw new Error("setup should not run without an environment file");
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:ordinary-thread": {
+          backend: "codex",
+          threadId: "ordinary-thread",
+          executionMode: "full-access",
+          codexEnvironmentRuntime: sourceRuntime,
+          extraLinkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      codexEnvironmentCommandRunner: commandRunner,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Backport the fix from master.",
+          title: "Backport fix",
+          workspaceMode: "new_worktree",
+          branchName: "origin/master",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    expect(commandRunner).not.toHaveBeenCalled();
+    expect(codexClient.lastStartThreadParams?.cwd).toBe(worktreePath);
+    expect(codexClient.lastStartThreadParams?.codexEnvironmentRuntime).toMatchObject({
+      environmentId: "environment",
+      environmentName: "GifGrabber",
+      cwd: worktreePath,
+      setupStatus: "failed",
+      setupOutput: expect.stringContaining("is not available in the forked worktree"),
+    });
+    expect(codexClient.lastStartTurnParams?.threadId).toBe("thread-1");
+    const prompt =
+      (codexClient.lastStartTurnParams?.input[0] as { text?: string } | undefined)
+        ?.text ?? "";
+    expect(prompt).toContain("Codex environment startup:");
+    expect(prompt).toContain("- Status: failed");
+    expect(prompt).toContain("is not available in the forked worktree");
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.codexEnvironmentStartupFailure).toMatchObject({
+      phase: "setup",
+      worktreeCleanupAvailable: true,
+      message: expect.stringContaining("is not available in the forked worktree"),
+    });
+    expect(payload.inheritedSettings.codexEnvironmentRuntime).toMatchObject({
+      environmentId: "environment",
+      cwd: worktreePath,
+      setupStatus: "failed",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      codexEnvironmentRuntime: {
+        environmentId: "environment",
+        cwd: worktreePath,
+        setupStatus: "failed",
+      },
+    });
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("rejects ungrouped same-workspace thread handoff dynamic tool calls", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -268,6 +268,33 @@ describe("GitDirectoryService", () => {
     );
   });
 
+  it("reports remote-tracking refs as worktree base branch candidates", async () => {
+    const remoteDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-remote-"));
+    cleanupPaths.push(remoteDir);
+    execFileSync("git", ["init", "--bare", remoteDir], { stdio: "ignore" });
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+    runGit(repoDir, ["push", "-u", "origin", "main"]);
+    runGit(repoDir, ["checkout", "release"]);
+    runGit(repoDir, ["push", "-u", "origin", "release"]);
+    runGit(repoDir, ["checkout", "main"]);
+    runGit(repoDir, ["update-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"]);
+    const service = new GitDirectoryService();
+
+    const status = await service.readDirectoryStatus({ path: repoDir });
+
+    expect(status?.branches).toEqual(expect.arrayContaining(["main", "release"]));
+    expect(status?.branches).not.toContain("origin/main");
+    expect(status?.baseBranches).toEqual(
+      expect.arrayContaining(["main", "release", "origin/main", "origin/release"]),
+    );
+    expect(status?.baseBranches).not.toContain("origin/HEAD");
+    expect(status?.baseBranchDetails?.map((detail) => detail.name)).toEqual(
+      status?.baseBranches,
+    );
+  });
+
   it("streams directory status lookups with bounded concurrency", async () => {
     const service = new GitDirectoryService({
       statusConcurrency: 2,

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -289,6 +289,7 @@ describe("GitDirectoryService", () => {
     expect(status?.baseBranches).toEqual(
       expect.arrayContaining(["main", "release", "origin/main", "origin/release"]),
     );
+    expect(status?.baseBranches).not.toContain("origin");
     expect(status?.baseBranches).not.toContain("origin/HEAD");
     expect(status?.baseBranchDetails?.map((detail) => detail.name)).toEqual(
       status?.baseBranches,

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -13,6 +13,7 @@ describe("pwragent thread orchestration agent tools", () => {
       expect.objectContaining({
         namespace: "pwragent",
         name: "handoff_task",
+        description: expect.stringContaining("backports"),
         deferLoading: false,
         inputSchema: expect.objectContaining({
           required: ["task"],
@@ -24,7 +25,10 @@ describe("pwragent thread orchestration agent tools", () => {
               enum: ["none", "subthread"],
             }),
             workspaceMode: expect.objectContaining({
-              enum: ["same", "new_worktree", "none"],
+              enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
+            }),
+            branchName: expect.objectContaining({
+              description: expect.stringContaining("existing base branch/ref"),
             }),
           }),
         }),
@@ -171,7 +175,7 @@ describe("pwragent thread orchestration agent tools", () => {
           task: "  Ship it  ",
           seedMode: "fork",
           groupingMode: "subthread",
-          workspaceMode: "same",
+          workspaceMode: "same_workspace",
           messagingAttachment: "auto",
         },
       },
@@ -188,7 +192,7 @@ describe("pwragent thread orchestration agent tools", () => {
         task: "Ship it",
         seedMode: "fork",
         groupingMode: "subthread",
-        workspaceMode: "same",
+        workspaceMode: "same_workspace",
         messagingAttachment: "auto",
       },
     });

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -94,7 +94,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread, and groupingMode=subthread only when the user asks for a sub-thread. For ungrouped handoffs, explicitly choose workspaceMode=new_worktree or workspaceMode=none.";
+      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree.";
     case "send_message_to_thread":
       return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead.";
   }
@@ -141,7 +141,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: HANDOFF_TASK_WORKSPACE_MODES,
             description:
-              "`same` inherits the current workspace and is valid only with groupingMode=subthread. `new_worktree` requests an isolated Git worktree. `none` allows a no-workspace thread.",
+              "`new_worktree` requests an isolated Git worktree and is the default for workspace-backed handoffs; set branchName to an existing base ref such as `origin/master` when the user asks for a specific source branch. `same_workspace` shares the caller's exact cwd and is valid only with groupingMode=subthread. `project_local` uses the project's primary/local checkout. `none` allows a no-workspace thread. `same` is a legacy alias for `same_workspace`.",
           },
           messagingAttachment: {
             type: "string",
@@ -160,7 +160,7 @@ function inputSchemaForOperation(
           branchName: {
             type: "string",
             description:
-              "Optional branch name for an explicit new-worktree handoff.",
+              "Optional existing base branch/ref for workspaceMode=new_worktree, for example `origin/master`. This is not the new feature branch name; tell the delegated thread to create or switch to its work branch in the task text.",
           },
         },
       };

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6762,6 +6762,7 @@ export class DesktopBackendRegistry {
     acpRuntime?: BackendAcpSessionRuntimeState;
     workMode?: NavigationLaunchpadDraft["workMode"];
     branchName?: string;
+    requiredWorkMode?: NavigationLaunchpadDraft["workMode"];
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
@@ -6772,6 +6773,7 @@ export class DesktopBackendRegistry {
       linkedDirectories,
       workMode,
       branchName,
+      requiredWorkMode,
       ...request
     } = params;
     const modelSettings = await this.resolveModelSettings(backend, request);
@@ -6802,6 +6804,19 @@ export class DesktopBackendRegistry {
             })
           : buildLocalLinkedDirectory(cwd);
     }
+    if (requiredWorkMode && effectiveWorkMode !== requiredWorkMode) {
+      throw new Error(
+        `Requested ${requiredWorkMode} workspace, but workspace preparation resolved to ${effectiveWorkMode ?? "none"}. Verify the source directory is a Git repository and branchName resolves to an existing branch or ref.`,
+      );
+    }
+    const codexEnvironmentRuntime =
+      backend === "codex" && request.codexEnvironmentRuntime && workMode
+        ? await this.buildForkedCodexEnvironmentRuntime({
+            cwd,
+            sourceRuntime: request.codexEnvironmentRuntime,
+            workMode: effectiveWorkMode ?? "local",
+          })
+        : request.codexEnvironmentRuntime;
 
     const acpAgent = isAcpBackendId(backend)
       ? this.acpBackend.getInstalledAgent(backend)
@@ -6890,7 +6905,7 @@ export class DesktopBackendRegistry {
           cwd,
           approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
           sandbox: request.sandbox ?? modeSettings.sandbox,
-          codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+          codexEnvironmentRuntime,
           ...(backend === "codex"
             ? {
                 defaultModeRequestUserInput:
@@ -6916,7 +6931,7 @@ export class DesktopBackendRegistry {
         executionMode: effectiveExecutionMode,
         ...modelSettings,
         acpRuntime,
-        codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+        codexEnvironmentRuntime,
         linkedDirectories: (
           resolvedLinkedDirectories?.length ? resolvedLinkedDirectories : buildLocalLinkedDirectory(cwd)
         ).map(normalizeLinkedDirectoryKind),
@@ -6952,11 +6967,11 @@ export class DesktopBackendRegistry {
       });
       this.invalidateThreadListCache(backend);
     }
-    if (request.codexEnvironmentRuntime) {
+    if (codexEnvironmentRuntime) {
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend,
         threadId: result.threadId,
-        codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+        codexEnvironmentRuntime,
       });
     }
     if (
@@ -6976,7 +6991,7 @@ export class DesktopBackendRegistry {
       backend,
       threadId: result.threadId,
       executionMode: effectiveExecutionMode,
-      codexEnvironmentRuntime: request.codexEnvironmentRuntime,
+      codexEnvironmentRuntime,
     };
   }
 
@@ -7065,6 +7080,11 @@ export class DesktopBackendRegistry {
       worktreeBranchMode: request.worktreeBranchMode,
       workMode: request.workMode ?? "local",
     });
+    if (request.workMode === "worktree" && preparedWorkspace.workMode !== "worktree") {
+      throw new Error(
+        `Requested worktree workspace, but workspace preparation resolved to ${preparedWorkspace.workMode}. Verify the source directory is a Git repository and branchName resolves to an existing branch or ref.`,
+      );
+    }
     request.onPreparedWorkspaceRollback?.(preparedWorkspace.rollback);
     const cwd = preparedWorkspace.cwd;
     const linkedDirectories =
@@ -14070,11 +14090,13 @@ export class DesktopBackendRegistry {
     const groupingMode: HandoffTaskGroupingMode =
       request.args.groupingMode ?? "none";
     const workspaceMode: HandoffTaskWorkspaceMode =
-      request.args.workspaceMode ?? "same";
-    if (workspaceMode === "same" && groupingMode !== "subthread") {
+      request.args.workspaceMode === "same"
+        ? "same_workspace"
+        : (request.args.workspaceMode ?? "new_worktree");
+    if (workspaceMode === "same_workspace" && groupingMode !== "subthread") {
       return threadOrchestrationFailure(
         "invalid_arguments",
-        'workspaceMode="same" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for an ungrouped delegated thread with an isolated worktree, or workspaceMode="none" for an unscoped local thread.',
+        'workspaceMode="same_workspace" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for a delegated thread with an isolated worktree, workspaceMode="project_local" for the project checkout, or workspaceMode="none" for an unscoped local thread.',
       );
     }
     const sourceThread = await this.findThreadForWorkspaceHandoff({
@@ -14095,7 +14117,7 @@ export class DesktopBackendRegistry {
     const sourceWorkspace = await this.buildThreadHandoffWorkspaceSummary({
       cwd: sourceCwd,
       linkedDirectory: sourceLinkedDirectory,
-      mode: "same",
+      mode: "same_workspace",
     });
 
     if (workspaceMode !== "none" && !sourceCwd?.trim()) {
@@ -14145,7 +14167,26 @@ export class DesktopBackendRegistry {
       instructions:
         "Work only on the delegated task from the parent PwrAgent thread. Keep progress and results in this thread.",
     };
-    const cwdForChild = workspaceMode === "none" ? undefined : sourceCwd;
+    const projectLocalCwd =
+      workspaceMode === "project_local"
+        ? await this.resolveProjectLocalHandoffCwd({
+            sourceCwd,
+            sourceLinkedDirectory,
+          })
+        : undefined;
+    if (workspaceMode === "project_local" && !projectLocalCwd?.trim()) {
+      return threadOrchestrationFailure(
+        "unsupported_workspace",
+        "The source thread has no project checkout available for workspaceMode=project_local.",
+        { workspace: sourceWorkspace },
+      );
+    }
+    const cwdForChild =
+      workspaceMode === "none"
+        ? undefined
+        : workspaceMode === "project_local"
+          ? projectLocalCwd
+          : sourceCwd;
 
     let threadId: string;
     let createdLinkedDirectory: LinkedDirectorySummary | undefined;
@@ -14175,6 +14216,7 @@ export class DesktopBackendRegistry {
         });
         threadId = forked.threadId;
         createdLinkedDirectory = forked.linkedDirectory;
+        inheritedSettings.codexEnvironmentRuntime = forked.codexEnvironmentRuntime;
         createdWorkspaceMode =
           forked.workMode === "worktree" ? "new_worktree" : workspaceMode;
         await this.overlayStore.setThreadAgent({
@@ -14189,6 +14231,7 @@ export class DesktopBackendRegistry {
           cwd: cwdForChild,
           workMode: workspaceMode === "new_worktree" ? "worktree" : "local",
           branchName: request.args.branchName,
+          requiredWorkMode: workspaceMode === "new_worktree" ? "worktree" : undefined,
           model: inheritedSettings.model,
           reasoningEffort: inheritedSettings.reasoningEffort,
           serviceTier: inheritedSettings.serviceTier,
@@ -14199,6 +14242,7 @@ export class DesktopBackendRegistry {
           agent,
         });
         threadId = started.threadId;
+        inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
         if (groupingMode === "subthread") {
           await this.overlayStore.setThreadParent?.({
             backend,
@@ -14425,6 +14469,26 @@ export class DesktopBackendRegistry {
       candidates.find((directory) => directory.kind === "local") ??
       candidates[0]
     );
+  }
+
+  private async resolveProjectLocalHandoffCwd(params: {
+    sourceCwd?: string;
+    sourceLinkedDirectory?: LinkedDirectorySummary;
+  }): Promise<string | undefined> {
+    const linkedDirectory = params.sourceLinkedDirectory;
+    if (linkedDirectory?.kind === "local" && linkedDirectory.path?.trim()) {
+      return linkedDirectory.path.trim();
+    }
+    const primaryWorkspace = await this.gitDirectoryService
+      .resolvePrimaryWorkspacePath(params.sourceCwd)
+      .catch(() => undefined);
+    if (primaryWorkspace?.trim()) {
+      return primaryWorkspace.trim();
+    }
+    if (linkedDirectory?.kind === "worktree" && linkedDirectory.path?.trim()) {
+      return linkedDirectory.path.trim();
+    }
+    return params.sourceCwd?.trim();
   }
 
   private async buildThreadHandoffWorkspaceSummary(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -49,6 +49,7 @@ import {
   type BackendCapabilities,
   type CodexEnvironmentActionRun,
   type CodexEnvironmentOption,
+  type CodexEnvironmentStartupFailure,
   type CodexEnvironmentSetupProgressEvent,
   type CodexThreadEnvironmentRuntime,
   type BackendLaunchpadOptions,
@@ -4125,6 +4126,7 @@ function buildHandoffTaskPrompt(params: {
   };
   inheritedSettings: HandoffTaskInheritedSettings;
   workspace: ThreadHandoffOriginWorkspace;
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 }): string {
   const lines = [
     "You are a PwrAgent handoff thread created by another Agent thread.",
@@ -4180,6 +4182,20 @@ function buildHandoffTaskPrompt(params: {
     `- New worktree supported: ${
       params.workspace.git.worktreeCreationAvailable ? "yes" : "no"
     }`,
+    ...(params.codexEnvironmentStartupFailure
+      ? [
+          "",
+          "Codex environment startup:",
+          `- Status: failed`,
+          `- Phase: ${params.codexEnvironmentStartupFailure.phase}`,
+          `- Message: ${params.codexEnvironmentStartupFailure.message}`,
+          `- Worktree cleanup available: ${
+            params.codexEnvironmentStartupFailure.worktreeCleanupAvailable
+              ? "yes"
+              : "no"
+          }`,
+        ]
+      : []),
     "",
     "Parent context reference:",
     "The thread that spawned this handoff is the source thread above. Use that reference if a future tool or UI surface can fetch more context from the parent.",
@@ -6783,6 +6799,7 @@ export class DesktopBackendRegistry {
         : request.cwd;
     let resolvedLinkedDirectories = linkedDirectories;
     let effectiveWorkMode = workMode;
+    let preparedWorkspaceRollback: (() => Promise<void>) | undefined;
     if (workMode === "worktree" && request.cwd?.trim()) {
       const preparedWorkspace =
         await this.gitDirectoryService.prepareLaunchpadWorkspace({
@@ -6793,6 +6810,7 @@ export class DesktopBackendRegistry {
           directoryPath: request.cwd,
           workMode: "worktree",
         });
+      preparedWorkspaceRollback = preparedWorkspace.rollback;
       cwd = preparedWorkspace.cwd;
       effectiveWorkMode = preparedWorkspace.workMode;
       resolvedLinkedDirectories =
@@ -6805,18 +6823,47 @@ export class DesktopBackendRegistry {
           : buildLocalLinkedDirectory(cwd);
     }
     if (requiredWorkMode && effectiveWorkMode !== requiredWorkMode) {
+      await preparedWorkspaceRollback?.().catch((error) => {
+        backendRegistryLog.warn("startThread workspace rollback failed", {
+          backend,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
       throw new Error(
         `Requested ${requiredWorkMode} workspace, but workspace preparation resolved to ${effectiveWorkMode ?? "none"}. Verify the source directory is a Git repository and branchName resolves to an existing branch or ref.`,
       );
     }
-    const codexEnvironmentRuntime =
-      backend === "codex" && request.codexEnvironmentRuntime && workMode
-        ? await this.buildForkedCodexEnvironmentRuntime({
+    let codexEnvironmentRuntime = request.codexEnvironmentRuntime;
+    let codexEnvironmentStartupFailure: CodexEnvironmentStartupFailure | undefined;
+    if (backend === "codex" && request.codexEnvironmentRuntime && workMode) {
+      try {
+        codexEnvironmentRuntime = await this.buildForkedCodexEnvironmentRuntime({
             cwd,
             sourceRuntime: request.codexEnvironmentRuntime,
             workMode: effectiveWorkMode ?? "local",
-          })
-        : request.codexEnvironmentRuntime;
+          });
+      } catch (error) {
+        if (error instanceof CodexEnvironmentStartupError) {
+          codexEnvironmentRuntime = error.runtime;
+          codexEnvironmentStartupFailure = {
+            message: error.message,
+            phase: error.phase,
+            worktreeCleanupAvailable: effectiveWorkMode === "worktree",
+          };
+        } else {
+          await preparedWorkspaceRollback?.().catch((rollbackError) => {
+            backendRegistryLog.warn("startThread workspace rollback failed", {
+              backend,
+              error:
+                rollbackError instanceof Error
+                  ? rollbackError.message
+                  : String(rollbackError),
+            });
+          });
+          throw error;
+        }
+      }
+    }
 
     const acpAgent = isAcpBackendId(backend)
       ? this.acpBackend.getInstalledAgent(backend)
@@ -6892,28 +6939,42 @@ export class DesktopBackendRegistry {
       fastMode: modelSettings.fastMode ?? null,
     });
 
-    const result = isAcpBackendId(backend)
-      ? await this.startAcpSession({
+    let result: { threadId: string };
+    try {
+      result = isAcpBackendId(backend)
+        ? await this.startAcpSession({
+            backend,
+            cwd,
+            executionMode: effectiveExecutionMode,
+            acpRuntime,
+          })
+        : await this.getClient(backend, effectiveExecutionMode).startThread({
+            ...request,
+            ...modelSettings,
+            cwd,
+            approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
+            sandbox: request.sandbox ?? modeSettings.sandbox,
+            codexEnvironmentRuntime,
+            ...(backend === "codex"
+              ? {
+                  defaultModeRequestUserInput:
+                    this.resolveCodexDefaultModeRequestUserInputFn(),
+                }
+              : {}),
+            dynamicTools,
+          });
+    } catch (error) {
+      await preparedWorkspaceRollback?.().catch((rollbackError) => {
+        backendRegistryLog.warn("startThread workspace rollback failed", {
           backend,
-          cwd,
-          executionMode: effectiveExecutionMode,
-          acpRuntime,
-        })
-      : await this.getClient(backend, effectiveExecutionMode).startThread({
-          ...request,
-          ...modelSettings,
-          cwd,
-          approvalPolicy: request.approvalPolicy ?? modeSettings.approvalPolicy,
-          sandbox: request.sandbox ?? modeSettings.sandbox,
-          codexEnvironmentRuntime,
-          ...(backend === "codex"
-            ? {
-                defaultModeRequestUserInput:
-                  this.resolveCodexDefaultModeRequestUserInputFn(),
-              }
-            : {}),
-          dynamicTools,
+          error:
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : String(rollbackError),
         });
+      });
+      throw error;
+    }
     const startedAt = Date.now();
     const pendingThreadKey = buildThreadIdentityKey(backend, result.threadId);
     const agentName = request.agent?.name?.trim();
@@ -6992,6 +7053,7 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       executionMode: effectiveExecutionMode,
       codexEnvironmentRuntime,
+      codexEnvironmentStartupFailure,
     };
   }
 
@@ -7015,8 +7077,16 @@ export class DesktopBackendRegistry {
     const environment = (await listCodexEnvironmentOptions(cwd))
       .find((candidate) => candidate.id === sourceRuntime.environmentId);
     if (!environment) {
-      throw new Error(
-        `Selected Codex environment '${sourceRuntime.environmentName}' is not available in the forked worktree.`,
+      const message = `Selected Codex environment '${sourceRuntime.environmentName}' is not available in the forked worktree.`;
+      const runtime = {
+        ...cloneCodexEnvironmentRuntimeForFork(sourceRuntime, cwd),
+        setupStatus: "failed",
+        setupOutput: message,
+      } satisfies CodexThreadEnvironmentRuntime;
+      throw new CodexEnvironmentStartupError(
+        message,
+        "setup",
+        runtime,
       );
     }
 
@@ -7104,12 +7174,25 @@ export class DesktopBackendRegistry {
 
     let result: { threadId: string };
     let forkedCodexEnvironmentRuntime: CodexThreadEnvironmentRuntime | undefined;
+    let codexEnvironmentStartupFailure: CodexEnvironmentStartupFailure | undefined;
     try {
-      forkedCodexEnvironmentRuntime = await this.buildForkedCodexEnvironmentRuntime({
-        cwd,
-        sourceRuntime: sourceOverlay?.codexEnvironmentRuntime,
-        workMode: preparedWorkspace.workMode,
-      });
+      try {
+        forkedCodexEnvironmentRuntime = await this.buildForkedCodexEnvironmentRuntime({
+          cwd,
+          sourceRuntime: sourceOverlay?.codexEnvironmentRuntime,
+          workMode: preparedWorkspace.workMode,
+        });
+      } catch (error) {
+        if (!(error instanceof CodexEnvironmentStartupError)) {
+          throw error;
+        }
+        forkedCodexEnvironmentRuntime = error.runtime;
+        codexEnvironmentStartupFailure = {
+          message: error.message,
+          phase: error.phase,
+          worktreeCleanupAvailable: preparedWorkspace.workMode === "worktree",
+        };
+      }
       result = await client.forkThread({
         threadId: request.sourceThreadId,
         ...(request.sourceThreadPath?.trim()
@@ -7216,6 +7299,7 @@ export class DesktopBackendRegistry {
       linkedDirectory: linkedDirectories[0],
       workMode: preparedWorkspace.workMode,
       codexEnvironmentRuntime: forkedCodexEnvironmentRuntime,
+      codexEnvironmentStartupFailure,
     };
   }
 
@@ -14191,6 +14275,9 @@ export class DesktopBackendRegistry {
     let threadId: string;
     let createdLinkedDirectory: LinkedDirectorySummary | undefined;
     let createdWorkspaceMode = workspaceMode;
+    let codexEnvironmentStartupFailure:
+      | HandoffTaskResult["codexEnvironmentStartupFailure"]
+      | undefined;
     try {
       if (seedMode === "fork") {
         const forked = await this.forkThread({
@@ -14217,6 +14304,7 @@ export class DesktopBackendRegistry {
         threadId = forked.threadId;
         createdLinkedDirectory = forked.linkedDirectory;
         inheritedSettings.codexEnvironmentRuntime = forked.codexEnvironmentRuntime;
+        codexEnvironmentStartupFailure = forked.codexEnvironmentStartupFailure;
         createdWorkspaceMode =
           forked.workMode === "worktree" ? "new_worktree" : workspaceMode;
         await this.overlayStore.setThreadAgent({
@@ -14243,6 +14331,7 @@ export class DesktopBackendRegistry {
         });
         threadId = started.threadId;
         inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
+        codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
         if (groupingMode === "subthread") {
           await this.overlayStore.setThreadParent?.({
             backend,
@@ -14310,6 +14399,7 @@ export class DesktopBackendRegistry {
       origin,
       inheritedSettings,
       workspace,
+      codexEnvironmentStartupFailure,
     });
     let turnId: string | undefined;
     let turnStartFailure: HandoffTaskResult["turnStartFailure"];
@@ -14364,6 +14454,9 @@ export class DesktopBackendRegistry {
         origin,
         workspace,
         messagingAttachment,
+        ...(codexEnvironmentStartupFailure
+          ? { codexEnvironmentStartupFailure }
+          : {}),
         ...(turnStartFailure ? { turnStartFailure } : {}),
       },
     };

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -652,7 +652,7 @@ export class GitDirectoryService {
       return undefined;
     }
 
-    const [rawCurrentBranch, branchesOutput, remoteHead, worktreeList] =
+    const [rawCurrentBranch, branchesOutput, baseBranchesOutput, remoteHead, worktreeList] =
       await Promise.all([
         runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
           () => "",
@@ -662,6 +662,17 @@ export class GitDirectoryService {
           [
             "for-each-ref",
             "refs/heads",
+            "--sort=-committerdate",
+            "--format=%(refname:short)%09%(committerdate:unix)",
+          ],
+          gitEnv,
+        ).catch(() => ""),
+        runGit(
+          repoRoot,
+          [
+            "for-each-ref",
+            "refs/heads",
+            "refs/remotes",
             "--sort=-committerdate",
             "--format=%(refname:short)%09%(committerdate:unix)",
           ],
@@ -689,6 +700,9 @@ export class GitDirectoryService {
       gitEnv,
     ).catch(() => "");
     const parsedBranchDetailsAll = parseGitBranchDetails(branchesOutput);
+    const parsedBaseBranchDetailsAll = parseGitBranchDetails(baseBranchesOutput).filter(
+      (detail) => !detail.name.endsWith("/HEAD"),
+    );
     // Resolve the default branch against the FULL list so a rarely-committed
     // `main` is still found, then cap everything we hold/persist downstream.
     const defaultBranch = resolveDefaultBranch({
@@ -699,7 +713,12 @@ export class GitDirectoryService {
       keep: [currentBranch, defaultBranch],
       limit: MAX_TRACKED_BRANCHES,
     });
+    const parsedBaseBranchDetails = capRecentBranchDetails(parsedBaseBranchDetailsAll, {
+      keep: [currentBranch, defaultBranch, remoteHead.trim()],
+      limit: MAX_TRACKED_BRANCHES,
+    });
     const branches = parsedBranchDetails.map((detail) => detail.name);
+    const baseBranches = parsedBaseBranchDetails.map((detail) => detail.name);
     const worktreeBranchNames = new Set(
       parseGitWorktreeEntries(worktreeList)
         .map((entry) => entry.branch)
@@ -711,11 +730,19 @@ export class GitDirectoryService {
           ? { ...detail, inUse: true }
           : { ...detail },
       );
+    const buildBaseBranchDetails = (): NavigationGitBranchDetail[] =>
+      parsedBaseBranchDetails.map((detail) =>
+        detail.name !== currentBranch && worktreeBranchNames.has(detail.name)
+          ? { ...detail, inUse: true }
+          : { ...detail },
+      );
     if (!currentBranch) {
       return {
         defaultBranch,
         branches,
+        baseBranches,
         branchDetails: buildBranchDetails(),
+        baseBranchDetails: buildBaseBranchDetails(),
         handoffBranches: branches,
         syncState: "untracked",
       };
@@ -733,7 +760,9 @@ export class GitDirectoryService {
         currentBranch,
         defaultBranch,
         branches,
+        baseBranches,
         branchDetails: buildBranchDetails(),
+        baseBranchDetails: buildBaseBranchDetails(),
         handoffBranches,
         syncState: "untracked",
       };
@@ -765,7 +794,9 @@ export class GitDirectoryService {
       behind,
       defaultBranch,
       branches,
+      baseBranches,
       branchDetails: buildBranchDetails(),
+      baseBranchDetails: buildBaseBranchDetails(),
       handoffBranches,
       syncState,
     };
@@ -790,6 +821,25 @@ export class GitDirectoryService {
       cwd: toForwardSlashesOptional(prepared.cwd),
       repositoryPath: toForwardSlashesOptional(prepared.repositoryPath),
     };
+  }
+
+  async resolvePrimaryWorkspacePath(cwd: string | undefined): Promise<string | undefined> {
+    const directoryPath = cwd?.trim();
+    if (!directoryPath) {
+      return undefined;
+    }
+    const sourceRoot = await readGitRoot(
+      directoryPath,
+      this.runGitCommand,
+      this.gitEnv,
+    );
+    if (!sourceRoot) {
+      return undefined;
+    }
+    const primary =
+      (await readPrimaryWorktreePath(sourceRoot, this.runGitCommand, this.gitEnv)) ??
+      sourceRoot;
+    return toForwardSlashes(primary);
   }
 
   private async prepareLaunchpadWorkspaceInternal(

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -303,6 +303,48 @@ function parseGitBranchDetails(
 }
 
 /**
+ * Parses `for-each-ref refs/heads refs/remotes` output formatted as
+ * `<full-refname>\t<short-name>\t<committerdate:unix>\t<symref>`.
+ *
+ * Remote HEAD aliases must be filtered before callers see the shortened name:
+ * Git can shorten `refs/remotes/origin/HEAD` to `origin`, which otherwise
+ * looks like a selectable branch.
+ */
+function parseGitBaseBranchDetails(
+  output: string,
+): { name: string; lastCommitAt?: number }[] {
+  const details: { name: string; lastCommitAt?: number }[] = [];
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (!line.trim()) {
+      continue;
+    }
+    const [refname = "", shortName = "", unixRaw = "", symref = ""] =
+      line.split("\t");
+    const fullRefname = refname.trim();
+    if (
+      fullRefname.startsWith("refs/remotes/") &&
+      fullRefname.endsWith("/HEAD")
+    ) {
+      continue;
+    }
+    if (symref.trim()) {
+      continue;
+    }
+    const name = shortName.trim();
+    if (!name) {
+      continue;
+    }
+    const unixValue = Number.parseInt(unixRaw.trim(), 10);
+    details.push({
+      name,
+      lastCommitAt: Number.isFinite(unixValue) ? unixValue : undefined,
+    });
+  }
+  return details;
+}
+
+/**
  * Upper bound on how many branches we enrich, hold in the navigation
  * snapshot, and persist to the directory git-status cache. Repos can have
  * thousands of branches; the picker (and the messaging / PR-status surfaces
@@ -674,7 +716,7 @@ export class GitDirectoryService {
             "refs/heads",
             "refs/remotes",
             "--sort=-committerdate",
-            "--format=%(refname:short)%09%(committerdate:unix)",
+            "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
           ],
           gitEnv,
         ).catch(() => ""),
@@ -700,9 +742,7 @@ export class GitDirectoryService {
       gitEnv,
     ).catch(() => "");
     const parsedBranchDetailsAll = parseGitBranchDetails(branchesOutput);
-    const parsedBaseBranchDetailsAll = parseGitBranchDetails(baseBranchesOutput).filter(
-      (detail) => !detail.name.endsWith("/HEAD"),
-    );
+    const parsedBaseBranchDetailsAll = parseGitBaseBranchDetails(baseBranchesOutput);
     // Resolve the default branch against the FULL list so a rarely-committed
     // `main` is still found, then cap everything we hold/persist downstream.
     const defaultBranch = resolveDefaultBranch({

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6675,7 +6675,10 @@ function buildLaunchpadBranchPickerOptions(
   launchpad: NavigationLaunchpadDraft,
   directory?: NavigationDirectorySummary,
 ): LaunchpadBranchOption[] {
-  const details = directory?.gitStatus?.branchDetails ?? [];
+  const details =
+    directory?.gitStatus?.baseBranchDetails ??
+    directory?.gitStatus?.branchDetails ??
+    [];
   const detailByName = new Map(details.map((detail) => [detail.name, detail]));
   const currentBranch = normalizeSelectableLaunchpadBranch(
     directory?.gitStatus?.currentBranch,
@@ -6705,7 +6708,7 @@ function buildLaunchpadBranchPickerOptions(
   const orderedNames =
     details.length > 0
       ? details.map((detail) => detail.name)
-      : (directory?.gitStatus?.branches ?? []);
+      : (directory?.gitStatus?.baseBranches ?? directory?.gitStatus?.branches ?? []);
   for (const name of orderedNames) {
     push(name);
   }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -6375,6 +6375,91 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows remote-tracking base refs for new-worktree sub-thread launchpads", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "GifGrabber",
+          path: "/Users/huntharo/.codex/profiles/sstk/worktrees/mqs3ew3f/GifGrabber",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "fix/upload-mp4-compression",
+            defaultBranch: "main",
+            branches: ["fix/upload-mp4-compression"],
+            branchDetails: [
+              {
+                name: "fix/upload-mp4-compression",
+                lastCommitAt: Math.floor(Date.now() / 1000) - 60,
+              },
+            ],
+            baseBranches: [
+              "fix/upload-mp4-compression",
+              "origin/main",
+              "origin/releases/4.3",
+            ],
+            baseBranchDetails: [
+              {
+                name: "fix/upload-mp4-compression",
+                lastCommitAt: Math.floor(Date.now() / 1000) - 60,
+              },
+              {
+                name: "origin/main",
+                lastCommitAt: Math.floor(Date.now() / 1000) - 3600,
+              },
+              {
+                name: "origin/releases/4.3",
+                lastCommitAt: Math.floor(Date.now() / 1000) - 7200,
+              },
+            ],
+            syncState: "untracked",
+          },
+        }}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:new-worktree",
+          directoryKind: "directory",
+          directoryLabel: "GifGrabber",
+          directoryPath: "/Users/huntharo/.codex/profiles/sstk/worktrees/mqs3ew3f/GifGrabber",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "fix/upload-mp4-compression",
+          parentThreadId: "thread-parent",
+          parentThreadTitle: "Fix oversized GIPHY uploads",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+
+    expect(
+      screen.getByRole("option", { name: "fix/upload-mp4-compression" })
+    ).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "origin/main" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "origin/releases/4.3" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "origin/main" }));
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "subthread:codex:thread-parent:new-worktree",
+        expect.objectContaining({ branchName: "origin/main" }),
+        { stickySettingsChanged: true }
+      );
+    });
+  });
+
   it("pins the selected, default, and current branches above the recency list", () => {
     const nowSeconds = Math.floor(Date.now() / 1000);
     render(

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -51,6 +51,13 @@ export type StartThreadResponse = {
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
+};
+
+export type CodexEnvironmentStartupFailure = {
+  message: string;
+  phase: "setup" | "action";
+  worktreeCleanupAvailable: boolean;
 };
 
 export type ForkThreadRequest = {
@@ -81,6 +88,7 @@ export type ForkThreadResponse = {
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 };
 
 export type ThreadMigrationOperation = "move" | "copy";
@@ -496,11 +504,7 @@ export type MaterializedDirectoryLaunchpadThread = {
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
-  codexEnvironmentStartupFailure?: {
-    message: string;
-    phase: "setup" | "action";
-    worktreeCleanupAvailable: boolean;
-  };
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 };
 
 export type MaterializeDirectoryLaunchpadOptions = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -499,6 +499,9 @@ export type NavigationDirectoryGitStatus = {
   behind?: number;
   branches?: string[];
   branchDetails?: NavigationGitBranchDetail[];
+  /** Candidate refs for creating a new worktree base. Includes local branches and remote-tracking refs. */
+  baseBranches?: string[];
+  baseBranchDetails?: NavigationGitBranchDetail[];
   handoffBranches?: string[];
   syncState?:
     | "in-sync"

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -5,6 +5,7 @@ import type {
   ThreadExecutionMode,
   ThreadIdentifier,
 } from "./normalized-app-server";
+import type { CodexEnvironmentStartupFailure } from "./agent";
 import type { MessagingChannelKind, MessagingConversationKind } from "./messaging";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
@@ -186,6 +187,7 @@ export type HandoffTaskResult = {
   origin: ThreadHandoffOrigin;
   workspace: ThreadHandoffOriginWorkspace;
   messagingAttachment: HandoffTaskMessagingAttachment;
+  codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
   turnStartFailure?: {
     message: string;
     phase: "turn";

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -43,9 +43,16 @@ export const HANDOFF_TASK_SEED_MODES = ["clean", "fork"] as const;
 export type HandoffTaskGroupingMode = "none" | "subthread";
 export const HANDOFF_TASK_GROUPING_MODES = ["none", "subthread"] as const;
 
-export type HandoffTaskWorkspaceMode = "same" | "new_worktree" | "none";
+export type HandoffTaskWorkspaceMode =
+  | "same"
+  | "same_workspace"
+  | "project_local"
+  | "new_worktree"
+  | "none";
 export const HANDOFF_TASK_WORKSPACE_MODES = [
   "same",
+  "same_workspace",
+  "project_local",
   "new_worktree",
   "none",
 ] as const;
@@ -78,6 +85,10 @@ export type HandoffTaskToolArgs = {
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;
   sandbox?: string;
+  /**
+   * Existing base branch/ref used when workspaceMode is "new_worktree".
+   * This is not the delegated thread's new feature branch name.
+   */
   branchName?: string;
 };
 


### PR DESCRIPTION
## Summary
- reject `handoff_task` requests that require `workspaceMode: "new_worktree"` when workspace preparation downgrades to local/source cwd
- rehydrate inherited Codex environment runtime against the prepared child workspace for clean handoffs, matching the fork path
- clarify the dynamic tool schema that `branchName` is the existing base branch/ref such as `origin/master`, not the delegated feature branch name

## Evidence
- beta.37 rollout `019ef7e4-2983-7240-8357-96f78c9c5b2a` called `handoff_task` with `workspaceMode: "new_worktree"`, `groupingMode: "none"`, `seedMode: "clean"`, and `branchName: "codex/swift-export-failure-alert"`
- the created thread `019ef9f3-4286-7411-81eb-cacb83c7f049` reported `mode: "new_worktree"` but started in the same caller profile worktree path, represented here as `<profile-worktree>/GifGrabber`
- the affected PwrAgent profile state database showed no parent thread id for the spawned thread, confirming it was ungrouped

## Tests
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "rejects new-worktree handoffs when workspace preparation falls back"` fails before the fix and passes after
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "handoff"`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Note
- `pnpm lint` currently fails on current `origin/main` at `licenses:check` because `THIRD_PARTY_LICENSES` is out of date; this patch does not change dependencies or that file.
