### PR TITLE
fix(desktop): expose thread title helper usage

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -222,6 +222,87 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual([]);
   });
 
+  it("ignores thought chunks while capturing control prompt output", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "name this thread",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_thought_chunk",
+      content: {
+        type: "text",
+        text: "The user wants a concise title. I should return JSON.",
+      },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: '{ "title": "Favorite cereal" }' },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      kind: "turn_finished",
+      outputText: '{ "title": "Favorite cereal" }',
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await expect(controlPrompt).resolves.toEqual({
+      text: '{ "title": "Favorite cereal" }',
+    });
+    expect(client.readReplay("session-1").messages).toEqual([]);
+  });
+
+  it("uses turn-finished output for suppressed control prompts without message chunks", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:qwen",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "name this thread",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: "Thinking out loud." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      kind: "turn_finished",
+      outputText: '{ "title": "Favorite cereal" }',
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await expect(controlPrompt).resolves.toEqual({
+      text: '{ "title": "Favorite cereal" }',
+    });
+    expect(client.readReplay("session-1").messages).toEqual([]);
+  });
+
   it("passes configured MCP servers when an ACP session id is known", async () => {
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -266,6 +266,41 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay("session-1").messages).toEqual([]);
   });
 
+  it("preserves split JSON control prompt chunks without inserted newlines", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:qwen",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "name this thread",
+    });
+    for (const text of ['{ "title": "', "Favorite cereal question", '" }']) {
+      transport.emitSessionUpdate(session.sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      });
+    }
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await expect(controlPrompt).resolves.toEqual({
+      text: '{ "title": "Favorite cereal question" }',
+    });
+    expect(client.readReplay("session-1").messages).toEqual([]);
+  });
+
   it("uses turn-finished output for suppressed control prompts without message chunks", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
@@ -8,6 +8,16 @@ describe("AcpThreadTitleGenerator", () => {
     const sendControlPrompt = vi.fn(async () => ({
       text: '{"title": "\nFavorite cereal question\n"}',
     }));
+    const startSession = vi.fn(async () => ({
+      backendId: backend,
+      sessionId: "qwen-title-helper",
+      title: "Name this thread",
+      createdAt: 1001,
+      updatedAt: 1001,
+      executionMode: "default" as const,
+      hidden: true,
+      status: "idle" as const,
+    }));
     const generator = new AcpThreadTitleGenerator({
       backend,
       getClient: async () => ({
@@ -20,7 +30,7 @@ describe("AcpThreadTitleGenerator", () => {
         refreshSession: vi.fn(),
         sendControlPrompt,
         startPrompt: vi.fn(),
-        startSession: vi.fn(),
+        startSession,
       }),
       getSession: () => ({
         backendId: backend,
@@ -46,6 +56,18 @@ describe("AcpThreadTitleGenerator", () => {
     ).resolves.toMatchObject({
       status: "ok",
       object: { title: " Favorite cereal question " },
+      helperThreadId: "qwen-title-helper",
+    });
+    expect(startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionMode: "default",
+        hidden: true,
+        title: "Name this thread",
+      }),
+    );
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "qwen-title-helper",
+      prompt: "Name this thread",
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpBackendId } from "@pwragent/shared";
+import { AcpThreadTitleGenerator } from "../app-server/acp-thread-title-generator";
+
+describe("AcpThreadTitleGenerator", () => {
+  it("extracts title JSON even when streamed chunks left raw newlines in the string", async () => {
+    const backend = "acp:qwen" as AcpBackendId;
+    const sendControlPrompt = vi.fn(async () => ({
+      text: '{"title": "\nFavorite cereal question\n"}',
+    }));
+    const generator = new AcpThreadTitleGenerator({
+      backend,
+      getClient: async () => ({
+        cancelSession: vi.fn(),
+        dispose: vi.fn(),
+        ensureSession: vi.fn(),
+        initialize: vi.fn(),
+        loadSession: vi.fn(),
+        readReplay: vi.fn(),
+        refreshSession: vi.fn(),
+        sendControlPrompt,
+        startPrompt: vi.fn(),
+        startSession: vi.fn(),
+      }),
+      getSession: () => ({
+        backendId: backend,
+        sessionId: "qwen-session-1",
+        title: "ACP session",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      }),
+    });
+
+    await expect(
+      generator.generateTitle({
+        backend,
+        prompt: "Name this thread",
+        promptVersion: "thread-title-v1",
+        schema: { type: "object" },
+        schemaName: "thread_title",
+        threadId: "qwen-session-1",
+        timeoutMs: 20_000,
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      object: { title: " Favorite cereal question " },
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1448,10 +1448,14 @@ function createAcpAgentStoreMock(records: AcpInstalledAgentRecord[]) {
 
 function createAcpSessionStoreMock(records: AcpSessionMetadata[]) {
   return {
-    listSessions: (backendId: string, params?: { archived?: boolean }) =>
+    listSessions: (
+      backendId: string,
+      params?: { archived?: boolean; includeHidden?: boolean },
+    ) =>
       records.filter(
         (record) =>
           record.backendId === backendId &&
+          (params?.includeHidden === true || !record.hidden) &&
           Boolean(record.archivedAt) === (params?.archived === true),
       ),
     getSession: (backendId: string, sessionId: string) =>
@@ -1544,17 +1548,25 @@ function createKimiAcpRegistry(options?: {
     initialize: vi.fn(async () => undefined),
     dispose: vi.fn(),
     startSession: vi.fn(async (params: {
+      acpRuntime?: BackendAcpSessionRuntimeState;
       cwd?: string;
       executionMode: "default" | "full-access";
+      hidden?: boolean;
+      title?: string;
     }) => {
+      const resolvedSessionId = params.hidden
+        ? `${sessionId}:title-helper:${sessions.length + 1}`
+        : sessionId;
       const metadata: AcpSessionMetadata = {
         backendId: acpBackendId,
-        sessionId,
-        title: "ACP session",
+        sessionId: resolvedSessionId,
+        title: params.title ?? "ACP session",
         cwd: params.cwd,
         createdAt: 1000,
         updatedAt: 1000,
         executionMode: params.executionMode,
+        ...(params.acpRuntime ? { acpRuntime: params.acpRuntime } : {}),
+        ...(params.hidden ? { hidden: true } : {}),
         status: "idle",
       };
       sessions.push(metadata);
@@ -11659,10 +11671,27 @@ command = "pnpm dev"
     const sendControlPrompt = vi.fn(async () => ({
       text: '{ "title": "Favorite cereal" }',
     }));
+    const helperSession: AcpSessionMetadata = {
+      backendId: acpBackendId,
+      sessionId: "kimi-title-helper",
+      title: "Name this thread",
+      cwd: "/repo/project",
+      createdAt: 1001,
+      updatedAt: 1001,
+      executionMode: "default",
+      acpRuntime: {
+        configValues: {
+          model: "kimi-k2-0711-preview",
+        },
+        updatedAt: 1001,
+      },
+      hidden: true,
+      status: "idle",
+    };
     const acpClient = {
       initialize: vi.fn(async () => undefined),
       dispose: vi.fn(),
-      startSession: vi.fn(async () => sessions[0]!),
+      startSession: vi.fn(async () => helperSession),
       ensureSession: vi.fn(async () => undefined),
       loadSession: vi.fn(),
       refreshSession: vi.fn(async () => undefined),
@@ -11701,24 +11730,20 @@ command = "pnpm dev"
     await emitCompletedTurn(registry, acpBackendId, "kimi-session-1");
     await waitForCondition(() => sessions[0]?.title === "Favorite cereal");
 
+    expect(acpClient.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/repo/project",
+        hidden: true,
+        title: "Name this thread",
+      }),
+    );
     expect(sendControlPrompt).toHaveBeenCalledWith({
-      sessionId: "kimi-session-1",
+      sessionId: "kimi-title-helper",
       prompt: expect.stringContaining(prompt),
     });
     expect(sessions[0]).toMatchObject({
       title: "Favorite cereal",
       titleSource: "derived",
-    });
-    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
-      backend: acpBackendId,
-      threadId: "kimi-session-1",
-      subAgent: expect.objectContaining({
-        monitorId: "system:title-helper:acp:kimi:kimi-session-1",
-        task: "Name this thread",
-        status: "pending",
-        agentName: "PwrAgent",
-        lastMessage: "Waiting for the initial turn to complete.",
-      }),
     });
     expect(upsertSubAgentSpy).toHaveBeenCalledWith({
       backend: acpBackendId,
@@ -11740,6 +11765,7 @@ command = "pnpm dev"
         status: "success",
         agentName: "PwrAgent",
         preferredModel: "kimi-k2-0711-preview",
+        monitorThreadId: "kimi-title-helper",
         lastMessage: "Generated title: Favorite cereal",
         outcome: "success",
       }),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11595,6 +11595,109 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("applies generated title helper names to ACP prompt-derived fallback sessions", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const prompt =
+      "We're testing something here... just tell me your favorite cereal.";
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "kimi-session-1",
+        title: "We're testing something here... just tell me your favorite cereal",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Favorite cereal",
+        helperThreadId: "title-helper-thread",
+        helperTurnId: "title-helper-turn",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        serviceTier: "priority",
+        tokenUsage: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 110,
+        },
+      })),
+    };
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async () => sessions[0]!),
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      startPrompt: vi.fn(() => ({
+        sessionId: "kimi-session-1",
+        turnId: "turn-1",
+      })),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      input: [{ type: "text", text: prompt }],
+    });
+    await waitForCondition(() => sessions[0]?.title === "Favorite cereal");
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      userPrompt: prompt,
+    });
+    expect(sessions[0]).toMatchObject({
+      title: "Favorite cereal",
+      titleSource: "derived",
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:acp:kimi:kimi-session-1",
+        task: "Name this thread",
+        status: "success",
+        agentName: "PwrAgent",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        monitorThreadId: "title-helper-thread",
+        monitorTurnId: "title-helper-turn",
+        lastMessage: "Generated title: Favorite cereal",
+        outcome: "success",
+      }),
+    });
+
+    await registry.close();
+  });
+
   it("does not replace an existing ACP prompt-derived fallback title with a later prompt", async () => {
     const acpBackendId = "acp:qwen" as AcpBackendId;
     const sessions: AcpSessionMetadata[] = [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10784,6 +10784,50 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("does not generate a Codex title when startTurn fails before lifecycle confirmation", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Should not apply",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      startTurnError: new Error("codex start failed"),
+      threads: [
+        {
+          id: "thread-start-failed-title",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-start-failed-title",
+        input: [{ type: "text", text: "Make button" }],
+      }),
+    ).rejects.toThrow("codex start failed");
+    await flushAsync();
+
+    expect(titleService.generateTitle).not.toHaveBeenCalled();
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("reports in-progress quit threads across Codex active, queued, and ACP active turns", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -11108,6 +11152,79 @@ command = "pnpm dev"
         totalTokens: 110,
       }),
     });
+
+    await registry.close();
+  });
+
+  it("logs title helper sub-agent persistence failures without retrying the same write", async () => {
+    mainLoggerMock.warn.mockClear();
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Readable thread title",
+        helperThreadId: "title-helper-thread",
+        helperTurnId: "title-helper-turn",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        serviceTier: "priority",
+        tokenUsage: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 110,
+        },
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi
+      .spyOn(overlayStore, "upsertThreadSubAgent")
+      .mockRejectedValue(new Error("overlay write failed"));
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title-helper-persist-failure",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title-helper-persist-failure",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() =>
+      mainLoggerMock.warn.mock.calls.some(
+        ([message]) => message === "threadTitleHelperSubAgentPersistence",
+      ),
+    );
+
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-title-helper-persist-failure",
+      name: "Readable thread title",
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledTimes(1);
+    expect(mainLoggerMock.warn).toHaveBeenCalledWith(
+      "threadTitleHelperSubAgentPersistence",
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-title-helper-persist-failure",
+        status: "success",
+        persistenceError: "overlay write failed",
+      }),
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11335,6 +11335,77 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("marks the title helper sub-agent failed when title generation throws", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => {
+        throw new Error("title helper unavailable");
+      }),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title-helper-throws",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title-helper-throws",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() =>
+      upsertSubAgentSpy.mock.calls.some(
+        ([call]) => call.subAgent.status === "failed",
+      ),
+    );
+
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-title-helper-throws",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-title-helper-throws",
+        status: "running",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        lastMessage: "Generating a title.",
+      }),
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-title-helper-throws",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-title-helper-throws",
+        status: "failed",
+        outcome: "failure",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        lastMessage: "Title generation failed: title helper unavailable",
+        completionSource: expect.objectContaining({
+          terminalStatus: "failed",
+        }),
+      }),
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("steers Codex turns through the single client and surfaces its error", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "turn/steer"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11031,12 +11031,20 @@ command = "pnpm dev"
 
   it("schedules Codex title generation from lifecycle events while turn/start is still pending", async () => {
     const startTurnDelay = createDeferred<void>();
+    const titleGenerationStarted = createDeferred<void>();
+    const titleGenerationRelease = createDeferred<void>();
     const titleService = {
-      generateTitle: vi.fn(async () => ({
-        status: "generated" as const,
-        title: "Lifecycle title",
-      })),
+      generateTitle: vi.fn(async () => {
+        titleGenerationStarted.resolve();
+        await titleGenerationRelease.promise;
+        return {
+          status: "generated" as const,
+          title: "Lifecycle title",
+        };
+      }),
     };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "thread/name/set"] },
       startTurnDelay: startTurnDelay.promise,
@@ -11055,7 +11063,7 @@ command = "pnpm dev"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok unavailable"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       threadTitleGenerationService: titleService,
     });
 
@@ -11078,6 +11086,29 @@ command = "pnpm dev"
         },
       },
     });
+    await titleGenerationStarted.promise;
+    await waitForCondition(() =>
+      upsertSubAgentSpy.mock.calls.some(
+        ([call]) => call.subAgent.status === "running",
+      ),
+    );
+
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-lifecycle-title",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-lifecycle-title",
+        task: "Name this thread",
+        status: "running",
+        backend: "codex",
+        agentName: "PwrAgent",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        lastMessage: "Generating a title.",
+      }),
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+    titleGenerationRelease.resolve();
     await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
@@ -11148,7 +11179,26 @@ command = "pnpm dev"
       threadId: "thread-title-helper-parent",
       input: [{ type: "text", text: "Make button" }],
     });
-    await waitForCondition(() => upsertSubAgentSpy.mock.calls.length > 0);
+    await waitForCondition(() =>
+      upsertSubAgentSpy.mock.calls.some(
+        ([call]) => call.subAgent.status === "success",
+      ),
+    );
+
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-title-helper-parent",
+        task: "Name this thread",
+        status: "running",
+        backend: "codex",
+        agentName: "PwrAgent",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        lastMessage: "Generating a title.",
+      }),
+    });
 
     expect(upsertSubAgentSpy).toHaveBeenCalledWith({
       backend: "codex",
@@ -11157,6 +11207,7 @@ command = "pnpm dev"
         monitorId: "system:title-helper:codex:thread-title-helper-parent",
         task: "Name this thread",
         status: "success",
+        backend: "codex",
         agentName: "PwrAgent",
         preferredModel: "gpt-5.4-mini",
         preferredReasoningEffort: "low",
@@ -11222,7 +11273,18 @@ command = "pnpm dev"
     const overlayStore = createOverlayStoreMock();
     const upsertSubAgentSpy = vi
       .spyOn(overlayStore, "upsertThreadSubAgent")
-      .mockRejectedValueOnce(new Error("overlay write failed"));
+      .mockImplementation(async ({ backend, threadId, subAgent }) => {
+        if (subAgent.status === "success") {
+          throw new Error("overlay write failed");
+        }
+        return {
+          backend,
+          threadId,
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [subAgent],
+        };
+      });
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "thread/name/set"] },
       threads: [
@@ -11259,7 +11321,7 @@ command = "pnpm dev"
       threadId: "thread-title-helper-persist-failure",
       name: "Readable thread title",
     });
-    expect(upsertSubAgentSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSubAgentSpy).toHaveBeenCalledTimes(2);
     expect(mainLoggerMock.warn).toHaveBeenCalledWith(
       "threadTitleHelperSubAgentPersistence",
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -51,6 +51,17 @@ import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
 import type { AcpSessionMetadata } from "../acp/acp-session-store";
 import type { ThreadSearchService } from "../thread-search/thread-search-service";
 
+const mainLoggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => mainLoggerMock),
+}));
+
 const localAcpDiscoveryMock = vi.hoisted(() => ({
   discoverLocalAcpAgentRecords: vi.fn(
     async () => [] as AcpInstalledAgentRecord[],
@@ -995,6 +1006,7 @@ class MockBackendClient {
       listThreadsDelay?: Promise<unknown>;
       archivedThreads?: AppServerThreadSummary[];
       startThreadResult?: { threadId: string };
+      startTurnDelay?: Promise<unknown>;
       startTurnError?: Error;
       steerTurnError?: Error;
       setThreadPermissionsError?: Error;
@@ -1196,6 +1208,7 @@ class MockBackendClient {
     dynamicTools?: unknown;
   }): Promise<{ threadId: string; turnId: string }> {
     this.startTurnCallCount += 1;
+    await this.options.startTurnDelay;
     if (this.options.startTurnError) {
       throw this.options.startTurnError;
     }
@@ -10871,6 +10884,229 @@ command = "pnpm dev"
     expect(codexClient.lastRenameThreadParams).toEqual({
       threadId: "thread-title",
       name: "Leopard tea button",
+    });
+
+    await registry.close();
+  });
+
+  it("logs Codex title generation failures to the main log", async () => {
+    mainLoggerMock.warn.mockClear();
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "failed" as const,
+        reason: "codex_title_helper_failed",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title-failure",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title-failure",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() =>
+      mainLoggerMock.warn.mock.calls.some(
+        ([message]) => message === "threadTitleGeneration",
+      ),
+    );
+
+    expect(mainLoggerMock.warn).toHaveBeenCalledWith(
+      "threadTitleGeneration",
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-title-failure",
+        status: "failed",
+        reason: "codex_title_helper_failed",
+      }),
+    );
+
+    await registry.close();
+  });
+
+  it("schedules Codex title generation from lifecycle events while turn/start is still pending", async () => {
+    const startTurnDelay = createDeferred<void>();
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Lifecycle title",
+      })),
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      startTurnDelay: startTurnDelay.promise,
+      threads: [
+        {
+          id: "thread-lifecycle-title",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: titleService,
+    });
+
+    const startTurnPromise = registry.startTurn({
+      backend: "codex",
+      threadId: "thread-lifecycle-title",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() => codexClient.startTurnCallCount === 1);
+
+    await (
+      registry as unknown as { emit(event: AgentEvent): Promise<void> }
+    ).emit({
+      backend: "codex",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-lifecycle-title",
+          status: { type: "active" },
+        },
+      },
+    });
+    await waitForCondition(() => codexClient.lastRenameThreadParams !== undefined);
+
+    expect(titleService.generateTitle).toHaveBeenCalledWith({
+      backend: "codex",
+      userPrompt: "Make button",
+    });
+    expect(codexClient.lastRenameThreadParams).toEqual({
+      threadId: "thread-lifecycle-title",
+      name: "Lifecycle title",
+    });
+
+    startTurnDelay.resolve();
+    await expect(startTurnPromise).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-lifecycle-title",
+      turnId: "turn-1",
+    });
+    expect(titleService.generateTitle).toHaveBeenCalledTimes(1);
+
+    await registry.close();
+  });
+
+  it("persists the Codex title helper as a system sub-agent with usage", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "generated" as const,
+        title: "Readable thread title",
+        helperThreadId: "title-helper-thread",
+        helperTurnId: "title-helper-turn",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        serviceTier: "priority",
+        tokenUsage: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 110,
+        },
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const upsertUsageLineSpy = vi.spyOn(overlayStore, "upsertThreadUsageLine");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-title-helper-parent",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() => upsertSubAgentSpy.mock.calls.length > 0);
+
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-title-helper-parent",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-title-helper-parent",
+        task: "Name this thread",
+        status: "success",
+        agentName: "PwrAgent",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        monitorThreadId: "title-helper-thread",
+        monitorTurnId: "title-helper-turn",
+        lastMessage: "Generated title: Readable thread title",
+        outcome: "success",
+        monitorUsage: expect.objectContaining({
+          model: "gpt-5.4-mini",
+          serviceTier: "priority",
+          tokenUsage: {
+            inputTokens: 100,
+            cachedInputTokens: 20,
+            uncachedInputTokens: 80,
+            outputTokens: 10,
+            reasoningOutputTokens: 0,
+            totalTokens: 110,
+          },
+        }),
+      }),
+    });
+    expect(upsertUsageLineSpy).toHaveBeenCalledWith({
+      line: expect.objectContaining({
+        backend: "codex",
+        source: "monitor",
+        sourceItemId: "system:title-helper:codex:thread-title-helper-parent",
+        scope: "monitor",
+        parentThreadId: "thread-title-helper-parent",
+        threadId: "title-helper-thread",
+        turnId: "title-helper-turn",
+        model: "gpt-5.4-mini",
+        serviceTier: "priority",
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        uncachedInputTokens: 80,
+        outputTokens: 10,
+        totalTokens: 110,
+      }),
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11753,6 +11753,8 @@ command = "pnpm dev"
         task: "Name this thread",
         status: "running",
         agentName: "PwrAgent",
+        backend: acpBackendId,
+        preferredModel: "kimi-k2-0711-preview",
         lastMessage: "Generating a title.",
       }),
     });
@@ -11764,6 +11766,7 @@ command = "pnpm dev"
         task: "Name this thread",
         status: "success",
         agentName: "PwrAgent",
+        backend: acpBackendId,
         preferredModel: "kimi-k2-0711-preview",
         monitorThreadId: "kimi-title-helper",
         lastMessage: "Generated title: Favorite cereal",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2962,14 +2962,15 @@ describe("DesktopBackendRegistry", () => {
     await waitForCondition(() =>
       emittedEvents.some((event) => event.notification.method === "thread/name/updated"),
     );
-    expect(emittedEvents.map((event) => event.notification.method)).toEqual([
+    const emittedMethods = emittedEvents.map((event) => event.notification.method);
+    expect(emittedMethods.filter((method) => method.startsWith("turn/"))).toEqual([
       "turn/started",
-      "thread/name/updated",
       "turn/completed",
       "turn/started",
       "turn/completed",
       "turn/cancelled",
     ]);
+    expect(emittedMethods).toContain("thread/name/updated");
 
     await registry.close();
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
@@ -11209,7 +11210,7 @@ command = "pnpm dev"
     const overlayStore = createOverlayStoreMock();
     const upsertSubAgentSpy = vi
       .spyOn(overlayStore, "upsertThreadSubAgent")
-      .mockRejectedValue(new Error("overlay write failed"));
+      .mockRejectedValueOnce(new Error("overlay write failed"));
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "thread/name/set"] },
       threads: [
@@ -11707,6 +11708,28 @@ command = "pnpm dev"
     expect(sessions[0]).toMatchObject({
       title: "Favorite cereal",
       titleSource: "derived",
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:acp:kimi:kimi-session-1",
+        task: "Name this thread",
+        status: "pending",
+        agentName: "PwrAgent",
+        lastMessage: "Waiting for the initial turn to complete.",
+      }),
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:acp:kimi:kimi-session-1",
+        task: "Name this thread",
+        status: "running",
+        agentName: "PwrAgent",
+        lastMessage: "Generating a title.",
+      }),
     });
     expect(upsertSubAgentSpy).toHaveBeenCalledWith({
       backend: acpBackendId,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -11,6 +11,7 @@ import {
 import type {
   AcpBackendId,
   AgentEvent,
+  AppServerBackendKind,
   AppServerNotification,
   AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
@@ -1602,6 +1603,31 @@ function createKimiAcpRegistry(options?: {
     sessions,
     startPrompt,
   };
+}
+
+async function emitCompletedTurn(
+  registry: DesktopBackendRegistry,
+  backend: AppServerBackendKind,
+  threadId: string,
+  turnId = "turn-1",
+): Promise<void> {
+  await (
+    registry as unknown as { emit(event: AgentEvent): Promise<void> }
+  ).emit({
+    backend,
+    notification: {
+      method: "turn/completed",
+      params: {
+        threadId,
+        turnId,
+        turn: {
+          id: turnId,
+          status: "completed",
+          output: [],
+        },
+      },
+    },
+  });
 }
 
 describe("DesktopBackendRegistry", () => {
@@ -4264,7 +4290,10 @@ script = "echo setup"
       },
     });
     await vi.waitFor(() => {
-      expect(sendControlPrompt).toHaveBeenCalledTimes(1);
+      expect(sendControlPrompt).toHaveBeenCalledWith({
+        sessionId: "kimi-session-1",
+        prompt: "/yolo",
+      });
       expect(sessions[0]?.executionMode).toBe("full-access");
     });
 
@@ -10923,6 +10952,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "codex",
+      threadId: "thread-title",
       userPrompt: "Make button",
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
@@ -11039,6 +11069,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "codex",
+      threadId: "thread-lifecycle-title",
       userPrompt: "Make button",
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
@@ -11361,6 +11392,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "codex",
+      threadId: "forked-thread-title",
       userPrompt: "Improve the sidebar followup",
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
@@ -11410,6 +11442,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "codex",
+      threadId: "thread-title",
       userPrompt: prompt,
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
@@ -11460,6 +11493,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "codex",
+      threadId: "thread-title",
       userPrompt: prompt,
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
@@ -11507,6 +11541,7 @@ command = "pnpm dev"
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: "grok",
+      threadId: "thread-title",
       userPrompt: "Issue 123 rename",
     });
     expect(grokClient.lastRenameThreadParams).toEqual({
@@ -11581,10 +11616,12 @@ command = "pnpm dev"
       threadId: "qwen-session-1",
       input: [{ type: "text", text: "Does this project build?" }],
     });
+    await emitCompletedTurn(registry, acpBackendId, "qwen-session-1");
     await waitForCondition(() => sessions[0]?.title === "Does this project build?");
 
     expect(titleService.generateTitle).toHaveBeenCalledWith({
       backend: acpBackendId,
+      threadId: "qwen-session-1",
       userPrompt: "Does this project build?",
     });
     expect(sessions[0]).toMatchObject({
@@ -11609,26 +11646,18 @@ command = "pnpm dev"
         createdAt: 1000,
         updatedAt: 1000,
         executionMode: "default",
+        acpRuntime: {
+          configValues: {
+            model: "kimi-k2-0711-preview",
+          },
+          updatedAt: 1000,
+        },
         status: "idle",
       },
     ];
-    const titleService = {
-      generateTitle: vi.fn(async () => ({
-        status: "generated" as const,
-        title: "Favorite cereal",
-        helperThreadId: "title-helper-thread",
-        helperTurnId: "title-helper-turn",
-        model: "gpt-5.4-mini",
-        reasoningEffort: "low",
-        serviceTier: "priority",
-        tokenUsage: {
-          inputTokens: 100,
-          cachedInputTokens: 20,
-          outputTokens: 10,
-          totalTokens: 110,
-        },
-      })),
-    };
+    const sendControlPrompt = vi.fn(async () => ({
+      text: '{ "title": "Favorite cereal" }',
+    }));
     const acpClient = {
       initialize: vi.fn(async () => undefined),
       dispose: vi.fn(),
@@ -11641,6 +11670,7 @@ command = "pnpm dev"
         sessionId: "kimi-session-1",
         turnId: "turn-1",
       })),
+      sendControlPrompt,
       readReplay: vi.fn((): AppServerThreadReplay => ({
         entries: [],
         messages: [],
@@ -11660,7 +11690,6 @@ command = "pnpm dev"
       acpAgentStore: createAcpAgentStoreMock([createKimiAgentRecord(acpBackendId)]),
       acpSessionStore: createAcpSessionStoreMock(sessions),
       createAcpClient: () => acpClient,
-      threadTitleGenerationService: titleService,
     });
 
     await registry.startTurn({
@@ -11668,11 +11697,12 @@ command = "pnpm dev"
       threadId: "kimi-session-1",
       input: [{ type: "text", text: prompt }],
     });
+    await emitCompletedTurn(registry, acpBackendId, "kimi-session-1");
     await waitForCondition(() => sessions[0]?.title === "Favorite cereal");
 
-    expect(titleService.generateTitle).toHaveBeenCalledWith({
-      backend: acpBackendId,
-      userPrompt: prompt,
+    expect(sendControlPrompt).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      prompt: expect.stringContaining(prompt),
     });
     expect(sessions[0]).toMatchObject({
       title: "Favorite cereal",
@@ -11686,10 +11716,7 @@ command = "pnpm dev"
         task: "Name this thread",
         status: "success",
         agentName: "PwrAgent",
-        preferredModel: "gpt-5.4-mini",
-        preferredReasoningEffort: "low",
-        monitorThreadId: "title-helper-thread",
-        monitorTurnId: "title-helper-turn",
+        preferredModel: "kimi-k2-0711-preview",
         lastMessage: "Generated title: Favorite cereal",
         outcome: "success",
       }),
@@ -11762,6 +11789,7 @@ command = "pnpm dev"
       threadId: "qwen-session-1",
       input: [{ type: "text", text: "what time is it?" }],
     });
+    await emitCompletedTurn(registry, acpBackendId, "qwen-session-1");
     await flushAsync();
     await flushAsync();
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6107,6 +6107,14 @@ describe("CodexAppServerClient", () => {
           serviceTier: "priority",
           config: {
             web_search: "disabled",
+            include_permissions_instructions: false,
+            include_apps_instructions: false,
+            include_collaboration_mode_instructions: false,
+            include_environment_context: false,
+            skills: {
+              include_instructions: false,
+              bundled: { enabled: false },
+            },
           },
         }),
       })

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -943,6 +943,26 @@ vi.mock("../codex-app-server/stdio-transport", () => {
   };
 });
 
+async function waitForLatestTransportRequest(
+  method: string,
+  timeoutMs = 1_000
+): Promise<MockTransport> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const transport = MockTransport.instances.at(-1);
+    if (
+      transport?.sentMessages.some((message) => {
+        const payload = JSON.parse(message) as { method?: string };
+        return payload.method === method;
+      })
+    ) {
+      return transport;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`Timed out waiting for ${method} request`);
+}
+
 describe("CodexAppServerClient", () => {
   beforeEach(() => {
     codexClientLogError.mockClear();
@@ -6025,9 +6045,7 @@ describe("CodexAppServerClient", () => {
       timeoutMs: 5_000,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const transport = MockTransport.instances.at(-1);
-    expect(transport).toBeDefined();
+    const transport = await waitForLatestTransportRequest("thread/start");
 
     transport!.emitInbound({
       jsonrpc: "2.0",
@@ -6098,10 +6116,13 @@ describe("CodexAppServerClient", () => {
     const requests = transport!.sentMessages.map(
       (message) => JSON.parse(message) as { method?: string; params?: Record<string, unknown> }
     );
+    const titleHelperWorkspace = path.join(os.tmpdir(), "pwragent", "codex-title-helper");
     expect(requests).toContainEqual(
       expect.objectContaining({
         method: "thread/start",
         params: expect.objectContaining({
+          cwd: titleHelperWorkspace,
+          runtimeWorkspaceRoots: [titleHelperWorkspace],
           ephemeral: true,
           model: "gpt-5.4-mini",
           serviceTier: "priority",
@@ -6180,9 +6201,7 @@ describe("CodexAppServerClient", () => {
       timeoutMs: 5_000,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const transport = MockTransport.instances.at(-1);
-    expect(transport).toBeDefined();
+    const transport = await waitForLatestTransportRequest("thread/start");
 
     transport!.emitInbound({
       jsonrpc: "2.0",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6044,6 +6044,21 @@ describe("CodexAppServerClient", () => {
 
     transport!.emitInbound({
       jsonrpc: "2.0",
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-title-helper",
+        turnId: "turn-title-helper",
+        tokenUsage: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 110,
+        },
+      },
+    });
+
+    transport!.emitInbound({
+      jsonrpc: "2.0",
       method: "turn/completed",
       params: {
         threadId: "thread-title-helper",
@@ -6065,6 +6080,17 @@ describe("CodexAppServerClient", () => {
       status: "ok",
       object: {
         title: "Add animated leopard tea button",
+      },
+      helperThreadId: "thread-title-helper",
+      helperTurnId: "turn-title-helper",
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: "priority",
+      tokenUsage: {
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 110,
       },
     });
     expect(forwardedNotifications).toEqual([]);
@@ -6184,6 +6210,11 @@ describe("CodexAppServerClient", () => {
       object: {
         title: "Animated jaguar tea button",
       },
+      helperThreadId: "thread-title-helper",
+      helperTurnId: "turn-title-helper",
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: "priority",
     });
 
     await client.close();
@@ -6245,6 +6276,11 @@ describe("CodexAppServerClient", () => {
       object: {
         title: "Early helper title",
       },
+      helperThreadId: "thread-title-helper",
+      helperTurnId: "turn-title-helper",
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: "priority",
     });
 
     await client.close();

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -57,6 +57,26 @@ describe("ThreadTitleGenerationService", () => {
     );
   });
 
+  it("uses the Codex title generator for ACP backends without their own generator", async () => {
+    const codexGenerator = makeGenerator({ title: "Favorite cereal" });
+    const service = new ThreadTitleGenerationService({
+      generators: { codex: codexGenerator },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "acp:kimi",
+        userPrompt:
+          "We're testing something here... just tell me your favorite cereal.",
+      })
+    ).resolves.toEqual({
+      status: "generated",
+      title: "Favorite cereal",
+      cachedTokens: 12,
+    });
+    expect(codexGenerator.generateTitle).toHaveBeenCalledOnce();
+  });
+
   it("preserves recognized issue and PR references", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -276,6 +276,7 @@ describe("GrokThreadTitleGenerator", () => {
       status: "ok",
       object: { title: "Thread naming" },
       cachedTokens: 8,
+      model: DEFAULT_GROK_THREAD_TITLE_MODEL,
     });
 
     expect(client.generateObject).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AppServerBackendKind } from "@pwragent/shared";
 import {
   DEFAULT_GROK_THREAD_TITLE_MODEL,
   GrokThreadTitleGenerator,
@@ -57,15 +58,21 @@ describe("ThreadTitleGenerationService", () => {
     );
   });
 
-  it("uses the Codex title generator for ACP backends without their own generator", async () => {
-    const codexGenerator = makeGenerator({ title: "Favorite cereal" });
+  it("uses a backend-specific resolver without falling back to Codex", async () => {
+    const acpGenerator = makeGenerator({ title: "Favorite cereal" });
+    const codexGenerator = makeGenerator({ title: "Wrong backend" });
+    const generatorResolver = vi.fn((backend: AppServerBackendKind) =>
+      backend === "acp:kimi" ? acpGenerator : undefined,
+    );
     const service = new ThreadTitleGenerationService({
       generators: { codex: codexGenerator },
+      generatorResolver,
     });
 
     await expect(
       service.generateTitle({
         backend: "acp:kimi",
+        threadId: "kimi-session-1",
         userPrompt:
           "We're testing something here... just tell me your favorite cereal.",
       })
@@ -74,7 +81,14 @@ describe("ThreadTitleGenerationService", () => {
       title: "Favorite cereal",
       cachedTokens: 12,
     });
-    expect(codexGenerator.generateTitle).toHaveBeenCalledOnce();
+    expect(generatorResolver).toHaveBeenCalledWith("acp:kimi");
+    expect(acpGenerator.generateTitle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "acp:kimi",
+        threadId: "kimi-session-1",
+      }),
+    );
+    expect(codexGenerator.generateTitle).not.toHaveBeenCalled();
   });
 
   it("preserves recognized issue and PR references", async () => {
@@ -286,6 +300,7 @@ describe("GrokThreadTitleGenerator", () => {
 
     await expect(
       generator.generateTitle({
+        backend: "grok",
         prompt: "Name this thread",
         promptVersion: THREAD_TITLE_PROMPT_VERSION,
         schema: { type: "object" },

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -102,6 +102,11 @@ type AcpSessionLoadState = {
   suppressTranscriptReplay: boolean;
 };
 
+type AcpSuppressedControlPrompt = {
+  fallbackOutputText?: string;
+  finalTextChunks: string[];
+};
+
 type AcpHydratedSessionHistory = {
   isComplete: boolean;
 };
@@ -152,7 +157,7 @@ export class AcpAgentClient {
   private readonly loadedSessionCwds = new Map<string, string | undefined>();
   private readonly suppressedControlPromptSessions = new Map<
     string,
-    { textChunks: string[] }
+    AcpSuppressedControlPrompt
   >();
   private readonly loadingSessions = new Map<string, AcpSessionLoadState>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
@@ -495,7 +500,7 @@ export class AcpAgentClient {
     prompt: string;
   }): Promise<{ text: string }> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
-    const suppression = { textChunks: [] };
+    const suppression: AcpSuppressedControlPrompt = { finalTextChunks: [] };
     this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
     try {
       await this.options.transport.request(
@@ -506,7 +511,12 @@ export class AcpAgentClient {
         },
         ACP_PROMPT_REQUEST_TIMEOUT_MS,
       );
-      return { text: suppression.textChunks.join("\n").trim() };
+      return {
+        text:
+          suppression.finalTextChunks.join("\n").trim() ||
+          suppression.fallbackOutputText?.trim() ||
+          "",
+      };
     } finally {
       this.suppressedControlPromptSessions.delete(protocolSessionId);
     }
@@ -619,9 +629,20 @@ export class AcpAgentClient {
     const suppressedControlPrompt =
       this.suppressedControlPromptSessions.get(protocolSessionId);
     if (suppressedControlPrompt) {
-      const text = readUpdateText(update);
-      if (text) {
-        suppressedControlPrompt.textChunks.push(text);
+      const updateKind = readUpdateKind(update);
+      if (updateKind === "agent_message_chunk") {
+        const text = readUpdateText(update);
+        if (text) {
+          suppressedControlPrompt.finalTextChunks.push(text);
+        }
+      } else if (
+        updateKind === "turn_finished" &&
+        suppressedControlPrompt.finalTextChunks.length === 0
+      ) {
+        const text = readUpdateText(update);
+        if (text) {
+          suppressedControlPrompt.fallbackOutputText = text;
+        }
       }
       return;
     }

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -513,7 +513,7 @@ export class AcpAgentClient {
       );
       return {
         text:
-          suppression.finalTextChunks.join("\n").trim() ||
+          suppression.finalTextChunks.join("").trim() ||
           suppression.fallbackOutputText?.trim() ||
           "",
       };

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -260,6 +260,7 @@ export class AcpAgentClient {
     title?: string;
     createdAt?: number;
     acpRuntime?: BackendAcpSessionRuntimeState;
+    hidden?: boolean;
   }): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
     const mcpServers = this.buildMcpServers({
@@ -305,6 +306,7 @@ export class AcpAgentClient {
       updatedAt: now,
       executionMode: params.executionMode,
       acpRuntime: combinedRuntimeState,
+      ...(params.hidden ? { hidden: true } : {}),
       status: "idle",
     };
     this.options.store.upsertSession(metadata);

--- a/apps/desktop/src/main/acp/acp-session-store.ts
+++ b/apps/desktop/src/main/acp/acp-session-store.ts
@@ -24,6 +24,7 @@ export type AcpSessionMetadata = {
   acpRuntime?: BackendAcpSessionRuntimeState;
   availableCommands?: AppServerAvailableCommandSummary[];
   status: "active" | "idle" | "failed" | "unknown";
+  hidden?: boolean;
   hasConversationHistory?: boolean;
   requiresAgentSessionRebind?: boolean;
   archivedAt?: number;
@@ -62,7 +63,7 @@ export class AcpSessionStore {
 
   listSessions(
     backendId: AcpBackendId,
-    params?: { archived?: boolean },
+    params?: { archived?: boolean; includeHidden?: boolean },
   ): AcpSessionMetadata[] {
     const rows = this.stateDb.raw
       .prepare(
@@ -75,6 +76,9 @@ export class AcpSessionStore {
     return rows.flatMap((row) => {
       const parsed = parseJson(row.payload);
       if (!isSessionMetadata(parsed)) {
+        return [];
+      }
+      if (parsed.hidden && params?.includeHidden !== true) {
         return [];
       }
       return Boolean(parsed.archivedAt) === archived

--- a/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
+++ b/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
@@ -11,6 +11,11 @@ import type {
 
 export type AcpThreadTitleGeneratorOptions = {
   backend: AcpBackendId;
+  configureHelperSession?: (params: {
+    client: AcpRuntimeClient;
+    parentSession?: AcpSessionMetadata;
+    session: AcpSessionMetadata;
+  }) => Promise<void>;
   getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
   getSession: (
     backend: AcpBackendId,
@@ -20,6 +25,11 @@ export type AcpThreadTitleGeneratorOptions = {
 
 export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
   private readonly backend: AcpBackendId;
+  private readonly configureHelperSession?: (params: {
+    client: AcpRuntimeClient;
+    parentSession?: AcpSessionMetadata;
+    session: AcpSessionMetadata;
+  }) => Promise<void>;
   private readonly getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
   private readonly getSession: (
     backend: AcpBackendId,
@@ -28,6 +38,7 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
 
   constructor(options: AcpThreadTitleGeneratorOptions) {
     this.backend = options.backend;
+    this.configureHelperSession = options.configureHelperSession;
     this.getClient = options.getClient;
     this.getSession = options.getSession;
   }
@@ -52,16 +63,30 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
     }
 
     try {
+      const parentSession = this.getSession(this.backend, threadId);
+      const helperSession = await client.startSession({
+        cwd: parentSession?.cwd,
+        executionMode: parentSession?.executionMode ?? "default",
+        title: "Name this thread",
+        acpRuntime: parentSession?.acpRuntime,
+        hidden: true,
+      });
+      await this.configureHelperSession?.({
+        client,
+        parentSession,
+        session: helperSession,
+      });
       const response = await client.sendControlPrompt({
-        sessionId: threadId,
+        sessionId: helperSession.sessionId,
         prompt: params.prompt,
       });
       const model = resolveAcpTitleModel(
-        this.getSession(this.backend, threadId)?.acpRuntime,
+        helperSession.acpRuntime ?? parentSession?.acpRuntime,
       );
       return {
         status: "ok",
         object: parseAcpTitleObject(response.text),
+        helperThreadId: helperSession.sessionId,
         ...(model ? { model } : {}),
       };
     } catch {

--- a/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
+++ b/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
@@ -1,0 +1,119 @@
+import type {
+  AcpBackendId,
+  BackendAcpSessionRuntimeState,
+} from "@pwragent/shared";
+import type { AcpRuntimeClient, AcpSessionMetadata } from "./acp-backend-adapter";
+import type {
+  ThreadTitleAdapterParams,
+  ThreadTitleAdapterResult,
+  ThreadTitleGenerator,
+} from "./thread-title-generation-service";
+
+export type AcpThreadTitleGeneratorOptions = {
+  backend: AcpBackendId;
+  getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
+  getSession: (
+    backend: AcpBackendId,
+    threadId: string,
+  ) => AcpSessionMetadata | undefined;
+};
+
+export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
+  private readonly backend: AcpBackendId;
+  private readonly getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
+  private readonly getSession: (
+    backend: AcpBackendId,
+    threadId: string,
+  ) => AcpSessionMetadata | undefined;
+
+  constructor(options: AcpThreadTitleGeneratorOptions) {
+    this.backend = options.backend;
+    this.getClient = options.getClient;
+    this.getSession = options.getSession;
+  }
+
+  async generateTitle(
+    params: ThreadTitleAdapterParams,
+  ): Promise<ThreadTitleAdapterResult> {
+    const threadId = params.threadId?.trim();
+    if (!threadId) {
+      return {
+        status: "unavailable",
+        reason: `${this.backend}_title_generator_thread_missing`,
+      };
+    }
+
+    const client = await this.getClient(this.backend);
+    if (!client.sendControlPrompt) {
+      return {
+        status: "unavailable",
+        reason: `${this.backend}_title_generator_unavailable`,
+      };
+    }
+
+    try {
+      const response = await client.sendControlPrompt({
+        sessionId: threadId,
+        prompt: params.prompt,
+      });
+      const model = resolveAcpTitleModel(
+        this.getSession(this.backend, threadId)?.acpRuntime,
+      );
+      return {
+        status: "ok",
+        object: parseAcpTitleObject(response.text),
+        ...(model ? { model } : {}),
+      };
+    } catch {
+      return {
+        status: "failed",
+        reason: `${this.backend}_title_generator_failed`,
+      };
+    }
+  }
+}
+
+function parseAcpTitleObject(text: string): unknown {
+  const trimmed = stripMarkdownFence(text.trim());
+  if (!trimmed) {
+    return {};
+  }
+
+  const parsed = tryParseJson(trimmed) ?? tryParseJson(extractJsonObject(trimmed));
+  if (parsed) {
+    return parsed;
+  }
+
+  return { title: trimmed };
+}
+
+function stripMarkdownFence(text: string): string {
+  const fence = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fence ? fence[1]?.trim() ?? "" : text;
+}
+
+function extractJsonObject(text: string): string {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end <= start) {
+    return "";
+  }
+  return text.slice(start, end + 1);
+}
+
+function tryParseJson(text: string): unknown | undefined {
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveAcpTitleModel(
+  runtime: BackendAcpSessionRuntimeState | undefined,
+): string | undefined {
+  return runtime?.currentModelId ?? runtime?.configValues?.model;
+}

--- a/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
+++ b/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
@@ -79,7 +79,12 @@ function parseAcpTitleObject(text: string): unknown {
     return {};
   }
 
-  const parsed = tryParseJson(trimmed) ?? tryParseJson(extractJsonObject(trimmed));
+  const jsonObject = extractJsonObject(trimmed);
+  const parsed =
+    tryParseJson(trimmed) ??
+    tryParseJson(escapeNewlinesInsideJsonStrings(trimmed)) ??
+    tryParseJson(jsonObject) ??
+    tryParseJson(escapeNewlinesInsideJsonStrings(jsonObject));
   if (parsed) {
     return parsed;
   }
@@ -110,6 +115,36 @@ function tryParseJson(text: string): unknown | undefined {
   } catch {
     return undefined;
   }
+}
+
+function escapeNewlinesInsideJsonStrings(text: string): string {
+  let escaped = "";
+  let inString = false;
+  let escapedPrevious = false;
+
+  for (const char of text) {
+    if (inString && (char === "\n" || char === "\r")) {
+      if (!escaped.endsWith(" ")) {
+        escaped += " ";
+      }
+      escapedPrevious = false;
+      continue;
+    }
+    escaped += char;
+    if (escapedPrevious) {
+      escapedPrevious = false;
+      continue;
+    }
+    if (char === "\\") {
+      escapedPrevious = true;
+      continue;
+    }
+    if (char === '"') {
+      inString = !inString;
+    }
+  }
+
+  return escaped;
 }
 
 function resolveAcpTitleModel(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7769,10 +7769,7 @@ export class DesktopBackendRegistry {
       if (reserveCodexStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
-      this.schedulePendingThreadTitleGenerationFromLifecycle({
-        backend: params.backend,
-        threadId: params.threadId,
-      });
+      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
       throw error;
     }
     this.activeCodexTurnModes.delete(
@@ -13789,7 +13786,7 @@ export class DesktopBackendRegistry {
           result?.reason ?? "title_generation_unavailable"
         );
         if (result?.status === "failed" || result?.status === "invalid") {
-          await this.persistTitleHelperSubAgent({
+          await this.safePersistTitleHelperSubAgent({
             backend: params.backend,
             threadId: params.threadId,
             status: "failed",
@@ -13839,7 +13836,7 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
         title: result.title,
       });
-      await this.persistTitleHelperSubAgent({
+      await this.safePersistTitleHelperSubAgent({
         backend: params.backend,
         threadId: params.threadId,
         result,
@@ -13850,7 +13847,7 @@ export class DesktopBackendRegistry {
       });
     } catch (error) {
       if (generatedResult) {
-        await this.persistTitleHelperSubAgent({
+        await this.safePersistTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
           result: generatedResult,
@@ -13868,6 +13865,26 @@ export class DesktopBackendRegistry {
       if (pending?.token === params.token) {
         this.pendingTitleGenerations.delete(params.key);
       }
+    }
+  }
+
+  private async safePersistTitleHelperSubAgent(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    status: "success" | "failed";
+    reason?: string;
+  }): Promise<void> {
+    try {
+      await this.persistTitleHelperSubAgent(params);
+    } catch (error) {
+      backendRegistryLog.warn("threadTitleHelperSubAgentPersistence", {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: params.status,
+        reason: params.reason ?? null,
+        persistenceError: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3750,6 +3750,13 @@ function buildTitleGenerationKey(
   return `${backend}:${threadId}`;
 }
 
+function titleHelperSubAgentId(
+  backend: AppServerBackendKind,
+  threadId: string,
+): string {
+  return `system:title-helper:${backend}:${threadId}`;
+}
+
 function buildPromptHash(prompt: string): string {
   return prompt.replace(/\s+/g, " ").trim().toLowerCase();
 }
@@ -4408,6 +4415,10 @@ export class DesktopBackendRegistry {
       promptHash: string;
       token: number;
     }
+  >();
+  private readonly pendingTitleGenerationInputs = new Map<
+    string,
+    AppServerTurnInputItem[]
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
@@ -7689,6 +7700,11 @@ export class DesktopBackendRegistry {
     }
 
     let result: { threadId: string; turnId: string };
+    const titleGenerationKey = buildTitleGenerationKey(
+      params.backend,
+      params.threadId,
+    );
+    this.pendingTitleGenerationInputs.set(titleGenerationKey, params.input);
     try {
       result =
         params.backend === "codex"
@@ -7753,6 +7769,10 @@ export class DesktopBackendRegistry {
       if (reserveCodexStart) {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
+      this.schedulePendingThreadTitleGenerationFromLifecycle({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
       throw error;
     }
     this.activeCodexTurnModes.delete(
@@ -7797,6 +7817,7 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       turnId: result.turnId,
     });
+    this.pendingTitleGenerationInputs.delete(titleGenerationKey);
     this.scheduleThreadTitleGeneration({
       backend: params.backend,
       threadId: result.threadId,
@@ -13677,6 +13698,7 @@ export class DesktopBackendRegistry {
     threadId: string;
     input: AppServerTurnInputItem[];
   }): void {
+    const key = buildTitleGenerationKey(params.backend, params.threadId);
     if (!this.threadTitleGenerationService) {
       return;
     }
@@ -13686,7 +13708,6 @@ export class DesktopBackendRegistry {
       return;
     }
 
-    const key = buildTitleGenerationKey(params.backend, params.threadId);
     if (this.attemptedTitleGenerations.has(key)) {
       return;
     }
@@ -13713,6 +13734,23 @@ export class DesktopBackendRegistry {
     });
   }
 
+  private schedulePendingThreadTitleGenerationFromLifecycle(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): void {
+    const key = buildTitleGenerationKey(params.backend, params.threadId);
+    const input = this.pendingTitleGenerationInputs.get(key);
+    if (!input) {
+      return;
+    }
+    this.pendingTitleGenerationInputs.delete(key);
+    this.scheduleThreadTitleGeneration({
+      backend: params.backend,
+      threadId: params.threadId,
+      input,
+    });
+  }
+
   private async generateAndApplyThreadTitle(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -13720,6 +13758,7 @@ export class DesktopBackendRegistry {
     key: string;
     token: number;
   }): Promise<void> {
+    let generatedResult: Extract<ThreadTitleGenerationResult, { status: "generated" }> | undefined;
     try {
       const currentThread = await this.findThreadForTitleGeneration({
         backend: params.backend,
@@ -13749,6 +13788,14 @@ export class DesktopBackendRegistry {
           params,
           result?.reason ?? "title_generation_unavailable"
         );
+        if (result?.status === "failed" || result?.status === "invalid") {
+          await this.persistTitleHelperSubAgent({
+            backend: params.backend,
+            threadId: params.threadId,
+            status: "failed",
+            reason: result.reason,
+          });
+        }
         if (isAcpBackendId(params.backend)) {
           await this.applyPromptDerivedAcpThreadTitle({
             backend: params.backend,
@@ -13758,6 +13805,7 @@ export class DesktopBackendRegistry {
         }
         return;
       }
+      generatedResult = result;
       this.logThreadTitleGeneration("generated", params, undefined, {
         generatedTitle: truncateLogValue(result.title),
         cachedTokens: result.cachedTokens ?? null,
@@ -13791,10 +13839,25 @@ export class DesktopBackendRegistry {
         threadId: params.threadId,
         title: result.title,
       });
+      await this.persistTitleHelperSubAgent({
+        backend: params.backend,
+        threadId: params.threadId,
+        result,
+        status: "success",
+      });
       this.logThreadTitleGeneration("applied", params, undefined, {
         generatedTitle: truncateLogValue(result.title),
       });
     } catch (error) {
+      if (generatedResult) {
+        await this.persistTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          result: generatedResult,
+          status: "failed",
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
       this.logThreadTitleGeneration(
         "failed",
         params,
@@ -13831,6 +13894,96 @@ export class DesktopBackendRegistry {
     this.logThreadTitleGeneration("applied", params, "prompt_derived_fallback", {
       generatedTitle: truncateLogValue(title),
     });
+  }
+
+  private async persistTitleHelperSubAgent(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    status: "success" | "failed";
+    reason?: string;
+  }): Promise<void> {
+    const now = Date.now();
+    const monitorId = titleHelperSubAgentId(params.backend, params.threadId);
+    const usageSnapshot = params.result?.tokenUsage
+      ? buildTaskMonitorUsageSnapshot({
+          model: params.result.model,
+          serviceTier: params.result.serviceTier,
+          tokenUsage: params.result.tokenUsage,
+        })
+      : undefined;
+    const subAgent: ThreadSubAgentSummary = {
+      monitorId,
+      task: "Name this thread",
+      status: params.status,
+      createdAt: now,
+      updatedAt: now,
+      agentName: "PwrAgent",
+      ...(params.result?.model ? { preferredModel: params.result.model } : {}),
+      ...(params.result?.reasoningEffort
+        ? { preferredReasoningEffort: params.result.reasoningEffort }
+        : {}),
+      ...(params.result?.helperThreadId
+        ? { monitorThreadId: params.result.helperThreadId }
+        : {}),
+      ...(params.result?.helperTurnId ? { monitorTurnId: params.result.helperTurnId } : {}),
+      lastMessage:
+        params.status === "success"
+          ? params.result?.title
+            ? `Generated title: ${params.result.title}`
+            : "Generated a title."
+          : params.reason
+            ? `Title generation failed: ${params.reason}`
+            : "Title generation failed.",
+      outcome: params.status === "success" ? "success" : "failure",
+      completedAt: now,
+      completionSource: {
+        type: "pwragent_fallback",
+        reason: "system_title_helper",
+        recoveryAttempted: false,
+        terminalStatus: params.status === "success" ? "completed" : "failed",
+      },
+      ...(usageSnapshot ? { monitorUsage: usageSnapshot } : {}),
+    };
+
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: params.backend,
+      threadId: params.threadId,
+      subAgent,
+    });
+    this.invalidateThreadListCache(params.backend);
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.threadId,
+        },
+      },
+    });
+    if (
+      usageSnapshot &&
+      params.result?.helperThreadId &&
+      typeof this.overlayStore.upsertThreadUsageLine === "function"
+    ) {
+      const line = buildTaskMonitorUsageLine({
+        backend: params.backend,
+        model: params.result.model,
+        monitorId,
+        monitorThreadId: params.result.helperThreadId,
+        monitorTurnId: params.result.helperTurnId,
+        parentThreadId: params.threadId,
+        serviceTier: params.result.serviceTier,
+        source: "monitor",
+        usage: usageSnapshot,
+      });
+      logUnpricedThreadUsageLine(line);
+      await this.overlayStore.upsertThreadUsageLine({ line });
+      await this.emitThreadPricingUpdated({
+        backend: params.backend,
+        threadId: line.parentThreadId ?? line.threadId,
+      });
+    }
   }
 
   private async applyGeneratedThreadTitle(params: {
@@ -13873,13 +14026,18 @@ export class DesktopBackendRegistry {
     reason?: string,
     details?: Record<string, unknown>,
   ): void {
-    logDebug("threadTitleGeneration", {
+    const payload = {
       backend: params.backend,
       threadId: params.threadId,
       status,
       reason: reason ?? null,
       ...details,
-    });
+    };
+    if (status === "failed" || status === "invalid" || status === "unavailable") {
+      backendRegistryLog.warn("threadTitleGeneration", payload);
+      return;
+    }
+    logDebug("threadTitleGeneration", payload);
   }
 
   private async handleServerRequest(
@@ -17487,6 +17645,17 @@ export class DesktopBackendRegistry {
 
     if (
       event.backend === "codex" &&
+      event.notification.method === "thread/status/changed" &&
+      readStatusType(event.notification.params.status) === "active"
+    ) {
+      this.schedulePendingThreadTitleGenerationFromLifecycle({
+        backend: event.backend,
+        threadId: event.notification.params.threadId,
+      });
+    }
+
+    if (
+      event.backend === "codex" &&
       event.notification.method === "configWarning"
     ) {
       this.latestCodexConfigWarning = event;
@@ -17503,6 +17672,10 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromStartedNotification(notification);
+      this.schedulePendingThreadTitleGenerationFromLifecycle({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+      });
       this.activeTurnKeys.add(
         buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
       );

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3758,6 +3758,32 @@ function titleHelperSubAgentId(
   return `system:title-helper:${backend}:${threadId}`;
 }
 
+function titleHelperSubAgentMessage(params: {
+  result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+  status: "pending" | "running" | "success" | "failed" | "cancelled";
+  reason?: string;
+}): string {
+  if (params.status === "pending") {
+    return params.reason ?? "Title generation is queued.";
+  }
+  if (params.status === "running") {
+    return params.reason ?? "Generating a title.";
+  }
+  if (params.status === "success") {
+    return params.result?.title
+      ? `Generated title: ${params.result.title}`
+      : "Generated a title.";
+  }
+  if (params.status === "cancelled") {
+    return params.reason
+      ? `Title generation cancelled: ${params.reason}`
+      : "Title generation cancelled.";
+  }
+  return params.reason
+    ? `Title generation failed: ${params.reason}`
+    : "Title generation failed.";
+}
+
 function buildPromptHash(prompt: string): string {
   return prompt.replace(/\s+/g, " ").trim().toLowerCase();
 }
@@ -7630,6 +7656,17 @@ export class DesktopBackendRegistry {
           params.threadId,
         );
         this.pendingTitleGenerationInputs.set(titleGenerationKey, params.input);
+        if (
+          this.threadTitleGenerationService &&
+          extractFirstMeaningfulTextInput(params.input)
+        ) {
+          await this.safePersistTitleHelperSubAgent({
+            backend: params.backend,
+            threadId: params.threadId,
+            status: "pending",
+            reason: "Waiting for the initial turn to complete.",
+          });
+        }
         try {
           return await this.startAcpTurn({
             backend: params.backend,
@@ -7638,6 +7675,12 @@ export class DesktopBackendRegistry {
           });
         } catch (error) {
           this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+          await this.safePersistExistingTitleHelperSubAgent({
+            backend: params.backend,
+            threadId: params.threadId,
+            status: "failed",
+            reason: error instanceof Error ? error.message : String(error),
+          });
           throw error;
         }
       } finally {
@@ -13786,9 +13829,21 @@ export class DesktopBackendRegistry {
           "current_title_not_eligible",
           buildTitleEligibilityLogDetails(currentThread, params.prompt)
         );
+        await this.safePersistExistingTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "cancelled",
+          reason: "Current title is no longer eligible.",
+        });
         return;
       }
 
+      await this.safePersistExistingTitleHelperSubAgent({
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "running",
+        reason: "Generating a title.",
+      });
       this.logThreadTitleGeneration("requesting", params, undefined, {
         promptTitle: truncateLogValue(shortenDerivedThreadTitle(params.prompt) ?? params.prompt),
       });
@@ -13803,14 +13858,12 @@ export class DesktopBackendRegistry {
           params,
           result?.reason ?? "title_generation_unavailable"
         );
-        if (result?.status === "failed" || result?.status === "invalid") {
-          await this.safePersistTitleHelperSubAgent({
-            backend: params.backend,
-            threadId: params.threadId,
-            status: "failed",
-            reason: result.reason,
-          });
-        }
+        await this.safePersistExistingTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "failed",
+          reason: result?.reason ?? "title_generation_unavailable",
+        });
         if (isAcpBackendId(params.backend)) {
           await this.applyPromptDerivedAcpThreadTitle({
             backend: params.backend,
@@ -13831,6 +13884,12 @@ export class DesktopBackendRegistry {
         this.logThreadTitleGeneration("skipped", params, "stale_generation", {
           generatedTitle: truncateLogValue(result.title),
         });
+        await this.safePersistExistingTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "cancelled",
+          reason: "Title generation became stale.",
+        });
         return;
       }
 
@@ -13846,6 +13905,12 @@ export class DesktopBackendRegistry {
           "latest_title_not_eligible",
           buildTitleEligibilityLogDetails(latestThread, params.prompt)
         );
+        await this.safePersistExistingTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "cancelled",
+          reason: "Latest title is no longer eligible.",
+        });
         return;
       }
 
@@ -13890,7 +13955,7 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind;
     threadId: string;
     result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
-    status: "success" | "failed";
+    status: "pending" | "running" | "success" | "failed" | "cancelled";
     reason?: string;
   }): Promise<void> {
     try {
@@ -13904,6 +13969,35 @@ export class DesktopBackendRegistry {
         persistenceError: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  private async safePersistExistingTitleHelperSubAgent(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    status: "running" | "success" | "failed" | "cancelled";
+    reason?: string;
+  }): Promise<void> {
+    try {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      const monitorId = titleHelperSubAgentId(params.backend, params.threadId);
+      if (!overlay?.subAgents?.some((subAgent) => subAgent.monitorId === monitorId)) {
+        return;
+      }
+    } catch (error) {
+      backendRegistryLog.warn("threadTitleHelperSubAgentLookup", {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: params.status,
+        reason: params.reason ?? null,
+        lookupError: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    await this.safePersistTitleHelperSubAgent(params);
   }
 
   private async applyPromptDerivedAcpThreadTitle(params: {
@@ -13935,11 +14029,18 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind;
     threadId: string;
     result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
-    status: "success" | "failed";
+    status: "pending" | "running" | "success" | "failed" | "cancelled";
     reason?: string;
   }): Promise<void> {
     const now = Date.now();
     const monitorId = titleHelperSubAgentId(params.backend, params.threadId);
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const existing = overlay?.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorId,
+    );
     const usageSnapshot = params.result?.tokenUsage
       ? buildTaskMonitorUsageSnapshot({
           model: params.result.model,
@@ -13947,11 +14048,23 @@ export class DesktopBackendRegistry {
           tokenUsage: params.result.tokenUsage,
         })
       : undefined;
+    const terminal =
+      params.status === "success" ||
+      params.status === "failed" ||
+      params.status === "cancelled";
+    const outcome =
+      params.status === "success"
+        ? "success"
+        : params.status === "failed"
+          ? "failure"
+          : params.status === "cancelled"
+            ? "cancelled"
+            : undefined;
     const subAgent: ThreadSubAgentSummary = {
       monitorId,
       task: "Name this thread",
       status: params.status,
-      createdAt: now,
+      createdAt: existing?.createdAt ?? now,
       updatedAt: now,
       agentName: "PwrAgent",
       ...(params.result?.model ? { preferredModel: params.result.model } : {}),
@@ -13962,22 +14075,24 @@ export class DesktopBackendRegistry {
         ? { monitorThreadId: params.result.helperThreadId }
         : {}),
       ...(params.result?.helperTurnId ? { monitorTurnId: params.result.helperTurnId } : {}),
-      lastMessage:
-        params.status === "success"
-          ? params.result?.title
-            ? `Generated title: ${params.result.title}`
-            : "Generated a title."
-          : params.reason
-            ? `Title generation failed: ${params.reason}`
-            : "Title generation failed.",
-      outcome: params.status === "success" ? "success" : "failure",
-      completedAt: now,
-      completionSource: {
-        type: "pwragent_fallback",
-        reason: "system_title_helper",
-        recoveryAttempted: false,
-        terminalStatus: params.status === "success" ? "completed" : "failed",
-      },
+      lastMessage: titleHelperSubAgentMessage(params),
+      ...(outcome ? { outcome } : {}),
+      ...(terminal ? { completedAt: now } : {}),
+      ...(terminal
+        ? {
+            completionSource: {
+              type: "pwragent_fallback",
+              reason: "system_title_helper",
+              recoveryAttempted: false,
+              terminalStatus:
+                params.status === "success"
+                  ? "completed"
+                  : params.status === "cancelled"
+                    ? "cancelled"
+                    : "failed",
+            },
+          }
+        : {}),
       ...(usageSnapshot ? { monitorUsage: usageSnapshot } : {}),
     };
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4796,6 +4796,17 @@ export class DesktopBackendRegistry {
                   isAcpBackendId(backend)
                     ? new AcpThreadTitleGenerator({
                         backend,
+                        configureHelperSession: async ({
+                          client,
+                          parentSession,
+                          session,
+                        }) => {
+                          await this.applyAcpRuntimeSelection(
+                            client,
+                            session.sessionId,
+                            session.acpRuntime ?? parentSession?.acpRuntime,
+                          );
+                        },
                         getClient: (acpBackend) =>
                           this.acpBackend.getClient(acpBackend),
                         getSession: (acpBackend, threadId) =>
@@ -7651,38 +7662,17 @@ export class DesktopBackendRegistry {
           params.backend,
           params.threadId,
         );
-        const titleGenerationKey = buildTitleGenerationKey(
-          params.backend,
-          params.threadId,
-        );
-        this.pendingTitleGenerationInputs.set(titleGenerationKey, params.input);
-        if (
-          this.threadTitleGenerationService &&
-          extractFirstMeaningfulTextInput(params.input)
-        ) {
-          await this.safePersistTitleHelperSubAgent({
-            backend: params.backend,
-            threadId: params.threadId,
-            status: "pending",
-            reason: "Waiting for the initial turn to complete.",
-          });
-        }
-        try {
-          return await this.startAcpTurn({
-            backend: params.backend,
-            threadId: params.threadId,
-            input: params.input,
-          });
-        } catch (error) {
-          this.pendingTitleGenerationInputs.delete(titleGenerationKey);
-          await this.safePersistExistingTitleHelperSubAgent({
-            backend: params.backend,
-            threadId: params.threadId,
-            status: "failed",
-            reason: error instanceof Error ? error.message : String(error),
-          });
-          throw error;
-        }
+        const result = await this.startAcpTurn({
+          backend: params.backend,
+          threadId: params.threadId,
+          input: params.input,
+        });
+        this.scheduleThreadTitleGeneration({
+          backend: params.backend,
+          threadId: result.threadId,
+          input: params.input,
+        });
+        return result;
       } finally {
         this.reservedAcpStartThreadKeys.delete(reservationKey);
       }
@@ -13838,12 +13828,14 @@ export class DesktopBackendRegistry {
         return;
       }
 
-      await this.safePersistExistingTitleHelperSubAgent({
-        backend: params.backend,
-        threadId: params.threadId,
-        status: "running",
-        reason: "Generating a title.",
-      });
+      if (isAcpBackendId(params.backend)) {
+        await this.safePersistTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "running",
+          reason: "Generating a title.",
+        });
+      }
       this.logThreadTitleGeneration("requesting", params, undefined, {
         promptTitle: truncateLogValue(shortenDerivedThreadTitle(params.prompt) ?? params.prompt),
       });
@@ -17956,12 +17948,7 @@ export class DesktopBackendRegistry {
           event.backend,
           notification.params.threadId,
         );
-        if (event.notification.method === "turn/completed") {
-          this.schedulePendingThreadTitleGenerationFromLifecycle({
-            backend: event.backend,
-            threadId: notification.params.threadId,
-          });
-        } else {
+        if (event.notification.method !== "turn/completed") {
           this.pendingTitleGenerationInputs.delete(
             buildTitleGenerationKey(event.backend, notification.params.threadId),
           );

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12461,6 +12461,7 @@ export class DesktopBackendRegistry {
       status,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
+      backend: "codex",
       monitorThreadId: params.receiverThreadId,
       ...(params.call.parentTurnId
         ? { monitorTurnId: params.call.parentTurnId }
@@ -12726,6 +12727,7 @@ export class DesktopBackendRegistry {
         (record.monitorThreadId ? "running" : "pending"),
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      backend: record.backend,
       preferredModel: record.preferredModel,
       preferredReasoningEffort: record.preferredReasoningEffort,
       ...(record.monitorThreadId ? { monitorThreadId: record.monitorThreadId } : {}),
@@ -12797,6 +12799,7 @@ export class DesktopBackendRegistry {
       status: patch.status ?? existing?.status ?? "running",
       createdAt: record.createdAt,
       updatedAt: patch.updatedAt ?? Date.now(),
+      backend: record.backend,
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
       ...(patch.lastMessage ?? existing?.lastMessage
@@ -13829,10 +13832,15 @@ export class DesktopBackendRegistry {
       }
 
       if (isAcpBackendId(params.backend)) {
+        const titleHelperRuntime = this.resolveTitleHelperRuntime(params);
         await this.safePersistTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
           status: "running",
+          ...(titleHelperRuntime.model ? { model: titleHelperRuntime.model } : {}),
+          ...(titleHelperRuntime.reasoningEffort
+            ? { reasoningEffort: titleHelperRuntime.reasoningEffort }
+            : {}),
           reason: "Generating a title.",
         });
       }
@@ -13948,6 +13956,8 @@ export class DesktopBackendRegistry {
     threadId: string;
     result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
     status: "pending" | "running" | "success" | "failed" | "cancelled";
+    model?: string;
+    reasoningEffort?: string;
     reason?: string;
   }): Promise<void> {
     try {
@@ -13968,6 +13978,8 @@ export class DesktopBackendRegistry {
     threadId: string;
     result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
     status: "running" | "success" | "failed" | "cancelled";
+    model?: string;
+    reasoningEffort?: string;
     reason?: string;
   }): Promise<void> {
     try {
@@ -14022,6 +14034,8 @@ export class DesktopBackendRegistry {
     threadId: string;
     result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
     status: "pending" | "running" | "success" | "failed" | "cancelled";
+    model?: string;
+    reasoningEffort?: string;
     reason?: string;
   }): Promise<void> {
     const now = Date.now();
@@ -14040,6 +14054,12 @@ export class DesktopBackendRegistry {
           tokenUsage: params.result.tokenUsage,
         })
       : undefined;
+    const preferredModel =
+      params.result?.model ?? params.model ?? existing?.preferredModel;
+    const preferredReasoningEffort =
+      params.result?.reasoningEffort ??
+      params.reasoningEffort ??
+      existing?.preferredReasoningEffort;
     const terminal =
       params.status === "success" ||
       params.status === "failed" ||
@@ -14058,10 +14078,11 @@ export class DesktopBackendRegistry {
       status: params.status,
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
+      backend: params.backend,
       agentName: "PwrAgent",
-      ...(params.result?.model ? { preferredModel: params.result.model } : {}),
-      ...(params.result?.reasoningEffort
-        ? { preferredReasoningEffort: params.result.reasoningEffort }
+      ...(preferredModel ? { preferredModel } : {}),
+      ...(preferredReasoningEffort
+        ? { preferredReasoningEffort }
         : {}),
       ...(params.result?.helperThreadId
         ? { monitorThreadId: params.result.helperThreadId }
@@ -14126,6 +14147,31 @@ export class DesktopBackendRegistry {
         threadId: line.parentThreadId ?? line.threadId,
       });
     }
+  }
+
+  private resolveTitleHelperRuntime(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): { model?: string; reasoningEffort?: string } {
+    if (!isAcpBackendId(params.backend)) {
+      return {};
+    }
+    const session = this.acpBackend.getSession(params.backend, params.threadId);
+    const model =
+      session?.acpRuntime?.currentModelId ??
+      (typeof session?.acpRuntime?.configValues?.model === "string"
+        ? session.acpRuntime.configValues.model
+        : undefined);
+    const reasoningEffort =
+      typeof session?.acpRuntime?.configValues?.reasoningEffort === "string"
+        ? session.acpRuntime.configValues.reasoningEffort
+        : typeof session?.acpRuntime?.configValues?.reasoning_effort === "string"
+          ? session.acpRuntime.configValues.reasoning_effort
+          : undefined;
+    return {
+      ...(model ? { model } : {}),
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+    };
   }
 
   private async applyGeneratedThreadTitle(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -208,7 +208,10 @@ import {
   type AcpSessionStoreLike,
   type LocalAcpDiscovery,
 } from "./acp-backend-adapter";
-import { CodexAppServerClient } from "../codex-app-server/client";
+import {
+  CodexAppServerClient,
+  DEFAULT_CODEX_THREAD_TITLE_MODEL,
+} from "../codex-app-server/client";
 import { ProviderTranscriptThreadSearchAdapter } from "../thread-search/thread-search-provider-adapters";
 import { ThreadSearchService } from "../thread-search/thread-search-service";
 import { ThreadSearchStore } from "../thread-search/thread-search-store";
@@ -988,7 +991,9 @@ type PendingServerRequest = {
   reject: (error: Error) => void;
 };
 
-type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle">;
+type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle"> & {
+  canGenerateTitle?: (backend: AppServerBackendKind) => boolean;
+};
 
 type ThreadTitleGenerationLogStatus =
   | ThreadTitleGenerationResult["status"]
@@ -13752,6 +13757,12 @@ export class DesktopBackendRegistry {
     if (!this.threadTitleGenerationService) {
       return;
     }
+    if (
+      this.threadTitleGenerationService.canGenerateTitle &&
+      !this.threadTitleGenerationService.canGenerateTitle(params.backend)
+    ) {
+      return;
+    }
 
     const prompt = extractFirstMeaningfulTextInput(params.input);
     if (!prompt) {
@@ -13831,7 +13842,7 @@ export class DesktopBackendRegistry {
         return;
       }
 
-      if (isAcpBackendId(params.backend)) {
+      if (params.backend === "codex" || isAcpBackendId(params.backend)) {
         const titleHelperRuntime = this.resolveTitleHelperRuntime(params);
         await this.safePersistTitleHelperSubAgent({
           backend: params.backend,
@@ -14153,6 +14164,12 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind;
     threadId: string;
   }): { model?: string; reasoningEffort?: string } {
+    if (params.backend === "codex") {
+      return {
+        model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+        reasoningEffort: "low",
+      };
+    }
     if (!isAcpBackendId(params.backend)) {
       return {};
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13940,19 +13940,27 @@ export class DesktopBackendRegistry {
         generatedTitle: truncateLogValue(result.title),
       });
     } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
       if (generatedResult) {
         await this.safePersistTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
           result: generatedResult,
           status: "failed",
-          reason: error instanceof Error ? error.message : String(error),
+          reason,
+        });
+      } else {
+        await this.safePersistExistingTitleHelperSubAgent({
+          backend: params.backend,
+          threadId: params.threadId,
+          status: "failed",
+          reason,
         });
       }
       this.logThreadTitleGeneration(
         "failed",
         params,
-        error instanceof Error ? error.message : String(error)
+        reason
       );
     } finally {
       const pending = this.pendingTitleGenerations.get(params.key);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -292,6 +292,7 @@ import {
   type ThreadTitleGenerator,
   type ThreadTitleGenerationResult,
 } from "./thread-title-generation-service";
+import { AcpThreadTitleGenerator } from "./acp-thread-title-generator";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getDesktopNotificationService } from "../notifications/desktop-notification-service";
@@ -4765,6 +4766,16 @@ export class DesktopBackendRegistry {
                       })
                     : undefined,
                 },
+                generatorResolver: (backend) =>
+                  isAcpBackendId(backend)
+                    ? new AcpThreadTitleGenerator({
+                        backend,
+                        getClient: (acpBackend) =>
+                          this.acpBackend.getClient(acpBackend),
+                        getSession: (acpBackend, threadId) =>
+                          this.acpBackend.getSession(acpBackend, threadId),
+                      })
+                    : undefined,
               }));
     this.threadInspectionSearchService =
       options && "threadSearchService" in options
@@ -7614,17 +7625,21 @@ export class DesktopBackendRegistry {
           params.backend,
           params.threadId,
         );
-        const result = await this.startAcpTurn({
-          backend: params.backend,
-          threadId: params.threadId,
-          input: params.input,
-        });
-        this.scheduleThreadTitleGeneration({
-          backend: params.backend,
-          threadId: result.threadId,
-          input: params.input,
-        });
-        return result;
+        const titleGenerationKey = buildTitleGenerationKey(
+          params.backend,
+          params.threadId,
+        );
+        this.pendingTitleGenerationInputs.set(titleGenerationKey, params.input);
+        try {
+          return await this.startAcpTurn({
+            backend: params.backend,
+            threadId: params.threadId,
+            input: params.input,
+          });
+        } catch (error) {
+          this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+          throw error;
+        }
       } finally {
         this.reservedAcpStartThreadKeys.delete(reservationKey);
       }
@@ -7814,12 +7829,14 @@ export class DesktopBackendRegistry {
       threadId: result.threadId,
       turnId: result.turnId,
     });
-    this.pendingTitleGenerationInputs.delete(titleGenerationKey);
-    this.scheduleThreadTitleGeneration({
-      backend: params.backend,
-      threadId: result.threadId,
-      input: params.input,
-    });
+    if (!isAcpBackendId(params.backend)) {
+      this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      this.scheduleThreadTitleGeneration({
+        backend: params.backend,
+        threadId: result.threadId,
+        input: params.input,
+      });
+    }
 
     return response;
   }
@@ -13777,6 +13794,7 @@ export class DesktopBackendRegistry {
       });
       const result = await this.threadTitleGenerationService?.generateTitle({
         backend: params.backend,
+        threadId: params.threadId,
         userPrompt: params.prompt,
       });
       if (!result || result.status !== "generated") {
@@ -17689,10 +17707,12 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromStartedNotification(notification);
-      this.schedulePendingThreadTitleGenerationFromLifecycle({
-        backend: event.backend,
-        threadId: notification.params.threadId,
-      });
+      if (!isAcpBackendId(event.backend)) {
+        this.schedulePendingThreadTitleGenerationFromLifecycle({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+        });
+      }
       this.activeTurnKeys.add(
         buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
       );
@@ -17821,6 +17841,16 @@ export class DesktopBackendRegistry {
           event.backend,
           notification.params.threadId,
         );
+        if (event.notification.method === "turn/completed") {
+          this.schedulePendingThreadTitleGenerationFromLifecycle({
+            backend: event.backend,
+            threadId: notification.params.threadId,
+          });
+        } else {
+          this.pendingTitleGenerationInputs.delete(
+            buildTitleGenerationKey(event.backend, notification.params.threadId),
+          );
+        }
       }
       void this.threadTurnQueue.releaseThread({
         backend: event.backend,

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -1,4 +1,4 @@
-import type { AppServerBackendKind } from "@pwragent/shared";
+import { isAcpBackendId, type AppServerBackendKind } from "@pwragent/shared";
 import {
   XaiEphemeralObjectCaller,
   type XaiObjectClientLike,
@@ -109,7 +109,9 @@ export class ThreadTitleGenerationService {
       };
     }
 
-    const generator = this.generators[params.backend];
+    const generator =
+      this.generators[params.backend] ??
+      (isAcpBackendId(params.backend) ? this.generators.codex : undefined);
     if (!generator) {
       return {
         status: "unavailable",

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -1,4 +1,4 @@
-import { isAcpBackendId, type AppServerBackendKind } from "@pwragent/shared";
+import type { AppServerBackendKind } from "@pwragent/shared";
 import {
   XaiEphemeralObjectCaller,
   type XaiObjectClientLike,
@@ -26,10 +26,12 @@ const THREAD_TITLE_RESPONSE_SCHEMA = {
 } as const;
 
 export type ThreadTitleAdapterParams = {
+  backend?: AppServerBackendKind;
   prompt: string;
   promptVersion: string;
   schema: Record<string, unknown>;
   schemaName: string;
+  threadId?: string;
   timeoutMs: number;
 };
 
@@ -73,6 +75,7 @@ export type ThreadTitleGenerationResult =
 
 export type ThreadTitleGenerationServiceOptions = {
   generators?: Partial<Record<AppServerBackendKind, ThreadTitleGenerator>>;
+  generatorResolver?: (backend: AppServerBackendKind) => ThreadTitleGenerator | undefined;
   timeoutMs?: number;
 };
 
@@ -87,6 +90,7 @@ export type GrokThreadTitleGeneratorOptions = {
 
 export class ThreadTitleGenerationService {
   private readonly generators: Partial<Record<AppServerBackendKind, ThreadTitleGenerator>>;
+  private readonly generatorResolver?: (backend: AppServerBackendKind) => ThreadTitleGenerator | undefined;
   private readonly timeoutMs: number;
 
   constructor(options: ThreadTitleGenerationServiceOptions = {}) {
@@ -94,11 +98,13 @@ export class ThreadTitleGenerationService {
       grok: new GrokThreadTitleGenerator({ timeoutMs: options.timeoutMs }),
       ...options.generators,
     };
+    this.generatorResolver = options.generatorResolver;
     this.timeoutMs = options.timeoutMs ?? THREAD_TITLE_TIMEOUT_MS;
   }
 
   async generateTitle(params: {
     backend: AppServerBackendKind;
+    threadId?: string;
     userPrompt: string;
   }): Promise<ThreadTitleGenerationResult> {
     const userPrompt = params.userPrompt.trim();
@@ -110,8 +116,7 @@ export class ThreadTitleGenerationService {
     }
 
     const generator =
-      this.generators[params.backend] ??
-      (isAcpBackendId(params.backend) ? this.generators.codex : undefined);
+      this.generators[params.backend] ?? this.generatorResolver?.(params.backend);
     if (!generator) {
       return {
         status: "unavailable",
@@ -120,10 +125,12 @@ export class ThreadTitleGenerationService {
     }
 
     const result = await generator.generateTitle({
+      backend: params.backend,
       prompt: buildThreadTitlePrompt(userPrompt),
       promptVersion: THREAD_TITLE_PROMPT_VERSION,
       schema: THREAD_TITLE_RESPONSE_SCHEMA,
       schemaName: "thread_title",
+      threadId: params.threadId,
       timeoutMs: this.timeoutMs,
     });
     if (result.status !== "ok") {

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -102,6 +102,12 @@ export class ThreadTitleGenerationService {
     this.timeoutMs = options.timeoutMs ?? THREAD_TITLE_TIMEOUT_MS;
   }
 
+  canGenerateTitle(backend: AppServerBackendKind): boolean {
+    return Boolean(
+      this.generators[backend] ?? this.generatorResolver?.(backend),
+    );
+  }
+
   async generateTitle(params: {
     backend: AppServerBackendKind;
     threadId?: string;

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -38,6 +38,12 @@ export type ThreadTitleAdapterResult =
       status: "ok";
       object: unknown;
       cachedTokens?: number;
+      helperThreadId?: string;
+      helperTurnId?: string;
+      model?: string;
+      reasoningEffort?: string;
+      serviceTier?: string;
+      tokenUsage?: unknown;
     }
   | {
       status: "unavailable" | "failed";
@@ -53,6 +59,12 @@ export type ThreadTitleGenerationResult =
       status: "generated";
       title: string;
       cachedTokens?: number;
+      helperThreadId?: string;
+      helperTurnId?: string;
+      model?: string;
+      reasoningEffort?: string;
+      serviceTier?: string;
+      tokenUsage?: unknown;
     }
   | {
       status: "unavailable" | "invalid" | "failed";
@@ -127,7 +139,13 @@ export class ThreadTitleGenerationService {
     return {
       status: "generated",
       title: normalized.title,
-      cachedTokens: result.cachedTokens,
+      ...(result.cachedTokens !== undefined ? { cachedTokens: result.cachedTokens } : {}),
+      ...(result.helperThreadId ? { helperThreadId: result.helperThreadId } : {}),
+      ...(result.helperTurnId ? { helperTurnId: result.helperTurnId } : {}),
+      ...(result.model ? { model: result.model } : {}),
+      ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
+      ...(result.serviceTier ? { serviceTier: result.serviceTier } : {}),
+      ...(result.tokenUsage !== undefined ? { tokenUsage: result.tokenUsage } : {}),
     };
   }
 }
@@ -176,6 +194,7 @@ export class GrokThreadTitleGenerator implements ThreadTitleGenerator {
       status: "ok",
       object: result.response.object,
       cachedTokens: result.response.cachedTokens,
+      model: this.model,
     };
   }
 }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -94,10 +94,28 @@ import type {
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 const ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
-const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
+export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
 const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
   web_search: "disabled",
+  include_permissions_instructions: false,
+  include_apps_instructions: false,
+  include_collaboration_mode_instructions: false,
+  include_environment_context: false,
+  skills: {
+    include_instructions: false,
+    bundled: { enabled: false },
+  },
+};
+const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
+  web_search: "disabled",
+  include_permissions_instructions: false,
+  include_apps_instructions: false,
+  include_collaboration_mode_instructions: false,
+  include_environment_context: false,
+  skills: {
+    include_instructions: false,
+  },
 };
 const CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY =
   "features.default_mode_request_user_input";
@@ -6240,8 +6258,19 @@ export class CodexAppServerClient {
           }),
           buildThreadStartPayload({
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            serviceTier: "priority",
+            ephemeral: true,
+            config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
+          }),
+          buildThreadStartPayload({
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             ephemeral: true,
             config: CODEX_THREAD_TITLE_CONFIG,
+          }),
+          buildThreadStartPayload({
+            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+            ephemeral: true,
+            config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
           }),
         ],
         timeoutMs,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -430,6 +430,22 @@ function buildHelperTurnKey(threadId: string, turnId: string): string {
   return `${threadId}:${turnId}`;
 }
 
+function readHelperTokenUsage(params: unknown): unknown {
+  const record = asRecord(params);
+  if (!record) {
+    return undefined;
+  }
+  const turn = asRecord(record.turn);
+  return (
+    record.tokenUsage ??
+    record.token_usage ??
+    record.usage ??
+    turn?.tokenUsage ??
+    turn?.token_usage ??
+    turn?.usage
+  );
+}
+
 function extractTurnIdFromNotificationParams(params: unknown): string | undefined {
   const directTurnId = readStringFromRecord(params, "turnId");
   if (directTurnId) {
@@ -5276,6 +5292,7 @@ type HelperTurnResult =
   | {
       status: "ok";
       object: unknown;
+      tokenUsage?: unknown;
     }
   | {
       status: "failed";
@@ -5313,13 +5330,14 @@ export class CodexAppServerClient {
   private readonly helperTurnWaiters = new Map<
     string,
     {
-      resolve: (object: unknown) => void;
+      resolve: (result: Extract<HelperTurnResult, { status: "ok" }>) => void;
       reject: (error: Error) => void;
       timer: ReturnType<typeof setTimeout>;
     }
   >();
   private readonly completedHelperTurnResults = new Map<string, HelperTurnResult>();
   private readonly helperTurnTitleObjects = new Map<string, unknown>();
+  private readonly helperTurnTokenUsage = new Map<string, unknown>();
 
   constructor(private readonly options: CodexClientOptions = {}) {
     this.connection = new JsonRpcConnection(
@@ -5429,6 +5447,7 @@ export class CodexAppServerClient {
     this.helperThreadIds.clear();
     this.completedHelperTurnResults.clear();
     this.helperTurnTitleObjects.clear();
+    this.helperTurnTokenUsage.clear();
     await this.connection.close();
   }
 
@@ -5564,7 +5583,8 @@ export class CodexAppServerClient {
     if (
       method !== "item/completed" &&
       method !== "turn/completed" &&
-      method !== "turn/failed"
+      method !== "turn/failed" &&
+      method !== "thread/tokenUsage/updated"
     ) {
       return;
     }
@@ -5576,6 +5596,13 @@ export class CodexAppServerClient {
     }
 
     const key = buildHelperTurnKey(threadId, turnId);
+    if (method === "thread/tokenUsage/updated") {
+      const tokenUsage = readHelperTokenUsage(notification.params);
+      if (tokenUsage !== undefined) {
+        this.helperTurnTokenUsage.set(key, tokenUsage);
+      }
+      return;
+    }
     if (method === "item/completed") {
       const object = extractGeneratedTitleObject(notification.params);
       if (object) {
@@ -5588,6 +5615,7 @@ export class CodexAppServerClient {
     if (method === "turn/failed") {
       const error = new Error("codex_title_turn_failed");
       this.helperTurnTitleObjects.delete(key);
+      this.helperTurnTokenUsage.delete(key);
       if (!waiter) {
         this.completedHelperTurnResults.set(key, {
           status: "failed",
@@ -5604,7 +5632,10 @@ export class CodexAppServerClient {
     const object =
       extractGeneratedTitleObject(notification.params) ??
       this.helperTurnTitleObjects.get(key);
+    const tokenUsage =
+      readHelperTokenUsage(notification.params) ?? this.helperTurnTokenUsage.get(key);
     this.helperTurnTitleObjects.delete(key);
+    this.helperTurnTokenUsage.delete(key);
     if (!object) {
       const error = new Error("codex_title_turn_completed_without_title");
       if (!waiter) {
@@ -5624,20 +5655,25 @@ export class CodexAppServerClient {
       this.completedHelperTurnResults.set(key, {
         status: "ok",
         object,
+        ...(tokenUsage !== undefined ? { tokenUsage } : {}),
       });
       return;
     }
 
     clearTimeout(waiter.timer);
     this.helperTurnWaiters.delete(key);
-    waiter.resolve(object);
+    waiter.resolve({
+      status: "ok",
+      object,
+      ...(tokenUsage !== undefined ? { tokenUsage } : {}),
+    });
   }
 
   private waitForHelperTurnTitle(params: {
     threadId: string;
     turnId: string;
     timeoutMs: number;
-  }): Promise<unknown> {
+  }): Promise<Extract<HelperTurnResult, { status: "ok" }>> {
     const key = buildHelperTurnKey(params.threadId, params.turnId);
     const completed = this.completedHelperTurnResults.get(key);
     if (completed) {
@@ -5645,7 +5681,7 @@ export class CodexAppServerClient {
       if (completed.status === "failed") {
         return Promise.reject(completed.error);
       }
-      return Promise.resolve(completed.object);
+      return Promise.resolve(completed);
     }
 
     return new Promise((resolve, reject) => {
@@ -6243,9 +6279,17 @@ export class CodexAppServerClient {
       });
       const immediateObject = extractGeneratedTitleObject(turnStartResult);
       if (immediateObject) {
+        const immediateTurnId = extractTurnIdFromValue(turnStartResult);
+        const tokenUsage = readHelperTokenUsage(turnStartResult);
         return {
           status: "ok",
           object: immediateObject,
+          helperThreadId,
+          ...(immediateTurnId ? { helperTurnId: immediateTurnId } : {}),
+          model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+          reasoningEffort: "low",
+          serviceTier: "priority",
+          ...(tokenUsage !== undefined ? { tokenUsage } : {}),
         };
       }
 
@@ -6257,13 +6301,22 @@ export class CodexAppServerClient {
         };
       }
 
+      const helperResult = await this.waitForHelperTurnTitle({
+        threadId: helperThreadId,
+        turnId,
+        timeoutMs,
+      });
       return {
         status: "ok",
-        object: await this.waitForHelperTurnTitle({
-          threadId: helperThreadId,
-          turnId,
-          timeoutMs,
-        }),
+        object: helperResult.object,
+        helperThreadId,
+        helperTurnId: turnId,
+        model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+        reasoningEffort: "low",
+        serviceTier: "priority",
+        ...(helperResult.tokenUsage !== undefined
+          ? { tokenUsage: helperResult.tokenUsage }
+          : {}),
       };
     } catch (error) {
       return {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,3 +1,5 @@
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   estimateOpenAiTokenUsageCost,
@@ -96,6 +98,11 @@ const ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.4-mini";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
+const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
+  tmpdir(),
+  "pwragent",
+  "codex-title-helper",
+);
 const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
   web_search: "disabled",
   include_permissions_instructions: false,
@@ -4739,6 +4746,7 @@ function normalizeCodexReasoningEffort(
 
 function buildThreadStartPayload(params: {
   cwd?: string;
+  runtimeWorkspaceRoots?: string[];
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
@@ -4757,6 +4765,9 @@ function buildThreadStartPayload(params: {
 
   if (params.cwd?.trim()) {
     base.cwd = params.cwd.trim();
+  }
+  if (params.runtimeWorkspaceRoots !== undefined) {
+    base.runtimeWorkspaceRoots = params.runtimeWorkspaceRoots;
   }
   if (params.model?.trim()) {
     base.model = params.model.trim();
@@ -5316,6 +5327,11 @@ type HelperTurnResult =
       status: "failed";
       error: Error;
     };
+
+async function ensureCodexThreadTitleWorkspace(): Promise<string> {
+  await mkdir(CODEX_THREAD_TITLE_WORKSPACE_DIR, { recursive: true });
+  return CODEX_THREAD_TITLE_WORKSPACE_DIR;
+}
 
 export class CodexAppServerClient {
   private readonly connection: JsonRpcConnection;
@@ -6245,29 +6261,38 @@ export class CodexAppServerClient {
 
     let helperThreadId: string | undefined;
     const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
+    const helperWorkspaceDir = await ensureCodexThreadTitleWorkspace();
     try {
       const threadStartResult = await requestWithFallbacks({
         client: this.connection,
         methods: ["thread/start"],
         payloads: [
           buildThreadStartPayload({
+            cwd: helperWorkspaceDir,
+            runtimeWorkspaceRoots: [helperWorkspaceDir],
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             serviceTier: "priority",
             ephemeral: true,
             config: CODEX_THREAD_TITLE_CONFIG,
           }),
           buildThreadStartPayload({
+            cwd: helperWorkspaceDir,
+            runtimeWorkspaceRoots: [helperWorkspaceDir],
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             serviceTier: "priority",
             ephemeral: true,
             config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
           }),
           buildThreadStartPayload({
+            cwd: helperWorkspaceDir,
+            runtimeWorkspaceRoots: [helperWorkspaceDir],
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             ephemeral: true,
             config: CODEX_THREAD_TITLE_CONFIG,
           }),
           buildThreadStartPayload({
+            cwd: helperWorkspaceDir,
+            runtimeWorkspaceRoots: [helperWorkspaceDir],
             model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
             ephemeral: true,
             config: LEGACY_CODEX_THREAD_TITLE_CONFIG,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -455,6 +455,57 @@ describe("ThreadContextPanel", () => {
     expect(modal.getByText("Codex native spawnAgent")).toBeInTheDocument();
   });
 
+  it("labels system title helper usage separately from monitor usage", () => {
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "system:title-helper:codex:thread-title-helper-parent",
+            task: "Name this thread",
+            status: "success",
+            createdAt: 2000,
+            completedAt: 3000,
+            updatedAt: 2500,
+            agentName: "PwrAgent",
+            lastMessage: "Generated title: Readable thread title",
+            monitorThreadId: "title-helper-thread",
+            monitorTurnId: "title-helper-turn",
+            preferredModel: "gpt-5.4-mini",
+            preferredReasoningEffort: "low",
+            monitorUsage: {
+              summary: "80 uncached in · 20 cached · 10 out",
+              tokenUsage: {
+                inputTokens: 100,
+                cachedInputTokens: 20,
+                uncachedInputTokens: 80,
+                outputTokens: 10,
+                totalTokens: 110,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByText("System usage: 80 uncached in · 20 cached · 10 out"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("PwrAgent")).toBeInTheDocument();
+    expect(screen.getByText("Spawned by PwrAgent system helper.")).toBeInTheDocument();
+    expect(screen.getByText("Generated title: Readable thread title")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Monitor usage: 80 uncached in · 20 cached · 10 out"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    const modal = within(screen.getByRole("dialog"));
+    expect(modal.getByText("Source")).toBeInTheDocument();
+    expect(modal.getByText("PwrAgent system helper")).toBeInTheDocument();
+  });
+
   it("does not duplicate the Codex native source line while running", () => {
     renderPanel({
       activeTab: "subagents",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -228,6 +228,7 @@ describe("ThreadContextPanel", () => {
             status: "running",
             createdAt: 2000,
             updatedAt: 2500,
+            backend: "codex",
             agentName: "Poincare",
             preferredModel: "gpt-5.4-mini",
             monitorThreadId: "monitor-thread-2",
@@ -265,6 +266,9 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Watch CI until it completes.")).toBeInTheDocument();
     expect(screen.getByText("Poincare")).toBeInTheDocument();
     expect(screen.getByText("Running")).toBeInTheDocument();
+    const firstCard = within(screen.getAllByRole("listitem")[0]!);
+    expect(firstCard.getByText("OpenAI")).toBeInTheDocument();
+    expect(firstCard.getByText("gpt-5.4-mini")).toBeInTheDocument();
     expect(screen.getByText("Lint is still running.")).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -293,6 +297,8 @@ describe("ThreadContextPanel", () => {
     expect(modal.getByText("Latest message")).toBeInTheDocument();
     expect(modal.getByText("Name")).toBeInTheDocument();
     expect(modal.getByText("Poincare")).toBeInTheDocument();
+    expect(modal.getByText("Provider")).toBeInTheDocument();
+    expect(modal.getByText("OpenAI")).toBeInTheDocument();
     expect(modal.getByText("Lint is still running.")).toBeInTheDocument();
     expect(modal.getByText("Tokens & pricing")).toBeInTheDocument();
     expect(modal.getByText("gpt-5.4-mini")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { ThreadSubAgentSummary } from "@pwragent/shared";
+import { formatBackendLabel } from "../../../lib/backend-label";
 import { formatTimestamp } from "./context-rail-shared";
 import {
   formatSubAgentUsageEstimates,
@@ -82,6 +83,7 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const tone = subAgentTone(subAgent.status);
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
+  const backendLabel = subAgent.backend ? formatBackendLabel(subAgent.backend) : undefined;
   const usageEstimates = usage
     ? formatSubAgentUsageEstimates({
         displayOptions: props.pricingDisplayOptions,
@@ -137,6 +139,12 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
             <div>
               <dt>Source</dt>
               <dd>{originLabel}</dd>
+            </div>
+          ) : null}
+          {backendLabel ? (
+            <div>
+              <dt>Provider</dt>
+              <dd>{backendLabel}</dd>
             </div>
           ) : null}
           {model ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -3,6 +3,7 @@ import type {
   NavigationThreadSummary,
   ThreadSubAgentSummary,
 } from "@pwragent/shared";
+import { formatBackendLabel } from "../../../lib/backend-label";
 import { useSubAgents } from "./useSubAgents";
 import { formatTimestamp } from "./context-rail-shared";
 import {
@@ -38,6 +39,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           {subAgents.map((subAgent) => {
             const tone = subAgentTone(subAgent.status);
             const originSentence = subAgentOriginSentence(subAgent);
+            const backend = subAgent.backend ?? props.thread.source;
             const latestMessage =
               subAgent.lastMessage && subAgent.lastMessage !== originSentence
                 ? subAgent.lastMessage
@@ -59,9 +61,16 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 <p className="rail-card__title" title={subAgent.task}>
                   {subAgent.task}
                 </p>
-                {subAgent.preferredModel ? (
-                  <p className="rail-card__model">{subAgent.preferredModel}</p>
-                ) : null}
+                <p className="rail-card__runtime">
+                  <span className="rail-card__provider-chip">
+                    {formatBackendLabel(backend)}
+                  </span>
+                  {subAgent.preferredModel ? (
+                    <span className="rail-card__model">
+                      {subAgent.preferredModel}
+                    </span>
+                  ) : null}
+                </p>
                 <p className="rail-card__times">
                   <span className="rail-card__time-label">Started</span>{" "}
                   {formatTimestamp(subAgent.createdAt)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
@@ -4,9 +4,18 @@ export function isCodexNativeSubAgent(subAgent: ThreadSubAgentSummary): boolean 
   return subAgent.monitorId.startsWith("codex-native:");
 }
 
+export function isSystemTitleHelperSubAgent(
+  subAgent: ThreadSubAgentSummary,
+): boolean {
+  return subAgent.monitorId.startsWith("system:title-helper:");
+}
+
 export function subAgentOriginLabel(
   subAgent: ThreadSubAgentSummary,
 ): string | undefined {
+  if (isSystemTitleHelperSubAgent(subAgent)) {
+    return "PwrAgent system helper";
+  }
   if (isCodexNativeSubAgent(subAgent)) {
     return "Codex native spawnAgent";
   }
@@ -21,6 +30,9 @@ export function subAgentOriginSentence(
 }
 
 export function subAgentUsageLabel(subAgent: ThreadSubAgentSummary): string {
+  if (isSystemTitleHelperSubAgent(subAgent)) {
+    return "System";
+  }
   if (isCodexNativeSubAgent(subAgent)) {
     return "Codex";
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11978,11 +11978,41 @@ textarea,
   white-space: nowrap;
 }
 
+.rail-card__runtime {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  margin: 0;
+}
+
+.rail-card__provider-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .rail-card__model {
   margin: 0;
   color: var(--text-secondary);
   font-family: var(--font-mono);
   font-size: 11px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
 }
 
 .rail-card__times {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -150,6 +150,7 @@ export type ThreadSubAgentSummary = {
   status: ThreadSubAgentStatus;
   createdAt: number;
   updatedAt: number;
+  backend?: AppServerBackendKind;
   agentName?: string;
   preferredModel?: string;
   preferredReasoningEffort?: string;


### PR DESCRIPTION
## Summary

- Harden Codex title generation scheduling so initial turn input can trigger naming from lifecycle events even if the `turn/start` response is delayed or fails after the turn is accepted.
- Return Codex title-helper metadata and token usage through the title-generation service.
- Persist actual title-helper runs as `system:title-helper:*` sub-agents and pricing usage lines when usage is available.
- Label those entries in the Sub-agents panel as `PwrAgent system helper` / `System usage`.

## Why

Thread naming is system-invoked but behaves like a hidden sub-agent: it has a helper thread, model choice, reasoning effort, service tier, and cost. When the naming helper is hidden, intermittent failures are hard to debug and users cannot see the cost source. Also, relying only on the `turn/start` response left a race where Codex could start the turn but PwrAgent would miss the title-generation scheduling path.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
