### PR TITLE
fix(desktop): pause idle navigation polling

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6,11 +6,13 @@ import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
 
 const codexClientLogError = vi.hoisted(() => vi.fn());
+const codexClientLogDebug = vi.hoisted(() => vi.fn());
 const codexClientLogInfo = vi.hoisted(() => vi.fn());
 const codexClientLogWarn = vi.hoisted(() => vi.fn());
 
 vi.mock("../log", () => ({
   getMainLogger: vi.fn(() => ({
+    debug: codexClientLogDebug,
     error: codexClientLogError,
     info: codexClientLogInfo,
     warn: codexClientLogWarn,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -370,7 +370,7 @@ function logDebug(event: string, payload: Record<string, unknown>): void {
     return;
   }
 
-  backendRegistryLog.info(event, payload);
+  backendRegistryLog.debug(event, payload);
 }
 
 async function pathExists(filePath: string): Promise<boolean> {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -283,7 +283,7 @@ function logCodexClientDebug(event: string, payload: Record<string, unknown>): v
     return;
   }
 
-  codexClientLog.info(event, payload);
+  codexClientLog.debug(event, payload);
 }
 
 function isApprovalLikeMethod(method: string): boolean {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1045,6 +1045,83 @@ describe("useThreadNavigation", () => {
     unmount();
   });
 
+  it("pauses opt-in foreground background polling while navigation is idle", async () => {
+    let intervalHandler: (() => void) | undefined;
+    const originalSetInterval = globalThis.setInterval;
+    vi.spyOn(globalThis, "setInterval").mockImplementation((handler, timeout, ...args) => {
+      if (timeout !== 5 * 60_000) {
+        return originalSetInterval(handler, timeout, ...args);
+      }
+      intervalHandler = typeof handler === "function" ? () => handler() : undefined;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+    const dateNowSpy = vi.spyOn(Date, "now");
+    dateNowSpy.mockReturnValue(1_000_000);
+
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit" as const,
+          summary: "First thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+    };
+
+    const { result, unmount } = renderHook(() =>
+      useThreadNavigation(desktopApi, { lightweightNavigationRefresh: true }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    expect(intervalHandler).toBeDefined();
+
+    dateNowSpy.mockReturnValue(1_000_000 + 31 * 60_000);
+    act(() => {
+      intervalHandler?.();
+    });
+
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+
+    dateNowSpy.mockReturnValue(1_000_000 + 31 * 60_000 + 1_000);
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+        forceRefresh: true,
+        refreshMode: "active-recent",
+      });
+    });
+
+    unmount();
+  });
+
   it("uses the ordinary scheduled refresh on focus by default", async () => {
     let focusListener: (() => void) | undefined;
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -72,8 +72,15 @@ export type CreatingThreadState = {
 const ROOT_NEW_THREAD_WORKSPACE_LAUNCHPAD_KEY = "workspace:new-thread";
 const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
+const NAVIGATION_BACKGROUND_REFRESH_IDLE_AFTER_MS = 30 * 60_000;
 const NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS = 60_000;
 const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
+const NAVIGATION_ACTIVITY_EVENTS = [
+  "input",
+  "keydown",
+  "paste",
+  "pointerdown",
+] as const;
 
 function normalizeBrowseMode(value: unknown): BrowseMode {
   return value === "inbox" || value === "recents" || value === "directories"
@@ -2238,6 +2245,8 @@ export function useThreadNavigation(
   const focusRefreshInFlightRef = useRef(false);
   const focusRefreshQueuedRef = useRef(false);
   const lastFocusRefreshCompletedAtRef = useRef(0);
+  const lastNavigationActivityAtRef = useRef(Date.now());
+  const backgroundRefreshIdleRef = useRef(false);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
   const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
@@ -2565,6 +2574,37 @@ export function useThreadNavigation(
     scheduledFocusRefreshTimerRef.current = setTimeout(runRefresh, delayMs);
   }, [refresh]);
 
+  const markNavigationActivity = useCallback(
+    (options: { refreshOnIdleResume?: boolean } = {}): void => {
+      const wasIdle = backgroundRefreshIdleRef.current;
+      lastNavigationActivityAtRef.current = Date.now();
+      backgroundRefreshIdleRef.current = false;
+
+      if (!wasIdle || options.refreshOnIdleResume === false) {
+        return;
+      }
+
+      if (
+        !enabled ||
+        !desktopApi?.getNavigationSnapshot ||
+        (lightweightNavigationRefresh && !isRendererViewForeground())
+      ) {
+        return;
+      }
+
+      scheduleRefresh(undefined, undefined, false, {
+        forceRefresh: true,
+        refreshMode: lightweightNavigationRefresh ? "active-recent" : undefined,
+      });
+    },
+    [
+      desktopApi?.getNavigationSnapshot,
+      enabled,
+      lightweightNavigationRefresh,
+      scheduleRefresh,
+    ]
+  );
+
   useEffect(() => {
     return () => {
       if (scheduledRefreshTimerRef.current !== undefined) {
@@ -2598,6 +2638,28 @@ export function useThreadNavigation(
   }, []);
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleNavigationActivity = () => {
+      markNavigationActivity();
+    };
+
+    for (const eventName of NAVIGATION_ACTIVITY_EVENTS) {
+      window.addEventListener(eventName, handleNavigationActivity, { capture: true });
+    }
+
+    return () => {
+      for (const eventName of NAVIGATION_ACTIVITY_EVENTS) {
+        window.removeEventListener(eventName, handleNavigationActivity, {
+          capture: true,
+        });
+      }
+    };
+  }, [markNavigationActivity]);
+
+  useEffect(() => {
     if (!enabled) {
       prChipLocationIndexRef.current = undefined;
       setState({
@@ -2622,6 +2684,12 @@ export function useThreadNavigation(
     }
 
     const timer = setInterval(() => {
+      const idleMs = Date.now() - lastNavigationActivityAtRef.current;
+      if (idleMs >= NAVIGATION_BACKGROUND_REFRESH_IDLE_AFTER_MS) {
+        backgroundRefreshIdleRef.current = true;
+        return;
+      }
+
       scheduleRefresh(undefined, undefined, false, {
         forceRefresh: true,
         refreshMode: lightweightNavigationRefresh ? "active-recent" : undefined,
@@ -2645,6 +2713,7 @@ export function useThreadNavigation(
     }
 
     return desktopApi.onWindowFocus(() => {
+      markNavigationActivity({ refreshOnIdleResume: false });
       if (lightweightNavigationRefresh) {
         scheduleFocusRefresh();
         return;
@@ -2655,6 +2724,7 @@ export function useThreadNavigation(
     desktopApi,
     enabled,
     lightweightNavigationRefresh,
+    markNavigationActivity,
     scheduleFocusRefresh,
     scheduleRefresh,
   ]);
@@ -2665,6 +2735,7 @@ export function useThreadNavigation(
     }
 
     return desktopApi.onAgentEvent((event) => {
+      markNavigationActivity({ refreshOnIdleResume: false });
       const method = event.notification.method as string;
       if (method === "navigation/directoryGitStatus/updated") {
         const params = event.notification
@@ -3174,7 +3245,7 @@ export function useThreadNavigation(
         scheduleRefresh();
       }
     });
-  }, [desktopApi, enabled, scheduleRefresh, state.response]);
+  }, [desktopApi, enabled, markNavigationActivity, scheduleRefresh, state.response]);
 
   // Bindings live in the navigation snapshot but are mutated outside
   // the agent-event bus (a Telegram callback creates a binding, a
@@ -3186,9 +3257,10 @@ export function useThreadNavigation(
       return;
     }
     return desktopApi.onMessagingBindingsChanged(() => {
+      markNavigationActivity({ refreshOnIdleResume: false });
       scheduleRefresh();
     });
-  }, [desktopApi, enabled, scheduleRefresh]);
+  }, [desktopApi, enabled, markNavigationActivity, scheduleRefresh]);
 
   const threads = useMemo(() => {
     const currentThreads = state.response?.threads ?? [];


### PR DESCRIPTION
## Summary

- Idle desktop windows now stop issuing the five-minute navigation snapshot refresh after 30 minutes without user, agent, or messaging activity.
- Keyboard/input/pointer activity resumes lightweight foreground polling with one active-recent refresh, while native focus, agent events, and messaging binding changes continue using their existing refresh paths without duplicate work.
- Repetitive thread-list cache/page diagnostics now stay available at DEBUG instead of filling normal INFO logs in development.

## Verification

- I verified `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- I verified `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- I verified `pnpm --filter @pwragent/desktop typecheck`

## Notes

- This specifically targets the long-idle foreground dev-instance log pattern where no clicks, typing, agent notifications, or messaging binding activity happened for hours.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
