### PR TITLE
feat(desktop): manage thread PR and directory links

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -277,8 +277,45 @@ const markThreadSeen = vi.fn(async (request: MarkThreadSeenRequest) => ({
   seenAt: request.seenAt ?? 2000,
   seenUpdatedAt: request.seenUpdatedAt,
 }));
+const registerDirectoryFromDiskService = vi.fn(async (request: { path: string }) => {
+  const directoryPath = path.resolve(request.path);
+  return {
+    ok: true as const,
+    directoryKey: `directory:${directoryPath}`,
+    directoryPath,
+    directoryLabel: path.basename(directoryPath) || directoryPath,
+    currentBranch: "main",
+    launchpad: {
+      directoryKey: `directory:${directoryPath}`,
+      directoryKind: "directory" as const,
+      directoryLabel: path.basename(directoryPath) || directoryPath,
+      directoryPath,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      branchName: "main",
+      workMode: "local" as const,
+      createdAt: 1000,
+      updatedAt: 1000,
+    },
+    defaults: {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    },
+  };
+});
 const getThreadOverlayState = vi.fn();
 const getThreadOverlayStates = vi.fn(async () => ({}));
+const addLinkedDirectory = vi.fn(async (request: {
+  backend: "codex" | "grok";
+  threadId: string;
+  directory: unknown;
+}) => ({
+  backend: request.backend,
+  threadId: request.threadId,
+  executionMode: "default" as const,
+  extraLinkedDirectories: [request.directory],
+}));
 const setThreadPullRequests = vi.fn(async (request: {
   backend: "codex" | "grok";
   threadId: string;
@@ -403,6 +440,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     markThreadSeen,
     getThreadOverlayState,
     getThreadOverlayStates,
+    addLinkedDirectory,
     setThreadPullRequests,
     readPrStatusCache,
     writePrStatusCacheEntries,
@@ -413,6 +451,10 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     readThreadGitWorkingStateCache,
     writeThreadGitWorkingStateCacheEntry,
   }),
+}));
+
+vi.mock("../app-server/directory-registration-service", () => ({
+  registerDirectoryFromDisk: registerDirectoryFromDiskService,
 }));
 
 vi.mock("../app-server/backend-registry", () => ({
@@ -481,6 +523,8 @@ describe("app server ipc", () => {
     publishLocalEvent.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
+    registerDirectoryFromDiskService.mockClear();
+    addLinkedDirectory.mockClear();
     getThreadOverlayState.mockReset();
     getThreadOverlayState.mockResolvedValue(undefined);
     getThreadOverlayStates.mockReset();
@@ -1983,6 +2027,186 @@ describe("app server ipc", () => {
         params: {
           threadId: "thread-1",
           prs: [previousPr, discoveredPr],
+        },
+      },
+    });
+  });
+
+  it("publishes the store-filtered PR list after background refreshes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "feat/detached-pr",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/detached-pr",
+      directoryPaths: ["/repo"],
+    });
+    const previousPr = githubPr({
+      number: 910,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/910",
+    });
+    const detachedPr = githubPr({
+      number: 911,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/911",
+    });
+    const discoveredPr = githubPr({
+      number: 912,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/912",
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      detachedPrKeys: ["github.com/pwrdrvr/pwragent#911"],
+      prs: [previousPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([detachedPr, discoveredPr]);
+    setThreadPullRequests.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [previousPr, discoveredPr],
+      prsFetchedAt: Date.now(),
+      prsRefreshKey: requestKey,
+    });
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [previousPr, detachedPr, discoveredPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [previousPr, discoveredPr],
+        },
+      },
+    });
+  });
+
+  it("returns and publishes the store-filtered PR list for lookup-cache hits", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "feat/cached-detached-pr",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feat/cached-detached-pr",
+      directoryPaths: ["/repo"],
+    });
+    const lookupKey = buildPrLookupKey({
+      branch: "feat/cached-detached-pr",
+      directoryPaths: ["/repo"],
+    });
+    const previousPr = githubPr({
+      number: 920,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/920",
+    });
+    const detachedPr = githubPr({
+      number: 921,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/921",
+    });
+    const cachedPr = githubPr({
+      number: 922,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/922",
+    });
+    readPrLookupCache.mockResolvedValueOnce({
+      [lookupKey]: {
+        lookupKey,
+        provider: "github.com",
+        branch: "feat/cached-detached-pr",
+        directoryPaths: ["/repo"],
+        fetchedAt: Date.now(),
+        prs: [detachedPr, cachedPr],
+      },
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      detachedPrKeys: ["github.com/pwrdrvr/pwragent#921"],
+      prs: [previousPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: "old-refresh-key",
+    });
+    setThreadPullRequests.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [previousPr, cachedPr],
+      prsFetchedAt: Date.now(),
+      prsRefreshKey: requestKey,
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      provider: "github.com",
+      ghAvailable: true,
+      prs: [previousPr, cachedPr],
+    });
+    expect(publishLocalEvent).toHaveBeenCalledWith({
+      backend: "codex",
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId: "thread-1",
+          prs: [previousPr, cachedPr],
         },
       },
     });
@@ -3506,5 +3730,45 @@ describe("app server ipc", () => {
         gitStatus: expect.objectContaining({ currentBranch: "fresh-branch" }),
       }),
     );
+  });
+
+  it("attaches directories with path-shaped linked directory ids", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL } = await import("../../shared/ipc");
+    const directoryPath = path.resolve("/repo/app");
+    const directoryPathId = directoryPath.replace(/\\/g, "/");
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL)?.(
+      {},
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        path: "/repo/app",
+      },
+    );
+
+    expect(addLinkedDirectory).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: directoryPathId,
+        kind: "local",
+        label: path.basename(directoryPath),
+        path: directoryPathId,
+      },
+    });
+    expect(response).toEqual({
+      ok: true,
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: directoryPathId,
+        kind: "local",
+        label: path.basename(directoryPath),
+        path: directoryPathId,
+      },
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2228,6 +2228,87 @@ describe("app server ipc", () => {
     });
   });
 
+  it("keeps detached PRs hidden when gh is unavailable and lookup cache still has them", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      trigger: "user",
+      branch: "feat/cached-detached-pr",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const lookupKey = buildPrLookupKey({
+      branch: "feat/cached-detached-pr",
+      directoryPaths: ["/repo"],
+    });
+    const previousPr = githubPr({
+      number: 920,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/920",
+    });
+    const detachedPr = githubPr({
+      number: 921,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/921",
+    });
+    const cachedPr = githubPr({
+      number: 922,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/922",
+    });
+    readPrLookupCache.mockResolvedValueOnce({
+      [lookupKey]: {
+        lookupKey,
+        provider: "github.com",
+        branch: "feat/cached-detached-pr",
+        directoryPaths: ["/repo"],
+        fetchedAt: Date.now(),
+        prs: [detachedPr, cachedPr],
+      },
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      detachedPrKeys: ["github.com/pwrdrvr/pwragent#921"],
+      prs: [previousPr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: "old-refresh-key",
+    });
+    isGhAvailable.mockResolvedValueOnce(false);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      provider: "github.com",
+      ghAvailable: false,
+      prs: [previousPr, cachedPr],
+    });
+    expect(setThreadPullRequests).not.toHaveBeenCalled();
+    expect(publishLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          method: "thread/pullRequests/updated",
+        }),
+      }),
+    );
+  });
+
   it("persists and publishes title-only PR updates", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
@@ -2701,6 +2782,7 @@ describe("app server ipc", () => {
         trigger: "user",
         branch: "fix/open",
         directoryPaths: ["/repo"],
+        includeStatusFreshness: true,
       } satisfies RefreshThreadPullRequestsRequest;
       const requestKey = buildThreadPrRequestKey({
         backend: "codex",
@@ -2731,7 +2813,17 @@ describe("app server ipc", () => {
 
       registerAppServerIpcHandlers();
 
-      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      const firstResponse = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+        {},
+        request,
+      );
+      expect(firstResponse).toMatchObject({
+        backend: "codex",
+        threadId: "thread-1",
+        refreshStarted: true,
+        lastStatusCheckAt: 2_000_000 - 120_000,
+        lastStatusCheckAgeMs: 120_000,
+      });
       await vi.waitFor(() => {
         expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
       });
@@ -2748,7 +2840,17 @@ describe("app server ipc", () => {
       mockAppServerLog.info.mockClear();
 
       vi.setSystemTime(2_000_000 + 9_000);
-      await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.({}, request);
+      const cooldownResponse = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+        {},
+        request,
+      );
+      expect(cooldownResponse).toMatchObject({
+        backend: "codex",
+        threadId: "thread-1",
+        refreshStarted: false,
+        lastStatusCheckAt: 2_000_000,
+        lastStatusCheckAgeMs: 9_000,
+      });
       await Promise.resolve();
       expect(detectPullRequestsForThread).toHaveBeenCalledTimes(1);
       expect(mockAppServerLog.info).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -330,6 +330,17 @@ const setThreadPullRequests = vi.fn(async (request: {
   prsFetchedAt: Date.now(),
   prsRefreshKey: request.refreshKey,
 }));
+const addThreadPullRequestReference = vi.fn(async (request: {
+  backend: "codex" | "grok";
+  threadId: string;
+  pr: PrSummary;
+}) => ({
+  backend: request.backend,
+  threadId: request.threadId,
+  executionMode: "default" as const,
+  extraLinkedDirectories: [],
+  prs: [request.pr],
+}));
 const readPrStatusCache = vi.fn(async () => ({}));
 const writePrStatusCacheEntries = vi.fn(async () => undefined);
 const readPrLookupCache = vi.fn(async () => ({}));
@@ -442,6 +453,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     getThreadOverlayStates,
     addLinkedDirectory,
     setThreadPullRequests,
+    addThreadPullRequestReference,
     readPrStatusCache,
     writePrStatusCacheEntries,
     readPrLookupCache,
@@ -530,6 +542,7 @@ describe("app server ipc", () => {
     getThreadOverlayStates.mockReset();
     getThreadOverlayStates.mockResolvedValue({});
     setThreadPullRequests.mockClear();
+    addThreadPullRequestReference.mockClear();
     readPrStatusCache.mockReset();
     readPrStatusCache.mockResolvedValue({});
     writePrStatusCacheEntries.mockClear();

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2573,6 +2573,80 @@ describe("app server ipc", () => {
     });
   });
 
+  it("refreshes retained detached PRs by URL when the current branch lookup is empty", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
+    const request = {
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    } satisfies RefreshThreadPullRequestsRequest;
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "codex/fix-reel-upload-button-swift",
+      directoryPaths: ["/repo"],
+    });
+    const detachedPr = githubPr({
+      number: 255,
+      org: "Giphy",
+      repo: "GifGrabber",
+      title: "[codex] Fix upload button after reel switching",
+      state: "passing",
+      url: "https://github.com/Giphy/GifGrabber/pull/255",
+    });
+    const mergedDetachedPr = githubPr({
+      ...detachedPr,
+      state: "passing",
+      lifecycleState: "merged",
+      commitShas: ["c".repeat(40)],
+    });
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      detachedPrKeys: ["github.com/giphy/gifgrabber#255"],
+      detachedPrs: [detachedPr],
+      prs: [],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    detectPullRequestsForThread.mockResolvedValueOnce([]);
+    fetchPullRequestByUrl.mockResolvedValueOnce(mergedDetachedPr);
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)?.(
+      {},
+      request,
+    );
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      provider: "github.com",
+      ghAvailable: true,
+      prs: [],
+    });
+    await vi.waitFor(() => {
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/repo",
+        url: "https://github.com/Giphy/GifGrabber/pull/255",
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [mergedDetachedPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+  });
+
   it("does not publish PR update events when retained PR status is unchanged", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_REFRESH_THREAD_PRS_CHANNEL } = await import("../../shared/ipc");
@@ -3567,6 +3641,68 @@ describe("app server ipc", () => {
         fetchedAt,
       );
     }
+  });
+
+  it("includes overlay attached directories in PR status tool default paths", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const cachedPr = githubPr({
+      number: 945,
+      org: "pwrdrvr",
+      repo: "agent-kit",
+      title: "Attached repo PR",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/agent-kit/pull/945",
+    });
+
+    listThreads.mockResolvedValue([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        gitBranch: "feat/status-tool",
+        linkedDirectories: [],
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [
+        {
+          id: "directory:/repo/agent-kit",
+          kind: "worktree",
+          label: "agent-kit",
+          path: "/repo/agent-kit",
+          worktreePath: "/repo/agent-kit-wt",
+        },
+      ],
+      prs: [cachedPr],
+      prsFetchedAt: Date.now() - 45_000,
+    });
+
+    registerAppServerIpcHandlers();
+    const handler = setThreadPullRequestStatusToolHandler.mock.calls.at(-1)?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    const response = await handler?.({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        pullRequestStatus: {
+          backend: "codex",
+          threadId: "thread-1",
+          prs: [cachedPr],
+          branch: "feat/status-tool",
+          directoryPaths: ["/repo/agent-kit-wt"],
+        },
+      },
+    });
   });
 
   it("refreshes a thread's working state after the agent finishes a turn", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -317,6 +317,16 @@ const addLinkedDirectory = vi.fn(async (request: {
   executionMode: "default" as const,
   extraLinkedDirectories: [request.directory],
 }));
+const removeLinkedDirectory = vi.fn(async (request: {
+  backend: "codex" | "grok";
+  threadId: string;
+  directory: unknown;
+}) => ({
+  backend: request.backend,
+  threadId: request.threadId,
+  executionMode: "default" as const,
+  extraLinkedDirectories: [],
+}));
 const setThreadPullRequests = vi.fn(async (request: {
   backend: "codex" | "grok";
   threadId: string;
@@ -453,6 +463,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     getThreadOverlayState,
     getThreadOverlayStates,
     addLinkedDirectory,
+    removeLinkedDirectory,
     setThreadPullRequests,
     addThreadPullRequestReference,
     readPrStatusCache,
@@ -540,6 +551,7 @@ describe("app server ipc", () => {
     markThreadSeen.mockClear();
     registerDirectoryFromDiskService.mockClear();
     addLinkedDirectory.mockClear();
+    removeLinkedDirectory.mockClear();
     getThreadOverlayState.mockReset();
     getThreadOverlayState.mockResolvedValue(undefined);
     getThreadOverlayStates.mockReset();
@@ -4151,6 +4163,116 @@ describe("app server ipc", () => {
         label: path.basename(directoryPath),
         path: directoryPathId,
       },
+    });
+  });
+
+  it("detaches a secondary directory while preserving the primary linked directory", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL } =
+      await import("../../shared/ipc");
+    const primaryDirectory = {
+      id: "/repo/pwragent",
+      kind: "worktree" as const,
+      label: "PwrAgent",
+      path: "/repo/pwragent",
+      worktreePath: "/repo/pwragent-wt",
+    };
+    const secondaryDirectory = {
+      id: "/repo/agent-kit",
+      kind: "local" as const,
+      label: "agent-kit",
+      path: "/repo/agent-kit",
+    };
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [primaryDirectory, secondaryDirectory],
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [secondaryDirectory],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(
+      NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
+    )?.(
+      {},
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        directory: secondaryDirectory,
+      },
+    );
+
+    expect(removeLinkedDirectory).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: secondaryDirectory,
+    });
+    expect(response).toEqual({
+      ok: true,
+      backend: "codex",
+      threadId: "thread-1",
+      directories: [],
+    });
+  });
+
+  it("rejects detaching the last linked directory", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL } =
+      await import("../../shared/ipc");
+    const onlyDirectory = {
+      id: "/repo/agent-kit",
+      kind: "local" as const,
+      label: "agent-kit",
+      path: "/repo/agent-kit",
+    };
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [onlyDirectory],
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockResolvedValueOnce({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [onlyDirectory],
+    });
+
+    registerAppServerIpcHandlers();
+
+    const response = await handlers.get(
+      NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
+    )?.(
+      {},
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        directory: onlyDirectory,
+      },
+    );
+
+    expect(removeLinkedDirectory).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      ok: false,
+      backend: "codex",
+      threadId: "thread-1",
+      reason: "last-directory",
+      message: "Cannot detach the last linked directory from a thread.",
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -247,6 +247,7 @@ function emitRegistryEvent(event: unknown): void {
   }
 }
 const publishLocalEvent = vi.fn(async () => undefined);
+const setThreadPullRequestStatusToolHandler = vi.fn();
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
   directoryKey: string;
   directoryKind: string;
@@ -487,6 +488,7 @@ vi.mock("../app-server/backend-registry", () => ({
     resolveEditCommitStates,
     onEvent,
     publishLocalEvent,
+    setThreadPullRequestStatusToolHandler,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
   }),
@@ -533,6 +535,7 @@ describe("app server ipc", () => {
     onEvent.mockClear();
     registryEventListeners.length = 0;
     publishLocalEvent.mockClear();
+    setThreadPullRequestStatusToolHandler.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
     registerDirectoryFromDiskService.mockClear();
@@ -3387,6 +3390,81 @@ describe("app server ipc", () => {
         },
       );
     });
+  });
+
+  it("registers a user-invoked PR status tool handler with freshness metadata", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const fetchedAt = Date.now() - 45_000;
+    const cachedPr = githubPr({
+      number: 944,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Cached PR",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/944",
+    });
+
+    listThreads.mockResolvedValue([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        gitBranch: "feat/status-tool",
+        linkedDirectories: [
+          {
+            id: "directory:/repo",
+            kind: "worktree",
+            label: "Repo",
+            path: "/repo",
+            worktreePath: "/repo/wt",
+          },
+        ],
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [cachedPr],
+      prsFetchedAt: fetchedAt,
+    });
+
+    registerAppServerIpcHandlers();
+    const handler = setThreadPullRequestStatusToolHandler.mock.calls.at(-1)?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    const response = await handler?.({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        pullRequestStatus: {
+          backend: "codex",
+          threadId: "thread-1",
+          provider: "github.com",
+          prs: [cachedPr],
+          ghAvailable: true,
+          refreshStarted: true,
+          lastStatusCheckAt: fetchedAt,
+          branch: "feat/status-tool",
+          directoryPaths: ["/repo/wt"],
+        },
+      },
+    });
+    if (response?.ok && "pullRequestStatus" in response.data) {
+      expect(response.data.pullRequestStatus.lastStatusCheckAgeMs).toBeGreaterThanOrEqual(
+        45_000,
+      );
+      expect(response.data.pullRequestStatus.requestedAt).toBeGreaterThanOrEqual(
+        fetchedAt,
+      );
+    }
   });
 
   it("refreshes a thread's working state after the agent finishes a turn", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -3323,6 +3323,59 @@ describe("app server ipc", () => {
     });
   });
 
+  it("passes detached merged PR commit SHAs into working-state probes", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const mergedPrSha = "b".repeat(40);
+    const detachedPr = githubPr({
+      number: 807,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Detached merged PR",
+      state: "passing",
+      lifecycleState: "merged",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/807",
+      commitShas: [mergedPrSha],
+    });
+
+    getThreadOverlayStates.mockResolvedValue({
+      "thread-1": {
+        backend: "codex",
+        threadId: "thread-1",
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        detachedPrKeys: ["github.com/pwrdrvr/pwragent#807"],
+        detachedPrs: [detachedPr],
+      },
+    });
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [],
+        updatedAt: 2000,
+        prs: [],
+      },
+    ] as never);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledWith(
+        ["/repo/wt"],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            "/repo/wt": [mergedPrSha],
+          },
+        },
+      );
+    });
+  });
+
   it("refreshes a thread's working state after the agent finishes a turn", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5638,6 +5638,34 @@ script = "echo setup"
       "Omit backend and threadId to inspect the current thread",
     );
     expect(getThreadStatusTool?.inputSchema?.required ?? []).toEqual([]);
+    const attachPullRequestTool = (
+      codexClient.lastStartThreadParams?.dynamicTools as Array<{
+        description?: string;
+        inputSchema?: {
+          required?: string[];
+        };
+        name: string;
+        namespace: string;
+      }> | undefined
+    )?.find((tool) => tool.name === "attach_thread_pull_request");
+    expect(attachPullRequestTool?.description).toContain(
+      "Omit backend and threadId to attach to the current thread",
+    );
+    expect(attachPullRequestTool?.inputSchema?.required ?? []).toEqual([]);
+    const checkPullRequestStatusTool = (
+      codexClient.lastStartThreadParams?.dynamicTools as Array<{
+        description?: string;
+        inputSchema?: {
+          required?: string[];
+        };
+        name: string;
+        namespace: string;
+      }> | undefined
+    )?.find((tool) => tool.name === "check_thread_pull_request_status");
+    expect(checkPullRequestStatusTool?.description).toContain(
+      "Omit backend and threadId to check the current thread",
+    );
+    expect(checkPullRequestStatusTool?.inputSchema?.required ?? []).toEqual([]);
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
@@ -18765,6 +18793,90 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("defaults PR reference attachment to the invoking thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Current work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_pull_request",
+        arguments: {
+          url: "https://github.com/pwrdrvr/PwrAgent/pull/904",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.pullRequestReference).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+      pr: {
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 904,
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/904",
+      },
+    });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.prs).toEqual([
+      expect.objectContaining({
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 904,
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("rejects explicit PR references with malformed URLs", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
@@ -18963,8 +19075,8 @@ script = "printf setup"
       ok: true,
       data: {
         pullRequestStatus: {
-          backend: args.backend,
-          threadId: args.threadId,
+          backend: args.backend ?? "codex",
+          threadId: args.threadId ?? "target-thread",
           provider: args.provider ?? "github.com",
           prs: [],
           ghAvailable: true,
@@ -19023,6 +19135,83 @@ script = "printf setup"
         branch: "feature/pr",
         directoryPaths: ["/repo"],
       },
+    });
+
+    await registry.close();
+  });
+
+  it("defaults user-invoked PR status checks to the invoking thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
+    });
+    const handler = vi.fn(async (args) => ({
+      ok: true as const,
+      data: {
+        pullRequestStatus: {
+          backend: args.backend ?? "codex",
+          threadId: args.threadId ?? "agent-thread",
+          provider: args.provider ?? "github.com",
+          prs: [],
+          ghAvailable: true,
+          refreshStarted: false,
+          requestedAt: 1_250,
+          branch: args.branch ?? "HEAD",
+          directoryPaths: args.directoryPaths ?? [],
+        },
+      },
+    }));
+    registry.setThreadPullRequestStatusToolHandler(handler);
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "check_thread_pull_request_status",
+        arguments: {
+          branch: "feature/pr",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(handler).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "agent-thread",
+      branch: "feature/pr",
+    });
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.pullRequestStatus).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+      branch: "feature/pr",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -655,6 +655,31 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    removeLinkedDirectory: async ({
+      backend,
+      threadId,
+      directory,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      directory: ThreadOverlayState["extraLinkedDirectories"][number];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        extraLinkedDirectories: current.extraLinkedDirectories.filter(
+          (candidate) => candidate.id !== directory.id,
+        ),
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     addThreadPullRequestReference: async ({
       backend,
       threadId,
@@ -18189,6 +18214,243 @@ script = "printf setup"
         repositoryPath: "/repo/pwragent",
       }),
     ]);
+
+    await registry.close();
+  });
+
+  it("lets an agent attach a managed worktree directory to the current thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: "/worktrees/agent-kit",
+      repositoryPath: "/repo/agent-kit",
+      rollback: vi.fn(async () => undefined),
+      workMode: "worktree" as const,
+    }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => undefined);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread,
+        resolvePrimaryWorkspacePath: vi.fn(async () => "/repo/agent-kit"),
+      } as never,
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_directory",
+        arguments: {
+          path: "/repo/agent-kit",
+          workspaceMode: "new_worktree",
+          branchName: "origin/main",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    expect(prepareLaunchpadWorkspace).toHaveBeenCalledWith({
+      backend: "codex",
+      branchName: "origin/main",
+      directoryKind: "directory",
+      directoryLabel: "agent-kit",
+      directoryPath: "/repo/agent-kit",
+      workMode: "worktree",
+      worktreeBranchMode: "detached",
+    });
+    expect(recordCodexWorktreeOwnerThread).toHaveBeenCalledWith({
+      threadId: "agent-thread",
+      worktreePath: "/worktrees/agent-kit",
+    });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+      workspaceMode: "new_worktree",
+      directory: {
+        kind: "worktree",
+        label: "agent-kit",
+        path: expectedDir("/repo/agent-kit"),
+        worktreePath: expectedDir("/worktrees/agent-kit"),
+      },
+    });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.extraLinkedDirectories).toEqual([
+      expect.objectContaining({
+        kind: "worktree",
+        path: expectedDir("/repo/agent-kit"),
+        worktreePath: expectedDir("/worktrees/agent-kit"),
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("lets an agent detach a secondary directory from the current thread", async () => {
+    const secondaryDirectory = {
+      id: expectedDir("/repo/agent-kit"),
+      kind: "local" as const,
+      label: "agent-kit",
+      path: expectedDir("/repo/agent-kit"),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": {
+          ...createAgentOverlay(),
+          extraLinkedDirectories: [secondaryDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "detach_thread_directory",
+        arguments: {
+          path: "/repo/agent-kit",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+      detachedDirectory: {
+        label: "agent-kit",
+        path: expectedDir("/repo/agent-kit"),
+      },
+      directories: [],
+    });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.extraLinkedDirectories).toEqual([]);
+
+    await registry.close();
+  });
+
+  it("rejects detaching the primary runtime directory through the dynamic tool", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "detach_thread_directory",
+        arguments: {
+          path: "/repo/pwragent",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message:
+                "Only secondary directories attached to this thread can be detached.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18327,6 +18327,24 @@ script = "printf setup"
     };
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Cross repo work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir("/repo/pwragent"),
+              kind: "worktree",
+              label: "PwrAgent",
+              path: expectedDir("/repo/pwragent"),
+              worktreePath: expectedDir("/repo/pwragent-wt"),
+            },
+          ],
+          updatedAt: 2000,
+        },
+      ],
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
@@ -18388,6 +18406,93 @@ script = "printf setup"
       threadId: "agent-thread",
     });
     expect(overlay?.extraLinkedDirectories).toEqual([]);
+
+    await registry.close();
+  });
+
+  it("rejects detaching the last linked directory through the dynamic tool", async () => {
+    const onlyDirectory = {
+      id: expectedDir("/repo/agent-kit"),
+      kind: "local" as const,
+      label: "agent-kit",
+      path: expectedDir("/repo/agent-kit"),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Directory-less work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": {
+          ...createAgentOverlay(),
+          extraLinkedDirectories: [onlyDirectory],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "detach_thread_directory",
+        arguments: {
+          path: "/repo/agent-kit",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "forbidden",
+              message: "Cannot detach the last linked directory from a thread.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.extraLinkedDirectories).toEqual([onlyDirectory]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18439,6 +18439,62 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("keeps future turns in the primary cwd when a secondary directory is attached", async () => {
+    const secondaryDirectory = {
+      id: expectedDir("/repo/agent-kit"),
+      kind: "local" as const,
+      label: "agent-kit",
+      path: expectedDir("/repo/agent-kit"),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Cross repo work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: expectedDir("/repo/pwragent"),
+              kind: "worktree",
+              label: "PwrAgent",
+              path: expectedDir("/repo/pwragent"),
+              worktreePath: expectedDir("/repo/pwragent-wt"),
+            },
+          ],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": {
+            ...createAgentOverlay(),
+            extraLinkedDirectories: [secondaryDirectory],
+          },
+        },
+      }),
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "agent-thread",
+      input: [{ type: "text", text: "Continue in the primary project." }],
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "agent-thread",
+      cwd: expectedDir("/repo/pwragent-wt"),
+    });
+
+    await registry.close();
+  });
+
   it("lets an agent detach a secondary directory from the current thread", async () => {
     const secondaryDirectory = {
       id: expectedDir("/repo/agent-kit"),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6104,6 +6104,71 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("deduplicates identical linked directories in thread summaries", async () => {
+    const repoPath = "/Users/huntharo/projects/PwrAgent";
+    const firstWorktreePath = "/Users/huntharo/.codex/worktrees/wt1/PwrAgent";
+    const secondWorktreePath = "/Users/huntharo/.codex/worktrees/wt2/PwrAgent";
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Transient duplicate",
+          titleSource: "explicit",
+          source: "codex",
+          projectKey: firstWorktreePath,
+          createdAt: 1_000,
+          updatedAt: 1_000,
+          linkedDirectories: [
+            {
+              id: "repo-dir",
+              label: "PwrAgent",
+              path: expectedDir(repoPath),
+              worktreePath: expectedDir(firstWorktreePath),
+              kind: "worktree",
+            },
+            {
+              id: "repo-dir-duplicate",
+              label: "PwrAgent",
+              path: expectedDir(repoPath),
+              worktreePath: expectedDir(firstWorktreePath),
+              kind: "worktree",
+            },
+            {
+              id: "repo-dir-second-worktree",
+              label: "PwrAgent other",
+              path: expectedDir(repoPath),
+              worktreePath: expectedDir(secondWorktreePath),
+              kind: "worktree",
+            },
+          ],
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const threads = await registry.listThreads({
+      backend: "codex",
+      callerReason: "thread-list",
+    });
+
+    expect(threads[0]?.linkedDirectories).toEqual([
+      expect.objectContaining({
+        path: expectedDir(repoPath),
+        worktreePath: expectedDir(firstWorktreePath),
+      }),
+      expect.objectContaining({
+        path: expectedDir(repoPath),
+        worktreePath: expectedDir(secondWorktreePath),
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("backfills Codex worktree parent directories so directory view shows one project", async () => {
     const projectA = "/Users/huntharo/projects/ProjectA";
     const worktree1 = "/Users/huntharo/.codex/worktrees/wt1/ProjectA";

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19,6 +19,7 @@ import type {
   AppServerThreadSummary,
   AppServerReviewTarget,
   AppServerTurnInputItem,
+  AttachThreadPullRequestToolArgs,
   BackendAccountSummary,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
@@ -19134,6 +19135,98 @@ script = "printf setup"
         },
       ],
     });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+    expect(overlay?.prs).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("rejects explicit PR references whose URL conflicts with identity fields", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "target-thread",
+          title: "Cross repo work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const cases: Array<{
+      conflict: string;
+      args: Partial<AttachThreadPullRequestToolArgs>;
+    }> = [
+      { conflict: "number", args: { number: 905 } },
+      { conflict: "provider", args: { provider: "ghe.example.test" } },
+      { conflict: "org", args: { org: "other-org" } },
+      { conflict: "repo", args: { repo: "OtherRepo" } },
+    ];
+    for (const [index, testCase] of cases.entries()) {
+      const response = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: `call-${index + 1}`,
+          requestId: `call-${index + 1}`,
+          namespace: "pwragent",
+          tool: "attach_thread_pull_request",
+          arguments: {
+            backend: "codex",
+            threadId: "target-thread",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/904",
+            ...testCase.args,
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(response).toEqual({
+        success: false,
+        contentItems: [
+          {
+            type: "inputText",
+            text: JSON.stringify(
+              {
+                code: "invalid_arguments",
+                message: `url conflicts with explicit ${testCase.conflict}. Provide matching PR identity fields or omit the conflicting fields.`,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    }
     const overlay = await overlayStore.getThreadOverlayState({
       backend: "codex",
       threadId: "target-thread",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18318,6 +18318,99 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("rolls back a managed worktree when owner recording fails", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const rollback = vi.fn(async () => undefined);
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: "/worktrees/agent-kit",
+      repositoryPath: "/repo/agent-kit",
+      rollback,
+      workMode: "worktree" as const,
+    }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => undefined);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread,
+        resolvePrimaryWorkspacePath: vi.fn(async () => "/repo/agent-kit"),
+      } as never,
+      overlayStore,
+    });
+    vi.spyOn(
+      registry as unknown as {
+        recordCodexWorktreeOwnerThread: (params: {
+          backend: "codex" | "grok" | `acp:${string}`;
+          threadId: string;
+          worktreePath?: string;
+        }) => Promise<void>;
+      },
+      "recordCodexWorktreeOwnerThread",
+    ).mockRejectedValueOnce(new Error("state db unavailable"));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_directory",
+        arguments: {
+          path: "/repo/agent-kit",
+          workspaceMode: "new_worktree",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "internal_error",
+              message: "state db unavailable",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    expect(rollback).toHaveBeenCalledTimes(1);
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.extraLinkedDirectories).toEqual([]);
+
+    await registry.close();
+  });
+
   it("lets an agent detach a secondary directory from the current thread", async () => {
     const secondaryDirectory = {
       id: expectedDir("/repo/agent-kit"),
@@ -18668,6 +18761,91 @@ script = "printf setup"
         ],
       },
     });
+
+    await registry.close();
+  });
+
+  it("rejects explicit PR references with malformed URLs", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "target-thread",
+          title: "Cross repo work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_pull_request",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          provider: "github.com",
+          org: "pwrdrvr",
+          repo: "PwrAgent",
+          number: 904,
+          url: "not a pull request URL",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: JSON.stringify(
+            {
+              code: "invalid_arguments",
+              message:
+                "url must look like a GitHub/GHE /pull/<number> URL or a GitLab /merge_requests/<number> URL.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+    expect(overlay?.prs).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -655,6 +655,40 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    addThreadPullRequestReference: async ({
+      backend,
+      threadId,
+      pr,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      pr: import("@pwragent/shared").PrSummary;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        prs: [
+          ...(current.prs ?? []).filter(
+            (candidate) =>
+              !(
+                candidate.provider.toLowerCase() === pr.provider.toLowerCase() &&
+                candidate.org.toLowerCase() === pr.org.toLowerCase() &&
+                candidate.repo.toLowerCase() === pr.repo.toLowerCase() &&
+                candidate.number === pr.number
+              ),
+          ),
+          pr,
+        ],
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     upsertWorktreeSnapshot: async ({
       backend,
       threadId,
@@ -17870,6 +17904,186 @@ script = "printf setup"
       codexClient.listThreadsCalls
         .map((call) => call.params?.archived)
     ).toEqual([false]);
+
+    await registry.close();
+  });
+
+  it("lets an agent attach an explicit PR reference to a thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "target-thread",
+          title: "Cross repo work",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "add_pull_request_reference",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          url: "https://ghe.example.test/PwrDrvr/AgentKit/pull/456",
+          title: "Cross repo PR",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      pullRequestReference: {
+        backend: "codex",
+        threadId: "target-thread",
+        pr: {
+          provider: "ghe.example.test",
+          org: "PwrDrvr",
+          repo: "AgentKit",
+          number: 456,
+          title: "Cross repo PR",
+          url: "https://ghe.example.test/PwrDrvr/AgentKit/pull/456",
+        },
+        prs: [
+          {
+            provider: "ghe.example.test",
+            org: "PwrDrvr",
+            repo: "AgentKit",
+            number: 456,
+          },
+        ],
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("lets an agent attach a bare PR number when the thread has one PR repo", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "target-thread",
+          title: "Durable PR refs",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": createAgentOverlay(),
+        "codex:target-thread": {
+          backend: "codex",
+          threadId: "target-thread",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          prs: [
+            {
+              provider: "github.com",
+              org: "pwrdrvr",
+              repo: "PwrAgent",
+              number: 123,
+              title: "Earlier PR",
+              state: "passing",
+              checkState: "passing",
+              lifecycleState: "open",
+              reviewState: "ready_for_review",
+              mergeState: "unknown",
+              url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "add_pull_request_reference",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          number: 789,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.pullRequestReference.pr).toMatchObject({
+      provider: "github.com",
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 789,
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/789",
+    });
+    expect(payload.pullRequestReference.prs.map(
+      (pr: { number: number }) => pr.number,
+    )).toEqual([123, 789]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5599,6 +5599,20 @@ script = "echo setup"
         ?.filter((tool) => tool.name === "create_monitor_delegation")
         .map((tool) => tool.name),
     ).toEqual(["create_monitor_delegation"]);
+    const getThreadStatusTool = (
+      codexClient.lastStartThreadParams?.dynamicTools as Array<{
+        description?: string;
+        inputSchema?: {
+          required?: string[];
+        };
+        name: string;
+        namespace: string;
+      }> | undefined
+    )?.find((tool) => tool.name === "get_thread_status");
+    expect(getThreadStatusTool?.description).toContain(
+      "Omit backend and threadId to inspect the current thread",
+    );
+    expect(getThreadStatusTool?.inputSchema?.required ?? []).toEqual([]);
     await expect(
       overlayStore.getThreadOverlayState({
         backend: "codex",
@@ -17785,6 +17799,103 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("includes overlay-attached directories in Agent thread search results", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-1",
+          title: "Sit tight",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: "directory:/repo/pwragent",
+              kind: "local",
+              label: "PwrAgent",
+              path: "/repo/pwragent",
+            },
+          ],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [
+              {
+                id: "directory:/repo/agent-kit",
+                kind: "local",
+                label: "agent-kit",
+                path: "/repo/agent-kit",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "search_threads",
+        arguments: {},
+      },
+    } as AppServerPendingRequestNotification);
+
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.threads[0].linkedDirectories).toEqual([
+      expect.objectContaining({
+        label: "agent-kit",
+        path: "/repo/agent-kit",
+      }),
+      expect.objectContaining({
+        label: "PwrAgent",
+        path: "/repo/pwragent",
+      }),
+    ]);
+    expect(payload.threads[0].linkedRepositories).toEqual([
+      expect.objectContaining({
+        labels: ["agent-kit"],
+        repositoryPath: "/repo/agent-kit",
+      }),
+      expect.objectContaining({
+        labels: ["PwrAgent"],
+        repositoryPath: "/repo/pwragent",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("matches thread search alternatives without an exact phrase", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
@@ -17969,6 +18080,115 @@ script = "printf setup"
       codexClient.listThreadsCalls
         .map((call) => call.params?.archived)
     ).toEqual([false]);
+
+    await registry.close();
+  });
+
+  it("defaults get_thread_status to the invoking thread and returns attached directories", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read"] },
+      threads: [
+        {
+          id: "agent-thread",
+          title: "Sit tight",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [
+            {
+              id: "directory:/repo/pwragent",
+              kind: "local",
+              label: "PwrAgent",
+              path: "/repo/pwragent",
+            },
+          ],
+          updatedAt: 2000,
+        },
+      ],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": {
+            ...createAgentOverlay(),
+            extraLinkedDirectories: [
+              {
+                id: "directory:/repo/agent-kit",
+                kind: "local",
+                label: "agent-kit",
+                path: "/repo/agent-kit",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {},
+      },
+    } as AppServerPendingRequestNotification);
+
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.thread).toMatchObject({
+      backend: "codex",
+      threadId: "agent-thread",
+      title: "Sit tight",
+      status: "idle",
+    });
+    expect(payload.thread.linkedDirectories).toEqual([
+      expect.objectContaining({
+        label: "agent-kit",
+        path: "/repo/agent-kit",
+      }),
+      expect.objectContaining({
+        label: "PwrAgent",
+        path: "/repo/pwragent",
+      }),
+    ]);
+    expect(payload.thread.linkedRepositories).toEqual([
+      expect.objectContaining({
+        labels: ["agent-kit"],
+        repositoryPath: "/repo/agent-kit",
+      }),
+      expect.objectContaining({
+        labels: ["PwrAgent"],
+        repositoryPath: "/repo/pwragent",
+      }),
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18326,7 +18326,7 @@ script = "printf setup"
       path: expectedDir("/repo/agent-kit"),
     };
     const codexClient = new MockBackendClient({
-      initializeResult: { methods: ["thread/list"] },
+      initializeResult: { methods: ["thread/list", "turn/start"] },
       threads: [
         {
           id: "agent-thread",
@@ -18406,6 +18406,32 @@ script = "printf setup"
       threadId: "agent-thread",
     });
     expect(overlay?.extraLinkedDirectories).toEqual([]);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "agent-thread",
+      input: [{ type: "text", text: "Continue in the remaining project." }],
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "agent-thread",
+      cwd: expectedDir("/repo/pwragent-wt"),
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18252,7 +18252,10 @@ script = "printf setup"
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
-        "codex:agent-thread": createAgentOverlay(),
+        "codex:agent-thread": {
+          ...createAgentOverlay(),
+          executionMode: "full-access",
+        },
       },
     });
     const prepareLaunchpadWorkspace = vi.fn(async () => ({
@@ -18346,13 +18349,135 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("rolls back a managed worktree when owner recording fails", async () => {
+  it("requires confirmation before attaching an untrusted directory in Default Access", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
     });
     const overlayStore = createOverlayStoreMock({
       overlays: {
         "codex:agent-thread": createAgentOverlay(),
+      },
+    });
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: "/worktrees/agent-kit",
+      repositoryPath: "/repo/agent-kit",
+      rollback: vi.fn(async () => undefined),
+      workMode: "worktree" as const,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        resolvePrimaryWorkspacePath: vi.fn(async () => "/repo/agent-kit"),
+      } as never,
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    const responsePromise = codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_directory",
+        arguments: {
+          path: "/repo/agent-kit",
+          workspaceMode: "new_worktree",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    await vi.waitFor(() => {
+      expect(
+        events.find(
+          (event) =>
+            event.notification.method === "item/tool/requestUserInput" &&
+            event.notification.params.threadId === "agent-thread",
+        ),
+      ).toBeDefined();
+    });
+    expect(prepareLaunchpadWorkspace).not.toHaveBeenCalled();
+    const inputRequest = events.find(
+      (event): event is AgentEvent & {
+        notification: Extract<
+          AppServerNotification,
+          { method: "item/tool/requestUserInput" }
+        >;
+      } =>
+        event.notification.method === "item/tool/requestUserInput" &&
+        event.notification.params.threadId === "agent-thread",
+    )!.notification;
+    expect(inputRequest.params.questions).toEqual([
+      expect.objectContaining({
+        id: "trust_directory",
+        question: expect.stringContaining(expectedDir("/repo/agent-kit")),
+      }),
+    ]);
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "agent-thread",
+      turnId: "turn-1",
+      requestId: inputRequest.params.requestId,
+      response: {
+        answers: {
+          trust_directory: {
+            answers: ["Cancel attachment"],
+          },
+        },
+      },
+    });
+
+    const response = await responsePromise;
+
+    expect(response).toMatchObject({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining("forbidden"),
+        },
+      ],
+    });
+    expect(prepareLaunchpadWorkspace).not.toHaveBeenCalled();
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "agent-thread",
+    });
+    expect(overlay?.extraLinkedDirectories).toEqual([]);
+    unsubscribe();
+    await registry.close();
+  });
+
+  it("rolls back a managed worktree when owner recording fails", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": {
+          ...createAgentOverlay(),
+          executionMode: "full-access",
+        },
       },
     });
     const rollback = vi.fn(async () => undefined);

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17954,7 +17954,7 @@ script = "printf setup"
         callId: "call-1",
         requestId: "call-1",
         namespace: "pwragent",
-        tool: "add_pull_request_reference",
+        tool: "attach_thread_pull_request",
         arguments: {
           backend: "codex",
           threadId: "target-thread",
@@ -18061,7 +18061,7 @@ script = "printf setup"
         callId: "call-1",
         requestId: "call-1",
         namespace: "pwragent",
-        tool: "add_pull_request_reference",
+        tool: "attach_thread_pull_request",
         arguments: {
           backend: "codex",
           threadId: "target-thread",
@@ -18084,6 +18084,90 @@ script = "printf setup"
     expect(payload.pullRequestReference.prs.map(
       (pr: { number: number }) => pr.number,
     )).toEqual([123, 789]);
+
+    await registry.close();
+  });
+
+  it("routes user-invoked PR status checks through the registered handler", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+        },
+      }),
+    });
+    registry.setThreadPullRequestStatusToolHandler(async (args) => ({
+      ok: true,
+      data: {
+        pullRequestStatus: {
+          backend: args.backend,
+          threadId: args.threadId,
+          provider: args.provider ?? "github.com",
+          prs: [],
+          ghAvailable: true,
+          refreshStarted: true,
+          lastStatusCheckAt: 1_000,
+          lastStatusCheckAgeMs: 250,
+          requestedAt: 1_250,
+          branch: args.branch ?? "main",
+          directoryPaths: args.directoryPaths ?? ["/repo"],
+        },
+      },
+    }));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "check_thread_pull_request_status",
+        arguments: {
+          backend: "codex",
+          threadId: "target-thread",
+          branch: "feature/pr",
+          directoryPaths: ["/repo"],
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      pullRequestStatus: {
+        backend: "codex",
+        threadId: "target-thread",
+        ghAvailable: true,
+        refreshStarted: true,
+        lastStatusCheckAt: 1_000,
+        lastStatusCheckAgeMs: 250,
+        requestedAt: 1_250,
+        branch: "feature/pr",
+        directoryPaths: ["/repo"],
+      },
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-linked-directories.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-linked-directories.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-linked-dirs-test-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore — linked directories", () => {
+  it("replaces same-path local directories even when their IDs use different shapes", async () => {
+    await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+
+    const overlay = await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "directory:/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+
+    expect(overlay.extraLinkedDirectories).toEqual([
+      {
+        id: "directory:/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/overlay-store-linked-directories.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-linked-directories.test.ts
@@ -53,4 +53,30 @@ describe("SqliteOverlayStore — linked directories", () => {
       },
     ]);
   });
+
+  it("removes same-path local directories even when their IDs use different shapes", async () => {
+    await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+
+    const overlay = await store.removeLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "directory:/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+
+    expect(overlay.extraLinkedDirectories).toEqual([]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -190,6 +190,34 @@ describe("SqliteOverlayStore — thread PRs", () => {
     expect(next.prs).toEqual([]);
   });
 
+  it("keeps detached prs hidden across later refresh writes", async () => {
+    await store.setThreadPullRequests({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [prPassing, prMerged],
+    });
+
+    const detached = await store.detachThreadPullRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      pr: prPassing,
+    });
+    expect(detached.detachedPrKeys).toEqual([
+      "github.com/pwrdrvr/pwragent#179",
+    ]);
+    expect(detached.prs).toEqual([prMerged]);
+
+    const refreshed = await store.setThreadPullRequests({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [prPassing, prMerged],
+    });
+    expect(refreshed.detachedPrKeys).toEqual([
+      "github.com/pwrdrvr/pwragent#179",
+    ]);
+    expect(refreshed.prs).toEqual([prMerged]);
+  });
+
   it("persists canonical PR status cache rows across reopen", async () => {
     await store.writePrStatusCacheEntries([
       {

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -227,6 +227,38 @@ describe("SqliteOverlayStore — thread PRs", () => {
     expect(refreshed.prs).toEqual([prMerged]);
   });
 
+  it("explicitly adding a PR reference makes a previously detached PR visible again", async () => {
+    await store.setThreadPullRequests({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [prPassing, prMerged],
+    });
+    await store.detachThreadPullRequest({
+      backend: "codex",
+      threadId: "thread-1",
+      pr: prPassing,
+    });
+
+    const added = await store.addThreadPullRequestReference({
+      backend: "codex",
+      threadId: "thread-1",
+      pr: {
+        ...prPassing,
+        title: "Explicitly restored PR",
+      },
+    });
+
+    expect(added.detachedPrKeys).toEqual([]);
+    expect(added.detachedPrs).toBeUndefined();
+    expect(added.prs).toEqual([
+      prMerged,
+      {
+        ...prPassing,
+        title: "Explicitly restored PR",
+      },
+    ]);
+  });
+
   it("persists canonical PR status cache rows across reopen", async () => {
     await store.writePrStatusCacheEntries([
       {

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -191,30 +191,39 @@ describe("SqliteOverlayStore — thread PRs", () => {
   });
 
   it("keeps detached prs hidden across later refresh writes", async () => {
+    const detachedPrSha = "a".repeat(40);
+    const detachedPr: PrSummary = {
+      ...prPassing,
+      lifecycleState: "merged",
+      commitShas: [detachedPrSha],
+    };
+
     await store.setThreadPullRequests({
       backend: "codex",
       threadId: "thread-1",
-      prs: [prPassing, prMerged],
+      prs: [detachedPr, prMerged],
     });
 
     const detached = await store.detachThreadPullRequest({
       backend: "codex",
       threadId: "thread-1",
-      pr: prPassing,
+      pr: detachedPr,
     });
     expect(detached.detachedPrKeys).toEqual([
       "github.com/pwrdrvr/pwragent#179",
     ]);
+    expect(detached.detachedPrs).toEqual([detachedPr]);
     expect(detached.prs).toEqual([prMerged]);
 
     const refreshed = await store.setThreadPullRequests({
       backend: "codex",
       threadId: "thread-1",
-      prs: [prPassing, prMerged],
+      prs: [prMerged],
     });
     expect(refreshed.detachedPrKeys).toEqual([
       "github.com/pwrdrvr/pwragent#179",
     ]);
+    expect(refreshed.detachedPrs).toEqual([detachedPr]);
     expect(refreshed.prs).toEqual([prMerged]);
   });
 

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -12,6 +12,40 @@ describe("pwragent thread orchestration agent tools", () => {
     expect(router.buildDynamicToolSpecs()).toEqual([
       expect.objectContaining({
         namespace: "pwragent",
+        name: "attach_thread_directory",
+        description: expect.stringContaining("secondary worktree"),
+        deferLoading: false,
+        inputSchema: expect.objectContaining({
+          required: ["path"],
+          properties: expect.objectContaining({
+            workspaceMode: expect.objectContaining({
+              enum: ["local", "new_worktree"],
+            }),
+            worktreeBranchMode: expect.objectContaining({
+              enum: ["attached", "detached"],
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        namespace: "pwragent",
+        name: "detach_thread_directory",
+        description: expect.stringContaining("primary provider/runtime cwd"),
+        deferLoading: false,
+        inputSchema: expect.objectContaining({
+          additionalProperties: false,
+          properties: expect.objectContaining({
+            directoryId: expect.objectContaining({
+              description: expect.stringContaining("linked-directory id"),
+            }),
+            worktreePath: expect.objectContaining({
+              description: expect.stringContaining("worktree path"),
+            }),
+          }),
+        }),
+      }),
+      expect.objectContaining({
+        namespace: "pwragent",
         name: "handoff_task",
         description: expect.stringContaining("backports"),
         deferLoading: false,
@@ -177,6 +211,79 @@ describe("pwragent thread orchestration agent tools", () => {
           tool: "move_thread_workspace",
           arguments: {
             sourcePath: "  ",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("validates attach_thread_directory before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "attach_thread_directory",
+          arguments: {
+            path: "  ",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-2",
+          namespace: "pwragent",
+          tool: "attach_thread_directory",
+          arguments: {
+            path: "/repo/app",
+            workspaceMode: "same_workspace",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("validates detach_thread_directory before dispatch", async () => {
+    const handler = vi.fn();
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "detach_thread_directory",
+          arguments: {},
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-2",
+          namespace: "pwragent",
+          tool: "detach_thread_directory",
+          arguments: {
+            path: "  ",
           },
         },
       }),
@@ -365,6 +472,113 @@ describe("pwragent thread orchestration agent tools", () => {
         repositoryPath: "/repo/app",
         sourcePath: "/repo/app",
         leaveLocalBranch: "main",
+      },
+    });
+  });
+
+  it("normalizes attach_thread_directory args and dispatches with caller context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        workspaceMode: "new_worktree" as const,
+        directory: {
+          id: "/repo/app",
+          kind: "worktree" as const,
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/worktrees/app",
+        },
+        message: "Attached a managed worktree directory to this thread.",
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "attach_thread_directory",
+        arguments: {
+          backend: " codex ",
+          path: " /repo/app ",
+          workspaceMode: "new_worktree",
+          branchName: " origin/main ",
+          worktreeBranchMode: "attached",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "attach_thread_directory",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        backend: "codex",
+        path: "/repo/app",
+        workspaceMode: "new_worktree",
+        branchName: "origin/main",
+        worktreeBranchMode: "attached",
+      },
+    });
+  });
+
+  it("normalizes detach_thread_directory args and dispatches with caller context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        detachedDirectory: {
+          id: "/repo/app",
+          kind: "local" as const,
+          label: "app",
+          path: "/repo/app",
+        },
+        directories: [],
+        message: "Detached a secondary directory from this thread.",
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "detach_thread_directory",
+        arguments: {
+          backend: " codex ",
+          directoryId: " directory:/repo/app ",
+          path: " /repo/app ",
+          worktreePath: " /worktrees/app ",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "detach_thread_directory",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        backend: "codex",
+        directoryId: "directory:/repo/app",
+        path: "/repo/app",
+        worktreePath: "/worktrees/app",
       },
     });
   });

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -75,7 +75,7 @@ function descriptionForOperation(
     case "read_thread":
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
-      return "Read status and compact metadata for a known PwrAgent thread, including pendingHandoffs when this thread has child handoffs that are still being created and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
+      return "Read status and compact metadata for a known PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -76,8 +76,10 @@ function descriptionForOperation(
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
       return "Read status and compact metadata for a known PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
-    case "add_pull_request_reference":
+    case "attach_thread_pull_request":
       return "Attach a pull request reference to a PwrAgent thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
+    case "check_thread_pull_request_status":
+      return "Run a user-invoked pull request status check for a thread using PwrAgent's provider integration instead of shelling out. Returns cached PR status immediately with freshness metadata, and starts a provider refresh when possible.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }
@@ -219,7 +221,7 @@ function inputSchemaForOperation(
           },
         },
       };
-    case "add_pull_request_reference":
+    case "attach_thread_pull_request":
       return {
         type: "object",
         additionalProperties: false,
@@ -257,6 +259,34 @@ function inputSchemaForOperation(
             type: "string",
             description:
               "Optional title to display until provider refresh hydrates current status.",
+          },
+        },
+      };
+    case "check_thread_pull_request_status":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend", "threadId"],
+        properties: {
+          backend: {
+            type: "string",
+          },
+          threadId: { type: "string" },
+          provider: {
+            type: "string",
+            description:
+              "Forge host such as github.com or a GitHub Enterprise host. Defaults to github.com.",
+          },
+          branch: {
+            type: "string",
+            description:
+              "Optional branch override. Defaults to the thread's observed/expected branch or HEAD.",
+          },
+          directoryPaths: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "Optional cwd list for provider lookups. Defaults to the thread's linked directories.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -76,6 +76,8 @@ function descriptionForOperation(
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
       return "Read status and compact metadata for a known PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
+    case "add_pull_request_reference":
+      return "Attach a pull request reference to a PwrAgent thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }
@@ -214,6 +216,47 @@ function inputSchemaForOperation(
             maximum: 20000,
             description:
               "Maximum characters retained in each text-like transcript field. Defaults to 4000.",
+          },
+        },
+      };
+    case "add_pull_request_reference":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["backend", "threadId"],
+        properties: {
+          backend: {
+            type: "string",
+          },
+          threadId: { type: "string" },
+          url: {
+            type: "string",
+            description:
+              "Full PR/MR URL, for example https://github.com/org/repo/pull/123 or https://gitlab.example.com/group/repo/-/merge_requests/123.",
+          },
+          provider: {
+            type: "string",
+            description:
+              "Forge host such as github.com, ghe.example.com, or gitlab.example.com. Required when url is omitted unless it can be inferred from the thread.",
+          },
+          org: {
+            type: "string",
+            description:
+              "Repo owner or group. For nested GitLab groups, use the slash-separated group path.",
+          },
+          repo: {
+            type: "string",
+          },
+          number: {
+            type: "integer",
+            minimum: 1,
+            description:
+              "PR/MR number. May be used alone only when the thread has exactly one inferable repository.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Optional title to display until provider refresh hydrates current status.",
           },
         },
       };

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -77,9 +77,9 @@ function descriptionForOperation(
     case "get_thread_status":
       return "Read status and compact metadata for a PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress. Omit backend and threadId to inspect the current thread; use this for questions like which directories or projects this thread is attached to.";
     case "attach_thread_pull_request":
-      return "Attach a pull request reference to a PwrAgent thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
+      return "Attach a pull request reference to a PwrAgent thread. Omit backend and threadId to attach to the current thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
     case "check_thread_pull_request_status":
-      return "Run a user-invoked pull request status check for a thread using PwrAgent's provider integration instead of shelling out. Returns cached PR status immediately with freshness metadata, and starts a provider refresh when possible.";
+      return "Run a user-invoked pull request status check for a thread using PwrAgent's provider integration instead of shelling out. Omit backend and threadId to check the current thread. Returns cached PR status immediately with freshness metadata, and starts a provider refresh when possible.";
     case "mutate_thread":
       return "Mutate guarded PwrAgent thread settings such as the PwrAgent thread title, model settings, or execution mode. This does not rename any attached Telegram topic, Discord thread, or other messaging surface.";
   }
@@ -230,12 +230,17 @@ function inputSchemaForOperation(
       return {
         type: "object",
         additionalProperties: false,
-        required: ["backend", "threadId"],
         properties: {
           backend: {
             type: "string",
+            description:
+              "Backend that owns the thread. Defaults to the invoking thread's backend.",
           },
-          threadId: { type: "string" },
+          threadId: {
+            type: "string",
+            description:
+              "Thread id to attach the PR reference to. Defaults to the invoking PwrAgent thread id.",
+          },
           url: {
             type: "string",
             description:
@@ -271,12 +276,17 @@ function inputSchemaForOperation(
       return {
         type: "object",
         additionalProperties: false,
-        required: ["backend", "threadId"],
         properties: {
           backend: {
             type: "string",
+            description:
+              "Backend that owns the thread. Defaults to the invoking thread's backend.",
           },
-          threadId: { type: "string" },
+          threadId: {
+            type: "string",
+            description:
+              "Thread id to check. Defaults to the invoking PwrAgent thread id.",
+          },
           provider: {
             type: "string",
             description:

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-agent-tools.ts
@@ -75,7 +75,7 @@ function descriptionForOperation(
     case "read_thread":
       return "Read a bounded page of another known PwrAgent thread's recent transcript and activity. Use search_threads first when the threadId is unknown.";
     case "get_thread_status":
-      return "Read status and compact metadata for a known PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress.";
+      return "Read status and compact metadata for a PwrAgent thread, including linked directories, repository groups, pull requests, pendingHandoffs when this thread has child handoffs that are still being created, and pendingWorkspaceMoves when this thread has same-thread workspace moves in progress. Omit backend and threadId to inspect the current thread; use this for questions like which directories or projects this thread is attached to.";
     case "attach_thread_pull_request":
       return "Attach a pull request reference to a PwrAgent thread. Use this when a PR was created outside the thread's current working directory or automatic branch-based discovery will not see it. Accepts a full PR/MR URL, a full provider/org/repo/number identity, or a bare number when the thread has exactly one inferable repository.";
     case "check_thread_pull_request_status":
@@ -167,12 +167,17 @@ function inputSchemaForOperation(
       return {
         type: "object",
         additionalProperties: false,
-        required: ["backend", "threadId"],
         properties: {
           backend: {
             type: "string",
+            description:
+              "Backend that owns the thread. Defaults to the invoking thread's backend.",
           },
-          threadId: { type: "string" },
+          threadId: {
+            type: "string",
+            description:
+              "Thread id to inspect. Defaults to the invoking PwrAgent thread id.",
+          },
         },
       };
     case "read_thread":

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -1,9 +1,13 @@
 import type {
+  AttachThreadDirectoryToolArgs,
+  AttachThreadDirectoryWorkspaceMode,
+  AttachThreadDirectoryWorktreeBranchMode,
   HandoffTaskGroupingMode,
   HandoffTaskMessagingAttachmentMode,
   HandoffTaskSeedMode,
   HandoffTaskToolArgs,
   HandoffTaskWorkspaceMode,
+  DetachThreadDirectoryToolArgs,
   MoveThreadWorkspaceToolArgs,
   PwrAgentThreadOrchestrationOperationName,
   PwrAgentThreadOrchestrationRequest,
@@ -11,6 +15,8 @@ import type {
   SendMessageToThreadToolArgs,
 } from "@pwragent/shared";
 import {
+  ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
+  ATTACH_THREAD_DIRECTORY_WORKTREE_BRANCH_MODES,
   DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
   HANDOFF_TASK_GROUPING_MODES,
   HANDOFF_TASK_MESSAGING_ATTACHMENT_MODES,
@@ -100,6 +106,10 @@ function descriptionForOperation(
   switch (operation) {
     case "handoff_task":
       return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use cwd=<source project/repo path> when the delegated thread should be created in a different project than the current thread. In Default Access, an explicit cwd that is not already trusted will trigger an operator confirmation before PwrAgent uses that directory for handoff workspaces. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree. Handoff startup can take several minutes while a worktree or Codex environment is prepared; if this call appears slow or uncertain, do not call handoff_task again. Use search_threads or get_thread_status and inspect pendingHandoffs until a threadId appears or the handoff reports failed.";
+    case "attach_thread_directory":
+      return "Attach an additional Git directory to the current PwrAgent thread. Use this for cross-project work when the user asks to link another repo or create a secondary worktree for another repo. Omitted backend targets the invoking thread. workspaceMode=local attaches the repository directory itself; workspaceMode=new_worktree asks PwrAgent to allocate and attach a managed worktree for the provided repository path. This does not change the thread's primary cwd; use detach_thread_directory separately if a temporary local reference should be removed.";
+    case "detach_thread_directory":
+      return "Detach a secondary linked directory from the current PwrAgent thread. Use this only for user-requested cleanup of extra directory references. The primary provider/runtime cwd cannot be detached. Pass directoryId when known, or path/worktreePath from get_thread_status linked directory metadata.";
     case "move_thread_workspace":
       return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
@@ -111,6 +121,65 @@ function inputSchemaForOperation(
   operation: PwrAgentThreadOrchestrationOperationName,
 ): Record<string, unknown> {
   switch (operation) {
+    case "attach_thread_directory":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["path"],
+        properties: {
+          backend: {
+            type: "string",
+            description:
+              "Optional backend override. Omitted defaults to the invoking thread backend; the first implementation supports the current thread only.",
+          },
+          path: {
+            type: "string",
+            description:
+              "Repository/local checkout path to attach, or to use as the parent repo for a new worktree.",
+          },
+          workspaceMode: {
+            type: "string",
+            enum: ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
+            description:
+              "`local` attaches the repository directory itself and is the default. `new_worktree` asks PwrAgent to allocate a managed worktree for that repository and attach it.",
+          },
+          branchName: {
+            type: "string",
+            description:
+              "Optional existing base branch/ref for workspaceMode=new_worktree, for example `origin/main`. This is not a new feature branch name.",
+          },
+          worktreeBranchMode: {
+            type: "string",
+            enum: ATTACH_THREAD_DIRECTORY_WORKTREE_BRANCH_MODES,
+            description:
+              "Whether the allocated worktree should be checked out on an attached branch or as a detached HEAD. Defaults to detached.",
+          },
+        },
+      };
+    case "detach_thread_directory":
+      return {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          backend: {
+            type: "string",
+            description:
+              "Optional backend override. Omitted defaults to the invoking thread backend; the first implementation supports the current thread only.",
+          },
+          directoryId: {
+            type: "string",
+            description: "Exact linked-directory id to detach when known.",
+          },
+          path: {
+            type: "string",
+            description: "Repository/local checkout path to detach.",
+          },
+          worktreePath: {
+            type: "string",
+            description: "Managed worktree path to detach.",
+          },
+        },
+      };
     case "handoff_task":
       return {
         type: "object",
@@ -256,11 +325,17 @@ function normalizeArgsForOperation(
   operation: PwrAgentThreadOrchestrationOperationName,
   args: Record<string, unknown>,
 ):
+  | AttachThreadDirectoryToolArgs
+  | DetachThreadDirectoryToolArgs
   | HandoffTaskToolArgs
   | MoveThreadWorkspaceToolArgs
   | SendMessageToThreadToolArgs
   | undefined {
   switch (operation) {
+    case "attach_thread_directory":
+      return normalizeAttachThreadDirectoryArgs(args);
+    case "detach_thread_directory":
+      return normalizeDetachThreadDirectoryArgs(args);
     case "handoff_task":
       return normalizeHandoffTaskArgs(args);
     case "move_thread_workspace":
@@ -274,6 +349,10 @@ function invalidArgumentsMessageForOperation(
   operation: PwrAgentThreadOrchestrationOperationName,
 ): string {
   switch (operation) {
+    case "attach_thread_directory":
+      return "attach_thread_directory requires a non-empty path and accepts only known workspaceMode/worktreeBranchMode values.";
+    case "detach_thread_directory":
+      return "detach_thread_directory requires at least one of directoryId, path, or worktreePath, and all provided string fields must be non-empty.";
     case "handoff_task":
       return "handoff_task requires a non-empty task string.";
     case "move_thread_workspace":
@@ -281,6 +360,91 @@ function invalidArgumentsMessageForOperation(
     case "send_message_to_thread":
       return "send_message_to_thread requires non-empty backend, threadId, and prompt strings.";
   }
+}
+
+function normalizeAttachThreadDirectoryArgs(
+  args: Record<string, unknown>,
+): AttachThreadDirectoryToolArgs | undefined {
+  const directoryPath = readTrimmedString(args.path);
+  if (!directoryPath) {
+    return undefined;
+  }
+  const workspaceMode =
+    args.workspaceMode === undefined
+      ? undefined
+      : readChoice(args.workspaceMode, ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES);
+  if (args.workspaceMode !== undefined && !workspaceMode) {
+    return undefined;
+  }
+  const worktreeBranchMode =
+    args.worktreeBranchMode === undefined
+      ? undefined
+      : readChoice(
+          args.worktreeBranchMode,
+          ATTACH_THREAD_DIRECTORY_WORKTREE_BRANCH_MODES,
+        );
+  if (args.worktreeBranchMode !== undefined && !worktreeBranchMode) {
+    return undefined;
+  }
+
+  const optionalStringFields = ["backend", "branchName"] as const;
+  for (const field of optionalStringFields) {
+    if (Object.hasOwn(args, field) && !readTrimmedString(args[field])) {
+      return undefined;
+    }
+  }
+
+  const backend = readTrimmedString(args.backend);
+  const branchName = readTrimmedString(args.branchName);
+  return {
+    path: directoryPath,
+    ...(backend
+      ? { backend: backend as AttachThreadDirectoryToolArgs["backend"] }
+      : {}),
+    ...(workspaceMode
+      ? { workspaceMode: workspaceMode as AttachThreadDirectoryWorkspaceMode }
+      : {}),
+    ...(branchName ? { branchName } : {}),
+    ...(worktreeBranchMode
+      ? {
+          worktreeBranchMode:
+            worktreeBranchMode as AttachThreadDirectoryWorktreeBranchMode,
+        }
+      : {}),
+  };
+}
+
+function normalizeDetachThreadDirectoryArgs(
+  args: Record<string, unknown>,
+): DetachThreadDirectoryToolArgs | undefined {
+  const optionalStringFields = [
+    "backend",
+    "directoryId",
+    "path",
+    "worktreePath",
+  ] as const;
+  for (const field of optionalStringFields) {
+    if (Object.hasOwn(args, field) && !readTrimmedString(args[field])) {
+      return undefined;
+    }
+  }
+
+  const backend = readTrimmedString(args.backend);
+  const directoryId = readTrimmedString(args.directoryId);
+  const directoryPath = readTrimmedString(args.path);
+  const worktreePath = readTrimmedString(args.worktreePath);
+  if (!directoryId && !directoryPath && !worktreePath) {
+    return undefined;
+  }
+
+  return {
+    ...(backend
+      ? { backend: backend as DetachThreadDirectoryToolArgs["backend"] }
+      : {}),
+    ...(directoryId ? { directoryId } : {}),
+    ...(directoryPath ? { path: directoryPath } : {}),
+    ...(worktreePath ? { worktreePath } : {}),
+  };
 }
 
 function normalizeHandoffTaskArgs(

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -107,7 +107,7 @@ function descriptionForOperation(
     case "handoff_task":
       return "Create and start a new PwrAgent Agent thread for a delegated task. Use this when the user asks to hand off or delegate work to a new thread. Omitted settings inherit from the invoking Agent turn. Clean new-thread handoff is the default; use seedMode=fork only when the user asks to fork this thread. Workspace-backed handoffs default to workspaceMode=new_worktree. Use cwd=<source project/repo path> when the delegated thread should be created in a different project than the current thread. In Default Access, an explicit cwd that is not already trusted will trigger an operator confirmation before PwrAgent uses that directory for handoff workspaces. Use groupingMode=subthread for related follow-up work, backports, or forward-ports that should stay grouped under the current thread; combine it with workspaceMode=new_worktree and branchName=<existing base ref> such as origin/main when the related work should start from another branch. Use workspaceMode=same_workspace only when the user explicitly asks to share the caller's exact workspace. Use workspaceMode=project_local only when the delegated thread should run in the project's primary checkout instead of a managed worktree. Handoff startup can take several minutes while a worktree or Codex environment is prepared; if this call appears slow or uncertain, do not call handoff_task again. Use search_threads or get_thread_status and inspect pendingHandoffs until a threadId appears or the handoff reports failed.";
     case "attach_thread_directory":
-      return "Attach an additional Git directory to the current PwrAgent thread. Use this for cross-project work when the user asks to link another repo or create a secondary worktree for another repo. Omitted backend targets the invoking thread. workspaceMode=local attaches the repository directory itself; workspaceMode=new_worktree asks PwrAgent to allocate and attach a managed worktree for the provided repository path. This does not change the thread's primary cwd; use detach_thread_directory separately if a temporary local reference should be removed.";
+      return "Attach an additional Git directory to the current PwrAgent thread. Use this for cross-project work when the user asks to link another repo or create a secondary worktree for another repo. Omitted backend targets the invoking thread. workspaceMode=local attaches the repository directory itself; workspaceMode=new_worktree asks PwrAgent to allocate and attach a managed worktree for the provided repository path. In Default Access, an untrusted path triggers operator confirmation before it can grant agent read/write/delete scope or allocate a managed worktree. This does not change the thread's primary cwd; use detach_thread_directory separately if a temporary local reference should be removed.";
     case "detach_thread_directory":
       return "Detach a secondary linked directory from the current PwrAgent thread. Use this only for user-requested cleanup of extra directory references. The primary provider/runtime cwd cannot be detached. Pass directoryId when known, or path/worktreePath from get_thread_status linked directory metadata.";
     case "move_thread_workspace":
@@ -135,13 +135,13 @@ function inputSchemaForOperation(
           path: {
             type: "string",
             description:
-              "Repository/local checkout path to attach, or to use as the parent repo for a new worktree.",
+              "Repository/local checkout path to attach, or to use as the parent repo for a new worktree. In Default Access, untrusted paths require operator confirmation first.",
           },
           workspaceMode: {
             type: "string",
             enum: ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
             description:
-              "`local` attaches the repository directory itself and is the default. `new_worktree` asks PwrAgent to allocate a managed worktree for that repository and attach it.",
+              "`local` attaches the repository directory itself and is the default. `new_worktree` asks PwrAgent to allocate a managed worktree for that repository and attach it after the source repo path is trusted.",
           },
           branchName: {
             type: "string",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -15057,6 +15057,21 @@ export class DesktopBackendRegistry {
         "Only secondary directories attached to this thread can be detached.",
       );
     }
+    const sourceThread = await this.findThreadForWorkspaceHandoff({
+      backend,
+      callerReason: "agent-thread-directory-detach",
+      threadId: sourceThreadId,
+    });
+    const totalLinkedDirectories = dedupeLinkedDirectoriesByNormalizedIdentity([
+      ...(sourceThread?.linkedDirectories ?? []),
+      ...(overlay?.extraLinkedDirectories ?? []),
+    ]).length;
+    if (totalLinkedDirectories <= 1) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Cannot detach the last linked directory from a thread.",
+      );
+    }
 
     const next = await this.overlayStore.removeLinkedDirectory({
       backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14993,23 +14993,36 @@ export class DesktopBackendRegistry {
     if (prepared.workMode !== "worktree" || !prepared.cwd?.trim()) {
       throw new Error("PwrAgent could not allocate a managed worktree.");
     }
-    const [directory] = buildWorktreeLinkedDirectory({
-      repositoryPath: prepared.repositoryPath ?? repositoryPath,
-      worktreePath: prepared.cwd,
-      label: path.basename(prepared.repositoryPath ?? repositoryPath) || repositoryPath,
-    });
-    if (!directory) {
-      throw new Error("failed to build worktree linked directory metadata.");
+    try {
+      const [directory] = buildWorktreeLinkedDirectory({
+        repositoryPath: prepared.repositoryPath ?? repositoryPath,
+        worktreePath: prepared.cwd,
+        label: path.basename(prepared.repositoryPath ?? repositoryPath) || repositoryPath,
+      });
+      if (!directory) {
+        throw new Error("failed to build worktree linked directory metadata.");
+      }
+      await this.recordCodexWorktreeOwnerThread({
+        backend: params.backend,
+        threadId: params.sourceThreadId,
+        worktreePath: prepared.cwd,
+      });
+      return {
+        directory,
+        rollback: prepared.rollback,
+      };
+    } catch (error) {
+      await prepared.rollback?.().catch((rollbackError) => {
+        backendRegistryLog.warn("attach_thread_directory worktree rollback failed", {
+          error:
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : String(rollbackError),
+          threadId: params.sourceThreadId,
+        });
+      });
+      throw error;
     }
-    await this.recordCodexWorktreeOwnerThread({
-      backend: params.backend,
-      threadId: params.sourceThreadId,
-      worktreePath: prepared.cwd,
-    });
-    return {
-      directory,
-      rollback: prepared.rollback,
-    };
   }
 
   private async detachThreadDirectory(
@@ -17557,6 +17570,13 @@ export class DesktopBackendRegistry {
     | { ok: false; message: string }
   > {
     const parsedUrl = parsePullRequestReferenceUrl(args.url);
+    if (args.url?.trim() && !parsedUrl) {
+      return {
+        ok: false,
+        message:
+          "url must look like a GitHub/GHE /pull/<number> URL or a GitLab /merge_requests/<number> URL.",
+      };
+    }
     const number = normalizePositivePullRequestNumber(args.number)
       ?? parsedUrl?.number;
     if (!number) {
@@ -17588,14 +17608,6 @@ export class DesktopBackendRegistry {
           }),
           urlBase: parsedUrl?.urlBase,
         },
-      };
-    }
-
-    if (args.url?.trim() && !parsedUrl) {
-      return {
-        ok: false,
-        message:
-          "url must look like a GitHub/GHE /pull/<number> URL or a GitLab /merge_requests/<number> URL.",
       };
     }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -578,13 +578,57 @@ function resolveThreadWorkspaceCwd(
   overlayDirectories: AppServerThreadSummary["linkedDirectories"] = [],
 ): string | undefined {
   if (!thread) {
-    return undefined;
+    return resolveLinkedDirectoryWorkspaceCwd(overlayDirectories);
   }
 
-  return resolveLinkedDirectoryWorkspaceCwd([
-    ...overlayDirectories,
-    ...thread.linkedDirectories,
-  ]) ?? thread.projectKey;
+  const overlayHandoffDirectory = overlayDirectories.find(isHandoffDirectory);
+  if (overlayHandoffDirectory) {
+    return overlayHandoffDirectory.worktreePath ?? overlayHandoffDirectory.path;
+  }
+
+  const providerDirectories = thread.linkedDirectories.filter(
+    (directory) =>
+      !overlayDirectories.some((overlayDirectory) =>
+        linkedDirectoriesHaveSameWorkspaceIdentity(directory, overlayDirectory),
+      ),
+  );
+
+  return (
+    resolveLinkedDirectoryWorkspaceCwd(providerDirectories) ??
+    resolveLinkedDirectoryWorkspaceCwd(thread.linkedDirectories) ??
+    resolveLinkedDirectoryWorkspaceCwd(overlayDirectories) ??
+    thread.projectKey
+  );
+}
+
+function linkedDirectoriesHaveSameWorkspaceIdentity(
+  left: LinkedDirectorySummary,
+  right: LinkedDirectorySummary,
+): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+
+  const leftPath = normalizeLinkedDirectoryIdentityPath(left.path);
+  const rightPath = normalizeLinkedDirectoryIdentityPath(right.path);
+  const leftWorktreePath = normalizeLinkedDirectoryIdentityPath(left.worktreePath);
+  const rightWorktreePath = normalizeLinkedDirectoryIdentityPath(right.worktreePath);
+  if (leftPath && rightPath && leftPath === rightPath) {
+    return leftWorktreePath === rightWorktreePath;
+  }
+
+  return Boolean(
+    leftWorktreePath &&
+      rightWorktreePath &&
+      leftWorktreePath === rightWorktreePath,
+  );
+}
+
+function normalizeLinkedDirectoryIdentityPath(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? toDirectoryId(path.resolve(normalized)) : undefined;
 }
 
 function resolveLinkedDirectoryWorkspaceCwd(
@@ -13526,19 +13570,17 @@ export class DesktopBackendRegistry {
     threadId: string,
     overlay?: ThreadOverlayState,
   ): Promise<string | undefined> {
-    const overlayCwd = resolveLinkedDirectoryWorkspaceCwd(
-      overlay?.extraLinkedDirectories,
-    );
-    if (overlayCwd?.trim()) {
-      return overlayCwd.trim();
-    }
-
     const pendingThread = this.pendingStartedThreads.get(
       buildThreadIdentityKey(backend, threadId),
     );
-    const pendingCwd = resolveThreadWorkspaceCwd(pendingThread);
-    if (pendingCwd?.trim()) {
-      return pendingCwd.trim();
+    if (pendingThread) {
+      const pendingCwd = resolveThreadWorkspaceCwd(
+        pendingThread,
+        overlay?.extraLinkedDirectories,
+      );
+      if (pendingCwd?.trim()) {
+        return pendingCwd.trim();
+      }
     }
 
     const thread = await this.findThreadForWorkspaceHandoff({
@@ -13546,7 +13588,16 @@ export class DesktopBackendRegistry {
       callerReason: "turn-cwd",
       threadId,
     });
-    return resolveThreadWorkspaceCwd(thread)?.trim() || undefined;
+    const threadCwd = resolveThreadWorkspaceCwd(
+      thread,
+      overlay?.extraLinkedDirectories,
+    );
+    if (threadCwd?.trim()) {
+      return threadCwd.trim();
+    }
+
+    return resolveLinkedDirectoryWorkspaceCwd(overlay?.extraLinkedDirectories)?.trim() ||
+      undefined;
   }
 
   private async recordCodexWorktreeOwnerThread(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -122,8 +122,12 @@ import {
   type PendingThreadHandoffPhase,
   type PendingThreadHandoffSummary,
   type PendingThreadWorkspaceMoveSummary,
+  type AttachThreadDirectoryResult,
+  type AttachThreadDirectoryToolArgs,
+  type AttachThreadDirectoryWorkspaceMode,
   type AttachThreadPullRequestToolArgs,
   type CheckThreadPullRequestStatusToolArgs,
+  type DetachThreadDirectoryToolArgs,
   type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
@@ -667,6 +671,35 @@ function buildWorktreeLinkedDirectory(params: {
       worktreePath: toDirectoryId(worktreePath),
     },
   ];
+}
+
+function normalizeLinkedDirectoryPathForMatch(
+  value: string | undefined,
+): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? toDirectoryId(path.resolve(normalized)) : undefined;
+}
+
+function linkedDirectoryMatchesDetachArgs(
+  directory: LinkedDirectorySummary,
+  args: DetachThreadDirectoryToolArgs,
+): boolean {
+  if (args.directoryId?.trim() && directory.id === args.directoryId.trim()) {
+    return true;
+  }
+  const requestedPath = normalizeLinkedDirectoryPathForMatch(args.path);
+  if (
+    requestedPath &&
+    normalizeLinkedDirectoryPathForMatch(directory.path) === requestedPath
+  ) {
+    return true;
+  }
+  const requestedWorktreePath = normalizeLinkedDirectoryPathForMatch(args.worktreePath);
+  return Boolean(
+    requestedWorktreePath &&
+      normalizeLinkedDirectoryPathForMatch(directory.worktreePath) ===
+        requestedWorktreePath,
+  );
 }
 
 function isLikelyToolManagedWorktreePath(projectKey: string | undefined): boolean {
@@ -14603,6 +14636,12 @@ export class DesktopBackendRegistry {
   private async handleThreadOrchestrationRequest(
     request: PwrAgentThreadOrchestrationRequest,
   ): Promise<PwrAgentThreadOrchestrationResponse> {
+    if (request.operation === "attach_thread_directory") {
+      return await this.attachThreadDirectory(request);
+    }
+    if (request.operation === "detach_thread_directory") {
+      return await this.detachThreadDirectory(request);
+    }
     if (request.operation === "handoff_task") {
       return await this.handoffTaskToThread(request);
     }
@@ -14808,6 +14847,242 @@ export class DesktopBackendRegistry {
       updatedAt: move.updatedAt,
       message: move.message ?? "Workspace move is pending.",
       ...(move.error ? { error: move.error } : {}),
+    };
+  }
+
+  private async attachThreadDirectory(
+    request: PwrAgentThreadOrchestrationRequest<"attach_thread_directory">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceBackend = request.context.backend;
+    const sourceThreadId = request.context.threadId;
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId ||
+      !this.isLiveDynamicToolCall(sourceBackend, {
+        threadId: sourceThreadId,
+        turnId: sourceTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Directory attachment tools must be invoked from a live turn.",
+      );
+    }
+    const backend = request.args.backend ?? sourceBackend;
+    if (!isAppServerBackendKind(backend)) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    if (backend !== sourceBackend) {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Directory attachment currently supports only the invoking thread backend.",
+      );
+    }
+
+    const sourcePath = request.args.path.trim();
+    const workspaceMode: AttachThreadDirectoryWorkspaceMode =
+      request.args.workspaceMode ?? "local";
+    let rollback: (() => Promise<void>) | undefined;
+    try {
+      const directory =
+        workspaceMode === "new_worktree"
+          ? await this.createAttachedWorktreeDirectory({
+              backend,
+              args: request.args,
+              sourceThreadId,
+            }).then((result) => {
+              rollback = result.rollback;
+              return result.directory;
+            })
+          : await this.createAttachedLocalDirectory(sourcePath);
+
+      const overlay = await this.overlayStore.addLinkedDirectory({
+        backend,
+        threadId: sourceThreadId,
+        directory,
+      });
+      rollback = undefined;
+      await this.publishLocalEvent({
+        backend,
+        notification: {
+          method: "navigation/threadDirectories/updated",
+          params: {
+            reason: "selected-thread",
+            threadIds: [sourceThreadId],
+          },
+        },
+      });
+
+      const branchSource = directory.worktreePath ?? directory.path;
+      const branch = branchSource
+        ? await readCurrentGitBranch(branchSource).catch(() => undefined)
+        : undefined;
+      return {
+        ok: true,
+        data: {
+          backend,
+          threadId: sourceThreadId,
+          directory: overlay.extraLinkedDirectories.find(
+            (current) => current.id === directory.id,
+          ) ?? directory,
+          workspaceMode,
+          ...(branch ? { branch } : {}),
+          message:
+            workspaceMode === "new_worktree"
+              ? "Attached a managed worktree directory to this thread."
+              : "Attached a secondary directory to this thread.",
+        } satisfies AttachThreadDirectoryResult,
+      };
+    } catch (error) {
+      await rollback?.().catch((rollbackError) => {
+        backendRegistryLog.warn("attach_thread_directory rollback failed", {
+          error:
+            rollbackError instanceof Error
+              ? rollbackError.message
+              : String(rollbackError),
+          threadId: sourceThreadId,
+        });
+      });
+      return threadOrchestrationFailure(
+        "internal_error",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private async createAttachedLocalDirectory(
+    directoryPath: string,
+  ): Promise<LinkedDirectorySummary> {
+    const primaryPath = await this.gitDirectoryService.resolvePrimaryWorkspacePath(
+      directoryPath,
+    );
+    if (!primaryPath) {
+      throw new Error("path must be inside a Git repository.");
+    }
+    const [directory] = buildLocalLinkedDirectory(primaryPath);
+    if (!directory) {
+      throw new Error("failed to build linked directory metadata.");
+    }
+    return directory;
+  }
+
+  private async createAttachedWorktreeDirectory(params: {
+    backend: AppServerBackendKind;
+    args: AttachThreadDirectoryToolArgs;
+    sourceThreadId: string;
+  }): Promise<{
+    directory: LinkedDirectorySummary;
+    rollback?: () => Promise<void>;
+  }> {
+    const sourcePath = params.args.path.trim();
+    const repositoryPath =
+      (await this.gitDirectoryService.resolvePrimaryWorkspacePath(sourcePath)) ??
+      sourcePath;
+    const prepared = await this.gitDirectoryService.prepareLaunchpadWorkspace({
+      backend: params.backend,
+      branchName: params.args.branchName,
+      directoryKind: "directory",
+      directoryLabel: path.basename(repositoryPath) || repositoryPath,
+      directoryPath: repositoryPath,
+      workMode: "worktree",
+      worktreeBranchMode: params.args.worktreeBranchMode ?? "detached",
+    });
+    if (prepared.workMode !== "worktree" || !prepared.cwd?.trim()) {
+      throw new Error("PwrAgent could not allocate a managed worktree.");
+    }
+    const [directory] = buildWorktreeLinkedDirectory({
+      repositoryPath: prepared.repositoryPath ?? repositoryPath,
+      worktreePath: prepared.cwd,
+      label: path.basename(prepared.repositoryPath ?? repositoryPath) || repositoryPath,
+    });
+    if (!directory) {
+      throw new Error("failed to build worktree linked directory metadata.");
+    }
+    await this.recordCodexWorktreeOwnerThread({
+      backend: params.backend,
+      threadId: params.sourceThreadId,
+      worktreePath: prepared.cwd,
+    });
+    return {
+      directory,
+      rollback: prepared.rollback,
+    };
+  }
+
+  private async detachThreadDirectory(
+    request: PwrAgentThreadOrchestrationRequest<"detach_thread_directory">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const sourceBackend = request.context.backend;
+    const sourceThreadId = request.context.threadId;
+    const sourceTurnId = request.context.turnId?.trim();
+    if (
+      !sourceTurnId ||
+      !this.isLiveDynamicToolCall(sourceBackend, {
+        threadId: sourceThreadId,
+        turnId: sourceTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Directory detachment tools must be invoked from a live turn.",
+      );
+    }
+    const backend = request.args.backend ?? sourceBackend;
+    if (!isAppServerBackendKind(backend)) {
+      return threadOrchestrationFailure(
+        "invalid_arguments",
+        "backend must be a known PwrAgent backend.",
+      );
+    }
+    if (backend !== sourceBackend) {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Directory detachment currently supports only the invoking thread backend.",
+      );
+    }
+
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend,
+      threadId: sourceThreadId,
+    });
+    const matched = overlay?.extraLinkedDirectories.find((directory) =>
+      linkedDirectoryMatchesDetachArgs(directory, request.args),
+    );
+    if (!matched) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "Only secondary directories attached to this thread can be detached.",
+      );
+    }
+
+    const next = await this.overlayStore.removeLinkedDirectory({
+      backend,
+      threadId: sourceThreadId,
+      directory: matched,
+    });
+    await this.publishLocalEvent({
+      backend,
+      notification: {
+        method: "navigation/threadDirectories/updated",
+        params: {
+          reason: "selected-thread",
+          threadIds: [sourceThreadId],
+        },
+      },
+    });
+
+    return {
+      ok: true,
+      data: {
+        backend,
+        threadId: sourceThreadId,
+        detachedDirectory: matched,
+        directories: next.extraLinkedDirectories,
+        message: "Detached a secondary directory from this thread.",
+      },
     };
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -18392,6 +18392,8 @@ function toThreadInspectionSummary(
     gitWorkingState: thread.gitWorkingState,
     ...(messagingBindings?.length ? { messagingBindings } : {}),
     linkedDirectories: thread.linkedDirectories,
+    linkedRepositories: summarizeLinkedRepositories(thread.linkedDirectories),
+    ...(overlay?.prs?.length ? { pullRequests: overlay.prs } : {}),
   };
 }
 
@@ -18413,6 +18415,8 @@ function toThreadInspectionSummaryFromSearchResult(
     handoffOrigin: overlay?.handoffOrigin,
     model: result.model,
     linkedDirectories: result.linkedDirectories,
+    linkedRepositories: summarizeLinkedRepositories(result.linkedDirectories),
+    ...(overlay?.prs?.length ? { pullRequests: overlay.prs } : {}),
     ...(messagingBindings?.length ? { messagingBindings } : {}),
     score: result.score,
     confidence: result.confidence,
@@ -18644,7 +18648,64 @@ function toThreadInspectionSearchSummary(
       path: directory.path,
       ...(directory.worktreePath ? { worktreePath: directory.worktreePath } : {}),
     })),
+    ...(thread.linkedRepositories?.length
+      ? {
+          linkedRepositories: thread.linkedRepositories.slice(0, 5).map((repo) => ({
+            repositoryPath: repo.repositoryPath,
+            directoryIds: repo.directoryIds.slice(0, 8),
+            labels: repo.labels.slice(0, 8),
+            worktreePaths: repo.worktreePaths.slice(0, 8),
+          })),
+        }
+      : {}),
+    ...(thread.pullRequests?.length
+      ? {
+          pullRequests: thread.pullRequests.slice(0, 8).map((pr) => ({
+            provider: pr.provider,
+            org: pr.org,
+            repo: pr.repo,
+            number: pr.number,
+            state: pr.state,
+            ...(pr.checkState ? { checkState: pr.checkState } : {}),
+            ...(pr.lifecycleState ? { lifecycleState: pr.lifecycleState } : {}),
+            ...(pr.reviewState ? { reviewState: pr.reviewState } : {}),
+            ...(pr.mergeState ? { mergeState: pr.mergeState } : {}),
+            ...(pr.title ? { title: pr.title } : {}),
+            url: pr.url,
+          })),
+        }
+      : {}),
   };
+}
+
+function summarizeLinkedRepositories(
+  directories: LinkedDirectorySummary[],
+): ThreadInspectionSummary["linkedRepositories"] {
+  if (directories.length === 0) {
+    return undefined;
+  }
+  const byRepositoryPath = new Map<
+    string,
+    NonNullable<ThreadInspectionSummary["linkedRepositories"]>[number]
+  >();
+  for (const directory of directories) {
+    const repositoryPath = directory.path;
+    const current = byRepositoryPath.get(repositoryPath) ?? {
+      repositoryPath,
+      directoryIds: [],
+      labels: [],
+      worktreePaths: [],
+    };
+    current.directoryIds.push(directory.id);
+    if (!current.labels.includes(directory.label)) {
+      current.labels.push(directory.label);
+    }
+    if (directory.worktreePath && !current.worktreePaths.includes(directory.worktreePath)) {
+      current.worktreePaths.push(directory.worktreePath);
+    }
+    byRepositoryPath.set(repositoryPath, current);
+  }
+  return [...byRepositoryPath.values()];
 }
 
 function toMessagingThreadBindingSummary(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17736,8 +17736,34 @@ export class DesktopBackendRegistry {
           "url must look like a GitHub/GHE /pull/<number> URL or a GitLab /merge_requests/<number> URL.",
       };
     }
-    const number = normalizePositivePullRequestNumber(args.number)
-      ?? parsedUrl?.number;
+    const explicitNumber = normalizePositivePullRequestNumber(args.number);
+    const explicitProvider = args.provider?.trim()
+      ? normalizePullRequestProvider(args.provider)
+      : undefined;
+    const explicitOrg = args.org?.trim();
+    const explicitRepo = args.repo?.trim();
+    if (parsedUrl) {
+      const conflicts = [
+        explicitNumber !== undefined && explicitNumber !== parsedUrl.number
+          ? "number"
+          : undefined,
+        explicitProvider && explicitProvider !== parsedUrl.provider
+          ? "provider"
+          : undefined,
+        explicitOrg && explicitOrg !== parsedUrl.org ? "org" : undefined,
+        explicitRepo && explicitRepo !== parsedUrl.repo ? "repo" : undefined,
+      ].filter((field): field is string => Boolean(field));
+      if (conflicts.length > 0) {
+        return {
+          ok: false,
+          message: `url conflicts with explicit ${conflicts.join(
+            "/",
+          )}. Provide matching PR identity fields or omit the conflicting fields.`,
+        };
+      }
+    }
+
+    const number = explicitNumber ?? parsedUrl?.number;
     if (!number) {
       return {
         ok: false,
@@ -17745,11 +17771,9 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const provider = args.provider?.trim()
-      ? normalizePullRequestProvider(args.provider)
-      : parsedUrl?.provider;
-    const org = args.org?.trim() || parsedUrl?.org;
-    const repo = args.repo?.trim() || parsedUrl?.repo;
+    const provider = explicitProvider ?? parsedUrl?.provider;
+    const org = explicitOrg || parsedUrl?.org;
+    const repo = explicitRepo || parsedUrl?.repo;
     if (provider && org && repo) {
       return {
         ok: true,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -122,7 +122,8 @@ import {
   type PendingThreadHandoffPhase,
   type PendingThreadHandoffSummary,
   type PendingThreadWorkspaceMoveSummary,
-  type AddPullRequestReferenceToolArgs,
+  type AttachThreadPullRequestToolArgs,
+  type CheckThreadPullRequestStatusToolArgs,
   type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
@@ -1211,6 +1212,10 @@ type PendingServerRequest = {
 };
 
 type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle">;
+
+type ThreadPullRequestStatusToolHandler = (
+  args: CheckThreadPullRequestStatusToolArgs,
+) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
 
 type ThreadTitleGenerationLogStatus =
   | ThreadTitleGenerationResult["status"]
@@ -4692,6 +4697,9 @@ export class DesktopBackendRegistry {
     async (request) => await this.handleThreadInspectionRequest(request);
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
+  private threadPullRequestStatusToolHandler:
+    | ThreadPullRequestStatusToolHandler
+    | undefined;
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -5184,6 +5192,12 @@ export class DesktopBackendRegistry {
     handler: PwrAgentAppManagementHandler | null | undefined,
   ): void {
     this.appManagementHandler = handler ?? undefined;
+  }
+
+  setThreadPullRequestStatusToolHandler(
+    handler: ThreadPullRequestStatusToolHandler | null | undefined,
+  ): void {
+    this.threadPullRequestStatusToolHandler = handler ?? undefined;
   }
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
@@ -17063,8 +17077,21 @@ export class DesktopBackendRegistry {
       return await this.handleReadThreadInspectionRequest(request.args);
     }
 
-    if (request.operation === "add_pull_request_reference") {
-      return await this.handleAddPullRequestReferenceInspectionRequest(request.args);
+    if (request.operation === "attach_thread_pull_request") {
+      return await this.handleAttachThreadPullRequestInspectionRequest(request.args);
+    }
+
+    if (request.operation === "check_thread_pull_request_status") {
+      if (!this.threadPullRequestStatusToolHandler) {
+        return {
+          ok: false,
+          error: {
+            code: "unsupported_operation",
+            message: "Pull request status checks are not available.",
+          },
+        };
+      }
+      return await this.threadPullRequestStatusToolHandler(request.args);
     }
 
     if (request.operation === "mutate_thread") {
@@ -17080,8 +17107,8 @@ export class DesktopBackendRegistry {
     };
   }
 
-  private async handleAddPullRequestReferenceInspectionRequest(
-    args: AddPullRequestReferenceToolArgs,
+  private async handleAttachThreadPullRequestInspectionRequest(
+    args: AttachThreadPullRequestToolArgs,
   ): Promise<PwrAgentThreadInspectionResponse> {
     if (!isAppServerBackendKind(args.backend)) {
       return {
@@ -17198,7 +17225,7 @@ export class DesktopBackendRegistry {
   }
 
   private async resolvePullRequestReferenceForThread(
-    args: AddPullRequestReferenceToolArgs,
+    args: AttachThreadPullRequestToolArgs,
     summary: ThreadInspectionSummary,
   ): Promise<
     | { ok: true; ref: PullRequestReferenceIdentity }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17416,7 +17416,11 @@ export class DesktopBackendRegistry {
     }
 
     if (request.operation === "attach_thread_pull_request") {
-      return await this.handleAttachThreadPullRequestInspectionRequest(request.args);
+      return await this.handleAttachThreadPullRequestInspectionRequest({
+        ...request.args,
+        backend: request.args.backend ?? request.context.backend,
+        threadId: request.args.threadId ?? request.context.threadId,
+      });
     }
 
     if (request.operation === "check_thread_pull_request_status") {
@@ -17429,7 +17433,11 @@ export class DesktopBackendRegistry {
           },
         };
       }
-      return await this.threadPullRequestStatusToolHandler(request.args);
+      return await this.threadPullRequestStatusToolHandler({
+        ...request.args,
+        backend: request.args.backend ?? request.context.backend,
+        threadId: request.args.threadId ?? request.context.threadId,
+      });
     }
 
     if (request.operation === "mutate_thread") {
@@ -17448,7 +17456,7 @@ export class DesktopBackendRegistry {
   private async handleAttachThreadPullRequestInspectionRequest(
     args: AttachThreadPullRequestToolArgs,
   ): Promise<PwrAgentThreadInspectionResponse> {
-    if (!isAppServerBackendKind(args.backend)) {
+    if (!args.backend || !isAppServerBackendKind(args.backend)) {
       return {
         ok: false,
         error: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -122,6 +122,7 @@ import {
   type PendingThreadHandoffPhase,
   type PendingThreadHandoffSummary,
   type PendingThreadWorkspaceMoveSummary,
+  type AddPullRequestReferenceToolArgs,
   type ReadThreadToolArgs,
   type PwrAgentThreadInspectionRequest,
   type PwrAgentThreadInspectionResponse,
@@ -158,6 +159,7 @@ import {
   type ThreadWorkspaceHandoffStrategy,
   type ThreadSubAgentSummary,
   type ThreadUsageLineRecord,
+  type PrSummary,
   type WorktreeSnapshotSummary,
   type UpdateDirectoryLaunchpadRequest,
   type UpdateDirectoryLaunchpadResponse,
@@ -170,6 +172,7 @@ import {
   buildThreadIdentityKey,
   isAcpBackendId,
   isAppServerBackendKind,
+  normalizePullRequestProvider,
   DEFAULT_THREAD_INSPECTION_RECENT_LIMIT,
   DEFAULT_THREAD_INSPECTION_SEARCH_LIMIT,
   MAX_THREAD_INSPECTION_SEARCH_LIMIT,
@@ -1072,6 +1075,134 @@ function linkedDirectoriesActiveWorkspaceCoversCwd(params: {
   ].some((directory) =>
     linkedDirectoryActiveWorkspaceCoversCwd(directory, params.cwd),
   );
+}
+
+type PullRequestRepositoryRef = {
+  provider: string;
+  org: string;
+  repo: string;
+  urlBase?: string;
+};
+
+type PullRequestReferenceIdentity = PullRequestRepositoryRef & {
+  number: number;
+  url: string;
+};
+
+function parsePullRequestReferenceUrl(
+  value: string | undefined,
+): PullRequestReferenceIdentity | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return undefined;
+  }
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  const markerIndex = segments.findIndex(
+    (segment) => segment === "pull" || segment === "merge_requests",
+  );
+  if (markerIndex <= 0 || markerIndex >= segments.length - 1) {
+    return undefined;
+  }
+  const number = Number.parseInt(segments[markerIndex + 1] ?? "", 10);
+  if (!Number.isInteger(number) || number <= 0) {
+    return undefined;
+  }
+  const repoIndex = segments[markerIndex - 1] === "-"
+    ? markerIndex - 2
+    : markerIndex - 1;
+  if (repoIndex <= 0) {
+    return undefined;
+  }
+  const org = segments.slice(0, repoIndex).join("/");
+  const repo = segments[repoIndex];
+  if (!org || !repo) {
+    return undefined;
+  }
+  return {
+    provider: normalizePullRequestProvider(parsed.hostname),
+    org,
+    repo,
+    number,
+    url: trimmed,
+    urlBase: `${parsed.protocol}//${parsed.host}`,
+  };
+}
+
+function parseGitRemoteRepositoryUrl(
+  value: string | undefined,
+): PullRequestRepositoryRef | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const sshMatch = /^git@([^:]+):(.+)$/.exec(trimmed);
+  const rawPath = sshMatch ? sshMatch[2] : undefined;
+  const provider = sshMatch?.[1]
+    ? normalizePullRequestProvider(sshMatch[1])
+    : undefined;
+  if (rawPath && provider) {
+    return parseGitRemotePath(provider, rawPath, `https://${provider}`);
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parseGitRemotePath(
+      normalizePullRequestProvider(parsed.hostname),
+      parsed.pathname,
+      `${parsed.protocol}//${parsed.host}`,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function parseGitRemotePath(
+  provider: string,
+  rawPath: string,
+  urlBase: string,
+): PullRequestRepositoryRef | undefined {
+  const segments = rawPath
+    .replace(/^\/+/, "")
+    .replace(/\.git$/i, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length < 2) {
+    return undefined;
+  }
+  const repo = segments.at(-1);
+  const org = segments.slice(0, -1).join("/");
+  if (!org || !repo) {
+    return undefined;
+  }
+  return { provider, org, repo, urlBase };
+}
+
+function pullRequestRepositoryKey(ref: PullRequestRepositoryRef): string {
+  return `${normalizePullRequestProvider(ref.provider)}/${ref.org.toLowerCase()}/${ref.repo.toLowerCase()}`;
+}
+
+function buildPullRequestReferenceUrl(ref: PullRequestRepositoryRef & { number: number }): string {
+  const provider = normalizePullRequestProvider(ref.provider);
+  const base = ref.urlBase?.replace(/\/+$/, "") || `https://${provider}`;
+  const encodedPath = [...ref.org.split("/"), ref.repo]
+    .map((part) => encodeURIComponent(part))
+    .join("/");
+  const marker = provider.includes("gitlab")
+    ? "-/merge_requests"
+    : "pull";
+  return `${base}/${encodedPath}/${marker}/${ref.number}`;
+}
+
+function normalizePositivePullRequestNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
 }
 
 type PendingServerRequest = {
@@ -16932,6 +17063,10 @@ export class DesktopBackendRegistry {
       return await this.handleReadThreadInspectionRequest(request.args);
     }
 
+    if (request.operation === "add_pull_request_reference") {
+      return await this.handleAddPullRequestReferenceInspectionRequest(request.args);
+    }
+
     if (request.operation === "mutate_thread") {
       return await this.handleMutateThreadInspectionRequest(request.args);
     }
@@ -16943,6 +17078,239 @@ export class DesktopBackendRegistry {
         message: "Unsupported PwrAgent thread inspection operation.",
       },
     };
+  }
+
+  private async handleAddPullRequestReferenceInspectionRequest(
+    args: AddPullRequestReferenceToolArgs,
+  ): Promise<PwrAgentThreadInspectionResponse> {
+    if (!isAppServerBackendKind(args.backend)) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "backend must be a known PwrAgent backend.",
+        },
+      };
+    }
+    const threadId = args.threadId?.trim();
+    if (!threadId) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "threadId is required.",
+        },
+      };
+    }
+
+    const summary = await this.readThreadInspectionSummaryForMutation({
+      backend: args.backend,
+      threadId,
+    });
+    if (!summary) {
+      return {
+        ok: false,
+        error: {
+          code: "not_found",
+          message: `Thread ${args.backend}:${threadId} was not found.`,
+        },
+      };
+    }
+
+    const resolved = await this.resolvePullRequestReferenceForThread(args, summary);
+    if (!resolved.ok) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: resolved.message,
+        },
+      };
+    }
+
+    const pr: PrSummary = {
+      provider: normalizePullRequestProvider(resolved.ref.provider),
+      org: resolved.ref.org,
+      repo: resolved.ref.repo,
+      number: resolved.ref.number,
+      ...(args.title?.trim() ? { title: args.title.trim() } : {}),
+      state: "pending",
+      checkState: "pending",
+      lifecycleState: "open",
+      reviewState: "ready_for_review",
+      mergeState: "unknown",
+      url: resolved.ref.url,
+    };
+
+    const overlay = await this.overlayStore.addThreadPullRequestReference({
+      backend: args.backend,
+      threadId,
+      pr,
+    });
+    const prs = overlay.prs ?? [];
+    await this.publishLocalEvent({
+      backend: args.backend,
+      notification: {
+        method: "thread/pullRequests/updated",
+        params: {
+          threadId,
+          prs,
+        },
+      },
+    });
+
+    return {
+      ok: true,
+      data: {
+        pullRequestReference: {
+          backend: args.backend,
+          threadId,
+          pr,
+          prs,
+        },
+      },
+    };
+  }
+
+  private async readThreadInspectionSummaryForMutation(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadInspectionSummary | undefined> {
+    const activeThreads = await this.listThreads({
+      backend: params.backend,
+      archived: false,
+      callerReason: "agent-thread-inspection",
+    });
+    let candidateThreads = activeThreads.filter(
+      (thread) => thread.id === params.threadId,
+    );
+    if (candidateThreads.length === 0) {
+      candidateThreads = (
+        await this.listThreads({
+          backend: params.backend,
+          archived: true,
+          callerReason: "agent-thread-inspection:archived",
+        })
+      ).filter((thread) => thread.id === params.threadId);
+    }
+    const [summary] = await this.enrichThreadInspectionSummaries(candidateThreads);
+    return summary;
+  }
+
+  private async resolvePullRequestReferenceForThread(
+    args: AddPullRequestReferenceToolArgs,
+    summary: ThreadInspectionSummary,
+  ): Promise<
+    | { ok: true; ref: PullRequestReferenceIdentity }
+    | { ok: false; message: string }
+  > {
+    const parsedUrl = parsePullRequestReferenceUrl(args.url);
+    const number = normalizePositivePullRequestNumber(args.number)
+      ?? parsedUrl?.number;
+    if (!number) {
+      return {
+        ok: false,
+        message: "number must be a positive integer unless url contains one.",
+      };
+    }
+
+    const provider = args.provider?.trim()
+      ? normalizePullRequestProvider(args.provider)
+      : parsedUrl?.provider;
+    const org = args.org?.trim() || parsedUrl?.org;
+    const repo = args.repo?.trim() || parsedUrl?.repo;
+    if (provider && org && repo) {
+      return {
+        ok: true,
+        ref: {
+          provider,
+          org,
+          repo,
+          number,
+          url: args.url?.trim() || buildPullRequestReferenceUrl({
+            provider,
+            org,
+            repo,
+            number,
+            urlBase: parsedUrl?.urlBase,
+          }),
+          urlBase: parsedUrl?.urlBase,
+        },
+      };
+    }
+
+    if (args.url?.trim() && !parsedUrl) {
+      return {
+        ok: false,
+        message:
+          "url must look like a GitHub/GHE /pull/<number> URL or a GitLab /merge_requests/<number> URL.",
+      };
+    }
+
+    const inferredRepositories = await this.inferPullRequestRepositories(summary);
+    if (inferredRepositories.length !== 1) {
+      return {
+        ok: false,
+        message:
+          inferredRepositories.length === 0
+            ? "provider/org/repo are required because no repository could be inferred from the thread."
+            : "provider/org/repo are required because the thread has multiple inferable repositories.",
+      };
+    }
+    const [inferred] = inferredRepositories;
+    return {
+      ok: true,
+      ref: {
+        ...inferred,
+        number,
+        url: buildPullRequestReferenceUrl({ ...inferred, number }),
+      },
+    };
+  }
+
+  private async inferPullRequestRepositories(
+    summary: ThreadInspectionSummary,
+  ): Promise<PullRequestRepositoryRef[]> {
+    const byKey = new Map<string, PullRequestRepositoryRef>();
+    for (const pr of summary.pullRequests ?? []) {
+      const ref = {
+        provider: normalizePullRequestProvider(pr.provider),
+        org: pr.org,
+        repo: pr.repo,
+        urlBase: parsePullRequestReferenceUrl(pr.url)?.urlBase,
+      };
+      byKey.set(pullRequestRepositoryKey(ref), ref);
+    }
+    await Promise.all(
+      summary.linkedDirectories.map(async (directory) => {
+        const cwd = directory.worktreePath?.trim() || directory.path.trim();
+        if (!cwd) {
+          return;
+        }
+        const ref = await this.readPullRequestRepositoryFromGitRemote(cwd);
+        if (ref) {
+          byKey.set(pullRequestRepositoryKey(ref), ref);
+        }
+      }),
+    );
+    return [...byKey.values()].sort((left, right) =>
+      pullRequestRepositoryKey(left).localeCompare(pullRequestRepositoryKey(right)),
+    );
+  }
+
+  private async readPullRequestRepositoryFromGitRemote(
+    cwd: string,
+  ): Promise<PullRequestRepositoryRef | undefined> {
+    try {
+      const result = await execFile(
+        "git",
+        ["-C", cwd, "config", "--get", "remote.origin.url"],
+        { env: process.env, timeout: 2_000 },
+      );
+      return parseGitRemoteRepositoryUrl(result.stdout);
+    } catch {
+      return undefined;
+    }
   }
 
   private async handleMutateThreadInspectionRequest(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9741,6 +9741,8 @@ export class DesktopBackendRegistry {
     threadId: string;
     turnId?: string;
     itemId?: string;
+    cancelLabel?: string;
+    cancelDescription?: string;
   }): Promise<boolean> {
     const normalizedCwd = toDirectoryId(path.resolve(params.cwd));
     const requestId = `${params.handoffId}:cwd-trust`;
@@ -9777,8 +9779,9 @@ export class DesktopBackendRegistry {
                         "Trust this directory for future Default Access agent work.",
                     },
                     {
-                      label: "Cancel handoff",
+                      label: params.cancelLabel ?? "Cancel handoff",
                       description:
+                        params.cancelDescription ??
                         "Do not add this directory or start the handoff.",
                     },
                   ],
@@ -9847,6 +9850,62 @@ export class DesktopBackendRegistry {
       preferredBackend: params.preferredBackend,
       registeredAt: Date.now(),
     });
+  }
+
+  private async ensureThreadDirectoryAttachmentTrusted(params: {
+    backend: AppServerBackendKind;
+    cwd: string;
+    executionMode: ThreadExecutionMode;
+    sourceOverlay?: ThreadOverlayState;
+    sourceThread?: AppServerThreadSummary;
+    sourceThreadId: string;
+    sourceTurnId: string;
+    callId?: string;
+  }): Promise<PwrAgentThreadOrchestrationResponse | undefined> {
+    if (
+      params.executionMode === "full-access" ||
+      linkedDirectoriesActiveWorkspaceCoversCwd({
+        cwd: params.cwd,
+        overlay: params.sourceOverlay,
+        thread: params.sourceThread,
+      }) ||
+      (await this.directoryLaunchpadCoversCwd(params.cwd))
+    ) {
+      return undefined;
+    }
+
+    const normalizedCwd = toDirectoryId(path.resolve(params.cwd));
+    const confirmed = await this.requestHandoffCwdTrustConfirmation({
+      backend: params.backend,
+      cwd: params.cwd,
+      handoffId: [
+        "attach-directory",
+        params.backend,
+        params.sourceThreadId,
+        params.sourceTurnId,
+        params.callId?.trim() || randomUUID(),
+      ].join(":"),
+      threadId: params.sourceThreadId,
+      turnId: params.sourceTurnId,
+      itemId: params.callId,
+      cancelLabel: "Cancel attachment",
+      cancelDescription: "Do not add this directory to the thread.",
+    });
+    if (!confirmed) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        `The operator did not approve adding ${normalizedCwd} to the Default Access write scope.`,
+        { cwd: normalizedCwd },
+      );
+    }
+
+    await this.ensureHandoffTrustedDirectoryLaunchpad({
+      cwd: params.cwd,
+      preferredBackend: params.backend,
+      parentThreadId: params.sourceThreadId,
+      parentThreadTitle: params.sourceThread?.title,
+    });
+    return undefined;
   }
 
   async ensureDirectoryLaunchpad(
@@ -14938,17 +14997,56 @@ export class DesktopBackendRegistry {
       request.args.workspaceMode ?? "local";
     let rollback: (() => Promise<void>) | undefined;
     try {
+      const sourceOverlay =
+        (await this.overlayStore.getThreadOverlayState({
+          backend,
+          threadId: sourceThreadId,
+        })) ?? undefined;
+      const sourceThread = await this.findThreadForWorkspaceHandoff({
+        backend,
+        callerReason: "attach-thread-directory",
+        threadId: sourceThreadId,
+      });
+      const executionMode =
+        this.activeCodexTurnModes.get(
+          buildActiveTurnModeKey(sourceThreadId, sourceTurnId),
+        ) ??
+        sourceOverlay?.executionMode ??
+        (backend === "codex"
+          ? await this.resolveCodexThreadExecutionModeForActiveTurn(sourceThreadId)
+          : "default");
+      const primaryPath =
+        await this.gitDirectoryService.resolvePrimaryWorkspacePath(sourcePath);
+      if (workspaceMode === "local" && !primaryPath) {
+        throw new Error("path must be inside a Git repository.");
+      }
+      const repositoryPath = primaryPath ?? sourcePath;
+      const trustFailure = await this.ensureThreadDirectoryAttachmentTrusted({
+        backend,
+        cwd: repositoryPath,
+        executionMode,
+        sourceOverlay,
+        sourceThread,
+        sourceThreadId,
+        sourceTurnId,
+        callId: request.context.callId,
+      });
+      if (trustFailure) {
+        return trustFailure;
+      }
+
       const directory =
         workspaceMode === "new_worktree"
           ? await this.createAttachedWorktreeDirectory({
               backend,
               args: request.args,
+              repositoryPath,
               sourceThreadId,
             }).then((result) => {
               rollback = result.rollback;
               return result.directory;
             })
-          : await this.createAttachedLocalDirectory(sourcePath);
+          : await this.createAttachedLocalDirectory(repositoryPath);
 
       const overlay = await this.overlayStore.addLinkedDirectory({
         backend,
@@ -15023,6 +15121,7 @@ export class DesktopBackendRegistry {
   private async createAttachedWorktreeDirectory(params: {
     backend: AppServerBackendKind;
     args: AttachThreadDirectoryToolArgs;
+    repositoryPath?: string;
     sourceThreadId: string;
   }): Promise<{
     directory: LinkedDirectorySummary;
@@ -15030,6 +15129,7 @@ export class DesktopBackendRegistry {
   }> {
     const sourcePath = params.args.path.trim();
     const repositoryPath =
+      params.repositoryPath ??
       (await this.gitDirectoryService.resolvePrimaryWorkspacePath(sourcePath)) ??
       sourcePath;
     const prepared = await this.gitDirectoryService.prepareLaunchpadWorkspace({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17029,7 +17029,8 @@ export class DesktopBackendRegistry {
     }
 
     if (request.operation === "get_thread_status") {
-      if (!isAppServerBackendKind(request.args.backend)) {
+      const backend = request.args.backend ?? request.context.backend;
+      if (!isAppServerBackendKind(backend)) {
         return {
           ok: false,
           error: {
@@ -17038,7 +17039,7 @@ export class DesktopBackendRegistry {
           },
         };
       }
-      const threadId = request.args.threadId?.trim();
+      const threadId = request.args.threadId?.trim() || request.context.threadId;
       if (!threadId) {
         return {
           ok: false,
@@ -17049,7 +17050,7 @@ export class DesktopBackendRegistry {
         };
       }
       const activeThreads = await this.listThreads({
-        backend: request.args.backend,
+        backend,
         archived: false,
         callerReason: "agent-thread-inspection",
       });
@@ -17057,7 +17058,7 @@ export class DesktopBackendRegistry {
       if (candidateThreads.length === 0) {
         candidateThreads = (
           await this.listThreads({
-            backend: request.args.backend,
+            backend,
             archived: true,
             callerReason: "agent-thread-inspection:archived",
           })
@@ -17069,27 +17070,27 @@ export class DesktopBackendRegistry {
           ok: false,
           error: {
             code: "not_found",
-            message: `Thread ${request.args.backend}:${threadId} was not found.`,
+            message: `Thread ${backend}:${threadId} was not found.`,
           },
         };
       }
       const status = await this.readThread({
-        backend: request.args.backend,
+        backend,
         includeTurns: false,
         limit: 0,
         threadId,
       })
         .then((response) => response.threadStatus ?? response.replay.threadStatus)
         .catch((): AppServerThreadStatus | undefined => undefined);
-      const queueKey = buildThreadIdentityKey(request.args.backend, threadId);
+      const queueKey = buildThreadIdentityKey(backend, threadId);
       const queued = this.getQueuedExecutionModesSnapshot()[queueKey];
       const pendingHandoffs = this.getPendingThreadHandoffsForInspection({
-        backend: request.args.backend,
+        backend,
         sourceThreadId: threadId,
       });
       const pendingWorkspaceMoves =
         this.getPendingThreadWorkspaceMovesForInspection({
-          backend: request.args.backend,
+          backend,
           sourceThreadId: threadId,
         });
       return {
@@ -18803,7 +18804,10 @@ function toThreadInspectionSummary(
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   const linkedDirectories = dedupeLinkedDirectoriesByNormalizedIdentity(
-    thread.linkedDirectories,
+    [
+      ...(overlay?.extraLinkedDirectories ?? []),
+      ...thread.linkedDirectories,
+    ],
   );
   return {
     backend: thread.source,
@@ -18835,7 +18839,10 @@ function toThreadInspectionSummaryFromSearchResult(
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
   const linkedDirectories = dedupeLinkedDirectoriesByNormalizedIdentity(
-    result.linkedDirectories,
+    [
+      ...(overlay?.extraLinkedDirectories ?? []),
+      ...result.linkedDirectories,
+    ],
   );
   return {
     backend: result.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -852,6 +852,31 @@ function normalizeLinkedDirectoryKind(
   return directory;
 }
 
+function linkedDirectoryIdentityKey(directory: LinkedDirectorySummary): string {
+  const normalized = normalizeLinkedDirectoryKind(directory);
+  const repositoryPath = path.resolve(normalized.path);
+  const worktreePath = normalized.worktreePath?.trim()
+    ? path.resolve(normalized.worktreePath)
+    : "";
+  return `${normalized.kind}:${repositoryPath}:${worktreePath}`;
+}
+
+function dedupeLinkedDirectoriesByNormalizedIdentity(
+  directories: LinkedDirectorySummary[],
+): LinkedDirectorySummary[] {
+  const seen = new Set<string>();
+  const deduped: LinkedDirectorySummary[] = [];
+  for (const directory of directories) {
+    const key = linkedDirectoryIdentityKey(directory);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(directory);
+  }
+  return deduped;
+}
+
 function pendingStartedThreadMatchesFilter(
   thread: AppServerThreadSummary,
   filter: string | undefined,
@@ -5873,7 +5898,7 @@ export class DesktopBackendRegistry {
         return {
           ...thread,
           executionMode,
-          linkedDirectories,
+          linkedDirectories: dedupeLinkedDirectoriesByNormalizedIdentity(linkedDirectories),
           codexEnvironmentOptions,
         };
       }),
@@ -7387,9 +7412,13 @@ export class DesktopBackendRegistry {
         ...modelSettings,
         acpRuntime,
         codexEnvironmentRuntime,
-        linkedDirectories: (
-          resolvedLinkedDirectories?.length ? resolvedLinkedDirectories : buildLocalLinkedDirectory(cwd)
-        ).map(normalizeLinkedDirectoryKind),
+        linkedDirectories: dedupeLinkedDirectoriesByNormalizedIdentity(
+          (
+            resolvedLinkedDirectories?.length
+              ? resolvedLinkedDirectories
+              : buildLocalLinkedDirectory(cwd)
+          ).map(normalizeLinkedDirectoryKind),
+        ),
         gitBranch,
       },
     );
@@ -7637,7 +7666,9 @@ export class DesktopBackendRegistry {
         ...(forkedCodexEnvironmentRuntime
           ? { codexEnvironmentRuntime: forkedCodexEnvironmentRuntime }
           : {}),
-        linkedDirectories: linkedDirectories.map(normalizeLinkedDirectoryKind),
+        linkedDirectories: dedupeLinkedDirectoriesByNormalizedIdentity(
+          linkedDirectories.map(normalizeLinkedDirectoryKind),
+        ),
         gitBranch,
       });
 
@@ -11835,6 +11866,9 @@ export class DesktopBackendRegistry {
           reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
           serviceTier: overlay?.serviceTier ?? thread.serviceTier,
           fastMode: overlay?.fastMode ?? thread.fastMode,
+          linkedDirectories: dedupeLinkedDirectoriesByNormalizedIdentity(
+            thread.linkedDirectories,
+          ),
           codexEnvironmentOptions,
         };
       }),
@@ -18768,6 +18802,9 @@ function toThreadInspectionSummary(
   overlay: ThreadOverlayState | undefined,
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
+  const linkedDirectories = dedupeLinkedDirectoriesByNormalizedIdentity(
+    thread.linkedDirectories,
+  );
   return {
     backend: thread.source,
     threadId: thread.id,
@@ -18786,8 +18823,8 @@ function toThreadInspectionSummary(
     fastMode: thread.fastMode,
     gitWorkingState: thread.gitWorkingState,
     ...(messagingBindings?.length ? { messagingBindings } : {}),
-    linkedDirectories: thread.linkedDirectories,
-    linkedRepositories: summarizeLinkedRepositories(thread.linkedDirectories),
+    linkedDirectories,
+    linkedRepositories: summarizeLinkedRepositories(linkedDirectories),
     ...(overlay?.prs?.length ? { pullRequests: overlay.prs } : {}),
   };
 }
@@ -18797,6 +18834,9 @@ function toThreadInspectionSummaryFromSearchResult(
   overlay: ThreadOverlayState | undefined,
   messagingBindings: MessagingThreadBindingSummary[] | undefined,
 ): ThreadInspectionSummary {
+  const linkedDirectories = dedupeLinkedDirectoriesByNormalizedIdentity(
+    result.linkedDirectories,
+  );
   return {
     backend: result.backend,
     threadId: result.threadId,
@@ -18809,8 +18849,8 @@ function toThreadInspectionSummaryFromSearchResult(
     agent: overlay?.agent,
     handoffOrigin: overlay?.handoffOrigin,
     model: result.model,
-    linkedDirectories: result.linkedDirectories,
-    linkedRepositories: summarizeLinkedRepositories(result.linkedDirectories),
+    linkedDirectories,
+    linkedRepositories: summarizeLinkedRepositories(linkedDirectories),
     ...(overlay?.prs?.length ? { pullRequests: overlay.prs } : {}),
     ...(messagingBindings?.length ? { messagingBindings } : {}),
     score: result.score,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1980,6 +1980,10 @@ class DesktopAppServerService {
       };
     }
 
+    const overlay = await this.getOverlayStore().getThreadOverlayState({
+      backend: args.backend,
+      threadId,
+    });
     const branch = args.branch?.trim()
       || thread.observedGitBranch?.trim()
       || thread.gitBranch?.trim()
@@ -1987,12 +1991,13 @@ class DesktopAppServerService {
     const directoryPaths = normalizePrLookupDirectoryPaths(
       args.directoryPaths?.length
         ? args.directoryPaths
-        : resolveThreadPullRequestDirectoryPaths(thread),
+        : resolveThreadPullRequestDirectoryPaths({
+            linkedDirectories: [
+              ...(thread.linkedDirectories ?? []),
+              ...(overlay?.extraLinkedDirectories ?? []),
+            ],
+          }),
     );
-    const overlay = await this.getOverlayStore().getThreadOverlayState({
-      backend: args.backend,
-      threadId,
-    });
     const lookupDirectoryPaths = directoryPaths.length > 0
       ? directoryPaths
       : (overlay?.prs?.length ? [os.homedir()] : []);
@@ -2059,7 +2064,10 @@ class DesktopAppServerService {
     });
     await this.loadPrStatusRegistry();
     await this.loadPrLookupRegistry();
-    const persistedPrs = existing?.prs ?? [];
+    const persistedPrs = this.mergePrHistory(
+      existing?.prs ?? [],
+      existing?.detachedPrs ?? [],
+    );
     this.rememberPrStatuses(persistedPrs, existing?.prsFetchedAt ?? 0);
     const existingPrs = this.canonicalizePrs(persistedPrs);
     const branch = request.branch.trim();
@@ -2215,7 +2223,7 @@ class DesktopAppServerService {
       requestKey,
       lookupKey,
       lookupDirectoryPaths,
-      previousPrs: visibleKnownPrs(),
+      previousPrs: knownPrs,
     });
 
     return {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -443,6 +443,10 @@ function normalizePrLookupDirectoryPaths(directoryPaths: string[]): string[] {
     .sort((left, right) => left.localeCompare(right));
 }
 
+function toLinkedDirectoryPathId(value: string): string {
+  return path.resolve(value).replace(/\\/g, "/");
+}
+
 function getPullRequestLookupKey(
   request: Pick<
     RefreshThreadPullRequestsRequest,
@@ -1920,7 +1924,7 @@ class DesktopAppServerService {
       : existingLookupMatches
         ? existingPrs
         : [];
-    const knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
+    let knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
     if (trigger === "user") {
       logDebug("threadPullRequestsRefresh:requested", userPrRefreshLogPayload({
         backend,
@@ -1938,7 +1942,7 @@ class DesktopAppServerService {
       }));
     }
     if (lookupEntry && lookupEntry.fetchedAt > 0) {
-      await this.persistPullRequestLookupHit({
+      knownPrs = await this.persistPullRequestLookupHit({
         backend,
         request,
         requestKey,
@@ -2286,20 +2290,21 @@ class DesktopAppServerService {
     await Promise.all(
       [...subscribers.values()].map(async (subscriber) => {
         const nextPrs = this.mergePrHistory(subscriber.previousPrs, params.prs);
-        await this.getOverlayStore().setThreadPullRequests({
+        const updated = await this.getOverlayStore().setThreadPullRequests({
           backend: subscriber.backend,
           threadId: subscriber.threadId,
           prs: nextPrs,
           fetchedAt: params.fetchedAt,
           refreshKey: subscriber.requestKey,
         });
+        const persistedPrs = updated.prs ?? [];
 
-        if (!prSummariesEqual(subscriber.previousPrs, nextPrs)) {
+        if (!prSummariesEqual(subscriber.previousPrs, persistedPrs)) {
           changedThreadCount += 1;
           await this.publishThreadPullRequestsUpdated({
             backend: subscriber.backend,
             threadId: subscriber.threadId,
-            prs: nextPrs,
+            prs: persistedPrs,
           });
         }
       }),
@@ -2315,30 +2320,32 @@ class DesktopAppServerService {
     persistedRefreshKey?: string;
     prs: PrSummary[];
     fetchedAt: number;
-  }): Promise<void> {
+  }): Promise<PrSummary[]> {
     const nextPrs = this.mergePrHistory(params.persistedPrs, params.prs);
     if (
       params.persistedRefreshKey === params.requestKey
       && prSummariesEqual(params.persistedPrs, nextPrs)
     ) {
-      return;
+      return params.persistedPrs;
     }
 
-    await this.getOverlayStore().setThreadPullRequests({
+    const updated = await this.getOverlayStore().setThreadPullRequests({
       backend: params.backend,
       threadId: params.request.threadId,
       prs: nextPrs,
       fetchedAt: params.fetchedAt,
       refreshKey: params.requestKey,
     });
+    const persistedPrs = updated.prs ?? [];
 
-    if (!prSummariesEqual(params.persistedPrs, nextPrs)) {
+    if (!prSummariesEqual(params.persistedPrs, persistedPrs)) {
       await this.publishThreadPullRequestsUpdated({
         backend: params.backend,
         threadId: params.request.threadId,
-        prs: nextPrs,
+        prs: persistedPrs,
       });
     }
+    return persistedPrs;
   }
 
   private claimPullRequestLookupRefreshKey(
@@ -3014,11 +3021,12 @@ class DesktopAppServerService {
       };
     }
 
+    const directoryPathId = toLinkedDirectoryPathId(registered.directoryPath);
     const directory: LinkedDirectorySummary = {
-      id: registered.directoryKey,
+      id: directoryPathId,
       kind: "local",
       label: registered.directoryLabel,
-      path: registered.directoryPath,
+      path: directoryPathId,
     };
     await this.getOverlayStore().addLinkedDirectory({
       backend,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -25,6 +25,8 @@ import {
   type AppServerListThreadsResponse,
   type AttachDirectoryToThreadRequest,
   type AttachDirectoryToThreadResponse,
+  type DetachDirectoryFromThreadRequest,
+  type DetachDirectoryFromThreadResponse,
   type CheckThreadPullRequestStatusToolArgs,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
@@ -146,6 +148,7 @@ import {
   NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
   NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+  NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
@@ -448,6 +451,31 @@ function normalizePrLookupDirectoryPaths(directoryPaths: string[]): string[] {
 
 function toLinkedDirectoryPathId(value: string): string {
   return path.resolve(value).replace(/\\/g, "/");
+}
+
+function normalizeLinkedDirectoryPathForMatch(
+  value: string | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? path.resolve(trimmed).replace(/\\/g, "/") : undefined;
+}
+
+function linkedDirectoriesMatchForDetach(
+  left: Pick<LinkedDirectorySummary, "id" | "kind" | "path" | "worktreePath">,
+  right: Pick<LinkedDirectorySummary, "id" | "kind" | "path" | "worktreePath">,
+): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  return (
+    normalizeLinkedDirectoryPathForMatch(left.path) ===
+      normalizeLinkedDirectoryPathForMatch(right.path) &&
+    normalizeLinkedDirectoryPathForMatch(left.worktreePath) ===
+      normalizeLinkedDirectoryPathForMatch(right.worktreePath)
+  );
 }
 
 function getPullRequestLookupKey(
@@ -3232,6 +3260,54 @@ class DesktopAppServerService {
     };
   }
 
+  async detachDirectoryFromThread(
+    request: DetachDirectoryFromThreadRequest,
+  ): Promise<DetachDirectoryFromThreadResponse> {
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().getThreadOverlayState({
+      backend,
+      threadId: request.threadId,
+    });
+    const currentDirectories = overlay?.extraLinkedDirectories ?? [];
+    const matched = currentDirectories.find((directory) =>
+      linkedDirectoriesMatchForDetach(directory, request.directory),
+    );
+    if (!matched) {
+      return {
+        ok: false,
+        backend,
+        threadId: request.threadId,
+        reason: "primary-directory",
+        message:
+          "Only secondary directories attached to this thread can be detached.",
+      };
+    }
+
+    const next = await this.getOverlayStore().removeLinkedDirectory({
+      backend,
+      threadId: request.threadId,
+      directory: matched,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: {
+        method: "navigation/threadDirectories/updated",
+        params: {
+          reason: "selected-thread",
+          threadIds: [request.threadId],
+        },
+      },
+    });
+
+    return {
+      ok: true,
+      backend,
+      threadId: request.threadId,
+      directories: next.extraLinkedDirectories,
+    };
+  }
+
   async analyzeFocusedDiff(
     request: FocusedDiffAnalysisRequest
   ): Promise<FocusedDiffAnalysisResponse> {
@@ -3879,6 +3955,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.attachDirectoryToThread(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
+    async (
+      _event,
+      request: DetachDirectoryFromThreadRequest,
+    ): Promise<DetachDirectoryFromThreadResponse> => {
+      return await appServerService.detachDirectoryFromThread(request);
+    },
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
@@ -3917,6 +4003,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
   getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(undefined);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1106,7 +1106,13 @@ class DesktopAppServerService {
     await this.loadThreadGitWorkingStateCache();
     this.rememberThreadWorktreePaths(canonicalSnapshot.threads);
     this.rememberThreadPrRefreshContexts(canonicalSnapshot.threads);
-    this.rememberMergedPrCommitShas(canonicalSnapshot.threads);
+    const detachedPrsByThreadKey = await this.readDetachedPrsByThreadKey(
+      canonicalSnapshot.threads,
+    );
+    this.rememberMergedPrCommitShas(
+      canonicalSnapshot.threads,
+      detachedPrsByThreadKey,
+    );
     const threadsWithWorkingState = canonicalSnapshot.threads.map((thread) =>
       this.applyCachedWorktreeWorkingState(thread),
     );
@@ -1226,15 +1232,50 @@ class DesktopAppServerService {
     }
   }
 
+  private async readDetachedPrsByThreadKey(
+    threads: NavigationSnapshot["threads"],
+  ): Promise<Map<string, PrSummary[]>> {
+    const threadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
+    for (const thread of threads) {
+      const threadIds = threadIdsByBackend.get(thread.source) ?? new Set<string>();
+      threadIds.add(thread.id);
+      threadIdsByBackend.set(thread.source, threadIds);
+    }
+
+    const detachedPrsByThreadKey = new Map<string, PrSummary[]>();
+    await Promise.all(
+      [...threadIdsByBackend.entries()].map(async ([backend, threadIds]) => {
+        const overlays = await this.getOverlayStore().getThreadOverlayStates({
+          backend,
+          threadIds: [...threadIds],
+        });
+        for (const [threadId, overlay] of Object.entries(overlays)) {
+          if (overlay?.detachedPrs?.length) {
+            detachedPrsByThreadKey.set(
+              buildThreadIdentityKey(backend, threadId),
+              overlay.detachedPrs,
+            );
+          }
+        }
+      }),
+    );
+    return detachedPrsByThreadKey;
+  }
+
   private rememberMergedPrCommitShas(
     threads: NavigationSnapshot["threads"],
+    detachedPrsByThreadKey: Map<string, PrSummary[]> = new Map(),
   ): void {
     for (const thread of threads) {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
       this.rememberMergedPrCommitShasForThread({
         backend: thread.source,
         threadId: thread.id,
         worktreePath: thread.projectKey,
-        prs: thread.prs ?? [],
+        prs: [
+          ...(thread.prs ?? []),
+          ...(detachedPrsByThreadKey.get(threadKey) ?? []),
+        ],
       });
     }
   }
@@ -1851,6 +1892,7 @@ class DesktopAppServerService {
       backend,
       threadId: request.threadId,
       prs,
+      detachedPrs: overlay.detachedPrs ?? [],
     });
     return {
       backend,
@@ -2305,6 +2347,7 @@ class DesktopAppServerService {
             backend: subscriber.backend,
             threadId: subscriber.threadId,
             prs: persistedPrs,
+            detachedPrs: updated.detachedPrs ?? [],
           });
         }
       }),
@@ -2343,6 +2386,7 @@ class DesktopAppServerService {
         backend: params.backend,
         threadId: params.request.threadId,
         prs: persistedPrs,
+        detachedPrs: updated.detachedPrs ?? [],
       });
     }
     return persistedPrs;
@@ -2549,8 +2593,12 @@ class DesktopAppServerService {
     backend: AppServerBackendKind;
     threadId: string;
     prs: PrSummary[];
+    detachedPrs?: PrSummary[];
   }): Promise<void> {
-    const worktreePath = this.rememberMergedPrCommitShasForThread(params);
+    const worktreePath = this.rememberMergedPrCommitShasForThread({
+      ...params,
+      prs: [...params.prs, ...(params.detachedPrs ?? [])],
+    });
     if (worktreePath) {
       getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
       void this.loadThreadGitWorkingStateCache().then(() => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1956,7 +1956,7 @@ class DesktopAppServerService {
   async checkThreadPullRequestStatusForTool(
     args: CheckThreadPullRequestStatusToolArgs,
   ): Promise<PwrAgentThreadInspectionResponse> {
-    if (!isAppServerBackendKind(args.backend)) {
+    if (!args.backend || !isAppServerBackendKind(args.backend)) {
       return {
         ok: false,
         error: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -25,6 +25,7 @@ import {
   type AppServerListThreadsResponse,
   type AttachDirectoryToThreadRequest,
   type AttachDirectoryToThreadResponse,
+  type CheckThreadPullRequestStatusToolArgs,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
   type PersistThreadUsageActivityRequest,
@@ -104,10 +105,12 @@ import {
   type UpdateDirectoryLaunchpadResponse,
   type UpdateSubthreadOrderRequest,
   type UpdateSubthreadOrderResponse,
+  type PwrAgentThreadInspectionResponse,
 } from "@pwragent/shared";
 import {
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
+  isAppServerBackendKind,
   normalizePullRequestProvider as normalizeSharedPullRequestProvider,
 } from "@pwragent/shared";
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
@@ -652,6 +655,22 @@ function userPrRefreshLogPayload(params: {
     requestKey: params.requestKey,
     threadId: params.threadId,
     trigger: params.trigger,
+  };
+}
+
+function pullRequestStatusFreshness(
+  fetchedAt: number | undefined,
+  now: number,
+): Pick<
+  RefreshThreadPullRequestsResponse,
+  "lastStatusCheckAt" | "lastStatusCheckAgeMs"
+> {
+  if (!fetchedAt || fetchedAt <= 0) {
+    return {};
+  }
+  return {
+    lastStatusCheckAt: fetchedAt,
+    lastStatusCheckAgeMs: Math.max(0, now - fetchedAt),
   };
 }
 
@@ -1878,6 +1897,88 @@ class DesktopAppServerService {
     }
   }
 
+  async checkThreadPullRequestStatusForTool(
+    args: CheckThreadPullRequestStatusToolArgs,
+  ): Promise<PwrAgentThreadInspectionResponse> {
+    if (!isAppServerBackendKind(args.backend)) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "backend must be a known PwrAgent backend.",
+        },
+      };
+    }
+    const threadId = args.threadId?.trim();
+    if (!threadId) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message: "threadId is required.",
+        },
+      };
+    }
+
+    const activeThreads = await this.listThreads({ backend: args.backend });
+    let thread = activeThreads.threads.find((candidate) => candidate.id === threadId);
+    if (!thread) {
+      const archivedThreads = await this.listThreads({
+        backend: args.backend,
+        archived: true,
+      });
+      thread = archivedThreads.threads.find((candidate) => candidate.id === threadId);
+    }
+    if (!thread) {
+      return {
+        ok: false,
+        error: {
+          code: "not_found",
+          message: `Thread ${args.backend}:${threadId} was not found.`,
+        },
+      };
+    }
+
+    const branch = args.branch?.trim()
+      || thread.observedGitBranch?.trim()
+      || thread.gitBranch?.trim()
+      || "HEAD";
+    const directoryPaths = normalizePrLookupDirectoryPaths(
+      args.directoryPaths?.length
+        ? args.directoryPaths
+        : resolveThreadPullRequestDirectoryPaths(thread),
+    );
+    const overlay = await this.getOverlayStore().getThreadOverlayState({
+      backend: args.backend,
+      threadId,
+    });
+    const lookupDirectoryPaths = directoryPaths.length > 0
+      ? directoryPaths
+      : (overlay?.prs?.length ? [os.homedir()] : []);
+    const requestedAt = Date.now();
+    const response = await this.refreshThreadPullRequests({
+      backend: args.backend,
+      threadId,
+      provider: args.provider,
+      trigger: "user",
+      branch,
+      directoryPaths: lookupDirectoryPaths,
+      includeStatusFreshness: true,
+    });
+
+    return {
+      ok: true,
+      data: {
+        pullRequestStatus: {
+          ...response,
+          requestedAt,
+          branch,
+          directoryPaths: lookupDirectoryPaths,
+        },
+      },
+    };
+  }
+
   async detachThreadPullRequest(
     request: DetachThreadPullRequestRequest,
   ): Promise<DetachThreadPullRequestResponse> {
@@ -1907,33 +2008,9 @@ class DesktopAppServerService {
     request: RefreshThreadPullRequestsRequest,
     requestKey: string,
   ): Promise<RefreshThreadPullRequestsResponse> {
+    const now = Date.now();
     const provider = normalizePullRequestProvider(request.provider);
     const trigger = request.trigger ?? "scheduled";
-    const fetcher = this.getPrFetcher();
-    const ghAvailable = await fetcher.isGhAvailable();
-    if (!ghAvailable) {
-      if (trigger === "user") {
-        logDebug("threadPullRequestsRefresh:skipped", userPrRefreshLogPayload({
-          backend,
-          branch: request.branch.trim(),
-          directoryPathCount: request.directoryPaths.length,
-          ghAvailable,
-          provider,
-          reason: "gh-unavailable",
-          requestKey,
-          threadId: request.threadId,
-          trigger,
-        }));
-      }
-      return {
-        backend,
-        threadId: request.threadId,
-        provider,
-        prs: [],
-        ghAvailable: false,
-      };
-    }
-
     const overlay = this.getOverlayStore();
     const existing = await overlay.getThreadOverlayState({
       backend,
@@ -1967,6 +2044,17 @@ class DesktopAppServerService {
         ? existingPrs
         : [];
     let knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
+    const statusFetchedAt = lookupEntry?.fetchedAt
+      ?? (existingPrs.length > 0 ? existing?.prsFetchedAt : undefined);
+    const freshness = pullRequestStatusFreshness(statusFetchedAt, now);
+    const responseFreshness = request.includeStatusFreshness === true
+      ? (refreshStarted: boolean) => ({
+          ...freshness,
+          refreshStarted,
+        })
+      : () => ({});
+    const fetcher = this.getPrFetcher();
+    const ghAvailable = await fetcher.isGhAvailable();
     if (trigger === "user") {
       logDebug("threadPullRequestsRefresh:requested", userPrRefreshLogPayload({
         backend,
@@ -1982,6 +2070,30 @@ class DesktopAppServerService {
         threadId: request.threadId,
         trigger,
       }));
+    }
+    if (!ghAvailable) {
+      if (trigger === "user") {
+        logDebug("threadPullRequestsRefresh:skipped", userPrRefreshLogPayload({
+          backend,
+          branch,
+          directoryPathCount: request.directoryPaths.length,
+          ghAvailable,
+          previousPrs: knownPrs,
+          provider,
+          reason: "gh-unavailable",
+          requestKey,
+          threadId: request.threadId,
+          trigger,
+        }));
+      }
+      return {
+        backend,
+        threadId: request.threadId,
+        provider,
+        prs: knownPrs,
+        ...responseFreshness(false),
+        ghAvailable: false,
+      };
     }
     if (lookupEntry && lookupEntry.fetchedAt > 0) {
       knownPrs = await this.persistPullRequestLookupHit({
@@ -2024,6 +2136,7 @@ class DesktopAppServerService {
         provider,
         prs: knownPrs,
         ghAvailable: true,
+        ...responseFreshness(false),
         shortCircuited: true,
       };
     }
@@ -2048,6 +2161,7 @@ class DesktopAppServerService {
         threadId: request.threadId,
         provider,
         prs: knownPrs,
+        ...responseFreshness(false),
         ghAvailable: true,
       };
     }
@@ -2066,6 +2180,7 @@ class DesktopAppServerService {
       threadId: request.threadId,
       provider,
       prs: knownPrs,
+      ...responseFreshness(true),
       ghAvailable: true,
     };
   }
@@ -3236,7 +3351,7 @@ function isFreshWorktreeWorkingStateCacheEntry(
 }
 
 function resolveThreadPullRequestDirectoryPaths(
-  thread: NavigationSnapshot["threads"][number],
+  thread: Pick<AppServerThreadSummary, "linkedDirectories">,
 ): string[] {
   const seen = new Set<string>();
   const paths: string[] = [];
@@ -3281,6 +3396,9 @@ export function registerAppServerIpcHandlers(): void {
   unsubscribeWorkingStateEvents = getDesktopBackendRegistry().onEvent((event) => {
     appServerService.handleAgentEventForWorkingState(event);
   });
+  getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(
+    async (args) => await appServerService.checkThreadPullRequestStatusForTool(args),
+  );
 
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.handle(
@@ -3785,6 +3903,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
+  getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(undefined);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -23,6 +23,8 @@ import {
   type AppServerListSkillsResponse,
   type AppServerListThreadsRequest,
   type AppServerListThreadsResponse,
+  type AttachDirectoryToThreadRequest,
+  type AttachDirectoryToThreadResponse,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
   type PersistThreadUsageActivityRequest,
@@ -40,7 +42,10 @@ import {
   type HandoffThreadWorkspaceResponse,
   type GetGhStatusRequest,
   type GhStatus,
+  type LinkedDirectorySummary,
   type PickDirectoryFromDiskResponse,
+  type DetachThreadPullRequestRequest,
+  type DetachThreadPullRequestResponse,
   type RefreshDirectoryGitStatusesRequest,
   type RefreshDirectoryGitStatusesResponse,
   type RefreshThreadPullRequestsRequest,
@@ -137,6 +142,8 @@ import {
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
   NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL,
   NAVIGATION_GET_WORKTREE_OTHER_CHANGE_DIFF_CHANNEL,
+  NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+  NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
   NAVIGATION_REORDER_THREAD_PINS_CHANNEL,
@@ -1826,6 +1833,29 @@ class DesktopAppServerService {
     }
   }
 
+  async detachThreadPullRequest(
+    request: DetachThreadPullRequestRequest,
+  ): Promise<DetachThreadPullRequestResponse> {
+    const backend = request.backend ?? "codex";
+    const overlay = await this.getOverlayStore().detachThreadPullRequest({
+      backend,
+      threadId: request.threadId,
+      pr: request.pr,
+    });
+    const prs = overlay.prs ?? [];
+    await this.publishThreadPullRequestsUpdated({
+      backend,
+      threadId: request.threadId,
+      prs,
+    });
+    return {
+      backend,
+      threadId: request.threadId,
+      detachedPrKeys: overlay.detachedPrKeys ?? [],
+      prs,
+    };
+  }
+
   private async refreshThreadPullRequestsUncached(
     backend: AppServerBackendKind,
     request: RefreshThreadPullRequestsRequest,
@@ -2966,6 +2996,55 @@ class DesktopAppServerService {
     return response;
   }
 
+  async attachDirectoryToThread(
+    request: AttachDirectoryToThreadRequest,
+  ): Promise<AttachDirectoryToThreadResponse> {
+    const backend = request.backend ?? "codex";
+    const registered = await this.registerDirectoryFromDisk({
+      path: request.path,
+      preferredBackend: request.preferredBackend ?? backend,
+    });
+    if (!registered.ok) {
+      return {
+        ok: false,
+        backend,
+        threadId: request.threadId,
+        reason: registered.reason,
+        message: registered.message,
+      };
+    }
+
+    const directory: LinkedDirectorySummary = {
+      id: registered.directoryKey,
+      kind: "local",
+      label: registered.directoryLabel,
+      path: registered.directoryPath,
+    };
+    await this.getOverlayStore().addLinkedDirectory({
+      backend,
+      threadId: request.threadId,
+      directory,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend,
+      notification: {
+        method: "navigation/threadDirectories/updated",
+        params: {
+          reason: "selected-thread",
+          threadIds: [request.threadId],
+        },
+      },
+    });
+
+    return {
+      ok: true,
+      backend,
+      threadId: request.threadId,
+      directory,
+    };
+  }
+
   async analyzeFocusedDiff(
     request: FocusedDiffAnalysisRequest
   ): Promise<FocusedDiffAnalysisResponse> {
@@ -3479,6 +3558,16 @@ export function registerAppServerIpcHandlers(): void {
       });
     },
   );
+  ipcMain.removeHandler(NAVIGATION_DETACH_THREAD_PR_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_DETACH_THREAD_PR_CHANNEL,
+    async (
+      _event,
+      request: DetachThreadPullRequestRequest,
+    ): Promise<DetachThreadPullRequestResponse> => {
+      return await appServerService.detachThreadPullRequest(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.handle(
     NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
@@ -3590,6 +3679,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.registerDirectoryFromDisk(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+    async (
+      _event,
+      request: AttachDirectoryToThreadRequest,
+    ): Promise<AttachDirectoryToThreadResponse> => {
+      return await appServerService.attachDirectoryToThread(request);
+    },
+  );
 }
 
 export async function disposeAppServerIpcHandlers(): Promise<void> {
@@ -3616,6 +3715,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_REACTION_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_AGENT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_DETACH_THREAD_PR_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_LIST_WORKTREE_OTHER_CHANGES_CHANNEL);
@@ -3626,6 +3726,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
   await appServerService.close();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -478,6 +478,21 @@ function linkedDirectoriesMatchForDetach(
   );
 }
 
+function countDistinctLinkedDirectories(
+  directories: LinkedDirectorySummary[],
+): number {
+  const seen = new Set<string>();
+  for (const directory of directories) {
+    const key = [
+      directory.kind,
+      normalizeLinkedDirectoryPathForMatch(directory.path),
+      normalizeLinkedDirectoryPathForMatch(directory.worktreePath),
+    ].join("\0");
+    seen.add(key);
+  }
+  return seen.size;
+}
+
 function getPullRequestLookupKey(
   request: Pick<
     RefreshThreadPullRequestsRequest,
@@ -3288,6 +3303,25 @@ class DesktopAppServerService {
         reason: "primary-directory",
         message:
           "Only secondary directories attached to this thread can be detached.",
+      };
+    }
+    const fullThread = await this.listThreads({ backend })
+      .then((response) =>
+        response.threads.find((thread) => thread.id === request.threadId),
+      )
+      .catch(() => undefined);
+    const totalLinkedDirectories = countDistinctLinkedDirectories([
+      ...(fullThread?.linkedDirectories ?? []),
+      ...currentDirectories,
+    ]);
+    if (totalLinkedDirectories <= 1) {
+      return {
+        ok: false,
+        backend,
+        threadId: request.threadId,
+        reason: "last-directory",
+        message:
+          "Cannot detach the last linked directory from a thread.",
       };
     }
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -538,6 +538,19 @@ function getPrStatusKey(
   return buildPullRequestStatusKey(pr);
 }
 
+function filterDetachedPullRequests(
+  prs: PrSummary[],
+  detachedPrKeys: string[] | undefined,
+): PrSummary[] {
+  if (!detachedPrKeys?.length) {
+    return prs;
+  }
+  const detached = new Set(
+    detachedPrKeys.map((key) => key.trim().toLowerCase()).filter(Boolean),
+  );
+  return prs.filter((pr) => !detached.has(getPrStatusKey(pr)));
+}
+
 function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
   if (left.length !== right.length) {
     return false;
@@ -2044,6 +2057,8 @@ class DesktopAppServerService {
         ? existingPrs
         : [];
     let knownPrs = this.mergePrHistory(existingPrs, currentLookupPrs);
+    const visibleKnownPrs = (): PrSummary[] =>
+      filterDetachedPullRequests(knownPrs, existing?.detachedPrKeys);
     const statusFetchedAt = lookupEntry?.fetchedAt
       ?? (existingPrs.length > 0 ? existing?.prsFetchedAt : undefined);
     const freshness = pullRequestStatusFreshness(statusFetchedAt, now);
@@ -2064,7 +2079,7 @@ class DesktopAppServerService {
         ghAvailable,
         lookupCacheHit: Boolean(lookupEntry),
         lookupKey,
-        previousPrs: knownPrs,
+        previousPrs: visibleKnownPrs(),
         provider,
         requestKey,
         threadId: request.threadId,
@@ -2078,7 +2093,7 @@ class DesktopAppServerService {
           branch,
           directoryPathCount: request.directoryPaths.length,
           ghAvailable,
-          previousPrs: knownPrs,
+          previousPrs: visibleKnownPrs(),
           provider,
           reason: "gh-unavailable",
           requestKey,
@@ -2090,7 +2105,7 @@ class DesktopAppServerService {
         backend,
         threadId: request.threadId,
         provider,
-        prs: knownPrs,
+        prs: visibleKnownPrs(),
         ...responseFreshness(false),
         ghAvailable: false,
       };
@@ -2134,7 +2149,7 @@ class DesktopAppServerService {
         backend,
         threadId: request.threadId,
         provider,
-        prs: knownPrs,
+        prs: visibleKnownPrs(),
         ghAvailable: true,
         ...responseFreshness(false),
         shortCircuited: true,
@@ -2148,7 +2163,7 @@ class DesktopAppServerService {
           branch,
           directoryPathCount: request.directoryPaths.length,
           ghAvailable: true,
-          previousPrs: knownPrs,
+          previousPrs: visibleKnownPrs(),
           provider,
           reason: !branch ? "missing-branch" : "missing-directory-paths",
           requestKey,
@@ -2160,27 +2175,27 @@ class DesktopAppServerService {
         backend,
         threadId: request.threadId,
         provider,
-        prs: knownPrs,
+        prs: visibleKnownPrs(),
         ...responseFreshness(false),
         ghAvailable: true,
       };
     }
 
-    this.startPullRequestLookupRefresh({
+    const refreshStarted = this.startPullRequestLookupRefresh({
       backend,
       request,
       requestKey,
       lookupKey,
       lookupDirectoryPaths,
-      previousPrs: knownPrs,
+      previousPrs: visibleKnownPrs(),
     });
 
     return {
       backend,
       threadId: request.threadId,
       provider,
-      prs: knownPrs,
-      ...responseFreshness(true),
+      prs: visibleKnownPrs(),
+      ...responseFreshness(refreshStarted),
       ghAvailable: true,
     };
   }
@@ -2292,7 +2307,7 @@ class DesktopAppServerService {
     lookupKey: string;
     lookupDirectoryPaths: string[];
     previousPrs: PrSummary[];
-  }): void {
+  }): boolean {
     const trigger = params.request.trigger ?? "scheduled";
     const provider = normalizePullRequestProvider(params.request.provider);
     const pending = this.pendingPrLookupRefreshes.get(params.lookupKey);
@@ -2311,7 +2326,7 @@ class DesktopAppServerService {
           trigger,
         }));
       }
-      return;
+      return true;
     }
 
     const claim = this.claimPullRequestLookupRefreshKey(
@@ -2343,7 +2358,7 @@ class DesktopAppServerService {
           nextAllowedInMs: claim.nextAllowedInMs,
         });
       }
-      return;
+      return false;
     }
     const refreshKey = claim.refreshKey;
 
@@ -2407,6 +2422,7 @@ class DesktopAppServerService {
         }
       });
     this.pendingPrLookupRefreshes.set(params.lookupKey, promise);
+    return true;
   }
 
   private addPullRequestLookupSubscriber(

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type {
   AppServerBackendScope,
   AppServerThreadSummary,
@@ -439,7 +440,7 @@ export class SqliteOverlayStore {
       ...current,
       extraLinkedDirectories: [
         ...current.extraLinkedDirectories.filter(
-          (d) => d.id !== params.directory.id,
+          (directory) => !linkedDirectoriesEquivalent(directory, params.directory),
         ),
         params.directory,
       ],
@@ -2130,6 +2131,30 @@ function isHandoffDirectory(directory: LinkedDirectorySummary): boolean {
     directory.id.startsWith("pwragent-handoff:") ||
     directory.id.startsWith("pwragnt-handoff:")  // legacy prefix from pre-rebrand data
   );
+}
+
+function linkedDirectoriesEquivalent(
+  left: LinkedDirectorySummary,
+  right: LinkedDirectorySummary,
+): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  if (normalizeLinkedDirectoryPath(left.path) !== normalizeLinkedDirectoryPath(right.path)) {
+    return false;
+  }
+  return (
+    normalizeLinkedDirectoryPath(left.worktreePath) ===
+    normalizeLinkedDirectoryPath(right.worktreePath)
+  );
+}
+
+function normalizeLinkedDirectoryPath(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? path.resolve(normalized) : undefined;
 }
 
 function normalizeThreadAgent(

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -30,6 +30,7 @@ import {
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   MAX_TURN_FAILURE_LOG_ENTRIES,
+  buildPullRequestStatusKey,
   buildThreadIdentityKey,
   applyNavigationLaunchpadProviderSettingsPatch,
   estimateOpenAiTokenUsageCost,
@@ -90,6 +91,24 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     mergeState: pr.mergeState ?? "unknown",
     commitShas: normalizeCommitShas(pr.commitShas),
   };
+}
+
+function normalizeDetachedPrKeys(keys: string[] | undefined): string[] {
+  return [
+    ...new Set(
+      (keys ?? [])
+        .map((key) => key.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+function filterDetachedPrs(prs: PrSummary[], detachedPrKeys: string[]): PrSummary[] {
+  if (detachedPrKeys.length === 0) {
+    return prs;
+  }
+  const detached = new Set(detachedPrKeys);
+  return prs.filter((pr) => !detached.has(buildPullRequestStatusKey(pr)));
 }
 
 function normalizeCommitShas(commitShas: string[] | undefined): string[] | undefined {
@@ -1151,11 +1170,42 @@ export class SqliteOverlayStore {
       executionMode: "default" as const,
       extraLinkedDirectories: [],
     };
+    const detachedPrKeys = normalizeDetachedPrKeys(current.detachedPrKeys);
     const nextState: ThreadOverlayState = {
       ...current,
-      prs: params.prs.map(normalizePrSummary),
+      detachedPrKeys,
+      prs: filterDetachedPrs(params.prs, detachedPrKeys).map(normalizePrSummary),
       prsFetchedAt: params.fetchedAt ?? Date.now(),
       prsRefreshKey: params.refreshKey,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async detachThreadPullRequest(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    pr: Pick<PrSummary, "provider" | "org" | "repo" | "number">;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextDetachedKeys = [
+      ...new Set([
+        ...normalizeDetachedPrKeys(current.detachedPrKeys),
+        buildPullRequestStatusKey(params.pr),
+      ]),
+    ].sort((left, right) => left.localeCompare(right));
+    const nextState: ThreadOverlayState = {
+      ...current,
+      detachedPrKeys: nextDetachedKeys,
+      prs: filterDetachedPrs(current.prs ?? [], nextDetachedKeys).map(
+        normalizePrSummary,
+      ),
     };
     this.putThread(threadKey, nextState);
     return nextState;
@@ -2521,6 +2571,7 @@ export type OverlayStoreLike = Pick<
   | "getDirectoryOverlayState"
   | "readAllDirectoryOverlays"
   | "setThreadPullRequests"
+  | "detachThreadPullRequest"
   | "readPrStatusCache"
   | "writePrStatusCacheEntries"
   | "readPrLookupCache"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1251,6 +1251,40 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async addThreadPullRequestReference(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    pr: PrSummary;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const normalizedPr = normalizePrSummary(params.pr);
+    const prKey = buildPullRequestStatusKey(normalizedPr);
+    const detachedPrKeys = normalizeDetachedPrKeys(current.detachedPrKeys).filter(
+      (key) => key !== prKey,
+    );
+    const detachedPrs = mergePrSummariesByStatusKey(
+      undefined,
+      (current.detachedPrs ?? []).filter(
+        (pr) => buildPullRequestStatusKey(pr) !== prKey,
+      ),
+    );
+    const prs = mergePrSummariesByStatusKey(current.prs, [normalizedPr]) ?? [];
+    const nextState: ThreadOverlayState = {
+      ...current,
+      detachedPrKeys,
+      detachedPrs,
+      prs,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async readPrStatusCache(): Promise<Record<string, PrStatusCacheEntry>> {
     const rows = this.stateDb.raw
       .prepare(
@@ -2636,6 +2670,7 @@ export type OverlayStoreLike = Pick<
   | "readAllDirectoryOverlays"
   | "setThreadPullRequests"
   | "detachThreadPullRequest"
+  | "addThreadPullRequestReference"
   | "readPrStatusCache"
   | "writePrStatusCacheEntries"
   | "readPrLookupCache"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -479,6 +479,28 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async removeLinkedDirectory(params: {
+    backend: ThreadOverlayState["backend"];
+    directory: LinkedDirectorySummary;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      extraLinkedDirectories: current.extraLinkedDirectories.filter(
+        (directory) => !linkedDirectoriesEquivalent(directory, params.directory),
+      ),
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async replaceWorkspaceLinkedDirectory(params: {
     backend: ThreadOverlayState["backend"];
     directory: LinkedDirectorySummary;
@@ -2647,6 +2669,7 @@ export type OverlayStoreLike = Pick<
   | "reconcileNavigationSnapshot"
   | "markThreadSeen"
   | "addLinkedDirectory"
+  | "removeLinkedDirectory"
   | "replaceWorkspaceLinkedDirectory"
   | "getThreadExecutionMode"
   | "getThreadOverlayState"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -112,6 +112,36 @@ function filterDetachedPrs(prs: PrSummary[], detachedPrKeys: string[]): PrSummar
   return prs.filter((pr) => !detached.has(buildPullRequestStatusKey(pr)));
 }
 
+function collectDetachedPrs(
+  prs: PrSummary[],
+  detachedPrKeys: string[],
+): PrSummary[] {
+  if (detachedPrKeys.length === 0) {
+    return [];
+  }
+  const detached = new Set(detachedPrKeys);
+  return prs.filter((pr) => detached.has(buildPullRequestStatusKey(pr)));
+}
+
+function mergePrSummariesByStatusKey(
+  existingPrs: PrSummary[] | undefined,
+  nextPrs: PrSummary[],
+): PrSummary[] | undefined {
+  const byKey = new Map<string, PrSummary>();
+  for (const pr of existingPrs ?? []) {
+    const normalized = normalizePrSummary(pr);
+    byKey.set(buildPullRequestStatusKey(normalized), normalized);
+  }
+  for (const pr of nextPrs) {
+    const normalized = normalizePrSummary(pr);
+    byKey.set(buildPullRequestStatusKey(normalized), normalized);
+  }
+  const merged = [...byKey.values()].sort((left, right) =>
+    buildPullRequestStatusKey(left).localeCompare(buildPullRequestStatusKey(right)),
+  );
+  return merged.length > 0 ? merged : undefined;
+}
+
 function normalizeCommitShas(commitShas: string[] | undefined): string[] | undefined {
   const normalized = [
     ...new Set(
@@ -1172,9 +1202,14 @@ export class SqliteOverlayStore {
       extraLinkedDirectories: [],
     };
     const detachedPrKeys = normalizeDetachedPrKeys(current.detachedPrKeys);
+    const detachedPrs = mergePrSummariesByStatusKey(
+      current.detachedPrs,
+      collectDetachedPrs(params.prs, detachedPrKeys),
+    );
     const nextState: ThreadOverlayState = {
       ...current,
       detachedPrKeys,
+      detachedPrs,
       prs: filterDetachedPrs(params.prs, detachedPrKeys).map(normalizePrSummary),
       prsFetchedAt: params.fetchedAt ?? Date.now(),
       prsRefreshKey: params.refreshKey,
@@ -1201,12 +1236,16 @@ export class SqliteOverlayStore {
         buildPullRequestStatusKey(params.pr),
       ]),
     ].sort((left, right) => left.localeCompare(right));
+    const currentPrs = (current.prs ?? []).map(normalizePrSummary);
+    const detachedPrs = mergePrSummariesByStatusKey(
+      current.detachedPrs,
+      collectDetachedPrs(currentPrs, nextDetachedKeys),
+    );
     const nextState: ThreadOverlayState = {
       ...current,
       detachedPrKeys: nextDetachedKeys,
-      prs: filterDetachedPrs(current.prs ?? [], nextDetachedKeys).map(
-        normalizePrSummary,
-      ),
+      detachedPrs,
+      prs: filterDetachedPrs(currentPrs, nextDetachedKeys),
     };
     this.putThread(threadKey, nextState);
     return nextState;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -72,6 +72,8 @@ import type {
   NavigationBrowseMode,
   AttachDirectoryToThreadRequest,
   AttachDirectoryToThreadResponse,
+  DetachDirectoryFromThreadRequest,
+  DetachDirectoryFromThreadResponse,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   ReorderDirectoryPinsRequest,
@@ -347,6 +349,7 @@ import {
   MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+  NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
@@ -1163,6 +1166,13 @@ const desktopApi = Object.freeze({
   ): Promise<AttachDirectoryToThreadResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+      request,
+    ),
+  detachDirectoryFromThread: async (
+    request: DetachDirectoryFromThreadRequest,
+  ): Promise<DetachDirectoryFromThreadResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
       request,
     ),
   reportRendererError: async (report: RendererErrorReport): Promise<void> => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -70,6 +70,8 @@ import type {
   ListAcpAgentSettingsRequest,
   ListAcpAgentSettingsResponse,
   NavigationBrowseMode,
+  AttachDirectoryToThreadRequest,
+  AttachDirectoryToThreadResponse,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
   ReorderDirectoryPinsRequest,
@@ -110,6 +112,8 @@ import type {
   SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
   PickGhCommandResponse,
+  DetachThreadPullRequestRequest,
+  DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
   RegisterDirectoryFromDiskResponse,
   UnbindMessagingThreadRequest,
@@ -342,6 +346,8 @@ import {
   MESSAGING_SHUTDOWN_RUNTIME_CHANNEL,
   MESSAGING_UNBIND_THREAD_CHANNEL,
   NAVIGATION_GET_GH_STATUS_CHANNEL,
+  NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
+  NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
@@ -1074,6 +1080,10 @@ const desktopApi = Object.freeze({
       NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
       request,
     ),
+  detachThreadPullRequest: async (
+    request: DetachThreadPullRequestRequest,
+  ): Promise<DetachThreadPullRequestResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_DETACH_THREAD_PR_CHANNEL, request),
   refreshDirectoryGitStatuses: async (
     request: RefreshDirectoryGitStatusesRequest,
   ): Promise<RefreshDirectoryGitStatusesResponse> =>
@@ -1146,6 +1156,13 @@ const desktopApi = Object.freeze({
   ): Promise<RegisterDirectoryFromDiskResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
+      request,
+    ),
+  attachDirectoryToThread: async (
+    request: AttachDirectoryToThreadRequest,
+  ): Promise<AttachDirectoryToThreadResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
       request,
     ),
   reportRendererError: async (report: RendererErrorReport): Promise<void> => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1180,6 +1180,15 @@ function DesktopAppShell(props: {
           onSetDirectoryPin={navigation.setDirectoryPin}
           onReorderDirectoryPins={navigation.reorderDirectoryPins}
           onPrefetchPullRequests={pullRequests.prefetch}
+          onDetachPullRequest={async (thread, pr) => {
+            if (!desktopApi?.detachThreadPullRequest) return;
+            await desktopApi.detachThreadPullRequest({
+              backend: thread.source,
+              threadId: thread.id,
+              pr,
+            });
+            await navigation.refresh?.();
+          }}
           onUnbindMessagingBinding={async (_thread, binding) => {
             if (!desktopApi?.unbindMessagingThread) return;
             await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -907,6 +907,9 @@ function DesktopAppShell(props: {
     onPickAndRegisterDirectory: () => {
       void navigation.pickAndRegisterDirectory();
     },
+    onPickAndAttachDirectoryToThread: () => {
+      void navigation.pickAndAttachDirectoryToSelectedThread();
+    },
     onClearPickDirectoryError: navigation.clearPickDirectoryError,
     setExecutionModeError: navigation.setThreadExecutionModeError,
     setThreadModelSettingsError: navigation.setThreadModelSettingsError,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -42,6 +42,7 @@ import {
   BranchIcon,
   CloseIcon,
   FileCodeIcon,
+  FolderIcon,
   LightningIcon,
   PlanIcon,
   PlayIcon,
@@ -182,6 +183,7 @@ type ComposerProps = {
   onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
+  onPickAndAttachDirectoryToThread?: () => void;
   onClearPickDirectoryError?: () => void;
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
@@ -6394,6 +6396,28 @@ export function Composer(props: ComposerProps) {
                 props.onPickAndRegisterDirectory?.();
               }}
             />
+          ) : null}
+
+          {props.thread && props.onPickAndAttachDirectoryToThread ? (
+            <>
+              <button
+                className="composer__action-button composer__attach-directory-button"
+                disabled={props.pickingDirectory}
+                type="button"
+                onClick={() => {
+                  props.onClearPickDirectoryError?.();
+                  props.onPickAndAttachDirectoryToThread?.();
+                }}
+              >
+                <FolderIcon size={14} aria-hidden="true" />
+                <span>{props.pickingDirectory ? "Adding" : "Add directory"}</span>
+              </button>
+              {props.pickDirectoryError ? (
+                <span className="composer__inline-error" role="alert">
+                  {props.pickDirectoryError}
+                </span>
+              ) : null}
+            </>
           ) : null}
 
           {props.launchpad ? (

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -60,6 +60,10 @@ type DirectoriesListProps = {
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onDetachPullRequest?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+  ) => void;
   onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
@@ -554,6 +558,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               }}
               onOpenContextMenu={props.onOpenThreadContextMenu}
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
+              onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
@@ -635,6 +640,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             }}
             onOpenContextMenu={props.onOpenThreadContextMenu}
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
+            onDetachPullRequest={props.onDetachPullRequest}
             onPrefetchPullRequests={props.onPrefetchPullRequests}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
@@ -993,6 +999,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           }}
                           onOpenContextMenu={props.onOpenThreadContextMenu}
                           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
+                          onDetachPullRequest={props.onDetachPullRequest}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -36,6 +36,10 @@ type RecentsListProps = {
     position: { x: number; y: number; anchorTop?: number }
   ) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onDetachPullRequest?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+  ) => void;
   onReorderThreadPins?: (orderedThreadKeys: string[]) => Promise<void>;
   onUpdateSubthreadOrder?: (
     parent: NavigationThreadSummary,
@@ -208,6 +212,7 @@ export function RecentsList(props: RecentsListProps) {
               }}
               onOpenContextMenu={props.onOpenThreadContextMenu}
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
+              onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
@@ -318,6 +323,7 @@ export function RecentsList(props: RecentsListProps) {
           onMovePinnedThread={pinned ? movePinnedThreadByKeyboard : undefined}
           onOpenContextMenu={props.onOpenThreadContextMenu}
           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
+          onDetachPullRequest={props.onDetachPullRequest}
           onPrefetchPullRequests={props.onPrefetchPullRequests}
           onSelectThread={props.onSelectThread}
           onSetReaction={props.onSetReaction}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -40,6 +40,10 @@ import {
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { formatPrimaryAccel } from "../../lib/keyboard-accel";
+import {
+  DetachPullRequestWarning,
+  shouldShowDetachPullRequestWarning,
+} from "../pr-status/DetachPullRequestWarning";
 import { SidebarSearchPopup } from "./SidebarSearchPopup";
 import {
   formatRateLimitLine,
@@ -154,6 +158,10 @@ type SidebarProps = {
    * fresh PR status before they click in.
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onDetachPullRequest?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+  ) => Promise<void>;
   /**
    * Called when the user unbinds a messaging conversation from a
    * thread via the binding chip. Receives the thread + binding so the
@@ -218,6 +226,13 @@ export function Sidebar(props: SidebarProps) {
         requestedPosition: ThreadContextMenuPosition;
         position?: { x: number; y: number };
         directory: NavigationDirectorySummary;
+      }
+    | undefined
+  >();
+  const [pendingDetachPullRequest, setPendingDetachPullRequest] = useState<
+    | {
+        thread: NavigationThreadSummary;
+        pr: PrSummary;
       }
     | undefined
   >();
@@ -597,6 +612,21 @@ export function Sidebar(props: SidebarProps) {
     void copyText(value);
   };
 
+  const detachPullRequest = (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+  ): void => {
+    if (!props.onDetachPullRequest) {
+      return;
+    }
+    setContextMenu(undefined);
+    if (shouldShowDetachPullRequestWarning()) {
+      setPendingDetachPullRequest({ thread, pr });
+      return;
+    }
+    void props.onDetachPullRequest(thread, pr);
+  };
+
   const submitRename = (): void => {
     if (!renameThread) {
       return;
@@ -893,6 +923,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onDetachPullRequest={detachPullRequest}
               onReorderThreadPins={props.onReorderThreadPins}
               onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
               onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
@@ -920,6 +951,7 @@ export function Sidebar(props: SidebarProps) {
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onOpenPullRequestContextMenu={openPullRequestContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
+                onDetachPullRequest={detachPullRequest}
                 onReorderThreadPins={props.onReorderThreadPins}
                 onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
                 onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
@@ -1186,13 +1218,26 @@ export function Sidebar(props: SidebarProps) {
           ) : null}
           <div className="thread-context-menu__section">
             {contextMenuPullRequest ? (
-              <button
-                role="menuitem"
-                type="button"
-                onClick={() => copyFromContextMenu(contextMenuPullRequest.url)}
-              >
-                Copy Pull Request URL
-              </button>
+              <>
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() => copyFromContextMenu(contextMenuPullRequest.url)}
+                >
+                  Copy Pull Request URL
+                </button>
+                {props.onDetachPullRequest ? (
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() =>
+                      detachPullRequest(contextMenu.thread, contextMenuPullRequest)
+                    }
+                  >
+                    Detach Pull Request
+                  </button>
+                ) : null}
+              </>
             ) : null}
             <button
               role="menuitem"
@@ -1230,6 +1275,18 @@ export function Sidebar(props: SidebarProps) {
             ) : null}
           </div>
         </div>
+      ) : null}
+
+      {pendingDetachPullRequest ? (
+        <DetachPullRequestWarning
+          pr={pendingDetachPullRequest.pr}
+          onCancel={() => setPendingDetachPullRequest(undefined)}
+          onConfirm={() => {
+            const pending = pendingDetachPullRequest;
+            setPendingDetachPullRequest(undefined);
+            void props.onDetachPullRequest?.(pending.thread, pending.pr);
+          }}
+        />
       ) : null}
 
       {directoryContextMenu ? (

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -64,6 +64,10 @@ type ThreadRowProps = {
    * thread key, respect terminal-state short-circuit on the main side).
    */
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
+  onDetachPullRequest?: (
+    thread: NavigationThreadSummary,
+    pr: PrSummary,
+  ) => void;
   /**
    * Called when the user picks "Unbind" from a per-thread messaging
    * binding chip. Receives the binding id; the parent owns the IPC call
@@ -275,6 +279,11 @@ export function ThreadRow(props: ThreadRowProps) {
                         targetPr,
                         position,
                       )
+                  : undefined
+              }
+              onDetach={
+                props.onDetachPullRequest
+                  ? (targetPr) => props.onDetachPullRequest!(props.thread, targetPr)
                   : undefined
               }
             />

--- a/apps/desktop/src/renderer/src/features/pr-status/DetachPullRequestWarning.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/DetachPullRequestWarning.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import type { PrSummary } from "@pwragent/shared";
+
+const DETACH_PR_WARNING_DISMISSED_KEY = "pwragent.detachPrWarning.dismissed";
+
+export function shouldShowDetachPullRequestWarning(): boolean {
+  try {
+    return window.localStorage.getItem(DETACH_PR_WARNING_DISMISSED_KEY) !== "1";
+  } catch {
+    return true;
+  }
+}
+
+function rememberDetachPullRequestWarningDismissed(): void {
+  try {
+    window.localStorage.setItem(DETACH_PR_WARNING_DISMISSED_KEY, "1");
+  } catch {
+    // Local storage can be unavailable in hardened/browser test contexts.
+  }
+}
+
+type DetachPullRequestWarningProps = {
+  pr: PrSummary;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export function DetachPullRequestWarning(props: DetachPullRequestWarningProps) {
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+  const prLabel = `${props.pr.org}/${props.pr.repo}#${props.pr.number}`;
+
+  return (
+    <div
+      className="pr-detach-warning-modal"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          props.onCancel();
+        }
+      }}
+    >
+      <div
+        aria-labelledby="pr-detach-warning-title"
+        aria-modal="true"
+        className="pr-detach-warning-dialog"
+        role="dialog"
+      >
+        <h2 id="pr-detach-warning-title">Detach pull request?</h2>
+        <p>
+          This removes {prLabel} from this thread's PR list. It does not close,
+          archive, or modify the pull request on its provider.
+        </p>
+        <label className="composer__checkbox pr-detach-warning-dialog__checkbox">
+          <input
+            checked={dontShowAgain}
+            type="checkbox"
+            onChange={(event) => setDontShowAgain(event.currentTarget.checked)}
+          />
+          <span>Don't show me this again</span>
+        </label>
+        <div className="pr-detach-warning-dialog__actions">
+          <button type="button" onClick={props.onCancel}>
+            Cancel
+          </button>
+          <button
+            className="button--danger"
+            type="button"
+            onClick={() => {
+              if (dontShowAgain) {
+                rememberDetachPullRequestWarningDismissed();
+              }
+              props.onConfirm();
+            }}
+          >
+            Detach PR
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, MouseEvent } from "react";
 import type { PrSummary } from "@pwragent/shared";
+import { CloseIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 type PrChipProps = {
@@ -20,6 +21,7 @@ type PrChipProps = {
     pr: PrSummary,
     position: { x: number; y: number; anchorTop?: number },
   ) => void;
+  onDetach?: (pr: PrSummary) => void;
 };
 
 export function PrChip(props: PrChipProps) {
@@ -70,6 +72,13 @@ export function PrChip(props: PrChipProps) {
     event.currentTarget.blur();
     props.onOpen(pr.url);
   };
+  const handleDetach = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    props.onDetach?.(pr);
+  };
 
   return (
     <>
@@ -106,6 +115,23 @@ export function PrChip(props: PrChipProps) {
       >
         <span className="pr-chip__dot" aria-hidden="true" />
         <span className="pr-chip__label">{label}</span>
+        {props.onDetach ? (
+          <span
+            aria-label={`Detach ${pr.org}/${pr.repo}#${pr.number} from thread`}
+            className="pr-chip__detach"
+            role="button"
+            tabIndex={0}
+            title={`Detach ${pr.org}/${pr.repo}#${pr.number} from thread`}
+            onClick={handleDetach}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                handleDetach(event);
+              }
+            }}
+          >
+            <CloseIcon size={11} aria-hidden="true" />
+          </span>
+        ) : null}
         {isDraft ? <span className="pr-chip__draft-bar" aria-hidden="true" /> : null}
       </span>
       {tooltipController.tooltipNode}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -704,10 +704,18 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "prs":
-        return <PullRequestsPanel thread={props.thread} />;
+        return (
+          <PullRequestsPanel
+            desktopApi={props.desktopApi}
+            onRefreshNavigation={props.onRefreshNavigation}
+            thread={props.thread}
+          />
+        );
       case "projects":
         return (
           <LinkedProjectsPanel
+            desktopApi={props.desktopApi}
+            onRefreshNavigation={props.onRefreshNavigation}
             thread={props.thread}
             showTooltip={showRailTooltip}
             hideTooltip={hideRailTooltip}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -760,6 +760,7 @@ export type ThreadViewProps = {
   onSelectDirectoryFromPicker?: (directory: NavigationDirectorySummary) => void;
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
+  onPickAndAttachDirectoryToThread?: () => void;
   onClearPickDirectoryError?: () => void;
   setExecutionModeError?: string;
   setThreadModelSettingsError?: string;
@@ -2422,6 +2423,9 @@ export function ThreadView(props: ThreadViewProps) {
               onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
               onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
               onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
+              onPickAndAttachDirectoryToThread={
+                props.onPickAndAttachDirectoryToThread
+              }
               onClearPickDirectoryError={props.onClearPickDirectoryError}
               pickDirectoryError={props.pickDirectoryError}
               pickingDirectory={props.pickingDirectory}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1671,6 +1671,63 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByLabelText("Path for PwrAgent Other")).toBeInTheDocument();
   });
 
+  it("detaches a secondary linked project from the Linked Projects tab", async () => {
+    const detachDirectoryFromThread = vi.fn(async () => ({
+      ok: true as const,
+      backend: "codex" as const,
+      threadId: "thread-1",
+      directories: [],
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+    renderPanel({
+      activeTab: "projects",
+      desktopApi: {
+        detachDirectoryFromThread,
+      },
+      onRefreshNavigation,
+      pinned: true,
+      thread: {
+        ...baseThread,
+        linkedDirectories: [
+          {
+            id: "primary-dir",
+            kind: "worktree",
+            label: "PwrAgent",
+            path: "/Users/huntharo/github/PwrAgent",
+            worktreePath:
+              "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main",
+          },
+          {
+            id: "agent-kit-dir",
+            kind: "local",
+            label: "agent-kit",
+            path: "/Users/huntharo/github/agent-kit",
+          },
+        ],
+      },
+    });
+
+    const detachButtons = screen.getAllByRole("button", { name: "Detach" });
+    expect(detachButtons).toHaveLength(1);
+    fireEvent.click(detachButtons[0]!);
+
+    await waitFor(() => {
+      expect(detachDirectoryFromThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        directory: {
+          id: "agent-kit-dir",
+          kind: "local",
+          label: "agent-kit",
+          path: "/Users/huntharo/github/agent-kit",
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("shows regular and Spark rate limits together on the Provider status tab", () => {
     renderPanel({ activeTab: "providers", pinned: true });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1688,6 +1688,7 @@ describe("ThreadContextPanel", () => {
       pinned: true,
       thread: {
         ...baseThread,
+        projectKey: "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main",
         linkedDirectories: [
           {
             id: "primary-dir",
@@ -1725,6 +1726,48 @@ describe("ThreadContextPanel", () => {
     });
     await waitFor(() => {
       expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("allows detaching the only linked project on a directory-less thread", async () => {
+    const detachDirectoryFromThread = vi.fn(async () => ({
+      ok: true as const,
+      backend: "codex" as const,
+      threadId: "thread-1",
+      directories: [],
+    }));
+    renderPanel({
+      activeTab: "projects",
+      desktopApi: {
+        detachDirectoryFromThread,
+      },
+      pinned: true,
+      thread: {
+        ...baseThread,
+        linkedDirectories: [
+          {
+            id: "agent-kit-dir",
+            kind: "local",
+            label: "agent-kit",
+            path: "/Users/huntharo/github/agent-kit",
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Detach" }));
+
+    await waitFor(() => {
+      expect(detachDirectoryFromThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        directory: {
+          id: "agent-kit-dir",
+          kind: "local",
+          label: "agent-kit",
+          path: "/Users/huntharo/github/agent-kit",
+        },
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1729,7 +1729,7 @@ describe("ThreadContextPanel", () => {
     });
   });
 
-  it("allows detaching the only linked project on a directory-less thread", async () => {
+  it("does not allow detaching the only linked project on a directory-less thread", () => {
     const detachDirectoryFromThread = vi.fn(async () => ({
       ok: true as const,
       backend: "codex" as const,
@@ -1755,20 +1755,8 @@ describe("ThreadContextPanel", () => {
       },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Detach" }));
-
-    await waitFor(() => {
-      expect(detachDirectoryFromThread).toHaveBeenCalledWith({
-        backend: "codex",
-        threadId: "thread-1",
-        directory: {
-          id: "agent-kit-dir",
-          kind: "local",
-          label: "agent-kit",
-          path: "/Users/huntharo/github/agent-kit",
-        },
-      });
-    });
+    expect(screen.queryByRole("button", { name: "Detach" })).not.toBeInTheDocument();
+    expect(detachDirectoryFromThread).not.toHaveBeenCalled();
   });
 
   it("shows regular and Spark rate limits together on the Provider status tab", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1632,6 +1632,45 @@ describe("ThreadContextPanel", () => {
     );
   });
 
+  it("deduplicates identical linked projects while preserving distinct worktrees", () => {
+    renderPanel({
+      activeTab: "projects",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        linkedDirectories: [
+          {
+            id: "repo-dir",
+            kind: "worktree",
+            label: "PwrAgent",
+            path: "/Users/huntharo/github/PwrAgent",
+            worktreePath:
+              "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main",
+          },
+          {
+            id: "repo-dir-duplicate",
+            kind: "worktree",
+            label: "PwrAgent",
+            path: "/Users/huntharo/github/PwrAgent",
+            worktreePath:
+              "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-main",
+          },
+          {
+            id: "repo-dir-other-worktree",
+            kind: "worktree",
+            label: "PwrAgent Other",
+            path: "/Users/huntharo/github/PwrAgent",
+            worktreePath:
+              "/Users/huntharo/github/PwrAgent/.worktrees/launchpad-pwragent-other",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getAllByLabelText("Path for PwrAgent")).toHaveLength(1);
+    expect(screen.getByLabelText("Path for PwrAgent Other")).toBeInTheDocument();
+  });
+
   it("shows regular and Spark rate limits together on the Provider status tab", () => {
     renderPanel({ activeTab: "providers", pinned: true });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -121,7 +121,8 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
           {directories.map((directory, index) => {
             const worktreePath = directory.worktreePath ?? directory.path;
             const canDetachDirectory = Boolean(
-              index > 0 && props.desktopApi?.detachDirectoryFromThread,
+              props.desktopApi?.detachDirectoryFromThread
+                && (index > 0 || !props.thread.projectKey?.trim()),
             );
             const detaching = detachingDirectoryId === directory.id;
             return (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -13,7 +13,10 @@ import {
 } from "./context-rail-shared";
 
 type LinkedProjectsPanelProps = {
-  desktopApi?: Pick<DesktopApi, "attachDirectoryToThread" | "pickDirectoryFromDisk">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "attachDirectoryToThread" | "detachDirectoryFromThread" | "pickDirectoryFromDisk"
+  >;
   onRefreshNavigation?: () => Promise<void>;
   thread: NavigationThreadSummary;
   showTooltip: ShowRailTooltip;
@@ -29,6 +32,8 @@ type LinkedProjectsPanelProps = {
 export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
   const [attachError, setAttachError] = useState<string>();
   const [attaching, setAttaching] = useState(false);
+  const [detachError, setDetachError] = useState<string>();
+  const [detachingDirectoryId, setDetachingDirectoryId] = useState<string>();
   const directories = dedupeLinkedProjectDirectories(props.thread.linkedDirectories);
   const prs = props.thread.prs ?? [];
   const branch = props.thread.gitBranch;
@@ -40,6 +45,7 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
       return;
     }
     setAttachError(undefined);
+    setDetachError(undefined);
     setAttaching(true);
     try {
       const picked = await props.desktopApi.pickDirectoryFromDisk();
@@ -59,6 +65,30 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
       await props.onRefreshNavigation?.();
     } finally {
       setAttaching(false);
+    }
+  };
+  const detachDirectory = async (
+    directory: NavigationThreadSummary["linkedDirectories"][number],
+  ): Promise<void> => {
+    if (!props.desktopApi?.detachDirectoryFromThread) {
+      return;
+    }
+    setAttachError(undefined);
+    setDetachError(undefined);
+    setDetachingDirectoryId(directory.id);
+    try {
+      const detached = await props.desktopApi.detachDirectoryFromThread({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        directory,
+      });
+      if (!detached.ok) {
+        setDetachError(detached.message);
+        return;
+      }
+      await props.onRefreshNavigation?.();
+    } finally {
+      setDetachingDirectoryId(undefined);
     }
   };
 
@@ -83,35 +113,56 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
       {attachError ? (
         <p className="context-empty context-empty--warning">{attachError}</p>
       ) : null}
+      {detachError ? (
+        <p className="context-empty context-empty--warning">{detachError}</p>
+      ) : null}
       {directories.length > 0 ? (
         <ul className="context-list linked-projects-list">
-          {directories.map((directory) => {
+          {directories.map((directory, index) => {
             const worktreePath = directory.worktreePath ?? directory.path;
+            const canDetachDirectory = Boolean(
+              index > 0 && props.desktopApi?.detachDirectoryFromThread,
+            );
+            const detaching = detachingDirectoryId === directory.id;
             return (
               <li key={directory.id} className="linked-project">
-                <div className="context-list__label">
-                  <CopyValueButton
-                    label={`Copy path for ${directory.label}`}
-                    value={worktreePath}
-                    onBlur={props.hideTooltip}
-                    onCopy={handleCopyPath}
-                    onShowTooltip={props.showTooltip}
-                  />
-                  <TooltipValue
-                    label={`Path for ${directory.label}`}
-                    value={worktreePath}
-                    onBlur={props.hideTooltip}
-                    onShowTooltip={props.showTooltip}
-                  >
-                    <span aria-hidden="true" className="context-list__icon">
-                      {directory.kind === "worktree" ? (
-                        <WorktreeIcon size={14} />
-                      ) : (
-                        <FolderIcon size={14} />
-                      )}
-                    </span>
-                    {directory.label}
-                  </TooltipValue>
+                <div className="linked-project__heading">
+                  <div className="context-list__label">
+                    <CopyValueButton
+                      label={`Copy path for ${directory.label}`}
+                      value={worktreePath}
+                      onBlur={props.hideTooltip}
+                      onCopy={handleCopyPath}
+                      onShowTooltip={props.showTooltip}
+                    />
+                    <TooltipValue
+                      label={`Path for ${directory.label}`}
+                      value={worktreePath}
+                      onBlur={props.hideTooltip}
+                      onShowTooltip={props.showTooltip}
+                    >
+                      <span aria-hidden="true" className="context-list__icon">
+                        {directory.kind === "worktree" ? (
+                          <WorktreeIcon size={14} />
+                        ) : (
+                          <FolderIcon size={14} />
+                        )}
+                      </span>
+                      {directory.label}
+                    </TooltipValue>
+                  </div>
+                  {canDetachDirectory ? (
+                    <button
+                      className="context-list__action context-list__action--danger"
+                      disabled={detaching}
+                      type="button"
+                      onClick={() => {
+                        void detachDirectory(directory);
+                      }}
+                    >
+                      {detaching ? "Detaching" : "Detach"}
+                    </button>
+                  ) : null}
                 </div>
                 <dl className="linked-project__facts">
                   <div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -29,7 +29,7 @@ type LinkedProjectsPanelProps = {
 export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
   const [attachError, setAttachError] = useState<string>();
   const [attaching, setAttaching] = useState(false);
-  const directories = props.thread.linkedDirectories;
+  const directories = dedupeLinkedProjectDirectories(props.thread.linkedDirectories);
   const prs = props.thread.prs ?? [];
   const branch = props.thread.gitBranch;
   const canAttachDirectory = Boolean(
@@ -161,4 +161,28 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
       ) : null}
     </section>
   );
+}
+
+function dedupeLinkedProjectDirectories(
+  directories: NavigationThreadSummary["linkedDirectories"],
+): NavigationThreadSummary["linkedDirectories"] {
+  const seen = new Set<string>();
+  const deduped: NavigationThreadSummary["linkedDirectories"] = [];
+  for (const directory of directories) {
+    const key = [
+      directory.kind,
+      normalizeLinkedProjectPath(directory.path),
+      normalizeLinkedProjectPath(directory.worktreePath ?? ""),
+    ].join("\0");
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(directory);
+  }
+  return deduped;
+}
+
+function normalizeLinkedProjectPath(value: string): string {
+  return value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { FolderIcon, WorktreeIcon } from "../../../icons";
+import type { DesktopApi } from "../../../lib/desktop-api";
 import { PrChip } from "../../pr-status/PrChip";
 import {
   CopyValueButton,
@@ -11,6 +13,8 @@ import {
 } from "./context-rail-shared";
 
 type LinkedProjectsPanelProps = {
+  desktopApi?: Pick<DesktopApi, "attachDirectoryToThread" | "pickDirectoryFromDisk">;
+  onRefreshNavigation?: () => Promise<void>;
   thread: NavigationThreadSummary;
   showTooltip: ShowRailTooltip;
   hideTooltip: HideRailTooltip;
@@ -23,13 +27,62 @@ type LinkedProjectsPanelProps = {
  * main-process `git status --porcelain` IPC (see TODO below).
  */
 export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
+  const [attachError, setAttachError] = useState<string>();
+  const [attaching, setAttaching] = useState(false);
   const directories = props.thread.linkedDirectories;
   const prs = props.thread.prs ?? [];
   const branch = props.thread.gitBranch;
+  const canAttachDirectory = Boolean(
+    props.desktopApi?.pickDirectoryFromDisk && props.desktopApi.attachDirectoryToThread,
+  );
+  const attachDirectory = async (): Promise<void> => {
+    if (!props.desktopApi?.pickDirectoryFromDisk || !props.desktopApi.attachDirectoryToThread) {
+      return;
+    }
+    setAttachError(undefined);
+    setAttaching(true);
+    try {
+      const picked = await props.desktopApi.pickDirectoryFromDisk();
+      if (picked.canceled) {
+        return;
+      }
+      const attached = await props.desktopApi.attachDirectoryToThread({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        path: picked.path,
+        preferredBackend: props.thread.source,
+      });
+      if (!attached.ok) {
+        setAttachError(attached.message);
+        return;
+      }
+      await props.onRefreshNavigation?.();
+    } finally {
+      setAttaching(false);
+    }
+  };
 
   return (
     <section className="context-panel__section">
-      <h3>Linked projects</h3>
+      <div className="linked-projects__header">
+        <h3>Linked projects</h3>
+        {canAttachDirectory ? (
+          <button
+            className="context-list__action"
+            disabled={attaching}
+            type="button"
+            onClick={() => {
+              void attachDirectory();
+            }}
+          >
+            <FolderIcon size={13} aria-hidden="true" />
+            {attaching ? "Adding" : "Add directory"}
+          </button>
+        ) : null}
+      </div>
+      {attachError ? (
+        <p className="context-empty context-empty--warning">{attachError}</p>
+      ) : null}
       {directories.length > 0 ? (
         <ul className="context-list linked-projects-list">
           {directories.map((directory) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -122,6 +122,7 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
             const worktreePath = directory.worktreePath ?? directory.path;
             const canDetachDirectory = Boolean(
               props.desktopApi?.detachDirectoryFromThread
+                && directories.length > 1
                 && (index > 0 || !props.thread.projectKey?.trim()),
             );
             const detaching = detachingDirectoryId === directory.id;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -1,9 +1,17 @@
+import { useState } from "react";
 import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import {
+  DetachPullRequestWarning,
+  shouldShowDetachPullRequestWarning,
+} from "../../pr-status/DetachPullRequestWarning";
 import { PrChip } from "../../pr-status/PrChip";
 import { openExternalUrl } from "./context-rail-shared";
 import { RailStatusChip, type RailChipTone } from "./RailStatusChip";
 
 type PullRequestsPanelProps = {
+  desktopApi?: Pick<DesktopApi, "detachThreadPullRequest">;
+  onRefreshNavigation?: () => Promise<void>;
   thread: NavigationThreadSummary;
 };
 
@@ -19,6 +27,7 @@ type CheckState = NonNullable<PrSummary["checkState"]>;
  * status pills (lifecycle, merge conflict, checks), above the title + repo.
  */
 export function PullRequestsPanel(props: PullRequestsPanelProps) {
+  const [pendingDetachPr, setPendingDetachPr] = useState<PrSummary>();
   // Newest first. `PrSummary` carries no creation timestamp, so sort by PR
   // number (monotonic with creation within a repo); for the rare multi-repo
   // thread, group by repo first so the numbers stay comparable.
@@ -26,6 +35,24 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
     const repoOrder = repositoryLabel(left).localeCompare(repositoryLabel(right));
     return repoOrder !== 0 ? repoOrder : right.number - left.number;
   });
+  const detachPr = async (pr: PrSummary): Promise<void> => {
+    if (!props.desktopApi?.detachThreadPullRequest) {
+      return;
+    }
+    await props.desktopApi.detachThreadPullRequest({
+      backend: props.thread.source,
+      threadId: props.thread.id,
+      pr,
+    });
+    await props.onRefreshNavigation?.();
+  };
+  const requestDetachPr = (pr: PrSummary): void => {
+    if (shouldShowDetachPullRequestWarning()) {
+      setPendingDetachPr(pr);
+      return;
+    }
+    void detachPr(pr);
+  };
 
   return (
     <section className="context-panel__section">
@@ -44,6 +71,7 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
                     showRepoPrefix={false}
                     onOpen={openExternalUrl}
                     withStatusPills
+                    onDetach={requestDetachPr}
                   />
                   {lifecycle === "merged" ? (
                     <RailStatusChip tone="merged">Merged</RailStatusChip>
@@ -81,6 +109,17 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
           No pull requests linked to this thread yet.
         </p>
       )}
+      {pendingDetachPr ? (
+        <DetachPullRequestWarning
+          pr={pendingDetachPr}
+          onCancel={() => setPendingDetachPr(undefined)}
+          onConfirm={() => {
+            const pr = pendingDetachPr;
+            setPendingDetachPr(undefined);
+            void detachPr(pr);
+          }}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -36,6 +36,8 @@ import type {
   AppServerListThreadsResponse,
   AttachDirectoryToThreadRequest,
   AttachDirectoryToThreadResponse,
+  DetachDirectoryFromThreadRequest,
+  DetachDirectoryFromThreadResponse,
   ThreadSearchRequest,
   ThreadSearchResponse,
   FocusedDiffAnalysisRequest,
@@ -655,6 +657,9 @@ export type DesktopApi = {
   attachDirectoryToThread?: (
     request: AttachDirectoryToThreadRequest,
   ) => Promise<AttachDirectoryToThreadResponse>;
+  detachDirectoryFromThread?: (
+    request: DetachDirectoryFromThreadRequest,
+  ) => Promise<DetachDirectoryFromThreadResponse>;
   normalizeImageForUpload?: (
     request: ImageUploadFallbackRequest
   ) => Promise<ImageUploadFallbackResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -34,6 +34,8 @@ import type {
   CreateAutomationRequest,
   AppServerListThreadsRequest,
   AppServerListThreadsResponse,
+  AttachDirectoryToThreadRequest,
+  AttachDirectoryToThreadResponse,
   ThreadSearchRequest,
   ThreadSearchResponse,
   FocusedDiffAnalysisRequest,
@@ -108,6 +110,8 @@ import type {
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
+  DetachThreadPullRequestRequest,
+  DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
   RegisterDirectoryFromDiskResponse,
   UnbindMessagingThreadRequest,
@@ -598,6 +602,9 @@ export type DesktopApi = {
   refreshThreadPullRequests?: (
     request: RefreshThreadPullRequestsRequest
   ) => Promise<RefreshThreadPullRequestsResponse>;
+  detachThreadPullRequest?: (
+    request: DetachThreadPullRequestRequest
+  ) => Promise<DetachThreadPullRequestResponse>;
   refreshDirectoryGitStatuses?: (
     request: RefreshDirectoryGitStatusesRequest
   ) => Promise<RefreshDirectoryGitStatusesResponse>;
@@ -645,6 +652,9 @@ export type DesktopApi = {
   registerDirectoryFromDisk?: (
     request: RegisterDirectoryFromDiskRequest,
   ) => Promise<RegisterDirectoryFromDiskResponse>;
+  attachDirectoryToThread?: (
+    request: AttachDirectoryToThreadRequest,
+  ) => Promise<AttachDirectoryToThreadResponse>;
   normalizeImageForUpload?: (
     request: ImageUploadFallbackRequest
   ) => Promise<ImageUploadFallbackResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2063,6 +2063,8 @@ export function useThreadNavigation(
   pickAndRegisterDirectory: (
     preferredBackend?: AppServerBackendKind,
   ) => Promise<void>;
+  /** Existing-thread picker: OS dialog -> validate -> attach as an extra linked directory. */
+  pickAndAttachDirectoryToSelectedThread: () => Promise<void>;
   pickDirectoryError?: string;
   pickingDirectory: boolean;
   clearPickDirectoryError: () => void;
@@ -4104,6 +4106,46 @@ export function useThreadNavigation(
     [desktopApi, refresh],
   );
 
+  const pickAndAttachDirectoryToSelectedThread = useCallback(async (): Promise<void> => {
+    if (
+      !desktopApi?.pickDirectoryFromDisk ||
+      !desktopApi.attachDirectoryToThread
+    ) {
+      setPickDirectoryError("Desktop bridge is missing the directory picker.");
+      return;
+    }
+    if (!selectedThread) {
+      setPickDirectoryError("Select a thread before adding a directory.");
+      return;
+    }
+
+    setPickDirectoryError(undefined);
+    setPickingDirectory(true);
+    try {
+      const pick = await desktopApi.pickDirectoryFromDisk();
+      if (pick.canceled) {
+        return;
+      }
+      const result = await desktopApi.attachDirectoryToThread({
+        backend: selectedThread.source,
+        threadId: selectedThread.id,
+        path: pick.path,
+        preferredBackend: selectedThread.source,
+      });
+      if (!result.ok) {
+        setPickDirectoryError(result.message);
+        return;
+      }
+      await refresh(buildThreadIdentityKey(selectedThread.source, selectedThread.id));
+    } catch (error) {
+      setPickDirectoryError(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setPickingDirectory(false);
+    }
+  }, [desktopApi, refresh, selectedThread]);
+
   const clearPickDirectoryError = useCallback((): void => {
     setPickDirectoryError(undefined);
   }, []);
@@ -5281,6 +5323,7 @@ export function useThreadNavigation(
     openDirectoryLaunchpad,
     openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
+    pickAndAttachDirectoryToSelectedThread,
     pickDirectoryError,
     pickingDirectory,
     clearPickDirectoryError,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12685,6 +12685,14 @@ textarea,
   gap: 8px;
 }
 
+.linked-project__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
 .linked-project__facts {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -14088,6 +14088,17 @@ textarea,
   cursor: default;
 }
 
+.composer__attach-directory-button {
+  gap: 6px;
+}
+
+.composer__inline-error {
+  max-width: min(320px, 100%);
+  color: var(--danger-text);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .composer__action-button--busy {
   min-width: 54px;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3757,6 +3757,90 @@ textarea,
   background: var(--status-error);
 }
 
+.pr-chip__detach {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: -4px;
+  border-radius: 50%;
+  color: var(--text-muted);
+}
+
+.pr-chip__detach:hover,
+.pr-chip__detach:focus-visible {
+  background: var(--danger-soft);
+  color: var(--danger-text);
+  outline: none;
+}
+
+.pr-detach-warning-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--modal-scrim);
+}
+
+.pr-detach-warning-dialog {
+  width: min(420px, 100%);
+  padding: 18px;
+  border: 1px solid var(--danger-border);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
+}
+
+.pr-detach-warning-dialog h2 {
+  margin: 0 0 8px;
+  color: var(--text-primary);
+  font-size: 15px;
+  line-height: 1.2;
+}
+
+.pr-detach-warning-dialog p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.pr-detach-warning-dialog__checkbox {
+  margin-top: 14px;
+}
+
+.pr-detach-warning-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.pr-detach-warning-dialog__actions button {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.pr-detach-warning-dialog__actions button:hover,
+.pr-detach-warning-dialog__actions button:focus-visible {
+  border-color: var(--border-strong);
+  outline: none;
+}
+
+.pr-detach-warning-dialog__actions .button--danger {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
 .thread-row__chip--muted {
   background: var(--bg-panel-elevated);
   color: var(--text-secondary);
@@ -12573,6 +12657,24 @@ textarea,
 }
 
 /* Linked Projects panel. */
+.linked-projects__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.linked-projects__header h3 {
+  margin: 0;
+}
+
+.linked-projects__header .context-list__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
 .linked-projects-list {
   gap: 14px;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3783,7 +3783,7 @@ textarea,
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: var(--modal-scrim);
+  background: var(--scrim-strong);
 }
 
 .pr-detach-warning-dialog {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -93,6 +93,8 @@ export const NAVIGATION_DETACH_THREAD_PR_CHANNEL =
   "navigation:detach-thread-pr";
 export const NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL =
   "navigation:attach-directory-to-thread";
+export const NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL =
+  "navigation:detach-directory-from-thread";
 export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
 export const NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL =

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -89,6 +89,10 @@ export const NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL =
   "navigation:reorder-directory-pins";
 export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
+export const NAVIGATION_DETACH_THREAD_PR_CHANNEL =
+  "navigation:detach-thread-pr";
+export const NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL =
+  "navigation:attach-directory-to-thread";
 export const NAVIGATION_GET_GH_STATUS_CHANNEL =
   "navigation:get-gh-status";
 export const NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL =

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { buildDirectorySummaries } from "../domain/directory-navigation";
 import {
+  buildNavigationSnapshot,
   buildNavigationSnapshotHash,
   materializeNavigationThreads,
 } from "../domain/navigation-state";
@@ -1242,6 +1243,56 @@ describe("buildDirectorySummaries", () => {
     // The repo row (a real checkout) wins over the worktree row.
     expect(rowsWithThread[0]?.key).toBe("directory:/Users/huntharo/pwrdrvr/PwrAgnt");
   });
+
+  it("keeps a worktree thread homed under its provider directory when another repo is attached", () => {
+    const snapshot = buildNavigationSnapshot({
+      backend: "codex",
+      fetchedAt: 1_000,
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: "directory:/Users/huntharo/pwrdrvr/agent-kit",
+              label: "agent-kit",
+              path: "/Users/huntharo/pwrdrvr/agent-kit",
+              kind: "local",
+            },
+          ],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          projectKey: "/Users/huntharo/.codex/worktrees/mr03ibdv/PwrAgnt",
+          linkedDirectories: [
+            {
+              id: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              worktreePath: "/Users/huntharo/.codex/worktrees/mr03ibdv/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+      unchanged: false,
+    });
+
+    const rowsWithThread = snapshot.directories.filter((directory) =>
+      directory.threadKeys.includes("codex:thread-1"),
+    );
+    expect(rowsWithThread).toHaveLength(1);
+    expect(rowsWithThread[0]).toEqual(
+      expect.objectContaining({
+        key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+        label: "PwrAgent",
+      }),
+    );
+  });
 });
 
 describe("materializeNavigationThreads", () => {
@@ -1333,6 +1384,46 @@ describe("materializeNavigationThreads", () => {
         worktreePath: "/Users/huntharo/.codex/profiles/sstk/worktrees/mp75j7bn/GifGrabber",
         kind: "worktree",
       },
+    ]);
+  });
+
+  it("keeps provider directories before user-attached extra directories", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [
+            {
+              id: "directory:/Users/huntharo/pwrdrvr/agent-kit",
+              label: "agent-kit",
+              path: "/Users/huntharo/pwrdrvr/agent-kit",
+              kind: "local",
+            },
+          ],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [
+        buildThread({
+          linkedDirectories: [
+            {
+              id: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              worktreePath: "/Users/huntharo/.codex/worktrees/mr03ibdv/PwrAgnt",
+              kind: "worktree",
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(thread?.linkedDirectories.map((directory) => directory.label)).toEqual([
+      "PwrAgent",
+      "agent-kit",
     ]);
   });
 });

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -129,6 +129,45 @@ describe("OverlayStore", () => {
     ]);
   });
 
+  it("adds and removes linked directories using path-compatible identities", async () => {
+    const store = await createStore();
+
+    await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+    let overlay = await store.addLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "directory:/repo/app",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+    expect(overlay.extraLinkedDirectories).toHaveLength(1);
+    expect(overlay.extraLinkedDirectories[0]?.id).toBe("directory:/repo/app");
+
+    overlay = await store.removeLinkedDirectory({
+      backend: "codex",
+      threadId: "thread-1",
+      directory: {
+        id: "/different-id",
+        kind: "local",
+        label: "app",
+        path: "/repo/app",
+      },
+    });
+    expect(overlay.extraLinkedDirectories).toEqual([]);
+  });
+
   it("replaces the active workspace linked directory while preserving unrelated links", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -279,8 +279,9 @@ function normalizeDirectoryDescriptor(
 //   1. A stable repo/local/workspace row over an ephemeral tool-managed
 //      worktree row, so the thread groups under its project (the main checkout)
 //      rather than a throwaway worktree folder.
-//   2. Deterministic tiebreak by key, so the choice is stable across snapshots,
-//      backends, and platforms (no flicker between rows on re-render).
+//   2. Existing linked-directory order, so provider/home metadata keeps
+//      precedence over user-attached secondary directories until true
+//      multi-homed directory listings are implemented.
 function pickHomeDirectory(
   descriptors: DirectoryDescriptor[],
 ): DirectoryDescriptor | undefined {
@@ -288,18 +289,22 @@ function pickHomeDirectory(
     return descriptors[0];
   }
 
-  return [...descriptors].sort((left, right) => {
-    const leftIsWorktree = left.path
-      ? isToolManagedWorktreePath(left.path)
-      : false;
-    const rightIsWorktree = right.path
-      ? isToolManagedWorktreePath(right.path)
-      : false;
-    if (leftIsWorktree !== rightIsWorktree) {
-      return leftIsWorktree ? 1 : -1;
-    }
-    return left.key.localeCompare(right.key);
-  })[0];
+  return descriptors
+    .map((descriptor, index) => ({ descriptor, index }))
+    .sort((left, right) => {
+      const leftDescriptor = left.descriptor;
+      const rightDescriptor = right.descriptor;
+      const leftIsWorktree = leftDescriptor.path
+        ? isToolManagedWorktreePath(leftDescriptor.path)
+        : false;
+      const rightIsWorktree = rightDescriptor.path
+        ? isToolManagedWorktreePath(rightDescriptor.path)
+        : false;
+      if (leftIsWorktree !== rightIsWorktree) {
+        return leftIsWorktree ? 1 : -1;
+      }
+      return left.index - right.index;
+    })[0]?.descriptor;
 }
 
 function ensureSummary(

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -52,9 +52,7 @@ function dedupeLinkedDirectories(
     byId.set(directory.id, directory);
   }
 
-  return [...byId.values()].sort((left, right) =>
-    left.label.localeCompare(right.label),
-  );
+  return [...byId.values()];
 }
 
 function normalizeLinkedDirectoryKind(

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -181,7 +181,7 @@ export class OverlayStore {
 
       const nextDirectories = [
         ...current.extraLinkedDirectories.filter(
-          (directory) => directory.id !== params.directory.id,
+          (directory) => !linkedDirectoriesEquivalent(directory, params.directory),
         ),
         params.directory,
       ];
@@ -189,6 +189,30 @@ export class OverlayStore {
       const nextState: ThreadOverlayState = {
         ...current,
         extraLinkedDirectories: nextDirectories,
+      };
+      data.threads[threadKey] = nextState;
+      return nextState;
+    });
+  }
+
+  async removeLinkedDirectory(params: {
+    backend: ThreadOverlayState["backend"];
+    directory: LinkedDirectorySummary;
+    threadId: string;
+  }): Promise<ThreadOverlayState> {
+    return await this.withData(async (data) => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = data.threads[threadKey] ?? {
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+      };
+      const nextState: ThreadOverlayState = {
+        ...current,
+        extraLinkedDirectories: current.extraLinkedDirectories.filter(
+          (directory) => !linkedDirectoriesEquivalent(directory, params.directory),
+        ),
       };
       data.threads[threadKey] = nextState;
       return nextState;
@@ -879,4 +903,28 @@ export class OverlayStore {
     await writeFile(tempPath, JSON.stringify(data, null, 2), "utf8");
     await rename(tempPath, this.filePath);
   }
+}
+
+function linkedDirectoriesEquivalent(
+  left: LinkedDirectorySummary,
+  right: LinkedDirectorySummary,
+): boolean {
+  if (left.id === right.id) {
+    return true;
+  }
+  if (left.kind !== right.kind) {
+    return false;
+  }
+  if (normalizeLinkedDirectoryPath(left.path) !== normalizeLinkedDirectoryPath(right.path)) {
+    return false;
+  }
+  return (
+    normalizeLinkedDirectoryPath(left.worktreePath) ===
+    normalizeLinkedDirectoryPath(right.worktreePath)
+  );
+}
+
+function normalizeLinkedDirectoryPath(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? path.resolve(normalized) : undefined;
 }

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
   DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY,
   PWRAGENT_THREAD_ORCHESTRATION_ERROR_CODES,
   PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES,
+  type AttachThreadDirectoryResult,
+  type AttachThreadDirectoryToolArgs,
+  type DetachThreadDirectoryResult,
+  type DetachThreadDirectoryToolArgs,
   type HandoffTaskResult,
   type HandoffTaskToolArgs,
   type MoveThreadWorkspaceResult,
@@ -14,6 +19,8 @@ import {
 describe("thread orchestration tool contracts", () => {
   it("defines the handoff task operation", () => {
     expect(PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES).toEqual([
+      "attach_thread_directory",
+      "detach_thread_directory",
       "handoff_task",
       "move_thread_workspace",
       "send_message_to_thread",
@@ -53,6 +60,47 @@ describe("thread orchestration tool contracts", () => {
       cwd: "/Users/test/OtherRepo",
       messagingAttachment: "new_child",
     });
+  });
+
+  it("models attach and detach directory operations", () => {
+    expect(ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES).toEqual([
+      "local",
+      "new_worktree",
+    ]);
+
+    const attachArgs = {
+      path: "/repo/agent-kit",
+      workspaceMode: "new_worktree",
+      branchName: "origin/main",
+      worktreeBranchMode: "detached",
+    } satisfies AttachThreadDirectoryToolArgs;
+    const attachResult: AttachThreadDirectoryResult = {
+      backend: "codex",
+      threadId: "thread-1",
+      workspaceMode: attachArgs.workspaceMode,
+      directory: {
+        id: "/repo/agent-kit",
+        kind: "worktree",
+        label: "agent-kit",
+        path: attachArgs.path,
+        worktreePath: "/worktrees/agent-kit",
+      },
+      message: "Attached a managed worktree directory to this thread.",
+    };
+    const detachArgs = {
+      worktreePath: "/worktrees/agent-kit",
+    } satisfies DetachThreadDirectoryToolArgs;
+    const detachResult: DetachThreadDirectoryResult = {
+      backend: "codex",
+      threadId: "thread-1",
+      detachedDirectory: attachResult.directory,
+      directories: [],
+      message: "Detached a secondary directory from this thread.",
+    };
+
+    expect(JSON.parse(JSON.stringify(attachResult))).toEqual(attachResult);
+    expect(JSON.parse(JSON.stringify(detachArgs))).toEqual(detachArgs);
+    expect(JSON.parse(JSON.stringify(detachResult))).toEqual(detachResult);
   });
 
   it("keeps handoff origin serializable and separate from parent grouping", () => {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1104,6 +1104,12 @@ export type ThreadOverlayState = {
    * explicit re-attach flow exists.
    */
   detachedPrKeys?: string[];
+  /**
+   * Detached PR summaries retained for non-UI bookkeeping. These PRs stay
+   * hidden from `prs`, but merged commit SHAs still need to classify local
+   * worktree commits after a remote PR branch is deleted.
+   */
+  detachedPrs?: PrSummary[];
   /** Wall-clock ms when `prs` was last refreshed via gh. */
   prsFetchedAt?: number;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -979,6 +979,7 @@ export type AttachDirectoryToThreadResponse =
 export type DetachDirectoryFromThreadFailureReason =
   | "not-found"
   | "primary-directory"
+  | "last-directory"
   | "not-attached";
 
 export type DetachDirectoryFromThreadRequest = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -927,6 +927,8 @@ export type RefreshThreadPullRequestsRequest = {
    * re-walk the snapshot.
    */
   directoryPaths: string[];
+  /** Include status freshness metadata in the response. Used by agent tools. */
+  includeStatusFreshness?: boolean;
 };
 
 export type DetachThreadPullRequestRequest = {
@@ -979,6 +981,15 @@ export type RefreshThreadPullRequestsResponse = {
   threadId: ThreadIdentifier;
   provider: PullRequestProvider;
   prs: PrSummary[];
+  /**
+   * Wall-clock ms for the provider/cache check that produced the returned
+   * statuses. Undefined means no successful provider check has been recorded.
+   */
+  lastStatusCheckAt?: number;
+  /** Milliseconds elapsed since `lastStatusCheckAt`, computed by main. */
+  lastStatusCheckAgeMs?: number;
+  /** True when main accepted this request and started a provider refresh. */
+  refreshStarted?: boolean;
   /** True when the host doesn't have `gh` installed; degrade silently. */
   ghAvailable: boolean;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -929,6 +929,51 @@ export type RefreshThreadPullRequestsRequest = {
   directoryPaths: string[];
 };
 
+export type DetachThreadPullRequestRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  pr: Pick<PrSummary, "provider" | "org" | "repo" | "number">;
+};
+
+export type DetachThreadPullRequestResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  detachedPrKeys: string[];
+  prs: PrSummary[];
+};
+
+export type AttachDirectoryToThreadRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /** Absolute path the user picked from the system dialog. */
+  path: string;
+  /**
+   * Backend the directory's launchpad should default to if the directory has
+   * not already been registered.
+   */
+  preferredBackend?: AppServerBackendKind;
+};
+
+export type AttachDirectoryToThreadFailureReason =
+  | "inaccessible"
+  | "not-a-directory"
+  | "not-a-git-repo";
+
+export type AttachDirectoryToThreadResponse =
+  | {
+      ok: true;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      directory: LinkedDirectorySummary;
+    }
+  | {
+      ok: false;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      reason: AttachDirectoryToThreadFailureReason;
+      message: string;
+    };
+
 export type RefreshThreadPullRequestsResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
@@ -1053,6 +1098,12 @@ export type ThreadOverlayState = {
    * sidebar/history purposes; status refreshes replace matching entries.
    */
   prs?: PrSummary[];
+  /**
+   * Normalized PR status keys the user removed from this thread. Refreshes
+   * keep collecting provider state, but these keys stay hidden until a future
+   * explicit re-attach flow exists.
+   */
+  detachedPrKeys?: string[];
   /** Wall-clock ms when `prs` was last refreshed via gh. */
   prsFetchedAt?: number;
   /**

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -976,6 +976,35 @@ export type AttachDirectoryToThreadResponse =
       message: string;
     };
 
+export type DetachDirectoryFromThreadFailureReason =
+  | "not-found"
+  | "primary-directory"
+  | "not-attached";
+
+export type DetachDirectoryFromThreadRequest = {
+  backend?: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  directory: Pick<
+    LinkedDirectorySummary,
+    "id" | "kind" | "label" | "path" | "worktreePath"
+  >;
+};
+
+export type DetachDirectoryFromThreadResponse =
+  | {
+      ok: true;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      directories: LinkedDirectorySummary[];
+    }
+  | {
+      ok: false;
+      backend: AppServerBackendKind;
+      threadId: ThreadIdentifier;
+      reason: DetachDirectoryFromThreadFailureReason;
+      message: string;
+    };
+
 export type RefreshThreadPullRequestsResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -11,6 +11,8 @@ import type { CodexEnvironmentStartupFailure } from "./agent";
 import type { MessagingChannelKind, MessagingConversationKind } from "./messaging";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
+  "attach_thread_directory",
+  "detach_thread_directory",
   "handoff_task",
   "move_thread_workspace",
   "send_message_to_thread",
@@ -134,6 +136,74 @@ export type MoveThreadWorkspaceToolArgs = {
   sourceBranch?: string;
   leaveLocalBranch?: string;
   newBranchName?: string;
+};
+
+export type AttachThreadDirectoryWorkspaceMode = "local" | "new_worktree";
+export const ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES = [
+  "local",
+  "new_worktree",
+] as const;
+
+export type AttachThreadDirectoryWorktreeBranchMode = "attached" | "detached";
+export const ATTACH_THREAD_DIRECTORY_WORKTREE_BRANCH_MODES = [
+  "attached",
+  "detached",
+] as const;
+
+export type AttachThreadDirectoryToolArgs = {
+  /**
+   * Optional backend override. Omitted defaults to the invoking thread backend.
+   * The first implementation supports current-thread attachment only.
+   */
+  backend?: AppServerBackendKind;
+  /** Repository/local checkout path to attach, or to use as the parent repo for a new worktree. */
+  path: string;
+  /**
+   * `local` attaches the repository directory itself. `new_worktree` asks
+   * PwrAgent to allocate a managed worktree for that repository and attach it.
+   */
+  workspaceMode?: AttachThreadDirectoryWorkspaceMode;
+  /**
+   * Existing base branch/ref used when workspaceMode is "new_worktree".
+   * This is not the new feature branch name.
+   */
+  branchName?: string;
+  /**
+   * Whether the allocated worktree should be checked out on an attached branch
+   * or as a detached HEAD. Defaults to detached.
+   */
+  worktreeBranchMode?: AttachThreadDirectoryWorktreeBranchMode;
+};
+
+export type DetachThreadDirectoryToolArgs = {
+  /**
+   * Optional backend override. Omitted defaults to the invoking thread backend.
+   * The first implementation supports current-thread detachment only.
+   */
+  backend?: AppServerBackendKind;
+  /** Preferred exact linked-directory identifier to detach. */
+  directoryId?: string;
+  /** Repository/local checkout path to detach. */
+  path?: string;
+  /** Managed worktree path to detach. */
+  worktreePath?: string;
+};
+
+export type AttachThreadDirectoryResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  directory: LinkedDirectorySummary;
+  workspaceMode: AttachThreadDirectoryWorkspaceMode;
+  branch?: string;
+  message: string;
+};
+
+export type DetachThreadDirectoryResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  detachedDirectory: LinkedDirectorySummary;
+  directories: LinkedDirectorySummary[];
+  message: string;
 };
 
 export type MoveThreadWorkspaceStatus =
@@ -280,6 +350,8 @@ export type SendMessageToThreadResult = {
 };
 
 export type PwrAgentThreadOrchestrationToolArgsByOperation = {
+  attach_thread_directory: AttachThreadDirectoryToolArgs;
+  detach_thread_directory: DetachThreadDirectoryToolArgs;
   handoff_task: HandoffTaskToolArgs;
   move_thread_workspace: MoveThreadWorkspaceToolArgs;
   send_message_to_thread: SendMessageToThreadToolArgs;
@@ -305,6 +377,8 @@ export type PwrAgentThreadOrchestrationResponse =
   | {
       ok: true;
       data:
+        | AttachThreadDirectoryResult
+        | DetachThreadDirectoryResult
         | HandoffTaskResult
         | MoveThreadWorkspaceResult
         | SendMessageToThreadResult;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -156,11 +156,16 @@ export type AttachThreadDirectoryToolArgs = {
    * The first implementation supports current-thread attachment only.
    */
   backend?: AppServerBackendKind;
-  /** Repository/local checkout path to attach, or to use as the parent repo for a new worktree. */
+  /**
+   * Repository/local checkout path to attach, or to use as the parent repo for a
+   * new worktree. In Default Access, untrusted paths require operator
+   * confirmation before they grant agent read/write/delete scope.
+   */
   path: string;
   /**
    * `local` attaches the repository directory itself. `new_worktree` asks
-   * PwrAgent to allocate a managed worktree for that repository and attach it.
+   * PwrAgent to allocate a managed worktree for that repository and attach it
+   * after the source repo path is trusted.
    */
   workspaceMode?: AttachThreadDirectoryWorkspaceMode;
   /**

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -151,8 +151,14 @@ export type MutateThreadToolArgs = {
 };
 
 export type AttachThreadPullRequestToolArgs = {
-  backend: AppServerBackendKind;
-  threadId: ThreadIdentifier;
+  /**
+   * Defaults to the invoking PwrAgent thread's backend when omitted.
+   */
+  backend?: AppServerBackendKind;
+  /**
+   * Defaults to the invoking PwrAgent thread id when omitted.
+   */
+  threadId?: ThreadIdentifier;
   /**
    * Full PR/MR URL. Supports GitHub/GHE `/pull/<number>` and GitLab
    * `/merge_requests/<number>` URL shapes.
@@ -180,8 +186,14 @@ export type AttachThreadPullRequestResult = {
 };
 
 export type CheckThreadPullRequestStatusToolArgs = {
-  backend: AppServerBackendKind;
-  threadId: ThreadIdentifier;
+  /**
+   * Defaults to the invoking PwrAgent thread's backend when omitted.
+   */
+  backend?: AppServerBackendKind;
+  /**
+   * Defaults to the invoking PwrAgent thread id when omitted.
+   */
+  threadId?: ThreadIdentifier;
   /** Forge host for this lookup. Defaults to github.com when omitted. */
   provider?: string;
   /** Optional branch override. Defaults to the thread's observed/expected branch or HEAD. */

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -15,6 +15,7 @@ import type { LinkedDirectorySummary } from "./normalized-app-server";
 import type {
   MessagingThreadBindingSummary,
   PrSummary,
+  RefreshThreadPullRequestsResponse,
   ThreadAgentMetadata,
 } from "./navigation";
 import type {
@@ -43,7 +44,8 @@ export const PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES = [
   "search_threads",
   "read_thread",
   "get_thread_status",
-  "add_pull_request_reference",
+  "attach_thread_pull_request",
+  "check_thread_pull_request_status",
   "mutate_thread",
 ] as const;
 
@@ -142,7 +144,7 @@ export type MutateThreadToolArgs = {
   dryRun?: boolean;
 };
 
-export type AddPullRequestReferenceToolArgs = {
+export type AttachThreadPullRequestToolArgs = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   /**
@@ -164,12 +166,34 @@ export type AddPullRequestReferenceToolArgs = {
   title?: string;
 };
 
-export type AddPullRequestReferenceResult = {
+export type AttachThreadPullRequestResult = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   pr: PrSummary;
   prs: PrSummary[];
 };
+
+export type CheckThreadPullRequestStatusToolArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /** Forge host for this lookup. Defaults to github.com when omitted. */
+  provider?: string;
+  /** Optional branch override. Defaults to the thread's observed/expected branch or HEAD. */
+  branch?: string;
+  /**
+   * Optional cwd list for provider lookups. Defaults to the thread's linked
+   * worktree/local directories, or a neutral cwd when only attached PR URLs
+   * need to be refreshed.
+   */
+  directoryPaths?: string[];
+};
+
+export type CheckThreadPullRequestStatusResult =
+  RefreshThreadPullRequestsResponse & {
+    requestedAt: number;
+    branch: string;
+    directoryPaths: string[];
+  };
 
 export type ThreadMutationField =
   | "title"
@@ -384,7 +408,8 @@ export type PwrAgentThreadInspectionToolArgsByOperation = {
   search_threads: SearchThreadsToolArgs;
   read_thread: ReadThreadToolArgs;
   get_thread_status: GetThreadStatusToolArgs;
-  add_pull_request_reference: AddPullRequestReferenceToolArgs;
+  attach_thread_pull_request: AttachThreadPullRequestToolArgs;
+  check_thread_pull_request_status: CheckThreadPullRequestStatusToolArgs;
   mutate_thread: MutateThreadToolArgs;
 };
 
@@ -428,7 +453,10 @@ export type PwrAgentThreadInspectionResponse =
             thread: ThreadStatusInspectionSummary;
           }
         | {
-            pullRequestReference: AddPullRequestReferenceResult;
+            pullRequestReference: AttachThreadPullRequestResult;
+          }
+        | {
+            pullRequestStatus: CheckThreadPullRequestStatusResult;
           }
         | {
             mutation: ThreadMutationResult;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -89,8 +89,14 @@ export type SearchThreadsToolArgs = {
 };
 
 export type GetThreadStatusToolArgs = {
-  backend: AppServerBackendKind;
-  threadId: ThreadIdentifier;
+  /**
+   * Defaults to the invoking PwrAgent thread's backend when omitted.
+   */
+  backend?: AppServerBackendKind;
+  /**
+   * Defaults to the invoking PwrAgent thread id when omitted.
+   */
+  threadId?: ThreadIdentifier;
 };
 
 export type ReadThreadToolArgs = {

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -43,6 +43,7 @@ export const PWRAGENT_THREAD_INSPECTION_OPERATION_NAMES = [
   "search_threads",
   "read_thread",
   "get_thread_status",
+  "add_pull_request_reference",
   "mutate_thread",
 ] as const;
 
@@ -139,6 +140,35 @@ export type MutateThreadToolArgs = {
    * Validate and report the requested mutations without applying them.
    */
   dryRun?: boolean;
+};
+
+export type AddPullRequestReferenceToolArgs = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /**
+   * Full PR/MR URL. Supports GitHub/GHE `/pull/<number>` and GitLab
+   * `/merge_requests/<number>` URL shapes.
+   */
+  url?: string;
+  /** Forge host, e.g. github.com, ghe.example.com, gitlab.example.com. */
+  provider?: string;
+  /** Repo owner or group. For nested GitLab groups, use the slash-separated group path. */
+  org?: string;
+  repo?: string;
+  /**
+   * PR/MR number. If provider/org/repo are omitted, the implementation may
+   * infer them when the thread has exactly one primary/linked repo.
+   */
+  number?: number;
+  /** Optional title to show until the next provider refresh can hydrate status. */
+  title?: string;
+};
+
+export type AddPullRequestReferenceResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  pr: PrSummary;
+  prs: PrSummary[];
 };
 
 export type ThreadMutationField =
@@ -354,6 +384,7 @@ export type PwrAgentThreadInspectionToolArgsByOperation = {
   search_threads: SearchThreadsToolArgs;
   read_thread: ReadThreadToolArgs;
   get_thread_status: GetThreadStatusToolArgs;
+  add_pull_request_reference: AddPullRequestReferenceToolArgs;
   mutate_thread: MutateThreadToolArgs;
 };
 
@@ -395,6 +426,9 @@ export type PwrAgentThreadInspectionResponse =
           }
         | {
             thread: ThreadStatusInspectionSummary;
+          }
+        | {
+            pullRequestReference: AddPullRequestReferenceResult;
           }
         | {
             mutation: ThreadMutationResult;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -14,6 +14,7 @@ import type {
 import type { LinkedDirectorySummary } from "./normalized-app-server";
 import type {
   MessagingThreadBindingSummary,
+  PrSummary,
   ThreadAgentMetadata,
 } from "./navigation";
 import type {
@@ -180,11 +181,22 @@ export type ThreadInspectionSummary = {
   fastMode?: boolean;
   gitWorkingState?: ThreadGitWorkingState;
   linkedDirectories: LinkedDirectorySummary[];
+  linkedRepositories?: ThreadLinkedRepositorySummary[];
+  pullRequests?: PrSummary[];
   score?: number;
   confidence?: ThreadSearchConfidenceBand;
   matchReasons?: ThreadSearchMatchReason[];
   messagingBindings?: MessagingThreadBindingSummary[];
   snippets?: ThreadSearchSnippet[];
+};
+
+export type ThreadLinkedRepositorySummary = {
+  /** Canonical parent checkout/repository path for this group. */
+  repositoryPath: string;
+  /** Directory ids whose repository/local checkout path maps to this group. */
+  directoryIds: string[];
+  labels: string[];
+  worktreePaths: string[];
 };
 
 export type ThreadStatusInspectionSummary = ThreadInspectionSummary & {


### PR DESCRIPTION
## Summary

Threads can shed stale pull request associations and pick up additional project directories without changing the underlying agent transcript. Detached PRs are remembered per thread, so scheduled refreshes do not bring back a PR the user intentionally removed.

The Linked Projects rail supports attaching and detaching secondary Git directories, and thread inspection/orchestration tools expose linked directories, repository groupings, and pull request metadata so agents can reason about cross-worktree and cross-repo context.

This now builds on the landed #910 handoff-cwd trust model instead of defining a separate directory trust path. In Default Access, attach_thread_directory uses the same trusted-directory launchpad/operator-confirmation boundary before an untrusted path can grant agent read/write/delete scope or allocate a managed worktree. Secondary attached directories remain references only; future turns keep the primary thread cwd unless an explicit handoff or workspace overlay changes it.

GitLab pull request reference support is intentionally tracked separately in #917.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/overlay-store-prs.test.ts apps/desktop/src/main/__tests__/overlay-store-linked-directories.test.ts`
- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts packages/agent-core/src/__tests__/overlay-store.test.ts`
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)