### PR TITLE
feat(desktop): add same-thread workspace moves

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14930,7 +14930,7 @@ script = "printf setup"
         params: {
           threadId: "ordinary-thread",
           turnId: "turn-1",
-          turn: { id: "turn-1" },
+          turn: { id: "turn-1", status: "completed", output: [] },
         },
       },
     });
@@ -15086,7 +15086,7 @@ script = "printf setup"
         params: {
           threadId: "ordinary-thread",
           turnId: "turn-1",
-          turn: { id: "turn-1" },
+          turn: { id: "turn-1", status: "completed", output: [] },
         },
       },
     });
@@ -15186,7 +15186,7 @@ script = "printf setup"
         params: {
           threadId: "ordinary-thread",
           turnId: "turn-1",
-          turn: { id: "turn-1" },
+          turn: { id: "turn-1", status: "completed", output: [] },
         },
       },
     });
@@ -15321,7 +15321,7 @@ script = "printf setup"
         params: {
           threadId: "ordinary-thread",
           turnId: "turn-1",
-          turn: { id: "turn-1" },
+          turn: { id: "turn-1", status: "completed", output: [] },
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14442,7 +14442,16 @@ script = "printf setup"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "default",
+            extraLinkedDirectories: thread.linkedDirectories ?? [],
+          },
+        },
+      }),
       gitWorkspaceHandoffService: {
         handoff,
       } as never,
@@ -14490,6 +14499,32 @@ script = "printf setup"
     });
     expect(handoff).not.toHaveBeenCalled();
 
+    const duplicateResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-2",
+        requestId: "move-call-1b",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+          leaveLocalBranch: "main",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const duplicatePayload = JSON.parse(
+      (duplicateResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(duplicatePayload).toMatchObject({
+      workspaceMoveId: payload.workspaceMoveId,
+      status: "queued",
+      sourcePath: "/repo/app",
+    });
+    expect(handoff).not.toHaveBeenCalled();
+
     const statusResponse = await codexClient.emitRequest({
       method: "item/tool/call",
       params: {
@@ -14517,6 +14552,275 @@ script = "printf setup"
         sourcePath: "/repo/app",
       }),
     ]);
+
+    const searchResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "search-call-1",
+        requestId: "search-call-1",
+        namespace: "pwragent",
+        tool: "search_threads",
+        arguments: {
+          backend: "codex",
+          query: "workspace-move",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const searchPayload = JSON.parse(
+      (searchResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(searchPayload.pendingWorkspaceMoves).toEqual([
+      expect.objectContaining({
+        workspaceMoveId:
+          "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
+        status: "queued",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("drains same-thread workspace moves from idle status boundaries", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      gitBranch: "feature/handoff",
+      updatedAt: 1000,
+    };
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "ordinary-thread",
+      direction: "local-to-worktree" as const,
+      workMode: "worktree" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:ordinary-thread",
+        kind: "worktree" as const,
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "default",
+            extraLinkedDirectories: thread.linkedDirectories ?? [],
+          },
+        },
+      }),
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "ordinary-thread",
+          status: { type: "idle" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(handoff).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "ordinary-thread",
+        direction: "local-to-worktree",
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+      });
+    });
+    await registry.close();
+  });
+
+  it("rejects invalid same-thread workspace move requests before handoff", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+        {
+          id: "directory:/repo/other",
+          kind: "local",
+          label: "other",
+          path: "/repo/other",
+        },
+      ],
+      updatedAt: 1000,
+    };
+    const handoff = vi.fn();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "active",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "default",
+            extraLinkedDirectories: thread.linkedDirectories ?? [],
+          },
+        },
+      }),
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+
+    async function callMove(
+      callId: string,
+      args: Record<string, unknown>,
+      turnId = "turn-1",
+    ) {
+      const response = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId,
+          callId,
+          requestId: callId,
+          namespace: "pwragent",
+          tool: "move_thread_workspace",
+          arguments: args,
+        },
+      } as AppServerPendingRequestNotification);
+      return JSON.parse(
+        (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+      );
+    }
+
+    await expect(callMove("move-call-no-turn", {})).resolves.toMatchObject({
+      code: "forbidden",
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await expect(
+      callMove("move-call-wrong-turn", {}, "turn-2"),
+    ).resolves.toMatchObject({
+      code: "forbidden",
+    });
+    const ambiguousPayload = await callMove("move-call-ambiguous", {});
+    expect(ambiguousPayload).toMatchObject({
+      code: "ambiguous_workspace",
+    });
+    await expect(
+      callMove("move-call-backend", {
+        backend: "grok",
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+      }),
+    ).resolves.toMatchObject({
+      code: "unsupported_backend",
+    });
+    await expect(
+      callMove("move-call-direction", {
+        direction: "worktree-to-local",
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+      }),
+    ).resolves.toMatchObject({
+      code: "unsupported_workspace",
+    });
+    expect(handoff).not.toHaveBeenCalled();
 
     await registry.close();
   });
@@ -14664,6 +14968,267 @@ script = "printf setup"
         : "";
     expect(prompt).toContain("PwrAgent workspace move completed");
     expect(prompt).toContain("New runtime cwd: /repo/app/.worktrees/app-feature-handoff");
+    await registry.close();
+  });
+
+  it("reports failed same-thread workspace moves through a continuation", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      gitBranch: "feature/handoff",
+      updatedAt: 1000,
+    };
+    const handoff = vi.fn(async () => {
+      throw new Error("worktree setup failed");
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "ordinary-thread",
+      });
+    });
+    const prompt =
+      codexClient.lastStartTurnParams?.input[0]?.type === "text"
+        ? codexClient.lastStartTurnParams.input[0].text
+        : "";
+    expect(prompt).toContain("PwrAgent workspace move failed");
+    expect(prompt).toContain("worktree setup failed");
+    expect(prompt).toContain("original runtime workspace remains authoritative");
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-2",
+          turn: { id: "turn-2" },
+        },
+      },
+    });
+    const statusResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-2",
+        callId: "status-call-1",
+        requestId: "status-call-1",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "ordinary-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const statusPayload = JSON.parse(
+      (statusResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(statusPayload.thread.pendingWorkspaceMoves).toEqual([
+      expect.objectContaining({
+        workspaceMoveId:
+          "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
+        status: "failed",
+        phase: "failed",
+        error: "worktree setup failed",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("keeps failed workspace move state when failure continuation cannot start", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      updatedAt: 1000,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+      startTurnError: new Error("continuation boom"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitWorkspaceHandoffService: {
+        handoff: vi.fn(async () => {
+          throw new Error("worktree setup failed");
+        }),
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(1);
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-2",
+          turn: { id: "turn-2" },
+        },
+      },
+    });
+    const statusResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-2",
+        callId: "status-call-1",
+        requestId: "status-call-1",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "ordinary-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const statusPayload = JSON.parse(
+      (statusResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(statusPayload.thread.pendingWorkspaceMoves).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        phase: "failed",
+        error: "continuation boom",
+        message: expect.stringContaining("failure continuation also failed"),
+      }),
+    ]);
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14798,6 +14798,14 @@ script = "printf setup"
     ).resolves.toMatchObject({
       code: "forbidden",
     });
+    await expect(
+      callMove("move-call-unlinked-path", {
+        repositoryPath: "/repo/unlinked",
+        sourcePath: "/repo/unlinked",
+      }),
+    ).resolves.toMatchObject({
+      code: "unsupported_workspace",
+    });
     const ambiguousPayload = await callMove("move-call-ambiguous", {});
     expect(ambiguousPayload).toMatchObject({
       code: "ambiguous_workspace",
@@ -14968,6 +14976,137 @@ script = "printf setup"
         : "";
     expect(prompt).toContain("PwrAgent workspace move completed");
     expect(prompt).toContain("New runtime cwd: /repo/app/.worktrees/app-feature-handoff");
+    await registry.close();
+  });
+
+  it("starts the workspace move continuation before queued same-thread turns", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      gitBranch: "feature/handoff",
+      updatedAt: 1000,
+    };
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "ordinary-thread",
+      direction: "local-to-worktree" as const,
+      workMode: "worktree" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:ordinary-thread",
+        kind: "worktree" as const,
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "default",
+            extraLinkedDirectories: thread.linkedDirectories ?? [],
+          },
+        },
+      }),
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await expect(
+      registry.submitTurn({
+        backend: "codex",
+        threadId: "ordinary-thread",
+        input: [{ type: "text", text: "queued normal turn" }],
+      }),
+    ).resolves.toMatchObject({ status: "queued" });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCalls.length).toBe(1);
+    });
+    const firstInput = codexClient.startTurnCalls[0]?.input[0];
+    expect(firstInput).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("PwrAgent workspace move completed"),
+    });
+    expect(codexClient.startTurnCalls).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          input: [{ type: "text", text: "queued normal turn" }],
+        }),
+      ]),
+    );
+
     await registry.close();
   });
 
@@ -15224,10 +15363,13 @@ script = "printf setup"
       expect.objectContaining({
         status: "failed",
         phase: "failed",
-        error: "continuation boom",
+        error: expect.stringContaining("Workspace handoff failed: worktree setup failed"),
         message: expect.stringContaining("failure continuation also failed"),
       }),
     ]);
+    expect(statusPayload.thread.pendingWorkspaceMoves[0].error).toContain(
+      "failure continuation failed: continuation boom",
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14407,6 +14407,266 @@ script = "printf setup"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("queues same-thread workspace moves from a live dynamic tool call", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      updatedAt: 1000,
+    };
+    const handoff = vi.fn();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "active",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+          leaveLocalBranch: "main",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      workspaceMoveId: "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
+      status: "queued",
+      phase: "waiting_for_turn_boundary",
+      direction: "local-to-worktree",
+      sourcePath: "/repo/app",
+      leaveLocalBranch: "main",
+      message: expect.stringContaining("Stop this turn"),
+    });
+    expect(handoff).not.toHaveBeenCalled();
+
+    const statusResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "status-call-1",
+        requestId: "status-call-1",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "ordinary-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const statusPayload = JSON.parse(
+      (statusResponse as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(statusPayload.thread.pendingWorkspaceMoves).toEqual([
+      expect.objectContaining({
+        workspaceMoveId:
+          "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
+        status: "queued",
+        phase: "waiting_for_turn_boundary",
+        sourcePath: "/repo/app",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("runs queued same-thread workspace moves after the invoking turn ends", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      gitBranch: "feature/handoff",
+      updatedAt: 1000,
+    };
+    const overlayStore = createOverlayStoreMock();
+    const handoff = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "ordinary-thread",
+      direction: "local-to-worktree" as const,
+      workMode: "worktree" as const,
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:ordinary-thread",
+        kind: "worktree" as const,
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      },
+      warnings: [],
+      completedAt: 1000,
+    }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => {});
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      gitDirectoryService: {
+        recordCodexWorktreeOwnerThread,
+      } as never,
+      gitWorkspaceHandoffService: {
+        handoff,
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+          leaveLocalBranch: "main",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(handoff).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "ordinary-thread",
+        direction: "local-to-worktree",
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+        leaveLocalBranch: "main",
+      });
+    });
+    await vi.waitFor(() => {
+      expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
+        threadId: "ordinary-thread",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      });
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "ordinary-thread",
+      }),
+    ).resolves.toMatchObject({
+      extraLinkedDirectories: [
+        expect.objectContaining({
+          id: "pwragent-handoff:codex:ordinary-thread",
+          kind: "worktree",
+          worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+        }),
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.lastStartTurnParams).toMatchObject({
+        threadId: "ordinary-thread",
+      });
+    });
+    const prompt =
+      codexClient.lastStartTurnParams?.input[0]?.type === "text"
+        ? codexClient.lastStartTurnParams.input[0].text
+        : "";
+    expect(prompt).toContain("PwrAgent workspace move completed");
+    expect(prompt).toContain("New runtime cwd: /repo/app/.worktrees/app-feature-handoff");
+    await registry.close();
+  });
+
   it("creates new-worktree handoff threads when inherited environment setup is unavailable", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-env-missing-"));
     const repoPath = path.join(root, "repo");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14493,6 +14493,7 @@ script = "printf setup"
       status: "queued",
       phase: "waiting_for_turn_boundary",
       direction: "local-to-worktree",
+      strategy: "move-branch",
       sourcePath: "/repo/app",
       leaveLocalBranch: "main",
       message: expect.stringContaining("Stop this turn"),
@@ -14521,6 +14522,7 @@ script = "printf setup"
     expect(duplicatePayload).toMatchObject({
       workspaceMoveId: payload.workspaceMoveId,
       status: "queued",
+      strategy: "move-branch",
       sourcePath: "/repo/app",
     });
     expect(handoff).not.toHaveBeenCalled();
@@ -14549,6 +14551,7 @@ script = "printf setup"
           "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
         status: "queued",
         phase: "waiting_for_turn_boundary",
+        strategy: "move-branch",
         sourcePath: "/repo/app",
       }),
     ]);
@@ -14577,6 +14580,7 @@ script = "printf setup"
         workspaceMoveId:
           "workspace-move:codex:ordinary-thread:turn-1:move-call-1",
         status: "queued",
+        strategy: "move-branch",
       }),
     ]);
 
@@ -14692,10 +14696,141 @@ script = "printf setup"
         backend: "codex",
         threadId: "ordinary-thread",
         direction: "local-to-worktree",
+        strategy: "detached-changes",
         repositoryPath: "/repo/app",
         sourcePath: "/repo/app",
       });
     });
+    await registry.close();
+  });
+
+  it("reports running workspace moves as in-progress quit work", async () => {
+    const handoffDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      direction: "local-to-worktree";
+      workMode: "worktree";
+      branch: string;
+      repositoryPath: string;
+      targetPath: string;
+      linkedDirectory: LinkedDirectorySummary;
+      warnings: string[];
+      completedAt: number;
+    }>();
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      gitBranch: "feature/handoff",
+      updatedAt: 1000,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "default",
+            extraLinkedDirectories: thread.linkedDirectories ?? [],
+          },
+        },
+      }),
+      gitWorkspaceHandoffService: {
+        handoff: vi.fn(async () => await handoffDeferred.promise),
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+        count: 1,
+        threadIds: ["codex:ordinary-thread"],
+      });
+    });
+
+    handoffDeferred.resolve({
+      backend: "codex",
+      threadId: "ordinary-thread",
+      direction: "local-to-worktree",
+      workMode: "worktree",
+      branch: "feature/handoff",
+      repositoryPath: "/repo/app",
+      targetPath: "/repo/app/.worktrees/app-feature-handoff",
+      linkedDirectory: {
+        id: "pwragent-handoff:codex:ordinary-thread",
+        kind: "worktree",
+        label: "app",
+        path: "/repo/app",
+        worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+      },
+      warnings: [],
+      completedAt: 1000,
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(1);
+    });
+
     await registry.close();
   });
 
@@ -14940,6 +15075,7 @@ script = "printf setup"
         backend: "codex",
         threadId: "ordinary-thread",
         direction: "local-to-worktree",
+        strategy: "move-branch",
         repositoryPath: "/repo/app",
         sourcePath: "/repo/app",
         leaveLocalBranch: "main",
@@ -15300,6 +15436,13 @@ script = "printf setup"
         },
       },
     });
+    await expect(
+      registry.submitTurn({
+        backend: "codex",
+        threadId: "ordinary-thread",
+        input: [{ type: "text", text: "queued normal turn" }],
+      }),
+    ).resolves.toMatchObject({ status: "queued" });
     await codexClient.emitRequest({
       method: "item/tool/call",
       params: {
@@ -15326,7 +15469,15 @@ script = "printf setup"
       },
     });
     await vi.waitFor(() => {
-      expect(codexClient.startTurnCallCount).toBe(1);
+      expect(codexClient.startTurnCallCount).toBe(2);
+    });
+    expect(registry.canStartThreadTurnImmediately({
+      backend: "codex",
+      threadId: "ordinary-thread",
+    })).toBe(true);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
     });
 
     await registry.publishLocalEvent({
@@ -15370,6 +15521,161 @@ script = "printf setup"
     expect(statusPayload.thread.pendingWorkspaceMoves[0].error).toContain(
       "failure continuation failed: continuation boom",
     );
+
+    await registry.close();
+  });
+
+  it("releases queued turns when success continuation cannot start", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "ordinary-thread",
+      title: "Parent Thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          kind: "local",
+          label: "app",
+          path: "/repo/app",
+        },
+      ],
+      updatedAt: 1000,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read", "turn/start"] },
+      threads: [thread],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+      startTurnError: new Error("continuation boom"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      gitWorkspaceHandoffService: {
+        handoff: vi.fn(async () => ({
+          backend: "codex" as const,
+          threadId: "ordinary-thread",
+          direction: "local-to-worktree" as const,
+          workMode: "worktree" as const,
+          branch: "feature/handoff",
+          repositoryPath: "/repo/app",
+          targetPath: "/repo/app/.worktrees/app-feature-handoff",
+          linkedDirectory: {
+            id: "pwragent-handoff:codex:ordinary-thread",
+            kind: "worktree" as const,
+            label: "app",
+            path: "/repo/app",
+            worktreePath: "/repo/app/.worktrees/app-feature-handoff",
+          },
+          warnings: [],
+          completedAt: 1000,
+        })),
+      } as never,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await expect(
+      registry.submitTurn({
+        backend: "codex",
+        threadId: "ordinary-thread",
+        input: [{ type: "text", text: "queued normal turn" }],
+      }),
+    ).resolves.toMatchObject({ status: "queued" });
+    await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "move-call-1",
+        requestId: "move-call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          sourcePath: "/repo/app",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(codexClient.startTurnCallCount).toBe(2);
+    });
+    expect(registry.canStartThreadTurnImmediately({
+      backend: "codex",
+      threadId: "ordinary-thread",
+    })).toBe(true);
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-2",
+          turn: { id: "turn-2" },
+        },
+      },
+    });
+    const statusResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-2",
+        callId: "status-call-1",
+        requestId: "status-call-1",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "ordinary-thread",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const statusPayload = JSON.parse(
+      (statusResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(statusPayload.thread.pendingWorkspaceMoves).toEqual([
+      expect.objectContaining({
+        status: "completed",
+        phase: "completed",
+        error: "continuation boom",
+        message: expect.stringContaining("continuation failed"),
+      }),
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -35,6 +35,26 @@ describe("pwragent thread orchestration agent tools", () => {
       }),
       expect.objectContaining({
         namespace: "pwragent",
+        name: "move_thread_workspace",
+        description: expect.stringContaining("same-thread continuation"),
+        deferLoading: false,
+        inputSchema: expect.objectContaining({
+          additionalProperties: false,
+          properties: expect.objectContaining({
+            direction: expect.objectContaining({
+              enum: ["local-to-worktree", "worktree-to-local"],
+            }),
+            strategy: expect.objectContaining({
+              enum: ["move-branch", "detached-changes", "new-branch"],
+            }),
+            sourcePath: expect.objectContaining({
+              description: expect.stringContaining("multiple linked directories"),
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        namespace: "pwragent",
         name: "send_message_to_thread",
         deferLoading: false,
         inputSchema: expect.objectContaining({
@@ -114,6 +134,46 @@ describe("pwragent thread orchestration agent tools", () => {
             backend: "codex",
             threadId: "target-thread",
             prompt: "  ",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("validates move_thread_workspace before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "move_thread_workspace",
+          arguments: {
+            direction: "sideways",
+            sourcePath: "/repo/app",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-2",
+          namespace: "pwragent",
+          tool: "move_thread_workspace",
+          arguments: {
+            sourcePath: "  ",
           },
         },
       }),
@@ -247,6 +307,59 @@ describe("pwragent thread orchestration agent tools", () => {
         prompt: "Check CI",
         model: "gpt-5.5",
         fastMode: true,
+      },
+    });
+  });
+
+  it("normalizes move_thread_workspace args and dispatches with caller context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        workspaceMoveId: "workspace-move:codex:thread-1:turn-1:call-1",
+        status: "queued" as const,
+        phase: "waiting_for_turn_boundary" as const,
+        direction: "local-to-worktree" as const,
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+        createdAt: 1_773_000_000_000,
+        updatedAt: 1_773_000_000_000,
+        message:
+          "Workspace move queued. Stop this turn and wait for the continuation.",
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "move_thread_workspace",
+        arguments: {
+          repositoryPath: " /repo/app ",
+          sourcePath: " /repo/app ",
+          leaveLocalBranch: " main ",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "move_thread_workspace",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        direction: "local-to-worktree",
+        repositoryPath: "/repo/app",
+        sourcePath: "/repo/app",
+        leaveLocalBranch: "main",
       },
     });
   });

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -71,11 +71,11 @@ function descriptionForOperation(
 ): string {
   switch (operation) {
     case "search_threads":
-      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread. The response may include pendingHandoffs for handoff_task calls from this thread that are still creating a child thread; do not retry those handoffs while they are starting.";
+      return "Search known PwrAgent threads by title, summary, Agent metadata, backend, and linked directory. Omit query to inspect recent lightweight thread candidates before choosing a thread. The response may include pendingHandoffs for handoff_task calls that are still creating a child thread and pendingWorkspaceMoves for move_thread_workspace calls that are still moving the same thread; do not retry those operations while they are starting.";
     case "read_thread":
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
-      return "Read status and compact metadata for a known PwrAgent thread, including pendingHandoffs when this thread has child handoffs that are still being created.";
+      return "Read status and compact metadata for a known PwrAgent thread, including pendingHandoffs when this thread has child handoffs that are still being created and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -4,6 +4,7 @@ import type {
   HandoffTaskSeedMode,
   HandoffTaskToolArgs,
   HandoffTaskWorkspaceMode,
+  MoveThreadWorkspaceToolArgs,
   PwrAgentThreadOrchestrationOperationName,
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
@@ -29,6 +30,17 @@ import { AgentToolRouter } from "./agent-tool-router.js";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE =
   "PwrAgent thread handoff tools are not available.";
+
+const MOVE_THREAD_WORKSPACE_DIRECTIONS = [
+  "local-to-worktree",
+  "worktree-to-local",
+] as const;
+
+const MOVE_THREAD_WORKSPACE_STRATEGIES = [
+  "move-branch",
+  "detached-changes",
+  "new-branch",
+] as const;
 
 export type PwrAgentThreadOrchestrationHandler = (
   request: PwrAgentThreadOrchestrationRequest,
@@ -96,6 +108,8 @@ function descriptionForOperation(
   switch (operation) {
     case "handoff_task":
       return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree. Handoff startup can take several minutes while a worktree or Codex environment is prepared; if this call appears slow or uncertain, do not call handoff_task again. Use search_threads or get_thread_status and inspect pendingHandoffs until a threadId appears or the handoff reports failed.";
+    case "move_thread_workspace":
+      return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
       return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead.";
   }
@@ -165,6 +179,51 @@ function inputSchemaForOperation(
           },
         },
       };
+    case "move_thread_workspace":
+      return {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          backend: {
+            type: "string",
+            description:
+              "Optional backend override. Omitted defaults to the invoking thread backend; the first implementation supports Codex self-move only.",
+          },
+          direction: {
+            type: "string",
+            enum: MOVE_THREAD_WORKSPACE_DIRECTIONS,
+            description:
+              "`local-to-worktree` is the default and first supported direction. `worktree-to-local` is reserved for compatible backends and may be rejected until implemented.",
+          },
+          strategy: {
+            type: "string",
+            enum: MOVE_THREAD_WORKSPACE_STRATEGIES,
+            description:
+              "Optional workspace handoff branch strategy using the existing PwrAgent workspace handoff vocabulary.",
+          },
+          repositoryPath: {
+            type: "string",
+            description:
+              "Repository/local checkout path that owns the worktree relationship.",
+          },
+          sourcePath: {
+            type: "string",
+            description:
+              "Current workspace path to move. Provide this when the thread has multiple linked directories or the intended source path is not obvious.",
+          },
+          sourceBranch: { type: "string" },
+          leaveLocalBranch: {
+            type: "string",
+            description:
+              "Branch/ref to leave checked out in the local checkout when moving the current branch to a worktree.",
+          },
+          newBranchName: {
+            type: "string",
+            description:
+              "Optional new branch name for the workspace handoff when strategy=new-branch.",
+          },
+        },
+      };
     case "send_message_to_thread":
       return {
         type: "object",
@@ -199,10 +258,16 @@ function inputSchemaForOperation(
 function normalizeArgsForOperation(
   operation: PwrAgentThreadOrchestrationOperationName,
   args: Record<string, unknown>,
-): HandoffTaskToolArgs | SendMessageToThreadToolArgs | undefined {
+):
+  | HandoffTaskToolArgs
+  | MoveThreadWorkspaceToolArgs
+  | SendMessageToThreadToolArgs
+  | undefined {
   switch (operation) {
     case "handoff_task":
       return normalizeHandoffTaskArgs(args);
+    case "move_thread_workspace":
+      return normalizeMoveThreadWorkspaceArgs(args);
     case "send_message_to_thread":
       return normalizeSendMessageToThreadArgs(args);
   }
@@ -214,6 +279,8 @@ function invalidArgumentsMessageForOperation(
   switch (operation) {
     case "handoff_task":
       return "handoff_task requires a non-empty task string.";
+    case "move_thread_workspace":
+      return "move_thread_workspace accepts only known direction/strategy values and non-empty string fields.";
     case "send_message_to_thread":
       return "send_message_to_thread requires non-empty backend, threadId, and prompt strings.";
   }
@@ -336,6 +403,66 @@ function normalizeSendMessageToThreadArgs(
       : {}),
     ...(readTrimmedString(args.sandbox)
       ? { sandbox: readTrimmedString(args.sandbox) }
+      : {}),
+  };
+}
+
+function normalizeMoveThreadWorkspaceArgs(
+  args: Record<string, unknown>,
+): MoveThreadWorkspaceToolArgs | undefined {
+  const direction =
+    args.direction === undefined
+      ? "local-to-worktree"
+      : readChoice(args.direction, MOVE_THREAD_WORKSPACE_DIRECTIONS);
+  if (!direction) {
+    return undefined;
+  }
+  const strategy =
+    args.strategy === undefined
+      ? undefined
+      : readChoice(args.strategy, MOVE_THREAD_WORKSPACE_STRATEGIES);
+  if (args.strategy !== undefined && !strategy) {
+    return undefined;
+  }
+
+  const optionalStringFields = [
+    "backend",
+    "repositoryPath",
+    "sourcePath",
+    "sourceBranch",
+    "leaveLocalBranch",
+    "newBranchName",
+  ] as const;
+  for (const field of optionalStringFields) {
+    if (Object.hasOwn(args, field) && !readTrimmedString(args[field])) {
+      return undefined;
+    }
+  }
+
+  return {
+    direction,
+    ...(strategy ? { strategy } : {}),
+    ...(readTrimmedString(args.backend)
+      ? {
+          backend: readTrimmedString(
+            args.backend,
+          ) as MoveThreadWorkspaceToolArgs["backend"],
+        }
+      : {}),
+    ...(readTrimmedString(args.repositoryPath)
+      ? { repositoryPath: readTrimmedString(args.repositoryPath) }
+      : {}),
+    ...(readTrimmedString(args.sourcePath)
+      ? { sourcePath: readTrimmedString(args.sourcePath) }
+      : {}),
+    ...(readTrimmedString(args.sourceBranch)
+      ? { sourceBranch: readTrimmedString(args.sourceBranch) }
+      : {}),
+    ...(readTrimmedString(args.leaveLocalBranch)
+      ? { leaveLocalBranch: readTrimmedString(args.leaveLocalBranch) }
+      : {}),
+    ...(readTrimmedString(args.newBranchName)
+      ? { newBranchName: readTrimmedString(args.newBranchName) }
       : {}),
   };
 }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -11,6 +11,7 @@ import type {
   SendMessageToThreadToolArgs,
 } from "@pwragent/shared";
 import {
+  DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
   HANDOFF_TASK_GROUPING_MODES,
   HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
   HANDOFF_TASK_SEED_MODES,
@@ -190,7 +191,7 @@ function inputSchemaForOperation(
             type: "string",
             enum: THREAD_WORKSPACE_HANDOFF_STRATEGIES,
             description:
-              "Optional workspace handoff branch strategy using the existing PwrAgent workspace handoff vocabulary.",
+              `Optional workspace handoff branch strategy using the existing PwrAgent workspace handoff vocabulary. Defaults to ${DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY} unless leaveLocalBranch or newBranchName implies a branch strategy.`,
           },
           repositoryPath: {
             type: "string",

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -17,6 +17,8 @@ import {
   HANDOFF_TASK_WORKSPACE_MODES,
   PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
   PWRAGENT_TOOL_NAMESPACE,
+  THREAD_WORKSPACE_HANDOFF_DIRECTIONS,
+  THREAD_WORKSPACE_HANDOFF_STRATEGIES,
 } from "@pwragent/shared";
 import type {
   AgentToolDefinition,
@@ -30,17 +32,6 @@ import { AgentToolRouter } from "./agent-tool-router.js";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_UNAVAILABLE_MESSAGE =
   "PwrAgent thread handoff tools are not available.";
-
-const MOVE_THREAD_WORKSPACE_DIRECTIONS = [
-  "local-to-worktree",
-  "worktree-to-local",
-] as const;
-
-const MOVE_THREAD_WORKSPACE_STRATEGIES = [
-  "move-branch",
-  "detached-changes",
-  "new-branch",
-] as const;
 
 export type PwrAgentThreadOrchestrationHandler = (
   request: PwrAgentThreadOrchestrationRequest,
@@ -191,13 +182,13 @@ function inputSchemaForOperation(
           },
           direction: {
             type: "string",
-            enum: MOVE_THREAD_WORKSPACE_DIRECTIONS,
+            enum: THREAD_WORKSPACE_HANDOFF_DIRECTIONS,
             description:
               "`local-to-worktree` is the default and first supported direction. `worktree-to-local` is reserved for compatible backends and may be rejected until implemented.",
           },
           strategy: {
             type: "string",
-            enum: MOVE_THREAD_WORKSPACE_STRATEGIES,
+            enum: THREAD_WORKSPACE_HANDOFF_STRATEGIES,
             description:
               "Optional workspace handoff branch strategy using the existing PwrAgent workspace handoff vocabulary.",
           },
@@ -413,14 +404,14 @@ function normalizeMoveThreadWorkspaceArgs(
   const direction =
     args.direction === undefined
       ? "local-to-worktree"
-      : readChoice(args.direction, MOVE_THREAD_WORKSPACE_DIRECTIONS);
+      : readChoice(args.direction, THREAD_WORKSPACE_HANDOFF_DIRECTIONS);
   if (!direction) {
     return undefined;
   }
   const strategy =
     args.strategy === undefined
       ? undefined
-      : readChoice(args.strategy, MOVE_THREAD_WORKSPACE_STRATEGIES);
+      : readChoice(args.strategy, THREAD_WORKSPACE_HANDOFF_STRATEGIES);
   if (args.strategy !== undefined && !strategy) {
     return undefined;
   }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -438,32 +438,22 @@ function normalizeMoveThreadWorkspaceArgs(
       return undefined;
     }
   }
+  const backend = readTrimmedString(args.backend);
+  const repositoryPath = readTrimmedString(args.repositoryPath);
+  const sourcePath = readTrimmedString(args.sourcePath);
+  const sourceBranch = readTrimmedString(args.sourceBranch);
+  const leaveLocalBranch = readTrimmedString(args.leaveLocalBranch);
+  const newBranchName = readTrimmedString(args.newBranchName);
 
   return {
     direction,
     ...(strategy ? { strategy } : {}),
-    ...(readTrimmedString(args.backend)
-      ? {
-          backend: readTrimmedString(
-            args.backend,
-          ) as MoveThreadWorkspaceToolArgs["backend"],
-        }
-      : {}),
-    ...(readTrimmedString(args.repositoryPath)
-      ? { repositoryPath: readTrimmedString(args.repositoryPath) }
-      : {}),
-    ...(readTrimmedString(args.sourcePath)
-      ? { sourcePath: readTrimmedString(args.sourcePath) }
-      : {}),
-    ...(readTrimmedString(args.sourceBranch)
-      ? { sourceBranch: readTrimmedString(args.sourceBranch) }
-      : {}),
-    ...(readTrimmedString(args.leaveLocalBranch)
-      ? { leaveLocalBranch: readTrimmedString(args.leaveLocalBranch) }
-      : {}),
-    ...(readTrimmedString(args.newBranchName)
-      ? { newBranchName: readTrimmedString(args.newBranchName) }
-      : {}),
+    ...(backend ? { backend: backend as MoveThreadWorkspaceToolArgs["backend"] } : {}),
+    ...(repositoryPath ? { repositoryPath } : {}),
+    ...(sourcePath ? { sourcePath } : {}),
+    ...(sourceBranch ? { sourceBranch } : {}),
+    ...(leaveLocalBranch ? { leaveLocalBranch } : {}),
+    ...(newBranchName ? { newBranchName } : {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -113,9 +113,12 @@ import {
   type ThreadTurnFailure,
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
+  type MoveThreadWorkspacePhase,
+  type MoveThreadWorkspaceResult,
   type MutateThreadToolArgs,
   type PendingThreadHandoffPhase,
   type PendingThreadHandoffSummary,
+  type PendingThreadWorkspaceMoveSummary,
   type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
@@ -4301,6 +4304,46 @@ function buildHandoffTaskPrompt(params: {
   return lines.join("\n");
 }
 
+function buildWorkspaceMoveSuccessPrompt(params: {
+  move: PendingThreadWorkspaceMoveSummary;
+  result: HandoffThreadWorkspaceResponse;
+}): string {
+  return [
+    "PwrAgent workspace move completed for this thread.",
+    "",
+    "Workspace result:",
+    `- Source path: ${params.move.sourcePath ?? "unknown"}`,
+    `- Repository path: ${params.result.repositoryPath}`,
+    `- New runtime cwd: ${
+      params.result.linkedDirectory.worktreePath ?? params.result.targetPath
+    }`,
+    `- Target path: ${params.result.targetPath}`,
+    ...(params.result.branch ? [`- Branch: ${params.result.branch}`] : []),
+    ...(params.result.warnings.length
+      ? ["", "Warnings:", ...params.result.warnings.map((warning) => `- ${warning}`)]
+      : []),
+    "",
+    "Continue the user's task from the new runtime workspace. Do not repeat the workspace move.",
+  ].join("\n");
+}
+
+function buildWorkspaceMoveFailurePrompt(params: {
+  error: unknown;
+  move: PendingThreadWorkspaceMoveSummary;
+}): string {
+  const message = params.error instanceof Error ? params.error.message : String(params.error);
+  return [
+    "PwrAgent workspace move failed for this thread.",
+    "",
+    "Workspace result:",
+    `- Source path: ${params.move.sourcePath ?? "unknown"}`,
+    `- Repository path: ${params.move.repositoryPath ?? "unknown"}`,
+    `- Error: ${message}`,
+    "",
+    "The original runtime workspace remains authoritative. Continue only after deciding whether to retry the move, choose another source path, or proceed in the original workspace.",
+  ].join("\n");
+}
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -4342,6 +4385,10 @@ export class DesktopBackendRegistry {
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly pendingThreadHandoffs = new Map<string, PendingThreadHandoffSummary>();
+  private readonly pendingThreadWorkspaceMoves = new Map<
+    string,
+    PendingThreadWorkspaceMoveSummary
+  >();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -14151,6 +14198,9 @@ export class DesktopBackendRegistry {
     if (request.operation === "handoff_task") {
       return await this.handoffTaskToThread(request);
     }
+    if (request.operation === "move_thread_workspace") {
+      return await this.moveThreadWorkspace(request);
+    }
     if (request.operation === "send_message_to_thread") {
       return await this.sendMessageToThread(request);
     }
@@ -14238,6 +14288,475 @@ export class DesktopBackendRegistry {
         this.pendingThreadHandoffs.delete(handoffId);
       }
     }
+  }
+
+  private startPendingThreadWorkspaceMove(
+    move: PendingThreadWorkspaceMoveSummary,
+  ): PendingThreadWorkspaceMoveSummary {
+    this.prunePendingThreadWorkspaceMoves(move.createdAt);
+    this.pendingThreadWorkspaceMoves.set(move.workspaceMoveId, move);
+    return move;
+  }
+
+  private updatePendingThreadWorkspaceMove(
+    workspaceMoveId: string | undefined,
+    patch: Partial<
+      Omit<PendingThreadWorkspaceMoveSummary, "workspaceMoveId" | "createdAt">
+    > & {
+      phase?: MoveThreadWorkspacePhase;
+    },
+  ): void {
+    if (!workspaceMoveId) {
+      return;
+    }
+    const current = this.pendingThreadWorkspaceMoves.get(workspaceMoveId);
+    if (!current) {
+      return;
+    }
+    const updatedAt = patch.updatedAt ?? Date.now();
+    this.pendingThreadWorkspaceMoves.set(workspaceMoveId, {
+      ...current,
+      ...patch,
+      updatedAt,
+    });
+  }
+
+  private failPendingThreadWorkspaceMove(
+    workspaceMoveId: string | undefined,
+    error: unknown,
+    patch: Partial<PendingThreadWorkspaceMoveSummary> = {},
+  ): void {
+    this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
+      ...patch,
+      status: "failed",
+      phase: "failed",
+      error: error instanceof Error ? error.message : String(error),
+      message:
+        "Workspace move failed. The original runtime workspace remains authoritative.",
+    });
+  }
+
+  private getPendingThreadWorkspaceMovesForInspection(params: {
+    backend?: AppServerBackendKind | "all";
+    query?: string;
+    sourceThreadId?: string;
+    limit?: number;
+  } = {}): PendingThreadWorkspaceMoveSummary[] {
+    this.prunePendingThreadWorkspaceMoves();
+    const clauses = parseThreadInspectionQuery(params.query);
+    const backend = params.backend;
+    return [...this.pendingThreadWorkspaceMoves.values()]
+      .filter((move) => {
+        if (
+          backend &&
+          backend !== "all" &&
+          move.backend !== backend &&
+          move.sourceBackend !== backend
+        ) {
+          return false;
+        }
+        if (params.sourceThreadId && move.sourceThreadId !== params.sourceThreadId) {
+          return false;
+        }
+        return pendingThreadWorkspaceMoveMatchesQuery(move, clauses);
+      })
+      .sort((left, right) => right.updatedAt - left.updatedAt)
+      .slice(0, params.limit ?? 10);
+  }
+
+  private prunePendingThreadWorkspaceMoves(now = Date.now()): void {
+    const maxAgeMs = 60 * 60 * 1000;
+    for (const [workspaceMoveId, move] of this.pendingThreadWorkspaceMoves) {
+      if (now - move.updatedAt > maxAgeMs) {
+        this.pendingThreadWorkspaceMoves.delete(workspaceMoveId);
+      }
+    }
+  }
+
+  private pendingThreadWorkspaceMoveToResult(
+    move: PendingThreadWorkspaceMoveSummary,
+  ): MoveThreadWorkspaceResult {
+    return {
+      backend: move.backend,
+      threadId: move.threadId,
+      workspaceMoveId: move.workspaceMoveId,
+      status: move.status,
+      phase: move.phase,
+      direction: move.direction,
+      ...(move.strategy ? { strategy: move.strategy } : {}),
+      ...(move.repositoryPath ? { repositoryPath: move.repositoryPath } : {}),
+      ...(move.sourcePath ? { sourcePath: move.sourcePath } : {}),
+      ...(move.sourceBranch ? { sourceBranch: move.sourceBranch } : {}),
+      ...(move.leaveLocalBranch ? { leaveLocalBranch: move.leaveLocalBranch } : {}),
+      ...(move.newBranchName ? { newBranchName: move.newBranchName } : {}),
+      ...(move.targetPath ? { targetPath: move.targetPath } : {}),
+      ...(move.branch ? { branch: move.branch } : {}),
+      ...(move.linkedDirectory ? { linkedDirectory: move.linkedDirectory } : {}),
+      ...(move.warnings ? { warnings: move.warnings } : {}),
+      ...(move.continuationTurnId
+        ? { continuationTurnId: move.continuationTurnId }
+        : {}),
+      createdAt: move.createdAt,
+      updatedAt: move.updatedAt,
+      message: move.message ?? "Workspace move is pending.",
+      ...(move.error ? { error: move.error } : {}),
+    };
+  }
+
+  private async moveThreadWorkspace(
+    request: PwrAgentThreadOrchestrationRequest<"move_thread_workspace">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceBackend = request.context.backend;
+    const sourceThreadId = request.context.threadId;
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId ||
+      !this.isLiveDynamicToolCall(sourceBackend, {
+        threadId: sourceThreadId,
+        turnId: sourceTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Thread workspace move tools must be invoked from a live turn.",
+      );
+    }
+    if (sourceBackend !== "codex") {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Thread workspace move tools are currently available only from Codex threads.",
+      );
+    }
+
+    const backend = request.args.backend ?? sourceBackend;
+    if (!isAppServerBackendKind(backend)) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    if (backend !== sourceBackend || backend !== "codex") {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Thread workspace move currently supports only same-thread Codex workspace moves.",
+      );
+    }
+
+    const direction = request.args.direction ?? "local-to-worktree";
+    if (direction !== "local-to-worktree") {
+      return threadOrchestrationFailure(
+        "unsupported_workspace",
+        'move_thread_workspace currently supports direction="local-to-worktree" only.',
+      );
+    }
+
+    const workspaceMoveId = [
+      "workspace-move",
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      request.context.callId?.trim() || randomUUID(),
+    ].join(":");
+    const existing = this.pendingThreadWorkspaceMoves.get(workspaceMoveId);
+    if (existing) {
+      return {
+        ok: true,
+        data: this.pendingThreadWorkspaceMoveToResult(existing),
+      };
+    }
+
+    const sourceThread = await this.findThreadForWorkspaceHandoff({
+      backend: sourceBackend,
+      callerReason: "agent-workspace-move",
+      threadId: sourceThreadId,
+    });
+    const sourceOverlay = await this.overlayStore.getThreadOverlayState({
+      backend: sourceBackend,
+      threadId: sourceThreadId,
+    });
+
+    let candidate: {
+      repositoryPath?: string;
+      sourceBranch?: string;
+      sourcePath?: string;
+    };
+    try {
+      candidate = this.resolveThreadWorkspaceMoveCandidate({
+        ...(sourceOverlay ? { overlay: sourceOverlay } : {}),
+        request,
+        ...(sourceThread ? { thread: sourceThread } : {}),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return threadOrchestrationFailure(
+        /ambiguous/i.test(message) ? "ambiguous_workspace" : "unsupported_workspace",
+        message,
+      );
+    }
+
+    const now = request.context.now ?? Date.now();
+    const move = this.startPendingThreadWorkspaceMove({
+      workspaceMoveId,
+      status: "queued",
+      phase: "waiting_for_turn_boundary",
+      sourceBackend,
+      sourceThreadId,
+      sourceTurnId,
+      backend,
+      threadId: sourceThreadId,
+      direction,
+      ...(request.args.strategy ? { strategy: request.args.strategy } : {}),
+      ...(candidate.repositoryPath ? { repositoryPath: candidate.repositoryPath } : {}),
+      ...(candidate.sourcePath ? { sourcePath: candidate.sourcePath } : {}),
+      ...(candidate.sourceBranch ? { sourceBranch: candidate.sourceBranch } : {}),
+      ...(request.args.leaveLocalBranch
+        ? { leaveLocalBranch: request.args.leaveLocalBranch }
+        : {}),
+      ...(request.args.newBranchName
+        ? { newBranchName: request.args.newBranchName }
+        : {}),
+      createdAt: now,
+      updatedAt: now,
+      message:
+        "Workspace move queued. Stop this turn and wait for the same-thread continuation before editing from the moved workspace.",
+    });
+    return {
+      ok: true,
+      data: this.pendingThreadWorkspaceMoveToResult(move),
+    };
+  }
+
+  private resolveThreadWorkspaceMoveCandidate(params: {
+    overlay?: ThreadOverlayState;
+    request: PwrAgentThreadOrchestrationRequest<"move_thread_workspace">;
+    thread?: AppServerThreadSummary;
+  }): {
+    repositoryPath?: string;
+    sourceBranch?: string;
+    sourcePath?: string;
+  } {
+    const args = params.request.args;
+    if (args.repositoryPath && args.sourcePath) {
+      return {
+        repositoryPath: args.repositoryPath,
+        ...(args.sourceBranch ? { sourceBranch: args.sourceBranch } : {}),
+        sourcePath: args.sourcePath,
+      };
+    }
+
+    const linkedDirectories = [
+      ...(params.overlay?.extraLinkedDirectories ?? []),
+      ...(params.thread?.linkedDirectories ?? []),
+    ];
+    const sourcePath = args.sourcePath?.trim();
+    if (sourcePath) {
+      const resolvedSourcePath = path.resolve(sourcePath);
+      const directory = linkedDirectories.find((candidate) => {
+        const candidatePaths = [
+          candidate.path,
+          candidate.worktreePath,
+        ].filter((value): value is string => Boolean(value?.trim()));
+        return candidatePaths.some(
+          (candidatePath) => path.resolve(candidatePath) === resolvedSourcePath,
+        );
+      });
+      return {
+        repositoryPath: args.repositoryPath ?? directory?.path ?? sourcePath,
+        ...(args.sourceBranch ? { sourceBranch: args.sourceBranch } : {}),
+        sourcePath,
+      };
+    }
+
+    const localDirectories = linkedDirectories.filter(
+      (directory) => directory.kind === "local" && directory.path?.trim(),
+    );
+    const uniqueRepositoryPaths = [
+      ...new Map(
+        localDirectories.map((directory) => [
+          path.resolve(directory.path),
+          directory,
+        ]),
+      ).values(),
+    ];
+    if (uniqueRepositoryPaths.length > 1) {
+      throw new Error(
+        "Thread has multiple eligible workspaces for workspace move. Pass sourcePath to choose one.",
+      );
+    }
+    const inferredThread = params.thread
+      ? {
+          ...params.thread,
+          linkedDirectories:
+            linkedDirectories.length > 0
+              ? linkedDirectories
+              : params.thread.linkedDirectories,
+        }
+      : undefined;
+    const candidate = this.resolveHandoffWorkspaceCandidate(inferredThread, {
+      backend: params.request.context.backend,
+      threadId: params.request.context.threadId,
+      direction: args.direction ?? "local-to-worktree",
+      ...(args.repositoryPath ? { repositoryPath: args.repositoryPath } : {}),
+      ...(args.sourceBranch ? { sourceBranch: args.sourceBranch } : {}),
+      ...(args.sourcePath ? { sourcePath: args.sourcePath } : {}),
+    });
+    if (!candidate.sourcePath) {
+      throw new Error("Thread does not have an eligible Git workspace for handoff.");
+    }
+    const sourceBranch = args.sourceBranch ?? candidate.sourceBranch;
+    const repositoryPath = args.repositoryPath ?? candidate.repositoryPath;
+    return {
+      ...(repositoryPath ? { repositoryPath } : {}),
+      ...(sourceBranch ? { sourceBranch } : {}),
+      sourcePath: candidate.sourcePath,
+    };
+  }
+
+  private drainPendingThreadWorkspaceMovesForTerminalTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId?: string;
+  }): void {
+    if (!params.turnId) {
+      return;
+    }
+    const moves = [...this.pendingThreadWorkspaceMoves.values()].filter(
+      (move) =>
+        move.status === "queued" &&
+        move.sourceBackend === params.backend &&
+        move.sourceThreadId === params.threadId &&
+        move.sourceTurnId === params.turnId,
+    );
+    for (const move of moves) {
+      void this.runPendingThreadWorkspaceMove(move.workspaceMoveId);
+    }
+  }
+
+  private async runPendingThreadWorkspaceMove(
+    workspaceMoveId: string,
+  ): Promise<void> {
+    const move = this.pendingThreadWorkspaceMoves.get(workspaceMoveId);
+    if (!move || move.status !== "queued") {
+      return;
+    }
+    this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
+      status: "running",
+      phase: "preparing_workspace",
+      message: "Workspace move is preparing the managed worktree.",
+    });
+
+    let handoffResult: HandoffThreadWorkspaceResponse;
+    try {
+      handoffResult = await this.handoffThreadWorkspace({
+        backend: move.backend,
+        threadId: move.threadId,
+        direction: move.direction,
+        ...(move.strategy ? { strategy: move.strategy } : {}),
+        ...(move.repositoryPath ? { repositoryPath: move.repositoryPath } : {}),
+        ...(move.sourcePath ? { sourcePath: move.sourcePath } : {}),
+        ...(move.sourceBranch ? { sourceBranch: move.sourceBranch } : {}),
+        ...(move.leaveLocalBranch ? { leaveLocalBranch: move.leaveLocalBranch } : {}),
+        ...(move.newBranchName ? { newBranchName: move.newBranchName } : {}),
+      });
+      this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
+        phase: "updating_metadata",
+        repositoryPath: handoffResult.repositoryPath,
+        ...(move.sourcePath ? { sourcePath: move.sourcePath } : {}),
+        targetPath: handoffResult.targetPath,
+        ...(handoffResult.branch ? { branch: handoffResult.branch } : {}),
+        linkedDirectory: handoffResult.linkedDirectory,
+        warnings: handoffResult.warnings,
+        message:
+          "Workspace move updated runtime workspace metadata and is waking the same thread.",
+      });
+    } catch (error) {
+      this.failPendingThreadWorkspaceMove(workspaceMoveId, error);
+      await this.startWorkspaceMoveContinuation({
+        error,
+        kind: "failure",
+        moveId: workspaceMoveId,
+      }).catch((continuationError) => {
+        backendRegistryLog.warn("workspace move failure continuation failed", {
+          error:
+            continuationError instanceof Error
+              ? continuationError.message
+              : String(continuationError),
+          workspaceMoveId,
+        });
+      });
+      return;
+    }
+
+    try {
+      await this.startWorkspaceMoveContinuation({
+        kind: "success",
+        moveId: workspaceMoveId,
+        result: handoffResult,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
+        status: "completed",
+        phase: "completed",
+        error: message,
+        message:
+          "Workspace move completed, but starting the same-thread continuation failed. Inspect the move result before retrying.",
+      });
+      backendRegistryLog.warn("workspace move success continuation failed", {
+        error: message,
+        workspaceMoveId,
+      });
+    }
+  }
+
+  private async startWorkspaceMoveContinuation(params:
+    | {
+        kind: "success";
+        moveId: string;
+        result: HandoffThreadWorkspaceResponse;
+      }
+    | {
+        kind: "failure";
+        moveId: string;
+        error: unknown;
+      },
+  ): Promise<void> {
+    const move = this.pendingThreadWorkspaceMoves.get(params.moveId);
+    if (!move) {
+      return;
+    }
+    this.updatePendingThreadWorkspaceMove(params.moveId, {
+      phase: "starting_continuation",
+      message:
+        params.kind === "success"
+          ? "Workspace move completed; starting the same-thread continuation."
+          : "Workspace move failed; starting the same-thread failure continuation.",
+    });
+
+    const prompt =
+      params.kind === "success"
+        ? buildWorkspaceMoveSuccessPrompt({
+            move,
+            result: params.result,
+          })
+        : buildWorkspaceMoveFailurePrompt({
+            error: params.error,
+            move,
+          });
+    const turn = await this.startTurn({
+      backend: move.backend,
+      threadId: move.threadId,
+      input: [{ type: "text", text: prompt }],
+    });
+    this.updatePendingThreadWorkspaceMove(params.moveId, {
+      status: params.kind === "success" ? "completed" : "failed",
+      phase: params.kind === "success" ? "completed" : "failed",
+      continuationTurnId: turn.turnId,
+      message:
+        params.kind === "success"
+          ? "Workspace move completed and same-thread continuation started."
+          : "Workspace move failed and same-thread continuation started from the original workspace.",
+    });
   }
 
   private async sendMessageToThread(
@@ -15845,6 +16364,13 @@ export class DesktopBackendRegistry {
         sourceThreadId: request.context.threadId,
         limit,
       });
+      const pendingWorkspaceMoves =
+        this.getPendingThreadWorkspaceMovesForInspection({
+          backend,
+          query: request.args.query,
+          sourceThreadId: request.context.threadId,
+          limit,
+        });
       const searchService = this.getThreadInspectionSearchService();
       if (searchService) {
         const projectKeys = nonEmptyStringArray(request.args.projectKeys);
@@ -15892,6 +16418,7 @@ export class DesktopBackendRegistry {
             limit,
             truncated: response.truncated === true || filtered.length > limit,
             ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+            ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
             query: response.query,
             searchedScopes: response.searchedScopes,
             unavailableScopes: response.unavailableScopes,
@@ -15930,6 +16457,7 @@ export class DesktopBackendRegistry {
           limit,
           truncated: filtered.length > limit,
           ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+          ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
         },
       };
     }
@@ -15993,6 +16521,11 @@ export class DesktopBackendRegistry {
         backend: request.args.backend,
         sourceThreadId: threadId,
       });
+      const pendingWorkspaceMoves =
+        this.getPendingThreadWorkspaceMovesForInspection({
+          backend: request.args.backend,
+          sourceThreadId: threadId,
+        });
       return {
         ok: true,
         data: {
@@ -16002,6 +16535,7 @@ export class DesktopBackendRegistry {
             queuedExecutionMode: queued?.mode,
             queuedExecutionModeAt: queued?.queuedAt,
             ...(pendingHandoffs.length ? { pendingHandoffs } : {}),
+            ...(pendingWorkspaceMoves.length ? { pendingWorkspaceMoves } : {}),
           },
         },
       };
@@ -16982,6 +17516,11 @@ export class DesktopBackendRegistry {
           notification.params.threadId,
         );
       }
+      this.drainPendingThreadWorkspaceMovesForTerminalTurn({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId,
+      });
     }
     if (
       event.notification.method === "turn/failed" &&
@@ -17542,6 +18081,43 @@ function pendingThreadHandoffMatchesQuery(
     handoff.workspace?.linkedDirectory?.worktreePath,
     handoff.message,
     handoff.error,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+  return clauses.some((tokens) => tokens.every((token) => haystack.includes(token)));
+}
+
+function pendingThreadWorkspaceMoveMatchesQuery(
+  move: PendingThreadWorkspaceMoveSummary,
+  clauses: string[][],
+): boolean {
+  if (clauses.length === 0) {
+    return true;
+  }
+  const haystack = [
+    move.workspaceMoveId,
+    move.sourceBackend,
+    move.sourceThreadId,
+    move.sourceTurnId,
+    move.backend,
+    move.threadId,
+    move.status,
+    move.phase,
+    move.direction,
+    move.strategy,
+    move.repositoryPath,
+    move.sourcePath,
+    move.sourceBranch,
+    move.leaveLocalBranch,
+    move.newBranchName,
+    move.targetPath,
+    move.branch,
+    move.linkedDirectory?.label,
+    move.linkedDirectory?.path,
+    move.linkedDirectory?.worktreePath,
+    move.message,
+    move.error,
   ]
     .filter((value): value is string => Boolean(value))
     .join(" ")

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -113,6 +113,7 @@ import {
   type ThreadTurnFailure,
   type ThreadAgentMetadata,
   type MessagingThreadBindingSummary,
+  DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
   type MoveThreadWorkspacePhase,
   type MoveThreadWorkspaceResult,
   type MutateThreadToolArgs,
@@ -152,6 +153,7 @@ import {
   type ThreadIdentifier,
   type ThreadOverlayState,
   type ThreadPricingSummary,
+  type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
   type ThreadUsageLineRecord,
   type WorktreeSnapshotSummary,
@@ -7538,6 +7540,11 @@ export class DesktopBackendRegistry {
     for (const entry of this.threadTurnQueue.getAllQueuedEntries()) {
       threadKeys.add(formatQuitThreadKey(entry.backend, entry.threadId));
     }
+    for (const move of this.pendingThreadWorkspaceMoves.values()) {
+      if (move.status === "queued" || move.status === "running") {
+        threadKeys.add(formatQuitThreadKey(move.backend, move.threadId));
+      }
+    }
     const threadIds = [...threadKeys].sort();
     return {
       count: threadIds.length,
@@ -14452,6 +14459,7 @@ export class DesktopBackendRegistry {
         'move_thread_workspace currently supports direction="local-to-worktree" only.',
       );
     }
+    const strategy = this.resolveMoveThreadWorkspaceStrategy(request.args);
 
     const workspaceMoveId = [
       "workspace-move",
@@ -14511,6 +14519,11 @@ export class DesktopBackendRegistry {
     if (duplicateMove) {
       const sameSource =
         duplicateMove.direction === direction &&
+        duplicateMove.strategy === strategy &&
+        (duplicateMove.leaveLocalBranch ?? "") ===
+          (request.args.leaveLocalBranch ?? "") &&
+        (duplicateMove.newBranchName ?? "") ===
+          (request.args.newBranchName ?? "") &&
         path.resolve(duplicateMove.sourcePath ?? "") ===
           path.resolve(candidate.sourcePath ?? "") &&
         path.resolve(duplicateMove.repositoryPath ?? "") ===
@@ -14538,7 +14551,7 @@ export class DesktopBackendRegistry {
       backend,
       threadId: sourceThreadId,
       direction,
-      ...(request.args.strategy ? { strategy: request.args.strategy } : {}),
+      strategy,
       ...(candidate.repositoryPath ? { repositoryPath: candidate.repositoryPath } : {}),
       ...(candidate.sourcePath ? { sourcePath: candidate.sourcePath } : {}),
       ...(candidate.sourceBranch ? { sourceBranch: candidate.sourceBranch } : {}),
@@ -14557,6 +14570,21 @@ export class DesktopBackendRegistry {
       ok: true,
       data: this.pendingThreadWorkspaceMoveToResult(move),
     };
+  }
+
+  private resolveMoveThreadWorkspaceStrategy(
+    args: PwrAgentThreadOrchestrationRequest<"move_thread_workspace">["args"],
+  ): ThreadWorkspaceHandoffStrategy {
+    if (args.strategy) {
+      return args.strategy;
+    }
+    if (args.newBranchName) {
+      return "new-branch";
+    }
+    if (args.leaveLocalBranch) {
+      return "move-branch";
+    }
+    return DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY;
   }
 
   private resolveThreadWorkspaceMoveCandidate(params: {
@@ -14738,11 +14766,13 @@ export class DesktopBackendRegistry {
     } catch (error) {
       const handoffError = error instanceof Error ? error.message : String(error);
       this.failPendingThreadWorkspaceMove(workspaceMoveId, error);
-      await this.startWorkspaceMoveContinuation({
-        error,
-        kind: "failure",
-        moveId: workspaceMoveId,
-      }).catch((continuationError) => {
+      try {
+        await this.startWorkspaceMoveContinuation({
+          error,
+          kind: "failure",
+          moveId: workspaceMoveId,
+        });
+      } catch (continuationError) {
         const message =
           continuationError instanceof Error
             ? continuationError.message
@@ -14758,7 +14788,8 @@ export class DesktopBackendRegistry {
           error: message,
           workspaceMoveId,
         });
-      });
+        await this.releaseThreadQueueAfterWorkspaceMoveContinuationFailure(move);
+      }
       return;
     }
 
@@ -14781,7 +14812,18 @@ export class DesktopBackendRegistry {
         error: message,
         workspaceMoveId,
       });
+      await this.releaseThreadQueueAfterWorkspaceMoveContinuationFailure(move);
     }
+  }
+
+  private async releaseThreadQueueAfterWorkspaceMoveContinuationFailure(
+    move: PendingThreadWorkspaceMoveSummary,
+  ): Promise<void> {
+    await this.threadTurnQueue.releaseThread({
+      backend: move.backend,
+      threadId: move.threadId,
+      status: "workspace_move_continuation_failed",
+    });
   }
 
   private async startWorkspaceMoveContinuation(params:

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14465,15 +14465,22 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const sourceThread = await this.findThreadForWorkspaceHandoff({
-      backend: sourceBackend,
-      callerReason: "agent-workspace-move",
-      threadId: sourceThreadId,
-    });
-    const sourceOverlay = await this.overlayStore.getThreadOverlayState({
-      backend: sourceBackend,
-      threadId: sourceThreadId,
-    });
+    const needsWorkspaceInference = !(
+      request.args.repositoryPath?.trim() && request.args.sourcePath?.trim()
+    );
+    const [sourceThread, sourceOverlay] = needsWorkspaceInference
+      ? await Promise.all([
+          this.findThreadForWorkspaceHandoff({
+            backend: sourceBackend,
+            callerReason: "agent-workspace-move",
+            threadId: sourceThreadId,
+          }),
+          this.overlayStore.getThreadOverlayState({
+            backend: sourceBackend,
+            threadId: sourceThreadId,
+          }),
+        ])
+      : [undefined, undefined];
 
     let candidate: {
       repositoryPath?: string;
@@ -14489,8 +14496,36 @@ export class DesktopBackendRegistry {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return threadOrchestrationFailure(
-        /ambiguous/i.test(message) ? "ambiguous_workspace" : "unsupported_workspace",
+        /ambiguous|multiple eligible/i.test(message)
+          ? "ambiguous_workspace"
+          : "unsupported_workspace",
         message,
+      );
+    }
+
+    const duplicateMove = [...this.pendingThreadWorkspaceMoves.values()].find(
+      (move) =>
+        (move.status === "queued" || move.status === "running") &&
+        move.sourceBackend === sourceBackend &&
+        move.sourceThreadId === sourceThreadId &&
+        move.sourceTurnId === sourceTurnId,
+    );
+    if (duplicateMove) {
+      const sameSource =
+        duplicateMove.direction === direction &&
+        path.resolve(duplicateMove.sourcePath ?? "") ===
+          path.resolve(candidate.sourcePath ?? "") &&
+        path.resolve(duplicateMove.repositoryPath ?? "") ===
+          path.resolve(candidate.repositoryPath ?? "");
+      if (sameSource) {
+        return {
+          ok: true,
+          data: this.pendingThreadWorkspaceMoveToResult(duplicateMove),
+        };
+      }
+      return threadOrchestrationFailure(
+        "unsupported_workspace",
+        "A workspace move is already queued for this thread turn. Wait for the continuation before requesting another workspace move.",
       );
     }
 
@@ -14632,6 +14667,20 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private drainPendingThreadWorkspaceMovesForTurnIds(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnIds: Iterable<string>;
+  }): void {
+    for (const turnId of params.turnIds) {
+      this.drainPendingThreadWorkspaceMovesForTerminalTurn({
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId,
+      });
+    }
+  }
+
   private async runPendingThreadWorkspaceMove(
     workspaceMoveId: string,
   ): Promise<void> {
@@ -14676,11 +14725,19 @@ export class DesktopBackendRegistry {
         kind: "failure",
         moveId: workspaceMoveId,
       }).catch((continuationError) => {
+        const message =
+          continuationError instanceof Error
+            ? continuationError.message
+            : String(continuationError);
+        this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
+          status: "failed",
+          phase: "failed",
+          error: message,
+          message:
+            "Workspace move failed, and starting the same-thread failure continuation also failed. The original runtime workspace remains authoritative.",
+        });
         backendRegistryLog.warn("workspace move failure continuation failed", {
-          error:
-            continuationError instanceof Error
-              ? continuationError.message
-              : String(continuationError),
+          error: message,
           workspaceMoveId,
         });
       });
@@ -17581,6 +17638,7 @@ export class DesktopBackendRegistry {
       const hasActiveCodexReviewTurn =
         event.backend === "codex" &&
         this.threadHasActiveCodexReviewTurn(threadId);
+      const endedTurnIds = new Set<string>();
       const genericKeyPrefix = `${event.backend}:${event.notification.params.threadId}:`;
       for (const key of Array.from(this.activeTurnKeys)) {
         if (key.startsWith(genericKeyPrefix)) {
@@ -17593,6 +17651,9 @@ export class DesktopBackendRegistry {
             )
           ) {
             continue;
+          }
+          if (parsed?.turnId && !parsed.turnId.startsWith("pending:")) {
+            endedTurnIds.add(parsed.turnId);
           }
           this.activeTurnKeys.delete(key);
         }
@@ -17621,6 +17682,10 @@ export class DesktopBackendRegistry {
             if (!key.startsWith(`${keyPrefix}pending:`)) {
               hadKnownActiveTurn = true;
             }
+            const parsed = parseThreadTurnKeyBody(key);
+            if (parsed?.turnId && !parsed.turnId.startsWith("pending:")) {
+              endedTurnIds.add(parsed.turnId);
+            }
             this.activeCodexTurnModes.delete(key);
           }
         }
@@ -17648,6 +17713,11 @@ export class DesktopBackendRegistry {
         // point where the thread becomes available again.
         return;
       }
+      this.drainPendingThreadWorkspaceMovesForTurnIds({
+        backend: event.backend,
+        threadId: event.notification.params.threadId,
+        turnIds: endedTurnIds,
+      });
       void this.threadTurnQueue.releaseThread({
         backend: event.backend,
         threadId: event.notification.params.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4766,7 +4766,10 @@ export class DesktopBackendRegistry {
     this.threadTurnQueue = new ThreadTurnQueue({
       startTurn: async (entry) => await this.startTurnNow(entry),
       isThreadActive: ({ backend, threadId }) =>
-        backend === "codex" ? this.threadHasActiveTurn(threadId) : false,
+        backend === "codex"
+          ? this.threadHasActiveTurn(threadId) ||
+            this.threadHasBlockingWorkspaceMove({ backend, threadId })
+          : false,
       onLifecycle: async (event) => await this.emitTurnQueueLifecycle(event),
     });
     this.taskMonitorWatchdogTimer = setInterval(() => {
@@ -14465,22 +14468,17 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const needsWorkspaceInference = !(
-      request.args.repositoryPath?.trim() && request.args.sourcePath?.trim()
-    );
-    const [sourceThread, sourceOverlay] = needsWorkspaceInference
-      ? await Promise.all([
-          this.findThreadForWorkspaceHandoff({
-            backend: sourceBackend,
-            callerReason: "agent-workspace-move",
-            threadId: sourceThreadId,
-          }),
-          this.overlayStore.getThreadOverlayState({
-            backend: sourceBackend,
-            threadId: sourceThreadId,
-          }),
-        ])
-      : [undefined, undefined];
+    const [sourceThread, sourceOverlay] = await Promise.all([
+      this.findThreadForWorkspaceHandoff({
+        backend: sourceBackend,
+        callerReason: "agent-workspace-move",
+        threadId: sourceThreadId,
+      }),
+      this.overlayStore.getThreadOverlayState({
+        backend: sourceBackend,
+        threadId: sourceThreadId,
+      }),
+    ]);
 
     let candidate: {
       repositoryPath?: string;
@@ -14571,14 +14569,6 @@ export class DesktopBackendRegistry {
     sourcePath?: string;
   } {
     const args = params.request.args;
-    if (args.repositoryPath && args.sourcePath) {
-      return {
-        repositoryPath: args.repositoryPath,
-        ...(args.sourceBranch ? { sourceBranch: args.sourceBranch } : {}),
-        sourcePath: args.sourcePath,
-      };
-    }
-
     const linkedDirectories = [
       ...(params.overlay?.extraLinkedDirectories ?? []),
       ...(params.thread?.linkedDirectories ?? []),
@@ -14595,8 +14585,23 @@ export class DesktopBackendRegistry {
           (candidatePath) => path.resolve(candidatePath) === resolvedSourcePath,
         );
       });
+      if (!directory) {
+        throw new Error(
+          "Workspace move sourcePath must match a linked directory for this thread.",
+        );
+      }
+      const repositoryPath = args.repositoryPath?.trim() ?? directory.path ?? sourcePath;
+      if (
+        args.repositoryPath?.trim() &&
+        directory.path?.trim() &&
+        path.resolve(args.repositoryPath) !== path.resolve(directory.path)
+      ) {
+        throw new Error(
+          "Workspace move repositoryPath must match the linked directory repository path for this thread.",
+        );
+      }
       return {
-        repositoryPath: args.repositoryPath ?? directory?.path ?? sourcePath,
+        repositoryPath,
         ...(args.sourceBranch ? { sourceBranch: args.sourceBranch } : {}),
         sourcePath,
       };
@@ -14681,6 +14686,18 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private threadHasBlockingWorkspaceMove(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): boolean {
+    return [...this.pendingThreadWorkspaceMoves.values()].some(
+      (move) =>
+        move.backend === params.backend &&
+        move.threadId === params.threadId &&
+        (move.status === "queued" || move.status === "running"),
+    );
+  }
+
   private async runPendingThreadWorkspaceMove(
     workspaceMoveId: string,
   ): Promise<void> {
@@ -14719,6 +14736,7 @@ export class DesktopBackendRegistry {
           "Workspace move updated runtime workspace metadata and is waking the same thread.",
       });
     } catch (error) {
+      const handoffError = error instanceof Error ? error.message : String(error);
       this.failPendingThreadWorkspaceMove(workspaceMoveId, error);
       await this.startWorkspaceMoveContinuation({
         error,
@@ -14732,7 +14750,7 @@ export class DesktopBackendRegistry {
         this.updatePendingThreadWorkspaceMove(workspaceMoveId, {
           status: "failed",
           phase: "failed",
-          error: message,
+          error: `Workspace handoff failed: ${handoffError}; failure continuation failed: ${message}`,
           message:
             "Workspace move failed, and starting the same-thread failure continuation also failed. The original runtime workspace remains authoritative.",
         });
@@ -17545,11 +17563,10 @@ export class DesktopBackendRegistry {
           });
         }
       }
-      void this.threadTurnQueue.releaseThread({
+      this.drainPendingThreadWorkspaceMovesForTerminalTurn({
         backend: event.backend,
         threadId: notification.params.threadId,
         turnId,
-        status: event.notification.method,
       });
       if (event.backend === "codex") {
         // Turn-end is the resume boundary — flush any queued mode change
@@ -17573,10 +17590,11 @@ export class DesktopBackendRegistry {
           notification.params.threadId,
         );
       }
-      this.drainPendingThreadWorkspaceMovesForTerminalTurn({
+      void this.threadTurnQueue.releaseThread({
         backend: event.backend,
         threadId: notification.params.threadId,
         turnId,
+        status: event.notification.method,
       });
     }
     if (

--- a/docs/plans/2026-06-28-001-feat-path-keyed-thread-workspace-handoff-plan.md
+++ b/docs/plans/2026-06-28-001-feat-path-keyed-thread-workspace-handoff-plan.md
@@ -4,7 +4,7 @@ type: feat
 date: 2026-06-28
 topic: path-keyed-thread-workspace-handoff
 artifact_contract: ce-unified-plan/v1
-artifact_readiness: requirements-only
+artifact_readiness: implementation-ready
 product_contract_source: ce-brainstorm
 execution: code
 ---
@@ -15,7 +15,7 @@ execution: code
 
 - **Objective:** Let an Agent move its current PwrAgent thread runtime workspace from a local checkout to an isolated worktree through a first-class async tool, without falling back to raw `git worktree` commands that leave PwrAgent metadata behind.
 - **Product authority:** The tool should preserve PwrAgent's thread-first navigation model and make workspace movement explicit, observable, and safe across active-turn boundaries.
-- **Open blockers:** Planning must decide the exact operation naming, callback/wake mechanism, and whether the worker is modeled as a PwrAgent monitor, a sub-agent, or a backend-managed async job.
+- **Resolved planning decisions:** Use a dedicated `move_thread_workspace` dynamic tool, execute the move as a backend-managed async job after the invoking turn reaches a terminal boundary, and wake the same thread with a continuation turn that reports the result.
 
 ---
 
@@ -135,3 +135,273 @@ flowchart TB
 - `packages/agent-core/src/persistence/overlay-store.ts` already stores `extraLinkedDirectories` and workspace replacement metadata.
 - `packages/agent-core/src/domain/navigation-state.ts` merges overlay `extraLinkedDirectories` into navigation summaries.
 - `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md` and `docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md` provide prior context for existing workspace handoff and task handoff behavior.
+
+## Planning Contract
+
+### Product Contract Preservation
+
+Product Contract unchanged. This implementation plan preserves the brainstorm decisions above and resolves only the plan-time choices needed to execute them.
+
+### Key Technical Decisions
+
+- KTD1. Add a new dynamic operation named `move_thread_workspace` in the existing `pwragent` namespace. Do not extend `mutate_thread`, because runtime workspace moves are filesystem and turn-lifecycle orchestration, and do not repurpose `handoff_task`, because that contract creates a child thread.
+- KTD2. Keep the public operation path-keyed. The tool accepts a source path, with optional repository/source branch fields that mirror existing workspace handoff vocabulary, and it must reject ambiguous multi-directory requests instead of guessing.
+- KTD3. Reuse `GitWorkspaceHandoffService` and the existing thread workspace handoff update path for Git movement, overlay replacement, branch metadata, and Codex worktree ownership recording. The new work is orchestration and Agent-facing contract, not a second Git handoff implementation.
+- KTD4. Treat the dynamic tool call as an enqueue operation. It may be invoked only from a live turn, returns an accepted/pending result immediately, and schedules the real move for the terminal turn boundary so the existing active-turn handoff guard remains meaningful.
+- KTD5. Track self-move operations separately from child-thread pending handoffs at the type level, while exposing them through thread inspection alongside pending handoffs. This keeps current `pendingHandoffs` behavior compatible and gives Agents a way to poll progress.
+- KTD6. Completion wakes the original thread by starting a same-thread continuation turn after the workspace move succeeds or fails. The continuation prompt must include the new runtime cwd on success and an explicit "original workspace preserved" statement on failure.
+- KTD7. The runtime workspace remains a single handoff-linked directory per thread. Additional associated directories stay as separate linked-directory overlay entries so follow-up multi-project support can add associations without changing the self-move contract.
+- KTD8. Codex is the first supported backend for Agent-initiated self-move. ACP backends keep their existing app-server handoff behavior, and the dynamic tool must return `unsupported_backend` until a backend can safely rebind future turns and be woken from the same async path.
+
+### High-Level Design
+
+The new operation extends the existing thread orchestration dynamic-tool family:
+
+1. The router advertises `pwragent.move_thread_workspace` from the shared operation list.
+2. The normalizer validates the path-keyed request and forwards it to `DesktopBackendRegistry`.
+3. The registry verifies the call is from a live dynamic tool invocation, resolves the requested source workspace, records a pending self-move operation, and returns a pending result.
+4. When the invoking turn reaches `turn/completed`, `turn/failed`, or `turn/cancelled`, the registry drains eligible pending self-move operations for that thread.
+5. The worker calls the existing workspace handoff path with the resolved request, updates overlay/runtime metadata through the existing service flow, records success/failure state, and starts a same-thread continuation turn with the result.
+
+```mermaid
+sequenceDiagram
+  participant Agent as Invoking Agent
+  participant Router as Dynamic Tool Router
+  participant Registry as DesktopBackendRegistry
+  participant Worker as Workspace Move Worker
+  participant Git as GitWorkspaceHandoffService
+  participant Thread as Same Thread
+
+  Agent->>Router: pwragent.move_thread_workspace(sourcePath)
+  Router->>Registry: enqueue self-move request
+  Registry-->>Agent: accepted + operation id + stop guidance
+  Thread-->>Registry: invoking turn reaches terminal boundary
+  Registry->>Worker: run pending move
+  Worker->>Git: local-to-worktree handoff
+  Git-->>Worker: target path, branch, linked directory
+  Worker->>Registry: persist overlay/runtime updates
+  Registry->>Thread: start continuation turn with result
+```
+
+The operation state machine is:
+
+- `queued`: accepted during a live dynamic tool call and waiting for the invoking turn to end.
+- `running`: the workspace handoff worker has started.
+- `completed`: overlay/runtime metadata was updated and the continuation turn was requested.
+- `failed`: the move failed and the original runtime workspace remains authoritative.
+
+### Error Handling
+
+- Invalid or blank source paths fail before queuing with `invalid_arguments`.
+- Multiple eligible workspace candidates with no explicit source path fail with `ambiguous_workspace`.
+- Unsupported backends fail with `unsupported_backend`.
+- Non-Git or non-worktree-capable paths fail with `unsupported_workspace`.
+- Duplicate requests with the same dynamic-tool call id return the existing pending operation instead of starting a second move.
+- Worker failures update pending state to `failed`, preserve existing overlay/runtime cwd, and wake the thread with the failure summary when same-thread wake is available.
+
+### Backward Compatibility
+
+- Existing `handoff_task` schema, default workspace behavior, and pending child-thread result shape remain unchanged.
+- Existing `send_message_to_thread` and `mutate_thread` behavior remains unchanged.
+- Existing app-server `handoffThreadWorkspace` remains the synchronous UI/API path and keeps rejecting direct Codex handoff while a turn is active.
+- The new shared types add a new operation and result union member; they do not remove or reinterpret existing fields.
+
+## Implementation Units
+
+### U1. Shared Operation Contract
+
+**Goal:** Define the public self-move contract and result types.
+
+**Files:**
+
+- `packages/shared/src/contracts/thread-orchestration-tools.ts`
+- `packages/shared/src/contracts/thread-tools.ts`
+
+**Work:**
+
+- Add `move_thread_workspace` to `PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES`.
+- Add `MoveThreadWorkspaceToolArgs`, `MoveThreadWorkspaceResult`, pending self-move status/phase types, and result union wiring.
+- Reuse existing `ThreadWorkspaceHandoffDirection` and `ThreadWorkspaceHandoffStrategy` names where they match the operation.
+- Model operation state separately from `PendingThreadHandoffSummary` while allowing thread status inspection to expose both pending child handoffs and pending workspace moves.
+
+**Requirements Covered:** R1, R2, R3, R4, R5, R8, R9, R13, R16
+
+**Test Scenarios:**
+
+- Type-level/tool-contract tests cover the new operation name and result union.
+- Existing handoff task contract tests still pass unchanged.
+
+### U2. Dynamic Tool Projection and Validation
+
+**Goal:** Advertise and dispatch `pwragent.move_thread_workspace` through the existing dynamic-tool router.
+
+**Files:**
+
+- `apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts`
+- `apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts`
+
+**Work:**
+
+- Add the tool description, JSON schema, invalid-argument message, and argument normalizer.
+- Include clear stop-and-wait language in the tool description and successful result shape.
+- Validate that source path is a non-empty string when provided and that direction defaults to `local-to-worktree`.
+- Keep `additionalProperties: false` so unsupported future fields do not silently pass through.
+
+**Requirements Covered:** R1, R2, R3, R4, R5, R10, R16
+
+**Test Scenarios:**
+
+- Dynamic specs include `move_thread_workspace` under namespace `pwragent`.
+- Invalid blank source paths and invalid enum values fail before handler dispatch.
+- Valid args normalize whitespace and dispatch with caller backend/thread/turn/call context.
+- Existing `handoff_task` and `send_message_to_thread` tests remain valid.
+
+### U3. Backend Pending Self-Move Orchestration
+
+**Goal:** Enqueue self-move requests during a live turn and execute them after the active turn boundary.
+
+**Files:**
+
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+
+**Work:**
+
+- Route `move_thread_workspace` in `handleThreadOrchestrationRequest`.
+- Require a live dynamic tool call, Codex backend, and source thread identity matching the invoking context.
+- Resolve the source workspace from the explicit source path plus the thread's current linked directories and overlay.
+- Record pending self-move state keyed by backend/thread/turn/call id.
+- Add a terminal-turn drain hook next to existing active-turn cleanup so queued moves run only after the current turn is no longer active.
+- Dedupe repeated tool calls by operation id.
+
+**Requirements Covered:** R1, R2, R4, R5, R10, R12, R13, R14
+
+**Test Scenarios:**
+
+- Live Codex dynamic tool call returns a pending self-move result and does not call the Git handoff service immediately.
+- Non-live calls fail with `forbidden`.
+- Unsupported backends fail with `unsupported_backend`.
+- Ambiguous source workspaces fail with `ambiguous_workspace`.
+- Duplicate call id returns the existing operation instead of queuing twice.
+
+### U4. Workspace Move Worker and Metadata Update
+
+**Goal:** Run the real workspace handoff through existing services and preserve runtime metadata correctness.
+
+**Files:**
+
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts`
+
+**Work:**
+
+- Invoke the existing `handoffThreadWorkspace` flow or a factored helper that performs the same validation, `GitWorkspaceHandoffService.handoff`, overlay replacement, branch metadata update, ACP session update hook, and Codex worktree owner recording.
+- Preserve the direct `handoffThreadWorkspace` active-turn rejection for UI/API callers.
+- On success, update pending self-move state with target path, branch, linked directory, warnings, and completion timestamp.
+- On failure, leave overlay/runtime cwd unchanged and mark pending state failed.
+
+**Requirements Covered:** R6, R7, R8, R9, R11, R12, R14, R15
+
+**Test Scenarios:**
+
+- Terminal-turn drain calls the Git handoff service with the resolved repository path/source path.
+- Success updates `replaceWorkspaceLinkedDirectory`, Codex branch metadata, and worktree owner tracking.
+- Failure does not call overlay replacement and reports preserved original workspace.
+- Direct app-server handoff while a Codex turn is active still rejects.
+
+### U5. Same-Thread Wake and Inspection
+
+**Goal:** Make completion observable to both the Agent and the operator.
+
+**Files:**
+
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `packages/shared/src/contracts/thread-tools.ts`
+- `apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts`
+- `apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-agent-tools.test.ts`
+
+**Work:**
+
+- Include pending self-move summaries in `get_thread_status`.
+- Add a bounded `pendingWorkspaceMoves` field rather than changing the meaning of `pendingHandoffs`.
+- Start a same-thread continuation turn after worker completion with a concise success/failure prompt.
+- Ensure the continuation turn inherits the thread's current execution settings and starts after the workspace overlay has been updated.
+
+**Requirements Covered:** R10, R11, R13, R14
+
+**Test Scenarios:**
+
+- `get_thread_status` shows queued/running/completed/failed self-move state.
+- Successful completion starts a same-thread turn with the new cwd and branch result.
+- Failed completion starts a same-thread turn with the failure and original-workspace-preserved statement.
+- If same-thread turn start fails, pending state records the failure and the move result remains inspectable.
+
+### U6. Navigation and Multi-Project Forward Compatibility
+
+**Goal:** Preserve the split between runtime workspace replacement and associated directories.
+
+**Files:**
+
+- `packages/agent-core/src/persistence/overlay-store.ts`
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+- `packages/agent-core/src/domain/navigation-state.ts`
+- `packages/agent-core/src/__tests__/overlay-store.test.ts`
+- `packages/agent-core/src/__tests__/navigation-state.test.ts`
+
+**Work:**
+
+- Confirm existing `replaceWorkspaceLinkedDirectory` behavior remains one handoff workspace per thread.
+- Add focused regression coverage only if the new pending state or result shape touches overlay/navigation materialization.
+- Do not implement general "associate another project path" UI or API in this plan.
+
+**Requirements Covered:** R6, R7, R8
+
+**Test Scenarios:**
+
+- Runtime handoff directory replaces a previous handoff directory for the same thread.
+- Non-runtime extra linked directories remain present after workspace replacement.
+- Navigation materialization shows the handoff worktree as the runtime workspace while preserving unrelated associated directories.
+
+## Verification Contract
+
+Run focused tests first:
+
+- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts`
+- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-agent-tools.test.ts`
+- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
+- `pnpm test apps/desktop/src/main/__tests__/git-workspace-handoff-service.test.ts`
+- `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts packages/agent-core/src/__tests__/navigation-state.test.ts`
+
+Run guardrails before landing:
+
+- `pnpm lint:boundaries`
+- `pnpm lint:codex-storage`
+- `pnpm test`
+
+Manual verification, if the dynamic tool can be exercised locally:
+
+- Start a Codex thread on a local Git checkout.
+- Invoke `pwragent.move_thread_workspace` for that checkout path.
+- Confirm the current turn receives the pending/stop result.
+- Confirm the same thread wakes after terminal turn completion with the worktree cwd.
+- Confirm a follow-up command runs from the worktree path and the thread appears under the worktree-linked project context.
+
+## Definition of Done
+
+- The Agent sees a dedicated `pwragent.move_thread_workspace` tool in dynamic tool specs.
+- The tool accepts a local-to-worktree self-move from a live Codex turn and returns a pending operation handle with stop-and-wait guidance.
+- The actual Git handoff runs only after the invoking turn reaches a terminal boundary.
+- Successful moves update future-turn runtime cwd, linked-directory overlay metadata, branch metadata, and Codex worktree owner tracking.
+- Failed moves leave the original runtime workspace authoritative and report the failure in the same thread.
+- Thread inspection exposes pending/completed/failed self-move status without changing existing `pendingHandoffs` semantics.
+- Existing `handoff_task`, `send_message_to_thread`, `mutate_thread`, and synchronous UI/API workspace handoff behavior remain backward-compatible.
+- Verification Contract commands pass, including dependency-boundary and Codex-storage guardrails.
+
+## Implementation Defaults
+
+- Start a same-thread continuation turn for completion wake, because it wakes the Agent without requiring UI polling.
+- Include `worktree-to-local` in the direction enum only if the normalizer returns a clear unsupported response until that direction is implemented; otherwise omit it from the public schema for this slice.
+- Expire completed self-move records on the same bounded retention window used by pending child handoffs unless implementation introduces a durable activity entry.

--- a/docs/plans/2026-06-28-001-feat-path-keyed-thread-workspace-handoff-plan.md
+++ b/docs/plans/2026-06-28-001-feat-path-keyed-thread-workspace-handoff-plan.md
@@ -1,0 +1,137 @@
+---
+title: Path-Keyed Thread Workspace Handoff - Plan
+type: feat
+date: 2026-06-28
+topic: path-keyed-thread-workspace-handoff
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: requirements-only
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Path-Keyed Thread Workspace Handoff - Plan
+
+## Goal Capsule
+
+- **Objective:** Let an Agent move its current PwrAgent thread runtime workspace from a local checkout to an isolated worktree through a first-class async tool, without falling back to raw `git worktree` commands that leave PwrAgent metadata behind.
+- **Product authority:** The tool should preserve PwrAgent's thread-first navigation model and make workspace movement explicit, observable, and safe across active-turn boundaries.
+- **Open blockers:** Planning must decide the exact operation naming, callback/wake mechanism, and whether the worker is modeled as a PwrAgent monitor, a sub-agent, or a backend-managed async job.
+
+---
+
+## Product Contract
+
+### Summary
+
+Add a path-keyed dynamic tool for moving the current thread's runtime workspace into a managed worktree.
+The invoking turn starts the move and then stops; an async worker performs the filesystem and metadata transition, posts the result back into the same thread, and future turns continue from the new runtime cwd.
+
+### Problem Frame
+
+Agents can already create a child thread in a new worktree through task handoff, and desktop/messaging flows can perform workspace handoff for an existing thread.
+An Agent cannot currently say "move this thread's current path to a worktree" through a dedicated dynamic tool.
+When it uses shell commands instead, Git may be correct but PwrAgent still believes the thread is attached to the old project path, so navigation, branch chips, linked directories, and future turns can drift from the work the Agent is doing.
+
+### Key Decisions
+
+- **Dedicated workspace tool, not `mutate_thread`:** Workspace movement is long-running filesystem and runtime choreography, while `mutate_thread` remains guarded metadata mutation for title, model, fast mode, and execution mode.
+- **Path-keyed operation:** The caller identifies the source path or linked directory being moved, because a thread can already carry multiple linked directories and future multi-project threads cannot rely on "the" thread workspace being obvious.
+- **Runtime workspace vs associated directories:** The tool changes the runtime workspace for future turns, while linked directory associations remain a separate concept used for navigation and project membership.
+- **Async handoff boundary:** The invoking turn should not continue as if its process cwd changed underneath it; a worker completes the move and wakes the thread with a result message.
+- **Self-move first:** The first slice moves one runtime path to a worktree and records the resulting linked directory; broader agent-managed project association is deferred but must not require an incompatible contract later.
+
+### Actors
+
+- A1. **Invoking Agent:** The current Codex Agent turn that decides a task should continue in an isolated worktree.
+- A2. **Workspace worker:** The asynchronous PwrAgent-controlled worker or sub-agent that performs the move after the invoking turn yields.
+- A3. **PwrAgent backend:** The authority that validates eligibility, records operation state, updates overlays, and posts the continuation result.
+- A4. **Operator:** The human who expects the thread to appear under the right project/worktree and to continue safely after the move.
+
+### Requirements
+
+**Agent Tool Surface**
+
+- R1. The Agent can start a workspace move for an existing thread through a first-class dynamic tool without creating a child task thread.
+- R2. The request identifies the path or linked directory being moved rather than relying only on the thread id.
+- R3. The request supports local-to-worktree movement as the first required direction.
+- R4. The tool returns an operation handle and clear "stop and wait for callback" guidance rather than implying that the current turn can keep working from the new path.
+- R5. The tool rejects ambiguous multi-directory requests unless the caller names the source path or directory explicitly.
+
+**Workspace Semantics**
+
+- R6. A successful move updates the runtime workspace used by future turns of the same thread.
+- R7. A successful move records the new worktree as a linked directory so thread navigation, project grouping, and status surfaces can show the new association.
+- R8. The result distinguishes runtime workspace changes from additional associated directories so later multi-project support can add paths without changing the thread's runtime cwd.
+- R9. The move preserves or reports branch strategy outcomes using the existing workspace handoff vocabulary where it applies.
+
+**Async Completion**
+
+- R10. The move runs outside the invoking turn and reports completion, failure, or cancellation back into the original thread.
+- R11. The completion message includes the new cwd, source path, target worktree path, branch result, warnings, and any required next instruction for the Agent.
+- R12. A failed move leaves the thread's runtime workspace and linked-directory metadata at the last known-good state.
+- R13. PwrAgent surfaces pending workspace-move state in thread inspection so a user or Agent can tell that a move is still in progress.
+
+**Safety and Compatibility**
+
+- R14. The tool is unavailable or explicitly blocked when the backend cannot safely update future-turn runtime cwd for that thread.
+- R15. The operation does not loosen dependency boundaries or bypass existing Git workspace handoff validation.
+- R16. Existing `handoff_task` behavior remains for delegated child-thread work and is not repurposed as self-move.
+
+### Key Flow
+
+- F1. **Self-move to worktree**
+  - **Trigger:** The invoking Agent is on a local checkout and determines that the task should continue in isolation.
+  - **Actors:** A1, A2, A3
+  - **Steps:** The Agent calls the path-keyed workspace tool with the local source path; PwrAgent validates the source and starts a pending operation; the Agent ends its turn; the worker creates or moves the worktree and updates PwrAgent metadata; PwrAgent posts a completion message into the same thread.
+  - **Outcome:** The next Agent turn starts with the worktree as its runtime workspace, and the thread appears under the appropriate worktree/project context.
+  - **Covered by:** R1, R2, R4, R6, R7, R10, R11
+
+```mermaid
+flowchart TB
+  A[Invoking Agent] --> B[Start path-keyed workspace move]
+  B --> C[PwrAgent records pending operation]
+  C --> D[Invoking turn ends]
+  D --> E[Workspace worker performs Git handoff]
+  E --> F[PwrAgent updates runtime workspace and linked directory metadata]
+  F --> G[Completion message wakes same thread]
+  G --> H[Future turn runs in worktree cwd]
+```
+
+### Acceptance Examples
+
+- AE1. **Covered by R1, R4, R10.** Given an Agent on a local checkout, when it starts a workspace move, then the tool returns a pending operation and tells the Agent not to continue working in the current turn.
+- AE2. **Covered by R2, R5.** Given a thread associated with two repositories, when the Agent requests a move without identifying a source path, then PwrAgent rejects the request as ambiguous.
+- AE3. **Covered by R6, R7, R11.** Given a successful move, when the same thread resumes, then the completion message names the new cwd and the thread metadata includes the new worktree association.
+- AE4. **Covered by R12.** Given a move that fails during worktree creation, when PwrAgent reports failure, then future turns still use the original runtime workspace.
+- AE5. **Covered by R16.** Given a request to delegate work to a child thread, when the Agent uses `handoff_task`, then existing child-thread behavior remains unchanged.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- Agent-managed "associate this other project path with this thread" support that does not change runtime cwd.
+- Multiple simultaneous runtime workspaces for one thread.
+- Worktree-to-local self-move through the Agent tool, unless planning finds it is nearly free once local-to-worktree exists.
+- UI polish for editing associated directories directly from the thread context panel.
+
+**Outside this feature**
+
+- Replacing desktop or messaging workspace handoff flows.
+- Making raw shell `git worktree` commands update PwrAgent thread metadata automatically.
+- Changing the semantics of `mutate_thread` from metadata mutation into filesystem operations.
+
+### Dependencies / Assumptions
+
+- PwrAgent already has linked-directory overlay storage that navigation can merge into thread summaries.
+- PwrAgent already has backend workspace handoff behavior for existing threads; this feature should expose the right Agent-facing orchestration rather than reimplementing Git movement.
+- Codex future-turn cwd rebinding is the critical capability gate: if a backend cannot guarantee future turns run in the moved workspace, the tool must fail clearly.
+- The async worker can post back to the original thread in a way that wakes or resumes the conversation without requiring the user to manually copy the new path.
+
+### Sources / Research
+
+- `apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts` defines `mutate_thread` as guarded metadata mutation.
+- `apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts` defines `handoff_task` as child-thread creation, including `workspaceMode: "new_worktree"`.
+- `apps/desktop/src/main/app-server/git-workspace-handoff-service.ts` contains the existing Git workspace handoff service.
+- `packages/agent-core/src/persistence/overlay-store.ts` already stores `extraLinkedDirectories` and workspace replacement metadata.
+- `packages/agent-core/src/domain/navigation-state.ts` merges overlay `extraLinkedDirectories` into navigation summaries.
+- `docs/plans/2026-04-29-001-feat-thread-workspace-handoff-plan.md` and `docs/plans/2026-06-18-001-feat-agent-task-handoff-tool-plan.md` provide prior context for existing workspace handoff and task handoff behavior.

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
   PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES,
   PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
   type HandoffTaskResult,
@@ -97,6 +98,8 @@ describe("thread orchestration tool contracts", () => {
   });
 
   it("models pending same-thread workspace moves separately from task handoffs", () => {
+    expect(DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY).toBe("detached-changes");
+
     const args = {
       direction: "local-to-worktree",
       repositoryPath: "/repo/app",

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -5,6 +5,8 @@ import {
   PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
   type HandoffTaskResult,
   type HandoffTaskToolArgs,
+  type MoveThreadWorkspaceResult,
+  type MoveThreadWorkspaceToolArgs,
   type ThreadHandoffOrigin,
 } from "../thread-orchestration-tools";
 
@@ -12,6 +14,7 @@ describe("thread orchestration tool contracts", () => {
   it("defines the handoff task operation", () => {
     expect(PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES).toEqual([
       "handoff_task",
+      "move_thread_workspace",
       "send_message_to_thread",
     ]);
   });
@@ -91,5 +94,32 @@ describe("thread orchestration tool contracts", () => {
 
     expect(JSON.parse(JSON.stringify(result))).toEqual(result);
     expect(result.groupedUnderThreadId).toBeUndefined();
+  });
+
+  it("models pending same-thread workspace moves separately from task handoffs", () => {
+    const args = {
+      direction: "local-to-worktree",
+      repositoryPath: "/repo/app",
+      sourcePath: "/repo/app",
+      leaveLocalBranch: "main",
+    } satisfies MoveThreadWorkspaceToolArgs;
+
+    const result: MoveThreadWorkspaceResult = {
+      backend: "codex",
+      threadId: "thread-1",
+      workspaceMoveId: "workspace-move:codex:thread-1:turn-1:call-1",
+      status: "queued",
+      phase: "waiting_for_turn_boundary",
+      direction: args.direction,
+      repositoryPath: args.repositoryPath,
+      sourcePath: args.sourcePath,
+      createdAt: 1_773_000_000_000,
+      updatedAt: 1_773_000_000_000,
+      message:
+        "Workspace move queued. Stop this turn and wait for the continuation.",
+    };
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+    expect(result.status).toBe("queued");
   });
 });

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -565,14 +565,22 @@ export type ArchiveWorktreeResponse = {
   snapshot: WorktreeSnapshotSummary;
 };
 
+export const THREAD_WORKSPACE_HANDOFF_DIRECTIONS = [
+  "local-to-worktree",
+  "worktree-to-local",
+] as const;
+
 export type ThreadWorkspaceHandoffDirection =
-  | "local-to-worktree"
-  | "worktree-to-local";
+  (typeof THREAD_WORKSPACE_HANDOFF_DIRECTIONS)[number];
+
+export const THREAD_WORKSPACE_HANDOFF_STRATEGIES = [
+  "move-branch",
+  "detached-changes",
+  "new-branch",
+] as const;
 
 export type ThreadWorkspaceHandoffStrategy =
-  | "move-branch"
-  | "detached-changes"
-  | "new-branch";
+  (typeof THREAD_WORKSPACE_HANDOFF_STRATEGIES)[number];
 
 export type ThreadWorkspaceHandoffStashSummary = {
   ref?: string;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -34,6 +34,9 @@ export const PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES = [
 export type PwrAgentThreadOrchestrationErrorCode =
   (typeof PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES)[number];
 
+export const DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY =
+  "detached-changes" satisfies ThreadWorkspaceHandoffStrategy;
+
 export type PwrAgentThreadOrchestrationContext = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -134,7 +134,6 @@ export type MoveThreadWorkspaceStatus =
   | "failed";
 
 export type MoveThreadWorkspacePhase =
-  | "resolving_source"
   | "waiting_for_turn_boundary"
   | "preparing_workspace"
   | "updating_metadata"

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -4,12 +4,15 @@ import type {
   LinkedDirectorySummary,
   ThreadExecutionMode,
   ThreadIdentifier,
+  ThreadWorkspaceHandoffDirection,
+  ThreadWorkspaceHandoffStrategy,
 } from "./normalized-app-server";
 import type { CodexEnvironmentStartupFailure } from "./agent";
 import type { MessagingChannelKind, MessagingConversationKind } from "./messaging";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
   "handoff_task",
+  "move_thread_workspace",
   "send_message_to_thread",
 ] as const;
 
@@ -105,6 +108,62 @@ export type SendMessageToThreadToolArgs = {
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;
   sandbox?: string;
+};
+
+export type MoveThreadWorkspaceToolArgs = {
+  /**
+   * Optional backend override. Omitted defaults to the invoking thread backend.
+   * The first implementation supports Codex self-move only.
+   */
+  backend?: AppServerBackendKind;
+  direction?: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
+  /** Repository/local checkout path that owns the worktree relationship. */
+  repositoryPath?: string;
+  /** Current workspace path before handoff. */
+  sourcePath?: string;
+  sourceBranch?: string;
+  leaveLocalBranch?: string;
+  newBranchName?: string;
+};
+
+export type MoveThreadWorkspaceStatus =
+  | "queued"
+  | "running"
+  | "completed"
+  | "failed";
+
+export type MoveThreadWorkspacePhase =
+  | "resolving_source"
+  | "waiting_for_turn_boundary"
+  | "preparing_workspace"
+  | "updating_metadata"
+  | "starting_continuation"
+  | "completed"
+  | "failed";
+
+export type MoveThreadWorkspaceResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  workspaceMoveId: string;
+  status: MoveThreadWorkspaceStatus;
+  phase: MoveThreadWorkspacePhase;
+  direction: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
+  repositoryPath?: string;
+  sourcePath?: string;
+  sourceBranch?: string;
+  leaveLocalBranch?: string;
+  newBranchName?: string;
+  targetPath?: string;
+  branch?: string;
+  linkedDirectory?: LinkedDirectorySummary;
+  warnings?: string[];
+  continuationTurnId?: string;
+  createdAt: number;
+  updatedAt: number;
+  message: string;
+  error?: string;
 };
 
 export type ThreadHandoffOriginWorkspace = {
@@ -214,6 +273,7 @@ export type SendMessageToThreadResult = {
 
 export type PwrAgentThreadOrchestrationToolArgsByOperation = {
   handoff_task: HandoffTaskToolArgs;
+  move_thread_workspace: MoveThreadWorkspaceToolArgs;
   send_message_to_thread: SendMessageToThreadToolArgs;
 };
 
@@ -236,7 +296,10 @@ export type PwrAgentThreadOrchestrationRequest<
 export type PwrAgentThreadOrchestrationResponse =
   | {
       ok: true;
-      data: HandoffTaskResult | SendMessageToThreadResult;
+      data:
+        | HandoffTaskResult
+        | MoveThreadWorkspaceResult
+        | SendMessageToThreadResult;
     }
   | {
       ok: false;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -8,6 +8,8 @@ import type {
   AppServerThreadStatus,
   ThreadExecutionMode,
   ThreadIdentifier,
+  ThreadWorkspaceHandoffDirection,
+  ThreadWorkspaceHandoffStrategy,
 } from "./normalized-app-server";
 import type { LinkedDirectorySummary } from "./normalized-app-server";
 import type {
@@ -18,6 +20,8 @@ import type {
   HandoffTaskGroupingMode,
   HandoffTaskSeedMode,
   HandoffTaskWorkspaceMode,
+  MoveThreadWorkspacePhase,
+  MoveThreadWorkspaceStatus,
   ThreadHandoffOrigin,
   ThreadHandoffOriginWorkspace,
 } from "./thread-orchestration-tools";
@@ -188,6 +192,7 @@ export type ThreadStatusInspectionSummary = ThreadInspectionSummary & {
   queuedExecutionMode?: ThreadExecutionMode;
   queuedExecutionModeAt?: number;
   pendingHandoffs?: PendingThreadHandoffSummary[];
+  pendingWorkspaceMoves?: PendingThreadWorkspaceMoveSummary[];
 };
 
 export type PendingThreadHandoffStatus = "starting" | "completed" | "failed";
@@ -218,6 +223,33 @@ export type PendingThreadHandoffSummary = {
   workspaceMode: HandoffTaskWorkspaceMode;
   branchName?: string;
   workspace?: ThreadHandoffOriginWorkspace;
+  createdAt: number;
+  updatedAt: number;
+  message?: string;
+  error?: string;
+};
+
+export type PendingThreadWorkspaceMoveSummary = {
+  workspaceMoveId: string;
+  status: MoveThreadWorkspaceStatus;
+  phase: MoveThreadWorkspacePhase;
+  sourceBackend: AppServerBackendKind;
+  sourceThreadId: ThreadIdentifier;
+  sourceTurnId?: ThreadIdentifier;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  direction: ThreadWorkspaceHandoffDirection;
+  strategy?: ThreadWorkspaceHandoffStrategy;
+  repositoryPath?: string;
+  sourcePath?: string;
+  sourceBranch?: string;
+  leaveLocalBranch?: string;
+  newBranchName?: string;
+  targetPath?: string;
+  branch?: string;
+  linkedDirectory?: LinkedDirectorySummary;
+  warnings?: string[];
+  continuationTurnId?: string;
   createdAt: number;
   updatedAt: number;
   message?: string;
@@ -338,6 +370,7 @@ export type PwrAgentThreadInspectionResponse =
             limit: number;
             truncated: boolean;
             pendingHandoffs?: PendingThreadHandoffSummary[];
+            pendingWorkspaceMoves?: PendingThreadWorkspaceMoveSummary[];
             query?: string;
             searchedScopes?: ThreadSearchScopeName[];
             unavailableScopes?: ThreadSearchUnavailableScope[];


### PR DESCRIPTION
## Summary

- Agents can now schedule a same-thread Codex workspace move to a linked worktree, end the current turn, and resume from a continuation in the moved workspace instead of creating a child handoff thread.
- The move is path-keyed to the invoking thread's linked directories, waits for terminal or idle turn boundaries, reuses the existing Git workspace handoff path, and exposes `pendingWorkspaceMoves` through thread inspection tools.
- Queue hardening keeps normal queued turns behind the workspace-move continuation, dedupes same-turn move requests, rejects unlinked explicit paths, and preserves both handoff and continuation errors for retry/debugging.

Closes #889.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm test`
- `pnpm test packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

## Notes

- The workspace-move status is process-local inspection state. A desktop restart during a queued or running move is still a future durability/recovery concern.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)
