### PR TITLE
fix(desktop): skip disabled Grok thread listing

### DIFF
--- a/apps/desktop/e2e/todo-list-rendering.spec.ts
+++ b/apps/desktop/e2e/todo-list-rendering.spec.ts
@@ -7,9 +7,10 @@ const todoListSpecDir = path.dirname(fileURLToPath(import.meta.url));
 
 async function openThreadByTitle(
   fixturePath: string,
-  threadTitle: string
+  threadTitle: string,
+  env?: Record<string, string | undefined>
 ) {
-  const app = await launchElectronApp({ fixturePath });
+  const app = await launchElectronApp({ fixturePath, env });
 
   await app.window.getByRole("button", { name: new RegExp(threadTitle, "i") }).first().click();
   await expect(
@@ -58,7 +59,8 @@ test("renders the Grok task plan contract with mixed step states", async () => {
       todoListSpecDir,
       "fixtures/grok-todo-list/replay.fixture.json"
     ),
-    "Grok to-do list replay"
+    "Grok to-do list replay",
+    { PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK: "1" }
   );
 
   try {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1649,6 +1649,124 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("does not list Grok threads while AgentCore-Grok is disabled", async () => {
+    const previous = process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+    process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "0";
+    const grokClient = new MockBackendClient({
+      listThreadsError: new Error("Grok API key is not set"),
+      threads: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    try {
+      await expect(registry.listThreads()).resolves.toEqual([]);
+
+      expect(grokClient.listThreadsCallCount).toBe(0);
+    } finally {
+      await registry.close();
+      if (previous === undefined) {
+        delete process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+      } else {
+        process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = previous;
+      }
+    }
+  });
+
+  it("does not reuse a disabled AgentCore-Grok aggregate thread cache after enabling", async () => {
+    const previous = process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+    process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "0";
+    const grokClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-grok",
+          title: "Grok thread",
+          titleSource: "explicit",
+          source: "grok",
+          linkedDirectories: [],
+          updatedAt: 2_000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    try {
+      await expect(registry.listThreads()).resolves.toEqual([]);
+      expect(grokClient.listThreadsCallCount).toBe(0);
+
+      process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "1";
+
+      await expect(registry.listThreads()).resolves.toEqual([
+        expect.objectContaining({
+          id: "thread-grok",
+          source: "grok",
+        }),
+      ]);
+      expect(grokClient.listThreadsCallCount).toBe(1);
+    } finally {
+      await registry.close();
+      if (previous === undefined) {
+        delete process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+      } else {
+        process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = previous;
+      }
+    }
+  });
+
+  it("does not reuse an enabled AgentCore-Grok aggregate thread cache after disabling", async () => {
+    const previous = process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+    process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "1";
+    const grokClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-grok",
+          title: "Grok thread",
+          titleSource: "explicit",
+          source: "grok",
+          linkedDirectories: [],
+          updatedAt: 2_000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    try {
+      await expect(registry.listThreads()).resolves.toEqual([
+        expect.objectContaining({
+          id: "thread-grok",
+          source: "grok",
+        }),
+      ]);
+      expect(grokClient.listThreadsCallCount).toBe(1);
+
+      process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "0";
+
+      await expect(registry.listThreads()).resolves.toEqual([]);
+      expect(grokClient.listThreadsCallCount).toBe(1);
+    } finally {
+      await registry.close();
+      if (previous === undefined) {
+        delete process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
+      } else {
+        process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = previous;
+      }
+    }
+  });
+
   it("returns ACP provider commands from session metadata", async () => {
     const session: AcpSessionMetadata = {
       backendId: "acp:kimi",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5222,6 +5222,8 @@ export class DesktopBackendRegistry {
       ...params,
       enrichDirectories:
         params.enrichDirectories ?? shouldEnrichThreadDirectories(params.callerReason),
+      agentCoreGrokEnabled:
+        params.backend === undefined ? resolveAgentCoreGrokEnabled() : undefined,
     };
     const cacheKey = this.buildThreadListCacheKey(normalizedParams);
     const now = Date.now();
@@ -5313,6 +5315,7 @@ export class DesktopBackendRegistry {
   }
 
   private async readThreadList(params: {
+    agentCoreGrokEnabled?: boolean;
     archived?: boolean;
     backend?: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
@@ -5395,13 +5398,15 @@ export class DesktopBackendRegistry {
         maxPages: params.maxPages,
         skipArchivedMetadataRefresh: params.skipArchivedMetadataRefresh,
       }),
-      this.listThreads({
-        backend: "grok",
-        archived: params.archived,
-        callerReason: params.callerReason,
-        enrichDirectories: params.enrichDirectories,
-        filter: params.filter,
-      }).catch(() => []),
+      params.agentCoreGrokEnabled === true
+        ? this.listThreads({
+            backend: "grok",
+            archived: params.archived,
+            callerReason: params.callerReason,
+            enrichDirectories: params.enrichDirectories,
+            filter: params.filter,
+          }).catch(() => [])
+        : Promise.resolve([]),
       this.listAllInstalledAcpThreads(params.filter, params.archived),
     ]);
 
@@ -10714,6 +10719,7 @@ export class DesktopBackendRegistry {
   }
 
   private buildThreadListCacheKey(params: {
+    agentCoreGrokEnabled?: boolean;
     archived?: boolean;
     backend?: AppServerBackendKind;
     callerReason?: ThreadListCallerReason;
@@ -10732,6 +10738,8 @@ export class DesktopBackendRegistry {
         : shouldBackfillCodexDirectoryRelationships(params.callerReason);
 
     return JSON.stringify({
+      agentCoreGrokEnabled:
+        params.backend === undefined ? params.agentCoreGrokEnabled === true : undefined,
       archived: params.archived === true,
       backend: params.backend ?? "all",
       codexDirectoryBackfill,
@@ -10746,6 +10754,7 @@ export class DesktopBackendRegistry {
 
   private findReusableThreadListCache(
     params: {
+      agentCoreGrokEnabled?: boolean;
       archived?: boolean;
       backend?: AppServerBackendKind;
       callerReason?: ThreadListCallerReason;


### PR DESCRIPTION
## Summary

- Skip the legacy AgentCore-Grok thread-list call from the implicit `backend=all` path when the experimental AgentCore-Grok flag is disabled.
- Add a regression test that verifies disabled AgentCore-Grok does not call the Grok client, even when the client would fail with a missing API key.

## Root Cause

`listBackends()` already respected the AgentCore-Grok experimental flag, but `readThreadList()` still expanded `backend=all` into Codex, Grok, and ACP thread lists. The Grok branch caught failures and returned an empty list, but the attempted call still produced noisy `Grok API key is not set` cache errors.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`