### PR TITLE
fix(desktop): replace promoted optimistic user messages

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -577,6 +577,129 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("replaces a promoted optimistic user message when the completed user item arrives later", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 10;
+      return now;
+    });
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.addOptimisticUserMessage("Please fix transcript ordering.");
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "assistant-message-1",
+              type: "agentMessage",
+              text: "Working on it.",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.response?.replay.messages).toEqual([
+      expect.objectContaining({
+        id: expect.stringMatching(/^optimistic-/),
+        role: "user",
+        text: "Please fix transcript ordering.",
+      }),
+      expect.objectContaining({
+        id: "assistant-message-1",
+        role: "assistant",
+        text: "Working on it.",
+      }),
+    ]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "user-message-1",
+              type: "userMessage",
+              content: [
+                {
+                  type: "text",
+                  text: "Please fix transcript ordering.",
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message" ? `${entry.id}:${entry.role}:${entry.text}` : entry.type
+      )
+    ).toEqual([
+      "user-message-1:user:Please fix transcript ordering.",
+      "assistant-message-1:assistant:Working on it.",
+    ]);
+    expect(
+      result.current.response?.replay.messages.filter(
+        (message) =>
+          message.role === "user" &&
+          message.text === "Please fix transcript ordering."
+      )
+    ).toEqual([
+      expect.objectContaining({
+        id: "user-message-1",
+      }),
+    ]);
+  });
+
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2460,6 +2460,89 @@ function mergeCompletedUserMessageWithOptimisticEntry(
   };
 }
 
+function isOptimisticUserMessageEntry(
+  entry: AppServerThreadEntry
+): entry is AppServerThreadMessageEntry {
+  return (
+    entry.type === "message" &&
+    entry.role === "user" &&
+    entry.id.startsWith("optimistic-")
+  );
+}
+
+function findPromotedOptimisticUserMessageEntry(
+  response: AppServerReadThreadResponse | undefined,
+  message: AppServerThreadMessageEntry
+): AppServerThreadMessageEntry | undefined {
+  return response?.replay.entries.find(
+    (entry): entry is AppServerThreadMessageEntry =>
+      isOptimisticUserMessageEntry(entry) &&
+      messageTextMatchesOptimisticEntry(message, entry)
+  );
+}
+
+function mergeCompletedUserMessageWithPromotedOptimisticEntry(
+  message: AppServerThreadMessageEntry,
+  response: AppServerReadThreadResponse | undefined
+): AppServerThreadMessageEntry {
+  const optimisticEntry = findPromotedOptimisticUserMessageEntry(response, message);
+  if (!optimisticEntry) {
+    return message;
+  }
+
+  const optimisticImageParts = optimisticEntry.parts?.some(
+    (part) => part.type === "image"
+  )
+    ? optimisticEntry.parts
+    : undefined;
+
+  return {
+    ...message,
+    ...(optimisticImageParts ? { parts: optimisticImageParts } : {}),
+    createdAt: optimisticEntry.createdAt ?? message.createdAt,
+  };
+}
+
+function removePromotedOptimisticUserMessage(
+  response: AppServerReadThreadResponse | undefined,
+  completedUserMessage: AppServerThreadMessageEntry
+): AppServerReadThreadResponse | undefined {
+  if (!response) {
+    return response;
+  }
+
+  const optimisticEntry = findPromotedOptimisticUserMessageEntry(
+    response,
+    completedUserMessage
+  );
+  if (!optimisticEntry) {
+    return response;
+  }
+
+  const entries = response.replay.entries.filter(
+    (entry) => entry.id !== optimisticEntry.id
+  );
+  const messages = response.replay.messages.filter(
+    (message) => message.id !== optimisticEntry.id
+  );
+
+  if (
+    entries.length === response.replay.entries.length &&
+    messages.length === response.replay.messages.length
+  ) {
+    return response;
+  }
+
+  return {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries,
+      messages,
+    },
+  };
+}
+
 function appendMessageEntries(
   response: AppServerReadThreadResponse | undefined,
   params: {
@@ -3744,12 +3827,19 @@ export function useThreadSessionState(params: {
             event.notification.params
           );
           if (userMessageEntry) {
-            const completedUserMessageEntry = mergeCompletedUserMessageWithOptimisticEntry(
-              userMessageEntry,
-              current.optimisticEntries
-            );
+            const completedUserMessageEntry =
+              mergeCompletedUserMessageWithPromotedOptimisticEntry(
+                mergeCompletedUserMessageWithOptimisticEntry(
+                  userMessageEntry,
+                  current.optimisticEntries
+                ),
+                current.response
+              );
             const nextResponse = appendMessageEntries(
-              current.response,
+              removePromotedOptimisticUserMessage(
+                current.response,
+                completedUserMessageEntry
+              ),
               {
                 backend: event.backend,
                 threadId: notificationThreadId,


### PR DESCRIPTION
## Summary

Duplicate-looking user prompts no longer appear when a real Codex user item arrives after PwrAgent has already promoted the optimistic local prompt into replay state. The completed provider item now replaces the matching optimistic id while preserving ordering and image metadata, so real repeated submissions remain distinct and only the local placeholder is removed.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
