### PR TITLE
fix(desktop): expose pending handoff status

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14184,6 +14184,233 @@ command = "pnpm dev"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("exposes in-progress handoffs before the child thread exists", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-pending-"));
+    const repoPath = path.join(root, "repo");
+    const worktreePath = path.join(root, "worktree");
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+    } catch {
+      await git(repoPath, ["init"]);
+      await git(repoPath, ["checkout", "-b", "main"]);
+    }
+    await writeFile(path.join(repoPath, "README.md"), "handoff\n", "utf8");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+    await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
+    await writeFile(
+      path.join(worktreePath, ".codex", "environments", "environment.toml"),
+      `
+version = 1
+name = "GifGrabber"
+
+[setup]
+script = "printf setup"
+`,
+      "utf8",
+    );
+
+    const setupStarted = createDeferred<void>();
+    const setupRelease = createDeferred<void>();
+    const sourceRuntime: CodexThreadEnvironmentRuntime = {
+      environmentId: "environment",
+      environmentName: "GifGrabber",
+      executionTarget: "local",
+      cwd: repoPath,
+      setupStatus: "completed",
+      setupCommand: "printf setup",
+    };
+    const commandRunner: CodexEnvironmentCommandRunner = vi.fn(async () => {
+      setupStarted.resolve();
+      await setupRelease.promise;
+      return {
+        durationMs: 5,
+        exitCode: 0,
+        output: "setup",
+      };
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "thread/read", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+          updatedAt: 1000,
+        },
+      ],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "active",
+      },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:ordinary-thread": {
+          backend: "codex",
+          threadId: "ordinary-thread",
+          executionMode: "full-access",
+          codexEnvironmentRuntime: sourceRuntime,
+          extraLinkedDirectories: [
+            {
+              id: expectedDir(repoPath),
+              kind: "local",
+              label: "repo",
+              path: expectedDir(repoPath),
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      codexEnvironmentCommandRunner: commandRunner,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: worktreePath,
+          repositoryPath: repoPath,
+          workMode: "worktree" as const,
+        })),
+        recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
+      } as never,
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const handoffPromise = codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "handoff-call-1",
+        requestId: "handoff-call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Make the Swift crash guard on origin/master.",
+          title: "Swift crash guard",
+          groupingMode: "subthread",
+          workspaceMode: "new_worktree",
+          branchName: "origin/master",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    try {
+      await setupStarted.promise;
+      expect(codexClient.lastStartThreadParams).toBeUndefined();
+
+      const searchResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "search-call-1",
+          requestId: "search-call-1",
+          namespace: "pwragent",
+          tool: "search_threads",
+          arguments: {
+            query: "Swift crash guard",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+      const searchPayload = JSON.parse(
+        (searchResponse as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+      );
+      expect(searchPayload.pendingHandoffs).toEqual([
+        expect.objectContaining({
+          handoffId: "handoff:codex:ordinary-thread:turn-1:handoff-call-1",
+          status: "starting",
+          phase: "starting_thread",
+          sourceThreadId: "ordinary-thread",
+          title: "Swift crash guard",
+          branchName: "origin/master",
+          message: expect.stringContaining("Do not retry"),
+        }),
+      ]);
+      expect(searchPayload.pendingHandoffs[0]).not.toHaveProperty("threadId");
+
+      const statusResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "status-call-1",
+          requestId: "status-call-1",
+          namespace: "pwragent",
+          tool: "get_thread_status",
+          arguments: {
+            backend: "codex",
+            threadId: "ordinary-thread",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+      const statusPayload = JSON.parse(
+        (statusResponse as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+      );
+      expect(statusPayload.thread.pendingHandoffs).toEqual([
+        expect.objectContaining({
+          handoffId: "handoff:codex:ordinary-thread:turn-1:handoff-call-1",
+          status: "starting",
+          phase: "starting_thread",
+        }),
+      ]);
+    } finally {
+      setupRelease.resolve();
+    }
+
+    const handoffResponse = await handoffPromise;
+    expect(handoffResponse).toMatchObject({ success: true });
+    const handoffPayload = JSON.parse(
+      (handoffResponse as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(handoffPayload).toMatchObject({
+      handoffId: "handoff:codex:ordinary-thread:turn-1:handoff-call-1",
+      threadId: "thread-1",
+      groupedUnderThreadId: "ordinary-thread",
+    });
+
+    await registry.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("creates new-worktree handoff threads when inherited environment setup is unavailable", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-env-missing-"));
     const repoPath = path.join(root, "repo");

--- a/apps/desktop/src/main/agent-tools/AGENTS.md
+++ b/apps/desktop/src/main/agent-tools/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Tool Contract Guidance
+
+PwrAgent dynamic tools are service contracts for existing Agent turns. Treat
+the advertised namespace, name, input schema, argument semantics, and response
+shape as backwards-compatible API surfaces.
+
+- Do not add a new required input field to an existing dynamic tool. Existing
+  threads may call the tool using the schema they were given before the update.
+- Do not remove a response field that an existing Agent turn may read. Additive
+  response fields are preferred when exposing new state.
+- Do not change the meaning of an existing field. Introduce a new field or a
+  new tool when semantics need to diverge.
+- Do not reorder ordinal parameters if a tool accepts array or tuple-like input.
+- Keep compatibility facades for renamed tools or namespaces. Mark them
+  `advertise: false` when they should remain callable for old turns but should
+  not be shown to new turns.
+- Envelope metadata such as `threadId`, `turnId`, and `callId` may be forwarded
+  through `AgentToolCallContext`, but must not become required tool input.
+

--- a/apps/desktop/src/main/agent-tools/CLAUDE.md
+++ b/apps/desktop/src/main/agent-tools/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
@@ -64,6 +64,7 @@ describe("AgentToolRouter", () => {
       { limit: 2 },
       {
         backend: "codex",
+        callId: "call-1",
         threadId: "thread-1",
         turnId: "turn-1",
         transport: "codex_dynamic_tool",

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -186,6 +186,7 @@ describe("pwragent thread orchestration agent tools", () => {
       context: {
         backend: "codex",
         threadId: "thread-1",
+        callId: "call-1",
         turnId: "turn-1",
       },
       args: {
@@ -237,6 +238,7 @@ describe("pwragent thread orchestration agent tools", () => {
       context: {
         backend: "codex",
         threadId: "thread-1",
+        callId: "call-1",
         turnId: "turn-1",
       },
       args: {

--- a/apps/desktop/src/main/agent-tools/agent-tool-definition.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-definition.ts
@@ -6,6 +6,7 @@ export type AgentToolTransport = "codex_dynamic_tool" | "acp_mcp";
 export type AgentToolCallContext = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  callId?: string;
   turnId?: string;
   transport: AgentToolTransport;
 };

--- a/apps/desktop/src/main/agent-tools/agent-tool-router.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-router.ts
@@ -94,6 +94,7 @@ export class AgentToolRouter {
     const context: AgentToolCallContext = {
       backend: params.backend,
       threadId: params.call.threadId,
+      callId: params.call.callId,
       turnId: params.call.turnId,
       transport: "codex_dynamic_tool",
     };

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -71,11 +71,11 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "search_threads":
-      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread.";
+      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread. The response may include pendingHandoffs for handoff_task calls from this thread that are still creating a child thread; do not retry those handoffs while they are starting.";
     case "read_thread":
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
-      return "Read status and compact metadata for a known PwrAgent thread.";
+      return "Read status and compact metadata for a known PwrAgent thread, including pendingHandoffs when this thread has child handoffs that are still being created.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -80,6 +80,7 @@ export function buildPwrAgentThreadOrchestrationToolDefinitions(
         context: {
           backend: context.backend,
           threadId: context.threadId,
+          callId: context.callId,
           turnId: context.turnId,
         },
         args: normalizedArgs,
@@ -94,7 +95,7 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "handoff_task":
-      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree.";
+      return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree. Handoff startup can take several minutes while a worktree or Codex environment is prepared; if this call appears slow or uncertain, do not call handoff_task again. Use search_threads or get_thread_status and inspect pendingHandoffs until a threadId appears or the handoff reports failed.";
     case "send_message_to_thread":
       return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead.";
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -114,6 +114,8 @@ import {
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
   type MutateThreadToolArgs,
+  type PendingThreadHandoffPhase,
+  type PendingThreadHandoffSummary,
   type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
@@ -4250,6 +4252,7 @@ export class DesktopBackendRegistry {
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
+  private readonly pendingThreadHandoffs = new Map<string, PendingThreadHandoffSummary>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -14044,6 +14047,86 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private startPendingThreadHandoff(
+    handoff: PendingThreadHandoffSummary,
+  ): PendingThreadHandoffSummary {
+    this.prunePendingThreadHandoffs(handoff.createdAt);
+    this.pendingThreadHandoffs.set(handoff.handoffId, handoff);
+    return handoff;
+  }
+
+  private updatePendingThreadHandoff(
+    handoffId: string | undefined,
+    patch: Partial<
+      Omit<PendingThreadHandoffSummary, "handoffId" | "createdAt">
+    > & {
+      phase?: PendingThreadHandoffPhase;
+    },
+  ): void {
+    if (!handoffId) {
+      return;
+    }
+    const current = this.pendingThreadHandoffs.get(handoffId);
+    if (!current) {
+      return;
+    }
+    const updatedAt = patch.updatedAt ?? Date.now();
+    this.pendingThreadHandoffs.set(handoffId, {
+      ...current,
+      ...patch,
+      updatedAt,
+    });
+  }
+
+  private failPendingThreadHandoff(
+    handoffId: string | undefined,
+    error: unknown,
+  ): void {
+    this.updatePendingThreadHandoff(handoffId, {
+      status: "failed",
+      phase: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      message: "Handoff creation failed. Do not retry unless the failure is understood.",
+    });
+  }
+
+  private getPendingThreadHandoffsForInspection(params: {
+    backend?: AppServerBackendKind | "all";
+    query?: string;
+    sourceThreadId?: string;
+    limit?: number;
+  } = {}): PendingThreadHandoffSummary[] {
+    this.prunePendingThreadHandoffs();
+    const clauses = parseThreadInspectionQuery(params.query);
+    const backend = params.backend;
+    return [...this.pendingThreadHandoffs.values()]
+      .filter((handoff) => {
+        if (
+          backend &&
+          backend !== "all" &&
+          handoff.backend !== backend &&
+          handoff.sourceBackend !== backend
+        ) {
+          return false;
+        }
+        if (params.sourceThreadId && handoff.sourceThreadId !== params.sourceThreadId) {
+          return false;
+        }
+        return pendingThreadHandoffMatchesQuery(handoff, clauses);
+      })
+      .sort((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, params.limit ?? 10);
+  }
+
+  private prunePendingThreadHandoffs(now = Date.now()): void {
+    const maxAgeMs = 60 * 60 * 1000;
+    for (const [handoffId, handoff] of this.pendingThreadHandoffs) {
+      if (now - handoff.updatedAt > maxAgeMs) {
+        this.pendingThreadHandoffs.delete(handoffId);
+      }
+    }
+  }
+
   private async sendMessageToThread(
     request: PwrAgentThreadOrchestrationRequest<"send_message_to_thread">,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
@@ -14201,6 +14284,37 @@ export class DesktopBackendRegistry {
         'workspaceMode="same_workspace" is only valid for grouped subthread handoffs. Use workspaceMode="new_worktree" for a delegated thread with an isolated worktree, workspaceMode="project_local" for the project checkout, or workspaceMode="none" for an unscoped local thread.',
       );
     }
+    const title =
+      request.args.title?.trim() ||
+      shortenDerivedThreadTitle(task) ||
+      "Delegated task";
+    const handoffStartedAt = request.context.now ?? Date.now();
+    const handoffId = [
+      "handoff",
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      request.context.callId?.trim() || randomUUID(),
+    ].join(":");
+    this.startPendingThreadHandoff({
+      handoffId,
+      status: "starting",
+      phase: "resolving_source",
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      backend,
+      title,
+      taskPreview: truncateThreadInspectionText(task, 240),
+      seedMode,
+      groupingMode,
+      workspaceMode,
+      ...(request.args.branchName ? { branchName: request.args.branchName } : {}),
+      createdAt: handoffStartedAt,
+      updatedAt: handoffStartedAt,
+      message:
+        "Handoff creation has started. Do not retry this request while it is still starting; inspect pendingHandoffs or wait for the child threadId.",
+    });
     const sourceThread = await this.findThreadForWorkspaceHandoff({
       backend: sourceBackend,
       callerReason: "agent-handoff",
@@ -14223,6 +14337,12 @@ export class DesktopBackendRegistry {
     });
 
     if (workspaceMode !== "none" && !sourceCwd?.trim()) {
+      this.failPendingThreadHandoff(
+        handoffId,
+        new Error(
+          "The source thread has no current workspace. Ask for workspaceMode=none to create an unscoped handoff thread.",
+        ),
+      );
       return threadOrchestrationFailure(
         "unsupported_workspace",
         "The source thread has no current workspace. Ask for workspaceMode=none to create an unscoped handoff thread.",
@@ -14232,6 +14352,13 @@ export class DesktopBackendRegistry {
       workspaceMode === "new_worktree" &&
       !sourceWorkspace.git.worktreeCreationAvailable
     ) {
+      this.failPendingThreadHandoff(
+        handoffId,
+        new Error(
+          sourceWorkspace.git.unavailableReason ??
+            "The source workspace cannot create a new Git worktree.",
+        ),
+      );
       return threadOrchestrationFailure(
         "unsupported_workspace",
         sourceWorkspace.git.unavailableReason ??
@@ -14260,10 +14387,6 @@ export class DesktopBackendRegistry {
       sandbox: request.args.sandbox ?? modeSettings.sandbox,
       codexEnvironmentRuntime: sourceOverlay.codexEnvironmentRuntime,
     };
-    const title =
-      request.args.title?.trim() ||
-      shortenDerivedThreadTitle(task) ||
-      "Delegated task";
     const agent = {
       name: title,
       instructions:
@@ -14277,6 +14400,12 @@ export class DesktopBackendRegistry {
           })
         : undefined;
     if (workspaceMode === "project_local" && !projectLocalCwd?.trim()) {
+      this.failPendingThreadHandoff(
+        handoffId,
+        new Error(
+          "The source thread has no project checkout available for workspaceMode=project_local.",
+        ),
+      );
       return threadOrchestrationFailure(
         "unsupported_workspace",
         "The source thread has no project checkout available for workspaceMode=project_local.",
@@ -14297,7 +14426,17 @@ export class DesktopBackendRegistry {
       | HandoffTaskResult["codexEnvironmentStartupFailure"]
       | undefined;
     try {
+      this.updatePendingThreadHandoff(handoffId, {
+        phase: "preparing_workspace",
+        message:
+          "Preparing the handoff workspace. Environment setup can take several minutes; do not retry while this is starting.",
+      });
       if (seedMode === "fork") {
+        this.updatePendingThreadHandoff(handoffId, {
+          phase: "starting_thread",
+          message:
+            "Forking the child thread and preparing its runtime. Do not retry this handoff.",
+        });
         const forked = await this.forkThread({
           backend,
           sourceThreadId,
@@ -14320,6 +14459,7 @@ export class DesktopBackendRegistry {
           sandbox: inheritedSettings.sandbox,
         });
         threadId = forked.threadId;
+        this.updatePendingThreadHandoff(handoffId, { threadId });
         createdLinkedDirectory = forked.linkedDirectory;
         inheritedSettings.codexEnvironmentRuntime = forked.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = forked.codexEnvironmentStartupFailure;
@@ -14331,6 +14471,11 @@ export class DesktopBackendRegistry {
           agent,
         });
       } else {
+        this.updatePendingThreadHandoff(handoffId, {
+          phase: "starting_thread",
+          message:
+            "Starting the child thread and preparing its runtime. Do not retry this handoff.",
+        });
         const started = await this.startThread({
           backend,
           executionMode,
@@ -14348,6 +14493,7 @@ export class DesktopBackendRegistry {
           agent,
         });
         threadId = started.threadId;
+        this.updatePendingThreadHandoff(handoffId, { threadId });
         inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
         if (groupingMode === "subthread") {
@@ -14368,6 +14514,7 @@ export class DesktopBackendRegistry {
         },
       );
     } catch (error) {
+      this.failPendingThreadHandoff(handoffId, error);
       return threadOrchestrationFailure(
         workspaceMode === "new_worktree" ? "unsupported_workspace" : "internal_error",
         error instanceof Error ? error.message : String(error),
@@ -14392,6 +14539,7 @@ export class DesktopBackendRegistry {
       linkedDirectory: childLinkedDirectory,
       mode: createdWorkspaceMode,
     });
+    this.updatePendingThreadHandoff(handoffId, { workspace });
     const createdAt = request.context.now ?? Date.now();
     const origin = {
       sourceBackend,
@@ -14422,6 +14570,11 @@ export class DesktopBackendRegistry {
     let turnId: string | undefined;
     let turnStartFailure: HandoffTaskResult["turnStartFailure"];
     try {
+      this.updatePendingThreadHandoff(handoffId, {
+        phase: "starting_turn",
+        message:
+          "Child thread exists; starting the delegated turn. Do not create a replacement handoff.",
+      });
       const turn = await this.startTurn({
         backend,
         threadId,
@@ -14435,6 +14588,7 @@ export class DesktopBackendRegistry {
         sandbox: inheritedSettings.sandbox,
       });
       turnId = turn.turnId;
+      this.updatePendingThreadHandoff(handoffId, { turnId });
     } catch (error) {
       turnStartFailure = {
         phase: "turn",
@@ -14447,6 +14601,11 @@ export class DesktopBackendRegistry {
       });
     }
 
+    this.updatePendingThreadHandoff(handoffId, {
+      phase: "attaching_messaging",
+      message:
+        "Child thread exists; finalizing optional messaging attachment. Do not create a replacement handoff.",
+    });
     const messagingAttachment = await this.attachHandoffThreadToMessaging({
       mode: request.args.messagingAttachment,
       sourceBackend,
@@ -14456,12 +14615,21 @@ export class DesktopBackendRegistry {
       threadId,
       title,
     });
+    this.updatePendingThreadHandoff(handoffId, {
+      status: turnStartFailure ? "failed" : "completed",
+      phase: turnStartFailure ? "failed" : "completed",
+      ...(turnStartFailure ? { error: turnStartFailure.message } : {}),
+      message: turnStartFailure
+        ? "The child thread was created, but its initial turn failed. Use the returned threadId instead of retrying the handoff."
+        : "Handoff creation completed. Use the returned threadId for follow-up status checks.",
+    });
     return {
       ok: true,
       data: {
         backend,
         threadId,
         turnId,
+        handoffId,
         title,
         seedMode,
         groupingMode,
@@ -15558,6 +15726,12 @@ export class DesktopBackendRegistry {
           : DEFAULT_THREAD_INSPECTION_RECENT_LIMIT,
         MAX_THREAD_INSPECTION_SEARCH_LIMIT,
       );
+      const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
+        backend,
+        query: request.args.query,
+        sourceThreadId: request.context.threadId,
+        limit,
+      });
       const searchService = this.getThreadInspectionSearchService();
       if (searchService) {
         const projectKeys = nonEmptyStringArray(request.args.projectKeys);
@@ -15604,6 +15778,7 @@ export class DesktopBackendRegistry {
             totalCount: filtered.length,
             limit,
             truncated: response.truncated === true || filtered.length > limit,
+            ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
             query: response.query,
             searchedScopes: response.searchedScopes,
             unavailableScopes: response.unavailableScopes,
@@ -15641,6 +15816,7 @@ export class DesktopBackendRegistry {
           totalCount: filtered.length,
           limit,
           truncated: filtered.length > limit,
+          ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
         },
       };
     }
@@ -15700,6 +15876,10 @@ export class DesktopBackendRegistry {
         .catch((): AppServerThreadStatus | undefined => undefined);
       const queueKey = buildThreadIdentityKey(request.args.backend, threadId);
       const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
+      const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
+        backend: request.args.backend,
+        sourceThreadId: threadId,
+      });
       return {
         ok: true,
         data: {
@@ -15708,6 +15888,7 @@ export class DesktopBackendRegistry {
             status,
             queuedExecutionMode: queued?.mode,
             queuedExecutionModeAt: queued?.queuedAt,
+            ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
           },
         },
       };
@@ -17218,6 +17399,41 @@ function parseThreadInspectionQuery(query: string | undefined): string[][] {
         .filter(Boolean),
     )
     .filter((tokens) => tokens.length > 0);
+}
+
+function pendingThreadHandoffMatchesQuery(
+  handoff: PendingThreadHandoffSummary,
+  clauses: string[][],
+): boolean {
+  if (clauses.length === 0) {
+    return true;
+  }
+  const haystack = [
+    handoff.handoffId,
+    handoff.sourceBackend,
+    handoff.sourceThreadId,
+    handoff.sourceTurnId,
+    handoff.backend,
+    handoff.threadId,
+    handoff.turnId,
+    handoff.title,
+    handoff.taskPreview,
+    handoff.seedMode,
+    handoff.groupingMode,
+    handoff.workspaceMode,
+    handoff.branchName,
+    handoff.workspace?.cwd,
+    handoff.workspace?.branch,
+    handoff.workspace?.linkedDirectory?.label,
+    handoff.workspace?.linkedDirectory?.path,
+    handoff.workspace?.linkedDirectory?.worktreePath,
+    handoff.message,
+    handoff.error,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+  return clauses.some((tokens) => tokens.every((token) => haystack.includes(token)));
 }
 
 function scoreThreadInspectionSummary(

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -34,6 +34,7 @@ export type PwrAgentThreadOrchestrationErrorCode =
 export type PwrAgentThreadOrchestrationContext = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
+  callId?: string;
   turnId?: string;
   now?: number;
 };
@@ -177,6 +178,7 @@ export type HandoffTaskMessagingAttachment =
 
 export type HandoffTaskResult = {
   backend: AppServerBackendKind;
+  handoffId?: string;
   threadId: ThreadIdentifier;
   turnId?: string;
   title?: string;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -14,7 +14,13 @@ import type {
   MessagingThreadBindingSummary,
   ThreadAgentMetadata,
 } from "./navigation";
-import type { ThreadHandoffOrigin } from "./thread-orchestration-tools";
+import type {
+  HandoffTaskGroupingMode,
+  HandoffTaskSeedMode,
+  HandoffTaskWorkspaceMode,
+  ThreadHandoffOrigin,
+  ThreadHandoffOriginWorkspace,
+} from "./thread-orchestration-tools";
 import type {
   ThreadSearchContentMode,
   ThreadSearchConfidenceBand,
@@ -181,6 +187,41 @@ export type ThreadStatusInspectionSummary = ThreadInspectionSummary & {
   status?: AppServerThreadStatus;
   queuedExecutionMode?: ThreadExecutionMode;
   queuedExecutionModeAt?: number;
+  pendingHandoffs?: PendingThreadHandoffSummary[];
+};
+
+export type PendingThreadHandoffStatus = "starting" | "completed" | "failed";
+
+export type PendingThreadHandoffPhase =
+  | "resolving_source"
+  | "preparing_workspace"
+  | "starting_thread"
+  | "starting_turn"
+  | "attaching_messaging"
+  | "completed"
+  | "failed";
+
+export type PendingThreadHandoffSummary = {
+  handoffId: string;
+  status: PendingThreadHandoffStatus;
+  phase: PendingThreadHandoffPhase;
+  sourceBackend: AppServerBackendKind;
+  sourceThreadId: ThreadIdentifier;
+  sourceTurnId?: ThreadIdentifier;
+  backend: AppServerBackendKind;
+  threadId?: ThreadIdentifier;
+  turnId?: ThreadIdentifier;
+  title: string;
+  taskPreview: string;
+  seedMode: HandoffTaskSeedMode;
+  groupingMode: HandoffTaskGroupingMode;
+  workspaceMode: HandoffTaskWorkspaceMode;
+  branchName?: string;
+  workspace?: ThreadHandoffOriginWorkspace;
+  createdAt: number;
+  updatedAt: number;
+  message?: string;
+  error?: string;
 };
 
 export type ThreadReadMessageSummary = Pick<
@@ -296,6 +337,7 @@ export type PwrAgentThreadInspectionResponse =
             totalCount: number;
             limit: number;
             truncated: boolean;
+            pendingHandoffs?: PendingThreadHandoffSummary[];
             query?: string;
             searchedScopes?: ThreadSearchScopeName[];
             unavailableScopes?: ThreadSearchUnavailableScope[];


### PR DESCRIPTION
## Summary
- Track `handoff_task` calls as pending before slow worktree and Codex environment setup runs.
- Surface `pendingHandoffs` from `search_threads` and `get_thread_status` so agents can inspect in-progress child-thread creation instead of retrying.
- Update tool descriptions and tests to discourage duplicate handoffs while a child thread is still being created.

## Root Cause
A handoff did not expose authoritative status until `thread/start` returned. When environment setup took several minutes, the parent agent could interpret the missing child thread as failure and create a duplicate handoff.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -- --runInBand`
- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`