### PR TITLE
fix(desktop): open terminals in current workspace

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1083,7 +1083,7 @@ export function ThreadView(props: ThreadViewProps) {
     ? terminalOpenByThread[selectedThreadKey] === true
     : false;
   const selectedThreadTerminalCwd = selectedThread
-    ? threadDirectoryPaths(selectedThread)[0]
+    ? resolveThreadTerminalCwd(selectedThread)
     : undefined;
   const selectedThreadTerminalHeight = selectedThreadKey
     ? terminalHeightByThread[selectedThreadKey] ?? 260
@@ -2912,4 +2912,15 @@ function threadDirectoryPaths(thread: NavigationThreadSummary): string[] {
     return paths;
   });
   return thread.projectKey ? [thread.projectKey, ...linkedDirectoryPaths] : linkedDirectoryPaths;
+}
+
+function resolveThreadTerminalCwd(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  const directory =
+    thread.linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
+    thread.linkedDirectories.find((candidate) => candidate.kind === "local") ??
+    thread.linkedDirectories[0];
+
+  return directory?.worktreePath ?? directory?.path ?? thread.projectKey;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -447,6 +447,101 @@ describe("ThreadView", () => {
     });
   });
 
+  it("opens the integrated terminal in the local handoff directory when projectKey is stale", async () => {
+    const selectedThread: NavigationThreadSummary = {
+      id: "thread-local-handoff",
+      title: "Local handoff",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      projectKey: "/repo/.codex/worktrees/stale/app",
+      linkedDirectories: [
+        {
+          id: "pwragent-handoff:codex:thread-local-handoff",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      inbox: {
+        inInbox: true,
+      },
+    };
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open integrated terminal" }));
+
+    expect(await screen.findByLabelText("Integrated terminal")).toHaveAttribute(
+      "data-cwd",
+      "/repo/app",
+    );
+  });
+
+  it("opens the integrated terminal in the linked worktree path instead of projectKey", async () => {
+    const selectedThread: NavigationThreadSummary = {
+      id: "thread-worktree-handoff",
+      title: "Worktree handoff",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      updatedAt: Date.now(),
+      projectKey: "/repo/app",
+      linkedDirectories: [
+        {
+          id: "pwragent-handoff:codex:thread-worktree-handoff",
+          kind: "worktree",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/app/.worktrees/app-feature",
+        },
+      ],
+      inbox: {
+        inInbox: true,
+      },
+    };
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={selectedThread}
+        skills={[]}
+        transcriptEntries={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open integrated terminal" }));
+
+    expect(await screen.findByLabelText("Integrated terminal")).toHaveAttribute(
+      "data-cwd",
+      "/repo/app/.worktrees/app-feature",
+    );
+  });
+
   it("hides the integrated terminal when the pty exits without closing it again", async () => {
     const selectedThread: NavigationThreadSummary = {
       id: "thread-a",


### PR DESCRIPTION
## Summary

- I fixed integrated terminals so they open in the thread's current handoff workspace instead of a stale Codex `projectKey`.
- Local handoff threads now use the local repository path, and worktree handoff threads now use the linked worktree path, which avoids falling back to `~` when an old worktree has been removed.

## Verification

- [x] `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- [x] `pnpm typecheck`
- [x] `pnpm lint:boundaries`

## Notes

- Root cause: the integrated terminal cwd helper preferred `thread.projectKey`, while workspace handoff state lives in linked directory overlay metadata. I added regression coverage for stale local-handoff `projectKey` and linked worktree cwd selection.
