### PR TITLE
fix(release): publish changelog notes automatically

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -50,12 +50,12 @@ Read these files before changing release metadata:
   and present on the intended release branch.
 - Do not create the GitHub Release by hand before the build succeeds. Let
   electron-builder create or update the release from the signed/notarized CI
-  build, then replace the generated/empty release notes with the changelog
-  entry.
+  build; the workflow publishes the matching changelog entry to the GitHub
+  Release body after release assets are uploaded.
 - Do not use GitHub generated release notes as the final notes.
 - A release is not complete when the workflow reaches the `apple-signing`
-  approval gate. After approval, continue monitoring until CI finishes, replace
-  the GitHub Release notes, and verify the release body is non-empty.
+  approval gate. After approval, continue monitoring through the release-notes
+  publishing job, and verify the release body is non-empty.
 - Do not force-push the default branch or rewrite an existing release tag
   without explicit user approval.
 - Keep MIT licensing intact: do not change first-party license metadata or
@@ -270,7 +270,8 @@ commit, and the version/changelog metadata match the tag.
 
 If monitoring is delegated and the monitor stops at the approval gate, resume
 monitoring after approval. Do not end the release turn as "done" at the
-approval gate; the post-success release-note edit is still required.
+approval gate; the workflow still has to publish and verify release notes after
+assets are uploaded.
 
 On failure, inspect logs yourself:
 
@@ -298,20 +299,26 @@ The stable `PwrAgent.dmg` alias is intentionally unversioned so the website can
 link to the latest release without knowing the current version. Do not remove
 or replace it with an arch-suffixed DMG.
 
-Then replace electron-builder's empty/default release notes. For beta releases
-that should be offered by the normal updater and stable landing-page download
-URLs, leave GitHub's release label as `None` so the release can become Latest;
-do not mark it as `Pre-release`. GitHub excludes pre-release entries from
-`/releases/latest`, which also breaks
+The workflow replaces electron-builder's empty/default release notes after
+release assets are published. For beta releases that should be offered by the
+normal updater and stable landing-page download URLs, leave GitHub's release
+label as `None` so the release can become Latest; do not mark it as
+`Pre-release`. GitHub excludes pre-release entries from `/releases/latest`,
+which also breaks
 `https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg` and
 the default Electron updater feed.
 
-This step is required, not cosmetic. Electron-builder may leave the body empty
-or duplicate the tag name, so always run it after assets are published:
+This release-note publication is required, not cosmetic. Electron-builder may
+leave the body empty or duplicate the tag name. If the workflow release-notes
+job fails or GitHub temporarily rejects the edit, run the manual fallback after
+confirming the extracted notes match the approved changelog entry:
 
 ```bash
+node scripts/extract-release-notes.mjs \
+  --tag v<version> \
+  --out .local/release/v<version>/RELEASE_NOTES.md
 gh release edit v<version> \
-  --title "v<version> - <short release theme>" \
+  --repo pwrdrvr/PwrAgent \
   --notes-file .local/release/v<version>/RELEASE_NOTES.md
 ```
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,3 +296,49 @@ jobs:
             linux-dist/*.deb
             linux-dist/SHA256SUMS
           retention-days: 30
+
+  publish-release-notes:
+    name: Publish release notes
+    runs-on: ubuntu-24.04
+    needs:
+      - sign
+      - linux-publish
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          persist-credentials: false
+
+      - name: Publish changelog notes to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_PAT || github.token }}
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${RELEASE_TAG:?}"
+          VERSION="${RELEASE_TAG#v}"
+          notes="$RUNNER_TEMP/RELEASE_NOTES.md"
+
+          node scripts/extract-release-notes.mjs \
+            --tag "$RELEASE_TAG" \
+            --out "$notes"
+
+          if [ ! -s "$notes" ]; then
+            echo "::error::No CHANGELOG.md notes found for $RELEASE_TAG ($VERSION)" >&2
+            exit 1
+          fi
+
+          gh release edit "$RELEASE_TAG" \
+            --repo pwrdrvr/PwrAgent \
+            --notes-file "$notes"
+
+          body_length="$(gh release view "$RELEASE_TAG" --repo pwrdrvr/PwrAgent --json body --jq '.body | length')"
+          if [ "$body_length" -le 0 ]; then
+            echo "::error::Release $RELEASE_TAG still has an empty body" >&2
+            exit 1
+          fi

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -136,6 +136,10 @@ release jobs:
    GitHub Release exists, combines both Linux architecture artifacts, generates
    `SHA256SUMS`, and uploads the `.deb` files plus checksums to the same
    release.
+5. `Publish release notes`, which waits for successful macOS and Linux release
+   asset publishing, extracts the matching `CHANGELOG.md` section, updates the
+   GitHub Release body, and fails the workflow if the body still reads back as
+   empty.
 
 The no-secret prepare job:
 
@@ -168,17 +172,35 @@ Do not approve the `apple-signing` environment unless the tag, commit, and
 metadata are the intended release. Do not create the GitHub Release manually
 before the build succeeds. A manually created release appears before
 signing/notarization finishes. The current flow lets electron-builder create or
-update the release from the successful CI build; afterward, edit the release to
-replace the generated/empty notes with the matching `CHANGELOG.md` content.
-The release is not complete at the `apple-signing` approval gate: after
-approval, continue watching the run, then edit the GitHub Release notes and
-verify the body is non-empty. If a monitor or handoff stops at the approval
-gate, resume after approval rather than treating the release as done.
+update the release from the successful CI build, then the workflow replaces the
+generated/empty notes with the matching `CHANGELOG.md` content after release
+assets are published. The release is not complete at the `apple-signing`
+approval gate: after approval, continue watching the run through `Publish
+release notes`, then verify the final GitHub Release body is non-empty. If a
+monitor or handoff stops at the approval gate, resume after approval rather than
+treating the release as done.
 For beta releases that should be offered by normal update checks and stable
 landing-page download links, leave GitHub's release label as `None` so the
 release can become Latest. Mark a release as `Pre-release` only when it should
 be hidden from `/releases/latest`, `PwrAgent.dmg`, and the default Electron
 updater feed.
+
+If the automated release-notes job fails or GitHub temporarily rejects the
+release edit, use this manual fallback after confirming the notes file contains
+the approved `CHANGELOG.md` entry:
+
+```bash
+RELEASE_TAG=v1.0.0-beta.21
+mkdir -p .local/release/"$RELEASE_TAG"
+node scripts/extract-release-notes.mjs \
+  --tag "$RELEASE_TAG" \
+  --out .local/release/"$RELEASE_TAG"/RELEASE_NOTES.md
+gh release edit "$RELEASE_TAG" \
+  --repo pwrdrvr/PwrAgent \
+  --notes-file .local/release/"$RELEASE_TAG"/RELEASE_NOTES.md
+gh release view "$RELEASE_TAG" --repo pwrdrvr/PwrAgent --json body \
+  --jq '.body | length'
+```
 
 If direct push to the release branch is rejected, use the repo-local release
 skill fallback: open a short-lived release PR against the release branch, wait

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -168,6 +168,10 @@ for (const expected of [
   "ubuntu-24.04-arm",
   "Package Linux DEB",
   "Publish Linux DEB artifacts",
+  "Publish release notes",
+  "scripts/extract-release-notes.mjs",
+  "--notes-file",
+  ".body | length",
   "PWRAGENT_LINUX_ARCH",
   "SHA256SUMS",
 ]) {

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function usage() {
+  console.error(
+    "Usage: RELEASE_TAG=v1.0.0-beta.1 node scripts/extract-release-notes.mjs --out /path/RELEASE_NOTES.md",
+  );
+  console.error(
+    "   or: node scripts/extract-release-notes.mjs --tag v1.0.0-beta.1 --out /path/RELEASE_NOTES.md",
+  );
+}
+
+function parseArgs(argv) {
+  const options = {
+    changelogPath: resolve(repoRoot, "CHANGELOG.md"),
+    outPath: undefined,
+    tag: process.env.RELEASE_TAG || process.env.GITHUB_REF_NAME,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tag") {
+      options.tag = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--tag=")) {
+      options.tag = arg.slice("--tag=".length);
+    } else if (arg === "--out") {
+      options.outPath = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--out=")) {
+      options.outPath = arg.slice("--out=".length);
+    } else if (arg === "--changelog") {
+      options.changelogPath = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith("--changelog=")) {
+      options.changelogPath = arg.slice("--changelog=".length);
+    } else {
+      throw new Error(`unknown argument ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function releaseVersionFromTag(tag) {
+  if (!tag) {
+    throw new Error("missing release tag");
+  }
+  return tag.startsWith("v") ? tag.slice(1) : tag;
+}
+
+function trimOuterBlankLines(lines) {
+  let start = 0;
+  let end = lines.length;
+
+  while (start < end && lines[start].trim() === "") {
+    start += 1;
+  }
+  while (end > start && lines[end - 1].trim() === "") {
+    end -= 1;
+  }
+
+  return lines.slice(start, end);
+}
+
+export function extractReleaseNotes(changelog, tag) {
+  const version = releaseVersionFromTag(tag);
+  const headingPattern = new RegExp(
+    `^##\\s+v?${escapeRegex(version)}(?:\\s|$)`,
+  );
+  const lines = changelog.split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => headingPattern.test(line));
+  if (startIndex === -1) {
+    return "";
+  }
+
+  const section = [];
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^##\s+/.test(line)) {
+      break;
+    }
+    section.push(line);
+  }
+
+  const notes = trimOuterBlankLines(section).join("\n");
+  return notes === "" ? "" : `${notes}\n`;
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    usage();
+    throw error;
+  }
+
+  if (!options.tag || !options.outPath) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const changelog = readFileSync(options.changelogPath, "utf8");
+  const notes = extractReleaseNotes(changelog, options.tag);
+  writeFileSync(options.outPath, notes, "utf8");
+
+  if (notes.trim() === "") {
+    console.error(`No CHANGELOG.md notes found for ${options.tag}`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/extract-release-notes.test.mjs
+++ b/scripts/extract-release-notes.test.mjs
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { extractReleaseNotes } from "./extract-release-notes.mjs";
+
+describe("extractReleaseNotes", () => {
+  it("extracts a matching v-prefixed changelog section", () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## v1.0.0-beta.21 - 2026-06-27",
+      "",
+      "- Desktop - Published release notes automatically.",
+      "- Release - Verified non-empty body after upload.",
+      "",
+      "## v1.0.0-beta.20 - 2026-06-20",
+      "",
+      "- Prior release.",
+      "",
+    ].join("\n");
+
+    expect(extractReleaseNotes(changelog, "v1.0.0-beta.21")).toBe(
+      [
+        "- Desktop - Published release notes automatically.",
+        "- Release - Verified non-empty body after upload.",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("extracts a matching unprefixed changelog section", () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## 1.2.3 - 2026-06-27",
+      "",
+      "- Release - Accepted headings without a leading v.",
+      "",
+      "## 1.2.2 - 2026-06-20",
+      "- Prior release.",
+    ].join("\n");
+
+    expect(extractReleaseNotes(changelog, "v1.2.3")).toBe(
+      "- Release - Accepted headings without a leading v.\n",
+    );
+  });
+
+  it("does not match prerelease headings for a stable tag", () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## v1.0.0-beta.1 - 2026-06-20",
+      "",
+      "- Beta notes.",
+      "",
+    ].join("\n");
+
+    expect(extractReleaseNotes(changelog, "v1.0.0")).toBe("");
+  });
+
+  it("returns an empty string when the matching section has no notes", () => {
+    const changelog = [
+      "# Changelog",
+      "",
+      "## v1.0.0 - 2026-06-27",
+      "",
+      "",
+      "## v0.9.0 - 2026-06-20",
+      "- Prior release.",
+    ].join("\n");
+
+    expect(extractReleaseNotes(changelog, "v1.0.0")).toBe("");
+  });
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           testTimeout: TEST_TIMEOUT_MS,
           environment: "node",
           include: [
+            "scripts/**/*.test.mjs",
             "apps/desktop/scripts/**/*.test.mjs",
             "apps/desktop/src/main/__tests__/**/*.test.ts",
             "apps/desktop/src/main/agent-tools/__tests__/**/*.test.ts",


### PR DESCRIPTION
## Summary

- I added a release workflow job that publishes the matching `CHANGELOG.md` entry to the GitHub Release body after macOS and Linux assets publish.
- I added a reusable release-notes extraction script with focused tests and wired the release metadata gate to catch future workflow regressions.
- I updated the release runbook and release skill so the automated path is documented while the manual fallback remains available.

## Verification

- I ran `pnpm test scripts/extract-release-notes.test.mjs`.
- I ran `RELEASE_TAG=v1.0.0-beta.38 pnpm release:check`.
- I smoke-tested the extraction script against the current `CHANGELOG.md`; it produced a non-empty 1004-byte notes file.
- I ran `git diff --check`.

## Notes

- This preserves the current release policy: beta releases that should feed normal updater/latest URLs remain normal GitHub releases, not prereleases, unless explicitly requested.
- Full app tests were not necessary because this change is scoped to release workflow/docs/skill behavior plus a small Node helper covered by focused tests.
