### PR TITLE
fix(desktop): surface thread base branch metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -110,6 +110,108 @@ describe("probeWorktreeWorkingState", () => {
     expect(state?.unpushedCommits).toBe(1);
   });
 
+  it("infers the likely base branch and behind-base count from git refs", async () => {
+    const headCommit = "a".repeat(40);
+    const mainTip = "b".repeat(40);
+    const mainBase = "c".repeat(40);
+    const releaseTip = "d".repeat(40);
+    const releaseBase = "e".repeat(40);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("rev-parse") && args.includes("--verify")) {
+        const target = args[args.length - 1];
+        if (target === "HEAD^{commit}") return `${headCommit}\n`;
+        if (target === "origin/main^{commit}") return `${mainTip}\n`;
+        if (target === "main^{commit}") return `${mainTip}\n`;
+        if (target === "releases/4.3^{commit}") return `${releaseTip}\n`;
+        if (target === "origin/releases/4.3^{commit}") return `${releaseTip}\n`;
+      }
+      if (args.includes("rev-parse") && args.includes("--abbrev-ref")) {
+        return "feature/work\n";
+      }
+      if (args.includes("config")) return "";
+      if (args.includes("symbolic-ref")) return "origin/main\n";
+      if (args.includes("for-each-ref")) {
+        return [
+          "main",
+          "releases/4.3",
+          "feature/work",
+          "origin/main",
+          "origin/releases/4.3",
+        ].join("\n");
+      }
+      if (args.includes("merge-base")) {
+        const target = args[args.length - 1];
+        if (target === "origin/main" || target === "main") return `${mainBase}\n`;
+        if (target === "releases/4.3" || target === "origin/releases/4.3") {
+          return `${releaseBase}\n`;
+        }
+      }
+      if (args.includes("rev-list") && args.includes("--count")) {
+        const range = args[args.length - 1];
+        if (range === "HEAD") return "0\n";
+        if (range === `${mainBase}..origin/main` || range === `${mainBase}..main`) {
+          return "7\n";
+        }
+        if (range === `${mainBase}..HEAD`) return "30\n";
+        if (
+          range === `${releaseBase}..releases/4.3` ||
+          range === `${releaseBase}..origin/releases/4.3`
+        ) {
+          return "2\n";
+        }
+        if (range === `${releaseBase}..HEAD`) return "5\n";
+      }
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", { runGit });
+
+    expect(state).toMatchObject({
+      baseBranch: "releases/4.3",
+      baseCommit: releaseBase,
+      baseTipCommit: releaseTip,
+      baseBehindCommitCount: 2,
+      baseAheadCommitCount: 5,
+      isBehindBase: true,
+    });
+  });
+
+  it("keeps base metadata when detached HEAD is exactly at the base tip", async () => {
+    const baseTip = "f".repeat(40);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "";
+      if (args.includes("rev-parse") && args.includes("--verify")) {
+        const target = args[args.length - 1];
+        if (target === "HEAD^{commit}") return `${baseTip}\n`;
+        if (target === "main^{commit}") return `${baseTip}\n`;
+      }
+      if (args.includes("rev-parse") && args.includes("--abbrev-ref")) {
+        return "HEAD\n";
+      }
+      if (args.includes("symbolic-ref")) return "";
+      if (args.includes("for-each-ref")) return "main\n";
+      if (args.includes("merge-base")) return `${baseTip}\n`;
+      if (args.includes("rev-list") && args.includes("--count")) return "0\n";
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", { runGit });
+
+    expect(state).toMatchObject({
+      baseBranch: "main",
+      baseCommit: baseTip,
+      baseTipCommit: baseTip,
+      baseBehindCommitCount: 0,
+      baseAheadCommitCount: 0,
+      isBehindBase: false,
+    });
+  });
+
   it("returns undefined when the directory is not a git checkout", async () => {
     const { runGit } = fakeGit(() => undefined);
     expect(await probeWorktreeWorkingState("/not/a/repo", { runGit })).toBeUndefined();
@@ -156,8 +258,8 @@ describe("GitWorkingStateService", () => {
     ]);
 
     expect(a).toEqual(b);
-    // numstat + status + remote + rev-list = 4 git calls for ONE probe.
-    expect(responder).toHaveBeenCalledTimes(4);
+    // numstat + status + remote + base HEAD probe + rev-list = 5 git calls for ONE probe.
+    expect(responder).toHaveBeenCalledTimes(5);
   });
 
   it("serves a fresh cache entry without re-probing, and re-probes after invalidate", async () => {
@@ -166,14 +268,14 @@ describe("GitWorkingStateService", () => {
     const service = new GitWorkingStateService({ runGit, cacheTtlMs: 60_000 });
 
     await service.readWorkingState("/repo/wt");
-    expect(responder).toHaveBeenCalledTimes(4);
+    expect(responder).toHaveBeenCalledTimes(5);
 
     await service.readWorkingState("/repo/wt");
-    expect(responder).toHaveBeenCalledTimes(4); // cached
+    expect(responder).toHaveBeenCalledTimes(5); // cached
 
     service.invalidate("/repo/wt");
     await service.readWorkingState("/repo/wt");
-    expect(responder).toHaveBeenCalledTimes(8); // re-probed
+    expect(responder).toHaveBeenCalledTimes(10); // re-probed
   });
 
   it("streams entries for many worktrees", async () => {

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -179,6 +179,44 @@ describe("probeWorktreeWorkingState", () => {
     });
   });
 
+  it("does not infer a release base for an attached default branch checkout", async () => {
+    const mainTip = "1".repeat(40);
+    const releaseTip = "2".repeat(40);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("rev-parse") && args.includes("--verify")) {
+        const target = args[args.length - 1];
+        if (target === "HEAD^{commit}") return `${mainTip}\n`;
+        if (target === "releases/4.3^{commit}") return `${releaseTip}\n`;
+      }
+      if (args.includes("rev-parse") && args.includes("--abbrev-ref")) {
+        return "main\n";
+      }
+      if (args.includes("rev-list") && args.includes("--count")) return "0\n";
+      if (
+        args.includes("config") ||
+        args.includes("symbolic-ref") ||
+        args.includes("for-each-ref") ||
+        args.includes("merge-base")
+      ) {
+        throw new Error(`base inference should short-circuit before ${args.join(" ")}`);
+      }
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", { runGit });
+
+    expect(state).toEqual({
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+    });
+  });
+
   it("keeps base metadata when detached HEAD is exactly at the base tip", async () => {
     const baseTip = "f".repeat(40);
     const { runGit } = fakeGit((args) => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -15858,7 +15858,19 @@ export class DesktopBackendRegistry {
           backend: thread.source,
           threadId: thread.id,
         });
-        return toThreadInspectionSummary(thread, overlay, messagingBindings);
+        const worktreePath = thread.projectKey?.trim();
+        const gitWorkingState =
+          thread.gitWorkingState ??
+          (worktreePath
+            ? await this.gitWorkingStateService.readWorkingState(worktreePath).catch(
+                () => undefined,
+              )
+            : undefined);
+        return toThreadInspectionSummary(
+          gitWorkingState ? { ...thread, gitWorkingState } : thread,
+          overlay,
+          messagingBindings,
+        );
       }),
     );
   }
@@ -16969,6 +16981,7 @@ function toThreadInspectionSummary(
     reasoningEffort: thread.reasoningEffort,
     serviceTier: thread.serviceTier,
     fastMode: thread.fastMode,
+    gitWorkingState: thread.gitWorkingState,
     ...(messagingBindings?.length ? { messagingBindings } : {}),
     linkedDirectories: thread.linkedDirectories,
   };

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -25,6 +25,7 @@ const DEFAULT_OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
 const HARD_OTHER_CHANGE_DIFF_MAX_BYTES = 500_000;
 const UNTRACKED_DIRECTORY_EXPANSION_MAX_BYTES = 128_000;
 const UNTRACKED_DIRECTORY_EXPANSION_TIMEOUT_MS = 1_500;
+const MAX_BASE_BRANCH_CANDIDATES = 24;
 
 type GitCommandRunner = (
   cwd: string,
@@ -35,6 +36,31 @@ type UntrackedPathFilter = (repoPath: string) => boolean;
 
 type AcceptedPushedCommitOptions = {
   acceptedPushedCommitShas?: string[];
+};
+
+type WorktreeBaseState = Pick<
+  ThreadGitWorkingState,
+  | "baseBranch"
+  | "baseCommit"
+  | "baseTipCommit"
+  | "baseBehindCommitCount"
+  | "baseAheadCommitCount"
+  | "isBehindBase"
+>;
+
+type ResolvedWorktreeBaseState = {
+  baseBranch: string;
+  baseCommit: string;
+  baseTipCommit: string;
+  baseBehindCommitCount: number;
+  baseAheadCommitCount: number;
+  isBehindBase: boolean;
+};
+
+type BaseBranchCandidate = {
+  ref: string;
+  label: string;
+  sourceRank: number;
 };
 
 function buildAcceptedPushedCommitSet(
@@ -87,6 +113,202 @@ function parseNumstat(output: string): {
     }
   }
   return { files, additions, deletions };
+}
+
+function parseGitCount(value: string | undefined): number {
+  const parsed = Number.parseInt(value?.trim() ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parseGitLines(output: string | undefined): string[] {
+  return (output ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function normalizeBaseBranchLabel(refName: string): string {
+  return refName
+    .trim()
+    .replace(/^refs\/heads\//, "")
+    .replace(/^refs\/remotes\//, "");
+}
+
+function remoteAgnosticBranchName(refName: string): string {
+  return normalizeBaseBranchLabel(refName).replace(
+    /^[^/]+\/(?=(?:main|master|develop|development|trunk)$|(?:release|releases|stable|support|maintenance)\/)/,
+    "",
+  );
+}
+
+function isLikelyBaseBranch(refName: string): boolean {
+  const branch = remoteAgnosticBranchName(refName);
+  return (
+    /^(main|master|develop|development|trunk)$/.test(branch) ||
+    /^(release|releases|stable|support|maintenance)\//.test(branch)
+  );
+}
+
+function isCurrentBranchRef(refName: string, currentBranch?: string): boolean {
+  if (!currentBranch) {
+    return false;
+  }
+  const label = normalizeBaseBranchLabel(refName);
+  return label === currentBranch || label.endsWith(`/${currentBranch}`);
+}
+
+function addBaseBranchCandidate(
+  candidates: BaseBranchCandidate[],
+  seen: Set<string>,
+  ref: string | undefined,
+  sourceRank: number,
+): void {
+  const normalizedRef = normalizeBaseBranchLabel(ref ?? "");
+  const label = remoteAgnosticBranchName(normalizedRef);
+  if (!normalizedRef || !label || label === "HEAD" || seen.has(label)) {
+    return;
+  }
+  seen.add(label);
+  candidates.push({ ref: normalizedRef, label, sourceRank });
+}
+
+function isBetterBaseState(
+  state: ResolvedWorktreeBaseState & { sourceRank: number },
+  best: (ResolvedWorktreeBaseState & { sourceRank: number }) | undefined,
+): boolean {
+  if (!best) {
+    return true;
+  }
+  if (state.sourceRank !== best.sourceRank) {
+    return state.sourceRank < best.sourceRank;
+  }
+  if (state.baseAheadCommitCount !== best.baseAheadCommitCount) {
+    return state.baseAheadCommitCount < best.baseAheadCommitCount;
+  }
+  if (state.baseBehindCommitCount !== best.baseBehindCommitCount) {
+    return state.baseBehindCommitCount < best.baseBehindCommitCount;
+  }
+  return state.baseBranch.localeCompare(best.baseBranch) < 0;
+}
+
+async function resolveWorktreeBaseState(
+  runGitNoLocks: (args: string[]) => Promise<string>,
+): Promise<WorktreeBaseState | undefined> {
+  const headCommit = (
+    await runGitNoLocks(["rev-parse", "--verify", "HEAD^{commit}"]).catch(
+      () => "",
+    )
+  ).trim();
+  if (!headCommit) {
+    return undefined;
+  }
+
+  const rawCurrentBranch = (
+    await runGitNoLocks(["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => "")
+  ).trim();
+  const currentBranch = rawCurrentBranch && rawCurrentBranch !== "HEAD"
+    ? rawCurrentBranch
+    : undefined;
+
+  const [configuredBase, remoteHead, refsOutput] = await Promise.all([
+    currentBranch
+      ? runGitNoLocks([
+          "config",
+          "--get",
+          `branch.${currentBranch}.vscode-merge-base`,
+        ]).catch(() => "")
+      : Promise.resolve(""),
+    runGitNoLocks(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"]).catch(
+      () => "",
+    ),
+    runGitNoLocks([
+      "for-each-ref",
+      "refs/heads",
+      "refs/remotes",
+      "--sort=-committerdate",
+      "--format=%(refname:short)",
+    ]).catch(() => ""),
+  ]);
+
+  const candidates: BaseBranchCandidate[] = [];
+  const seen = new Set<string>();
+  addBaseBranchCandidate(candidates, seen, configuredBase, 0);
+  if (!isCurrentBranchRef(remoteHead, currentBranch)) {
+    addBaseBranchCandidate(candidates, seen, remoteHead, 10);
+  }
+
+  for (const ref of parseGitLines(refsOutput)) {
+    const label = normalizeBaseBranchLabel(ref);
+    if (
+      label === "origin/HEAD" ||
+      isCurrentBranchRef(label, currentBranch) ||
+      !isLikelyBaseBranch(label)
+    ) {
+      continue;
+    }
+    addBaseBranchCandidate(candidates, seen, label, 10);
+    if (candidates.length >= MAX_BASE_BRANCH_CANDIDATES) {
+      break;
+    }
+  }
+
+  let best:
+    | (ResolvedWorktreeBaseState & {
+        sourceRank: number;
+      })
+    | undefined;
+
+  for (const candidate of candidates) {
+    const baseTipCommit = (
+      await runGitNoLocks([
+        "rev-parse",
+        "--verify",
+        `${candidate.ref}^{commit}`,
+      ]).catch(() => "")
+    ).trim();
+    if (!baseTipCommit) {
+      continue;
+    }
+
+    const baseCommit = (
+      await runGitNoLocks(["merge-base", "HEAD", candidate.ref]).catch(() => "")
+    ).trim();
+    if (!baseCommit) {
+      continue;
+    }
+
+    const [baseBehindOutput, baseAheadOutput] = await Promise.all([
+      runGitNoLocks([
+        "rev-list",
+        "--count",
+        `${baseCommit}..${candidate.ref}`,
+      ]).catch(() => ""),
+      runGitNoLocks(["rev-list", "--count", `${baseCommit}..HEAD`]).catch(
+        () => "",
+      ),
+    ]);
+    const baseBehindCommitCount = parseGitCount(baseBehindOutput);
+    const baseAheadCommitCount = parseGitCount(baseAheadOutput);
+    const state: ResolvedWorktreeBaseState & { sourceRank: number } = {
+      baseBranch: candidate.label,
+      baseCommit,
+      baseTipCommit,
+      baseBehindCommitCount,
+      baseAheadCommitCount,
+      isBehindBase: baseBehindCommitCount > 0,
+      sourceRank: candidate.sourceRank,
+    };
+
+    if (isBetterBaseState(state, best)) {
+      best = state;
+    }
+  }
+
+  if (!best) {
+    return undefined;
+  }
+  const { sourceRank: _sourceRank, ...state } = best;
+  return state;
 }
 
 function clampPositiveInteger(
@@ -564,7 +786,7 @@ export async function probeWorktreeWorkingState(
   const runGitNoLocks = (args: string[]): Promise<string> =>
     runGit(worktreePath, ["--no-optional-locks", ...args], gitEnv);
 
-  const [numstatOutput, statusOutput, remotesOutput] = await Promise.all([
+  const [numstatOutput, statusOutput, remotesOutput, baseState] = await Promise.all([
     // Staged + unstaged line counts vs HEAD. Fails on an unborn HEAD
     // (fresh repo with no commits) — treated as "no tracked changes".
     runGitNoLocks(["diff", "--numstat", "HEAD"]).catch(() => undefined),
@@ -575,6 +797,7 @@ export async function probeWorktreeWorkingState(
       "--untracked-files=normal",
     ]).catch(() => undefined),
     runGitNoLocks(["remote"]).catch(() => undefined),
+    resolveWorktreeBaseState(runGitNoLocks).catch(() => undefined),
   ]);
   if (numstatOutput === undefined && statusOutput === undefined) {
     return undefined;
@@ -623,6 +846,7 @@ export async function probeWorktreeWorkingState(
     dirtyDeletions: numstat.deletions,
     untrackedFiles: untracked.files,
     unpushedCommits,
+    ...(baseState ?? {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -209,6 +209,9 @@ async function resolveWorktreeBaseState(
   const currentBranch = rawCurrentBranch && rawCurrentBranch !== "HEAD"
     ? rawCurrentBranch
     : undefined;
+  if (currentBranch && isLikelyBaseBranch(currentBranch)) {
+    return undefined;
+  }
 
   const [configuredBase, remoteHead, refsOutput] = await Promise.all([
     currentBranch

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -169,6 +169,7 @@ export function ThreadMetaChips({
             kind: thread.gitBranch ? "expected" : "current",
           })}
           className="thread-row__chip path-copy-target tooltip-target thread-row__chip--mono"
+          tooltipText={formatBranchTooltip(branchChip, gitWorking)}
           value={branchChip}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
@@ -247,15 +248,51 @@ function formatBranchCopyLabel(params: {
   return `Copy ${branchKind} ${params.branch}`;
 }
 
+function formatCommit(value: string | undefined): string | undefined {
+  const commit = value?.trim();
+  return commit ? commit.slice(0, 12) : undefined;
+}
+
+function formatCommitCount(value: number | undefined, label: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return `${label}: ${value.toLocaleString()} commit${value === 1 ? "" : "s"}`;
+}
+
+function formatBranchTooltip(
+  branch: string,
+  gitWorking: NavigationThreadSummary["gitWorkingState"],
+): string {
+  if (!gitWorking?.baseBranch) {
+    return branch;
+  }
+  const baseCommit = formatCommit(gitWorking.baseCommit);
+  const baseTipCommit = formatCommit(gitWorking.baseTipCommit);
+
+  return [
+    branch,
+    `Base: ${gitWorking.baseBranch}`,
+    baseCommit ? `Base commit: ${baseCommit}` : undefined,
+    baseTipCommit ? `Base tip: ${baseTipCommit}` : undefined,
+    formatCommitCount(gitWorking.baseBehindCommitCount, "Behind base"),
+    formatCommitCount(gitWorking.baseAheadCommitCount, "Ahead of base"),
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
 function CopyableThreadChip(props: {
   "aria-label": string;
   children: ReactNode;
   className: string;
+  tooltipText?: string;
   value: string;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const [copied, setCopied] = useState(false);
-  const tooltipText = copied ? "Copied" : `${props.value}\nClick to copy to clipboard`;
+  const tooltipBody = props.tooltipText ?? props.value;
+  const tooltipText = copied ? "Copied" : `${tooltipBody}\nClick to copy to clipboard`;
 
   useEffect(() => {
     if (!copied) {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2468,6 +2468,63 @@ describe("Sidebar", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows base branch and behind-base metadata in the branch tooltip", async () => {
+    const threadWithBase = {
+      ...sharedThread,
+      gitWorkingState: {
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 0,
+        baseBranch: "releases/4.3",
+        baseCommit: "1111111111111111111111111111111111111111",
+        baseTipCommit: "2222222222222222222222222222222222222222",
+        baseBehindCommitCount: 2,
+        baseAheadCommitCount: 5,
+        isBehindBase: true,
+      },
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[threadWithBase]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[threadWithBase]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const branchChip = screen.getByRole("button", {
+      name: "Copy branch codex/thread-centric-ui",
+    });
+    fireEvent.mouseEnter(branchChip);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip").textContent).toBe(
+        [
+          "codex/thread-centric-ui",
+          "Base: releases/4.3",
+          "Base commit: 111111111111",
+          "Base tip: 222222222222",
+          "Behind base: 2 commits",
+          "Ahead of base: 5 commits",
+          "Click to copy to clipboard",
+        ].join("\n"),
+      );
+    });
+  });
+
   it("copies a pull request URL from the PR chip context menu", async () => {
     const copyText = vi.fn(async () => undefined);
     const onSelectThread = vi.fn();

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -271,6 +271,18 @@ export type ThreadGitWorkingState = {
   untrackedFiles: number;
   /** Local commits not present on any remote ref (0 when no remotes). */
   unpushedCommits: number;
+  /** Best-effort git-derived branch this work appears to be based on. */
+  baseBranch?: string;
+  /** Merge-base commit between HEAD and `baseBranch`. */
+  baseCommit?: string;
+  /** Current tip commit of `baseBranch` when probed. */
+  baseTipCommit?: string;
+  /** Commits on `baseBranch` after `baseCommit`; > 0 means this work is behind its base. */
+  baseBehindCommitCount?: number;
+  /** Commits on HEAD after `baseCommit`. */
+  baseAheadCommitCount?: number;
+  /** True when `baseBranch` has commits after `baseCommit`. */
+  isBehindBase?: boolean;
 };
 
 export type AppServerThreadSummary = {

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -4,6 +4,7 @@ import type {
   AppServerThreadMessage,
   AppServerThreadReplayPagination,
   AppServerThreadTurnMetadata,
+  ThreadGitWorkingState,
   AppServerThreadStatus,
   ThreadExecutionMode,
   ThreadIdentifier,
@@ -167,6 +168,7 @@ export type ThreadInspectionSummary = {
   reasoningEffort?: string;
   serviceTier?: string;
   fastMode?: boolean;
+  gitWorkingState?: ThreadGitWorkingState;
   linkedDirectories: LinkedDirectorySummary[];
   score?: number;
   confidence?: ThreadSearchConfidenceBand;


### PR DESCRIPTION
## Summary

Thread rows and agent-facing thread status now show the base branch context that matters after a worktree has been created. The git working-state cache derives a likely base branch, merge-base commit, base tip, and whether the thread is behind that base, so long-lived release branches like `releases/4.3` are visible after thread creation.

The branch chip tooltip now includes the base branch and ahead/behind-base counts when that metadata is available. `get_thread_status` also returns the same `gitWorkingState` payload, so agents can inspect base branch and stale-base status without scraping the UI.

Git does not persist the original creation branch as first-class metadata, so the cache uses bounded git-derived inference: explicit merge-base config wins, then likely base refs such as `main` and `releases/*` are ranked by closest merge-base.

## Testing

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

## Post-Deploy Monitoring & Validation

Watch desktop logs for `worktreeWorkingStateRefresh:failed` and user reports around branch chip tooltip content or slow sidebar refreshes. Healthy behavior is branch tooltips showing base metadata after the background working-state probe lands, and `get_thread_status` returning `gitWorkingState.baseBranch` / `isBehindBase` for git-backed threads. Failure signals are repeated working-state refresh failures, missing base metadata for obvious release-branch worktrees, or noticeably slower thread-list refreshes; mitigation is to narrow or disable the base-branch inference path in `GitWorkingStateService`. Validate during normal desktop dogfood over the first release cycle after merge; owner: desktop maintainer on rotation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
