### PR TITLE
feat(messaging): add shared conversation response modes

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -75,6 +75,7 @@ describe("desktop messaging config", () => {
       "botToken",
       "channel",
       "enabled",
+      "responseMode",
       "streamingResponses",
     ]);
     expect(Object.keys(DESKTOP_MESSAGING_CHANNEL_CONFIG_FIELD_IMPACTS.discord).sort()).toEqual([
@@ -110,6 +111,7 @@ describe("desktop messaging config", () => {
       "enabled",
       "inboundMode",
       "registerSlashCommands",
+      "responseMode",
       "signingSecret",
       "slashCommandPrefix",
       "streamingResponses",
@@ -183,6 +185,8 @@ describe("desktop messaging config", () => {
         authorization: {
           authorizedActorIds: ["user-1", "user-2"],
           authorizedConversationIds: ["-1001", "-1002"],
+          conversationResponseModes: [],
+          responseMode: undefined,
         },
       });
   });
@@ -238,6 +242,7 @@ describe("desktop messaging config", () => {
         channel: "telegram",
         enabled: true,
         botToken: "tg-token",
+        responseMode: "every_message",
         streamingResponses: false,
         authorizedActorIds: [
           { id: "user-1", displayName: "" },
@@ -475,6 +480,7 @@ describe("desktop messaging config", () => {
         channel: "telegram",
         enabled: true,
         botToken: "settings-telegram-token",
+        responseMode: "every_message",
         streamingResponses: true,
         authorizedActorIds: [{ id: "111111111", displayName: "" }],
         authorizedSupergroupIds: [],

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2776,6 +2776,116 @@ describe("MessagingController", () => {
     }
   });
 
+  it("routes raw shared-channel text to a strict thread binding even in mention-only mode", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("500");
+    const event = buildTextEvent("continue the implementation", { channel });
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:500:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue the implementation" }],
+      }),
+    );
+  });
+
+  it("applies mention-only response mode to agent-thread bindings", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("501");
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:501:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("side discussion", { channel }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("apply the decision", { botMention: true, channel }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "apply the decision" }],
+      }),
+    );
+  });
+
+  it("applies mention-only response mode to unbound shared channels", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("502");
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("ambient chatter", { channel }),
+    );
+
+    expect(harness.delivered).toEqual([]);
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("hello", { botMention: true, channel }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent commands",
+    });
+  });
+
+  it("treats mentioned media captions with known commands as commands", async () => {
+    const harness = await createHarness();
+    const channel = buildTopicChannel("503");
+
+    await harness.controller.handleInboundEvent({
+      ...buildTextEvent("resume", { botMention: true, channel }),
+      id: "event-media-command",
+      kind: "media",
+      attachments: [
+        {
+          id: "file-1",
+          kind: "image",
+          name: "screenshot.png",
+          disposition: "available",
+        },
+      ],
+      disposition: "available",
+      text: "resume",
+    });
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "thread_picker",
+    });
+  });
+
   it("updates the clicked resume picker when multiple pickers are active", async () => {
     const harness = await createHarness();
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume"));
@@ -13787,6 +13897,7 @@ async function createHarness(options?: {
   onFullAccessPolicyViolation?: MessagingControllerOptions["onFullAccessPolicyViolation"];
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+  responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
   getManagedConversationRights?: MessagingAdapter["getManagedConversationRights"];
   createManagedConversation?: MessagingAdapter["createManagedConversation"];
   closeManagedConversation?: MessagingAdapter["closeManagedConversation"];
@@ -14222,6 +14333,7 @@ async function createHarness(options?: {
       ? {}
       : { onBindingChanged }),
     store,
+    responseModeForConversation: options?.responseModeForConversation,
     streamingResponsesDefault: options?.streamingResponsesDefault,
     toolUpdateDefaultMode: options?.toolUpdateDefaultMode,
   });
@@ -14674,6 +14786,7 @@ function buildTopicChannel(topicId: string): MessagingInboundEvent["channel"] {
 function buildTextEvent(
   text: string,
   params: {
+    botMention?: boolean;
     channel?: MessagingInboundTextEvent["channel"];
     routingState?: MessagingInboundTextEvent["routingState"];
   } = {},
@@ -14692,6 +14805,7 @@ function buildTextEvent(
       },
     },
     receivedAt: 1000,
+    ...(params.botMention ? { botMention: true } : {}),
     routingState: params.routingState,
     text,
   };

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -2058,6 +2058,8 @@ describe("DesktopMessagingRuntime", () => {
     expect(telegramAdapter.updateAuthorization).toHaveBeenCalledWith({
       authorizedActorIds: ["user-1", "user-2"],
       authorizedConversationIds: ["-1001", "-1002"],
+      responseMode: undefined,
+      conversationResponseModes: [],
     });
     expect(replacementTelegramAdapter.start).not.toHaveBeenCalled();
     expect(bridge.getNavigationSnapshot).toHaveBeenCalledWith({

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -14,6 +14,7 @@ const runtimeMock = vi.hoisted(() => ({
 }));
 const settingsServiceMock = vi.hoisted(() => ({
   readSettings: vi.fn(),
+  resolveSlackBotTokenSync: vi.fn(),
   writeConfigPatch: vi.fn(async () => ({ configPath: "/tmp/pwragent-config.toml" })),
 }));
 const pairingStoreMock = vi.hoisted(() => ({
@@ -48,6 +49,9 @@ const leaseCoordinatorMock = vi.hoisted(() => ({
   shutdown: vi.fn(async (runtime: typeof runtimeMock) => {
     await runtime.stop();
   }),
+}));
+const slackProviderMock = vi.hoisted(() => ({
+  resolveContact: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
@@ -107,6 +111,8 @@ vi.mock("../messaging-activity-window", () => ({
   showMessagingActivityWindow: vi.fn(),
 }));
 
+vi.mock("@pwragent/messaging-provider-slack", () => slackProviderMock);
+
 describe("messaging status ipc", () => {
   beforeEach(() => {
     handlers.clear();
@@ -122,6 +128,7 @@ describe("messaging status ipc", () => {
     runtimeMock.onPlatformStatus.mockClear();
     runtimeMock.stop.mockClear();
     settingsServiceMock.readSettings.mockReset();
+    settingsServiceMock.resolveSlackBotTokenSync.mockReset();
     settingsServiceMock.writeConfigPatch.mockClear();
     settingsServiceMock.writeConfigPatch.mockResolvedValue({
       configPath: "/tmp/pwragent-config.toml",
@@ -134,6 +141,7 @@ describe("messaging status ipc", () => {
     leaseCoordinatorMock.applyLatestConfig.mockClear();
     leaseCoordinatorMock.disableForSession.mockClear();
     leaseCoordinatorMock.shutdown.mockClear();
+    slackProviderMock.resolveContact.mockReset();
   });
 
   it("loads startup eligibility diagnostics when enabling messaging at runtime", async () => {
@@ -271,6 +279,60 @@ describe("messaging status ipc", () => {
         line: {
           authorizedRooms: [
             { id: "R0123456789abcdef0123456789abcdef", displayName: "LINE room" },
+          ],
+        },
+      },
+    });
+  });
+
+  it("resolves Slack workspace pairing labels from the team lookup", async () => {
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_APPROVE_PAIRING_CHANNEL } = await import("../../shared/ipc");
+    const entry = {
+      id: "pairing-slack-workspace",
+      platform: "slack",
+      instanceId: "default",
+      scope: "bucket",
+      status: "observed",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+      observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
+      observedChat: {
+        id: "C012ABCDEF0",
+        kind: "channel",
+        title: "hi",
+        bucketId: "T025C2NKT",
+      },
+    };
+    const consumed = { ...entry, status: "consumed" };
+    runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
+    settingsServiceMock.readSettings.mockResolvedValue(slackSettingsSnapshot());
+    settingsServiceMock.resolveSlackBotTokenSync.mockReturnValue("xoxb-token");
+    slackProviderMock.resolveContact.mockResolvedValue({
+      status: "ok",
+      id: "T025C2NKT",
+      displayName: "Giphy",
+      detail: "workspace",
+    });
+    pairingStoreMock.markStatus.mockReturnValue(consumed);
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_APPROVE_PAIRING_CHANNEL)?.({}, { entryId: entry.id }),
+    ).resolves.toMatchObject({ added: true, entry: consumed });
+
+    expect(slackProviderMock.resolveContact).toHaveBeenCalledWith(
+      { botToken: "xoxb-token" },
+      { id: "T025C2NKT", kind: "workspace" },
+    );
+    expect(settingsServiceMock.writeConfigPatch).toHaveBeenCalledWith({
+      messaging: {
+        slack: {
+          authorizedWorkspaces: [
+            { id: "T025C2NKT", displayName: "Giphy" },
           ],
         },
       },
@@ -437,6 +499,18 @@ function feishuSettingsSnapshot() {
         authorizedUserIds: { value: [], source: "default" },
         authorizedChats: { value: [], source: "default" },
         authorizedTenants: { value: [], source: "default" },
+      },
+    },
+  };
+}
+
+function slackSettingsSnapshot() {
+  return {
+    messaging: {
+      slack: {
+        authorizedUserIds: { value: [], source: "default" },
+        authorizedWorkspaces: { value: [], source: "default" },
+        authorizedChannels: { value: [], source: "default" },
       },
     },
   };

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -395,7 +395,7 @@ describe("TelegramAdapter", () => {
     expect(request?.text).toContain("Choose a thread to resume");
   });
 
-  it("treats a photo caption like `@PwrAgentBot resume` as a command, not media", async () => {
+  it("marks a photo caption like `@PwrAgentBot resume` as mentioned media", async () => {
     const harness = await createControllerHarness();
     const events: MessagingInboundEvent[] = [];
     await harness.adapter.start(async (event) => {
@@ -430,9 +430,9 @@ describe("TelegramAdapter", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
-      kind: "command",
-      command: "resume",
-      rawText: "/resume",
+      kind: "media",
+      botMention: true,
+      text: "resume",
     });
   });
 
@@ -472,7 +472,8 @@ describe("TelegramAdapter", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       kind: "media",
-      text: "@PwrAgentBot",
+      botMention: true,
+      text: "",
       attachments: [
         expect.objectContaining({
           id: "telegram:photo:AgADBA",
@@ -483,7 +484,7 @@ describe("TelegramAdapter", () => {
     });
   });
 
-  it("treats `@PwrAgentBot help` as a command and a non-leading mention as text", async () => {
+  it("marks `@PwrAgentBot help` as mentioned text and a non-leading mention as text", async () => {
     const harness = await createControllerHarness();
     const events: MessagingInboundEvent[] = [];
     await harness.adapter.start(async (event) => {
@@ -529,9 +530,9 @@ describe("TelegramAdapter", () => {
 
     expect(events).toHaveLength(2);
     expect(events[0]).toMatchObject({
-      kind: "command",
-      command: "help",
-      rawText: "/help",
+      kind: "text",
+      botMention: true,
+      text: "help",
     });
     expect(events[1]).toMatchObject({
       kind: "text",

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -30,6 +30,7 @@ import { getMainLogger } from "../log";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import { showMessagingActivityWindow } from "../messaging-activity-window";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import type { DesktopSettingsService } from "../settings/desktop-settings-service";
 import { resolveRuntimeMessagingOverride } from "../runtime-flags";
 import { getRuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
 import { subscribersForChannel } from "../window-channels";
@@ -96,15 +97,16 @@ function markPairingRejected(entryId: string): MessagingPairingEntry | undefined
   });
 }
 
-function buildPairingApprovalPatch(
+async function buildPairingApprovalPatch(
   entry: MessagingPairingEntry,
   snapshot: DesktopSettingsSnapshot,
-): { added: boolean; patch: DesktopSettingsConfigPatch } {
+  service: DesktopSettingsService,
+): Promise<{ added: boolean; patch: DesktopSettingsConfigPatch }> {
   if (entry.status !== "observed" || !entry.observedActor || !entry.observedChat) {
     throw new Error("Pairing request has not been observed yet.");
   }
 
-  const contact = contactForPairing(entry);
+  const contact = await contactForPairing(entry, service);
   const merge = (
     current: DesktopAuthorizedContact[],
   ): { added: boolean; contacts: DesktopAuthorizedContact[] } => {
@@ -246,13 +248,28 @@ function buildPairingApprovalPatch(
   }
 }
 
-function contactForPairing(entry: MessagingPairingEntry): DesktopAuthorizedContact {
+async function contactForPairing(
+  entry: MessagingPairingEntry,
+  service: DesktopSettingsService,
+): Promise<DesktopAuthorizedContact> {
   if (!entry.observedActor || !entry.observedChat) {
     throw new Error("Pairing request is missing observed identity.");
   }
   if (entry.scope === "bucket") {
+    const id = entry.observedChat.bucketId ?? entry.observedChat.parentId ?? entry.observedChat.id;
+    if (entry.platform === "slack") {
+      const displayName = await resolveSlackWorkspaceDisplayName(service, id);
+      return {
+        id,
+        displayName:
+          displayName
+          ?? entry.observedChat.parentTitle
+          ?? entry.observedChat.title
+          ?? "",
+      };
+    }
     return {
-      id: entry.observedChat.bucketId ?? entry.observedChat.parentId ?? entry.observedChat.id,
+      id,
       displayName: entry.observedChat.title ?? entry.observedChat.parentTitle ?? "",
     };
   }
@@ -262,6 +279,30 @@ function contactForPairing(entry: MessagingPairingEntry): DesktopAuthorizedConta
       entry.observedActor.displayName
       ?? (entry.observedActor.username ? `@${entry.observedActor.username}` : ""),
   };
+}
+
+async function resolveSlackWorkspaceDisplayName(
+  service: DesktopSettingsService,
+  id: string,
+): Promise<string | undefined> {
+  const botToken = service.resolveSlackBotTokenSync();
+  if (!botToken) return undefined;
+  try {
+    const provider = await import("@pwragent/messaging-provider-slack");
+    const result = await provider.resolveContact(
+      { botToken },
+      { id, kind: "workspace" },
+    );
+    if (result.status === "ok" && result.displayName) {
+      return result.displayName;
+    }
+  } catch (error) {
+    log.warn("slack workspace pairing lookup failed", {
+      workspaceId: id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return undefined;
 }
 
 function recordPairingActivity(entry: MessagingPairingEntry, summary: string): void {
@@ -374,7 +415,11 @@ export function registerMessagingStatusIpcHandlers(): void {
       const pairing = runtime.listPairingRequests({ includeResolved: true }).entries
         .find((entry) => entry.id === request.entryId);
       if (!pairing) throw new Error("Pairing request not found.");
-      const approval = buildPairingApprovalPatch(pairing, await service.readSettings());
+      const approval = await buildPairingApprovalPatch(
+        pairing,
+        await service.readSettings(),
+        service,
+      );
       const next = await service.writeConfigPatch(approval.patch);
       await getRuntimeMessagingLeaseCoordinator().applyLatestConfig(
         runtime,

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -704,7 +704,11 @@ async function resolveMessagingContact(
       );
     }
     case "slack": {
-      if (request.kind !== "user" && request.kind !== "workspace") {
+      if (
+        request.kind !== "user"
+        && request.kind !== "workspace"
+        && request.kind !== "channel"
+      ) {
         return unsupportedLookup(request);
       }
       const botToken = service.resolveSlackBotTokenSync();

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -71,6 +71,7 @@ import type {
   MessagingPendingIntentRecord,
   MessagingQuestionnaireAnswer,
   MessagingQuestionnaireIntent,
+  MessagingResponseMode,
   MessagingStreamUpdateIntent,
   MessagingSurfaceAction,
   MessagingSurfaceRef,
@@ -545,6 +546,9 @@ export type MessagingControllerOptions = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
   streamingResponsesDefault?: boolean;
+  responseModeForConversation?: (
+    channel: MessagingChannelRef,
+  ) => Promise<MessagingResponseMode> | MessagingResponseMode;
   toolUpdateDefaultMode?: MessagingToolUpdateDefaultModeResolver;
   fullAccessControls?: MessagingFullAccessControlsResolver;
   deliveryBudget?: MessagingDeliveryBudget;
@@ -1355,6 +1359,20 @@ export class MessagingController {
       return;
     }
 
+    const mentionCommand = event.botMention
+      ? parseMentionCommand(event.text)
+      : undefined;
+    if (mentionCommand) {
+      await this.handleCommand({
+        ...event,
+        kind: "command",
+        command: mentionCommand.command,
+        args: mentionCommand.args,
+        rawText: `/${[mentionCommand.command, ...mentionCommand.args].join(" ")}`,
+      });
+      return;
+    }
+
     const pendingNewThread = await this.findPendingNewThreadSession(event);
     const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
       actorId: event.actor.platformUserId,
@@ -1448,7 +1466,17 @@ export class MessagingController {
 
     const binding = await this.options.store.findActiveBindingForChannel(event.channel);
     if (!binding) {
+      if (!await this.shouldHandleAmbientSharedMessage(event)) {
+        return;
+      }
       await this.presentHelp(event);
+      return;
+    }
+
+    if (
+      binding.targetKind === "agent_thread" &&
+      !await this.shouldHandleAmbientSharedMessage(event, binding)
+    ) {
       return;
     }
 
@@ -1476,6 +1504,19 @@ export class MessagingController {
       });
       return;
     }
+    const mentionCommand = event.botMention && event.text
+      ? parseMentionCommand(event.text)
+      : undefined;
+    if (mentionCommand) {
+      await this.handleCommand({
+        ...event,
+        kind: "command",
+        command: mentionCommand.command,
+        args: mentionCommand.args,
+        rawText: `/${[mentionCommand.command, ...mentionCommand.args].join(" ")}`,
+      });
+      return;
+    }
 
     const pendingNewThread = await this.findPendingNewThreadSession(event);
     if (pendingNewThread) {
@@ -1485,6 +1526,9 @@ export class MessagingController {
 
     const binding = await this.options.store.findActiveBindingForChannel(event.channel);
     if (!binding) {
+      if (!await this.shouldHandleAmbientSharedMessage(event)) {
+        return;
+      }
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("needs-binding-media"),
@@ -1508,7 +1552,34 @@ export class MessagingController {
       return;
     }
 
+    if (
+      binding.targetKind === "agent_thread" &&
+      !await this.shouldHandleAmbientSharedMessage(event, binding)
+    ) {
+      return;
+    }
+
     await this.turnAdmission.append({ binding, event });
+  }
+
+  private async shouldHandleAmbientSharedMessage(
+    event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
+    binding?: MessagingBindingRecord,
+  ): Promise<boolean> {
+    if (event.channel.conversation.kind === "dm") {
+      return true;
+    }
+    if (binding?.targetKind === "thread") {
+      return true;
+    }
+    const responseMode = await this.responseModeForConversation(event.channel);
+    return responseMode === "every_message" || event.botMention === true;
+  }
+
+  private async responseModeForConversation(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingResponseMode> {
+    return await this.options.responseModeForConversation?.(channel) ?? "every_message";
   }
 
   private async handleAdmittedTurnBundle(
@@ -13947,6 +14018,14 @@ function parseTextCommandArgs(text: string): string[] {
   }
 
   return trimmed.slice(1).split(/\s+/).slice(1).filter(Boolean);
+}
+
+function parseMentionCommand(
+  text: string,
+): { command: string; args: string[] } | undefined {
+  const tokens = text.trim().split(/\s+/).filter(Boolean);
+  const command = matchMessagingCommandVerb(tokens[0] ?? "");
+  return command ? { command, args: tokens.slice(1) } : undefined;
 }
 
 function skillSearchCwdsForThreadState(

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -15,6 +15,7 @@ import type {
 import type {
   MessagingAdapterAuthorizationUpdate,
   MessagingAdapterRenderingPreferencesUpdate,
+  MessagingConversationResponseMode,
 } from "@pwragent/messaging-interface";
 import type { MessagingAttachmentPolicy } from "./core/messaging-attachment-processor";
 import type { DesktopSettingsService } from "../settings/desktop-settings-service";
@@ -215,6 +216,7 @@ export const DESKTOP_MESSAGING_CHANNEL_CONFIG_FIELD_IMPACTS = {
     botToken: "connection",
     channel: "irrelevant",
     enabled: "connection",
+    responseMode: "authorization",
     streamingResponses: "rendering",
   },
   discord: {
@@ -250,6 +252,7 @@ export const DESKTOP_MESSAGING_CHANNEL_CONFIG_FIELD_IMPACTS = {
     enabled: "connection",
     inboundMode: "connection",
     registerSlashCommands: "connection",
+    responseMode: "authorization",
     signingSecret: "connection",
     slashCommandPrefix: "connection",
     streamingResponses: "rendering",
@@ -541,6 +544,7 @@ export function loadDesktopMessagingConfig(
             channel: "telegram" as const,
             enabled: true,
             botToken: telegramBotToken,
+            responseMode: "every_message",
             streamingResponses: readEnvBoolean(
               env,
               TELEGRAM_STREAMING_RESPONSES_ENV,
@@ -616,6 +620,7 @@ export function loadDesktopMessagingConfig(
               env,
               SLACK_STREAMING_RESPONSES_ENV,
             ).value ?? false,
+            responseMode: "mention_only",
             authorizedActorIds: slackAuthorizedActorIds,
             authorizedTeamIds: slackAuthorizedWorkspaces,
           },
@@ -743,6 +748,9 @@ export async function loadDesktopMessagingConfigFromSettings(
   const slackAuthorizedTeamIds =
     envConfig.slack?.authorizedTeamIds
     ?? snapshot.messaging.slack.authorizedWorkspaces.value;
+  const slackAuthorizedConversationIds =
+    envConfig.slack?.authorizedConversationIds
+    ?? snapshot.messaging.slack.authorizedChannels.value;
   const feishuAuthorizedActorIds =
     envConfig.feishu?.authorizedActorIds
     ?? snapshot.messaging.feishu.authorizedUserIds.value;
@@ -903,6 +911,7 @@ export async function loadDesktopMessagingConfigFromSettings(
           channel: "telegram" as const,
           enabled: true,
           botToken: telegramBotToken!,
+          responseMode: snapshot.messaging.telegram.responseMode.value,
           streamingResponses: snapshot.messaging.telegram.streamingResponses.value,
           authorizedActorIds: telegramAuthorizedActorIds,
           authorizedSupergroupIds: telegramAuthorizedSupergroupIds,
@@ -993,8 +1002,10 @@ export async function loadDesktopMessagingConfigFromSettings(
               : {}),
             registerSlashCommands: slackRegisterSlashCommands,
             streamingResponses: snapshot.messaging.slack.streamingResponses.value,
+            responseMode: snapshot.messaging.slack.responseMode.value,
             authorizedActorIds: slackAuthorizedActorIds,
             authorizedTeamIds: slackAuthorizedTeamIds,
+            authorizedConversationIds: slackAuthorizedConversationIds,
           },
         }
       : {};
@@ -1381,6 +1392,10 @@ function authorizationUpdateForChannelConfig(
       return {
         authorizedActorIds: contactIds(config.telegram?.authorizedActorIds),
         authorizedConversationIds: contactIds(config.telegram?.authorizedSupergroupIds),
+        conversationResponseModes: conversationResponseModes(
+          config.telegram?.authorizedSupergroupIds,
+        ),
+        responseMode: config.telegram?.responseMode,
       };
     case "discord":
       return {
@@ -1399,6 +1414,10 @@ function authorizationUpdateForChannelConfig(
       return {
         authorizedActorIds: contactIds(config.slack?.authorizedActorIds),
         authorizedConversationIds: contactIds(config.slack?.authorizedConversationIds),
+        conversationResponseModes: conversationResponseModes(
+          config.slack?.authorizedConversationIds,
+        ),
+        responseMode: config.slack?.responseMode,
         authorizedWorkspaceIds: contactIds(config.slack?.authorizedTeamIds),
       };
     case "feishu":
@@ -1450,6 +1469,21 @@ function contactIds(
   contacts: readonly { id: string }[] | undefined,
 ): readonly string[] {
   return contacts?.map((contact) => contact.id) ?? [];
+}
+
+function conversationResponseModes(
+  contacts:
+    | readonly {
+        id: string;
+        responseMode?: MessagingConversationResponseMode["responseMode"];
+      }[]
+    | undefined,
+): MessagingConversationResponseMode[] {
+  return contacts?.flatMap((contact) =>
+    contact.responseMode
+      ? [{ conversationId: contact.id, responseMode: contact.responseMode }]
+      : [],
+  ) ?? [];
 }
 
 function stableMessagingConfigStringify(value: unknown): string {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -50,6 +50,7 @@ import type {
   MessagingRateLimitInfo,
   MessagingReconnectInfo,
   MessagingRejectedInboundEvent,
+  MessagingResponseMode,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
 import {
@@ -851,6 +852,29 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     await run;
   }
 
+  private async shouldDropAmbientSharedMessage(params: {
+    channel: MessagingChannelKind;
+    event: MessagingInboundEvent;
+    store: MessagingStoreLike;
+  }): Promise<boolean> {
+    const { event } = params;
+    if (event.kind !== "text" && event.kind !== "media") {
+      return false;
+    }
+    if (event.botMention || event.channel.conversation.kind === "dm") {
+      return false;
+    }
+    const binding = await params.store.findActiveBindingForChannel(event.channel);
+    if (binding?.targetKind === "thread") {
+      return false;
+    }
+    return responseModeForChannel(
+      await this.loadConfig(),
+      params.channel,
+      event.channel,
+    ) === "mention_only";
+  }
+
   private async startRunningAdapter(params: {
     adapter: DesktopMessagingAdapter;
     config: DesktopMessagingConfig;
@@ -883,6 +907,12 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         config,
         adapter.channel,
       ),
+      responseModeForConversation: async (channel) =>
+        responseModeForChannel(
+          await this.loadConfig(),
+          adapter.channel,
+          channel,
+        ),
       toolUpdateDefaultMode: async () =>
         (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
       fullAccessControls: async () =>
@@ -945,6 +975,16 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           return;
         }
         const authorized = authorization.actorIdSet.has(event.actor.platformUserId);
+        if (
+          authorized &&
+          await this.shouldDropAmbientSharedMessage({
+            channel: adapter.channel,
+            event,
+            store,
+          })
+        ) {
+          return;
+        }
         this.recordActivityFromInbound(adapter.channel, event, authorized);
         try {
           if (!authorized) {
@@ -2199,6 +2239,33 @@ function streamingResponsesDefaultForChannel(
       return config.telegram?.streamingResponses ?? false;
     default:
       return false;
+  }
+}
+
+function responseModeForChannel(
+  config: DesktopMessagingConfig,
+  channel: MessagingChannelKind,
+  channelRef: MessagingChannelRef,
+): MessagingResponseMode {
+  const conversationIds = [
+    channelRef.conversation.id,
+    channelRef.conversation.parentId,
+  ].filter((id): id is string => Boolean(id));
+  switch (channel) {
+    case "slack": {
+      const specificMode = config.slack?.authorizedConversationIds
+        ?.find((contact) => conversationIds.includes(contact.id))
+        ?.responseMode;
+      return specificMode ?? config.slack?.responseMode ?? "mention_only";
+    }
+    case "telegram": {
+      const specificMode = config.telegram?.authorizedSupergroupIds
+        ?.find((contact) => conversationIds.includes(contact.id))
+        ?.responseMode;
+      return specificMode ?? config.telegram?.responseMode ?? "every_message";
+    }
+    default:
+      return "every_message";
   }
 }
 

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -14,6 +14,7 @@ import type {
   DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingFullAccessWarningUserPolicy,
   DesktopMessagingImageProfile,
+  DesktopMessagingResponseMode,
   DesktopOnboardingCompletedSource,
   DesktopSettingsConfigPatch,
   DesktopUpdateChannel,
@@ -138,6 +139,7 @@ export type DesktopSettingsConfig = {
     };
     telegram?: {
       enabled?: boolean;
+      responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       authorizedUserIds?: AuthorizedContactConfig[];
       authorizedSupergroups?: AuthorizedContactConfig[];
@@ -162,6 +164,7 @@ export type DesktopSettingsConfig = {
     };
     slack?: {
       enabled?: boolean;
+      responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       workspaceUrl?: string;
       inboundMode?: "socket" | "events";
@@ -169,6 +172,7 @@ export type DesktopSettingsConfig = {
       registerSlashCommands?: boolean;
       authorizedUserIds?: AuthorizedContactConfig[];
       authorizedWorkspaces?: AuthorizedContactConfig[];
+      authorizedChannels?: AuthorizedContactConfig[];
     };
     feishu?: {
       enabled?: boolean;
@@ -560,6 +564,7 @@ export function desktopSettingsPatchToEdits(
         ...(contact.fullAccessWarningDismissed === true
           ? { full_access_warning_dismissed: true }
           : {}),
+        ...(contact.responseMode ? { response_mode: contact.responseMode } : {}),
       })),
     });
   };
@@ -881,6 +886,9 @@ export function desktopSettingsPatchToEdits(
   if (telegram?.enabled !== undefined) {
     set(["messaging", "telegram", "enabled"], telegram.enabled);
   }
+  if (telegram?.responseMode !== undefined) {
+    set(["messaging", "telegram", "response_mode"], telegram.responseMode);
+  }
   if (telegram?.streamingResponses !== undefined) {
     set(["messaging", "telegram", "streaming_responses"], telegram.streamingResponses);
   }
@@ -993,6 +1001,9 @@ export function desktopSettingsPatchToEdits(
   if (slack?.enabled !== undefined) {
     set(["messaging", "slack", "enabled"], slack.enabled);
   }
+  if (slack?.responseMode !== undefined) {
+    set(["messaging", "slack", "response_mode"], slack.responseMode);
+  }
   if (slack?.streamingResponses !== undefined) {
     set(["messaging", "slack", "streaming_responses"], slack.streamingResponses);
   }
@@ -1026,6 +1037,14 @@ export function desktopSettingsPatchToEdits(
       "authorized_workspaces",
       "authorized_workspaces",
       slack.authorizedWorkspaces,
+    );
+  }
+  if (slack?.authorizedChannels !== undefined) {
+    setAuthorizedContacts(
+      ["messaging", "slack"],
+      "authorized_channels",
+      "authorized_channels",
+      slack.authorizedChannels,
     );
   }
 
@@ -1316,6 +1335,7 @@ function normalizeDesktopConfig(
       },
       telegram: {
         enabled: readBoolean(telegram?.enabled),
+        responseMode: readMessagingResponseMode(telegram?.response_mode),
         streamingResponses: readBoolean(telegram?.streaming_responses),
         authorizedUserIds: readAuthorizedContacts(
           telegram?.authorized_users,
@@ -1368,6 +1388,7 @@ function normalizeDesktopConfig(
       },
       slack: {
         enabled: readBoolean(slack?.enabled),
+        responseMode: readMessagingResponseMode(slack?.response_mode),
         streamingResponses: readBoolean(slack?.streaming_responses),
         workspaceUrl: readString(slack?.workspace_url),
         inboundMode: readSlackInboundMode(slack?.inbound_mode),
@@ -1381,6 +1402,10 @@ function normalizeDesktopConfig(
         authorizedWorkspaces: readAuthorizedContacts(
           slack?.authorized_workspaces_list,
           slack?.authorized_workspaces,
+        ),
+        authorizedChannels: readAuthorizedContacts(
+          slack?.authorized_channels_list,
+          slack?.authorized_channels,
         ),
       },
       feishu: {
@@ -1857,6 +1882,18 @@ function readFullAccessWarningGlobalPolicy(
     : undefined;
 }
 
+function readMessagingResponseMode(
+  value: TomlScalar | undefined,
+): DesktopMessagingResponseMode | undefined {
+  return isMessagingResponseMode(value) ? value : undefined;
+}
+
+function isMessagingResponseMode(
+  value: unknown,
+): value is DesktopMessagingResponseMode {
+  return value === "every_message" || value === "mention_only";
+}
+
 function isFullAccessWarningUserPolicy(
   value: unknown,
 ): value is DesktopMessagingFullAccessWarningUserPolicy {
@@ -1934,6 +1971,11 @@ function readAuthorizedContactArray(
       fullAccessWarningDismissed:
         entry.full_access_warning_dismissed === true ||
         entry.fullAccessWarningDismissed === true,
+      responseMode: isMessagingResponseMode(entry.response_mode)
+        ? entry.response_mode
+        : isMessagingResponseMode(entry.responseMode)
+          ? entry.responseMode
+          : undefined,
     })),
   );
 }
@@ -1951,6 +1993,9 @@ function normalizeAuthorizedContacts(
         : {}),
       ...(contact.fullAccessWarningDismissed === true
         ? { fullAccessWarningDismissed: true }
+        : {}),
+      ...(isMessagingResponseMode(contact.responseMode)
+        ? { responseMode: contact.responseMode }
         : {}),
     }))
     .filter((contact) => contact.id.length > 0);

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -12,6 +12,7 @@ import type {
   DesktopIntegratedTerminalWindowsShell,
   DesktopMessagingFullAccessWarningGlobalPolicy,
   DesktopMessagingImageProfile,
+  DesktopMessagingResponseMode,
   DesktopOnboardingCompletedSource,
   DesktopOnboardingSnapshot,
   DesktopSettingsConfigPatch,
@@ -670,6 +671,10 @@ export class DesktopSettingsService {
             false,
             TELEGRAM_ENABLED_ENV,
           ),
+          responseMode: this.resolveConfigMessagingResponseMode(
+            config.messaging?.telegram?.responseMode,
+            "every_message",
+          ),
           streamingResponses: this.resolveBoolean(
             config.messaging?.telegram?.streamingResponses,
             false,
@@ -760,6 +765,10 @@ export class DesktopSettingsService {
             false,
             SLACK_ENABLED_ENV,
           ),
+          responseMode: this.resolveConfigMessagingResponseMode(
+            config.messaging?.slack?.responseMode,
+            "mention_only",
+          ),
           streamingResponses: this.resolveBoolean(
             config.messaging?.slack?.streamingResponses,
             false,
@@ -792,6 +801,9 @@ export class DesktopSettingsService {
           authorizedWorkspaces: this.resolveList(
             config.messaging?.slack?.authorizedWorkspaces,
             SLACK_AUTHORIZED_WORKSPACES_ENV,
+          ),
+          authorizedChannels: this.resolveConfigList(
+            config.messaging?.slack?.authorizedChannels,
           ),
         },
         feishu: {
@@ -1844,6 +1856,16 @@ export class DesktopSettingsService {
     };
   }
 
+  private resolveConfigMessagingResponseMode(
+    configValue: DesktopMessagingResponseMode | undefined,
+    defaultValue: DesktopMessagingResponseMode,
+  ): DesktopSettingsValue<DesktopMessagingResponseMode> {
+    return {
+      value: configValue ?? defaultValue,
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
   private resolveWorktrees(
     configValue: DesktopWorktreeStorageLocation | undefined,
   ): {
@@ -1885,6 +1907,15 @@ export class DesktopSettingsService {
       };
     }
 
+    return {
+      value: configValue ?? [],
+      source: configValue === undefined ? "default" : "config",
+    };
+  }
+
+  private resolveConfigList(
+    configValue: DesktopAuthorizedContact[] | undefined,
+  ): DesktopSettingsValue<DesktopAuthorizedContact[]> {
     return {
       value: configValue ?? [],
       source: configValue === undefined ? "default" : "config",

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -481,6 +481,7 @@ describe("App", () => {
         toolUpdateMode: { value: "show_some", source: "default" },
         telegram: {
           enabled: { value: false, source: "default" },
+          responseMode: { value: "every_message", source: "default" },
           streamingResponses: { value: false, source: "default" },
           botToken: { configured: false, source: "unset", writable: true },
           authorizedUserIds: { value: [], source: "default" },
@@ -509,6 +510,7 @@ describe("App", () => {
         },
         slack: {
           enabled: { value: false, source: "default" },
+          responseMode: { value: "mention_only", source: "default" },
           streamingResponses: { value: false, source: "default" },
           botToken: { configured: false, source: "unset", writable: true },
           appToken: { configured: false, source: "unset", writable: true },
@@ -519,6 +521,7 @@ describe("App", () => {
           registerSlashCommands: { value: false, source: "default" },
           authorizedUserIds: { value: [], source: "default" },
           authorizedWorkspaces: { value: [], source: "default" },
+          authorizedChannels: { value: [], source: "default" },
         },
         feishu: {
           enabled: { value: false, source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -15,6 +15,7 @@ import {
   validateLineGroupId,
   validateLineRoomId,
   validateLineUserId,
+  validateSlackChannelId,
   validateMattermostId,
   validateSlackTeamId,
   validateSlackUserId,
@@ -23,6 +24,7 @@ import {
   validateTelegramPositiveId,
   type DesktopAuthorizedContact,
   type DesktopMessagingImageProfile,
+  type DesktopMessagingResponseMode,
   type DesktopMessagingContactLookupKind,
   type DesktopMessagingContactLookupPlatform,
   type DesktopMessagingContactLookupResponse,
@@ -296,6 +298,23 @@ export function MessagingSettings(props: {
             scopeOptions={TELEGRAM_PAIRING_SCOPE_OPTIONS}
             supportsBucket
           />
+          <SegmentedField
+            disabled={props.saving}
+            label="Respond to"
+            sub="In authorized Telegram groups and topics, choose whether regular chat reaches PwrAgent or only leading @bot mentions do. DMs and slash commands still work."
+            options={RESPONSE_MODE_OPTIONS}
+            source={sourceBadge(telegram.responseMode)}
+            value={telegram.responseMode.value}
+            onChange={(responseMode) => {
+              void props.onSaveTelegram({
+                ...telegram,
+                responseMode: {
+                  ...telegram.responseMode,
+                  value: responseMode,
+                },
+              });
+            }}
+          />
           <ToggleField
             checked={telegram.streamingResponses.value}
             disabled={props.saving}
@@ -350,6 +369,7 @@ export function MessagingSettings(props: {
             source={optionalListSourceBadge(telegram.authorizedSupergroups)}
             validateEntry={validateTelegramGroupChatEntry}
             value={telegram.authorizedSupergroups.value}
+            responseModePolicy
             onSave={(authorizedSupergroups) => {
               void props.onSaveTelegram({
                 ...telegram,
@@ -818,6 +838,23 @@ export function MessagingSettings(props: {
             onClearSecret={props.onClearSecret}
             onReplaceSecret={props.onReplaceSecret}
           />
+          <SegmentedField
+            disabled={props.saving}
+            label="Respond to"
+            sub="In authorized Slack channels, choose whether regular chat reaches PwrAgent or only @mentions do. DMs and slash commands still work."
+            options={RESPONSE_MODE_OPTIONS}
+            source={sourceBadge(slack.responseMode)}
+            value={slack.responseMode.value}
+            onChange={(responseMode) => {
+              void props.onSaveSlack({
+                ...slack,
+                responseMode: {
+                  ...slack.responseMode,
+                  value: responseMode,
+                },
+              });
+            }}
+          />
           <ToggleField
             checked={slack.streamingResponses.value}
             disabled={props.saving}
@@ -898,9 +935,9 @@ export function MessagingSettings(props: {
               "slack",
               "workspace",
             )}
-            label="Authorized Workspaces"
-            sub="Optional Slack workspace/team IDs allowed for this bot."
-            help="Slack workspace IDs start with T, e.g. T012ABCDEF0."
+            label="Authorized Workspace / Team IDs"
+            sub="Slack team IDs allowed for shared channel access. Authorizing a workspace allows any channel or group DM in that workspace where the bot is present."
+            help="Slack team/workspace IDs start with T, e.g. T012ABCDEF0. These are not channel IDs."
             source={optionalListSourceBadge(slack.authorizedWorkspaces)}
             validateEntry={validateSlackWorkspaceIdEntry}
             value={slack.authorizedWorkspaces.value}
@@ -910,6 +947,30 @@ export function MessagingSettings(props: {
                 authorizedWorkspaces: {
                   ...slack.authorizedWorkspaces,
                   value: authorizedWorkspaces,
+                },
+              });
+            }}
+          />
+          <AuthorizedListField
+            disabled={props.saving}
+            lookup={contactLookup(
+              props.desktopApi,
+              "slack",
+              "channel",
+            )}
+            label="Authorized Channels"
+            sub="Slack channel, private channel, DM, or group DM IDs allowed even when the whole workspace is not authorized."
+            help="Slack conversation IDs start with C, G, or D, e.g. C012ABCDEF0. Add a row here to give one channel a different Respond to mode than the workspace default."
+            source={optionalListSourceBadge(slack.authorizedChannels)}
+            validateEntry={validateSlackChannelIdEntry}
+            value={slack.authorizedChannels.value}
+            responseModePolicy
+            onSave={(authorizedChannels) => {
+              void props.onSaveSlack({
+                ...slack,
+                authorizedChannels: {
+                  ...slack.authorizedChannels,
+                  value: authorizedChannels,
                 },
               });
             }}
@@ -1373,6 +1434,14 @@ const IMAGE_PROFILE_OPTIONS: Array<{
   { label: "Medium", value: "medium" },
   { label: "High", value: "high" },
   { label: "Actual", value: "actual" },
+];
+
+const RESPONSE_MODE_OPTIONS: Array<{
+  label: string;
+  value: DesktopMessagingResponseMode;
+}> = [
+  { label: "@ mention only", value: "mention_only" },
+  { label: "Every message", value: "every_message" },
 ];
 
 const FULL_ACCESS_WARNING_POLICY_OPTIONS: Array<{
@@ -1892,6 +1961,7 @@ function AuthorizedListField(props: {
   help?: ReactNode;
   label: string;
   lookup?: (id: string) => Promise<DesktopMessagingContactLookupResponse>;
+  responseModePolicy?: boolean;
   sub?: ReactNode;
   source: string;
   validateEntry?: (value: string) => string | undefined;
@@ -2076,6 +2146,8 @@ function AuthorizedListField(props: {
                   className={`settings-authorized-list__row${
                     props.fullAccessWarningPolicy
                       ? " settings-authorized-list__row--with-warning"
+                      : props.responseModePolicy
+                        ? " settings-authorized-list__row--with-response-mode"
                       : ""
                   }`}
                 >
@@ -2150,6 +2222,39 @@ function AuthorizedListField(props: {
                       }
                     >
                       {FULL_ACCESS_WARNING_USER_POLICY_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
+                  {props.responseModePolicy ? (
+                    <select
+                      aria-label={`${props.label} response mode ${index + 1}`}
+                      className="settings-input settings-authorized-list__response-mode"
+                      disabled={props.disabled}
+                      value={row.responseMode ?? ""}
+                      onBlur={() => {
+                        const nextRows = rows.map((current, rowIndex) =>
+                          rowIndex === index
+                            ? normalizeAuthorizedContactRow(current)
+                            : current,
+                        );
+                        setRows(nextRows);
+                        saveIfValid(nextRows);
+                      }}
+                      onChange={(event) =>
+                        updateRow(index, {
+                          responseMode:
+                            event.currentTarget.value === ""
+                              ? undefined
+                              : event.currentTarget
+                                .value as DesktopMessagingResponseMode,
+                        })
+                      }
+                    >
+                      <option value="">Default</option>
+                      {RESPONSE_MODE_OPTIONS.map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
@@ -2296,6 +2401,10 @@ function normalizeAuthorizedContactRow(
     ...(contact.fullAccessWarningDismissed === true
       ? { fullAccessWarningDismissed: true }
       : {}),
+    ...(contact.responseMode === "every_message" ||
+    contact.responseMode === "mention_only"
+      ? { responseMode: contact.responseMode }
+      : {}),
   };
 }
 
@@ -2378,6 +2487,13 @@ function validateSlackWorkspaceIdEntry(value: string): string | undefined {
   return validationMessage(validateSlackTeamId(value), "Slack workspace ID", {
     format: "Use a Slack workspace/team ID starting with T, e.g. T012ABCDEF0.",
     length: "Slack workspace IDs must be 64 characters or fewer.",
+  });
+}
+
+function validateSlackChannelIdEntry(value: string): string | undefined {
+  return validationMessage(validateSlackChannelId(value), "Slack channel ID", {
+    format: "Use a Slack channel/conversation ID starting with C, G, or D, e.g. C012ABCDEF0.",
+    length: "Slack channel IDs must be 64 characters or fewer.",
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-patch-delta.test.ts
@@ -15,6 +15,7 @@ type Mattermost = DesktopSettingsSnapshot["messaging"]["mattermost"];
 function telegramSnapshot(overrides: Partial<Telegram> = {}): Telegram {
   return {
     enabled: { value: false, source: "default" },
+    responseMode: { value: "every_message", source: "default" },
     streamingResponses: { value: false, source: "default" },
     botToken: { configured: false, source: "unset", writable: true },
     authorizedUserIds: { value: [], source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -192,6 +192,7 @@ function createSnapshot(
       toolUpdateMode: { value: "show_some", source: "default" },
       telegram: {
         enabled: { value: false, source: "default" },
+        responseMode: { value: "every_message", source: "default" },
         streamingResponses: { value: false, source: "default" },
         botToken: { configured: false, source: "unset", writable: true },
         authorizedUserIds: { value: [], source: "default" },
@@ -220,6 +221,7 @@ function createSnapshot(
       },
       slack: {
         enabled: { value: false, source: "default" },
+        responseMode: { value: "mention_only", source: "default" },
         streamingResponses: { value: false, source: "default" },
         botToken: { configured: false, source: "unset", writable: true },
         appToken: { configured: false, source: "unset", writable: true },
@@ -230,6 +232,7 @@ function createSnapshot(
         registerSlashCommands: { value: false, source: "default" },
         authorizedUserIds: { value: [], source: "default" },
         authorizedWorkspaces: { value: [], source: "default" },
+        authorizedChannels: { value: [], source: "default" },
       },
       feishu: {
         enabled: { value: false, source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
+++ b/apps/desktop/src/renderer/src/features/settings/settings-patch-delta.ts
@@ -32,6 +32,9 @@ export function buildTelegramPatchDelta(
   if (snapshot.enabled.value !== candidate.enabled.value) {
     patch.enabled = candidate.enabled.value;
   }
+  if (snapshot.responseMode.value !== candidate.responseMode.value) {
+    patch.responseMode = candidate.responseMode.value;
+  }
   if (snapshot.streamingResponses.value !== candidate.streamingResponses.value) {
     patch.streamingResponses = candidate.streamingResponses.value;
   }
@@ -159,6 +162,9 @@ export function buildSlackPatchDelta(
   if (snapshot.enabled.value !== candidate.enabled.value) {
     patch.enabled = candidate.enabled.value;
   }
+  if (snapshot.responseMode.value !== candidate.responseMode.value) {
+    patch.responseMode = candidate.responseMode.value;
+  }
   if (snapshot.streamingResponses.value !== candidate.streamingResponses.value) {
     patch.streamingResponses = candidate.streamingResponses.value;
   }
@@ -191,6 +197,14 @@ export function buildSlackPatchDelta(
     )
   ) {
     patch.authorizedWorkspaces = candidate.authorizedWorkspaces.value;
+  }
+  if (
+    !authorizedContactArrayEqual(
+      snapshot.authorizedChannels.value,
+      candidate.authorizedChannels.value,
+    )
+  ) {
+    patch.authorizedChannels = candidate.authorizedChannels.value;
   }
 
   return Object.keys(patch).length === 0 ? undefined : patch;
@@ -319,7 +333,8 @@ function authorizedContactArrayEqual(
       a[i]?.id !== b[i]?.id ||
       a[i]?.displayName !== b[i]?.displayName ||
       a[i]?.fullAccessWarningOverride !== b[i]?.fullAccessWarningOverride ||
-      a[i]?.fullAccessWarningDismissed !== b[i]?.fullAccessWarningDismissed
+      a[i]?.fullAccessWarningDismissed !== b[i]?.fullAccessWarningDismissed ||
+      a[i]?.responseMode !== b[i]?.responseMode
     ) {
       return false;
     }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5939,9 +5939,19 @@ textarea,
     auto;
 }
 
+.settings-authorized-list__row--with-response-mode {
+  grid-template-columns:
+    minmax(140px, 1fr)
+    minmax(140px, 1fr)
+    minmax(128px, 0.7fr)
+    auto
+    auto;
+}
+
 .settings-authorized-list__id,
 .settings-authorized-list__name,
-.settings-authorized-list__warning {
+.settings-authorized-list__warning,
+.settings-authorized-list__response-mode {
   min-width: 0;
 }
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -312,7 +312,16 @@ export type MessagingActorIdentity = {
 export type MessagingAdapterAuthorizationUpdate = {
   authorizedActorIds: readonly string[];
   authorizedConversationIds?: readonly string[];
+  conversationResponseModes?: readonly MessagingConversationResponseMode[];
+  responseMode?: MessagingResponseMode;
   authorizedWorkspaceIds?: readonly string[];
+};
+
+export type MessagingResponseMode = "every_message" | "mention_only";
+
+export type MessagingConversationResponseMode = {
+  conversationId: string;
+  responseMode: MessagingResponseMode;
 };
 
 export type MessagingAdapterRenderingPreferencesUpdate = {
@@ -1053,6 +1062,12 @@ export type MessagingInboundBaseEvent = {
   actor: MessagingActorIdentity;
   channel: MessagingChannelRef;
   receivedAt: number;
+  /**
+   * True when the original platform message explicitly addressed the bot via
+   * a textual @mention. Slash commands and button callbacks are already
+   * explicit event kinds and do not need this marker.
+   */
+  botMention?: boolean;
   routingState?: MessagingAdapterState;
 };
 
@@ -1730,7 +1745,8 @@ export type MessagingContactLookupKind =
   | "user"
   | "supergroup"
   | "guild"
-  | "workspace";
+  | "workspace"
+  | "channel";
 
 export type MessagingContactLookupRequest = {
   id: string;

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -16,6 +16,7 @@ const baseConfig = {
   signingSecret: "test-signing-secret",
   authorizedActorIds: [{ id: "U012ABCDEF0", displayName: "Alice" }],
   authorizedTeamIds: [{ id: "T012ABCDEF0", displayName: "PwrDrvr" }],
+  responseMode: "every_message" as const,
 };
 
 function fakeStore(): MessagingCallbackHandleStore & {
@@ -408,7 +409,7 @@ describe("SlackAdapter", () => {
     ]);
   });
 
-  it("routes leading app mentions as commands", async () => {
+  it("routes leading app mentions as mentioned text", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({
       config: baseConfig,
@@ -437,10 +438,9 @@ describe("SlackAdapter", () => {
 
     expect(events).toEqual([
       expect.objectContaining({
-        kind: "command",
-        command: "help",
-        args: ["status"],
-        rawText: "/help status",
+        kind: "text",
+        botMention: true,
+        text: "help status",
       }),
     ]);
   });
@@ -478,6 +478,91 @@ describe("SlackAdapter", () => {
         command: "help",
         args: [],
         rawText: "/help",
+      }),
+    ]);
+  });
+
+  it("routes non-mention channel text for controller response-mode handling", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: { ...baseConfig, responseMode: "mention_only" },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "general channel chatter",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        text: "general channel chatter",
+      }),
+    ]);
+    expect(rejected).toEqual([]);
+  });
+
+  it("uses a Slack channel response-mode override before the workspace default", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        responseMode: "mention_only",
+        authorizedConversationIds: [
+          {
+            id: "C012ABCDEF0",
+            displayName: "alerts",
+            responseMode: "every_message",
+          },
+        ],
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023032.123456",
+        user: "U012ABCDEF0",
+        text: "alert details",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        text: "alert details",
       }),
     ]);
   });
@@ -521,9 +606,9 @@ describe("SlackAdapter", () => {
 
     expect(events).toEqual([
       expect.objectContaining({
-        kind: "command",
-        command: "help",
-        rawText: "/help",
+        kind: "text",
+        botMention: true,
+        text: "help",
       }),
     ]);
   });

--- a/packages/messaging/providers/slack/src/resolve-contact.ts
+++ b/packages/messaging/providers/slack/src/resolve-contact.ts
@@ -15,7 +15,11 @@ export async function resolveContact(
   if (!config.botToken) {
     return { status: "unset", id: request.id };
   }
-  if (request.kind !== "user" && request.kind !== "workspace") {
+  if (
+    request.kind !== "user"
+    && request.kind !== "workspace"
+    && request.kind !== "channel"
+  ) {
     return {
       status: "unsupported",
       id: request.id,
@@ -40,6 +44,25 @@ export async function resolveContact(
         id: request.id,
         displayName: sanitizeOptionalContactLabel(auth.team) ?? request.id,
         detail: "workspace",
+      };
+    }
+
+    if (request.kind === "channel") {
+      const conversation = await api.conversationsInfo?.({ channel: request.id });
+      if (!conversation) {
+        return {
+          status: "not_found",
+          id: request.id,
+          errorMessage:
+            "Slack channel was not found or conversations.info is unavailable.",
+        };
+      }
+      return {
+        status: "ok",
+        id: request.id,
+        displayName:
+          sanitizeOptionalContactLabel(conversation.name) ?? request.id,
+        detail: "channel",
       };
     }
 

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -24,6 +24,7 @@ import type {
   MessagingJsonValue,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
+  MessagingResponseMode,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
   MessagingSurfaceRef,
@@ -330,6 +331,9 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
     this.authorizedActorIdsValue = [...update.authorizedActorIds];
+    if (update.responseMode !== undefined) {
+      this.config.responseMode = update.responseMode;
+    }
     this.config.authorizedActorIds = slackContactsFromIds(
       update.authorizedActorIds,
       this.config.authorizedActorIds,
@@ -338,6 +342,20 @@ export class SlackAdapter implements SlackProviderAdapter {
       update.authorizedConversationIds ?? [],
       this.config.authorizedConversationIds,
     );
+    if (update.conversationResponseModes) {
+      const responseModeById = new Map(
+        update.conversationResponseModes.map((entry) => [
+          entry.conversationId,
+          entry.responseMode,
+        ]),
+      );
+      this.config.authorizedConversationIds =
+        this.config.authorizedConversationIds.map((contact) => {
+          const { responseMode: _discard, ...rest } = contact;
+          const responseMode = responseModeById.get(contact.id);
+          return responseMode ? { ...rest, responseMode } : rest;
+        });
+    }
     this.config.authorizedTeamIds = slackContactsFromIds(
       update.authorizedWorkspaceIds ?? [],
       this.config.authorizedTeamIds,
@@ -618,8 +636,8 @@ export class SlackAdapter implements SlackProviderAdapter {
     const isMention = strippedText !== rawText;
     const text = strippedText.trim();
     const isPairingMessage = Boolean(extractMessagingPairingToken(rawText));
-    const command = isMention
-      ? parseBareCommand(text || "help")
+    const command = isMention && text.length === 0
+      ? { command: "help", args: [] }
       : parseCommand(text);
     const kind = command ? "command" : event.files?.length ? "media" : "text";
 
@@ -640,6 +658,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         channel,
         receivedAt: this.now(),
         routingState,
+        ...(isMention ? { botMention: true } : {}),
         text: text || undefined,
         disposition: "available",
         attachments: event.files.flatMap((file) => this.describeFile(file)),
@@ -655,9 +674,10 @@ export class SlackAdapter implements SlackProviderAdapter {
         channel,
         receivedAt: this.now(),
         routingState,
+        ...(isMention ? { botMention: true } : {}),
         command: command.command,
         args: command.args,
-        rawText: isMention ? `/${text || "help"}` : text,
+        rawText: isMention && text.length === 0 ? "/help" : text,
       });
       return;
     }
@@ -670,6 +690,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       channel,
       receivedAt: this.now(),
       routingState,
+      ...(isMention ? { botMention: true } : {}),
       text,
     });
   }
@@ -1566,12 +1587,6 @@ function parseCommand(text: string): { command: string; args: string[] } | undef
   return command ? { command, args } : undefined;
 }
 
-function parseBareCommand(text: string): { command: string; args: string[] } | undefined {
-  const trimmed = text.trim();
-  if (!/^[A-Za-z0-9_]+(?:\s|$)/.test(trimmed)) return undefined;
-  return parseCommand(`/${trimmed}`);
-}
-
 function normalizeSlackSlashCommand(
   command: string,
   prefix: string | undefined,
@@ -1612,8 +1627,14 @@ function callbackAllowedActorIds(
 
 function slackContactsFromIds(
   ids: readonly string[],
-  previous: readonly { id: string; displayName: string }[] | undefined,
-): { id: string; displayName: string }[] {
+  previous:
+    | readonly {
+        id: string;
+        displayName: string;
+        responseMode?: MessagingResponseMode;
+      }[]
+    | undefined,
+): { id: string; displayName: string; responseMode?: MessagingResponseMode }[] {
   const previousById = new Map((previous ?? []).map((contact) => [contact.id, contact]));
   return ids.map((id) => previousById.get(id) ?? { id, displayName: "" });
 }

--- a/packages/messaging/providers/slack/src/slack-config.ts
+++ b/packages/messaging/providers/slack/src/slack-config.ts
@@ -1,6 +1,9 @@
+import type { MessagingResponseMode } from "@pwragent/messaging-interface";
+
 export type SlackAuthorizedContact = {
   id: string;
   displayName: string;
+  responseMode?: MessagingResponseMode;
 };
 
 export type SlackInboundMode = "socket" | "events";
@@ -15,6 +18,7 @@ export type SlackMessagingConfig = {
   enabled?: boolean;
   inboundMode?: SlackInboundMode;
   registerSlashCommands?: boolean;
+  responseMode?: MessagingResponseMode;
   signingSecret?: string;
   slashCommandPrefix?: string;
   streamingResponses?: boolean;

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts
@@ -159,16 +159,15 @@ describe("TelegramAdapter inbound security boundary", () => {
     expect(listener).toHaveBeenCalledWith(
       expect.objectContaining({
         actor: expect.objectContaining({ platformUserId: "99" }),
-        args: ["123456789ABCDEFGHJKLMNPQRSTUVWXY"],
+        botMention: true,
         channel: expect.objectContaining({
           conversation: expect.objectContaining({
             id: "-1009999999999",
             kind: "channel",
           }),
         }),
-        command: "pair",
-        kind: "command",
-        rawText: "/pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
+        kind: "text",
+        text: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
       }),
     );
     expect(rejectedEvents).toEqual([]);
@@ -234,6 +233,63 @@ describe("TelegramAdapter inbound security boundary", () => {
       expect.objectContaining({
         chatId: "-1009999999999",
       }),
+    );
+  });
+
+  it("routes non-mention group text for controller response-mode handling", async () => {
+    const listener = vi.fn();
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+    const adapter = new TelegramAdapter({
+      bot: fakeBot(),
+      config: {
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+        authorizedSupergroupIds: [
+          {
+            id: "-1001234567890",
+            displayName: "Alerts",
+            responseMode: "mention_only",
+          },
+        ],
+        botToken: "token",
+        channel: "telegram",
+        responseMode: "every_message",
+      },
+      logger,
+      pollOnStart: false,
+    });
+    const rejectedEvents: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejectedEvents.push(event);
+    });
+    await adapter.start(listener);
+
+    await adapter.handleUpdate({
+      update_id: 102,
+      message: {
+        chat: {
+          id: -1001234567890,
+          title: "Alerts",
+          type: "supergroup",
+        },
+        from: {
+          id: 42,
+          first_name: "Harold",
+        },
+        message_id: 202,
+        text: "general group chatter",
+      },
+    });
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "text",
+        text: "general group chatter",
+      }),
+    );
+    expect(rejectedEvents).toEqual([]);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "telegram inbound ignored unauthorized conversation",
+      expect.anything(),
     );
   });
 

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -25,6 +25,7 @@ import type {
   MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
+  MessagingResponseMode,
   MessagingSurfaceAction,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -560,6 +561,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   }
 
   async updateAuthorization(update: MessagingAdapterAuthorizationUpdate): Promise<void> {
+    if (update.responseMode !== undefined) {
+      this.options.config.responseMode = update.responseMode;
+    }
     this.options.config.authorizedActorIds = telegramContactsFromIds(
       update.authorizedActorIds,
       this.options.config.authorizedActorIds,
@@ -568,6 +572,20 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       update.authorizedConversationIds ?? [],
       this.options.config.authorizedSupergroupIds,
     );
+    if (update.conversationResponseModes) {
+      const responseModeById = new Map(
+        update.conversationResponseModes.map((entry) => [
+          entry.conversationId,
+          entry.responseMode,
+        ]),
+      );
+      this.options.config.authorizedSupergroupIds =
+        this.options.config.authorizedSupergroupIds.map((contact) => {
+          const { responseMode: _discard, ...rest } = contact;
+          const responseMode = responseModeById.get(contact.id);
+          return responseMode ? { ...rest, responseMode } : rest;
+        });
+    }
   }
 
   async updateRenderingPreferences(
@@ -1458,25 +1476,19 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       // controller's normal "bind before attachments" response.
       !(mentionRemainder.length === 0 && attachments.length > 0)
     ) {
-      // If the remainder after the mention doesn't form a valid verb
-      // (e.g. a second mention, or a digit-leading token), we
-      // deliberately fall through to the attachment / slash / text
-      // paths below so the user's original message is dispatched as
-      // media or plain text rather than a half-recognized command.
-      const synthRaw = mentionRemainder.length === 0 ? "/help" : `/${mentionRemainder}`;
-      const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
-      if (mentionCommandMatch) {
+      if (mentionRemainder.length === 0) {
         this.options.logger?.debug(
-          `telegram inbound mention-command update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} command=${mentionCommandMatch[1]} preview="${compactPreview(mentionCandidate)}"`,
+          `telegram inbound mention-command update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} command=help preview="${compactPreview(mentionCandidate)}"`,
         );
         await listener({
           id: `telegram:update:${updateId}:message:${message.message_id}`,
           kind: "command",
           actor: this.actorFromUser(message.from),
-          args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
+          args: [],
+          botMention: true,
           channel: this.channelFromMessage(message),
-          command: mentionCommandMatch[1]?.toLowerCase() ?? "",
-          rawText: synthRaw,
+          command: "help",
+          rawText: "/help",
           receivedAt: this.messageReceivedAt(message),
           routingState: this.routingStateFromMessage(message),
         });
@@ -1506,32 +1518,35 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         },
         receivedAt: this.messageReceivedAt(message),
         routingState: this.routingStateFromMessage(message),
-        text: message.caption,
+        ...(mentionRemainder !== undefined ? { botMention: true } : {}),
+        text: mentionRemainder ?? message.caption,
       });
       return;
     }
 
-    if (!message.text) {
+    const inboundText = mentionRemainder ?? message.text;
+    if (!inboundText) {
       return;
     }
 
-    const commandMatch = /^\/([A-Za-z0-9_]+)(?:@\S+)?(?:\s+(.*))?$/.exec(message.text);
+    const commandMatch = /^\/([A-Za-z0-9_]+)(?:@\S+)?(?:\s+(.*))?$/.exec(inboundText);
     this.options.logger?.debug(
-      `telegram inbound ${commandMatch ? "command" : "text"} update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} chars=${message.text.length} preview="${compactPreview(message.text)}"`,
+      `telegram inbound ${commandMatch ? "command" : "text"} update=${updateId} message=${message.message_id} chat=${message.chat.id} actor=${message.from.id} chars=${inboundText.length} preview="${compactPreview(inboundText)}"`,
     );
     await listener({
       id: `telegram:update:${updateId}:message:${message.message_id}`,
       kind: commandMatch ? "command" : "text",
       actor: this.actorFromUser(message.from),
       channel: this.channelFromMessage(message),
+      ...(mentionRemainder !== undefined ? { botMention: true } : {}),
       ...(commandMatch
         ? {
             args: commandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
             command: commandMatch[1]?.toLowerCase() ?? "",
-            rawText: message.text,
+            rawText: inboundText,
           }
         : {
-            text: message.text,
+            text: inboundText,
           }),
       receivedAt: this.messageReceivedAt(message),
       routingState: this.routingStateFromMessage(message),
@@ -2822,8 +2837,14 @@ function callbackAllowedActorIds(intent: MessagingSurfaceIntent): string[] {
 
 function telegramContactsFromIds(
   ids: readonly string[],
-  previous: readonly { id: string; displayName: string }[] | undefined,
-): { id: string; displayName: string }[] {
+  previous:
+    | readonly {
+        id: string;
+        displayName: string;
+        responseMode?: MessagingResponseMode;
+      }[]
+    | undefined,
+): { id: string; displayName: string; responseMode?: MessagingResponseMode }[] {
   const previousById = new Map((previous ?? []).map((contact) => [contact.id, contact]));
   return ids.map((id) => previousById.get(id) ?? { id, displayName: "" });
 }

--- a/packages/messaging/providers/telegram/src/telegram-config.ts
+++ b/packages/messaging/providers/telegram/src/telegram-config.ts
@@ -1,6 +1,9 @@
+import type { MessagingResponseMode } from "@pwragent/messaging-interface";
+
 export type TelegramAuthorizedContact = {
   id: string;
   displayName: string;
+  responseMode?: MessagingResponseMode;
 };
 
 export type TelegramMessagingConfig = {
@@ -9,5 +12,6 @@ export type TelegramMessagingConfig = {
   botToken: string;
   channel: "telegram";
   enabled?: boolean;
+  responseMode?: MessagingResponseMode;
   streamingResponses?: boolean;
 };

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -156,6 +156,7 @@ describe("desktop settings contracts", () => {
         },
         telegram: {
           enabled: { value: true, source: "config" },
+          responseMode: { value: "every_message", source: "default" },
           streamingResponses: { value: true, source: "config" },
           botToken: {
             configured: true,
@@ -210,6 +211,7 @@ describe("desktop settings contracts", () => {
         },
         slack: {
           enabled: { value: false, source: "default" },
+          responseMode: { value: "mention_only", source: "default" },
           streamingResponses: { value: false, source: "default" },
           botToken: {
             configured: false,
@@ -232,6 +234,7 @@ describe("desktop settings contracts", () => {
           registerSlashCommands: { value: false, source: "default" },
           authorizedUserIds: { value: [], source: "default" },
           authorizedWorkspaces: { value: [], source: "default" },
+          authorizedChannels: { value: [], source: "default" },
         },
         feishu: {
           enabled: { value: false, source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -107,7 +107,10 @@ export type DesktopAuthorizedContact = {
   displayName: string;
   fullAccessWarningDismissed?: boolean;
   fullAccessWarningOverride?: DesktopMessagingFullAccessWarningUserPolicy;
+  responseMode?: DesktopMessagingResponseMode;
 };
+
+export type DesktopMessagingResponseMode = "every_message" | "mention_only";
 
 export type DesktopMessagingFullAccessWarningGlobalPolicy =
   | "always"
@@ -133,6 +136,7 @@ export type DesktopMessagingContactLookupKind =
   | "supergroup"
   | "guild"
   | "workspace"
+  | "channel"
   | "chat"
   | "tenant"
   | "group"
@@ -543,6 +547,7 @@ export type DesktopSettingsSnapshot = {
     attachments: DesktopMessagingAttachmentSettingsSnapshot;
     telegram: {
       enabled: DesktopSettingsValue<boolean>;
+      responseMode: DesktopSettingsValue<DesktopMessagingResponseMode>;
       streamingResponses: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
       authorizedUserIds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
@@ -571,6 +576,7 @@ export type DesktopSettingsSnapshot = {
     };
     slack: {
       enabled: DesktopSettingsValue<boolean>;
+      responseMode: DesktopSettingsValue<DesktopMessagingResponseMode>;
       streamingResponses: DesktopSettingsValue<boolean>;
       botToken: DesktopSettingsSecretState;
       appToken: DesktopSettingsSecretState;
@@ -581,6 +587,7 @@ export type DesktopSettingsSnapshot = {
       registerSlashCommands: DesktopSettingsValue<boolean>;
       authorizedUserIds: DesktopSettingsValue<DesktopAuthorizedContact[]>;
       authorizedWorkspaces: DesktopSettingsValue<DesktopAuthorizedContact[]>;
+      authorizedChannels: DesktopSettingsValue<DesktopAuthorizedContact[]>;
     };
     feishu: {
       enabled: DesktopSettingsValue<boolean>;
@@ -754,6 +761,7 @@ export type DesktopSettingsConfigPatch = {
     };
     telegram?: {
       enabled?: boolean;
+      responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       authorizedUserIds?: DesktopAuthorizedContact[];
       authorizedSupergroups?: DesktopAuthorizedContact[];
@@ -778,6 +786,7 @@ export type DesktopSettingsConfigPatch = {
     };
     slack?: {
       enabled?: boolean;
+      responseMode?: DesktopMessagingResponseMode;
       streamingResponses?: boolean;
       workspaceUrl?: string;
       inboundMode?: "socket" | "events";
@@ -785,6 +794,7 @@ export type DesktopSettingsConfigPatch = {
       registerSlashCommands?: boolean;
       authorizedUserIds?: DesktopAuthorizedContact[];
       authorizedWorkspaces?: DesktopAuthorizedContact[];
+      authorizedChannels?: DesktopAuthorizedContact[];
     };
     feishu?: {
       enabled?: boolean;


### PR DESCRIPTION
## Summary

PwrAgent can now be present in shared messaging surfaces without treating every authorized channel message as an agent turn. Slack shared channels default to `@ mention only`, while Telegram keeps the prior `Every message` default for compatibility; both platforms expose a `Respond to` setting plus per-authorized-conversation overrides.

Response mode is now binding-aware. Strict thread bindings continue routing raw shared-channel/topic messages to the bound development thread. Agent-thread bindings and completely unbound shared channels honor the configured response mode, so ambient chatter is ignored under `@ mention only` unless the bot is explicitly mentioned. Slash commands, callbacks, DMs, and pairing attempts remain explicit and continue to route.

Slack authorization is clearer: `T...` IDs are labeled as workspace/team IDs, and channels have their own allowlist backed by Slack conversation IDs (`C...`, `G...`, or `D...`). Slack workspace pairing also resolves the real team name instead of labeling the workspace with the channel title.

## Validation

- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts`

## Post-Deploy Monitoring & Validation

- Watch Messaging Activity for Slack/Telegram inbound rejects and unexpected admitted turns after inviting the bot to shared channels.
- Healthy signal: strict thread bindings still route raw shared-channel/topic text; agent-thread and unbound shared-channel messages without a mention do not create turns when the platform or conversation setting is `@ mention only`.
- Healthy signal: `@PwrAgent ...`, slash commands, DMs, callbacks, and pairing still route normally.
- Failure signal: authorized shared-channel messages without a mention start agent turns for agent-thread or unbound surfaces under `@ mention only`; mitigate by switching Slack off or removing the channel/workspace allowlist until fixed.
- Validation window: first live Slack/Telegram shared-channel rollout for #847; owner: PwrAgent operator merging the Slack integration work.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
