### PR TITLE
fix(desktop): repair local handoff branch metadata

### DIFF
--- a/apps/desktop/e2e/thread-branch-drift.spec.ts
+++ b/apps/desktop/e2e/thread-branch-drift.spec.ts
@@ -119,7 +119,7 @@ test("updates the expected branch when the user accepts the current branch", asy
   }
 });
 
-test("does not reopen a HEAD drift warning after accepting the current branch", async () => {
+test("repairs a stale HEAD drift without opening a warning", async () => {
   const fixture = await createBranchDriftFixture({ expectedBranch: "HEAD" });
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -129,20 +129,16 @@ test("does not reopen a HEAD drift warning after accepting the current branch", 
   });
 
   try {
-    await app.window
-      .getByRole("button", {
-        name: "Accept current branch as correct. Continue working on codex/current-branch without further warnings",
-      })
-      .click();
-
     const dialog = app.window.getByRole("dialog", {
       name: "Thread branch changed",
     });
     await expect(dialog).toBeHidden();
-    expect(readThreadPayload(fixture.homeDir)).toMatchObject({
-      gitBranch: "codex/current-branch",
-      observedGitBranch: "codex/current-branch",
-    });
+    await expect
+      .poll(() => readThreadPayload(fixture.homeDir))
+      .toMatchObject({
+        gitBranch: "codex/current-branch",
+        observedGitBranch: "codex/current-branch",
+      });
 
     const staleRendererCheck = await app.window.evaluate(async () =>
       await (window as any).pwragent.checkThreadBranchDrift({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -536,15 +536,11 @@ function createOverlayStoreMock(params?: {
         previousObservedBranch !== nextObservedBranch
           ? previousObservedBranch
           : undefined;
-      const requestedExpectedBranch =
-        expectedBranch?.trim() && expectedBranch.trim() !== nextObservedBranch
-          ? expectedBranch.trim()
-          : undefined;
+      const requestedExpectedBranch = expectedBranch?.trim() || undefined;
       const next = {
         ...current,
-        gitBranch: current.gitBranch?.trim()
-          ? current.gitBranch
-          : requestedExpectedBranch ?? fallbackExpectedBranch,
+        gitBranch: requestedExpectedBranch
+          ?? (current.gitBranch?.trim() ? current.gitBranch : fallbackExpectedBranch),
         observedGitBranch: branch,
       } as ThreadOverlayState;
       overlays.set(key, next);
@@ -19987,6 +19983,188 @@ script = "printf setup"
     });
 
     await registry.close();
+  });
+
+  it("records a detached local handoff with the current destination branch when available", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-handoff-branch-"));
+    const repoPath = path.join(root, "PwrAgnt");
+
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+      await git(repoPath, ["config", "user.email", "test@example.com"]);
+      await git(repoPath, ["config", "user.name", "Test User"]);
+      await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+      await git(repoPath, ["add", "README.md"]);
+      await git(repoPath, ["commit", "-m", "initial"]);
+
+      const thread: AppServerThreadSummary = {
+        id: "thread-1",
+        title: "Detached handoff",
+        titleSource: "explicit",
+        linkedDirectories: [
+          {
+            id: "pwragent-handoff:codex:thread-1",
+            label: "PwrAgnt",
+            path: repoPath,
+            worktreePath: path.join(root, ".codex", "worktrees", "old", "PwrAgnt"),
+            kind: "worktree",
+          },
+        ],
+        source: "codex",
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        updatedAt: 2,
+      };
+      const overlayStore = createOverlayStoreMock();
+      const handoff = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        direction: "worktree-to-local" as const,
+        strategy: "detached-changes" as const,
+        workMode: "local" as const,
+        baseSha: "abc123",
+        repositoryPath: repoPath,
+        targetPath: repoPath,
+        linkedDirectory: {
+          id: "pwragent-handoff:codex:thread-1",
+          label: "PwrAgnt",
+          path: repoPath,
+          kind: "local" as const,
+        },
+        warnings: [],
+        completedAt: 1000,
+      }));
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [thread],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        overlayStore,
+        gitWorkspaceHandoffService: {
+          handoff,
+        } as never,
+      });
+
+      await registry.handoffThreadWorkspace({
+        backend: "codex",
+        threadId: "thread-1",
+        direction: "worktree-to-local",
+      });
+
+      expect(codexClient.lastUpdateThreadMetadataParams).toEqual({
+        threadId: "thread-1",
+        gitInfo: {
+          branch: "main",
+        },
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+      ).resolves.toMatchObject({
+        gitBranch: "main",
+        observedGitBranch: "main",
+        extraLinkedDirectories: [
+          expect.objectContaining({
+            id: "pwragent-handoff:codex:thread-1",
+            kind: "local",
+          }),
+        ],
+      });
+
+      await registry.close();
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
+  it("repairs stale detached branch state from the current local handoff workspace", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-drift-local-"));
+    const repoPath = path.join(root, "PwrAgnt");
+
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+      await git(repoPath, ["config", "user.email", "test@example.com"]);
+      await git(repoPath, ["config", "user.name", "Test User"]);
+      await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+      await git(repoPath, ["add", "README.md"]);
+      await git(repoPath, ["commit", "-m", "initial"]);
+
+      const staleWorktreePath = path.join(root, ".codex", "worktrees", "old", "PwrAgnt");
+      const thread: AppServerThreadSummary = {
+        id: "thread-1",
+        title: "Moved thread",
+        titleSource: "explicit",
+        linkedDirectories: [
+          {
+            id: "directory:stale-worktree",
+            label: "PwrAgnt",
+            path: repoPath,
+            worktreePath: staleWorktreePath,
+            kind: "worktree",
+          },
+        ],
+        source: "codex",
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        updatedAt: 2,
+      };
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "full-access",
+            gitBranch: "HEAD",
+            observedGitBranch: "HEAD",
+            extraLinkedDirectories: [
+              {
+                id: "pwragent-handoff:codex:thread-1",
+                kind: "local",
+                label: "PwrAgnt",
+                path: repoPath,
+              },
+            ],
+          },
+        },
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient: new MockBackendClient({
+          initializeResult: { methods: ["thread/list"] },
+          threads: [thread],
+        }),
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        overlayStore,
+      });
+
+      const response = await registry.checkThreadBranchDrift({
+        backend: "codex",
+        expectedBranch: "HEAD",
+        threadId: "thread-1",
+      });
+
+      expect(response).toMatchObject({
+        expectedBranch: "main",
+        observedBranch: "main",
+        drifted: false,
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+      ).resolves.toMatchObject({
+        gitBranch: "main",
+        observedGitBranch: "main",
+      });
+
+      await registry.close();
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
   });
 
   it("uses an observed handoff branch as expected when legacy overlay state has no gitBranch", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20167,6 +20167,101 @@ script = "printf setup"
     }
   });
 
+  it("notifies listeners when branch drift repair updates only the expected branch", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-drift-repair-"));
+    const repoPath = path.join(root, "PwrAgnt");
+
+    try {
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+      await git(repoPath, ["config", "user.email", "test@example.com"]);
+      await git(repoPath, ["config", "user.name", "Test User"]);
+      await writeFile(path.join(repoPath, "README.md"), "base\n", "utf8");
+      await git(repoPath, ["add", "README.md"]);
+      await git(repoPath, ["commit", "-m", "initial"]);
+
+      const thread: AppServerThreadSummary = {
+        id: "thread-1",
+        title: "Moved thread",
+        titleSource: "explicit",
+        linkedDirectories: [],
+        source: "codex",
+        gitBranch: "HEAD",
+        observedGitBranch: "main",
+        updatedAt: 2,
+      };
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "full-access",
+            gitBranch: "HEAD",
+            observedGitBranch: "main",
+            extraLinkedDirectories: [
+              {
+                id: "pwragent-handoff:codex:thread-1",
+                kind: "local",
+                label: "PwrAgnt",
+                path: repoPath,
+              },
+            ],
+          },
+        },
+      });
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/list", "thread/metadata/update"] },
+        threads: [thread],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        overlayStore,
+      });
+      const events: AgentEvent[] = [];
+      const unsubscribe = registry.onEvent((event) => {
+        events.push(event);
+      });
+
+      try {
+        const response = await registry.checkThreadBranchDrift({
+          backend: "codex",
+          expectedBranch: "HEAD",
+          threadId: "thread-1",
+        });
+
+        expect(response).toMatchObject({
+          expectedBranch: "main",
+          observedBranch: "main",
+          drifted: false,
+        });
+        await expect(
+          overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+        ).resolves.toMatchObject({
+          gitBranch: "main",
+          observedGitBranch: "main",
+        });
+        expect(events).toContainEqual({
+          backend: "codex",
+          notification: {
+            method: "thread/branch/updated",
+            params: {
+              threadId: "thread-1",
+              branch: "main",
+            },
+          },
+        });
+      } finally {
+        unsubscribe();
+        await registry.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
   it("uses an observed handoff branch as expected when legacy overlay state has no gitBranch", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
@@ -64,4 +64,26 @@ describe("SqliteOverlayStore branch metadata", () => {
       observedGitBranch: "feature/current",
     });
   });
+
+  it("replaces a stale expected branch when the caller supplies a repair", async () => {
+    await store.setThreadExpectedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "HEAD",
+    });
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "main",
+      expectedBranch: "main",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "main",
+      observedGitBranch: "main",
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9114,6 +9114,24 @@ export class DesktopBackendRegistry {
           : undefined,
     });
 
+    if (expectedBranchResolution.repairedDetachedHandoffBranch && expectedBranch) {
+      await this.updateThreadGitBranchMetadata({
+        backend: params.backend,
+        threadId: params.threadId,
+        branch: expectedBranch,
+      });
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/branch/updated",
+          params: {
+            threadId: params.threadId,
+            branch: expectedBranch,
+          },
+        },
+      } as unknown as AgentEvent);
+    }
+
     if (drifted) {
       backendRegistryLog.debug("checked thread branch drift", {
         backend: params.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -574,6 +574,11 @@ function resolveThreadWorkspaceCwd(
 function resolveLinkedDirectoryWorkspaceCwd(
   linkedDirectories: AppServerThreadSummary["linkedDirectories"] = [],
 ): string | undefined {
+  const handoffDirectory = linkedDirectories.find(isHandoffDirectory);
+  if (handoffDirectory) {
+    return handoffDirectory.worktreePath ?? handoffDirectory.path;
+  }
+
   const directory =
     linkedDirectories.find((candidate) => candidate.kind === "worktree") ??
     linkedDirectories.find((candidate) => candidate.kind === "local") ??
@@ -876,6 +881,90 @@ function resolveExpectedThreadBranch(params: {
   }
 
   return params.thread?.gitBranch?.trim() || undefined;
+}
+
+function shouldUseObservedBranchForDetachedHandoff(params: {
+  branch?: string;
+  observedBranch?: string;
+  overlay?: ThreadOverlayState;
+}): boolean {
+  const branch = params.branch?.trim();
+  const observedBranch = params.observedBranch?.trim();
+  return Boolean(
+    branch === "HEAD" &&
+      observedBranch &&
+      observedBranch !== "HEAD" &&
+      hasHandoffWorkspace(params.overlay?.extraLinkedDirectories),
+  );
+}
+
+function resolveBranchDriftExpectedBranch(params: {
+  observedBranch?: string;
+  overlay?: ThreadOverlayState;
+  requestedExpectedBranch?: string;
+  thread?: Pick<AppServerThreadSummary, "gitBranch">;
+}): { expectedBranch?: string; repairedDetachedHandoffBranch: boolean } {
+  const overlayBranch = params.overlay?.gitBranch?.trim();
+  if (
+    shouldUseObservedBranchForDetachedHandoff({
+      branch: overlayBranch,
+      observedBranch: params.observedBranch,
+      overlay: params.overlay,
+    })
+  ) {
+    return {
+      expectedBranch: params.observedBranch,
+      repairedDetachedHandoffBranch: true,
+    };
+  }
+  if (overlayBranch) {
+    return {
+      expectedBranch: overlayBranch,
+      repairedDetachedHandoffBranch: false,
+    };
+  }
+
+  const requestedBranch = params.requestedExpectedBranch?.trim();
+  if (
+    shouldUseObservedBranchForDetachedHandoff({
+      branch: requestedBranch,
+      observedBranch: params.observedBranch,
+      overlay: params.overlay,
+    })
+  ) {
+    return {
+      expectedBranch: params.observedBranch,
+      repairedDetachedHandoffBranch: true,
+    };
+  }
+  if (requestedBranch) {
+    return {
+      expectedBranch: requestedBranch,
+      repairedDetachedHandoffBranch: false,
+    };
+  }
+
+  const fallbackBranch = resolveExpectedThreadBranch({
+    overlay: params.overlay,
+    thread: params.thread,
+  });
+  if (
+    shouldUseObservedBranchForDetachedHandoff({
+      branch: fallbackBranch,
+      observedBranch: params.observedBranch,
+      overlay: params.overlay,
+    })
+  ) {
+    return {
+      expectedBranch: params.observedBranch,
+      repairedDetachedHandoffBranch: true,
+    };
+  }
+
+  return {
+    expectedBranch: fallbackBranch,
+    repairedDetachedHandoffBranch: false,
+  };
 }
 
 async function readCurrentGitBranch(sourcePath: string): Promise<string | undefined> {
@@ -6460,7 +6549,12 @@ export class DesktopBackendRegistry {
       sourcePath: request.sourcePath ?? candidate.sourcePath,
       sourceBranch: request.sourceBranch ?? candidate.sourceBranch,
     });
-    const resultBranch = result.strategy === "detached-changes" ? "HEAD" : result.branch;
+    const resultBranch =
+      result.strategy === "detached-changes"
+        ? (result.workMode === "local"
+            ? await readCurrentGitBranch(result.targetPath).catch(() => undefined)
+            : undefined) ?? "HEAD"
+        : result.branch;
 
     await this.overlayStore.replaceWorkspaceLinkedDirectory({
       backend: request.backend,
@@ -8981,15 +9075,6 @@ export class DesktopBackendRegistry {
       callerReason: "branch-drift",
       threadId: params.threadId,
     });
-    const overlayExpectedBranch = overlay?.gitBranch?.trim();
-    const requestedExpectedBranch = params.expectedBranch?.trim();
-    const expectedBranch =
-      overlayExpectedBranch ||
-      requestedExpectedBranch ||
-      resolveExpectedThreadBranch({
-        overlay,
-        thread,
-      });
     const workspaceCwd = resolveThreadWorkspaceCwd(
       thread,
       overlay?.extraLinkedDirectories ?? [],
@@ -8998,6 +9083,13 @@ export class DesktopBackendRegistry {
       ? await readCurrentGitBranch(workspaceCwd).catch(() => thread?.observedGitBranch)
       : thread?.observedGitBranch;
     const normalizedObservedBranch = observedBranch?.trim() || undefined;
+    const expectedBranchResolution = resolveBranchDriftExpectedBranch({
+      observedBranch: normalizedObservedBranch,
+      overlay,
+      requestedExpectedBranch: params.expectedBranch,
+      thread,
+    });
+    const expectedBranch = expectedBranchResolution.expectedBranch;
 
     const drifted = isBranchDrifted(expectedBranch, normalizedObservedBranch);
 
@@ -9016,7 +9108,10 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
       branch: normalizedObservedBranch,
-      expectedBranch: drifted ? expectedBranch : undefined,
+      expectedBranch:
+        drifted || expectedBranchResolution.repairedDetachedHandoffBranch
+          ? expectedBranch
+          : undefined,
     });
 
     if (drifted) {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1535,16 +1535,11 @@ export class SqliteOverlayStore {
       previousObservedBranch !== nextObservedBranch
         ? previousObservedBranch
         : undefined;
-    const requestedExpectedBranch =
-      params.expectedBranch?.trim() &&
-      params.expectedBranch.trim() !== nextObservedBranch
-        ? params.expectedBranch.trim()
-        : undefined;
+    const requestedExpectedBranch = params.expectedBranch?.trim() || undefined;
     const nextState: ThreadOverlayState = {
       ...current,
-      gitBranch: current.gitBranch?.trim()
-        ? current.gitBranch
-        : requestedExpectedBranch ?? fallbackExpectedBranch,
+      gitBranch: requestedExpectedBranch
+        ?? (current.gitBranch?.trim() ? current.gitBranch : fallbackExpectedBranch),
       observedGitBranch: params.branch,
     };
     this.putThread(threadKey, nextState);


### PR DESCRIPTION
## Summary

- I fixed local handoff threads so the branch chip can recover from stale `HEAD` metadata when the live local checkout is actually on a named branch like `main`.
- Workspace commands now prefer the explicit handoff-linked directory before older thread metadata, so branch drift checks read the current local repo instead of an archived worktree path.
- Detached worktree-to-local handoff recording now reads the destination checkout branch when available, while still preserving `HEAD` for genuinely detached destinations.

## Verification

- [x] `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/overlay-store-branches.test.ts`
- [x] `pnpm lint`

## Notes

- I added regression coverage for the stale local-handoff `HEAD` case and for persisting repaired expected-branch metadata in the overlay store.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
