### PR TITLE
fix(desktop): skip unloadable automations and surface boot failures

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -441,4 +441,84 @@ describe("AutomationStore", () => {
         .get(),
     ).toEqual({ count: 1 });
   });
+
+  function insertRawAutomationRow(params: {
+    id: string;
+    name: string;
+    status?: string;
+    payload: string;
+  }): void {
+    stateDb.raw
+      .prepare(
+        `INSERT INTO automations (
+          automation_id, backend, thread_id, name, status, backlog_policy,
+          next_run_at, last_run_at, created_at, updated_at, deleted_at, payload
+        ) VALUES (?, 'codex', 'thread-1', ?, ?, 'coalesce', NULL, NULL, 1000, 1000, NULL, ?)`,
+      )
+      .run(params.id, params.name, params.status ?? "enabled", params.payload);
+  }
+
+  it("skips automations it can't load without mutating or running them", () => {
+    // A trigger-only automation written by a newer build: enabled, but its
+    // payload has no schedule this version understands.
+    insertRawAutomationRow({
+      id: "automation-future",
+      name: "Slack trigger",
+      payload: JSON.stringify({
+        taskPrompt: "do the thing",
+        triggers: [{ kind: "inbound_message" }],
+        scheduleSummary: "inbound",
+      }),
+    });
+    // A corrupt payload.
+    insertRawAutomationRow({
+      id: "automation-corrupt",
+      name: "Corrupt one",
+      payload: "{not valid json",
+    });
+    // A normal, loadable automation alongside them.
+    store.createAutomation({
+      id: "automation-ok",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Healthy",
+      taskPrompt: "ok",
+      schedule: { kind: "interval", every: 5, unit: "minutes" },
+      now: 1_000,
+    });
+
+    // Only the healthy automation is returned; the unloadable ones are skipped.
+    expect(store.listAutomations().map((automation) => automation.id)).toEqual([
+      "automation-ok",
+    ]);
+
+    // The skipped rows are reported, not silently dropped.
+    const issues = store.getAutomationLoadIssues();
+    expect(issues.map((issue) => issue.id).sort()).toEqual([
+      "automation-corrupt",
+      "automation-future",
+    ]);
+    expect(issues.find((issue) => issue.id === "automation-future")?.name).toBe(
+      "Slack trigger",
+    );
+
+    // The underlying rows are untouched — not paused, not deleted.
+    const rows = stateDb.raw
+      .prepare(
+        "SELECT status FROM automations WHERE automation_id IN ('automation-future', 'automation-corrupt') ORDER BY automation_id",
+      )
+      .all() as Array<{ status: string }>;
+    expect(rows).toEqual([{ status: "enabled" }, { status: "enabled" }]);
+  });
+
+  it("does not report skipped issues for soft-deleted unloadable rows", () => {
+    insertRawAutomationRow({
+      id: "automation-deleted",
+      name: "Deleted future automation",
+      status: "deleted",
+      payload: JSON.stringify({ taskPrompt: "x", triggers: [] }),
+    });
+    expect(store.listAutomations()).toEqual([]);
+    expect(store.getAutomationLoadIssues()).toEqual([]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -379,6 +379,15 @@ describe("bootstrapApp", () => {
         return process;
       },
     );
+    // installBootErrorHandlers attaches an unhandledRejection listener via
+    // process.on. The module re-imports per test, so without this spy the real
+    // process accumulates a listener each time (MaxListenersExceededWarning).
+    vi.spyOn(process, "on").mockImplementation(
+      (event: string | symbol, handler: (...args: unknown[]) => void) => {
+        processEventHandlers.set(String(event), handler);
+        return process;
+      },
+    );
     mainWindowHandlers.clear();
     createMainWindowMock.mockReset();
     // createMainWindow returns the BrowserWindow; index.ts wraps each call in
@@ -388,6 +397,10 @@ describe("bootstrapApp", () => {
       on: (event: string, handler: (...args: unknown[]) => void) => {
         mainWindowHandlers.set(event, handler);
       },
+      once: (event: string, handler: (...args: unknown[]) => void) => {
+        mainWindowHandlers.set(event, handler);
+      },
+      isVisible: () => false,
     }));
     registerAppServerIpcHandlersMock.mockReset();
     disposeAppServerIpcHandlersMock.mockReset();

--- a/apps/desktop/src/main/app-log-window.ts
+++ b/apps/desktop/src/main/app-log-window.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from "electron";
-import { getMainLogger } from "./log";
+import { getMainLogFilePath, getMainLogger } from "./log";
 import {
   applyWindowSecurityHardening,
   getPreloadPath,
@@ -62,7 +62,13 @@ export function showAppLogWindow(source: WindowPlacementSource = {}): void {
       contextIsolation: true,
       sandbox: true,
       nodeIntegration: false,
-      additionalArguments: themedWindowAdditionalArguments(appearance),
+      additionalArguments: [
+        ...themedWindowAdditionalArguments(appearance),
+        // Hand the log file's on-disk path to the renderer up front so the
+        // Logs window can show + reveal it even if the snapshot IPC read later
+        // fails — that failure is exactly when finding the log matters most.
+        `--pwragent-log-file-path=${JSON.stringify(getMainLogFilePath() ?? "")}`,
+      ],
     },
   });
   registerAuxiliaryWindowTitle(window, LOGS_WINDOW_TITLE);

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -4,6 +4,7 @@ import type {
   AutomationBacklogPolicy,
   AutomationGateConfig,
   AutomationListItemSummary,
+  AutomationLoadIssue,
   AutomationRunArtifact,
   AutomationRunOutputDecision,
   AutomationRunStatus,
@@ -17,13 +18,33 @@ import type {
   ThreadIdentifier,
 } from "@pwragent/shared";
 import {
+  AUTOMATION_SCHEDULE_KINDS,
   DEFAULT_AUTOMATION_BACKLOG_POLICY,
   buildThreadIdentityKey,
   formatAutomationScheduleSummary,
 } from "@pwragent/shared";
+import { getMainLogger } from "../log.js";
 import type { StateDb } from "../state/state-db.js";
 
 const DEFAULT_RUN_HISTORY_LIMIT = 200;
+
+const automationStoreLog = getMainLogger("pwragent:automations");
+
+const UNDERSTOOD_SCHEDULE_KINDS = new Set<string>(AUTOMATION_SCHEDULE_KINDS);
+
+/**
+ * True only when `schedule` is a shape this build can actually run. Anything
+ * else — missing schedule (e.g. a trigger-only automation written by a newer
+ * build), a non-object, or an unrecognized `kind` — is something we must skip
+ * rather than dereference. Never throws; safe to call on untrusted JSON.
+ */
+function isUnderstoodSchedule(
+  schedule: unknown,
+): schedule is AutomationScheduleDefinition {
+  if (!schedule || typeof schedule !== "object") return false;
+  const kind = (schedule as { kind?: unknown }).kind;
+  return typeof kind === "string" && UNDERSTOOD_SCHEDULE_KINDS.has(kind);
+}
 
 export type AutomationRecord = {
   id: string;
@@ -164,10 +185,43 @@ type AutomationRunArtifactPayload = {
 };
 
 export class AutomationStore {
+  /**
+   * Automations that couldn't be loaded this process lifetime, keyed by id.
+   * Populated as a side effect of `recordFromRow` whenever a row's payload is
+   * unparseable. Surfaced (read-only) via `getAutomationLoadIssues` so the UI
+   * can warn the user; the underlying rows are never mutated.
+   */
+  private readonly loadIssues = new Map<string, { name: string; reason: string }>();
+
   constructor(
     private readonly stateDb: StateDb,
     private readonly options: { runHistoryLimit?: number } = {},
   ) {}
+
+  /** Snapshot of automation rows skipped because this build can't load them. */
+  getAutomationLoadIssues(): AutomationLoadIssue[] {
+    return [...this.loadIssues.entries()].map(([id, value]) => ({
+      id,
+      name: value.name,
+      reason: value.reason,
+    }));
+  }
+
+  private noteAutomationLoadIssue(row: AutomationRow, reason: string): void {
+    // Don't warn about soft-deleted rows — they never run and aren't shown.
+    if (row.deleted_at != null || row.status === "deleted") {
+      this.loadIssues.delete(row.automation_id);
+      return;
+    }
+    if (this.loadIssues.get(row.automation_id)?.reason !== reason) {
+      automationStoreLog.warn("skipping automation that could not be loaded", {
+        automationId: row.automation_id,
+        name: row.name,
+        reason,
+      });
+    }
+    this.loadIssues.set(row.automation_id, { name: row.name, reason });
+  }
 
   createAutomation(input: CreateAutomationInput): AutomationRecord {
     const now = input.now ?? Date.now();
@@ -911,7 +965,22 @@ export class AutomationStore {
 
   private recordFromRow(row: AutomationRow): AutomationRecord | undefined {
     const payload = parseJson<AutomationPayload>(row.payload);
-    if (!payload) return undefined;
+    if (!payload) {
+      this.noteAutomationLoadIssue(row, "The automation's stored data is corrupt.");
+      return undefined;
+    }
+    if (!isUnderstoodSchedule(payload.schedule)) {
+      // A trigger-only automation, or one using a schedule kind a newer build
+      // introduced. We can't run it safely, so skip it for this process
+      // lifetime rather than dereference a shape we don't understand — and
+      // never throw out of a startup/list pass over an unrelated bad row.
+      this.noteAutomationLoadIssue(
+        row,
+        "This automation was created by a newer version of PwrAgent.",
+      );
+      return undefined;
+    }
+    this.loadIssues.delete(row.automation_id);
     return {
       id: row.automation_id,
       backend: row.backend,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -7,6 +7,7 @@ import type {
   AutomationInspectionErrorCode,
   AutomationInspectionResponse,
   AutomationIdRequest,
+  AutomationLoadIssue,
   AutomationMutationResponse,
   AutomationRunSummary,
   AutomationRunStatus,
@@ -150,6 +151,15 @@ export class DesktopAutomationService {
     this.unsubscribeRegistryEvents?.();
     this.unsubscribeRegistryEvents = undefined;
     this.options.registry.setAutomationInspectionHandler?.(null);
+  }
+
+  /**
+   * Automations the store couldn't load this process lifetime (corrupt payload,
+   * or a schedule/trigger shape this build predates). Surfaced to the renderer
+   * so the user sees a warning instead of silently missing automations.
+   */
+  getLoadIssues(): AutomationLoadIssue[] {
+    return this.options.store.getAutomationLoadIssues();
   }
 
   list(request: ListAutomationsRequest = {}): ListAutomationsResponse {
@@ -678,7 +688,11 @@ export class DesktopAutomationService {
     const nextRunAtByAutomationId = Object.fromEntries(
       this.options.store
         .listAutomations()
-        .filter((automation) => automation.status === "enabled")
+        // `listAutomations` already skips rows whose schedule this build can't
+        // load; the explicit `schedule` guard is belt-and-suspenders so a
+        // schedule-less record can never reach computeNextAutomationRunAt and
+        // abort the whole startup reconcile.
+        .filter((automation) => automation.status === "enabled" && automation.schedule)
         .map((automation) => [
           automation.id,
           computeNextAutomationRunAt(automation.schedule, now),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, nativeImage, shell } from "electron";
+import { app, BrowserWindow, dialog, Menu, nativeImage, shell } from "electron";
 import { join } from "node:path";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
@@ -77,6 +77,7 @@ import {
   registerWindowPointerIpcHandlers,
 } from "./ipc/window-pointer";
 import {
+  getMainLogFilePath,
   getMainLogger,
   initializeMainLogger,
   resolveMainLogProfileName,
@@ -146,6 +147,139 @@ let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
 let startupCpuProfilerForNewWindows:
   | NonNullable<Parameters<typeof createMainWindow>[0]>["startupCpuProfiler"]
   | undefined;
+
+// --- Boot failure surfacing -------------------------------------------------
+// A failed startup must never leave the app "running but unusable" with no
+// explanation. We track whether the main window ever became visible; if boot
+// rejects (a throw anywhere in the whenReady chain) or simply never produces a
+// visible window within a grace period, we log it and put a native dialog in
+// front of the user with the actual error and a one-click path to the log
+// file. This is the backstop for the class of incident where an automation row
+// written by a newer build threw during startup reconciliation, rejected the
+// whenReady promise, and silently aborted the rest of boot — no window, no
+// dialog, not even a log line.
+const BOOT_WATCHDOG_MS = 25_000;
+let mainWindowEverShown = false;
+let bootFailureSurfaced = false;
+let bootWatchdogTimer: NodeJS.Timeout | undefined;
+let lastBootError: unknown;
+
+function clearBootWatchdog(): void {
+  if (bootWatchdogTimer) {
+    clearTimeout(bootWatchdogTimer);
+    bootWatchdogTimer = undefined;
+  }
+}
+
+function startBootWatchdog(): void {
+  clearBootWatchdog();
+  bootWatchdogTimer = setTimeout(() => {
+    surfaceBootFailure("watchdog-timeout");
+  }, BOOT_WATCHDOG_MS);
+  // Never let the watchdog itself keep the process alive.
+  bootWatchdogTimer.unref?.();
+}
+
+function markMainWindowBooted(window: BrowserWindow): void {
+  const onShown = (): void => {
+    mainWindowEverShown = true;
+    clearBootWatchdog();
+  };
+  if (window.isVisible()) {
+    onShown();
+    return;
+  }
+  window.once("show", onShown);
+}
+
+function formatBootError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? `${error.name}: ${error.message}`;
+  }
+  if (error === undefined) {
+    return "PwrAgent started but its main window never appeared.";
+  }
+  return String(error);
+}
+
+function surfaceBootFailure(reason: string, error?: unknown): void {
+  if (mainWindowEverShown || bootFailureSurfaced || quitInProgress) {
+    return;
+  }
+  bootFailureSurfaced = true;
+  clearBootWatchdog();
+  const detail = error ?? lastBootError;
+  const logFilePath = getMainLogFilePath();
+  mainLog.error("startup failed before the main window appeared", {
+    reason,
+    error: detail instanceof Error ? (detail.stack ?? detail.message) : detail,
+    logFilePath,
+  });
+  const detailText = [
+    formatBootError(detail),
+    logFilePath ? `\n\nLog file:\n${logFilePath}` : "",
+  ]
+    .join("")
+    .trim();
+  const buttons = logFilePath
+    ? ["Open Log File", "Reveal in Finder", "Quit"]
+    : ["Quit"];
+  let choice = buttons.length - 1;
+  try {
+    choice = dialog.showMessageBoxSync({
+      type: "error",
+      title: "PwrAgent failed to start",
+      message:
+        "PwrAgent ran into a problem during startup and the main window could not open.",
+      detail: detailText,
+      buttons,
+      defaultId: 0,
+      cancelId: buttons.length - 1,
+      noLink: true,
+    });
+  } catch (dialogError) {
+    mainLog.error("failed to show boot-failure dialog", {
+      error:
+        dialogError instanceof Error
+          ? dialogError.message
+          : String(dialogError),
+    });
+  }
+  if (logFilePath && choice === 0) {
+    void shell.openPath(logFilePath);
+  } else if (logFilePath && choice === 1) {
+    shell.showItemInFolder(logFilePath);
+  } else {
+    app.quit();
+  }
+}
+
+let bootErrorHandlersInstalled = false;
+
+function installBootErrorHandlers(): void {
+  // Idempotent: bootstrapApp may run more than once across a process (notably
+  // in unit tests), and we must not stack a new process listener each time.
+  if (bootErrorHandlersInstalled) {
+    return;
+  }
+  bootErrorHandlersInstalled = true;
+  // We deliberately do NOT register an uncaughtException handler here: doing so
+  // would change Node/Electron's crash semantics for *post*-boot exceptions.
+  // The watchdog above is the catch-all for "the window never appeared" no
+  // matter how boot failed; this handler just gives faster, more specific
+  // reporting for the common async-rejection case and ensures stray rejections
+  // are always logged (previously they produced no log line at all).
+  process.on("unhandledRejection", (reason) => {
+    mainLog.error("unhandled promise rejection", {
+      bootCompleted: mainWindowEverShown,
+      error: reason instanceof Error ? (reason.stack ?? reason.message) : reason,
+    });
+    if (!mainWindowEverShown) {
+      lastBootError = reason;
+      surfaceBootFailure("unhandledRejection", reason);
+    }
+  });
+}
 
 registerTranscriptImageProtocolScheme();
 
@@ -534,8 +668,10 @@ export function bootstrapApp(): void {
     profileName: resolveMainLogProfileName(bootDecision),
   });
   installProcessShutdownHandlers();
+  installBootErrorHandlers();
 
   app.whenReady().then(async () => {
+    startBootWatchdog();
     const startupCpuProfiler = new StartupCpuProfiler();
     startupCpuProfilerForNewWindows = startupCpuProfiler;
     await startupCpuProfiler.start();
@@ -701,11 +837,14 @@ export function bootstrapApp(): void {
     // still exists (default config); status returns []  / never emits.
     registerMessagingStatusIpcHandlers();
     recordStartupProfileEvent({ type: "main-window-create:start" });
-    quitAppOnMainWindowClose(
-      createMainWindow({
-        startupCpuProfiler,
-      }),
-    );
+    const mainWindow = createMainWindow({
+      startupCpuProfiler,
+    });
+    // Boot is "done" once the main window actually shows; this cancels the
+    // boot watchdog and downgrades later unhandled rejections from "fatal
+    // startup failure dialog" to "log only".
+    markMainWindowBooted(mainWindow);
+    quitAppOnMainWindowClose(mainWindow);
     recordStartupProfileEvent({ type: "main-window-create:end" });
     recordStartupProfileEvent({ type: "startup-thread-list-prewarm:start" });
     prewarmInitialThreadList();
@@ -728,6 +867,11 @@ export function bootstrapApp(): void {
         );
       }
     });
+  }).catch((error: unknown) => {
+    // A throw anywhere in the startup chain above rejects this promise. Without
+    // this handler the rejection was silent and the rest of boot just stopped,
+    // leaving a windowless, unusable process. Surface it instead.
+    surfaceBootFailure("whenReady", error);
   });
 
   app.on("window-all-closed", () => {

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -6,7 +6,11 @@ import type {
   OpenPathRequest,
   OpenPathResponse,
 } from "@pwragent/shared";
-import { APPLICATION_OPEN_CHANNEL, PATH_OPEN_CHANNEL } from "../../shared/ipc";
+import {
+  APPLICATION_OPEN_CHANNEL,
+  PATH_OPEN_CHANNEL,
+  PATH_REVEAL_CHANNEL,
+} from "../../shared/ipc";
 import { openDesktopApplication } from "../settings/application-discovery";
 
 /**
@@ -31,6 +35,27 @@ async function openPathWithOsDefault(
   return error ? { opened: false, error } : { opened: true };
 }
 
+/**
+ * Reveal a filesystem path in the OS file manager (Finder on macOS),
+ * highlighting the item. Used by the Logs window's "Reveal" button so the user
+ * can grab the log file off disk even while it's open in the viewer.
+ */
+async function revealPathInFolder(
+  request: OpenPathRequest,
+): Promise<OpenPathResponse> {
+  const target = request.path?.trim();
+  if (!target) {
+    return { opened: false, error: "No file path was provided." };
+  }
+  try {
+    await access(target);
+  } catch {
+    return { opened: false, error: `Path does not exist: ${target}` };
+  }
+  shell.showItemInFolder(target);
+  return { opened: true };
+}
+
 export function registerApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.handle(
@@ -47,9 +72,17 @@ export function registerApplicationIpcHandlers(): void {
     async (_event, request: OpenPathRequest): Promise<OpenPathResponse> =>
       openPathWithOsDefault(request),
   );
+
+  ipcMain.removeHandler(PATH_REVEAL_CHANNEL);
+  ipcMain.handle(
+    PATH_REVEAL_CHANNEL,
+    async (_event, request: OpenPathRequest): Promise<OpenPathResponse> =>
+      revealPathInFolder(request),
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.removeHandler(PATH_OPEN_CHANNEL);
+  ipcMain.removeHandler(PATH_REVEAL_CHANNEL);
 }

--- a/apps/desktop/src/main/ipc/automation-ipc.ts
+++ b/apps/desktop/src/main/ipc/automation-ipc.ts
@@ -5,6 +5,7 @@ import type {
   GetAutomationRunArtifactResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
+  ListAutomationLoadIssuesResponse,
   AutomationMutationResponse,
   CreateAutomationRequest,
   ListAutomationRunsRequest,
@@ -21,6 +22,7 @@ import {
   AUTOMATIONS_LIST_CARDS_CHANNEL,
   AUTOMATIONS_LIST_CHANNEL,
   AUTOMATIONS_LIST_RUNS_CHANNEL,
+  AUTOMATIONS_LOAD_ISSUES_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
   AUTOMATIONS_RUN_NOW_CHANNEL,
@@ -39,6 +41,14 @@ export function registerAutomationIpcHandlers(): void {
     AUTOMATIONS_LIST_CHANNEL,
     (_event, request?: ListAutomationsRequest): ListAutomationsResponse =>
       getDesktopAutomationService().list(request),
+  );
+
+  ipcMain.removeHandler(AUTOMATIONS_LOAD_ISSUES_CHANNEL);
+  ipcMain.handle(
+    AUTOMATIONS_LOAD_ISSUES_CHANNEL,
+    (): ListAutomationLoadIssuesResponse => ({
+      issues: getDesktopAutomationService().getLoadIssues(),
+    }),
   );
 
   ipcMain.removeHandler(AUTOMATIONS_CREATE_CHANNEL);
@@ -128,6 +138,7 @@ export function registerAutomationIpcHandlers(): void {
 
 export function disposeAutomationIpcHandlers(): void {
   ipcMain.removeHandler(AUTOMATIONS_LIST_CHANNEL);
+  ipcMain.removeHandler(AUTOMATIONS_LOAD_ISSUES_CHANNEL);
   ipcMain.removeHandler(AUTOMATIONS_CREATE_CHANNEL);
   ipcMain.removeHandler(AUTOMATIONS_UPDATE_CHANNEL);
   ipcMain.removeHandler(AUTOMATIONS_DELETE_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -19,6 +19,7 @@ import type {
   InterruptTurnResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
+  ListAutomationLoadIssuesResponse,
   ListAutomationRunsRequest,
   ListAutomationRunsResponse,
   ListAutomationsRequest,
@@ -263,6 +264,7 @@ import {
   AUTOMATIONS_LIST_CARDS_CHANNEL,
   AUTOMATIONS_LIST_CHANNEL,
   AUTOMATIONS_LIST_RUNS_CHANNEL,
+  AUTOMATIONS_LOAD_ISSUES_CHANNEL,
   AUTOMATIONS_PAUSE_CHANNEL,
   AUTOMATIONS_RESUME_CHANNEL,
   AUTOMATIONS_RUN_NOW_CHANNEL,
@@ -302,6 +304,7 @@ import {
   INTEGRATED_TERMINAL_RESIZE_CHANNEL,
   INTEGRATED_TERMINAL_WRITE_CHANNEL,
   PATH_OPEN_CHANNEL,
+  PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
@@ -604,6 +607,8 @@ const desktopApi = Object.freeze({
     request: GetAutomationRunArtifactRequest,
   ): Promise<GetAutomationRunArtifactResponse> =>
     await ipcRenderer.invoke(AUTOMATIONS_GET_RUN_ARTIFACT_CHANNEL, request),
+  listAutomationLoadIssues: async (): Promise<ListAutomationLoadIssuesResponse> =>
+    await ipcRenderer.invoke(AUTOMATIONS_LOAD_ISSUES_CHANNEL),
   listPwrAgentProfiles: async (): Promise<ListDesktopPwrAgentProfilesResponse> =>
     await ipcRenderer.invoke(PROFILES_LIST_CHANNEL),
   openPwrAgentProfile: async (
@@ -750,6 +755,8 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(APPLICATION_OPEN_CHANNEL, request),
   openPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>
     await ipcRenderer.invoke(PATH_OPEN_CHANNEL, request),
+  revealPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>
+    await ipcRenderer.invoke(PATH_REVEAL_CHANNEL, request),
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>
@@ -1406,6 +1413,25 @@ function readBootstrapHomeDir(): string {
 }
 const bootstrapHomeDir = readBootstrapHomeDir();
 
+// Decode the active main-process log file path passed from main via
+// `webPreferences.additionalArguments` (Logs window only). The renderer uses
+// `window.__pwragentLogFilePath` as a fallback so the path + reveal button stay
+// available even when the live log-snapshot IPC read fails.
+const LOG_FILE_PATH_ARG_PREFIX = "--pwragent-log-file-path=";
+function readBootstrapLogFilePath(): string {
+  for (const arg of process.argv) {
+    if (!arg.startsWith(LOG_FILE_PATH_ARG_PREFIX)) continue;
+    try {
+      const raw = JSON.parse(arg.slice(LOG_FILE_PATH_ARG_PREFIX.length));
+      return typeof raw === "string" ? raw : "";
+    } catch {
+      break;
+    }
+  }
+  return "";
+}
+const bootstrapLogFilePath = readBootstrapLogFilePath();
+
 if (process.contextIsolated) {
   contextBridge.exposeInMainWorld("pwragent", desktopApi);
   contextBridge.exposeInMainWorld("__pwragentAppearance", bootstrapAppearance);
@@ -1419,6 +1445,10 @@ if (process.contextIsolated) {
     bootstrapNavigationPreferences,
   );
   contextBridge.exposeInMainWorld("__pwragentHomeDir", bootstrapHomeDir);
+  contextBridge.exposeInMainWorld(
+    "__pwragentLogFilePath",
+    bootstrapLogFilePath,
+  );
   recordPreloadLog("info", "exposed context bridge", {
     keyCount: Object.keys(desktopApi).length
   });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -258,6 +258,13 @@ function DesktopAppShell(props: {
   // mid-outage failure can't slip past unnoticed.
   const [backendErrorNotice, setBackendErrorNotice] =
     useState<AppNoticeToastNotice>();
+  // One-shot warning surfaced when the main process skipped automations it
+  // couldn't load (corrupt data, or a schedule/trigger shape written by a
+  // newer build). The skipped automations are left untouched in storage — this
+  // is the only signal the user gets that they were quietly not run, so it
+  // stays until dismissed.
+  const [automationLoadNotice, setAutomationLoadNotice] =
+    useState<AppNoticeToastNotice>();
   // Latest thread list, mirrored into a ref so the backend-error toast
   // subscription can resolve a thread's title without re-subscribing on
   // every navigation change. Kept fresh by an effect below, once
@@ -294,6 +301,44 @@ function DesktopAppShell(props: {
         ].join(""),
       });
     });
+  }, [desktopApi]);
+
+  // On startup, ask the main process whether it skipped any automations it
+  // couldn't load. Startup reconciliation runs before this window exists, so a
+  // pushed event would be missed — we pull the result once the renderer is up.
+  useEffect(() => {
+    if (!desktopApi?.listAutomationLoadIssues) {
+      return;
+    }
+    let cancelled = false;
+    void desktopApi
+      .listAutomationLoadIssues()
+      .then((response) => {
+        if (cancelled || response.issues.length === 0) {
+          return;
+        }
+        const issues = response.issues;
+        const names = issues.map((issue) => issue.name).filter(Boolean);
+        const namesSummary =
+          names.length > 0 ? names.slice(0, 5).join(", ") : undefined;
+        setAutomationLoadNotice({
+          autoDismiss: false,
+          id: `automation-load-issues:${issues.map((issue) => issue.id).join(",")}`,
+          title:
+            issues.length === 1
+              ? "1 automation was skipped"
+              : `${issues.length} automations were skipped`,
+          message:
+            "PwrAgent couldn't load some automations, so they did not run this session. They were left unchanged — open them in a newer version, or remove them.",
+          detail: namesSummary,
+        });
+      })
+      .catch(() => {
+        // Best-effort warning; never let it interfere with startup.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [desktopApi]);
 
   // Surface backend turn failures + system errors as a durable toast. The
@@ -1356,6 +1401,11 @@ function DesktopAppShell(props: {
             desktopApi={desktopApi}
             notice={backendErrorNotice}
             onDismiss={() => setBackendErrorNotice(undefined)}
+          />
+          <AppNoticeToast
+            desktopApi={desktopApi}
+            notice={automationLoadNotice}
+            onDismiss={() => setAutomationLoadNotice(undefined)}
           />
           <AppUpdateBanner desktopApi={desktopApi} />
         </div>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -329,7 +329,7 @@ function DesktopAppShell(props: {
               ? "1 automation was skipped"
               : `${issues.length} automations were skipped`,
           message:
-            "PwrAgent couldn't load some automations, so they did not run this session. They were left unchanged — open them in a newer version, or remove them.",
+            "PwrAgent couldn't load some automations, so they did not run this session. They were left unchanged — open them in the newer version of PwrAgent that created them.",
           detail: namesSummary,
         });
       })

--- a/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/logs/LogsWindow.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { AppLogEntry, AppLogSnapshot } from "../../../../shared/app-metadata";
-import { CopyIcon } from "../../icons";
+import { CopyIcon, FolderIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import { useDesktopApi } from "../../lib/desktop-api";
 
@@ -51,6 +51,16 @@ type LogLinePartTone =
   | "level-warn"
   | "scope";
 
+// The log file path is also injected at window-creation time via the preload
+// (`window.__pwragentLogFilePath`). The snapshot IPC normally supplies it, but
+// if that read fails — exactly when the user most needs to find the log on
+// disk — this bootstrap value keeps the path + reveal button available.
+function readBootstrapLogFilePath(): string | undefined {
+  const value = (window as unknown as { __pwragentLogFilePath?: unknown })
+    .__pwragentLogFilePath;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 export function LogsWindow() {
   const desktopApi = useDesktopApi();
   const logViewportRef = useRef<HTMLDivElement | null>(null);
@@ -64,7 +74,9 @@ export function LogsWindow() {
   const copyResetTimerRef = useRef<number | undefined>(undefined);
   const [renderVersion, setRenderVersion] = useState(0);
   const [truncated, setTruncated] = useState(false);
-  const [logFilePath, setLogFilePath] = useState<string | undefined>();
+  const [logFilePath, setLogFilePath] = useState<string | undefined>(
+    readBootstrapLogFilePath,
+  );
   const [copiedLogFilePath, setCopiedLogFilePath] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(false);
@@ -84,7 +96,7 @@ export function LogsWindow() {
   const applySnapshot = useCallback((value: AppLogSnapshot) => {
     entryBufferRef.current = createRenderedLogEntryBuffer(value.entries);
     setRenderVersion((version) => version + 1);
-    setLogFilePath(value.logFilePath);
+    setLogFilePath(value.logFilePath ?? readBootstrapLogFilePath());
     confirmedDebugCollectionRef.current = value.debugCollectionEnabled;
     setDebugCollectionEnabled(value.debugCollectionEnabled);
     setTruncated(value.truncated || value.entries.length > MAX_RENDERED_LOG_ENTRIES);
@@ -326,6 +338,16 @@ export function LogsWindow() {
       });
   }, [desktopApi, logFilePath]);
 
+  const handleRevealLogFile = useCallback(() => {
+    if (!logFilePath) {
+      return;
+    }
+    const reveal = desktopApi?.revealPath ?? desktopApi?.openPath;
+    void reveal?.({ path: logFilePath }).catch((revealError: unknown) => {
+      console.error("Failed to reveal log file", revealError);
+    });
+  }, [desktopApi, logFilePath]);
+
   const activeMatchLabel =
     rendered.matchCount > 0 ? `${activeMatchIndex + 1} / ${rendered.matchCount}` : "0";
 
@@ -431,6 +453,16 @@ export function LogsWindow() {
               >
                 <CopyIcon size={13} aria-hidden="true" />
                 <span>{copiedLogFilePath ? "Copied" : "Copy"}</span>
+              </button>
+              <button
+                className="log-window__file-copy"
+                type="button"
+                aria-label="Reveal log file in file manager"
+                title="Reveal log file in file manager"
+                onClick={handleRevealLogFile}
+              >
+                <FolderIcon size={13} aria-hidden="true" />
+                <span>Reveal</span>
               </button>
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -58,6 +58,7 @@ import type {
   LatestCodexConfigWarningResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
+  ListAutomationLoadIssuesResponse,
   ListAutomationRunsRequest,
   ListAutomationRunsResponse,
   ListAutomationsRequest,
@@ -300,6 +301,7 @@ export type DesktopApi = {
   getAutomationRunArtifact?: (
     request: GetAutomationRunArtifactRequest,
   ) => Promise<GetAutomationRunArtifactResponse>;
+  listAutomationLoadIssues?: () => Promise<ListAutomationLoadIssuesResponse>;
   listPwrAgentProfiles?: () => Promise<ListDesktopPwrAgentProfilesResponse>;
   openPwrAgentProfile?: (
     request: OpenDesktopPwrAgentProfileRequest,
@@ -513,6 +515,7 @@ export type DesktopApi = {
     request: OpenDesktopApplicationRequest
   ) => Promise<OpenDesktopApplicationResponse>;
   openPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
+  revealPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -127,6 +127,7 @@ export const AUTOMATIONS_LIST_RUNS_CHANNEL = "automations:list-runs";
 export const AUTOMATIONS_LIST_CARDS_CHANNEL = "automations:list-cards";
 export const AUTOMATIONS_GET_RUN_ARTIFACT_CHANNEL =
   "automations:get-run-artifact";
+export const AUTOMATIONS_LOAD_ISSUES_CHANNEL = "automations:load-issues";
 /**
  * Fire-and-forget IPC: opens the dedicated Messaging Activity window
  * (or focuses it if already open). The activity surface is a separate
@@ -271,6 +272,7 @@ export const ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL =
   "onboarding:complete-codex-bootstrap";
 export const APPLICATION_OPEN_CHANNEL = "application:open";
 export const PATH_OPEN_CHANNEL = "path:open";
+export const PATH_REVEAL_CHANNEL = "path:reveal";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -80,6 +80,21 @@ export type AutomationScheduleDefinition =
   | AutomationWeeklyScheduleDefinition
   | AutomationWeekdaysScheduleDefinition;
 
+/**
+ * Every schedule discriminant this build understands. Used by the desktop
+ * automation store to recognize — and safely skip — automation rows whose
+ * persisted schedule shape this version can't parse (e.g. a row written by a
+ * newer build that introduced a new schedule/trigger kind). Keep this in sync
+ * with the `AutomationScheduleDefinition` union and the
+ * `computeNextAutomationRunAt` switch.
+ */
+export const AUTOMATION_SCHEDULE_KINDS = [
+  "interval",
+  "weekly",
+  "weekdays",
+] as const;
+export type AutomationScheduleKind = (typeof AUTOMATION_SCHEDULE_KINDS)[number];
+
 export type AutomationScheduleValidationResult =
   | {
       ok: true;
@@ -260,6 +275,23 @@ export type ListAutomationsRequest = {
 
 export type ListAutomationsResponse = {
   automations: AutomationDetail[];
+};
+
+/**
+ * One automation row the running build could not load (malformed payload, or a
+ * schedule/trigger shape this version doesn't understand). The row is left
+ * untouched in storage and excluded from results for this process lifetime —
+ * not paused, not deleted — so an older build silently skips data a newer
+ * build wrote instead of crashing on it.
+ */
+export type AutomationLoadIssue = {
+  id: string;
+  name: string;
+  reason: string;
+};
+
+export type ListAutomationLoadIssuesResponse = {
+  issues: AutomationLoadIssue[];
 };
 
 export type AutomationMutationResponse = {


### PR DESCRIPTION
## Summary

- An installed older build (`beta.38`) became **running-but-unusable** (main window never appeared; Logs/Settings menu windows opened but their IPC was dead) after a newer build wrote an **enabled, trigger-only automation** (no `schedule`) into the shared default profile.
- Root cause: startup reconciliation called `computeNextAutomationRunAt(automation.schedule)` on an `undefined` schedule → `TypeError: Cannot read properties of undefined (reading 'kind')` → rejected the `app.whenReady()` promise. With **no `unhandledRejection` handler and no `.catch`**, the rest of boot silently aborted — no window, no dialog, not even a log line. The DB `user_version` 22→23 bump was additive and **not** the cause; the real downgrade-incompatibility is forward-written automation data an older build can't parse.
- This PR makes the app resilient instead of relying on every future data shape staying readable by every past build:
  - **Automation load safety valve** — `AutomationStore.recordFromRow` skips rows it can't load (corrupt payload, or a schedule kind not in `AUTOMATION_SCHEDULE_KINDS`). Skipped rows are excluded for the process lifetime — **never paused, deleted, or otherwise mutated** — tracked via `getAutomationLoadIssues()` and surfaced as a one-shot startup toast in the renderer (new `automations:load-issues` IPC). One bad automation can no longer abort startup; everything else keeps working.
  - **Boot error safety net** (`main/index.ts`) — an `unhandledRejection` handler, a 25s boot watchdog cleared once the main window shows, and a `.catch` on the `whenReady` chain. Any boot failure now logs and shows a native dialog with the error **plus the log-file path and Open Log / Reveal in Finder buttons**.
  - **Logs window** — a Reveal-in-Finder button (new `path:reveal` IPC) and the log file path injected at window creation (`window.__pwragentLogFilePath`) so the path + buttons remain available even when the log-snapshot IPC read fails.
  - **Settings** failing to open was the same root cause (its handlers register after the crash point) and is fixed transitively.

## Verification

- `typecheck` clean (shared + desktop).
- vitest: `shared` + `desktop-main` (2346 tests) and `desktop-renderer` (1283 tests) pass; added store tests covering skip / report / no-mutate, and `process.on` is spied in the boot tests.
- `lint:boundaries`, `lint:sql`, `lint:colors`, `lint:codex-storage` all pass.
- Manually reproduced the silent wedge against the live default profile (captured the actual `TypeError`), then confirmed boot recovers once the offending automation is skipped.

## Notes

- **Release sequencing:** this can't retroactively save already-installed older builds — it makes *current and future* builds degrade gracefully (skip + warn) instead of bricking. The next release is what closes the silent-wedge window going forward.
- The feat branch that introduced inbound/trigger automations already guards its own reconcile; this PR is the systemic resilience layer and is intended to land on `main` ahead of that work (and ahead of a release).
- No schema/migration changes here — the v23 migration is unrelated and was a red herring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)