### PR TITLE
feat(desktop): preview markdown file links

### DIFF
--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -1,17 +1,32 @@
-import { access } from "node:fs/promises";
-import { ipcMain, shell } from "electron";
+import { access, readFile, stat } from "node:fs/promises";
+import { BrowserWindow, ipcMain, shell } from "electron";
 import type {
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenMarkdownFileViewerRequest,
+  OpenMarkdownFileViewerResponse,
   OpenPathRequest,
   OpenPathResponse,
+  ReadMarkdownFileRequest,
+  ReadMarkdownFileResponse,
+  ReadMarkdownFileViewerSnapshotRequest,
+  ReadMarkdownFileViewerSnapshotResponse,
 } from "@pwragent/shared";
 import {
   APPLICATION_OPEN_CHANNEL,
+  MARKDOWN_FILE_READ_CHANNEL,
+  MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
+  MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
 } from "../../shared/ipc";
+import {
+  readMarkdownFileViewerSnapshot,
+  showMarkdownFileViewerWindow,
+} from "../markdown-files-window";
 import { openDesktopApplication } from "../settings/application-discovery";
+
+const MAX_MARKDOWN_FILE_BYTES = 2 * 1024 * 1024;
 
 /**
  * Open a filesystem path with the OS default handler. The fallback the
@@ -56,6 +71,36 @@ async function revealPathInFolder(
   return { opened: true };
 }
 
+async function readMarkdownFile(
+  request: ReadMarkdownFileRequest,
+): Promise<ReadMarkdownFileResponse> {
+  const target = request.path?.trim();
+  if (!target) {
+    return { path: "", error: "No file path was provided." };
+  }
+
+  if (!/\.(?:md|markdown)$/i.test(target)) {
+    return { path: target, error: "Only Markdown files can be previewed." };
+  }
+
+  try {
+    const fileStat = await stat(target);
+    if (!fileStat.isFile()) {
+      return { path: target, error: `Path is not a file: ${target}` };
+    }
+    if (fileStat.size > MAX_MARKDOWN_FILE_BYTES) {
+      return { path: target, error: "Markdown file is too large to preview." };
+    }
+
+    return {
+      path: target,
+      content: await readFile(target, "utf8"),
+    };
+  } catch {
+    return { path: target, error: `Path does not exist: ${target}` };
+  }
+}
+
 export function registerApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.handle(
@@ -79,10 +124,46 @@ export function registerApplicationIpcHandlers(): void {
     async (_event, request: OpenPathRequest): Promise<OpenPathResponse> =>
       revealPathInFolder(request),
   );
+
+  ipcMain.removeHandler(MARKDOWN_FILE_READ_CHANNEL);
+  ipcMain.handle(
+    MARKDOWN_FILE_READ_CHANNEL,
+    async (
+      _event,
+      request: ReadMarkdownFileRequest,
+    ): Promise<ReadMarkdownFileResponse> => readMarkdownFile(request),
+  );
+
+  ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL);
+  ipcMain.handle(
+    MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
+    async (
+      event,
+      request: OpenMarkdownFileViewerRequest,
+    ): Promise<OpenMarkdownFileViewerResponse> => {
+      showMarkdownFileViewerWindow(request, {
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
+      return { opened: true };
+    },
+  );
+
+  ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
+  ipcMain.handle(
+    MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
+    async (
+      _event,
+      request: ReadMarkdownFileViewerSnapshotRequest,
+    ): Promise<ReadMarkdownFileViewerSnapshotResponse> =>
+      readMarkdownFileViewerSnapshot(request.contextKey),
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(APPLICATION_OPEN_CHANNEL);
   ipcMain.removeHandler(PATH_OPEN_CHANNEL);
   ipcMain.removeHandler(PATH_REVEAL_CHANNEL);
+  ipcMain.removeHandler(MARKDOWN_FILE_READ_CHANNEL);
+  ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL);
+  ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
 }

--- a/apps/desktop/src/main/markdown-files-window.ts
+++ b/apps/desktop/src/main/markdown-files-window.ts
@@ -1,0 +1,164 @@
+import { BrowserWindow } from "electron";
+import type {
+  MarkdownFileViewerFile,
+  MarkdownFileViewerSnapshot,
+  OpenMarkdownFileViewerRequest,
+  ReadMarkdownFileViewerSnapshotResponse,
+} from "@pwragent/shared";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_MARKDOWN_FILES,
+  registerWindowChannels,
+} from "./window-channels";
+import {
+  APPEARANCE_CHANGED_EVENT_CHANNEL,
+  MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
+} from "../shared/ipc";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:markdown-files-window");
+const FILES_HASH = "files";
+const FILES_WINDOW_WIDTH = 1040;
+const FILES_WINDOW_HEIGHT = 780;
+
+type WindowState = {
+  snapshot: MarkdownFileViewerSnapshot;
+  window?: BrowserWindow;
+};
+
+const fileViewerWindows = new Map<string, WindowState>();
+
+export function readMarkdownFileViewerSnapshot(
+  contextKey: string,
+): ReadMarkdownFileViewerSnapshotResponse {
+  return { snapshot: fileViewerWindows.get(contextKey)?.snapshot };
+}
+
+export function showMarkdownFileViewerWindow(
+  request: OpenMarkdownFileViewerRequest,
+  source: WindowPlacementSource = {},
+): void {
+  const contextKey = request.context.key.trim();
+  if (!contextKey) {
+    throw new Error("Markdown file viewer requires a context key.");
+  }
+
+  const current = fileViewerWindows.get(contextKey);
+  const snapshot = upsertSnapshotFile(
+    current?.snapshot ?? {
+      context: request.context,
+      files: [],
+      selectedPath: request.file.path,
+      editorApplication: request.editorApplication,
+    },
+    request.file,
+    request.editorApplication,
+  );
+  fileViewerWindows.set(contextKey, {
+    snapshot,
+    window: current?.window,
+  });
+
+  if (current?.window && !current.window.isDestroyed()) {
+    current.window.webContents.send(
+      MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
+      { snapshot },
+    );
+    positionWindowForSourceDisplay(current.window, source);
+    showAndFocusAuxiliaryWindow(current.window);
+    return;
+  }
+
+  const windowTitle = snapshot.context.title || "Files";
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(
+      FILES_WINDOW_WIDTH,
+      FILES_WINDOW_HEIGHT,
+      source,
+    ),
+    width: FILES_WINDOW_WIDTH,
+    height: FILES_WINDOW_HEIGHT,
+    minWidth: 720,
+    minHeight: 520,
+    show: false,
+    title: windowTitle,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, windowTitle);
+  hideAuxiliaryWindowMenuBar(window);
+
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_MARKDOWN_FILES, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const rendererEntry = getRendererEntry();
+  const hash = `${FILES_HASH}/${encodeURIComponent(contextKey)}`;
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${hash}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash });
+  }
+
+  showAuxiliaryWindowWhenReady(window);
+
+  window.on("closed", () => {
+    const latest = fileViewerWindows.get(contextKey);
+    if (latest?.window === window) {
+      fileViewerWindows.delete(contextKey);
+    }
+    log.debug("markdown files window closed", { contextKey });
+  });
+
+  fileViewerWindows.set(contextKey, { snapshot, window });
+  log.debug("markdown files window created", { contextKey });
+}
+
+function upsertSnapshotFile(
+  snapshot: MarkdownFileViewerSnapshot,
+  file: MarkdownFileViewerFile,
+  editorApplication: OpenMarkdownFileViewerRequest["editorApplication"],
+): MarkdownFileViewerSnapshot {
+  const existingIndex = snapshot.files.findIndex((candidate) => candidate.path === file.path);
+  const files =
+    existingIndex >= 0
+      ? snapshot.files.map((candidate, index) => index === existingIndex ? file : candidate)
+      : [...snapshot.files, file];
+
+  return {
+    ...snapshot,
+    files,
+    selectedPath: file.path,
+    ...(editorApplication ? { editorApplication } : {}),
+  };
+}

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -36,12 +36,14 @@ export const WINDOW_KIND_MESSAGING_ACTIVITY = "messaging-activity" as const;
 export const WINDOW_KIND_CHANGELOG = "changelog" as const;
 export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
+export const WINDOW_KIND_MARKDOWN_FILES = "markdown-files" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
   | typeof WINDOW_KIND_CHANGELOG
   | typeof WINDOW_KIND_LICENSE_DOCUMENT
-  | typeof WINDOW_KIND_APP_LOGS;
+  | typeof WINDOW_KIND_APP_LOGS
+  | typeof WINDOW_KIND_MARKDOWN_FILES;
 
 interface Entry {
   kind: WindowKind;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -176,8 +176,14 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenMarkdownFileViewerRequest,
+  OpenMarkdownFileViewerResponse,
   OpenPathRequest,
   OpenPathResponse,
+  ReadMarkdownFileRequest,
+  ReadMarkdownFileResponse,
+  ReadMarkdownFileViewerSnapshotRequest,
+  ReadMarkdownFileViewerSnapshotResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
@@ -296,6 +302,10 @@ import {
   APP_SERVER_READ_THREAD_CHANNEL,
   APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL,
   APPLICATION_OPEN_CHANNEL,
+  MARKDOWN_FILE_READ_CHANNEL,
+  MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
+  MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
+  MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
   INTEGRATED_TERMINAL_CREATE_CHANNEL,
   INTEGRATED_TERMINAL_ERROR_CHANNEL,
@@ -757,6 +767,30 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(PATH_OPEN_CHANNEL, request),
   revealPath: async (request: OpenPathRequest): Promise<OpenPathResponse> =>
     await ipcRenderer.invoke(PATH_REVEAL_CHANNEL, request),
+  readMarkdownFile: async (
+    request: ReadMarkdownFileRequest,
+  ): Promise<ReadMarkdownFileResponse> =>
+    await ipcRenderer.invoke(MARKDOWN_FILE_READ_CHANNEL, request),
+  openMarkdownFileViewer: async (
+    request: OpenMarkdownFileViewerRequest,
+  ): Promise<OpenMarkdownFileViewerResponse> =>
+    await ipcRenderer.invoke(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL, request),
+  readMarkdownFileViewerSnapshot: async (
+    request: ReadMarkdownFileViewerSnapshotRequest,
+  ): Promise<ReadMarkdownFileViewerSnapshotResponse> =>
+    await ipcRenderer.invoke(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL, request),
+  onMarkdownFileViewerSnapshotChanged: (
+    callback: (snapshot: Readonly<ReadMarkdownFileViewerSnapshotResponse>) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: ReadMarkdownFileViewerSnapshotResponse,
+    ) => callback(payload);
+    ipcRenderer.on(MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL, listener);
+    return () => {
+      ipcRenderer.off(MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL, listener);
+    };
+  },
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import type {
   DesktopApplicationsSnapshot,
   MarkdownFileViewerFile,
@@ -24,6 +24,10 @@ export function MarkdownFilesWindow() {
   const markdownApplications = useMemo(
     () => applicationsSnapshotForEditor(snapshot),
     [snapshot],
+  );
+  const breadcrumbParts = useMemo(
+    () => markdownFilesBreadcrumbParts(snapshot?.context),
+    [snapshot?.context],
   );
   const [loadState, setLoadState] = useState<LoadState>({ status: "idle" });
 
@@ -139,14 +143,28 @@ export function MarkdownFilesWindow() {
           <p className="activity-titlebar__brand">
             Pwr<span className="activity-titlebar__brand-accent">Agent</span>
           </p>
-          <div className="activity-titlebar__breadcrumb">
-            <span className="activity-titlebar__eyebrow">Thread</span>
-            <span aria-hidden="true" className="activity-titlebar__separator">
-              ›
-            </span>
-            <span className="activity-titlebar__current">
-              {snapshot?.context.title ?? "Files"}
-            </span>
+          <div
+            className="activity-titlebar__breadcrumb"
+            aria-label={breadcrumbParts.join(" > ")}
+          >
+            {breadcrumbParts.map((part, index) => (
+              <Fragment key={`${part}:${index}`}>
+                {index > 0 ? (
+                  <span aria-hidden="true" className="activity-titlebar__separator">
+                    ›
+                  </span>
+                ) : null}
+                <span
+                  className={
+                    index === breadcrumbParts.length - 1
+                      ? "activity-titlebar__current"
+                      : "activity-titlebar__crumb"
+                  }
+                >
+                  {part}
+                </span>
+              </Fragment>
+            ))}
           </div>
           <div className="activity-titlebar__spacer" />
         </header>
@@ -266,6 +284,23 @@ function relativeFilePath(filePath: string, projectPath: string | undefined): st
   return filePath === projectPath || filePath.startsWith(`${projectPath}/`)
     ? filePath.slice(projectPath.length).replace(/^\//, "") || filePath
     : filePath;
+}
+
+function markdownFilesBreadcrumbParts(
+  context: MarkdownFileViewerSnapshot["context"] | undefined,
+): string[] {
+  const projectLabel = projectLabelFromPath(context?.projectPath);
+  const threadTitle = context?.threadTitle?.trim();
+
+  const parts = [projectLabel, threadTitle, "Files"].filter(
+    (part): part is string => Boolean(part),
+  );
+  return parts.length > 0 ? parts : ["Files"];
+}
+
+function projectLabelFromPath(projectPath: string | undefined): string | undefined {
+  const label = projectPath?.split(/[\\/]/).filter(Boolean).at(-1)?.trim();
+  return label || undefined;
 }
 
 function applicationsSnapshotForEditor(

--- a/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
+  DesktopApplicationsSnapshot,
   MarkdownFileViewerFile,
   MarkdownFileViewerSnapshot,
 } from "@pwragent/shared";
@@ -20,6 +21,10 @@ export function MarkdownFilesWindow() {
   const selectedFile = snapshot?.files.find(
     (file) => file.path === snapshot.selectedPath,
   ) ?? snapshot?.files[0];
+  const markdownApplications = useMemo(
+    () => applicationsSnapshotForEditor(snapshot),
+    [snapshot],
+  );
   const [loadState, setLoadState] = useState<LoadState>({ status: "idle" });
 
   useEffect(() => {
@@ -228,6 +233,7 @@ export function MarkdownFilesWindow() {
               ) : null}
               {loadState.status === "loaded" ? (
                 <ThreadMarkdown
+                  applications={markdownApplications}
                   className="markdown-files-window__markdown"
                   desktopApi={desktopApi}
                   fileViewerContext={snapshot?.context}
@@ -260,4 +266,32 @@ function relativeFilePath(filePath: string, projectPath: string | undefined): st
   return filePath === projectPath || filePath.startsWith(`${projectPath}/`)
     ? filePath.slice(projectPath.length).replace(/^\//, "") || filePath
     : filePath;
+}
+
+function applicationsSnapshotForEditor(
+  snapshot: MarkdownFileViewerSnapshot | undefined,
+): DesktopApplicationsSnapshot | undefined {
+  if (!snapshot?.editorApplication) {
+    return undefined;
+  }
+
+  return {
+    editors: [snapshot.editorApplication],
+    terminals: [],
+    preferredEditorId: {
+      value: snapshot.editorApplication.id,
+      source: "config",
+    },
+    preferredTerminalId: {
+      value: "",
+      source: "default",
+    },
+    gh: {
+      path: { value: "", source: "default" },
+      discovery: { candidates: [] },
+    },
+    git: {
+      discovery: { candidates: [] },
+    },
+  };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/MarkdownFilesWindow.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  MarkdownFileViewerFile,
+  MarkdownFileViewerSnapshot,
+} from "@pwragent/shared";
+import { AppIcon } from "../../components/AppIcon";
+import { CloseIcon } from "../../icons";
+import { useDesktopApi } from "../../lib/desktop-api";
+import { ThreadMarkdown } from "./ThreadMarkdown";
+
+type LoadState =
+  | { status: "idle" | "loading" }
+  | { status: "loaded"; content: string }
+  | { status: "error"; error: string };
+
+export function MarkdownFilesWindow() {
+  const desktopApi = useDesktopApi();
+  const contextKey = useMemo(() => markdownFilesContextKeyFromHash(), []);
+  const [snapshot, setSnapshot] = useState<MarkdownFileViewerSnapshot | undefined>();
+  const selectedFile = snapshot?.files.find(
+    (file) => file.path === snapshot.selectedPath,
+  ) ?? snapshot?.files[0];
+  const [loadState, setLoadState] = useState<LoadState>({ status: "idle" });
+
+  useEffect(() => {
+    if (!snapshot?.context.title) {
+      return;
+    }
+    document.title = snapshot.context.title;
+  }, [snapshot?.context.title]);
+
+  useEffect(() => {
+    if (!contextKey || !desktopApi?.readMarkdownFileViewerSnapshot) {
+      return;
+    }
+
+    let cancelled = false;
+    void desktopApi
+      .readMarkdownFileViewerSnapshot({ contextKey })
+      .then((response) => {
+        if (!cancelled) {
+          setSnapshot(response.snapshot);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to read markdown files snapshot", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [contextKey, desktopApi]);
+
+  useEffect(() => {
+    if (!desktopApi?.onMarkdownFileViewerSnapshotChanged) {
+      return undefined;
+    }
+
+    return desktopApi.onMarkdownFileViewerSnapshotChanged((response) => {
+      if (!contextKey || response.snapshot?.context.key !== contextKey) {
+        return;
+      }
+      setSnapshot(response.snapshot);
+    });
+  }, [contextKey, desktopApi]);
+
+  useEffect(() => {
+    const reader = desktopApi?.readMarkdownFile;
+    if (!reader || !selectedFile) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoadState({ status: "loading" });
+    void reader({ path: selectedFile.path })
+      .then((response) => {
+        if (cancelled) return;
+        if (response.error || response.content === undefined) {
+          setLoadState({
+            status: "error",
+            error: response.error ?? "Markdown file could not be read.",
+          });
+          return;
+        }
+        setLoadState({ status: "loaded", content: response.content });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadState({
+          status: "error",
+          error: error instanceof Error ? error.message : "Markdown file could not be read.",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopApi, selectedFile?.path]);
+
+  const selectFile = useCallback(
+    (file: MarkdownFileViewerFile) => {
+      if (!snapshot) {
+        return;
+      }
+      setSnapshot({
+        ...snapshot,
+        selectedPath: file.path,
+      });
+    },
+    [snapshot],
+  );
+
+  const openSelectedFileInEditor = useCallback(() => {
+    if (!desktopApi?.openApplication || !snapshot?.editorApplication || !selectedFile) {
+      return;
+    }
+    void desktopApi
+      .openApplication({
+        applicationId: snapshot.editorApplication.id,
+        kind: "editor",
+        targetPath: selectedFile.path,
+        targetLine: selectedFile.line,
+        targetColumn: selectedFile.column,
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to open markdown file in editor", error);
+      });
+  }, [desktopApi, selectedFile, snapshot?.editorApplication]);
+
+  return (
+    <div className="document-window markdown-files-window">
+      <section aria-label="Files" className="activity-screen">
+        <header className="activity-titlebar">
+          <p className="activity-titlebar__brand">
+            Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+          </p>
+          <div className="activity-titlebar__breadcrumb">
+            <span className="activity-titlebar__eyebrow">Thread</span>
+            <span aria-hidden="true" className="activity-titlebar__separator">
+              ›
+            </span>
+            <span className="activity-titlebar__current">
+              {snapshot?.context.title ?? "Files"}
+            </span>
+          </div>
+          <div className="activity-titlebar__spacer" />
+        </header>
+
+        <main className="markdown-files-window__shell">
+          <aside className="markdown-files-window__sidebar" aria-label="Open files">
+            <p className="markdown-files-window__sidebar-label">Files</p>
+            <div className="markdown-files-window__file-list">
+              {(snapshot?.files ?? []).map((file) => (
+                <button
+                  key={file.path}
+                  type="button"
+                  className={[
+                    "markdown-files-window__file-button",
+                    file.path === selectedFile?.path
+                      ? "markdown-files-window__file-button--active"
+                      : undefined,
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  title={file.path}
+                  onClick={() => selectFile(file)}
+                >
+                  <span>{file.label}</span>
+                  <span>{relativeFilePath(file.path, snapshot?.context.projectPath)}</span>
+                </button>
+              ))}
+            </div>
+          </aside>
+
+          <article className="markdown-files-window__content">
+            <header className="markdown-files-window__file-header">
+              <div className="markdown-files-window__file-title-wrap">
+                <h1 className="markdown-files-window__file-title">
+                  {selectedFile?.label ?? "No file selected"}
+                </h1>
+                {selectedFile ? (
+                  <p className="markdown-files-window__file-path">
+                    {selectedFile.path}
+                  </p>
+                ) : null}
+                {snapshot?.context.projectPath ? (
+                  <p className="markdown-files-window__project">
+                    Project: {snapshot.context.projectPath}
+                  </p>
+                ) : null}
+              </div>
+              <div className="markdown-files-window__file-actions">
+                {snapshot?.editorApplication && selectedFile ? (
+                  <button
+                    type="button"
+                    className="markdown-files-window__icon-button"
+                    aria-label={`Open file in ${snapshot.editorApplication.name}: ${selectedFile.label}`}
+                    title={`Open file in ${snapshot.editorApplication.name}`}
+                    onClick={openSelectedFileInEditor}
+                  >
+                    <AppIcon
+                      application={snapshot.editorApplication}
+                      className="markdown-files-window__app-icon"
+                      size={16}
+                    />
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="markdown-files-window__icon-button"
+                  aria-label="Close window"
+                  title="Close"
+                  onClick={() => window.close()}
+                >
+                  <CloseIcon size={18} aria-hidden="true" />
+                </button>
+              </div>
+            </header>
+
+            <div className="markdown-files-window__markdown-scroll">
+              {loadState.status === "loading" ? (
+                <p className="markdown-files-window__status">Loading document...</p>
+              ) : null}
+              {loadState.status === "error" ? (
+                <p className="markdown-files-window__status markdown-files-window__status--error">
+                  {loadState.error}
+                </p>
+              ) : null}
+              {loadState.status === "loaded" ? (
+                <ThreadMarkdown
+                  className="markdown-files-window__markdown"
+                  desktopApi={desktopApi}
+                  fileViewerContext={snapshot?.context}
+                  text={loadState.content}
+                  variant="summary"
+                />
+              ) : null}
+            </div>
+          </article>
+        </main>
+      </section>
+    </div>
+  );
+}
+
+function markdownFilesContextKeyFromHash(): string | undefined {
+  const hash = window.location.hash.replace(/^#/, "");
+  if (!hash.startsWith("files/")) {
+    return undefined;
+  }
+
+  return decodeURIComponent(hash.slice("files/".length));
+}
+
+function relativeFilePath(filePath: string, projectPath: string | undefined): string {
+  if (!projectPath) {
+    return filePath;
+  }
+
+  return filePath === projectPath || filePath.startsWith(`${projectPath}/`)
+    ? filePath.slice(projectPath.length).replace(/^\//, "") || filePath
+    : filePath;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -1,11 +1,24 @@
 import type {
   AppServerSkillSummary,
   DesktopApplicationsSnapshot,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
-import { memo, useCallback, useMemo, type MouseEvent, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import ReactMarkdown, { type Components, type UrlTransform } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
+import { AppIcon } from "../../components/AppIcon";
+import { CloseIcon, ProjectsIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { repairNestedLanguageFences } from "../../lib/markdown-fences";
 import { SkillChip } from "../composer/SkillChip";
@@ -15,14 +28,32 @@ import { TranscriptCopyButton } from "./TranscriptCopyButton";
 type ThreadMarkdownProps = {
   applications?: DesktopApplicationsSnapshot;
   className?: string;
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
+  fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
   text: string;
   variant?: "message" | "summary";
 };
 
+type EditorApplication = DesktopApplicationsSnapshot["editors"][number];
+
+type LocalFileTarget = {
+  path: string;
+  line?: number;
+  column?: number;
+};
+
+type MarkdownViewerTarget = LocalFileTarget & {
+  label: string;
+};
+
 export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdownProps) {
   const markdownText = useMemo(() => repairNestedLanguageFences(props.text), [props.text]);
+  const [markdownViewerTarget, setMarkdownViewerTarget] =
+    useState<MarkdownViewerTarget>();
   const editorApplication = useMemo(
     () =>
       props.applications?.editors.find(
@@ -44,14 +75,12 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
     [props.skills]
   );
 
-  const openLocalFileLink = useCallback(
-    (event: MouseEvent<HTMLAnchorElement>, href: string): void => {
-      const target = localFileTargetFromHref(href);
-      if (!target || !editorApplication || !props.desktopApi?.openApplication) {
-        return;
+  const openLocalFileInEditor = useCallback(
+    (target: LocalFileTarget): boolean => {
+      if (!editorApplication || !props.desktopApi?.openApplication) {
+        return false;
       }
 
-      event.preventDefault();
       void props.desktopApi
         .openApplication({
           applicationId: editorApplication.id,
@@ -63,14 +92,42 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         .catch((error: unknown) => {
           console.error("Failed to open transcript file link", error);
         });
+      return true;
     },
     [editorApplication, props.desktopApi]
+  );
+
+  const openLocalFileLink = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, href: string, label: string): void => {
+      const target = localFileTargetFromHref(href);
+      if (!target) {
+        return;
+      }
+
+      if (isMarkdownFilePath(target.path) && props.desktopApi?.readMarkdownFile) {
+        event.preventDefault();
+        setMarkdownViewerTarget({
+          ...target,
+          label: label || fileNameFromPath(target.path),
+        });
+        return;
+      }
+
+      if (openLocalFileInEditor(target)) {
+        event.preventDefault();
+      }
+    },
+    [openLocalFileInEditor, props.desktopApi]
   );
 
   const components = useMemo<Components>(
     () => ({
       a(anchorProps) {
         const href = typeof anchorProps.href === "string" ? anchorProps.href : "";
+        const localTarget = localFileTargetFromHref(href);
+        const isLocalMarkdownFile = Boolean(
+          localTarget && isMarkdownFilePath(localTarget.path)
+        );
         const skillPath = normalizeSkillPath(href);
         const label = extractTextContent(anchorProps.children).trim();
         const source = sourceForNode(markdownText, anchorProps.node);
@@ -95,20 +152,51 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           return <>{anchorProps.children}</>;
         }
 
-        return (
+        const link = (
           <a
             className="transcript-message__link"
             href={href || undefined}
             onClick={(event) => {
-              openLocalFileLink(event, href);
+              openLocalFileLink(event, href, label);
             }}
             rel="noopener noreferrer"
             target="_blank"
-            title={href || undefined}
+            title={isLocalMarkdownFile ? "Open in PwrAgent" : href || undefined}
           >
             {anchorProps.children}
           </a>
         );
+
+        if (isLocalMarkdownFile && localTarget) {
+          return (
+            <span className="thread-markdown__file-link">
+              {link}
+              {editorApplication && props.desktopApi?.openApplication ? (
+                <button
+                  type="button"
+                  className="thread-markdown__editor-link"
+                  aria-label={openFileInEditorLabel(
+                    label || fileNameFromPath(localTarget.path),
+                    editorApplication.name,
+                  )}
+                  title={openFileInEditorTitle(editorApplication.name)}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openLocalFileInEditor(localTarget);
+                  }}
+                >
+                  <AppIcon
+                    application={editorApplication}
+                    className="thread-markdown__editor-link-icon"
+                    size={13}
+                  />
+                </button>
+              ) : null}
+            </span>
+          );
+        }
+
+        return link;
       },
       blockquote(blockquoteProps) {
         const copyText = normalizeBlockquoteCopyText(
@@ -250,7 +338,14 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         return <ul className="transcript-message__list">{listProps.children}</ul>;
       },
     }),
-    [markdownText, openLocalFileLink, skillsByPath]
+    [
+      editorApplication,
+      markdownText,
+      openLocalFileInEditor,
+      openLocalFileLink,
+      props.desktopApi,
+      skillsByPath,
+    ]
   );
 
   return (
@@ -270,11 +365,243 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       >
         {markdownText}
       </ReactMarkdown>
+      {markdownViewerTarget ? (
+        <MarkdownDocumentModal
+          applications={props.applications}
+          desktopApi={props.desktopApi}
+          editorApplication={editorApplication}
+          fileViewerContext={props.fileViewerContext}
+          onClose={() => setMarkdownViewerTarget(undefined)}
+          onOpenInEditor={openLocalFileInEditor}
+          skills={props.skills}
+          target={markdownViewerTarget}
+        />
+      ) : null}
     </div>
   );
 });
 
 ThreadMarkdown.displayName = "ThreadMarkdown";
+
+function MarkdownDocumentModal(props: {
+  applications?: DesktopApplicationsSnapshot;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
+  editorApplication?: EditorApplication;
+  fileViewerContext?: MarkdownFileViewerContext;
+  onClose: () => void;
+  onOpenInEditor: (target: LocalFileTarget) => boolean;
+  skills?: AppServerSkillSummary[];
+  target: MarkdownViewerTarget;
+}) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [loadState, setLoadState] = useState<
+    | { status: "loading" }
+    | { status: "loaded"; content: string }
+    | { status: "error"; error: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadState({ status: "loading" });
+
+    const readMarkdownFile = props.desktopApi?.readMarkdownFile;
+    if (!readMarkdownFile) {
+      setLoadState({
+        status: "error",
+        error: "Markdown preview is unavailable.",
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void readMarkdownFile({ path: props.target.path })
+      .then((response) => {
+        if (cancelled) return;
+        if (response.error || response.content === undefined) {
+          setLoadState({
+            status: "error",
+            error: response.error ?? "Markdown file could not be read.",
+          });
+          return;
+        }
+
+        setLoadState({ status: "loaded", content: response.content });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setLoadState({
+          status: "error",
+          error: error instanceof Error ? error.message : "Markdown file could not be read.",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [props.desktopApi, props.target.path]);
+
+  useEffect(() => {
+    const restoreFocus = document.activeElement as HTMLElement | null;
+    const focusables = (): HTMLElement[] =>
+      Array.from(
+        contentRef.current?.querySelectorAll<HTMLElement>(
+          'button, a[href], [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      ).filter((element) => !element.hasAttribute("disabled"));
+
+    focusables()[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        props.onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const items = focusables();
+      if (items.length === 0) {
+        return;
+      }
+
+      const first = items[0]!;
+      const last = items[items.length - 1]!;
+      const active = document.activeElement;
+      if (!contentRef.current?.contains(active)) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      restoreFocus?.focus?.();
+    };
+  }, [props.onClose]);
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="markdown-document-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Markdown document: ${props.target.label}`}
+      onClick={props.onClose}
+    >
+      <div
+        ref={contentRef}
+        className="markdown-document-modal__content"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="markdown-document-modal__head">
+          <div className="markdown-document-modal__title-wrap">
+            <h2 className="markdown-document-modal__title">{props.target.label}</h2>
+            <p className="markdown-document-modal__path">{props.target.path}</p>
+          </div>
+          <div className="markdown-document-modal__actions">
+            {props.editorApplication ? (
+              <button
+                type="button"
+                className="markdown-document-modal__icon-button"
+                aria-label={openFileInEditorLabel(
+                  props.target.label,
+                  props.editorApplication.name,
+                )}
+                title={openFileInEditorTitle(props.editorApplication.name)}
+                onClick={() => {
+                  props.onOpenInEditor(props.target);
+                }}
+              >
+                <AppIcon
+                  application={props.editorApplication}
+                  className="markdown-document-modal__app-icon"
+                  size={16}
+                />
+              </button>
+            ) : null}
+            {props.desktopApi?.openMarkdownFileViewer ? (
+              <button
+                type="button"
+                className="markdown-document-modal__icon-button"
+                aria-label="Open in detached files window"
+                title="Open in detached files window"
+                onClick={() => {
+                  const context = props.fileViewerContext ??
+                    fallbackFileViewerContext(props.target.path);
+                  void props.desktopApi
+                    ?.openMarkdownFileViewer?.({
+                      context,
+                      editorApplication: props.editorApplication,
+                      file: {
+                        path: props.target.path,
+                        label: props.target.label,
+                        line: props.target.line,
+                        column: props.target.column,
+                      },
+                    })
+                    .catch((error: unknown) => {
+                      console.error("Failed to open markdown file viewer", error);
+                    });
+                }}
+              >
+                <ProjectsIcon size={16} aria-hidden="true" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="markdown-document-modal__icon-button"
+              aria-label="Close"
+              title="Close"
+              onClick={props.onClose}
+            >
+              <CloseIcon size={18} aria-hidden="true" />
+            </button>
+          </div>
+        </header>
+
+        <div className="markdown-document-modal__body">
+          {loadState.status === "loading" ? (
+            <p className="markdown-document-modal__status">Loading document...</p>
+          ) : null}
+          {loadState.status === "error" ? (
+            <p className="markdown-document-modal__status markdown-document-modal__status--error">
+              {loadState.error}
+            </p>
+          ) : null}
+          {loadState.status === "loaded" ? (
+            <ThreadMarkdown
+              applications={props.applications}
+              className="markdown-document-modal__markdown"
+              desktopApi={props.desktopApi}
+              fileViewerContext={props.fileViewerContext}
+              skills={props.skills}
+              text={loadState.content}
+              variant="summary"
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
 
 const normalizeMarkdownUrl: UrlTransform = (url) => {
   const trimmed = url.trim();
@@ -378,7 +705,7 @@ function normalizeSkillPath(href: string): string | undefined {
 
 function localFileTargetFromHref(
   href: string
-): { path: string; line?: number; column?: number } | undefined {
+): LocalFileTarget | undefined {
   if (href.startsWith("file://")) {
     return splitFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
   }
@@ -388,6 +715,31 @@ function localFileTargetFromHref(
   }
 
   return undefined;
+}
+
+function isMarkdownFilePath(filePath: string): boolean {
+  return /\.(?:md|markdown)$/i.test(filePath);
+}
+
+function fileNameFromPath(filePath: string): string {
+  return filePath.split("/").filter(Boolean).pop() ?? filePath;
+}
+
+function openFileInEditorTitle(editorName: string): string {
+  return `Open file in ${editorName}`;
+}
+
+function openFileInEditorLabel(fileLabel: string, editorName: string): string {
+  return `${openFileInEditorTitle(editorName)}: ${fileLabel}`;
+}
+
+function fallbackFileViewerContext(filePath: string): MarkdownFileViewerContext {
+  const directory = filePath.slice(0, Math.max(0, filePath.lastIndexOf("/"))) || filePath;
+  return {
+    key: `files:${directory}`,
+    title: "Files",
+    projectPath: directory,
+  };
 }
 
 function denormalizeMarkdownUrl(url: string): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -18,7 +18,7 @@ import ReactMarkdown, { type Components, type UrlTransform } from "react-markdow
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { AppIcon } from "../../components/AppIcon";
-import { CloseIcon, ProjectsIcon } from "../../icons";
+import { CloseIcon, PopoutIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { repairNestedLanguageFences } from "../../lib/markdown-fences";
 import { SkillChip } from "../composer/SkillChip";
@@ -561,7 +561,7 @@ function MarkdownDocumentModal(props: {
                     });
                 }}
               >
-                <ProjectsIcon size={16} aria-hidden="true" />
+                <PopoutIcon size={16} aria-hidden="true" />
               </button>
             ) : null}
             <button

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -30,6 +30,7 @@ import type {
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   HandoffThreadWorkspaceRequest,
+  MarkdownFileViewerContext,
   MessagingChannelKind,
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
@@ -1079,6 +1080,23 @@ export function ThreadView(props: ThreadViewProps) {
   const selectedThreadKey = selectedThread
     ? `${selectedThread.source}:${selectedThread.id}`
     : undefined;
+  const fileViewerContext = useMemo<MarkdownFileViewerContext | undefined>(() => {
+    if (!selectedThread || !selectedThreadKey) {
+      return undefined;
+    }
+
+    const projectPath =
+      selectedThread.projectKey ??
+      selectedThread.linkedDirectories[0]?.worktreePath ??
+      selectedThread.linkedDirectories[0]?.path;
+
+    return {
+      key: selectedThreadKey,
+      title: `Files - ${selectedThread.title}`,
+      threadTitle: selectedThread.title,
+      ...(projectPath ? { projectPath } : {}),
+    };
+  }, [selectedThread, selectedThreadKey]);
   const selectedThreadTerminalOpen = selectedThreadKey
     ? terminalOpenByThread[selectedThreadKey] === true
     : false;
@@ -2508,6 +2526,7 @@ export function ThreadView(props: ThreadViewProps) {
               directoryPaths={threadDirectoryPaths(selectedThread!)}
               desktopApi={props.desktopApi}
               error={props.transcriptError}
+              fileViewerContext={fileViewerContext}
               loading={props.loading}
               loadingMore={props.loadingMore}
               pagination={props.transcriptPagination}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -3,6 +3,7 @@ import type {
   AppServerSkillSummary,
   AppServerThreadActivityEntry,
   DesktopApplicationsSnapshot,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
@@ -12,8 +13,12 @@ import { TranscriptDiff } from "./TranscriptDiff";
 
 type TranscriptActivityProps = {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
   entry: AppServerThreadActivityEntry;
+  fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
 };
 
@@ -104,6 +109,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                   applications={props.applications}
                   className="transcript-activity__detail-markdown"
                   desktopApi={props.desktopApi}
+                  fileViewerContext={props.fileViewerContext}
                   skills={props.skills}
                   text={markdown}
                   variant="summary"

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -26,6 +26,7 @@ import type {
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
   ThreadTurnFailure,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import {
   buildPendingRequestActions,
@@ -69,7 +70,12 @@ type TranscriptListProps = {
   applications?: DesktopApplicationsSnapshot;
   desktopApi?: Pick<
     DesktopApi,
-    "copyText" | "openApplication" | "listAutomationCards" | "onAgentEvent"
+    | "copyText"
+    | "openApplication"
+    | "openMarkdownFileViewer"
+    | "readMarkdownFile"
+    | "listAutomationCards"
+    | "onAgentEvent"
   >;
   directoryPaths?: string[];
   entries: AppServerThreadEntry[];
@@ -94,6 +100,7 @@ type TranscriptListProps = {
   restoredViewport?: TranscriptViewport;
   reglueRequestKey?: number;
   threadId?: string;
+  fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onViewportChange?: (viewport?: TranscriptViewport) => void;
@@ -1152,6 +1159,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   desktopApi={props.desktopApi}
                   entries={item.entries}
                   expanded={expandedCommentaryGroupIds.has(item.id)}
+                  fileViewerContext={props.fileViewerContext}
                   label={item.label}
                   skills={skills}
                   onOpenImage={props.onOpenImage}
@@ -1164,6 +1172,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   applications={props.applications}
                   desktopApi={props.desktopApi}
                   entry={item.entry}
+                  fileViewerContext={props.fileViewerContext}
                   skills={skills}
                 />
               ) : item.entry.type === "plan" ? (
@@ -1171,6 +1180,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   applications={props.applications}
                   desktopApi={props.desktopApi}
                   entry={item.entry}
+                  fileViewerContext={props.fileViewerContext}
                 />
               ) : item.entry.type === "review" ? (
                 <TranscriptReview
@@ -1178,12 +1188,14 @@ export function TranscriptList(props: TranscriptListProps) {
                   directoryPaths={props.directoryPaths}
                   desktopApi={props.desktopApi}
                   entry={item.entry}
+                  fileViewerContext={props.fileViewerContext}
                 />
               ) : (
                 <TranscriptMessage
                   applications={props.applications}
                   desktopApi={props.desktopApi}
                   message={item.entry}
+                  fileViewerContext={props.fileViewerContext}
                   skills={skills}
                   onOpenImage={props.onOpenImage}
                 />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -5,6 +5,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadMessagePart,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptImage } from "./TranscriptImage";
@@ -13,7 +14,11 @@ import { TranscriptCopyButton } from "./TranscriptCopyButton";
 
 type TranscriptMessageProps = {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
+  fileViewerContext?: MarkdownFileViewerContext;
   message: AppServerThreadMessageEntry;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -76,6 +81,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
               index,
               applications: props.applications,
               desktopApi: props.desktopApi,
+              fileViewerContext: props.fileViewerContext,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
             })}
@@ -303,7 +309,11 @@ function appendTextSegment(segments: MessagePartSegment[], text: string): void {
 
 function renderMessageSegment(params: {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
+  fileViewerContext?: MarkdownFileViewerContext;
   segment: MessagePartSegment;
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -333,6 +343,7 @@ function renderMessageSegment(params: {
       applications={params.applications}
       className="transcript-message__text-block"
       desktopApi={params.desktopApi}
+      fileViewerContext={params.fileViewerContext}
       skills={params.skills}
       text={params.segment.type === "table" ? params.segment.text : params.segment.part.text}
     />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptPlan.tsx
@@ -1,14 +1,19 @@
 import type {
   AppServerThreadPlanEntry,
   DesktopApplicationsSnapshot,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptPlanProps = {
   applications?: DesktopApplicationsSnapshot;
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
   entry: AppServerThreadPlanEntry;
+  fileViewerContext?: MarkdownFileViewerContext;
 };
 
 function formatPlanSummary(completedCount: number, totalCount: number): string {
@@ -76,6 +81,7 @@ export function TranscriptPlan(props: TranscriptPlanProps) {
           applications={props.applications}
           className="transcript-plan__markdown"
           desktopApi={props.desktopApi}
+          fileViewerContext={props.fileViewerContext}
           text={props.entry.markdown}
         />
       ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -2,6 +2,7 @@ import type {
   AppServerReviewFinding,
   AppServerThreadReviewEntry,
   DesktopApplicationsSnapshot,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
@@ -11,8 +12,12 @@ import { ThreadMarkdown } from "./ThreadMarkdown";
 type TranscriptReviewProps = {
   applications?: DesktopApplicationsSnapshot;
   directoryPaths?: string[];
-  desktopApi?: Pick<DesktopApi, "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
   entry: AppServerThreadReviewEntry;
+  fileViewerContext?: MarkdownFileViewerContext;
 };
 
 function formatConfidence(value: number | undefined): string | undefined {
@@ -186,6 +191,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
               applications={props.applications}
               className="transcript-review__body"
               desktopApi={props.desktopApi}
+              fileViewerContext={props.fileViewerContext}
               text={body}
             />
           ) : null}
@@ -245,6 +251,7 @@ export function TranscriptReview(props: TranscriptReviewProps) {
                   applications={props.applications}
                   className="transcript-review__finding-body"
                   desktopApi={props.desktopApi}
+                  fileViewerContext={props.fileViewerContext}
                   text={finding.body}
                 />
                 <div className="transcript-review__location">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -4,6 +4,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadImagePart,
   DesktopApplicationsSnapshot,
+  MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptActivity } from "./TranscriptActivity";
@@ -17,9 +18,13 @@ type TranscriptWorkPhaseGroupProps = {
   applications?: DesktopApplicationsSnapshot;
   collapsible: boolean;
   directoryPaths?: string[];
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
   entries: AppServerThreadEntry[];
   expanded: boolean;
+  fileViewerContext?: MarkdownFileViewerContext;
   label: string;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -66,6 +71,7 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
               directoryPaths: props.directoryPaths,
               desktopApi: props.desktopApi,
               entry,
+              fileViewerContext: props.fileViewerContext,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
             })
@@ -108,8 +114,12 @@ function TranscriptWorkPhaseGroupLabel(props: {
 function renderEntry(params: {
   applications?: DesktopApplicationsSnapshot;
   directoryPaths?: string[];
-  desktopApi?: Pick<DesktopApi, "copyText" | "openApplication">;
+  desktopApi?: Pick<
+    DesktopApi,
+    "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
+  >;
   entry: AppServerThreadEntry;
+  fileViewerContext?: MarkdownFileViewerContext;
   skills: AppServerSkillSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 }) {
@@ -120,6 +130,7 @@ function renderEntry(params: {
       applications={params.applications}
       desktopApi={params.desktopApi}
       entry={entry}
+      fileViewerContext={params.fileViewerContext}
       skills={params.skills}
     />
   ) : entry.type === "plan" ? (
@@ -128,6 +139,7 @@ function renderEntry(params: {
       applications={params.applications}
       desktopApi={params.desktopApi}
       entry={entry}
+      fileViewerContext={params.fileViewerContext}
     />
   ) : entry.type === "review" ? (
     <TranscriptReview
@@ -136,12 +148,14 @@ function renderEntry(params: {
       directoryPaths={params.directoryPaths}
       desktopApi={params.desktopApi}
       entry={entry}
+      fileViewerContext={params.fileViewerContext}
     />
   ) : (
     <TranscriptMessage
       key={entry.id}
       applications={params.applications}
       desktopApi={params.desktopApi}
+      fileViewerContext={params.fileViewerContext}
       message={entry}
       skills={params.skills}
       onOpenImage={params.onOpenImage}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
@@ -41,11 +41,13 @@ describe("MarkdownFilesWindow", () => {
     const readMarkdownFileViewerSnapshot = vi.fn(async () => snapshotResponse);
     const readMarkdownFile = vi.fn(async () => ({
       path: "/repo/PwrAgent/docs/plan.md",
-      content: "# Plan\n\nShip it.",
+      content: "# Plan\n\nShip it. See [source](/repo/PwrAgent/src/foo.ts:12).",
     }));
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
 
     (window as Window & { pwragent?: DesktopApi }).pwragent = {
       onMarkdownFileViewerSnapshotChanged: () => () => undefined,
+      openApplication,
       readMarkdownFile,
       readMarkdownFileViewerSnapshot,
     };
@@ -63,6 +65,18 @@ describe("MarkdownFilesWindow", () => {
       });
       expect(readMarkdownFile).toHaveBeenCalledWith({
         path: "/repo/PwrAgent/docs/plan.md",
+      });
+    });
+
+    screen.getByRole("link", { name: "source" }).click();
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "vscode",
+        kind: "editor",
+        targetPath: "/repo/PwrAgent/src/foo.ts",
+        targetLine: 12,
+        targetColumn: undefined,
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
@@ -57,6 +57,9 @@ describe("MarkdownFilesWindow", () => {
     expect(
       await screen.findByRole("heading", { name: "docs/plan.md" }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("PwrAgent > Slack-to-Agent automation plan > Files"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Project: /repo/PwrAgent")).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Plan" })).toBeInTheDocument();
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx
@@ -1,0 +1,69 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReadMarkdownFileViewerSnapshotResponse } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { MarkdownFilesWindow } from "../MarkdownFilesWindow";
+
+describe("MarkdownFilesWindow", () => {
+  afterEach(() => {
+    delete (window as Window & { pwragent?: DesktopApi }).pwragent;
+    window.location.hash = "";
+  });
+
+  it("renders the selected markdown file with thread and project context", async () => {
+    window.location.hash = "#files/codex%3Athread-1";
+    const snapshotResponse: ReadMarkdownFileViewerSnapshotResponse = {
+      snapshot: {
+        context: {
+          key: "codex:thread-1",
+          title: "Files - Slack-to-Agent automation plan",
+          threadTitle: "Slack-to-Agent automation plan",
+          projectPath: "/repo/PwrAgent",
+        },
+        editorApplication: {
+          id: "vscode",
+          kind: "editor",
+          name: "VS Code",
+          source: "application",
+          appPath: "/Applications/Visual Studio Code.app",
+          canOpenWorkspace: true,
+        },
+        files: [
+          {
+            path: "/repo/PwrAgent/docs/plan.md",
+            label: "docs/plan.md",
+          },
+        ],
+        selectedPath: "/repo/PwrAgent/docs/plan.md",
+      },
+    };
+    const readMarkdownFileViewerSnapshot = vi.fn(async () => snapshotResponse);
+    const readMarkdownFile = vi.fn(async () => ({
+      path: "/repo/PwrAgent/docs/plan.md",
+      content: "# Plan\n\nShip it.",
+    }));
+
+    (window as Window & { pwragent?: DesktopApi }).pwragent = {
+      onMarkdownFileViewerSnapshotChanged: () => () => undefined,
+      readMarkdownFile,
+      readMarkdownFileViewerSnapshot,
+    };
+
+    render(<MarkdownFilesWindow />);
+
+    expect(
+      await screen.findByRole("heading", { name: "docs/plan.md" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Project: /repo/PwrAgent")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Plan" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(readMarkdownFileViewerSnapshot).toHaveBeenCalledWith({
+        contextKey: "codex:thread-1",
+      });
+      expect(readMarkdownFile).toHaveBeenCalledWith({
+        path: "/repo/PwrAgent/docs/plan.md",
+      });
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -51,6 +51,10 @@ describe("ThreadMarkdown", () => {
       "href",
       "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
     );
+    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
+      "title",
+      "Open in PwrAgent"
+    );
   });
 
   it("opens local file links in the configured editor", async () => {
@@ -102,6 +106,103 @@ describe("ThreadMarkdown", () => {
         targetPath: "/repo/PwrAgent/AGENTS.md",
         targetLine: 17,
         targetColumn: undefined,
+      });
+    });
+  });
+
+  it("opens markdown file links in a document modal and keeps the editor icon separate", async () => {
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+    const openMarkdownFileViewer = vi.fn(async () => ({ opened: true as const }));
+    const readMarkdownFile = vi.fn(async (request: { path: string }) => ({
+      path: request.path,
+      content: "# AGENTS\n\nUse the repo guidance.",
+    }));
+
+    render(
+      <ThreadMarkdown
+        applications={{
+          editors: [
+            {
+              id: "zed",
+              kind: "editor",
+              name: "Zed",
+              source: "application",
+              appPath: "/Applications/Zed.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "zed", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
+        desktopApi={{ openApplication, openMarkdownFileViewer, readMarkdownFile }}
+        fileViewerContext={{
+          key: "codex:thread-1",
+          title: "Files - Thread title",
+          threadTitle: "Thread title",
+          projectPath: "/repo/PwrAgent",
+        }}
+        text={"I updated [AGENTS.md](/repo/PwrAgent/AGENTS.md:17)."}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
+      "title",
+      "Open in PwrAgent"
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open file in Zed: AGENTS.md" })
+    );
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "zed",
+        kind: "editor",
+        targetPath: "/repo/PwrAgent/AGENTS.md",
+        targetLine: 17,
+        targetColumn: undefined,
+      });
+    });
+
+    openApplication.mockClear();
+    fireEvent.click(screen.getByRole("link", { name: "AGENTS.md" }));
+
+    expect(await screen.findByRole("dialog", { name: "Markdown document: AGENTS.md" }))
+      .toBeInTheDocument();
+    expect(readMarkdownFile).toHaveBeenCalledWith({
+      path: "/repo/PwrAgent/AGENTS.md",
+    });
+    expect(screen.getByRole("heading", { name: "AGENTS" })).toBeInTheDocument();
+    expect(openApplication).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open in detached files window" }));
+
+    await waitFor(() => {
+      expect(openMarkdownFileViewer).toHaveBeenCalledWith({
+        context: {
+          key: "codex:thread-1",
+          title: "Files - Thread title",
+          threadTitle: "Thread title",
+          projectPath: "/repo/PwrAgent",
+        },
+        editorApplication: expect.objectContaining({
+          id: "zed",
+          name: "Zed",
+        }),
+        file: {
+          path: "/repo/PwrAgent/AGENTS.md",
+          label: "AGENTS.md",
+          line: 17,
+          column: undefined,
+        },
       });
     });
   });

--- a/apps/desktop/src/renderer/src/icons/PopoutIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/PopoutIcon.tsx
@@ -1,0 +1,11 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function PopoutIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M14 5h5v5" />
+      <path d="m10 14 9-9" />
+      <path d="M19 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h4" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -13,6 +13,7 @@ import {
   MattermostIcon,
   NewThreadIcon,
   PinIcon,
+  PopoutIcon,
   SettingsIcon,
   SmileyIcon,
   TelegramIcon,
@@ -40,6 +41,7 @@ const ALL_ICONS = [
   ["ChevronLeftIcon", ChevronLeftIcon],
   ["ChevronRightIcon", ChevronRightIcon],
   ["PinIcon", PinIcon],
+  ["PopoutIcon", PopoutIcon],
 ] as const;
 
 describe("icon library", () => {

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -20,6 +20,7 @@ export { NewThreadIcon } from "./NewThreadIcon";
 export { PinIcon } from "./PinIcon";
 export { PlanIcon } from "./PlanIcon";
 export { PlayIcon } from "./PlayIcon";
+export { PopoutIcon } from "./PopoutIcon";
 export { PricingIcon } from "./PricingIcon";
 export { ProjectsIcon } from "./ProjectsIcon";
 export { PullRequestIcon } from "./PullRequestIcon";

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -191,8 +191,14 @@ import type {
   DesktopSettingsWriteResponse,
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
+  OpenMarkdownFileViewerRequest,
+  OpenMarkdownFileViewerResponse,
   OpenPathRequest,
   OpenPathResponse,
+  ReadMarkdownFileRequest,
+  ReadMarkdownFileResponse,
+  ReadMarkdownFileViewerSnapshotRequest,
+  ReadMarkdownFileViewerSnapshotResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
@@ -516,6 +522,18 @@ export type DesktopApi = {
   ) => Promise<OpenDesktopApplicationResponse>;
   openPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
   revealPath?: (request: OpenPathRequest) => Promise<OpenPathResponse>;
+  readMarkdownFile?: (
+    request: ReadMarkdownFileRequest
+  ) => Promise<ReadMarkdownFileResponse>;
+  openMarkdownFileViewer?: (
+    request: OpenMarkdownFileViewerRequest
+  ) => Promise<OpenMarkdownFileViewerResponse>;
+  readMarkdownFileViewerSnapshot?: (
+    request: ReadMarkdownFileViewerSnapshotRequest
+  ) => Promise<ReadMarkdownFileViewerSnapshotResponse>;
+  onMarkdownFileViewerSnapshotChanged?: (
+    callback: (snapshot: ReadMarkdownFileViewerSnapshotResponse) => void
+  ) => () => void;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -115,6 +115,10 @@ const MessagingActivityWindow = lazy(async () => ({
   default: (await import("./features/messaging-activity/MessagingActivityWindow"))
     .MessagingActivityWindow,
 }));
+const MarkdownFilesWindow = lazy(async () => ({
+  default: (await import("./features/thread-detail/MarkdownFilesWindow"))
+    .MarkdownFilesWindow,
+}));
 
 /**
  * Routes recognized by `chooseRoot` below. The Messaging Activity
@@ -147,6 +151,10 @@ const routes: Array<{
   {
     match: (hash) => hash === "logs",
     render: () => <LogsWindow />,
+  },
+  {
+    match: (hash) => hash.startsWith("files/"),
+    render: () => <MarkdownFilesWindow />,
   },
 ];
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1688,6 +1688,16 @@ textarea,
   line-height: 1;
 }
 
+.activity-titlebar__crumb {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .activity-titlebar__current {
   overflow: hidden;
   color: var(--text-primary);

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8508,6 +8508,37 @@ textarea,
   text-decoration-color: currentColor;
 }
 
+.thread-markdown__file-link {
+  display: inline;
+}
+
+.thread-markdown__editor-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-left: 4px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg-panel-hover);
+  color: var(--text-muted);
+  cursor: pointer;
+  vertical-align: text-bottom;
+}
+
+.thread-markdown__editor-link:hover {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-elevated);
+  color: var(--accent-bright);
+}
+
+.thread-markdown__editor-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .thread-markdown__table-scroll {
   max-width: 100%;
   overflow-x: auto;
@@ -8611,6 +8642,292 @@ textarea,
 .thread-markdown__td[data-col-kind="label"] .transcript-message__link,
 .thread-markdown__td[data-col-kind="label"] .transcript-message__code {
   white-space: normal;
+}
+
+.markdown-document-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 62;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--scrim-opaque);
+  -webkit-app-region: no-drag;
+}
+
+.markdown-document-modal__content {
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 920px);
+  max-height: min(100vh - 72px, 860px);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  box-shadow: 0 18px 48px color-mix(in srgb, var(--shadow-base) 36%, transparent);
+  overflow: hidden;
+}
+
+.markdown-document-modal__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.markdown-document-modal__title-wrap {
+  min-width: 0;
+}
+
+.markdown-document-modal__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.markdown-document-modal__path {
+  margin: 3px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.markdown-document-modal__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.markdown-document-modal__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.markdown-document-modal__icon-button:hover {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.markdown-document-modal__icon-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.markdown-document-modal__app-icon {
+  display: block;
+}
+
+.markdown-document-modal__body {
+  min-height: 240px;
+  overflow: auto;
+  padding: 18px 20px 22px;
+}
+
+.markdown-document-modal__markdown {
+  max-width: 78ch;
+}
+
+.markdown-document-modal__markdown .transcript-message__pre {
+  max-height: none;
+}
+
+.markdown-document-modal__status {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.markdown-document-modal__status--error {
+  color: var(--danger-text);
+}
+
+.markdown-files-window {
+  height: 100vh;
+}
+
+.markdown-files-window__shell {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
+  min-height: 0;
+  flex: 1;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.markdown-files-window__sidebar {
+  min-width: 0;
+  padding: 14px 12px;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  overflow: auto;
+}
+
+.markdown-files-window__sidebar-label {
+  margin: 0 0 10px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.markdown-files-window__file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.markdown-files-window__file-button {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+  padding: 8px 9px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.markdown-files-window__file-button:hover,
+.markdown-files-window__file-button--active {
+  border-color: var(--border-subtle);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.markdown-files-window__file-button span:first-child {
+  font-size: 12px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.markdown-files-window__file-button span:last-child {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.markdown-files-window__content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg-app);
+}
+
+.markdown-files-window__file-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.markdown-files-window__file-title-wrap {
+  min-width: 0;
+}
+
+.markdown-files-window__file-title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.markdown-files-window__file-path,
+.markdown-files-window__project {
+  margin: 3px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.markdown-files-window__file-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.markdown-files-window__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.markdown-files-window__icon-button:hover {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.markdown-files-window__icon-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.markdown-files-window__app-icon {
+  display: block;
+}
+
+.markdown-files-window__markdown-scroll {
+  min-height: 0;
+  overflow: auto;
+  padding: 22px 26px 32px;
+}
+
+.markdown-files-window__markdown {
+  max-width: 82ch;
+}
+
+.markdown-files-window__markdown .transcript-message__pre {
+  max-height: none;
+}
+
+.markdown-files-window__status {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.markdown-files-window__status--error {
+  color: var(--danger-text);
 }
 
 .transcript-message__image-button {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -273,6 +273,12 @@ export const ONBOARDING_COMPLETE_CODEX_BOOTSTRAP_CHANNEL =
 export const APPLICATION_OPEN_CHANNEL = "application:open";
 export const PATH_OPEN_CHANNEL = "path:open";
 export const PATH_REVEAL_CHANNEL = "path:reveal";
+export const MARKDOWN_FILE_READ_CHANNEL = "markdown-file:read";
+export const MARKDOWN_FILE_VIEWER_OPEN_CHANNEL = "markdown-file-viewer:open";
+export const MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL =
+  "markdown-file-viewer:read-snapshot";
+export const MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL =
+  "markdown-file-viewer:snapshot-changed";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1201,6 +1201,55 @@ export type OpenPathResponse = {
   error?: string;
 };
 
+export type ReadMarkdownFileRequest = {
+  path: string;
+};
+
+export type ReadMarkdownFileResponse = {
+  path: string;
+  content?: string;
+  error?: string;
+};
+
+export type MarkdownFileViewerFile = {
+  path: string;
+  label: string;
+  line?: number;
+  column?: number;
+};
+
+export type MarkdownFileViewerContext = {
+  key: string;
+  title: string;
+  threadTitle?: string;
+  projectPath?: string;
+};
+
+export type OpenMarkdownFileViewerRequest = {
+  context: MarkdownFileViewerContext;
+  file: MarkdownFileViewerFile;
+  editorApplication?: DesktopApplicationDiscoveryCandidate;
+};
+
+export type OpenMarkdownFileViewerResponse = {
+  opened: true;
+};
+
+export type MarkdownFileViewerSnapshot = {
+  context: MarkdownFileViewerContext;
+  files: MarkdownFileViewerFile[];
+  selectedPath: string;
+  editorApplication?: DesktopApplicationDiscoveryCandidate;
+};
+
+export type ReadMarkdownFileViewerSnapshotRequest = {
+  contextKey: string;
+};
+
+export type ReadMarkdownFileViewerSnapshotResponse = {
+  snapshot?: MarkdownFileViewerSnapshot;
+};
+
 export function isDesktopChatReplyComposer(
   value: string,
 ): value is DesktopChatReplyComposer {


### PR DESCRIPTION
## Summary

- Add an in-app Markdown preview for local `.md` transcript links, with the link tooltip set to `Open in PwrAgent`.
- Keep editor opening as a separate icon-only action using the configured editor icon and matching editor tooltip style.
- Add a detached `Files - [Thread Name]` window that reuses the same thread/workspace context for multiple opened Markdown files.
- Add focused renderer coverage for the Markdown modal and detached Files window.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-files-window.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
