### PR TITLE
fix(desktop): preserve active review turn during idle reads

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7620,6 +7620,127 @@ describe("useThreadSessionState", () => {
     expect(result.current.threadBusy).toBe(false);
   });
 
+  it("keeps a review turn active when idle hydration contains its in-progress review entry", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [
+          {
+            type: "review" as const,
+            id: "review-entered",
+            review: "Review changes against main",
+            displayText: "Review changes against main",
+            createdAt: 2_000,
+            turn: {
+              id: "turn-review",
+              status: "in_progress" as const,
+              startedAt: 1_500,
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          optimisticActiveTurn: {
+            id: "turn-review",
+            statusText: "Reviewing",
+            startedAt: 1_500,
+            reviewDisplayText: "Review changes against main",
+          },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.pendingStatusText).toBe("Reviewing");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-sibling",
+            turn: {
+              id: "turn-sibling",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-review");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-exited",
+              type: "exitedReviewMode",
+              review: "No findings.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("seeds launchpad active turns alongside optimistic user messages", async () => {
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7741,6 +7741,76 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("clears stale review thinking when idle hydration also contains a terminal review entry", async () => {
+    const readThread = vi.fn(async ({ backend, threadId }) => ({
+      backend: backend ?? "codex",
+      fetchedAt: Date.now(),
+      threadId,
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [
+          {
+            type: "review" as const,
+            id: "review-entered",
+            review: "Review changes against main",
+            displayText: "Review changes against main",
+            createdAt: 2_000,
+            turn: {
+              id: "turn-review",
+              status: "in_progress" as const,
+              startedAt: 1_500,
+            },
+          },
+          {
+            type: "review" as const,
+            id: "review-exited",
+            review: "No findings.",
+            createdAt: 3_000,
+            turn: {
+              id: "turn-review",
+              status: "completed" as const,
+              startedAt: 1_500,
+              completedAt: 3_000,
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          optimisticActiveTurn: {
+            id: "turn-review",
+            statusText: "Reviewing",
+            startedAt: 1_500,
+            reviewDisplayText: "Review changes against main",
+          },
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("seeds launchpad active turns alongside optimistic user messages", async () => {
     const desktopApi: DesktopApi = {
       onAgentEvent: () => () => undefined,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1365,6 +1365,19 @@ function readResponseThreadStatus(
   return response.threadStatus ?? response.replay.threadStatus;
 }
 
+function responseHasInProgressTurn(
+  response: AppServerReadThreadResponse,
+  turnId: string | undefined
+): boolean {
+  if (!turnId) {
+    return false;
+  }
+
+  return response.replay.entries.some(
+    (entry) => entry.turn?.id === turnId && entry.turn.status === "in_progress"
+  );
+}
+
 function normalizeNotificationTimestamp(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
@@ -3094,7 +3107,8 @@ export function useThreadSessionState(params: {
           const shouldClearStaleThinking =
             readResponseThreadStatus(response) === "idle" &&
             thinkingReasons.length > 0 &&
-            !hasPendingInteraction(current);
+            !hasPendingInteraction(current) &&
+            !responseHasInProgressTurn(responseWithLoadedHistory, current.activeTurnId);
 
           if (shouldClearStaleThinking) {
             if (targetThread.optimisticActiveTurn) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1373,9 +1373,14 @@ function responseHasInProgressTurn(
     return false;
   }
 
-  return response.replay.entries.some(
-    (entry) => entry.turn?.id === turnId && entry.turn.status === "in_progress"
+  const turnEntries = response.replay.entries.filter(
+    (entry) => entry.turn?.id === turnId
   );
+  if (turnEntries.some((entry) => isCompletedTurnMetadata(entry.turn))) {
+    return false;
+  }
+
+  return turnEntries.some((entry) => entry.turn?.status === "in_progress");
 }
 
 function normalizeNotificationTimestamp(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary

- Review turns now stay attached when an idle thread read races with hydrated replay data that still shows the review turn in progress.
- This prevents a sibling Codex `turn/started` notification from taking over the renderer state and leaving the thread stuck as thinking after the matching review completion arrives.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx -- --runInBand`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

## Notes

- Investigated the stuck default-profile thread `019f0cb3-9d9e-7cf1-b17f-28a472ee3e84`; logs showed the review turn completed while the renderer had adopted a sibling active turn id.
- The fix commit is signed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
