### PR TITLE
messaging: add Slack assistant typing status

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -48,6 +48,7 @@ function conversationKey(channel: MessagingChannelRef): string {
 }
 
 function fakeApi(spies: {
+  assistantStatusError?: Error;
   assistantStatuses?: Array<{ channelId: string; status: string; threadTs: string }>;
   conversations?: Record<string, string>;
   deleted?: Array<{ channel: string; ts: string }>;
@@ -64,6 +65,9 @@ function fakeApi(spies: {
       team_id: "T012ABCDEF0",
     }),
     setAssistantThreadStatus: async (params) => {
+      if (spies.assistantStatusError) {
+        throw spies.assistantStatusError;
+      }
       spies.assistantStatuses?.push(params);
     },
     conversationsInfo: async (params) => ({
@@ -246,6 +250,72 @@ describe("SlackAdapter", () => {
     });
 
     expect(assistantStatuses).toEqual([]);
+  });
+
+  it("disables Slack Assistant status after unsupported scope errors", async () => {
+    let attempts = 0;
+    const missingScopeError = Object.assign(
+      new Error("An API error occurred: missing_scope"),
+      {
+        data: {
+          error: "missing_scope",
+          needed: "chat:write",
+        },
+      },
+    );
+    const api = fakeApi({});
+    api.setAssistantThreadStatus = async () => {
+      attempts += 1;
+      throw missingScopeError;
+    };
+    const warnings: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api,
+      socketClient: fakeSocket(),
+      logger: {
+        warn: (_message, data) => {
+          warnings.push(data);
+        },
+      },
+    });
+    const activity = {
+      id: "activity-unsupported",
+      kind: "activity" as const,
+      activity: "typing" as const,
+      createdAt: 1,
+      state: "active" as const,
+      targetSurface: {
+        channel: "slack" as const,
+        id: "binding-1",
+        state: {
+          opaque: {
+            channelId: "C012ABCDEF0",
+            threadTs: "1712023030.000000",
+          },
+        },
+      },
+    };
+
+    await expect(adapter.deliver(activity)).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "discarded",
+    });
+    await expect(adapter.deliver({
+      ...activity,
+      id: "activity-after-disable",
+    })).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "discarded",
+    });
+
+    expect(attempts).toBe(1);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        requiredScope: "chat:write or assistant:write",
+      }),
+    ]);
   });
 
   it("returns structured rate-limit feedback when Slack rejects a send", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -48,6 +48,7 @@ function conversationKey(channel: MessagingChannelRef): string {
 }
 
 function fakeApi(spies: {
+  assistantStatuses?: Array<{ channelId: string; status: string; threadTs: string }>;
   conversations?: Record<string, string>;
   deleted?: Array<{ channel: string; ts: string }>;
   posted?: unknown[];
@@ -62,6 +63,9 @@ function fakeApi(spies: {
       team: "PwrDrvr",
       team_id: "T012ABCDEF0",
     }),
+    setAssistantThreadStatus: async (params) => {
+      spies.assistantStatuses?.push(params);
+    },
     conversationsInfo: async (params) => ({
       id: params.channel,
       name: spies.conversations?.[params.channel],
@@ -133,6 +137,115 @@ describe("SlackAdapter", () => {
     expect(adapter.capabilityProfile.actions?.maxActions).toBe(25);
     expect(adapter.capabilityProfile.actions?.supportsLayoutHints).toBe(true);
     expect(adapter.capabilityProfile.text.markdownDialect).toBe("slack-mrkdwn");
+  });
+
+  it("signals Slack Assistant thread status for active typing activity", async () => {
+    const assistantStatuses: Array<{ channelId: string; status: string; threadTs: string }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ assistantStatuses }),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await expect(adapter.deliver({
+      id: "activity-1",
+      kind: "activity",
+      activity: "typing",
+      createdAt: 1,
+      leaseMs: 10_000,
+      state: "active",
+      targetSurface: {
+        channel: "slack",
+        id: "binding-1",
+        state: {
+          opaque: {
+            channelId: "C012ABCDEF0",
+            threadTs: "1712023030.000000",
+          },
+        },
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      deliveredAt: 1_700_000_000_000,
+      outcome: "signaled",
+    });
+
+    expect(assistantStatuses).toEqual([{
+      channelId: "C012ABCDEF0",
+      status: "is working on your request...",
+      threadTs: "1712023030.000000",
+    }]);
+  });
+
+  it("clears Slack Assistant thread status for idle typing activity", async () => {
+    const assistantStatuses: Array<{ channelId: string; status: string; threadTs: string }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ assistantStatuses }),
+      socketClient: fakeSocket(),
+    });
+
+    await expect(adapter.deliver({
+      id: "activity-2",
+      kind: "activity",
+      activity: "typing",
+      createdAt: 1,
+      state: "idle",
+      targetSurface: {
+        channel: "slack",
+        id: "binding-1",
+        state: {
+          opaque: {
+            channelId: "C012ABCDEF0",
+            ts: "1712023030.000000",
+          },
+        },
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "signaled",
+    });
+
+    expect(assistantStatuses).toEqual([{
+      channelId: "C012ABCDEF0",
+      status: "",
+      threadTs: "1712023030.000000",
+    }]);
+  });
+
+  it("discards Slack typing activity when no thread timestamp is available", async () => {
+    const assistantStatuses: Array<{ channelId: string; status: string; threadTs: string }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ assistantStatuses }),
+      socketClient: fakeSocket(),
+    });
+
+    await expect(adapter.deliver({
+      id: "activity-3",
+      kind: "activity",
+      activity: "typing",
+      createdAt: 1,
+      state: "active",
+      targetSurface: {
+        channel: "slack",
+        id: "binding-1",
+        state: {
+          opaque: {
+            channelId: "C012ABCDEF0",
+          },
+        },
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "discarded",
+    });
+
+    expect(assistantStatuses).toEqual([]);
   });
 
   it("returns structured rate-limit feedback when Slack rejects a send", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -295,6 +295,7 @@ export class SlackAdapter implements SlackProviderAdapter {
   private botAccount: string | undefined;
   private botAccountDetail: string | undefined;
   private botUserId: string | undefined;
+  private assistantThreadStatusDisabled = false;
   private conversationInfoLookupDisabled = false;
   private threadInfoLookupDisabled = false;
   private userInfoLookupDisabled = false;
@@ -1437,7 +1438,12 @@ export class SlackAdapter implements SlackProviderAdapter {
 
     const target = this.resolveTarget(intent);
     const threadTs = target?.threadTs ?? target?.ts;
-    if (!target || !threadTs || !this.api.setAssistantThreadStatus) {
+    if (
+      !target
+      || !threadTs
+      || !this.api.setAssistantThreadStatus
+      || this.assistantThreadStatusDisabled
+    ) {
       return {
         channel: this.channel,
         deliveredAt: this.now(),
@@ -1457,6 +1463,18 @@ export class SlackAdapter implements SlackProviderAdapter {
         outcome: "signaled",
       };
     } catch (error) {
+      if (isSlackAssistantThreadStatusUnsupportedError(error)) {
+        this.assistantThreadStatusDisabled = true;
+        this.logger.warn?.("slack assistant thread status unavailable", {
+          reason: slackErrorReason(error),
+          requiredScope: "chat:write or assistant:write",
+        });
+        return {
+          channel: this.channel,
+          deliveredAt: this.now(),
+          outcome: "discarded",
+        };
+      }
       return {
         channel: this.channel,
         deliveredAt: this.now(),
@@ -1788,6 +1806,23 @@ function retryAfterMsFromError(error: unknown): number | undefined {
   return status === 429 ? 1_000 : undefined;
 }
 
+function isSlackAssistantThreadStatusUnsupportedError(error: unknown): boolean {
+  const reason = slackErrorReason(error).toLowerCase();
+  return reason.includes("missing_scope")
+    || reason.includes("not_assistant")
+    || reason.includes("assistant_not")
+    || reason.includes("not an assistant")
+    || reason.includes("method_not_supported")
+    || reason.includes("unsupported");
+}
+
+function slackErrorReason(error: unknown): string {
+  const dataError = readNestedStringProperty(error, "data", "error");
+  const dataNeeded = readNestedStringProperty(error, "data", "needed");
+  const message = error instanceof Error ? error.message : String(error);
+  return [dataError, dataNeeded, message].filter(Boolean).join(" ");
+}
+
 function readNumberProperty(value: unknown, key: string): number | undefined {
   if (!value || typeof value !== "object" || !(key in value)) {
     return undefined;
@@ -1796,6 +1831,22 @@ function readNumberProperty(value: unknown, key: string): number | undefined {
   return typeof property === "number" && Number.isFinite(property)
     ? property
     : undefined;
+}
+
+function readNestedStringProperty(
+  value: unknown,
+  parentKey: string,
+  childKey: string,
+): string | undefined {
+  if (!value || typeof value !== "object" || !(parentKey in value)) {
+    return undefined;
+  }
+  const parent = (value as Record<string, unknown>)[parentKey];
+  if (!parent || typeof parent !== "object" || !(childKey in parent)) {
+    return undefined;
+  }
+  const property = (parent as Record<string, unknown>)[childKey];
+  return typeof property === "string" ? property : undefined;
 }
 
 function safeEqual(left: string, right: string): boolean {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -63,6 +63,12 @@ export type SlackProviderLogger = {
 };
 
 export type SlackApi = {
+  setAssistantThreadStatus?(params: {
+    channelId: string;
+    loadingMessages?: string[];
+    status: string;
+    threadTs: string;
+  }): Promise<void>;
   authTest(): Promise<SlackAuthTestResult>;
   conversationsInfo?(params: { channel: string }): Promise<SlackConversationInfo | undefined>;
   conversationsReplies?(params: {
@@ -404,14 +410,10 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   async deliver(intent: MessagingSurfaceIntent): Promise<MessagingDeliveryResult> {
-    const deliveredAt = this.now();
     if (intent.kind === "activity") {
-      return {
-        outcome: "discarded",
-        channel: this.channel,
-        deliveredAt,
-      };
+      return await this.deliverActivity(intent);
     }
+    const deliveredAt = this.now();
     if (intent.kind === "dismiss") {
       return await this.deliverDismiss(intent);
     }
@@ -612,6 +614,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     });
     const routingState = this.routingStateForChannel(channel, {
       teamId: ids.teamId,
+      ts: ids.ts,
     });
     const rawText = event.text ?? "";
     const strippedText = stripBotMention(rawText, this.botUserId);
@@ -776,6 +779,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     });
     const routingState = this.routingStateForChannel(channel, {
       teamId: ids.teamId,
+      ...(body.thread_ts ? { ts: ids.ts } : {}),
     });
     if (!this.authorizeInbound({
       actor,
@@ -1420,6 +1424,48 @@ export class SlackAdapter implements SlackProviderAdapter {
     }
   }
 
+  private async deliverActivity(
+    intent: MessagingSurfaceIntent & { kind: "activity" },
+  ): Promise<MessagingDeliveryResult> {
+    if (intent.activity !== "typing") {
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        outcome: "unsupported",
+      };
+    }
+
+    const target = this.resolveTarget(intent);
+    const threadTs = target?.threadTs ?? target?.ts;
+    if (!target || !threadTs || !this.api.setAssistantThreadStatus) {
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        outcome: "discarded",
+      };
+    }
+
+    try {
+      await this.api.setAssistantThreadStatus({
+        channelId: target.channelId,
+        status: intent.state === "active" ? "is working on your request..." : "",
+        threadTs,
+      });
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        outcome: "signaled",
+      };
+    } catch (error) {
+      return {
+        channel: this.channel,
+        deliveredAt: this.now(),
+        errorMessage: error instanceof Error ? error.message : String(error),
+        outcome: "failed",
+      };
+    }
+  }
+
   private isDuplicateMessageEvent(
     event: SlackMessageEvent,
     ids: { channelId: string; teamId?: string; ts: string; userId: string },
@@ -1477,6 +1523,27 @@ export function createSlackApi(botToken: string): SlackApi {
   return {
     async authTest() {
       return (await client.auth.test()) as SlackAuthTestResult;
+    },
+    async setAssistantThreadStatus(params) {
+      const assistant = client.assistant as unknown as {
+        threads?: {
+          setStatus(input: {
+            channel_id: string;
+            loading_messages?: string[];
+            status: string;
+            thread_ts: string;
+          }): Promise<unknown>;
+        };
+      };
+      if (!assistant.threads?.setStatus) {
+        throw new Error("Slack assistant.threads.setStatus is unavailable");
+      }
+      await assistant.threads.setStatus({
+        channel_id: params.channelId,
+        ...(params.loadingMessages ? { loading_messages: params.loadingMessages } : {}),
+        status: params.status,
+        thread_ts: params.threadTs,
+      });
     },
     async conversationsInfo(params) {
       const response = await client.conversations.info(params);


### PR DESCRIPTION
## Summary

- Map Slack typing activity intents to Slack Assistant thread status when the adapter has a channel and thread timestamp.
- Preserve inbound Slack message timestamps in routing state so root Slack messages can be used as status targets.
- Add Slack adapter tests for active status, idle clear, and missing-target fallback.

## Notes

This is intentionally low-risk: if the Slack app or SDK surface cannot call `assistant.threads.setStatus`, the adapter reports the activity as discarded or failed without changing normal message delivery.

## Validation

- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts`
- `pnpm --filter @pwragent/messaging-provider-slack typecheck`
