### PR TITLE
feat(federation): encrypted, mutually-authenticated LAN transport (Noise_IK)

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -284,6 +284,31 @@ describe("DesktopSettingsService", () => {
     });
   });
 
+  it("persists and reuses a federation Noise static keypair", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const secretStore = new MemoryDesktopSecretStore();
+    const service = new DesktopSettingsService({ configPath, env: {}, secretStore });
+
+    const first = await service.getOrCreateFederationNoiseStaticKeyPair();
+    expect(first.privateKeyBase64.length).toBeGreaterThan(0);
+    expect(Buffer.from(first.publicKeyBase64, "base64").length).toBe(32);
+
+    // A fresh service over the same secret store reuses the persisted key.
+    const reopened = new DesktopSettingsService({ configPath, env: {}, secretStore });
+    const second = await reopened.getOrCreateFederationNoiseStaticKeyPair();
+    expect(second.privateKeyBase64).toBe(first.privateKeyBase64);
+    expect(second.publicKeyBase64).toBe(first.publicKeyBase64);
+
+    // Stored under its own secret name, distinct from the Ed25519 identity.
+    expect(await secretStore.getSecret("federationNoiseStaticPrivateKey")).toBe(
+      first.privateKeyBase64,
+    );
+    expect(
+      await secretStore.getSecret("federationInstancePrivateKey"),
+    ).toBeUndefined();
+  });
+
   it("defaults federation settings and exposes stored federation secrets", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/federation-noise.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-noise.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  NoiseIKHandshake,
+  generateNoiseStaticKeyPair,
+  noiseKeyPairFromRawPrivate,
+  type NoiseKeyPair,
+} from "../federation/federation-noise";
+
+// Official test vector for Noise_IK_25519_ChaChaPoly_SHA256 (snow / noise-c
+// vector set). Fixed static + ephemeral keys make the handshake deterministic
+// so we can byte-compare against the canonical ciphertexts. This is the real
+// correctness guarantee for the hand-written state machine.
+const VECTOR = {
+  prologue:
+    "5468657265206973206e6f20726967687420616e642077726f6e672e2054686572652773206f6e6c792066756e20616e6420626f72696e672e",
+  initStatic: "f49f93c5112c0787acc808d61716d7e090e076a58f15a3f78d92773f8dcb473b",
+  initEphemeral:
+    "dae68498c41315cff7e4a34dded8d973199d8f0cf3fcb8b6651c169de77de8be",
+  initRemoteStatic:
+    "2ea5942829bac414e25aa4cbb1bcc43394816ebb1bd12550d7d0eb4415e42951",
+  respStatic: "b790546f98b1e933c48cd01f17e7b281469d46fcacc9a3b584ae65b1d6272e8e",
+  respEphemeral:
+    "c0875a5b59c8492bd2135e5432d7d484f938e0a1f5009428c4bcb70b2f69f69f",
+  messages: [
+    {
+      payload: "95a8f51c435a9530ff1f30868ed7b23ec952eb513c26a0774fed82d2978a8c81",
+      ciphertext:
+        "6d21fec9141f3f37cc464e936a48b2d9521b5a44e0f3d960895d3c3fba30282f731f445c25e898e2534ac0536715b24308c108fc46bd260c887b36c3f68e3a05654fc8295c068ed53fb2022560961224e0b10b0835e1efc82fc587cd50f7178fe3d9eb06e0351c6e7334162c10bed670bfa2a105f7b2768a140b3fd597782601",
+    },
+    {
+      payload: "b866b807a6d8b83182b884dbfedc861843c5082bd6e480cb54e4245a72083041",
+      ciphertext:
+        "e64e1fb8701c4f4bc3850b255fea657d4d835338b059c89acc99628fbe52473b41a4e79e3c1e6abc46bf80f078a005e15d8a3e04f989af3e6cb99b52031165006163ac3e17b928af8c116009d7bf4fb2",
+    },
+    {
+      payload: "e3a4937faef391028f759758b428b57652e0069a8dee64dfed01b60846938740",
+      ciphertext:
+        "2bebe19102169cdfe79cf41e38930bfd20a5b2fc78ccf33e853ddd939c0983174656eb27b61464a607762848892ca1c0",
+    },
+    {
+      payload: "693972f27b0cb98aeac1fb54d782125431e7540e0cb2fa882cf51a8184d724fd",
+      ciphertext:
+        "c7c56da33b45d12f4754e17978bd49999c9c8f51d00db460f902aba2e6e245d0c46662f507915de8596f43b1d175f1db",
+    },
+  ],
+} as const;
+
+function hex(value: string): Buffer {
+  return Buffer.from(value, "hex");
+}
+
+function fixedEphemeral(rawPrivateHex: string): () => NoiseKeyPair {
+  return () => noiseKeyPairFromRawPrivate(hex(rawPrivateHex));
+}
+
+describe("Noise_IK_25519_ChaChaPoly_SHA256", () => {
+  it("derives the responder static public key from the vector private seed", () => {
+    const resp = noiseKeyPairFromRawPrivate(hex(VECTOR.respStatic));
+    expect(resp.publicKeyRaw.toString("hex")).toBe(VECTOR.initRemoteStatic);
+  });
+
+  it("matches the official handshake and transport ciphertexts", () => {
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: noiseKeyPairFromRawPrivate(hex(VECTOR.initStatic)),
+      remoteStaticPublicKey: hex(VECTOR.initRemoteStatic),
+      prologue: hex(VECTOR.prologue),
+      generateEphemeral: fixedEphemeral(VECTOR.initEphemeral),
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: noiseKeyPairFromRawPrivate(hex(VECTOR.respStatic)),
+      prologue: hex(VECTOR.prologue),
+      generateEphemeral: fixedEphemeral(VECTOR.respEphemeral),
+    });
+
+    // Message 1: initiator -> responder.
+    const msg1 = initiator.writeMessage1(hex(VECTOR.messages[0].payload));
+    expect(msg1.toString("hex")).toBe(VECTOR.messages[0].ciphertext);
+    expect(responder.readMessage1(msg1).toString("hex")).toBe(
+      VECTOR.messages[0].payload,
+    );
+
+    // The responder learns and exposes the initiator's static key (the higher
+    // layer pins this — "only a caller I approved").
+    expect(responder.remoteStaticPublicKey()?.toString("hex")).toBe(
+      noiseKeyPairFromRawPrivate(hex(VECTOR.initStatic)).publicKeyRaw.toString(
+        "hex",
+      ),
+    );
+
+    // Message 2: responder -> initiator.
+    const msg2 = responder.writeMessage2(hex(VECTOR.messages[1].payload));
+    expect(msg2.toString("hex")).toBe(VECTOR.messages[1].ciphertext);
+    expect(initiator.readMessage2(msg2).toString("hex")).toBe(
+      VECTOR.messages[1].payload,
+    );
+
+    const initiatorTransport = initiator.split();
+    const responderTransport = responder.split();
+
+    // Both ends derive the same handshake hash (binds higher-layer proofs).
+    expect(initiatorTransport.handshakeHash.toString("hex")).toBe(
+      responderTransport.handshakeHash.toString("hex"),
+    );
+
+    // Transport message 3: initiator -> responder.
+    const t1 = initiatorTransport.encrypt(hex(VECTOR.messages[2].payload));
+    expect(t1.toString("hex")).toBe(VECTOR.messages[2].ciphertext);
+    expect(responderTransport.decrypt(t1).toString("hex")).toBe(
+      VECTOR.messages[2].payload,
+    );
+
+    // Transport message 4: responder -> initiator.
+    const t2 = responderTransport.encrypt(hex(VECTOR.messages[3].payload));
+    expect(t2.toString("hex")).toBe(VECTOR.messages[3].ciphertext);
+    expect(initiatorTransport.decrypt(t2).toString("hex")).toBe(
+      VECTOR.messages[3].payload,
+    );
+  });
+
+  it("completes a handshake with random keys and exchanges encrypted traffic", () => {
+    const gateway = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: gateway.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: gateway,
+    });
+
+    responder.readMessage1(initiator.writeMessage1());
+    initiator.readMessage2(responder.writeMessage2());
+
+    const clientChannel = initiator.split();
+    const gatewayChannel = responder.split();
+
+    const message = Buffer.from("startTurn: rm -rf nothing", "utf8");
+    const onWire = clientChannel.encrypt(message);
+    expect(onWire.equals(message)).toBe(false); // ciphertext != plaintext
+    expect(gatewayChannel.decrypt(onWire).toString("utf8")).toBe(
+      message.toString("utf8"),
+    );
+    // Reverse direction.
+    const reply = Buffer.from("ok", "utf8");
+    expect(
+      clientChannel.decrypt(gatewayChannel.encrypt(reply)).toString("utf8"),
+    ).toBe("ok");
+  });
+
+  it("rejects a tampered transport frame", () => {
+    const gateway = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: gateway.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({ role: "responder", localStatic: gateway });
+    responder.readMessage1(initiator.writeMessage1());
+    initiator.readMessage2(responder.writeMessage2());
+    const clientChannel = initiator.split();
+    const gatewayChannel = responder.split();
+
+    const frame = clientChannel.encrypt(Buffer.from("authentic", "utf8"));
+    const tampered = Buffer.from(frame);
+    tampered[0] ^= 0x01;
+    expect(() => gatewayChannel.decrypt(tampered)).toThrow();
+  });
+
+  it("fails the handshake when the client pins the wrong gateway key (MITM / wrong machine)", () => {
+    const realGateway = generateNoiseStaticKeyPair();
+    const attacker = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+
+    // Client pins the ATTACKER's key but connects to the real gateway.
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: attacker.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: realGateway,
+    });
+
+    // The real gateway cannot decrypt message 1 because the `es`/`ss` DH
+    // outputs diverge from what the client mixed against the attacker key.
+    expect(() => responder.readMessage1(initiator.writeMessage1())).toThrow();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -12,6 +12,7 @@ import {
   generateFederationIdentityKeyPair,
   signFederationMessage,
 } from "../federation/federation-identity";
+import { generateNoiseStaticKeyPair } from "../federation/federation-noise";
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
@@ -134,6 +135,123 @@ describe("federation transport", () => {
         capabilities: ["remote_window"],
       }),
     ).rejects.toThrow("unknown_peer");
+  });
+
+  it("runs an encrypted, channel-bound handshake and carries envelopes (Noise mode)", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-encrypted",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        noiseStatic: gatewayNoise,
+        onEnvelope: (envelope, connection) => {
+          connection.sendEnvelope({
+            id: "response-1",
+            kind: "response",
+            requestId: envelope.id,
+            protocolVersion: 1,
+            sourceInstanceId: "gateway_one",
+            targetInstanceId: connection.peerId,
+            createdAt: 2_000,
+            result: { ok: true },
+          });
+          resolve(envelope);
+        },
+      });
+    });
+    const { url } = await server!.start();
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+        onEnvelope: resolve,
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(received).resolves.toMatchObject({ id: "request-1", kind: "request" });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "request-1",
+      result: { ok: true },
+    });
+    expect(store.getPeer("client_one")).toMatchObject({
+      status: "connected",
+      pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
+    });
+  });
+
+  it("fails when the client pins the wrong gateway Noise key (wrong machine / MITM)", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const attackerNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-wrong-gateway",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      noiseStatic: gatewayNoise,
+    });
+    const { url } = await server.start();
+
+    await expect(
+      connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        // Pin the WRONG (attacker) gateway key — the handshake must fail.
+        gatewayNoisePublicKey: attackerNoise.publicKeyRaw,
+      }),
+    ).rejects.toThrow();
+    expect(store.getPeer("client_one")).toBeUndefined();
   });
 
   it("rejects auth proofs signed with a client-selected nonce", async () => {

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -66,6 +66,8 @@ export function completeFederationEnrollment(params: {
   gatewayInstanceId: FederationInstanceId;
   inviteToken: string;
   now: number;
+  /** Base64 Noise handshake hash to bind the identity proof to the channel. */
+  channelBinding?: string;
   peer: {
     instanceId: FederationInstanceId;
     label: string;
@@ -120,6 +122,7 @@ export function completeFederationEnrollment(params: {
     protocolVersion: params.peer.protocolVersion,
     nonce: params.peer.nonce,
     capabilities: params.peer.capabilities,
+    channelBinding: params.channelBinding,
   });
   const signatureValid = verifyFederationMessageSignature({
     publicKeyPem: params.peer.publicKeyPem,
@@ -169,6 +172,8 @@ export function authenticateFederationReconnect(params: {
   requestedCapabilities: readonly FederationCapability[];
   signatureBase64: string;
   now: number;
+  /** Base64 Noise handshake hash to bind the identity proof to the channel. */
+  channelBinding?: string;
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peerInstanceId)) {
     return {
@@ -206,6 +211,7 @@ export function authenticateFederationReconnect(params: {
     protocolVersion: params.protocolVersion,
     nonce: params.nonce,
     capabilities: params.requestedCapabilities,
+    channelBinding: params.channelBinding,
   });
   const signatureValid = verifyFederationMessageSignature({
     publicKeyPem: peer.pinnedPublicKeyPem,
@@ -242,9 +248,17 @@ export function buildFederationProofMessage(params: {
   protocolVersion: number;
   nonce: string;
   capabilities: readonly FederationCapability[];
+  /**
+   * Base64 Noise handshake hash binding this identity proof to the specific
+   * encrypted channel. Empty in tunnel mode. If a MITM splices a different
+   * channel, the client and gateway derive different hashes, the reconstructed
+   * proof message differs, and the Ed25519 signature fails to verify.
+   */
+  channelBinding?: string;
 }): string {
   return JSON.stringify({
     capabilities: params.capabilities.slice().sort(),
+    channelBinding: params.channelBinding ?? "",
     gatewayInstanceId: params.gatewayInstanceId,
     nonce: params.nonce,
     peerInstanceId: params.peerInstanceId,

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -1,0 +1,349 @@
+// Noise_IK_25519_ChaChaPoly_SHA256 — a hand-written implementation of the one
+// Noise handshake pattern federation needs, built on Node's audited crypto
+// primitives (X25519, ChaCha20-Poly1305, HMAC-SHA256). We implement only the
+// state-machine plumbing; every cryptographic primitive is delegated to
+// OpenSSL via node:crypto. Correctness is locked down against the official
+// Noise test vectors in federation-noise.test.ts.
+//
+// IK gives us exactly the two properties LAN federation needs:
+//   - the initiator (client) knows the responder's (gateway's) static public
+//     key in advance and the handshake proves the gateway holds it (the client
+//     "connects to the machine it approved");
+//   - the responder learns and authenticates the initiator's static key (the
+//     gateway "only talks to a caller it approved").
+// Plus confidentiality + integrity + forward secrecy on every transport frame.
+//
+// IK message pattern (from the Noise spec):
+//   <- s                 (pre-message: initiator already knows responder static)
+//   -> e, es, s, ss      (message 1, initiator -> responder)
+//   <- e, ee, se         (message 2, responder -> initiator)
+//   ... Split() -> transport cipher states
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  type KeyObject,
+} from "node:crypto";
+
+const PROTOCOL_NAME = "Noise_IK_25519_ChaChaPoly_SHA256";
+const HASHLEN = 32;
+const TAGLEN = 16;
+const KEYLEN = 32;
+
+// Fixed DER prefixes for raw <-> KeyObject conversion of X25519 keys (RFC 8410).
+const X25519_SPKI_PREFIX = Buffer.from("302a300506032b656e032100", "hex"); // + 32-byte public
+const X25519_PKCS8_PREFIX = Buffer.from(
+  "302e020100300506032b656e04220420",
+  "hex",
+); // + 32-byte private seed
+
+export type NoiseKeyPair = {
+  privateKey: KeyObject;
+  publicKeyRaw: Buffer;
+};
+
+export type NoiseRole = "initiator" | "responder";
+
+export type NoiseTransport = {
+  /** Encrypt an outbound transport frame (AEAD, monotonic nonce). */
+  encrypt(plaintext: Buffer): Buffer;
+  /** Decrypt an inbound transport frame; throws on tamper/replay. */
+  decrypt(ciphertext: Buffer): Buffer;
+  /** Final handshake hash `h` — bind higher-layer identity proofs to this. */
+  handshakeHash: Buffer;
+};
+
+function sha256(data: Buffer): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+function hmac(key: Buffer, data: Buffer): Buffer {
+  return createHmac("sha256", key).update(data).digest();
+}
+
+// Noise's HKDF (HMAC chain), returning the first two 32-byte outputs.
+function hkdf2(chainingKey: Buffer, ikm: Buffer): [Buffer, Buffer] {
+  const tempKey = hmac(chainingKey, ikm);
+  const output1 = hmac(tempKey, Buffer.from([0x01]));
+  const output2 = hmac(tempKey, Buffer.concat([output1, Buffer.from([0x02])]));
+  return [output1, output2];
+}
+
+export function rawPublicKey(key: KeyObject): Buffer {
+  return Buffer.from(key.export({ type: "spki", format: "der" })).subarray(
+    -KEYLEN,
+  );
+}
+
+export function importNoisePublicKey(raw: Buffer): KeyObject {
+  if (raw.length !== KEYLEN) {
+    throw new Error("Invalid X25519 public key length");
+  }
+  return createPublicKey({
+    key: Buffer.concat([X25519_SPKI_PREFIX, raw]),
+    format: "der",
+    type: "spki",
+  });
+}
+
+export function generateNoiseStaticKeyPair(): NoiseKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync("x25519");
+  return { privateKey, publicKeyRaw: rawPublicKey(publicKey) };
+}
+
+// Rebuild a keypair from a raw 32-byte X25519 private seed. Used for the
+// persisted static key and for injecting fixed keys in test vectors.
+export function noiseKeyPairFromRawPrivate(raw: Buffer): NoiseKeyPair {
+  if (raw.length !== KEYLEN) {
+    throw new Error("Invalid X25519 private key length");
+  }
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([X25519_PKCS8_PREFIX, raw]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return { privateKey, publicKeyRaw: rawPublicKey(createPublicKey(privateKey)) };
+}
+
+export function rawPrivateKey(key: KeyObject): Buffer {
+  return Buffer.from(key.export({ type: "pkcs8", format: "der" })).subarray(
+    -KEYLEN,
+  );
+}
+
+function dh(localPrivate: KeyObject, remoteRaw: Buffer): Buffer {
+  return diffieHellman({
+    privateKey: localPrivate,
+    publicKey: importNoisePublicKey(remoteRaw),
+  });
+}
+
+class CipherState {
+  private key?: Buffer;
+  private nonce = 0n;
+
+  initializeKey(key: Buffer): void {
+    this.key = key;
+    this.nonce = 0n;
+  }
+
+  hasKey(): boolean {
+    return this.key !== undefined;
+  }
+
+  private nextNonce(): Buffer {
+    // Noise nonce: 4 zero bytes followed by the 64-bit counter, little-endian.
+    const buf = Buffer.alloc(12);
+    buf.writeBigUInt64LE(this.nonce, 4);
+    return buf;
+  }
+
+  encryptWithAd(ad: Buffer, plaintext: Buffer): Buffer {
+    if (this.key === undefined) return plaintext;
+    if (this.nonce >= 0xffffffffffffffffn) {
+      throw new Error("Noise nonce exhausted");
+    }
+    const cipher = createCipheriv("chacha20-poly1305", this.key, this.nextNonce(), {
+      authTagLength: TAGLEN,
+    });
+    cipher.setAAD(ad, { plaintextLength: plaintext.length });
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    this.nonce += 1n;
+    return Buffer.concat([ciphertext, tag]);
+  }
+
+  decryptWithAd(ad: Buffer, data: Buffer): Buffer {
+    if (this.key === undefined) return data;
+    if (data.length < TAGLEN) {
+      throw new Error("Noise ciphertext too short");
+    }
+    if (this.nonce >= 0xffffffffffffffffn) {
+      throw new Error("Noise nonce exhausted");
+    }
+    const ciphertext = data.subarray(0, data.length - TAGLEN);
+    const tag = data.subarray(data.length - TAGLEN);
+    const decipher = createDecipheriv(
+      "chacha20-poly1305",
+      this.key,
+      this.nextNonce(),
+      { authTagLength: TAGLEN },
+    );
+    decipher.setAAD(ad, { plaintextLength: ciphertext.length });
+    decipher.setAuthTag(tag);
+    // final() throws if the tag does not verify; only advance on success.
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]);
+    this.nonce += 1n;
+    return plaintext;
+  }
+}
+
+class SymmetricState {
+  private chainingKey: Buffer;
+  hash: Buffer;
+  readonly cipher = new CipherState();
+
+  constructor() {
+    const name = Buffer.from(PROTOCOL_NAME, "utf8");
+    // Protocol name is <= HASHLEN, so h is the name zero-padded to 32 bytes —
+    // NOT hashed.
+    this.hash =
+      name.length <= HASHLEN
+        ? Buffer.concat([name, Buffer.alloc(HASHLEN - name.length)])
+        : sha256(name);
+    this.chainingKey = Buffer.from(this.hash);
+  }
+
+  mixKey(ikm: Buffer): void {
+    const [chainingKey, tempKey] = hkdf2(this.chainingKey, ikm);
+    this.chainingKey = chainingKey;
+    this.cipher.initializeKey(tempKey);
+  }
+
+  mixHash(data: Buffer): void {
+    this.hash = sha256(Buffer.concat([this.hash, data]));
+  }
+
+  encryptAndHash(plaintext: Buffer): Buffer {
+    const ciphertext = this.cipher.encryptWithAd(this.hash, plaintext);
+    this.mixHash(ciphertext);
+    return ciphertext;
+  }
+
+  decryptAndHash(ciphertext: Buffer): Buffer {
+    const plaintext = this.cipher.decryptWithAd(this.hash, ciphertext);
+    this.mixHash(ciphertext);
+    return plaintext;
+  }
+
+  split(): [CipherState, CipherState] {
+    const [k1, k2] = hkdf2(this.chainingKey, Buffer.alloc(0));
+    const c1 = new CipherState();
+    c1.initializeKey(k1);
+    const c2 = new CipherState();
+    c2.initializeKey(k2);
+    return [c1, c2];
+  }
+}
+
+export type NoiseHandshakeOptions = {
+  role: NoiseRole;
+  localStatic: NoiseKeyPair;
+  /** Required for the initiator: the pinned responder (gateway) static pubkey. */
+  remoteStaticPublicKey?: Buffer;
+  prologue?: Buffer;
+  /** Test seam: supply a deterministic ephemeral keypair. Defaults to random. */
+  generateEphemeral?: () => NoiseKeyPair;
+};
+
+export class NoiseIKHandshake {
+  private readonly sym = new SymmetricState();
+  private readonly role: NoiseRole;
+  private readonly localStatic: NoiseKeyPair;
+  private readonly generateEphemeral: () => NoiseKeyPair;
+  private localEphemeral?: NoiseKeyPair;
+  private remoteStatic?: Buffer;
+  private remoteEphemeral?: Buffer;
+
+  constructor(options: NoiseHandshakeOptions) {
+    this.role = options.role;
+    this.localStatic = options.localStatic;
+    this.generateEphemeral =
+      options.generateEphemeral ?? generateNoiseStaticKeyPair;
+
+    this.sym.mixHash(options.prologue ?? Buffer.alloc(0));
+
+    // Pre-message: IK has `<- s` (responder static), hashed by both sides.
+    if (this.role === "initiator") {
+      if (!options.remoteStaticPublicKey) {
+        throw new Error("Initiator requires the pinned responder static key");
+      }
+      this.remoteStatic = Buffer.from(options.remoteStaticPublicKey);
+      this.sym.mixHash(this.remoteStatic);
+    } else {
+      this.sym.mixHash(this.localStatic.publicKeyRaw);
+    }
+  }
+
+  /** Initiator: write message 1 (e, es, s, ss + payload). */
+  writeMessage1(payload: Buffer = Buffer.alloc(0)): Buffer {
+    if (this.role !== "initiator") throw new Error("writeMessage1 is initiator-only");
+    if (!this.remoteStatic) throw new Error("Missing pinned responder static");
+    this.localEphemeral = this.generateEphemeral();
+    this.sym.mixHash(this.localEphemeral.publicKeyRaw);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteStatic)); // es
+    const encStatic = this.sym.encryptAndHash(this.localStatic.publicKeyRaw); // s
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteStatic)); // ss
+    const encPayload = this.sym.encryptAndHash(payload);
+    return Buffer.concat([this.localEphemeral.publicKeyRaw, encStatic, encPayload]);
+  }
+
+  /** Responder: read message 1. Returns the (decrypted) payload. */
+  readMessage1(message: Buffer): Buffer {
+    if (this.role !== "responder") throw new Error("readMessage1 is responder-only");
+    let offset = 0;
+    this.remoteEphemeral = message.subarray(offset, offset + KEYLEN);
+    offset += KEYLEN;
+    this.sym.mixHash(this.remoteEphemeral);
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteEphemeral)); // es
+    const encStatic = message.subarray(offset, offset + KEYLEN + TAGLEN);
+    offset += KEYLEN + TAGLEN;
+    this.remoteStatic = this.sym.decryptAndHash(encStatic); // s
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteStatic)); // ss
+    return this.sym.decryptAndHash(message.subarray(offset));
+  }
+
+  /** Responder: write message 2 (e, ee, se + payload). */
+  writeMessage2(payload: Buffer = Buffer.alloc(0)): Buffer {
+    if (this.role !== "responder") throw new Error("writeMessage2 is responder-only");
+    if (!this.remoteEphemeral || !this.remoteStatic) {
+      throw new Error("writeMessage2 requires readMessage1 first");
+    }
+    this.localEphemeral = this.generateEphemeral();
+    this.sym.mixHash(this.localEphemeral.publicKeyRaw);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteEphemeral)); // ee
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteStatic)); // se (responder: DH(e, rs))
+    const encPayload = this.sym.encryptAndHash(payload);
+    return Buffer.concat([this.localEphemeral.publicKeyRaw, encPayload]);
+  }
+
+  /** Initiator: read message 2. Returns the (decrypted) payload. */
+  readMessage2(message: Buffer): Buffer {
+    if (this.role !== "initiator") throw new Error("readMessage2 is initiator-only");
+    if (!this.localEphemeral) throw new Error("readMessage2 requires writeMessage1 first");
+    let offset = 0;
+    this.remoteEphemeral = message.subarray(offset, offset + KEYLEN);
+    offset += KEYLEN;
+    this.sym.mixHash(this.remoteEphemeral);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteEphemeral)); // ee
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteEphemeral)); // se (initiator: DH(s, re))
+    return this.sym.decryptAndHash(message.subarray(offset));
+  }
+
+  /** The remote static key the responder learned during the handshake. */
+  remoteStaticPublicKey(): Buffer | undefined {
+    return this.remoteStatic ? Buffer.from(this.remoteStatic) : undefined;
+  }
+
+  /** Finalize: split into directional transport cipher states. */
+  split(): NoiseTransport {
+    const [c1, c2] = this.sym.split();
+    // Initiator sends with the first cipher state; responder with the second.
+    const send = this.role === "initiator" ? c1 : c2;
+    const recv = this.role === "initiator" ? c2 : c1;
+    const handshakeHash = Buffer.from(this.sym.hash);
+    return {
+      handshakeHash,
+      encrypt: (plaintext) => send.encryptWithAd(Buffer.alloc(0), plaintext),
+      decrypt: (ciphertext) => recv.decryptWithAd(Buffer.alloc(0), ciphertext),
+    };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -116,6 +116,29 @@ export function rawPrivateKey(key: KeyObject): Buffer {
   );
 }
 
+export type FederationNoiseStaticKeyPair = {
+  /** Raw 32-byte X25519 private seed, base64. Persisted in the secret store. */
+  privateKeyBase64: string;
+  /** Raw 32-byte X25519 public key, base64. Pinned by peers. */
+  publicKeyBase64: string;
+};
+
+export function generateFederationNoiseStaticKeyPair(): FederationNoiseStaticKeyPair {
+  const keyPair = generateNoiseStaticKeyPair();
+  return {
+    privateKeyBase64: rawPrivateKey(keyPair.privateKey).toString("base64"),
+    publicKeyBase64: keyPair.publicKeyRaw.toString("base64"),
+  };
+}
+
+export function noisePublicKeyBase64FromPrivateBase64(
+  privateKeyBase64: string,
+): string {
+  return noiseKeyPairFromRawPrivate(
+    Buffer.from(privateKeyBase64, "base64"),
+  ).publicKeyRaw.toString("base64");
+}
+
 function dh(localPrivate: KeyObject, remoteRaw: Buffer): Buffer {
   return diffieHellman({
     privateKey: localPrivate,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -75,10 +75,12 @@ import {
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
 } from "./federation-transport";
+import { noiseKeyPairFromRawPrivate } from "./federation-noise";
 
 const log = getMainLogger("pwragent:federation-runtime");
 const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
+const GATEWAY_NOISE_PUBLIC_KEY_META_KEY = "federation_gateway_noise_public_key";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 
@@ -98,6 +100,8 @@ type FederationInvitePayload = {
   token: string;
   gatewayInstanceId: FederationInstanceId;
   gatewayUrl: string;
+  /** Gateway's Noise static public key (base64) — the client pins this. */
+  gatewayNoisePublicKey: string;
   expiresAt: number;
 };
 
@@ -171,6 +175,8 @@ export class DesktopFederationRuntime {
     }
     const now = Date.now();
     const expiresAt = now + Math.max(60_000, Math.min(request.ttlMs ?? 3_600_000, 86_400_000));
+    const noise =
+      await getDesktopSettingsService().getOrCreateFederationNoiseStaticKeyPair();
     const entry = createFederationEnrollmentInvite({
       store: this.store(),
       token: randomBytes(24).toString("base64url"),
@@ -187,6 +193,7 @@ export class DesktopFederationRuntime {
         token: entry.token,
         gatewayInstanceId: this.ensureLocalInstanceId(),
         gatewayUrl,
+        gatewayNoisePublicKey: noise.publicKeyBase64,
         expiresAt,
       }),
       expiresAt,
@@ -201,6 +208,10 @@ export class DesktopFederationRuntime {
     const payload = decodeInvite(invite);
     const stateDb = getAppStateDb();
     stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, payload.gatewayInstanceId);
+    stateDb.setMeta(
+      GATEWAY_NOISE_PUBLIC_KEY_META_KEY,
+      payload.gatewayNoisePublicKey,
+    );
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
     await getDesktopSettingsService().writeConfigPatch({
       federation: {
@@ -295,12 +306,19 @@ export class DesktopFederationRuntime {
     this.router = router;
     this.subscribeLocalBackendEvents();
 
+    const noise =
+      await getDesktopSettingsService().getOrCreateFederationNoiseStaticKeyPair();
+    const noiseStatic = noiseKeyPairFromRawPrivate(
+      Buffer.from(noise.privateKeyBase64, "base64"),
+    );
+
     if (mode === "gateway" || mode === "dual") {
       this.server = new FederationGatewayWebSocketServer({
         gatewayInstanceId: localInstanceId,
         host: settings.federation.listenHost.value,
         port: settings.federation.listenPort.value,
         store: this.store(),
+        noiseStatic,
         onConnection: (connection) => this.registerGatewayConnection(connection),
         onDisconnect: (connection) => this.unregisterGatewayConnection(connection),
         onEnvelope: (envelope, connection) =>
@@ -324,9 +342,20 @@ export class DesktopFederationRuntime {
       return;
     }
     this.gatewayInstanceId = gatewayInstanceId;
+    const gatewayNoisePublicKeyBase64 = getAppStateDb().getMeta(
+      GATEWAY_NOISE_PUBLIC_KEY_META_KEY,
+    );
+    if (!gatewayNoisePublicKeyBase64) {
+      log.error(
+        "federation client missing pinned gateway encryption key; refusing to connect without encryption. Re-import the federation invite.",
+      );
+      return;
+    }
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
+    const noise =
+      await getDesktopSettingsService().getOrCreateFederationNoiseStaticKeyPair();
     this.gatewayUrl = gatewayUrl;
     this.client = await connectFederationClient({
       url: gatewayUrl,
@@ -339,6 +368,10 @@ export class DesktopFederationRuntime {
       inviteToken: pendingInviteToken || undefined,
       label: getAppStateDb().getMeta("profile_name") || this.ensureLocalInstanceId(),
       role: "client",
+      noiseStatic: noiseKeyPairFromRawPrivate(
+        Buffer.from(noise.privateKeyBase64, "base64"),
+      ),
+      gatewayNoisePublicKey: Buffer.from(gatewayNoisePublicKeyBase64, "base64"),
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
     });
@@ -781,6 +814,7 @@ function decodeInvite(invite: string): FederationInvitePayload {
     typeof parsed.token !== "string" ||
     typeof parsed.gatewayInstanceId !== "string" ||
     typeof parsed.gatewayUrl !== "string" ||
+    typeof parsed.gatewayNoisePublicKey !== "string" ||
     typeof parsed.expiresAt !== "number"
   ) {
     throw new Error("Invalid federation invite.");

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -19,6 +19,11 @@ import {
 } from "./federation-enrollment";
 import { signFederationMessage } from "./federation-identity";
 import {
+  NoiseIKHandshake,
+  type NoiseKeyPair,
+  type NoiseTransport,
+} from "./federation-noise";
+import {
   federationFailure,
   type FederationRedactedFailure,
 } from "./federation-redaction";
@@ -87,6 +92,13 @@ export type FederationGatewayWebSocketServerOptions = {
   port: number;
   store: FederationStore;
   sessions?: FederationSessionRegistry;
+  /**
+   * Gateway's Noise static keypair. When set, every connection runs a Noise_IK
+   * handshake (responder role) before auth, and all frames are encrypted. When
+   * unset, the transport runs in plaintext "tunnel" mode (confidentiality is
+   * expected from an outer TLS tunnel, e.g. Cloudflare).
+   */
+  noiseStatic?: NoiseKeyPair;
   onConnection?: (connection: FederationGatewayConnection) => void;
   onDisconnect?: (connection: FederationGatewayConnection) => void;
   onEnvelope?: (
@@ -112,7 +124,7 @@ export class FederationGatewayWebSocketServer {
     }
     this.httpServer = http.createServer();
     this.wsServer = new WebSocketServer({ server: this.httpServer });
-    this.wsServer.on("connection", (socket) => this.handleSocket(socket));
+    this.wsServer.on("connection", (socket) => void this.handleSocket(socket));
 
     await new Promise<void>((resolve, reject) => {
       const server = this.httpServer;
@@ -146,87 +158,112 @@ export class FederationGatewayWebSocketServer {
     await new Promise<void>((resolve) => httpServer?.close(() => resolve()) ?? resolve());
   }
 
-  private handleSocket(socket: WebSocket): void {
-    let connection: FederationGatewayConnection | undefined;
-    const challengeNonce = `challenge:${randomUUID()}`;
-    sendSocketMessage(socket, {
-      kind: "auth.challenge",
-      gatewayInstanceId: this.options.gatewayInstanceId,
-      protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      nonce: challengeNonce,
-    });
-    socket.once("message", (raw) => {
-      const message = parseSocketMessage(raw);
-      if (!message || message.kind !== "auth") {
-        sendSocketMessage(socket, {
-          kind: "auth.rejected",
-          failure: federationFailure("policy_denied"),
-        });
-        socket.close();
-        return;
-      }
-      if (message.nonce !== challengeNonce) {
-        sendSocketMessage(socket, {
-          kind: "auth.rejected",
-          failure: federationFailure("policy_denied"),
-        });
-        socket.close();
-        return;
-      }
-      const decision = this.authenticate(message);
-      if (!decision.accepted) {
-        sendSocketMessage(socket, {
-          kind: "auth.rejected",
-          failure: decision.failure,
-        });
-        socket.close();
-        return;
-      }
+  private async handleSocket(socket: WebSocket): Promise<void> {
+    const reader = new FederationFrameReader(socket);
 
-      const sessionId = `federation-session:${randomUUID()}`;
-      this.sessions.openSession({
-        sessionId,
-        peerId: decision.peer.id,
-        connectedAt: Date.now(),
-        capabilities: decision.capabilities,
-      });
-      connection = {
-        peerId: decision.peer.id,
-        sessionId,
-        capabilities: decision.capabilities,
-        sendEnvelope: (envelope) => {
-          sendSocketMessage(socket, { kind: "envelope", envelope });
-        },
-        close: () => socket.close(),
-      };
-      sendSocketMessage(socket, {
+    // Phase 1: Noise_IK handshake (responder). Skipped in tunnel mode.
+    let transport: NoiseTransport | undefined;
+    let channelBinding = "";
+    if (this.options.noiseStatic) {
+      try {
+        const handshake = new NoiseIKHandshake({
+          role: "responder",
+          localStatic: this.options.noiseStatic,
+        });
+        handshake.readMessage1(await reader.next());
+        socket.send(handshake.writeMessage2());
+        transport = handshake.split();
+        channelBinding = transport.handshakeHash.toString("base64");
+      } catch {
+        socket.close();
+        return;
+      }
+    }
+
+    // Phase 2: identity auth (inside the encrypted channel when present).
+    const challengeNonce = `challenge:${randomUUID()}`;
+    sendFrame(
+      socket,
+      {
+        kind: "auth.challenge",
+        gatewayInstanceId: this.options.gatewayInstanceId,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        nonce: challengeNonce,
+      },
+      transport,
+    );
+
+    let authFrame: Buffer;
+    try {
+      authFrame = await reader.next();
+    } catch {
+      return;
+    }
+    const message = decodeFrame(authFrame, transport);
+    if (!message || message.kind !== "auth" || message.nonce !== challengeNonce) {
+      sendFrame(socket, { kind: "auth.rejected", failure: federationFailure("policy_denied") }, transport);
+      socket.close();
+      return;
+    }
+    const decision = this.authenticate(message, channelBinding);
+    if (!decision.accepted) {
+      sendFrame(socket, { kind: "auth.rejected", failure: decision.failure }, transport);
+      socket.close();
+      return;
+    }
+
+    const sessionId = `federation-session:${randomUUID()}`;
+    this.sessions.openSession({
+      sessionId,
+      peerId: decision.peer.id,
+      connectedAt: Date.now(),
+      capabilities: decision.capabilities,
+    });
+    const connection: FederationGatewayConnection = {
+      peerId: decision.peer.id,
+      sessionId,
+      capabilities: decision.capabilities,
+      sendEnvelope: (envelope) => {
+        sendFrame(socket, { kind: "envelope", envelope }, transport);
+      },
+      close: () => socket.close(),
+    };
+    sendFrame(
+      socket,
+      {
         kind: "auth.accepted",
         sessionId,
         protocolVersion: FEDERATION_PROTOCOL_VERSION,
         capabilities: decision.capabilities,
+      },
+      transport,
+    );
+    this.options.onConnection?.(connection);
+    socket.once("close", () => {
+      this.sessions.closeSession({
+        sessionId,
+        closedAt: Date.now(),
+        reason: "transport_closed",
       });
-      this.options.onConnection?.(connection);
-
-      socket.on("message", (nextRaw) => {
-        const next = parseSocketMessage(nextRaw);
-        if (!next || next.kind !== "envelope" || !connection) return;
-        this.sessions.heartbeat(sessionId, Date.now());
-        this.options.onEnvelope?.(next.envelope, connection);
-      });
-      socket.once("close", () => {
-        this.sessions.closeSession({
-          sessionId,
-          closedAt: Date.now(),
-          reason: "transport_closed",
-        });
-        if (connection) {
-          this.options.onDisconnect?.(connection);
-        }
-      });
+      this.options.onDisconnect?.(connection);
     });
+
+    // Phase 3: stream envelopes.
+    for (;;) {
+      let frame: Buffer;
+      try {
+        frame = await reader.next();
+      } catch {
+        return;
+      }
+      const next = decodeFrame(frame, transport);
+      if (!next || next.kind !== "envelope") continue;
+      this.sessions.heartbeat(sessionId, Date.now());
+      this.options.onEnvelope?.(next.envelope, connection);
+    }
   }
 
-  private authenticate(message: FederationSocketAuthMessage) {
+  private authenticate(message: FederationSocketAuthMessage, channelBinding: string) {
     if (message.gatewayInstanceId !== this.options.gatewayInstanceId) {
       return {
         accepted: false as const,
@@ -245,6 +282,7 @@ export class FederationGatewayWebSocketServer {
         gatewayInstanceId: this.options.gatewayInstanceId,
         inviteToken: message.inviteToken,
         now: Date.now(),
+        channelBinding,
         peer: {
           instanceId: message.peerInstanceId,
           label: message.label ?? message.peerInstanceId,
@@ -267,6 +305,7 @@ export class FederationGatewayWebSocketServer {
       nonce: message.nonce,
       requestedCapabilities: message.capabilities,
       signatureBase64: message.signatureBase64,
+      channelBinding,
       now: Date.now(),
     });
   }
@@ -293,22 +332,59 @@ export async function connectFederationClient(params: {
   endpoint?: string;
   profileName?: string;
   headers?: Record<string, string>;
+  /** Client's Noise static keypair. Enables encryption (initiator role). */
+  noiseStatic?: NoiseKeyPair;
+  /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
+  gatewayNoisePublicKey?: Buffer;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
 }): Promise<FederationClientWebSocketClient> {
   const socket = new WebSocket(params.url, {
     headers: params.headers,
   });
-  const [challenge] = await Promise.all([
-    waitForAuthChallenge(socket),
-    waitForOpen(socket),
-  ]);
+  // Attach the reader before "open" so no inbound frame can be missed.
+  const reader = new FederationFrameReader(socket);
+  await waitForOpen(socket);
+
+  // Phase 1: Noise_IK handshake (initiator). Skipped in tunnel mode.
+  let transport: NoiseTransport | undefined;
+  let channelBinding = "";
+  if (params.noiseStatic) {
+    if (!params.gatewayNoisePublicKey) {
+      socket.close();
+      throw new Error("Missing pinned gateway Noise key for encrypted federation");
+    }
+    try {
+      const handshake = new NoiseIKHandshake({
+        role: "initiator",
+        localStatic: params.noiseStatic,
+        remoteStaticPublicKey: params.gatewayNoisePublicKey,
+      });
+      socket.send(handshake.writeMessage1());
+      handshake.readMessage2(await reader.next());
+      transport = handshake.split();
+      channelBinding = transport.handshakeHash.toString("base64");
+    } catch (error) {
+      socket.close();
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  // Phase 2: identity auth.
+  const challenge = decodeFrame(await reader.next(), transport);
+  if (challenge?.kind === "auth.rejected") {
+    socket.close();
+    throw new Error(challenge.failure.code);
+  }
   if (
+    !challenge ||
+    challenge.kind !== "auth.challenge" ||
     challenge.gatewayInstanceId !== params.gatewayInstanceId ||
     challenge.protocolVersion !== FEDERATION_PROTOCOL_VERSION
   ) {
     socket.close();
     throw new Error("Invalid federation auth challenge");
   }
+
   const messageToSign = buildFederationProofMessage({
     purpose: params.mode === "enroll" ? "enroll" : "reconnect",
     gatewayInstanceId: params.gatewayInstanceId,
@@ -317,6 +393,7 @@ export async function connectFederationClient(params: {
     protocolVersion: FEDERATION_PROTOCOL_VERSION,
     nonce: challenge.nonce,
     capabilities: params.capabilities,
+    channelBinding,
   });
   const authMessage: FederationSocketAuthMessage = {
     kind: "auth",
@@ -337,76 +414,124 @@ export async function connectFederationClient(params: {
     endpoint: params.endpoint,
     profileName: params.profileName,
   };
+  sendFrame(socket, authMessage, transport);
 
-  sendSocketMessage(socket, authMessage);
-  const accepted = await waitForAuthResult(socket);
-  socket.on("message", (raw) => {
-    const message = parseSocketMessage(raw);
-    if (message?.kind === "envelope") {
-      params.onEnvelope?.(message.envelope);
+  const accepted = decodeFrame(await reader.next(), transport);
+  if (accepted?.kind === "auth.rejected") {
+    socket.close();
+    throw new Error(accepted.failure.code);
+  }
+  if (!accepted || accepted.kind !== "auth.accepted") {
+    socket.close();
+    throw new Error("Unexpected federation auth response");
+  }
+
+  // Phase 3: stream envelopes.
+  void (async () => {
+    for (;;) {
+      let frame: Buffer;
+      try {
+        frame = await reader.next();
+      } catch {
+        return;
+      }
+      const message = decodeFrame(frame, transport);
+      if (message?.kind === "envelope") {
+        params.onEnvelope?.(message.envelope);
+      }
     }
-  });
+  })();
+
   return {
     sessionId: accepted.sessionId,
     capabilities: accepted.capabilities,
     sendEnvelope: (envelope) => {
-      sendSocketMessage(socket, { kind: "envelope", envelope });
+      sendFrame(socket, { kind: "envelope", envelope }, transport);
     },
     close: () => socket.close(),
   };
 }
 
+// A race-free, ordered reader over a WebSocket's discrete messages. Attaching
+// it before any await guarantees no frame is dropped between socket events and
+// the next read — important because the Noise handshake and auth exchange must
+// consume frames in a strict order.
+class FederationFrameReader {
+  private readonly queue: Buffer[] = [];
+  private pending?: { resolve: (frame: Buffer) => void; reject: (error: Error) => void };
+  private failure?: Error;
+
+  constructor(socket: WebSocket) {
+    socket.on("message", (raw) => this.push(rawDataToBuffer(raw)));
+    socket.once("close", () => this.fail(new Error("Federation socket closed")));
+    socket.once("error", (error) =>
+      this.fail(error instanceof Error ? error : new Error(String(error))),
+    );
+  }
+
+  private push(frame: Buffer): void {
+    if (this.pending) {
+      const { resolve } = this.pending;
+      this.pending = undefined;
+      resolve(frame);
+      return;
+    }
+    this.queue.push(frame);
+  }
+
+  private fail(error: Error): void {
+    this.failure ??= error;
+    if (this.pending) {
+      const { reject } = this.pending;
+      this.pending = undefined;
+      reject(error);
+    }
+  }
+
+  next(): Promise<Buffer> {
+    const queued = this.queue.shift();
+    if (queued) return Promise.resolve(queued);
+    if (this.failure) return Promise.reject(this.failure);
+    return new Promise((resolve, reject) => {
+      this.pending = { resolve, reject };
+    });
+  }
+}
+
+function rawDataToBuffer(raw: WebSocket.RawData): Buffer {
+  if (Buffer.isBuffer(raw)) return raw;
+  if (Array.isArray(raw)) return Buffer.concat(raw);
+  return Buffer.from(raw as ArrayBuffer);
+}
+
 function waitForOpen(socket: WebSocket): Promise<void> {
   return new Promise((resolve, reject) => {
+    if (socket.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
     socket.once("open", () => resolve());
     socket.once("error", reject);
   });
 }
 
-function waitForAuthChallenge(socket: WebSocket): Promise<FederationSocketChallengeMessage> {
-  return new Promise((resolve, reject) => {
-    socket.once("message", (raw) => {
-      const message = parseSocketMessage(raw);
-      if (message?.kind === "auth.challenge") {
-        resolve(message);
-        return;
-      }
-      if (message?.kind === "auth.rejected") {
-        reject(new Error(message.failure.code));
-        return;
-      }
-      reject(new Error("Unexpected federation auth challenge"));
-    });
-    socket.once("error", reject);
-  });
-}
-
-function waitForAuthResult(socket: WebSocket): Promise<FederationSocketAcceptedMessage> {
-  return new Promise((resolve, reject) => {
-    socket.once("message", (raw) => {
-      const message = parseSocketMessage(raw);
-      if (message?.kind === "auth.accepted") {
-        resolve(message);
-        return;
-      }
-      if (message?.kind === "auth.rejected") {
-        reject(new Error(message.failure.code));
-        return;
-      }
-      reject(new Error("Unexpected federation auth response"));
-    });
-    socket.once("error", reject);
-  });
-}
-
-function sendSocketMessage(socket: WebSocket, message: FederationSocketMessage): void {
+function sendFrame(
+  socket: WebSocket,
+  message: FederationSocketMessage,
+  transport?: NoiseTransport,
+): void {
   if (socket.readyState !== WebSocket.OPEN) return;
-  socket.send(JSON.stringify(message));
+  const json = Buffer.from(JSON.stringify(message), "utf8");
+  socket.send(transport ? transport.encrypt(json) : json);
 }
 
-function parseSocketMessage(raw: WebSocket.RawData): FederationSocketMessage | undefined {
+function decodeFrame(
+  frame: Buffer,
+  transport?: NoiseTransport,
+): FederationSocketMessage | undefined {
   try {
-    const parsed = JSON.parse(raw.toString()) as Partial<FederationSocketMessage>;
+    const json = transport ? transport.decrypt(frame) : frame;
+    const parsed = JSON.parse(json.toString("utf8")) as Partial<FederationSocketMessage>;
     if (parsed.kind === "auth" && isAuthMessage(parsed)) return parsed;
     if (parsed.kind === "auth.challenge" && isChallengeMessage(parsed)) return parsed;
     if (parsed.kind === "auth.accepted" && isAcceptedMessage(parsed)) return parsed;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -44,6 +44,11 @@ import {
   publicKeyPemFromPrivateKey,
   type FederationIdentityKeyPair,
 } from "../federation/federation-identity";
+import {
+  generateFederationNoiseStaticKeyPair,
+  noisePublicKeyBase64FromPrivateBase64,
+  type FederationNoiseStaticKeyPair,
+} from "../federation/federation-noise";
 
 import {
   applyDesktopSettingsPatch,
@@ -1221,6 +1226,24 @@ export class DesktopSettingsService {
     await this.options.secretStore.setSecret(
       "federationInstancePrivateKey",
       keyPair.privateKeyPem,
+    );
+    return keyPair;
+  }
+
+  async getOrCreateFederationNoiseStaticKeyPair(): Promise<FederationNoiseStaticKeyPair> {
+    const existing = await this.options.secretStore.getSecret(
+      "federationNoiseStaticPrivateKey",
+    );
+    if (existing) {
+      return {
+        privateKeyBase64: existing,
+        publicKeyBase64: noisePublicKeyBase64FromPrivateBase64(existing),
+      };
+    }
+    const keyPair = generateFederationNoiseStaticKeyPair();
+    await this.options.secretStore.setSecret(
+      "federationNoiseStaticPrivateKey",
+      keyPair.privateKeyBase64,
     );
     return keyPair;
   }

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -192,6 +192,7 @@ export type DesktopSettingsSecretName =
   | "lineChannelAccessToken"
   | "lineChannelSecret"
   | "federationInstancePrivateKey"
+  | "federationNoiseStaticPrivateKey"
   | "federationCloudflareClientCertificate"
   | "federationCloudflareClientPrivateKey"
   | "federationCloudflareAccessClientId"
@@ -231,6 +232,7 @@ export function isMessagingRuntimeSecret(
       return true;
     case "grokApiKey":
     case "federationInstancePrivateKey":
+    case "federationNoiseStaticPrivateKey":
     case "federationCloudflareClientCertificate":
     case "federationCloudflareClientPrivateKey":
     case "federationCloudflareAccessClientId":


### PR DESCRIPTION
## Summary

Makes federation **safe to enable on a LAN**. Today the transport is plain `ws://` and only the handshake is authenticated — an on-path attacker can read every envelope and inject agent-control frames, and the client's "is this the right gateway?" check is an unauthenticated id string a MITM can spoof. This stacks a **Noise_IK** encrypted, mutually-authenticated channel inside the existing WebSocket, reusing the pinned per-instance identity.

Delivers the three properties requested:
- **Encryption** — every frame is ChaCha20-Poly1305 AEAD with forward secrecy.
- **Approved caller** (gateway pins client) — the existing Ed25519 enrollment, now **channel-bound** to the Noise handshake hash so the identity is tied to this specific encrypted channel.
- **Right machine** (client pins gateway) — the invite carries the gateway's Noise static key; the IK handshake cryptographically proves the gateway holds it. A wrong/spoofed gateway key **fails the handshake** (ssh `known_hosts` for the gateway).

## Approach

Hand-implemented just the one `Noise_IK_25519_ChaChaPoly_SHA256` pattern on Node's built-in crypto (X25519, ChaCha20-Poly1305, HMAC-SHA256) — **no native module, no hand-rolled cipher**; only the state-machine plumbing is ours, every primitive is OpenSSL. Library options were evaluated and rejected (native-module pain or abandonware).

Correctness is locked to the **official Noise test vectors**: handshake *and* transport ciphertexts match byte-for-byte.

## Commits
1. `feat(federation): add Noise_IK crypto core` — `federation-noise.ts` + vector tests.
2. `feat(federation): wire Noise IK into the transport with channel binding` — handshake-first framing, per-frame encryption, channel-bound proof, race-free frame reader. Tunnel mode preserved byte-identical.
3. `feat(federation): persist Noise keys, pin the gateway via invite, encrypt by default` — key persistence, invite carries+pins the gateway key, runtime always encrypts (no plaintext path), client fails closed without a pinned gateway key.
4. `test(federation): cover Noise static keypair persistence`.

## Security model notes
- **Encrypted by construction.** The runtime always supplies Noise keys, so there is no config flag that can accidentally leave a LAN bind in cleartext.
- Channel binding closes identity-misbinding gaps between the Noise channel and the Ed25519 identity.
- This supersedes the plan-only `transport_security`/tunnel toggle: always-on encryption is simpler and strictly safer (works inside a Cloudflare TLS tunnel too).

## Verification
- Official Noise vector match (handshake + transport), tamper rejection, wrong-pinned-key handshake failure.
- Encrypted enroll + request/response **over a real in-process socket** with channel binding.
- Tunnel-mode (plaintext) tests unchanged; full federation suite (94 tests incl. noise) green; shared + desktop typecheck; `lint:boundaries` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)