### PR TITLE
fix(desktop): preserve integrated terminal views

### DIFF
--- a/apps/desktop/e2e/integrated-terminal.spec.ts
+++ b/apps/desktop/e2e/integrated-terminal.spec.ts
@@ -54,7 +54,7 @@ test("keeps a per-thread integrated terminal alive while hidden", async () => {
       'node -e "setTimeout(() => console.log(\'PWRAGENT_TERMINAL_HIDDEN_DONE\'), 500)"',
     );
     await app.window.getByRole("button", { name: "Hide integrated terminal" }).click();
-    await expect(app.window.getByLabel("Integrated terminal", { exact: true })).toHaveCount(0);
+    await expect(app.window.getByLabel("Integrated terminal", { exact: true })).toBeHidden();
 
     await app.window.getByRole("button", { name: "Open integrated terminal" }).click();
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -106,6 +106,10 @@ export function IntegratedTerminal({
 
         const dataDisposable = terminal.onData((data) => {
           if (replayingBufferedOutputRef.current) {
+            if (isReplayGeneratedTerminalReply(data)) {
+              return;
+            }
+            pendingInputRef.current.push(data);
             return;
           }
           const sessionId = sessionIdRef.current;
@@ -309,3 +313,17 @@ function clampTerminalHeight(value: number): number {
     Math.max(TERMINAL_MIN_HEIGHT, Math.round(value)),
   );
 }
+
+function isReplayGeneratedTerminalReply(data: string): boolean {
+  return REPLAY_GENERATED_TERMINAL_REPLY_PATTERN.test(data);
+}
+
+const replayGeneratedTerminalReplyToken =
+  "(?:\\x1b\\[(?:\\?[0-9;]*|>[0-9;]*|[0-9;]*)c)" +
+  "|(?:\\x1b\\[[0-9]+;[0-9]+R)" +
+  "|(?:\\x1b\\[\\??[0-9;]+;[0-9]+\\$y)" +
+  "|(?:\\x1b\\](?:1[012]|4;[0-9]+);rgb:[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}(?:\\x07|\\x1b\\\\))";
+
+const REPLAY_GENERATED_TERMINAL_REPLY_PATTERN = new RegExp(
+  `^(?:${replayGeneratedTerminalReplyToken})+$`,
+);

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -35,6 +35,7 @@ export function IntegratedTerminal({
   const terminalRef = useRef<Terminal | null>(null);
   const sessionIdRef = useRef<string | undefined>(undefined);
   const pendingInputRef = useRef<string[]>([]);
+  const replayingBufferedOutputRef = useRef(false);
   const [status, setStatus] = useState<string>("Starting shell...");
 
   useLayoutEffect(() => {
@@ -104,6 +105,9 @@ export function IntegratedTerminal({
         };
 
         const dataDisposable = terminal.onData((data) => {
+          if (replayingBufferedOutputRef.current) {
+            return;
+          }
           const sessionId = sessionIdRef.current;
           if (!sessionId) {
             pendingInputRef.current.push(data);
@@ -129,19 +133,28 @@ export function IntegratedTerminal({
             if (disposed) return;
             sessionIdRef.current = response.sessionId;
             setStatus(response.cwd);
+            const finishAttach = () => {
+              if (disposed) return;
+              const pendingInput = pendingInputRef.current.join("");
+              pendingInputRef.current = [];
+              if (pendingInput && desktopApi.writeIntegratedTerminal) {
+                void desktopApi.writeIntegratedTerminal({
+                  sessionId: response.sessionId,
+                  data: pendingInput,
+                });
+              }
+              fitAndResize();
+              terminal.focus();
+            };
             if (response.buffer) {
-              terminal.write(response.buffer);
-            }
-            const pendingInput = pendingInputRef.current.join("");
-            pendingInputRef.current = [];
-            if (pendingInput && desktopApi.writeIntegratedTerminal) {
-              void desktopApi.writeIntegratedTerminal({
-                sessionId: response.sessionId,
-                data: pendingInput,
+              replayingBufferedOutputRef.current = true;
+              terminal.write(response.buffer, () => {
+                replayingBufferedOutputRef.current = false;
+                finishAttach();
               });
+            } else {
+              finishAttach();
             }
-            fitAndResize();
-            terminal.focus();
           })
           .catch((error) => {
             if (disposed) return;
@@ -164,6 +177,7 @@ export function IntegratedTerminal({
       disposed = true;
       sessionIdRef.current = undefined;
       pendingInputRef.current = [];
+      replayingBufferedOutputRef.current = false;
       cleanupTerminal?.();
     };
   }, [cwd, desktopApi, threadKey]);

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -342,7 +342,8 @@ function isReplayGeneratedTerminalReply(data: string): boolean {
 
 const replayGeneratedTerminalReplyToken =
   "(?:\\x1b\\[(?:\\?[0-9;]*|>[0-9;]*|[0-9;]*)c)" +
-  "|(?:\\x1b\\[[0-9]+;[0-9]+R)" +
+  "|(?:\\x1b\\[0n)" +
+  "|(?:\\x1b\\[\\??[0-9]+;[0-9]+R)" +
   "|(?:\\x1b\\[\\??[0-9;]+;[0-9]+\\$y)" +
   "|(?:\\x1b\\](?:1[012]|4;[0-9]+);rgb:[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}/[0-9a-fA-F]{1,4}(?:\\x07|\\x1b\\\\))";
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/IntegratedTerminal.tsx
@@ -17,6 +17,7 @@ type IntegratedTerminalProps = {
   threadKey: string;
   cwd?: string;
   height: number;
+  visible?: boolean;
   onHeightChange: (height: number) => void;
   onClose: () => void;
   onExit: () => void;
@@ -27,6 +28,7 @@ export function IntegratedTerminal({
   threadKey,
   cwd,
   height,
+  visible = true,
   onHeightChange,
   onClose,
   onExit,
@@ -36,7 +38,13 @@ export function IntegratedTerminal({
   const sessionIdRef = useRef<string | undefined>(undefined);
   const pendingInputRef = useRef<string[]>([]);
   const replayingBufferedOutputRef = useRef(false);
+  const fitAndResizeRef = useRef<() => void>(() => undefined);
+  const visibleRef = useRef(visible);
   const [status, setStatus] = useState<string>("Starting shell...");
+
+  useEffect(() => {
+    visibleRef.current = visible;
+  }, [visible]);
 
   useLayoutEffect(() => {
     const container = containerRef.current;
@@ -93,6 +101,7 @@ export function IntegratedTerminal({
         terminalRef.current = terminal;
 
         const fitAndResize = () => {
+          if (!visibleRef.current) return;
           if (disposed || !desktopApi.resizeIntegratedTerminal) return;
           fitAddon.fit();
           const sessionId = sessionIdRef.current;
@@ -103,6 +112,7 @@ export function IntegratedTerminal({
             rows: terminal.rows,
           });
         };
+        fitAndResizeRef.current = fitAndResize;
 
         const dataDisposable = terminal.onData((data) => {
           if (replayingBufferedOutputRef.current) {
@@ -148,7 +158,9 @@ export function IntegratedTerminal({
                 });
               }
               fitAndResize();
-              terminal.focus();
+              if (visibleRef.current) {
+                terminal.focus();
+              }
             };
             if (response.buffer) {
               replayingBufferedOutputRef.current = true;
@@ -182,9 +194,18 @@ export function IntegratedTerminal({
       sessionIdRef.current = undefined;
       pendingInputRef.current = [];
       replayingBufferedOutputRef.current = false;
+      fitAndResizeRef.current = () => undefined;
       cleanupTerminal?.();
     };
   }, [cwd, desktopApi, threadKey]);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    fitAndResizeRef.current();
+    terminalRef.current?.focus();
+  }, [height, visible]);
 
   const resizeBy = (delta: number) => {
     onHeightChange(clampTerminalHeight(height + delta));
@@ -254,6 +275,7 @@ export function IntegratedTerminal({
     <section
       className="integrated-terminal"
       aria-label="Integrated terminal"
+      hidden={!visible}
       style={
         {
           "--integrated-terminal-height": `${clampTerminalHeight(height)}px`,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -101,6 +101,11 @@ type LaunchpadEnvironmentSetupProgress = {
   status: "starting" | "running" | "completed" | "failed";
 };
 
+type RetainedIntegratedTerminal = {
+  threadKey: string;
+  cwd?: string;
+};
+
 const LazyIntegratedTerminal = lazy(async () => {
   const module = await import("./IntegratedTerminal");
   return { default: module.IntegratedTerminal };
@@ -949,6 +954,9 @@ export function ThreadView(props: ThreadViewProps) {
   const [terminalHeightByThread, setTerminalHeightByThread] = useState<
     Record<string, number>
   >({});
+  const [retainedTerminalByThread, setRetainedTerminalByThread] = useState<
+    Record<string, RetainedIntegratedTerminal>
+  >({});
   const [launchpadMaterializeError, setLaunchpadMaterializeError] =
     useState<string>();
   const [setupFailureDismissedThreadKeys, setSetupFailureDismissedThreadKeys] =
@@ -1085,40 +1093,56 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadTerminalCwd = selectedThread
     ? resolveThreadTerminalCwd(selectedThread)
     : undefined;
-  const selectedThreadTerminalHeight = selectedThreadKey
-    ? terminalHeightByThread[selectedThreadKey] ?? 260
-    : 260;
   const toggleSelectedThreadTerminal = useCallback(() => {
     if (!selectedThreadKey) return;
+    const isOpening = terminalOpenByThread[selectedThreadKey] !== true;
+    if (isOpening) {
+      setRetainedTerminalByThread((current) => ({
+        ...current,
+        [selectedThreadKey]: {
+          threadKey: selectedThreadKey,
+          cwd: selectedThreadTerminalCwd,
+        },
+      }));
+    }
     setTerminalOpenByThread((current) => ({
       ...current,
       [selectedThreadKey]: current[selectedThreadKey] !== true,
     }));
-  }, [selectedThreadKey]);
-  const closeSelectedThreadTerminal = useCallback(() => {
-    if (!selectedThreadKey) return;
+  }, [selectedThreadKey, selectedThreadTerminalCwd, terminalOpenByThread]);
+  const hideTerminalByThread = useCallback((threadKey: string) => {
     setTerminalOpenByThread((current) => ({
       ...current,
-      [selectedThreadKey]: false,
+      [threadKey]: false,
     }));
-    void props.desktopApi?.closeIntegratedTerminal?.({
-      threadKey: selectedThreadKey,
+  }, []);
+  const removeRetainedTerminalByThread = useCallback((threadKey: string) => {
+    setRetainedTerminalByThread((current) => {
+      if (!(threadKey in current)) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[threadKey];
+      return next;
     });
-  }, [props.desktopApi, selectedThreadKey]);
-  const handleSelectedThreadTerminalExit = useCallback(() => {
-    if (!selectedThreadKey) return;
-    setTerminalOpenByThread((current) => ({
-      ...current,
-      [selectedThreadKey]: false,
-    }));
-  }, [selectedThreadKey]);
-  const setSelectedThreadTerminalHeight = useCallback((height: number) => {
-    if (!selectedThreadKey) return;
+  }, []);
+  const closeTerminalByThread = useCallback((threadKey: string) => {
+    hideTerminalByThread(threadKey);
+    removeRetainedTerminalByThread(threadKey);
+    void props.desktopApi?.closeIntegratedTerminal?.({
+      threadKey,
+    });
+  }, [hideTerminalByThread, props.desktopApi, removeRetainedTerminalByThread]);
+  const handleTerminalExitByThread = useCallback((threadKey: string) => {
+    hideTerminalByThread(threadKey);
+    removeRetainedTerminalByThread(threadKey);
+  }, [hideTerminalByThread, removeRetainedTerminalByThread]);
+  const setTerminalHeightForThread = useCallback((threadKey: string, height: number) => {
     setTerminalHeightByThread((current) => ({
       ...current,
-      [selectedThreadKey]: height,
+      [threadKey]: height,
     }));
-  }, [selectedThreadKey]);
+  }, []);
   const suppressBranchDriftDialogRef = useRef(
     props.suppressBranchDriftDialog ?? false
   );
@@ -2634,19 +2658,31 @@ export function ThreadView(props: ThreadViewProps) {
             updatingExecutionMode={props.updatingExecutionMode}
           />
 
-          {selectedThreadTerminalOpen && selectedThreadKey ? (
-            <Suspense fallback={null}>
-              <LazyIntegratedTerminal
-                desktopApi={props.desktopApi}
-                threadKey={selectedThreadKey}
-                cwd={selectedThreadTerminalCwd}
-                height={selectedThreadTerminalHeight}
-                onHeightChange={setSelectedThreadTerminalHeight}
-                onClose={closeSelectedThreadTerminal}
-                onExit={handleSelectedThreadTerminalExit}
-              />
-            </Suspense>
-          ) : null}
+          {Object.values(retainedTerminalByThread).map((terminal) => {
+            const terminalVisible =
+              terminal.threadKey === selectedThreadKey &&
+              terminalOpenByThread[terminal.threadKey] === true;
+            return (
+              <Suspense key={terminal.threadKey} fallback={null}>
+                <LazyIntegratedTerminal
+                  desktopApi={props.desktopApi}
+                  threadKey={terminal.threadKey}
+                  cwd={terminal.cwd}
+                  height={terminalHeightByThread[terminal.threadKey] ?? 260}
+                  visible={terminalVisible}
+                  onHeightChange={(height) => {
+                    setTerminalHeightForThread(terminal.threadKey, height);
+                  }}
+                  onClose={() => {
+                    closeTerminalByThread(terminal.threadKey);
+                  }}
+                  onExit={() => {
+                    handleTerminalExitByThread(terminal.threadKey);
+                  }}
+                />
+              </Suspense>
+            );
+          })}
         </div>
 
         <ThreadContextPanel

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
@@ -228,6 +228,9 @@ describe("IntegratedTerminal", () => {
   it("does not send terminal replies from replayed output back to the pty", async () => {
     xtermState.replayDataEvents.set("saved terminal output", [
       "\u001b[>0;276;0c\u001b]10;rgb:cccc/cccc/cccc\u001b\\",
+      "\u001b[0n",
+      "\u001b[12;34R",
+      "\u001b[?12;34R",
     ]);
     const writeIntegratedTerminal = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
@@ -12,7 +12,9 @@ const xtermState = vi.hoisted(() => ({
     focus: ReturnType<typeof vi.fn>;
     handlers: Array<(data: string) => void>;
     emitData: (data: string) => void;
+    write: ReturnType<typeof vi.fn>;
   }>,
+  replayResponses: new Map<string, string>(),
 }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -28,7 +30,13 @@ vi.mock("@xterm/xterm", () => ({
 
     loadAddon = vi.fn();
     open = vi.fn();
-    write = vi.fn();
+    write = vi.fn((data: string, callback?: () => void) => {
+      const response = xtermState.replayResponses.get(data);
+      if (response) {
+        this.emitData(response);
+      }
+      callback?.();
+    });
     dispose = vi.fn();
 
     onData(callback: (data: string) => void) {
@@ -59,6 +67,7 @@ class MockResizeObserver {
 describe("IntegratedTerminal", () => {
   beforeEach(() => {
     xtermState.instances.length = 0;
+    xtermState.replayResponses.clear();
     Object.defineProperty(window, "ResizeObserver", {
       configurable: true,
       value: MockResizeObserver,
@@ -201,6 +210,60 @@ describe("IntegratedTerminal", () => {
       expect(writeIntegratedTerminal).toHaveBeenCalledWith({
         sessionId: "session-1",
         data: "exit\r",
+      });
+    });
+  });
+
+  it("does not send terminal replies from replayed output back to the pty", async () => {
+    xtermState.replayResponses.set(
+      "saved terminal output",
+      "\u001b[>0;276;0c\u001b]10;rgb:cccc/cccc/cccc\u001b\\",
+    );
+    const writeIntegratedTerminal = vi.fn(async () => undefined);
+
+    render(
+      <IntegratedTerminal
+        desktopApi={{
+          createIntegratedTerminal: vi.fn(async () => ({
+            sessionId: "session-1",
+            threadKey: "codex:thread-a",
+            cwd: "/repo/a",
+            shell: "/bin/zsh",
+            buffer: "saved terminal output",
+          })),
+          writeIntegratedTerminal,
+          resizeIntegratedTerminal: vi.fn(async () => undefined),
+          onIntegratedTerminalOutput: vi.fn(() => () => undefined),
+          onIntegratedTerminalExit: vi.fn(() => () => undefined),
+          onIntegratedTerminalError: vi.fn(() => () => undefined),
+        }}
+        threadKey="codex:thread-a"
+        cwd="/repo/a"
+        height={260}
+        onHeightChange={() => undefined}
+        onClose={() => undefined}
+        onExit={() => undefined}
+      />,
+    );
+
+    await waitFor(() => expect(xtermState.instances).toHaveLength(1));
+    await waitFor(() => {
+      expect(xtermState.instances[0]!.write).toHaveBeenCalled();
+    });
+    expect(xtermState.instances[0]!.write.mock.calls[0]?.[0]).toBe(
+      "saved terminal output",
+    );
+
+    expect(writeIntegratedTerminal).not.toHaveBeenCalled();
+
+    act(() => {
+      xtermState.instances[0]!.emitData("echo still forwards\r");
+    });
+
+    await waitFor(() => {
+      expect(writeIntegratedTerminal).toHaveBeenCalledWith({
+        sessionId: "session-1",
+        data: "echo still forwards\r",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx
@@ -14,7 +14,9 @@ const xtermState = vi.hoisted(() => ({
     emitData: (data: string) => void;
     write: ReturnType<typeof vi.fn>;
   }>,
-  replayResponses: new Map<string, string>(),
+  deferWriteCallbacks: false,
+  pendingWriteCallbacks: [] as Array<() => void>,
+  replayDataEvents: new Map<string, string[]>(),
 }));
 
 vi.mock("@xterm/xterm", () => ({
@@ -31,11 +33,18 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon = vi.fn();
     open = vi.fn();
     write = vi.fn((data: string, callback?: () => void) => {
-      const response = xtermState.replayResponses.get(data);
-      if (response) {
+      const responses = xtermState.replayDataEvents.get(data) ?? [];
+      for (const response of responses) {
         this.emitData(response);
       }
-      callback?.();
+      if (!callback) {
+        return;
+      }
+      if (xtermState.deferWriteCallbacks) {
+        xtermState.pendingWriteCallbacks.push(callback);
+      } else {
+        callback();
+      }
     });
     dispose = vi.fn();
 
@@ -67,7 +76,9 @@ class MockResizeObserver {
 describe("IntegratedTerminal", () => {
   beforeEach(() => {
     xtermState.instances.length = 0;
-    xtermState.replayResponses.clear();
+    xtermState.deferWriteCallbacks = false;
+    xtermState.pendingWriteCallbacks.length = 0;
+    xtermState.replayDataEvents.clear();
     Object.defineProperty(window, "ResizeObserver", {
       configurable: true,
       value: MockResizeObserver,
@@ -215,10 +226,9 @@ describe("IntegratedTerminal", () => {
   });
 
   it("does not send terminal replies from replayed output back to the pty", async () => {
-    xtermState.replayResponses.set(
-      "saved terminal output",
+    xtermState.replayDataEvents.set("saved terminal output", [
       "\u001b[>0;276;0c\u001b]10;rgb:cccc/cccc/cccc\u001b\\",
-    );
+    ]);
     const writeIntegratedTerminal = vi.fn(async () => undefined);
 
     render(
@@ -264,6 +274,59 @@ describe("IntegratedTerminal", () => {
       expect(writeIntegratedTerminal).toHaveBeenCalledWith({
         sessionId: "session-1",
         data: "echo still forwards\r",
+      });
+    });
+  });
+
+  it("queues user input typed while replayed output is still rendering", async () => {
+    xtermState.deferWriteCallbacks = true;
+    xtermState.replayDataEvents.set("saved terminal output", [
+      "\u001b[>0;276;0c",
+      "echo typed during replay\r",
+    ]);
+    const writeIntegratedTerminal = vi.fn(async () => undefined);
+
+    render(
+      <IntegratedTerminal
+        desktopApi={{
+          createIntegratedTerminal: vi.fn(async () => ({
+            sessionId: "session-1",
+            threadKey: "codex:thread-a",
+            cwd: "/repo/a",
+            shell: "/bin/zsh",
+            buffer: "saved terminal output",
+          })),
+          writeIntegratedTerminal,
+          resizeIntegratedTerminal: vi.fn(async () => undefined),
+          onIntegratedTerminalOutput: vi.fn(() => () => undefined),
+          onIntegratedTerminalExit: vi.fn(() => () => undefined),
+          onIntegratedTerminalError: vi.fn(() => () => undefined),
+        }}
+        threadKey="codex:thread-a"
+        cwd="/repo/a"
+        height={260}
+        onHeightChange={() => undefined}
+        onClose={() => undefined}
+        onExit={() => undefined}
+      />,
+    );
+
+    await waitFor(() => expect(xtermState.instances).toHaveLength(1));
+    await waitFor(() => {
+      expect(xtermState.pendingWriteCallbacks).toHaveLength(1);
+    });
+
+    expect(writeIntegratedTerminal).not.toHaveBeenCalled();
+
+    act(() => {
+      xtermState.pendingWriteCallbacks.shift()?.();
+    });
+
+    await waitFor(() => {
+      expect(writeIntegratedTerminal).toHaveBeenCalledTimes(1);
+      expect(writeIntegratedTerminal).toHaveBeenCalledWith({
+        sessionId: "session-1",
+        data: "echo typed during replay\r",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../IntegratedTerminal", () => ({
     threadKey: string;
     cwd?: string;
     height: number;
+    visible?: boolean;
     onClose: () => void;
     onExit: () => void;
   }) => (
@@ -29,6 +30,7 @@ vi.mock("../IntegratedTerminal", () => ({
       data-cwd={props.cwd ?? ""}
       data-height={props.height}
       data-thread-key={props.threadKey}
+      hidden={props.visible === false}
     >
       <button type="button" title="Close terminal" onClick={props.onClose}>
         Close terminal
@@ -395,7 +397,7 @@ describe("ThreadView", () => {
       transcriptEntries: [],
     };
 
-    const { rerender } = render(
+    const { container, rerender } = render(
       <ThreadView {...commonProps} selectedThread={firstThread} />,
     );
 
@@ -416,7 +418,10 @@ describe("ThreadView", () => {
 
     rerender(<ThreadView {...commonProps} selectedThread={secondThread} />);
 
-    expect(screen.queryByLabelText("Integrated terminal")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Integrated terminal")).not.toBeVisible();
+    expect(
+      container.querySelector('[aria-label="Integrated terminal"]'),
+    ).toHaveAttribute("hidden");
     expect(closeIntegratedTerminal).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Open integrated terminal" })).toHaveAttribute(
       "aria-pressed",
@@ -436,7 +441,10 @@ describe("ThreadView", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Hide integrated terminal" }));
 
-    expect(screen.queryByLabelText("Integrated terminal")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Integrated terminal")).not.toBeVisible();
+    expect(
+      container.querySelector('[aria-label="Integrated terminal"]'),
+    ).toHaveAttribute("hidden");
     expect(closeIntegratedTerminal).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "Open integrated terminal" }));

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12315,6 +12315,10 @@ textarea,
   background: transparent;
 }
 
+.integrated-terminal[hidden] {
+  display: none;
+}
+
 .integrated-terminal__resize-handle {
   flex: 0 0 10px;
   min-height: 10px;


### PR DESCRIPTION
## Summary

Integrated terminals now keep their live xterm view when hidden or when the user switches threads, so returning to a thread preserves the terminal scrollback viewport and avoids rebuilding the terminal from a replay buffer. Previously, PwrAgent destroyed the renderer terminal on each hide/show or thread navigation event, which reset the visual state and could replay historical terminal probes into a fresh xterm instance.

The retained view is hidden with normal DOM visibility instead of being unmounted; closing the terminal or shell exit still tears down the PTY session. The replay path remains as a fallback for true attach/reload cases, but generated xterm replies from replayed output are filtered so device-status, cursor-position, color, and device-attribute responses cannot be written back into the live shell.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/IntegratedTerminal.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/desktop test:e2e e2e/integrated-terminal.spec.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
