### PR TITLE
fix(desktop): default review chooser to base branch

### DIFF
--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -38,8 +38,8 @@ test("review command asks for target and preserves transcript order", async () =
       .poll(async () => await app.getLastStartReview())
       .toBeUndefined();
 
-    await reviewTarget.getByRole("button", { name: /Base branch/ }).click();
-    await reviewTarget.getByLabel("Base branch").fill("main");
+    await reviewTarget.getByRole("button", { name: "Base branch", exact: true }).click();
+    await reviewTarget.getByRole("option", { name: "main" }).click();
     await reviewTarget.getByRole("button", { name: "Start review" }).click();
 
     await expect

--- a/apps/desktop/e2e/review-command-flow.spec.ts
+++ b/apps/desktop/e2e/review-command-flow.spec.ts
@@ -38,7 +38,7 @@ test("review command asks for target and preserves transcript order", async () =
       .poll(async () => await app.getLastStartReview())
       .toBeUndefined();
 
-    await reviewTarget.getByRole("button", { name: "Base branch", exact: true }).click();
+    await reviewTarget.getByRole("combobox", { name: "Base branch" }).click();
     await reviewTarget.getByRole("option", { name: "main" }).click();
     await reviewTarget.getByRole("button", { name: "Start review" }).click();
 

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GitDirectoryService,
+  MAX_TRACKED_COMMITS,
   MAX_TRACKED_BRANCHES,
   capRecentBranchDetails,
   computeWorktreePath,
@@ -266,6 +267,31 @@ describe("GitDirectoryService", () => {
     expect(detailNames.indexOf("recent")).toBeLessThan(
       detailNames.indexOf("older"),
     );
+    expect(status?.recentCommits?.[0]).toMatchObject({
+      subject: "Seed fixture repo",
+    });
+  });
+
+  it("reports at most the newest recent commits for the current branch", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    for (let index = 0; index < MAX_TRACKED_COMMITS + 5; index += 1) {
+      execFileSync(
+        "git",
+        ["-C", repoDir, "commit", "--allow-empty", "-m", `Commit ${index}`],
+        { stdio: "ignore" },
+      );
+    }
+    const service = new GitDirectoryService();
+
+    const status = await service.readDirectoryStatus({ path: repoDir });
+
+    expect(status?.recentCommits).toHaveLength(MAX_TRACKED_COMMITS);
+    expect(status?.recentCommits?.[0]).toMatchObject({
+      shortSha: expect.any(String),
+      subject: `Commit ${MAX_TRACKED_COMMITS + 4}`,
+    });
+    expect(status?.recentCommits?.at(-1)?.subject).toBe("Commit 5");
   });
 
   it("reports remote-tracking refs as worktree base branch candidates", async () => {

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -11,6 +11,7 @@ import type {
   NavigationDirectoryGitStatus,
   NavigationDirectorySummary,
   NavigationGitBranchDetail,
+  NavigationGitCommitSummary,
   NavigationLaunchpadDraft,
 } from "@pwragent/shared";
 import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
@@ -344,6 +345,33 @@ function parseGitBaseBranchDetails(
   return details;
 }
 
+function parseGitCommitSummaries(output: string): NavigationGitCommitSummary[] {
+  const commits: NavigationGitCommitSummary[] = [];
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (!line.trim()) {
+      continue;
+    }
+    const [sha = "", shortSha = "", committedAtRaw = "", subject = ""] =
+      line.split("\x1f");
+    const fullSha = sha.trim();
+    const abbreviatedSha = shortSha.trim();
+    if (!fullSha || !abbreviatedSha) {
+      continue;
+    }
+    const committedAtValue = Number.parseInt(committedAtRaw.trim(), 10);
+    commits.push({
+      sha: fullSha,
+      shortSha: abbreviatedSha,
+      committedAt: Number.isFinite(committedAtValue)
+        ? committedAtValue
+        : undefined,
+      subject: subject.trim(),
+    });
+  }
+  return commits;
+}
+
 /**
  * Upper bound on how many branches we enrich, hold in the navigation
  * snapshot, and persist to the directory git-status cache. Repos can have
@@ -353,6 +381,7 @@ function parseGitBaseBranchDetails(
  * nothing past this many branches is retained or written to disk.
  */
 export const MAX_TRACKED_BRANCHES = 100;
+export const MAX_TRACKED_COMMITS = 20;
 
 /**
  * Keeps the most recently touched `limit` branches, always retaining the
@@ -694,8 +723,14 @@ export class GitDirectoryService {
       return undefined;
     }
 
-    const [rawCurrentBranch, branchesOutput, baseBranchesOutput, remoteHead, worktreeList] =
-      await Promise.all([
+    const [
+      rawCurrentBranch,
+      branchesOutput,
+      baseBranchesOutput,
+      remoteHead,
+      worktreeList,
+      recentCommitsOutput,
+    ] = await Promise.all([
         runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
           () => "",
         ),
@@ -728,6 +763,15 @@ export class GitDirectoryService {
         runGit(repoRoot, ["worktree", "list", "--porcelain"], gitEnv).catch(
           () => "",
         ),
+        runGit(
+          repoRoot,
+          [
+            "log",
+            `--max-count=${MAX_TRACKED_COMMITS}`,
+            "--format=%H%x1f%h%x1f%ct%x1f%s",
+          ],
+          gitEnv,
+        ).catch(() => ""),
       ]);
     const currentBranch =
       rawCurrentBranch.trim() === "HEAD" ? "" : rawCurrentBranch.trim();
@@ -743,6 +787,10 @@ export class GitDirectoryService {
     ).catch(() => "");
     const parsedBranchDetailsAll = parseGitBranchDetails(branchesOutput);
     const parsedBaseBranchDetailsAll = parseGitBaseBranchDetails(baseBranchesOutput);
+    const recentCommits = parseGitCommitSummaries(recentCommitsOutput).slice(
+      0,
+      MAX_TRACKED_COMMITS,
+    );
     // Resolve the default branch against the FULL list so a rarely-committed
     // `main` is still found, then cap everything we hold/persist downstream.
     const defaultBranch = resolveDefaultBranch({
@@ -783,6 +831,7 @@ export class GitDirectoryService {
         baseBranches,
         branchDetails: buildBranchDetails(),
         baseBranchDetails: buildBaseBranchDetails(),
+        recentCommits,
         handoffBranches: branches,
         syncState: "untracked",
       };
@@ -803,6 +852,7 @@ export class GitDirectoryService {
         baseBranches,
         branchDetails: buildBranchDetails(),
         baseBranchDetails: buildBaseBranchDetails(),
+        recentCommits,
         handoffBranches,
         syncState: "untracked",
       };
@@ -837,6 +887,7 @@ export class GitDirectoryService {
       baseBranches,
       branchDetails: buildBranchDetails(),
       baseBranchDetails: buildBaseBranchDetails(),
+      recentCommits,
       handoffBranches,
       syncState,
     };

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -441,11 +441,13 @@ function buildReviewBranchOptions(params: {
   thread?: NavigationThreadSummary;
 }): string[] {
   const candidates = [
+    params.directory?.gitStatus?.defaultBranch,
+    params.directory?.gitStatus?.upstreamBranch?.replace(/^origin\//, ""),
+    ...(params.directory?.gitStatus?.baseBranches ?? []),
     "main",
     params.thread?.gitBranch,
     params.thread?.observedGitBranch,
     params.directory?.gitStatus?.currentBranch,
-    params.directory?.gitStatus?.upstreamBranch?.replace(/^origin\//, ""),
     ...(params.directory?.gitStatus?.branches ?? []),
   ];
   const options = new Set<string>();
@@ -476,6 +478,7 @@ function createReviewConfig(params: {
     branch: buildReviewBranchOptions(params)[0] ?? "main",
     commit: "",
     customInstructions: "",
+    target: "baseBranch",
   };
 }
 
@@ -1502,6 +1505,7 @@ export function Composer(props: ComposerProps) {
   const inputRef = useRef<ComposerInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
+  const reviewBranchInputRef = useRef<HTMLInputElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
   const confirmedActiveTurnIdRef = useRef<string | undefined>(undefined);
   const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
@@ -2453,6 +2457,14 @@ export function Composer(props: ComposerProps) {
   );
 
   useEffect(() => {
+    if (!isReviewComposerOpen || reviewConfig?.target !== "baseBranch") {
+      return;
+    }
+    reviewBranchInputRef.current?.focus();
+    reviewBranchInputRef.current?.select();
+  }, [isReviewComposerOpen, reviewConfig?.target]);
+
+  useEffect(() => {
     if (!supportsReview && reviewConfig) {
       setReviewConfig(undefined);
     }
@@ -3202,6 +3214,14 @@ export function Composer(props: ComposerProps) {
     requestAnimationFrame(() => inputRef.current?.focus());
   };
 
+  const submitConfiguredReviewComposer = async (): Promise<void> => {
+    const configuredReviewCommand = buildConfiguredReviewCommand(reviewConfig);
+    if (!configuredReviewCommand) {
+      return;
+    }
+    await submitReviewCommand(configuredReviewCommand);
+  };
+
   const buildTurnPayload = (
     textDraft: string,
     attachments: ComposerImageAttachment[],
@@ -3644,19 +3664,14 @@ export function Composer(props: ComposerProps) {
 
     if (reviewCommand) {
       if (isBareReviewCommand) {
-        const nextReviewConfig =
+        setReviewConfig(
           reviewConfig ??
-          createReviewConfig({
-            directory: props.directory,
-            thread: props.thread,
-          });
-        const configuredReviewCommand = buildConfiguredReviewCommand(nextReviewConfig);
-        if (!configuredReviewCommand) {
-          setReviewConfig(nextReviewConfig);
-          setSendError(undefined);
-          return;
-        }
-        await submitReviewCommand(configuredReviewCommand);
+            createReviewConfig({
+              directory: props.directory,
+              thread: props.thread,
+            })
+        );
+        setSendError(undefined);
         return;
       }
 
@@ -5140,7 +5155,11 @@ export function Composer(props: ComposerProps) {
         data-composer-implementation="tiptap-wysiwyg-markdown-chips"
         onSubmit={(event) => {
           event.preventDefault();
-          void submitTurn();
+          if (isReviewComposerOpen) {
+            void submitConfiguredReviewComposer();
+          } else {
+            void submitTurn();
+          }
         }}
       >
         {/* Issue #240: removed the visible "Reply" / "New thread" /
@@ -5378,6 +5397,7 @@ export function Composer(props: ComposerProps) {
               <label className="composer__review-field">
                 <span>Base branch</span>
                 <input
+                  ref={reviewBranchInputRef}
                   className="composer__review-input"
                   list="composer-review-branches"
                   value={reviewConfig.branch}
@@ -5461,12 +5481,7 @@ export function Composer(props: ComposerProps) {
                 className="composer__primary-action"
                 disabled={!buildConfiguredReviewCommand(reviewConfig)}
                 onClick={() => {
-                  const configuredReviewCommand =
-                    buildConfiguredReviewCommand(reviewConfig);
-                  if (!configuredReviewCommand) {
-                    return;
-                  }
-                  void submitReviewCommand(configuredReviewCommand);
+                  void submitConfiguredReviewComposer();
                 }}
               >
                 Start review

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -440,10 +440,41 @@ function buildReviewBranchOptions(params: {
   directory?: NavigationDirectorySummary;
   thread?: NavigationThreadSummary;
 }): string[] {
+  const currentBranches = new Set(
+    [
+      params.thread?.gitBranch,
+      params.thread?.observedGitBranch,
+      params.directory?.gitStatus?.currentBranch,
+    ]
+      .map((branch) => branch?.trim())
+      .filter((branch): branch is string => Boolean(branch)),
+  );
+  const isCurrentBranch = (candidate?: string): boolean => {
+    const value = candidate?.trim();
+    if (!value) {
+      return false;
+    }
+    if (currentBranches.has(value)) {
+      return true;
+    }
+    return (
+      value.startsWith("origin/") &&
+      currentBranches.has(value.slice("origin/".length))
+    );
+  };
+  const preferredBaseBranches = (params.directory?.gitStatus?.baseBranches ?? []).filter(
+    (branch) => !isCurrentBranch(branch),
+  );
+  const upstreamBranch = params.directory?.gitStatus?.upstreamBranch?.replace(
+    /^origin\//,
+    "",
+  );
   const candidates = [
-    params.directory?.gitStatus?.defaultBranch,
-    params.directory?.gitStatus?.upstreamBranch?.replace(/^origin\//, ""),
-    ...(params.directory?.gitStatus?.baseBranches ?? []),
+    ...preferredBaseBranches,
+    !isCurrentBranch(params.directory?.gitStatus?.defaultBranch)
+      ? params.directory?.gitStatus?.defaultBranch
+      : undefined,
+    !isCurrentBranch(upstreamBranch) ? upstreamBranch : undefined,
     "main",
     params.thread?.gitBranch,
     params.thread?.observedGitBranch,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1537,6 +1537,7 @@ export function Composer(props: ComposerProps) {
   const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
   const inFlightReviewSubmissionKeyRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const reviewOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const skillListboxId = useId();
   const slashListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
@@ -2483,6 +2484,17 @@ export function Composer(props: ComposerProps) {
   );
 
   useEffect(() => {
+    if (!isReviewComposerOpen || reviewConfig?.showBranchPicker) {
+      return;
+    }
+    const target = reviewConfig?.target ?? "baseBranch";
+    const optionIndex = REVIEW_TARGET_OPTIONS.findIndex(
+      (option) => option.target === target,
+    );
+    reviewOptionRefs.current[optionIndex === -1 ? 0 : optionIndex]?.focus();
+  }, [isReviewComposerOpen, reviewConfig?.showBranchPicker, reviewConfig?.target]);
+
+  useEffect(() => {
     if (!supportsReview && reviewConfig) {
       setReviewConfig(undefined);
     }
@@ -3238,6 +3250,53 @@ export function Composer(props: ComposerProps) {
       return;
     }
     await submitReviewCommand(configuredReviewCommand);
+  };
+
+  const focusReviewOption = (index: number): void => {
+    requestAnimationFrame(() => {
+      reviewOptionRefs.current[index]?.focus();
+    });
+  };
+
+  const selectReviewTarget = (
+    target: ReviewTargetChoice,
+    options?: { showBranchPicker?: boolean },
+  ): void => {
+    setReviewConfig((current) => ({
+      ...(current ??
+        createReviewConfig({
+          directory: props.directory,
+          thread: props.thread,
+        })),
+      showBranchPicker: options?.showBranchPicker,
+      target,
+    }));
+    setSendError(undefined);
+  };
+
+  const handleReviewOptionKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ): void => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      void submitConfiguredReviewComposer();
+      return;
+    }
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const direction = event.key === "ArrowRight" ? 1 : -1;
+    const nextIndex =
+      (index + direction + REVIEW_TARGET_OPTIONS.length) %
+      REVIEW_TARGET_OPTIONS.length;
+    selectReviewTarget(REVIEW_TARGET_OPTIONS[nextIndex]!.target, {
+      showBranchPicker: false,
+    });
+    focusReviewOption(nextIndex);
   };
 
   const buildTurnPayload = (
@@ -5387,24 +5446,21 @@ export function Composer(props: ComposerProps) {
           <fieldset className="composer__review-config" aria-label="Review target">
             <legend>Review target</legend>
             <div className="composer__review-options">
-              {REVIEW_TARGET_OPTIONS.map((option) => (
+              {REVIEW_TARGET_OPTIONS.map((option, index) => (
                 <button
                   key={option.target}
+                  ref={(element) => {
+                    reviewOptionRefs.current[index] = element;
+                  }}
                   type="button"
                   aria-pressed={reviewConfig?.target === option.target}
                   className={`composer__review-option${reviewConfig?.target === option.target ? " is-active" : ""}`}
                   onClick={() => {
-                    setReviewConfig((current) => ({
-                      ...(current ??
-                        createReviewConfig({
-                          directory: props.directory,
-                          thread: props.thread,
-                        })),
+                    selectReviewTarget(option.target, {
                       showBranchPicker: option.target === "baseBranch",
-                      target: option.target,
-                    }));
-                    setSendError(undefined);
+                    });
                   }}
+                  onKeyDown={(event) => handleReviewOptionKeyDown(event, index)}
                 >
                   <span>{option.label}</span>
                   <small>{option.description}</small>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4,6 +4,7 @@ import {
   type DragEvent,
   type FormEvent as ReactFormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
+  type Ref,
   useEffect,
   useId,
   useLayoutEffect,
@@ -29,6 +30,7 @@ import type {
   DesktopChatReplyComposer,
   HandoffThreadWorkspaceRequest,
   NavigationDirectorySummary,
+  NavigationGitCommitSummary,
   NavigationLaunchpadDraft,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
@@ -522,6 +524,12 @@ function buildReviewBranchPickerOptions(params: {
       isDefault: defaultBranch ? name === defaultBranch : false,
     };
   });
+}
+
+function buildReviewCommitOptions(
+  directory?: NavigationDirectorySummary,
+): NavigationGitCommitSummary[] {
+  return (directory?.gitStatus?.recentCommits ?? []).slice(0, 20);
 }
 
 function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined {
@@ -1236,6 +1244,7 @@ type LaunchpadBranchOption = {
  */
 function BranchPicker(props: {
   ariaLabel: string;
+  className?: string;
   disabled?: boolean;
   id?: string;
   onChange: (value: string) => void;
@@ -1423,7 +1432,13 @@ function BranchPicker(props: {
 
   return (
     <div
-      className="composer-dropdown composer-dropdown--compact composer-dropdown--branch branch-picker"
+      className={[
+        "composer-dropdown composer-dropdown--compact composer-dropdown--branch branch-picker",
+        open ? "composer-dropdown--open" : "",
+        props.className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
       ref={ref}
     >
       <button
@@ -1512,6 +1527,152 @@ function BranchPicker(props: {
   );
 }
 
+function ReviewCommitPicker(props: {
+  inputRef?: Ref<HTMLInputElement>;
+  onChange: (value: string) => void;
+  options: NavigationGitCommitSummary[];
+  value: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputId = useId();
+  const listboxId = useId();
+  const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
+  const nowMs = Date.now();
+  const query = props.value.trim().toLowerCase();
+  const visibleOptions = useMemo(() => {
+    if (!query) {
+      return props.options.slice(0, 20);
+    }
+    return props.options
+      .filter((option) => {
+        const haystack = `${option.sha} ${option.shortSha} ${option.subject}`.toLowerCase();
+        return haystack.includes(query);
+      })
+      .slice(0, 20);
+  }, [props.options, query]);
+
+  useEffect(() => {
+    if (open) {
+      setActiveIndex(0);
+    }
+  }, [open, query]);
+
+  const commit = (option: NavigationGitCommitSummary): void => {
+    props.onChange(option.sha);
+    setOpen(false);
+  };
+
+  const handleKeyDown = (
+    event: ReactKeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key === "ArrowDown") {
+      if (visibleOptions.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      setOpen(true);
+      setActiveIndex((current) =>
+        Math.min(visibleOptions.length - 1, current + 1),
+      );
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      if (visibleOptions.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      setOpen(true);
+      setActiveIndex((current) => Math.max(0, current - 1));
+      return;
+    }
+    if (event.key === "Enter" && open) {
+      const option = visibleOptions[activeIndex];
+      if (option) {
+        event.preventDefault();
+        commit(option);
+      }
+      return;
+    }
+    if (event.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  const shouldShowMenu = open && visibleOptions.length > 0;
+
+  return (
+    <div className="review-commit-picker" ref={ref}>
+      <label htmlFor={inputId}>Commit SHA</label>
+      <input
+        aria-autocomplete="list"
+        aria-controls={shouldShowMenu ? listboxId : undefined}
+        aria-expanded={shouldShowMenu}
+        aria-haspopup="listbox"
+        className="composer__review-input"
+        id={inputId}
+        ref={props.inputRef}
+        role="combobox"
+        value={props.value}
+        onChange={(event) => {
+          props.onChange(event.target.value);
+          setOpen(true);
+        }}
+        onClick={() => setOpen(true)}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+      />
+      {shouldShowMenu ? (
+        <div
+          aria-label="Recent commits"
+          className="review-commit-picker__menu"
+          id={listboxId}
+          role="listbox"
+        >
+          {visibleOptions.map((option, index) => {
+            const relativeTime = formatBranchRelativeTime(
+              option.committedAt,
+              nowMs,
+            );
+            return (
+              <button
+                aria-label={`${option.shortSha} ${option.subject}`}
+                aria-selected={option.sha === props.value.trim()}
+                className={[
+                  "review-commit-picker__option",
+                  index === activeIndex ? "is-active" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
+                key={option.sha}
+                role="option"
+                type="button"
+                onClick={() => commit(option)}
+                onMouseEnter={() => setActiveIndex(index)}
+              >
+                <span className="review-commit-picker__sha">
+                  {option.shortSha}
+                </span>
+                <span className="review-commit-picker__subject">
+                  {option.subject || "Untitled commit"}
+                </span>
+                {relativeTime ? (
+                  <span
+                    aria-hidden="true"
+                    className="review-commit-picker__time"
+                  >
+                    {relativeTime}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ComposerApplicationButton(props: {
   application: DesktopApplicationDiscoveryCandidate;
   label: string;
@@ -1575,6 +1736,8 @@ export function Composer(props: ComposerProps) {
   const inFlightReviewSubmissionKeyRef = useRef<string | undefined>(undefined);
   const autocompleteOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const reviewOptionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const reviewCommitInputRef = useRef<HTMLInputElement | null>(null);
+  const reviewCustomTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const skillListboxId = useId();
   const slashListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
@@ -2515,6 +2678,10 @@ export function Composer(props: ComposerProps) {
       }),
     [props.directory, props.thread],
   );
+  const reviewCommitOptions = useMemo(
+    () => buildReviewCommitOptions(props.directory),
+    [props.directory],
+  );
   const isBareReviewCommand = draft.trim() === "/review";
   const isCompactCommand = supportsCompactCommand && draft.trim() === "/compact";
   const isReviewComposerOpen = Boolean(
@@ -3283,7 +3450,13 @@ export function Composer(props: ComposerProps) {
   };
 
   const submitConfiguredReviewComposer = async (): Promise<void> => {
-    const configuredReviewCommand = buildConfiguredReviewCommand(reviewConfig);
+    await submitReviewConfig(reviewConfig);
+  };
+
+  const submitReviewConfig = async (
+    config: ReviewConfigState | undefined,
+  ): Promise<void> => {
+    const configuredReviewCommand = buildConfiguredReviewCommand(config);
     if (!configuredReviewCommand) {
       return;
     }
@@ -3296,8 +3469,30 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  const focusReviewDetail = (target: ReviewTargetChoice): void => {
+    requestAnimationFrame(() => {
+      if (target === "commit") {
+        reviewCommitInputRef.current?.focus();
+      } else if (target === "custom") {
+        reviewCustomTextareaRef.current?.focus();
+      }
+    });
+  };
+
+  const getReviewConfigWithTarget = (
+    target: ReviewTargetChoice,
+  ): ReviewConfigState => ({
+    ...(reviewConfig ??
+      createReviewConfig({
+        directory: props.directory,
+        thread: props.thread,
+      })),
+    target,
+  });
+
   const selectReviewTarget = (
     target: ReviewTargetChoice,
+    options?: { focusDetail?: boolean },
   ): void => {
     setReviewConfig((current) => ({
       ...(current ??
@@ -3308,6 +3503,36 @@ export function Composer(props: ComposerProps) {
       target,
     }));
     setSendError(undefined);
+    if (options?.focusDetail) {
+      focusReviewDetail(target);
+    }
+  };
+
+  const submitFocusedReviewTarget = (
+    target: ReviewTargetChoice,
+  ): void => {
+    const nextConfig = getReviewConfigWithTarget(target);
+    setReviewConfig(nextConfig);
+    setSendError(undefined);
+    if (
+      (target === "commit" && !nextConfig.commit.trim()) ||
+      (target === "custom" && !nextConfig.customInstructions.trim())
+    ) {
+      focusReviewDetail(target);
+      return;
+    }
+    void submitReviewConfig(nextConfig);
+  };
+
+  const handleReviewConfigKeyDown = (
+    event: ReactKeyboardEvent<HTMLFieldSetElement>,
+  ): void => {
+    if (event.key !== "Escape") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    exitReviewComposer();
   };
 
   const handleReviewOptionKeyDown = (
@@ -3317,7 +3542,7 @@ export function Composer(props: ComposerProps) {
     if (event.key === "Enter") {
       event.preventDefault();
       event.stopPropagation();
-      void submitConfiguredReviewComposer();
+      submitFocusedReviewTarget(REVIEW_TARGET_OPTIONS[index]!.target);
       return;
     }
     if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
@@ -5477,7 +5702,11 @@ export function Composer(props: ComposerProps) {
 
       <div className="composer__input-wrap" ref={inputWrapRef}>
         {isReviewComposerOpen ? (
-          <fieldset className="composer__review-config" aria-label="Review target">
+          <fieldset
+            className="composer__review-config"
+            aria-label="Review target"
+            onKeyDown={handleReviewConfigKeyDown}
+          >
             <legend>Review target</legend>
             <div className="composer__review-options">
               {REVIEW_TARGET_OPTIONS.map((option, index) => (
@@ -5490,7 +5719,10 @@ export function Composer(props: ComposerProps) {
                   aria-pressed={reviewConfig?.target === option.target}
                   className={`composer__review-option${reviewConfig?.target === option.target ? " is-active" : ""}`}
                   onClick={() => {
-                    selectReviewTarget(option.target);
+                    selectReviewTarget(option.target, {
+                      focusDetail:
+                        option.target === "commit" || option.target === "custom",
+                    });
                   }}
                   onKeyDown={(event) => handleReviewOptionKeyDown(event, index)}
                 >
@@ -5505,6 +5737,7 @@ export function Composer(props: ComposerProps) {
                 <span>Base branch</span>
                 <BranchPicker
                   ariaLabel="Base branch"
+                  className="branch-picker--review"
                   options={reviewBranchPickerOptions}
                   value={reviewConfig.branch}
                   onChange={(branch) => {
@@ -5524,25 +5757,25 @@ export function Composer(props: ComposerProps) {
             ) : null}
 
             {reviewConfig?.target === "commit" ? (
-              <label className="composer__review-field">
-                <span>Commit SHA</span>
-                <input
-                  className="composer__review-input"
+              <div className="composer__review-field">
+                <ReviewCommitPicker
+                  inputRef={reviewCommitInputRef}
+                  options={reviewCommitOptions}
                   value={reviewConfig.commit}
-                  onChange={(event) => {
+                  onChange={(commit) => {
                     setReviewConfig((current) => ({
                       ...(current ??
                         createReviewConfig({
                           directory: props.directory,
                           thread: props.thread,
                         })),
-                      commit: event.target.value,
+                      commit,
                       target: "commit",
                     }));
                     setSendError(undefined);
                   }}
                 />
-              </label>
+              </div>
             ) : null}
 
             {reviewConfig?.target === "custom" ? (
@@ -5550,6 +5783,7 @@ export function Composer(props: ComposerProps) {
                 <span>Instructions</span>
                 <textarea
                   className="composer__review-input composer__review-input--textarea"
+                  ref={reviewCustomTextareaRef}
                   value={reviewConfig.customInstructions}
                   onChange={(event) => {
                     setReviewConfig((current) => ({

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -412,6 +412,8 @@ const REVIEW_TARGET_OPTIONS: Array<{
   },
 ];
 
+const REVIEW_PREFERRED_BASE_BRANCHES = ["main", "master", "develop", "trunk"];
+
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
   return (
@@ -507,14 +509,24 @@ function buildReviewBranchOptions(params: {
     pushIfKnown(value);
   };
 
-  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
-  pushPreferredDefault("main");
-  pushPreferredDefault("master");
+  const reportedDefaultBranch = params.directory?.gitStatus?.defaultBranch
+    ?.trim()
+    .replace(/^origin\//, "");
+  if (
+    reportedDefaultBranch &&
+    REVIEW_PREFERRED_BASE_BRANCHES.includes(reportedDefaultBranch)
+  ) {
+    pushPreferredDefault(reportedDefaultBranch);
+  }
+  for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
+    pushPreferredDefault(branch);
+  }
+  push("main", { allowCurrent: true });
   pushIfKnown(upstreamBranch);
   for (const candidate of baseBranches) {
     push(candidate);
   }
-  push("main", { allowCurrent: true });
+  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
   push(params.thread?.gitBranch);
   push(params.thread?.observedGitBranch);
   push(params.directory?.gitStatus?.currentBranch);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -468,6 +468,17 @@ function buildReviewBranchOptions(params: {
     /^origin\//,
     "",
   );
+  const baseBranches = params.directory?.gitStatus?.baseBranches ?? [];
+  const knownBranches = new Set(
+    [
+      ...baseBranches,
+      ...(params.directory?.gitStatus?.branches ?? []),
+      params.directory?.gitStatus?.defaultBranch,
+      upstreamBranch,
+    ]
+      .map((branch) => branch?.trim())
+      .filter((branch): branch is string => Boolean(branch)),
+  );
   const options = new Set<string>();
   const push = (
     candidate?: string,
@@ -481,11 +492,28 @@ function buildReviewBranchOptions(params: {
       options.add(value);
     }
   };
-  for (const candidate of params.directory?.gitStatus?.baseBranches ?? []) {
+  const pushIfKnown = (candidate?: string): void => {
+    const value = candidate?.trim();
+    if (value && knownBranches.has(value)) {
+      push(value);
+    }
+  };
+  const pushPreferredDefault = (candidate?: string): void => {
+    const value = candidate?.trim().replace(/^origin\//, "");
+    if (!value) {
+      return;
+    }
+    pushIfKnown(`origin/${value}`);
+    pushIfKnown(value);
+  };
+
+  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
+  pushPreferredDefault("main");
+  pushPreferredDefault("master");
+  pushIfKnown(upstreamBranch);
+  for (const candidate of baseBranches) {
     push(candidate);
   }
-  push(params.directory?.gitStatus?.defaultBranch);
-  push(upstreamBranch);
   push("main", { allowCurrent: true });
   push(params.thread?.gitBranch);
   push(params.thread?.observedGitBranch);
@@ -1537,6 +1565,7 @@ function ReviewCommitPicker(props: {
   const [activeIndex, setActiveIndex] = useState(0);
   const inputId = useId();
   const listboxId = useId();
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
   const nowMs = Date.now();
   const query = props.value.trim().toLowerCase();
@@ -1553,10 +1582,28 @@ function ReviewCommitPicker(props: {
   }, [props.options, query]);
 
   useEffect(() => {
-    if (open) {
-      setActiveIndex(0);
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      visibleOptions.length === 0
+        ? 0
+        : Math.min(current, visibleOptions.length - 1),
+    );
+  }, [visibleOptions.length]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
     }
-  }, [open, query]);
+    const option = optionRefs.current[activeIndex];
+    if (typeof option?.scrollIntoView === "function") {
+      option.scrollIntoView({
+        block: "nearest",
+      });
+    }
+  }, [activeIndex, open]);
 
   const commit = (option: NavigationGitCommitSummary): void => {
     props.onChange(option.sha);
@@ -1571,9 +1618,10 @@ function ReviewCommitPicker(props: {
         return;
       }
       event.preventDefault();
+      const wasOpen = open;
       setOpen(true);
       setActiveIndex((current) =>
-        Math.min(visibleOptions.length - 1, current + 1),
+        wasOpen ? Math.min(visibleOptions.length - 1, current + 1) : 0,
       );
       return;
     }
@@ -1582,8 +1630,12 @@ function ReviewCommitPicker(props: {
         return;
       }
       event.preventDefault();
+      const wasOpen = open;
       setOpen(true);
       setActiveIndex((current) => Math.max(0, current - 1));
+      if (!wasOpen) {
+        setActiveIndex(visibleOptions.length - 1);
+      }
       return;
     }
     if (event.key === "Enter" && open) {
@@ -1595,17 +1647,25 @@ function ReviewCommitPicker(props: {
       return;
     }
     if (event.key === "Escape") {
-      setOpen(false);
+      if (shouldShowMenu) {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(false);
+      }
     }
   };
 
   const shouldShowMenu = open && visibleOptions.length > 0;
+  const activeOptionId = shouldShowMenu
+    ? `${listboxId}-option-${activeIndex}`
+    : undefined;
 
   return (
     <div className="review-commit-picker" ref={ref}>
       <label htmlFor={inputId}>Commit SHA</label>
       <input
         aria-autocomplete="list"
+        aria-activedescendant={activeOptionId}
         aria-controls={shouldShowMenu ? listboxId : undefined}
         aria-expanded={shouldShowMenu}
         aria-haspopup="listbox"
@@ -1618,8 +1678,14 @@ function ReviewCommitPicker(props: {
           props.onChange(event.target.value);
           setOpen(true);
         }}
-        onClick={() => setOpen(true)}
-        onFocus={() => setOpen(true)}
+        onClick={() => {
+          setActiveIndex(0);
+          setOpen(visibleOptions.length > 0);
+        }}
+        onFocus={() => {
+          setActiveIndex(0);
+          setOpen(visibleOptions.length > 0);
+        }}
         onKeyDown={handleKeyDown}
       />
       {shouldShowMenu ? (
@@ -1644,8 +1710,13 @@ function ReviewCommitPicker(props: {
                 ]
                   .filter(Boolean)
                   .join(" ")}
+                id={`${listboxId}-option-${index}`}
                 key={option.sha}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
                 role="option"
+                tabIndex={-1}
                 type="button"
                 onClick={() => commit(option)}
                 onMouseEnter={() => setActiveIndex(index)}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1567,6 +1567,216 @@ function BranchPicker(props: {
   );
 }
 
+function ReviewBranchPicker(props: {
+  ariaLabel: string;
+  onChange: (value: string) => void;
+  options: LaunchpadBranchOption[];
+  value: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [filterText, setFilterText] = useState("");
+  const inputId = useId();
+  const listboxId = useId();
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
+  const nowMs = Date.now();
+  const query = filterText.trim().toLowerCase();
+  const visibleOptions = useMemo(() => {
+    if (!query) {
+      return props.options;
+    }
+    return props.options.filter((option) =>
+      option.name.toLowerCase().includes(query),
+    );
+  }, [props.options, query]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filterText]);
+
+  useEffect(() => {
+    setActiveIndex((current) =>
+      visibleOptions.length === 0
+        ? 0
+        : Math.min(current, visibleOptions.length - 1),
+    );
+  }, [visibleOptions.length]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    const option = optionRefs.current[activeIndex];
+    if (typeof option?.scrollIntoView === "function") {
+      option.scrollIntoView({ block: "nearest" });
+    }
+  }, [activeIndex, open]);
+
+  const commit = (name: string): void => {
+    props.onChange(name);
+    setFilterText("");
+    setOpen(false);
+  };
+
+  const handleKeyDown = (
+    event: ReactKeyboardEvent<HTMLInputElement>,
+  ): void => {
+    if (event.key === "ArrowDown") {
+      if (visibleOptions.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      const wasOpen = open;
+      setOpen(true);
+      setActiveIndex((current) =>
+        wasOpen ? Math.min(visibleOptions.length - 1, current + 1) : 0,
+      );
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      if (visibleOptions.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      const wasOpen = open;
+      setOpen(true);
+      setActiveIndex((current) => Math.max(0, current - 1));
+      if (!wasOpen) {
+        setActiveIndex(visibleOptions.length - 1);
+      }
+      return;
+    }
+    if (event.key === "Enter" && open) {
+      const option = visibleOptions[activeIndex];
+      if (option) {
+        event.preventDefault();
+        commit(option.name);
+      }
+      return;
+    }
+    if (event.key === "Escape" && open && visibleOptions.length > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      setOpen(false);
+    }
+  };
+
+  const shouldShowMenu = open && visibleOptions.length > 0;
+  const activeOptionId = shouldShowMenu
+    ? `${listboxId}-option-${activeIndex}`
+    : undefined;
+
+  return (
+    <div className="review-branch-picker" ref={ref}>
+      <input
+        aria-activedescendant={activeOptionId}
+        aria-autocomplete="list"
+        aria-controls={shouldShowMenu ? listboxId : undefined}
+        aria-expanded={shouldShowMenu}
+        aria-haspopup="listbox"
+        aria-label={props.ariaLabel}
+        className="composer__review-input"
+        id={inputId}
+        role="combobox"
+        value={props.value}
+        onChange={(event) => {
+          props.onChange(event.target.value);
+          setFilterText(event.target.value);
+          setOpen(true);
+        }}
+        onClick={() => {
+          setFilterText("");
+          setOpen(props.options.length > 0);
+        }}
+        onFocus={() => {
+          setFilterText("");
+          setOpen(props.options.length > 0);
+        }}
+        onKeyDown={handleKeyDown}
+      />
+      {shouldShowMenu ? (
+        <div
+          aria-label={props.ariaLabel}
+          className="branch-picker__menu review-branch-picker__menu"
+          id={listboxId}
+          role="listbox"
+        >
+          <div className="branch-picker__list">
+            {visibleOptions.map((option, index) => {
+              const isSelected = option.name === props.value.trim();
+              const relativeTime = formatBranchRelativeTime(
+                option.lastCommitAt,
+                nowMs,
+              );
+              return (
+                <button
+                  aria-label={option.name}
+                  aria-selected={isSelected}
+                  className={[
+                    "branch-picker__option",
+                    index === activeIndex ? "is-active" : "",
+                    isSelected ? "is-selected" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  id={`${listboxId}-option-${index}`}
+                  key={option.name}
+                  ref={(element) => {
+                    optionRefs.current[index] = element;
+                  }}
+                  role="option"
+                  tabIndex={-1}
+                  type="button"
+                  onClick={() => commit(option.name)}
+                  onMouseEnter={() => setActiveIndex(index)}
+                >
+                  <span aria-hidden="true" className="branch-picker__option-check">
+                    {isSelected ? "✓" : ""}
+                  </span>
+                  <span aria-hidden="true" className="branch-picker__option-icon">
+                    <BranchIcon size={12} />
+                  </span>
+                  <span className="branch-picker__option-name">{option.name}</span>
+                  {option.current ? (
+                    <span
+                      aria-hidden="true"
+                      className="branch-picker__badge branch-picker__badge--current"
+                    >
+                      Current
+                    </span>
+                  ) : null}
+                  {option.isDefault ? (
+                    <span
+                      aria-hidden="true"
+                      className="branch-picker__badge branch-picker__badge--default"
+                    >
+                      Default
+                    </span>
+                  ) : null}
+                  {option.inUse ? (
+                    <span
+                      aria-hidden="true"
+                      className="branch-picker__badge branch-picker__badge--in-use"
+                    >
+                      In use
+                    </span>
+                  ) : null}
+                  {relativeTime ? (
+                    <span aria-hidden="true" className="branch-picker__option-time">
+                      {relativeTime}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function ReviewCommitPicker(props: {
   inputRef?: Ref<HTMLInputElement>;
   onChange: (value: string) => void;
@@ -5819,9 +6029,8 @@ export function Composer(props: ComposerProps) {
             {reviewConfig?.target === "baseBranch" ? (
               <div className="composer__review-field">
                 <span>Base branch</span>
-                <BranchPicker
+                <ReviewBranchPicker
                   ariaLabel="Base branch"
-                  className="branch-picker--review"
                   options={reviewBranchPickerOptions}
                   value={reviewConfig.branch}
                   onChange={(branch) => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5801,6 +5801,7 @@ export function Composer(props: ComposerProps) {
                   type="button"
                   aria-pressed={reviewConfig?.target === option.target}
                   className={`composer__review-option${reviewConfig?.target === option.target ? " is-active" : ""}`}
+                  tabIndex={reviewConfig?.target === option.target ? 0 : -1}
                   onClick={() => {
                     selectReviewTarget(option.target, {
                       focusDetail:

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -324,7 +324,6 @@ type ReviewConfigState = {
   branch: string;
   commit: string;
   customInstructions: string;
-  showBranchPicker?: boolean;
   target?: ReviewTargetChoice;
 };
 
@@ -467,24 +466,62 @@ function buildReviewBranchOptions(params: {
     /^origin\//,
     "",
   );
-  const candidates = [
-    ...(params.directory?.gitStatus?.baseBranches ?? []),
-    params.directory?.gitStatus?.defaultBranch,
-    upstreamBranch,
-    "main",
-    params.thread?.gitBranch,
-    params.thread?.observedGitBranch,
-    params.directory?.gitStatus?.currentBranch,
-    ...(params.directory?.gitStatus?.branches ?? []),
-  ];
   const options = new Set<string>();
-  for (const candidate of candidates) {
+  const push = (
+    candidate?: string,
+    optionsForCandidate?: { allowCurrent?: boolean },
+  ): void => {
     const value = candidate?.trim();
-    if (value && !isCurrentBranch(value)) {
+    if (
+      value &&
+      (optionsForCandidate?.allowCurrent || !isCurrentBranch(value))
+    ) {
       options.add(value);
     }
+  };
+  for (const candidate of params.directory?.gitStatus?.baseBranches ?? []) {
+    push(candidate);
+  }
+  push(params.directory?.gitStatus?.defaultBranch);
+  push(upstreamBranch);
+  push("main", { allowCurrent: true });
+  push(params.thread?.gitBranch);
+  push(params.thread?.observedGitBranch);
+  push(params.directory?.gitStatus?.currentBranch);
+  for (const candidate of params.directory?.gitStatus?.branches ?? []) {
+    push(candidate);
   }
   return [...options];
+}
+
+function buildReviewBranchPickerOptions(params: {
+  directory?: NavigationDirectorySummary;
+  thread?: NavigationThreadSummary;
+}): LaunchpadBranchOption[] {
+  const details =
+    params.directory?.gitStatus?.baseBranchDetails ??
+    params.directory?.gitStatus?.branchDetails ??
+    [];
+  const detailByName = new Map(details.map((detail) => [detail.name, detail]));
+  const currentBranch = normalizeSelectableLaunchpadBranch(
+    params.directory?.gitStatus?.currentBranch ??
+      params.thread?.gitBranch ??
+      params.thread?.observedGitBranch,
+  );
+  const defaultBranch = normalizeSelectableLaunchpadBranch(
+    params.directory?.gitStatus?.defaultBranch,
+  );
+
+  return buildReviewBranchOptions(params).map((name) => {
+    const detail = detailByName.get(name);
+    return {
+      name,
+      lastCommitAt: detail?.lastCommitAt,
+      inUse: detail?.inUse,
+      current: currentBranch ? name === currentBranch : false,
+      isDefault: defaultBranch ? name === defaultBranch : false,
+    };
+  });
 }
 
 function getLaunchpadDirectoryKeyFromScope(scopeKey: string): string | undefined {
@@ -2470,12 +2507,13 @@ export function Composer(props: ComposerProps) {
     autocompleteListboxId && autocompleteKind
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
-  const reviewBranchOptions = useMemo(
-    () => buildReviewBranchOptions({
-      directory: props.directory,
-      thread: props.thread,
-    }),
-    [props.directory, props.thread]
+  const reviewBranchPickerOptions = useMemo(
+    () =>
+      buildReviewBranchPickerOptions({
+        directory: props.directory,
+        thread: props.thread,
+      }),
+    [props.directory, props.thread],
   );
   const isBareReviewCommand = draft.trim() === "/review";
   const isCompactCommand = supportsCompactCommand && draft.trim() === "/compact";
@@ -2484,7 +2522,7 @@ export function Composer(props: ComposerProps) {
   );
 
   useEffect(() => {
-    if (!isReviewComposerOpen || reviewConfig?.showBranchPicker) {
+    if (!isReviewComposerOpen) {
       return;
     }
     const target = reviewConfig?.target ?? "baseBranch";
@@ -2492,7 +2530,7 @@ export function Composer(props: ComposerProps) {
       (option) => option.target === target,
     );
     reviewOptionRefs.current[optionIndex === -1 ? 0 : optionIndex]?.focus();
-  }, [isReviewComposerOpen, reviewConfig?.showBranchPicker, reviewConfig?.target]);
+  }, [isReviewComposerOpen, reviewConfig?.target]);
 
   useEffect(() => {
     if (!supportsReview && reviewConfig) {
@@ -3260,7 +3298,6 @@ export function Composer(props: ComposerProps) {
 
   const selectReviewTarget = (
     target: ReviewTargetChoice,
-    options?: { showBranchPicker?: boolean },
   ): void => {
     setReviewConfig((current) => ({
       ...(current ??
@@ -3268,7 +3305,6 @@ export function Composer(props: ComposerProps) {
           directory: props.directory,
           thread: props.thread,
         })),
-      showBranchPicker: options?.showBranchPicker,
       target,
     }));
     setSendError(undefined);
@@ -3293,9 +3329,7 @@ export function Composer(props: ComposerProps) {
     const nextIndex =
       (index + direction + REVIEW_TARGET_OPTIONS.length) %
       REVIEW_TARGET_OPTIONS.length;
-    selectReviewTarget(REVIEW_TARGET_OPTIONS[nextIndex]!.target, {
-      showBranchPicker: false,
-    });
+    selectReviewTarget(REVIEW_TARGET_OPTIONS[nextIndex]!.target);
     focusReviewOption(nextIndex);
   };
 
@@ -5456,9 +5490,7 @@ export function Composer(props: ComposerProps) {
                   aria-pressed={reviewConfig?.target === option.target}
                   className={`composer__review-option${reviewConfig?.target === option.target ? " is-active" : ""}`}
                   onClick={() => {
-                    selectReviewTarget(option.target, {
-                      showBranchPicker: option.target === "baseBranch",
-                    });
+                    selectReviewTarget(option.target);
                   }}
                   onKeyDown={(event) => handleReviewOptionKeyDown(event, index)}
                 >
@@ -5468,35 +5500,27 @@ export function Composer(props: ComposerProps) {
               ))}
             </div>
 
-            {reviewConfig?.target === "baseBranch" && reviewConfig.showBranchPicker ? (
-              <label className="composer__review-field">
+            {reviewConfig?.target === "baseBranch" ? (
+              <div className="composer__review-field">
                 <span>Base branch</span>
-                <input
-                  className="composer__review-input"
-                  list="composer-review-branches"
+                <BranchPicker
+                  ariaLabel="Base branch"
+                  options={reviewBranchPickerOptions}
                   value={reviewConfig.branch}
-                  onChange={(event) => {
+                  onChange={(branch) => {
                     setReviewConfig((current) => ({
                       ...(current ??
                         createReviewConfig({
                           directory: props.directory,
                           thread: props.thread,
                         })),
-                      branch: event.target.value,
-                      showBranchPicker: true,
+                      branch,
                       target: "baseBranch",
                     }));
                     setSendError(undefined);
                   }}
                 />
-                {reviewBranchOptions.length > 0 ? (
-                  <datalist id="composer-review-branches">
-                    {reviewBranchOptions.map((branch) => (
-                      <option key={branch} value={branch} />
-                    ))}
-                  </datalist>
-                ) : null}
-              </label>
+              </div>
             ) : null}
 
             {reviewConfig?.target === "commit" ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -324,6 +324,7 @@ type ReviewConfigState = {
   branch: string;
   commit: string;
   customInstructions: string;
+  showBranchPicker?: boolean;
   target?: ReviewTargetChoice;
 };
 
@@ -462,19 +463,14 @@ function buildReviewBranchOptions(params: {
       currentBranches.has(value.slice("origin/".length))
     );
   };
-  const preferredBaseBranches = (params.directory?.gitStatus?.baseBranches ?? []).filter(
-    (branch) => !isCurrentBranch(branch),
-  );
   const upstreamBranch = params.directory?.gitStatus?.upstreamBranch?.replace(
     /^origin\//,
     "",
   );
   const candidates = [
-    ...preferredBaseBranches,
-    !isCurrentBranch(params.directory?.gitStatus?.defaultBranch)
-      ? params.directory?.gitStatus?.defaultBranch
-      : undefined,
-    !isCurrentBranch(upstreamBranch) ? upstreamBranch : undefined,
+    ...(params.directory?.gitStatus?.baseBranches ?? []),
+    params.directory?.gitStatus?.defaultBranch,
+    upstreamBranch,
     "main",
     params.thread?.gitBranch,
     params.thread?.observedGitBranch,
@@ -484,7 +480,7 @@ function buildReviewBranchOptions(params: {
   const options = new Set<string>();
   for (const candidate of candidates) {
     const value = candidate?.trim();
-    if (value) {
+    if (value && !isCurrentBranch(value)) {
       options.add(value);
     }
   }
@@ -1536,7 +1532,6 @@ export function Composer(props: ComposerProps) {
   const inputRef = useRef<ComposerInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
-  const reviewBranchInputRef = useRef<HTMLInputElement>(null);
   const activeTurnIdRef = useRef<string | undefined>(props.activeTurnId);
   const confirmedActiveTurnIdRef = useRef<string | undefined>(undefined);
   const activeReviewTurnIdRef = useRef<string | undefined>(undefined);
@@ -2486,14 +2481,6 @@ export function Composer(props: ComposerProps) {
   const isReviewComposerOpen = Boolean(
     supportsReview && reviewConfig && isBareReviewCommand
   );
-
-  useEffect(() => {
-    if (!isReviewComposerOpen || reviewConfig?.target !== "baseBranch") {
-      return;
-    }
-    reviewBranchInputRef.current?.focus();
-    reviewBranchInputRef.current?.select();
-  }, [isReviewComposerOpen, reviewConfig?.target]);
 
   useEffect(() => {
     if (!supportsReview && reviewConfig) {
@@ -5413,6 +5400,7 @@ export function Composer(props: ComposerProps) {
                           directory: props.directory,
                           thread: props.thread,
                         })),
+                      showBranchPicker: option.target === "baseBranch",
                       target: option.target,
                     }));
                     setSendError(undefined);
@@ -5424,11 +5412,10 @@ export function Composer(props: ComposerProps) {
               ))}
             </div>
 
-            {reviewConfig?.target === "baseBranch" ? (
+            {reviewConfig?.target === "baseBranch" && reviewConfig.showBranchPicker ? (
               <label className="composer__review-field">
                 <span>Base branch</span>
                 <input
-                  ref={reviewBranchInputRef}
                   className="composer__review-input"
                   list="composer-review-branches"
                   value={reviewConfig.branch}
@@ -5440,6 +5427,7 @@ export function Composer(props: ComposerProps) {
                           thread: props.thread,
                         })),
                       branch: event.target.value,
+                      showBranchPicker: true,
                       target: "baseBranch",
                     }));
                     setSendError(undefined);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4880,10 +4880,7 @@ describe("Composer", () => {
       "aria-pressed",
       "true",
     );
-    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
-    await waitFor(() => {
-      expect(screen.getByLabelText("Base branch")).toHaveFocus();
-    });
+    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
     expect(startReview).not.toHaveBeenCalled();
 
     const reviewTarget = screen.getByRole("group", { name: "Review target" });
@@ -4896,6 +4893,61 @@ describe("Composer", () => {
         backend: "codex",
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("shows the base branch override only after the base branch card is explicitly clicked", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+    fireEvent.change(screen.getByLabelText("Base branch"), {
+      target: { value: "release" },
+    });
+
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    const form = reviewTarget.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "release" },
         delivery: "inline",
       });
     });
@@ -4954,7 +5006,7 @@ describe("Composer", () => {
       "aria-pressed",
       "true",
     );
-    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
+    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
 
     const reviewTarget = screen.getByRole("group", { name: "Review target" });
     const form = reviewTarget.closest("form");
@@ -4966,6 +5018,80 @@ describe("Composer", () => {
         backend: "codex",
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "origin/main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("falls back to main when only self branches are reported as review base options", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "fix/review-base-default-submit",
+            defaultBranch: "fix/review-base-default-submit",
+            upstreamBranch: "origin/fix/review-base-default-submit",
+            branches: ["fix/review-base-default-submit"],
+            baseBranches: [
+              "fix/review-base-default-submit",
+              "origin/fix/review-base-default-submit",
+            ],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "fix/review-base-default-submit",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
+
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    const form = reviewTarget.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
       });
     });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4901,6 +4901,76 @@ describe("Composer", () => {
     });
   });
 
+  it("keeps the base branch card selected while preferring remote base refs over the current branch", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "fix/review-base-default-submit",
+            defaultBranch: "fix/review-base-default-submit",
+            branches: ["fix/review-base-default-submit"],
+            baseBranches: ["fix/review-base-default-submit", "origin/main"],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "fix/review-base-default-submit",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
+
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    const form = reviewTarget.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/main" },
+        delivery: "inline",
+      });
+    });
+  });
+
   it("submits current changes when selected from the bare review target prompt", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4662,7 +4662,11 @@ describe("Composer", () => {
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
 
     rerender(<Composer {...baseProps} activeTurnId="turn-1" />);
-    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Compare this branch with a base branch/i,
+      }),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Start review" }));
 
     expect(startReview).not.toHaveBeenCalled();
@@ -4876,17 +4880,20 @@ describe("Composer", () => {
 
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+    const baseBranchTarget = screen.getByRole("button", {
+      name: /Compare this branch with a base branch/i,
+    });
+    expect(baseBranchTarget).toHaveAttribute(
       "aria-pressed",
       "true",
     );
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Base branch/i })).toHaveFocus();
+      expect(baseBranchTarget).toHaveFocus();
     });
-    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
     expect(startReview).not.toHaveBeenCalled();
 
-    fireEvent.keyDown(screen.getByRole("button", { name: /Base branch/i }), {
+    fireEvent.keyDown(baseBranchTarget, {
       key: "Enter",
     });
 
@@ -4932,11 +4939,14 @@ describe("Composer", () => {
       target: { value: "/review" },
     });
     await clickButton("Send");
+    const baseBranchTarget = screen.getByRole("button", {
+      name: /Compare this branch with a base branch/i,
+    });
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Base branch/i })).toHaveFocus();
+      expect(baseBranchTarget).toHaveFocus();
     });
 
-    fireEvent.keyDown(screen.getByRole("button", { name: /Base branch/i }), {
+    fireEvent.keyDown(baseBranchTarget, {
       key: "ArrowRight",
     });
 
@@ -4962,7 +4972,7 @@ describe("Composer", () => {
     });
   });
 
-  it("shows the base branch override only after the base branch card is explicitly clicked", async () => {
+  it("uses the branch picker to override the selected base branch", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -4975,6 +4985,21 @@ describe("Composer", () => {
         desktopApi={{
           onAgentEvent: () => () => undefined,
           startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "release", "main"],
+            baseBranches: ["main", "release"],
+            syncState: "untracked",
+          },
         }}
         disabled={false}
         skills={[]}
@@ -4995,12 +5020,9 @@ describe("Composer", () => {
     });
     await clickButton("Send");
 
-    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
     expect(screen.getByLabelText("Base branch")).toHaveValue("main");
-    fireEvent.change(screen.getByLabelText("Base branch"), {
-      target: { value: "release" },
-    });
+    fireEvent.click(screen.getByLabelText("Base branch"));
+    fireEvent.click(screen.getByRole("option", { name: "release" }));
 
     const reviewTarget = screen.getByRole("group", { name: "Review target" });
     const form = reviewTarget.closest("form");
@@ -5066,11 +5088,15 @@ describe("Composer", () => {
     });
     await clickButton("Send");
 
-    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+    expect(
+      screen.getByRole("button", {
+        name: /Compare this branch with a base branch/i,
+      }),
+    ).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
 
     const reviewTarget = screen.getByRole("group", { name: "Review target" });
     const form = reviewTarget.closest("form");
@@ -5140,11 +5166,15 @@ describe("Composer", () => {
     });
     await clickButton("Send");
 
-    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+    expect(
+      screen.getByRole("button", {
+        name: /Compare this branch with a base branch/i,
+      }),
+    ).toHaveAttribute(
       "aria-pressed",
       "true",
     );
-    expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
 
     const reviewTarget = screen.getByRole("group", { name: "Review target" });
     const form = reviewTarget.closest("form");

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4887,6 +4887,23 @@ describe("Composer", () => {
       "aria-pressed",
       "true",
     );
+    expect(baseBranchTarget).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("button", { name: /Current changes/i })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByRole("button", { name: /Review one commit by SHA/i })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByRole("button", { name: /Review using custom instructions/i })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByLabelText("Base branch")).not.toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
     await waitFor(() => {
       expect(baseBranchTarget).toHaveFocus();
     });
@@ -4956,6 +4973,11 @@ describe("Composer", () => {
     expect(screen.getByRole("button", { name: /Current changes/i })).toHaveAttribute(
       "aria-pressed",
       "true",
+    );
+    expect(baseBranchTarget).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: /Current changes/i })).toHaveAttribute(
+      "tabindex",
+      "0",
     );
 
     fireEvent.keyDown(screen.getByRole("button", { name: /Current changes/i }), {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4880,19 +4880,83 @@ describe("Composer", () => {
       "aria-pressed",
       "true",
     );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Base branch/i })).toHaveFocus();
+    });
     expect(screen.queryByLabelText("Base branch")).not.toBeInTheDocument();
     expect(startReview).not.toHaveBeenCalled();
 
-    const reviewTarget = screen.getByRole("group", { name: "Review target" });
-    const form = reviewTarget.closest("form");
-    expect(form).not.toBeNull();
-    fireEvent.submit(form!);
+    fireEvent.keyDown(screen.getByRole("button", { name: /Base branch/i }), {
+      key: "Enter",
+    });
 
     await waitFor(() => {
       expect(startReview).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("moves review target focus with arrow keys and submits the focused target with Enter", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Base branch/i })).toHaveFocus();
+    });
+
+    fireEvent.keyDown(screen.getByRole("button", { name: /Base branch/i }), {
+      key: "ArrowRight",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Current changes/i })).toHaveFocus();
+    });
+    expect(screen.getByRole("button", { name: /Current changes/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: /Current changes/i }), {
+      key: "Enter",
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "uncommittedChanges" },
         delivery: "inline",
       });
     });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5233,6 +5233,58 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
   });
 
+  it("falls back to main before unrelated directory branches for review base", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "fix/pr-chip-tooltip-dismiss",
+            defaultBranch: "fix/pr-chip-tooltip-dismiss",
+            branches: ["fix/pr-chip-tooltip-dismiss"],
+            baseBranches: ["fix/pr-chip-tooltip-dismiss"],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Msg - Control response scope",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "feat/messaging-response-mode",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+  });
+
   it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4876,19 +4876,26 @@ describe("Composer", () => {
 
     expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Reply")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Base branch/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Base branch")).toHaveFocus();
+    });
     expect(startReview).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /Base branch/i }));
-    fireEvent.change(screen.getByLabelText("Base branch"), {
-      target: { value: "release" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    const form = reviewTarget.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
 
     await waitFor(() => {
       expect(startReview).toHaveBeenCalledWith({
         backend: "codex",
         threadId: "thread-1",
-        target: { type: "baseBranch", branch: "release" },
+        target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
       });
     });

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5193,6 +5193,75 @@ describe("Composer", () => {
     });
   });
 
+  it("accepts a custom review base ref that is not in the branch picker options", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "main"],
+            baseBranches: ["main"],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    const baseBranchInput = screen.getByLabelText("Base branch");
+    fireEvent.change(baseBranchInput, {
+      target: { value: "origin/releases/2026.07" },
+    });
+    expect(baseBranchInput).toHaveValue("origin/releases/2026.07");
+    expect(
+      screen.queryByRole("option", { name: "origin/releases/2026.07" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/releases/2026.07" },
+        delivery: "inline",
+      });
+    });
+  });
+
   it("prefers origin main over unrelated recent local branches for review base", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5171,6 +5171,68 @@ describe("Composer", () => {
     });
   });
 
+  it("prefers origin main over unrelated recent local branches for review base", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "fix/review-base-default-submit",
+            defaultBranch: "fix/review-base-default-submit",
+            branches: [
+              "fix/desktop-terminal-replay-responses",
+              "fix/review-base-default-submit",
+              "main",
+            ],
+            baseBranches: [
+              "fix/desktop-terminal-replay-responses",
+              "fix/review-base-default-submit",
+              "origin/fix/review-base-default-submit",
+              "origin/main",
+              "main",
+            ],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "fix/review-base-default-submit",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
+  });
+
   it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
@@ -5233,6 +5295,19 @@ describe("Composer", () => {
     });
 
     expect(screen.getAllByRole("option")).toHaveLength(20);
+    expect(screen.getAllByRole("option").map((option) => option.getAttribute("tabindex"))).toEqual(
+      Array.from({ length: 20 }, () => "-1"),
+    );
+    expect(screen.getByRole("option", { name: /c00 Commit subject 0/i })).toHaveClass(
+      "is-active",
+    );
+    fireEvent.keyDown(commitInput, { key: "ArrowDown" });
+    expect(screen.getByRole("option", { name: /c00 Commit subject 0/i })).not.toHaveClass(
+      "is-active",
+    );
+    expect(screen.getByRole("option", { name: /c01 Commit subject 1/i })).toHaveClass(
+      "is-active",
+    );
     fireEvent.click(screen.getByRole("option", { name: /c03 Commit subject 3/i }));
     expect(commitInput).toHaveValue(recentCommits[3]!.sha);
 
@@ -5246,6 +5321,70 @@ describe("Composer", () => {
         delivery: "inline",
       });
     });
+  });
+
+  it("closes commit suggestions with Escape before cancelling the review prompt", async () => {
+    const recentCommits = Array.from({ length: 2 }, (_, index) => ({
+      sha: `${index.toString(16).padStart(40, "0")}`,
+      shortSha: `c${index}`,
+      committedAt: Math.floor(Date.now() / 1000) - index * 60,
+      subject: `Commit subject ${index}`,
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "main"],
+            recentCommits,
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("listbox", { name: "Recent commits" })).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(commitInput, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox", { name: "Recent commits" })).not.toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+
+    fireEvent.keyDown(commitInput, { key: "Escape" });
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
   });
 
   it("still accepts a pasted raw commit SHA", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4972,6 +4972,138 @@ describe("Composer", () => {
     });
   });
 
+  it("submits the focused review target when keyboard focus moves without changing selection", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    const currentChangesTarget = screen.getByRole("button", {
+      name: /Current changes/i,
+    });
+    currentChangesTarget.focus();
+    expect(currentChangesTarget).toHaveFocus();
+    expect(currentChangesTarget).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.keyDown(currentChangesTarget, {
+      key: "Enter",
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "uncommittedChanges" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("cancels the bare review target prompt with Escape from cards and fields", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    const { rerender } = render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: /Compare this branch with a base branch/i,
+      }),
+      { key: "Escape" },
+    );
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reply")).toHaveFocus();
+    });
+
+    rerender(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    await waitFor(() => {
+      expect(commitInput).toHaveFocus();
+    });
+    fireEvent.keyDown(commitInput, { key: "Escape" });
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
+  });
+
   it("uses the branch picker to override the selected base branch", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
@@ -5034,6 +5166,134 @@ describe("Composer", () => {
         backend: "codex",
         threadId: "thread-1",
         target: { type: "baseBranch", branch: "release" },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const recentCommits = Array.from({ length: 25 }, (_, index) => ({
+      sha: `${index.toString(16).padStart(40, "0")}`,
+      shortSha: `c${index.toString().padStart(2, "0")}`,
+      committedAt: Math.floor(Date.now() / 1000) - index * 60,
+      subject: `Commit subject ${index}`,
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "main"],
+            recentCommits,
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    await waitFor(() => {
+      expect(commitInput).toHaveFocus();
+    });
+
+    expect(screen.getAllByRole("option")).toHaveLength(20);
+    fireEvent.click(screen.getByRole("option", { name: /c03 Commit subject 3/i }));
+    expect(commitInput).toHaveValue(recentCommits[3]!.sha);
+
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "commit", sha: recentCommits[3]!.sha, title: null },
+        delivery: "inline",
+      });
+    });
+  });
+
+  it("still accepts a pasted raw commit SHA", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    fireEvent.change(commitInput, {
+      target: { value: "abc123def456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "commit", sha: "abc123def456", title: null },
         delivery: "inline",
       });
     });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13501,6 +13501,27 @@ textarea,
   max-height: min(440px, calc(100dvh - 128px));
 }
 
+.branch-picker--review {
+  width: min(100%, 640px);
+  max-width: 100%;
+}
+
+.branch-picker--review .composer-dropdown__button {
+  min-height: 34px;
+  justify-content: flex-start;
+  border-radius: 6px;
+  font-weight: 700;
+}
+
+.branch-picker--review .branch-picker__menu {
+  right: auto;
+  left: 0;
+  z-index: 45;
+  min-width: min(100%, 420px);
+  width: min(640px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+}
+
 .branch-picker__list {
   display: flex;
   flex-direction: column;
@@ -14519,6 +14540,17 @@ textarea,
   font-weight: 700;
 }
 
+.review-commit-picker {
+  position: relative;
+  width: min(100%, 640px);
+  max-width: 100%;
+}
+
+.review-commit-picker label {
+  display: block;
+  margin-bottom: 6px;
+}
+
 .composer__review-input {
   width: 100%;
   min-height: 34px;
@@ -14528,6 +14560,79 @@ textarea,
   background: var(--bg-input);
   color: var(--text-primary);
   font: inherit;
+}
+
+.review-commit-picker__menu {
+  position: absolute;
+  z-index: 45;
+  bottom: calc(100% + 8px);
+  left: 0;
+  display: flex;
+  width: min(640px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  max-height: min(360px, calc(100dvh - 128px));
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.review-commit-picker__option {
+  display: grid;
+  width: 100%;
+  min-height: 38px;
+  grid-template-columns: minmax(64px, max-content) minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.35;
+  text-align: left;
+}
+
+.review-commit-picker__option:hover,
+.review-commit-picker__option:focus-visible,
+.review-commit-picker__option.is-active {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  outline: none;
+}
+
+.review-commit-picker__sha {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.review-commit-picker__subject {
+  min-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.review-commit-picker__time {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.review-commit-picker__option:hover .review-commit-picker__time,
+.review-commit-picker__option:focus-visible .review-commit-picker__time,
+.review-commit-picker__option.is-active .review-commit-picker__time {
+  color: var(--accent-bright);
 }
 
 .composer__review-input--textarea {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13522,6 +13522,26 @@ textarea,
   max-width: calc(100vw - 32px);
 }
 
+.review-branch-picker {
+  position: relative;
+  width: min(100%, 640px);
+  max-width: 100%;
+}
+
+.review-branch-picker .composer__review-input {
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.review-branch-picker__menu {
+  right: auto;
+  left: 0;
+  z-index: 45;
+  min-width: min(100%, 420px);
+  width: min(640px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+}
+
 .branch-picker__list {
   display: flex;
   flex-direction: column;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -491,6 +491,14 @@ export type NavigationGitBranchDetail = {
   inUse?: boolean;
 };
 
+export type NavigationGitCommitSummary = {
+  sha: string;
+  shortSha: string;
+  /** Commit time in unix seconds. */
+  committedAt?: number;
+  subject: string;
+};
+
 export type NavigationDirectoryGitStatus = {
   currentBranch?: string;
   defaultBranch?: string;
@@ -502,6 +510,8 @@ export type NavigationDirectoryGitStatus = {
   /** Candidate refs for creating a new worktree base. Includes local branches and remote-tracking refs. */
   baseBranches?: string[];
   baseBranchDetails?: NavigationGitBranchDetail[];
+  /** Most recent commits on the checked-out branch, newest first. */
+  recentCommits?: NavigationGitCommitSummary[];
   handoffBranches?: string[];
   syncState?:
     | "in-sync"


### PR DESCRIPTION
## Summary

Bare `/review` now opens the review target picker with Base branch selected, preferring the repository's default, upstream, or known base refs before falling back to `main`. The picker focuses the Base branch input and submits the selected review target from the form, so hitting Enter after the chooser opens starts the review without an extra click.

Users can still switch to current changes, commit, or custom instructions before starting the review.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
