### PR TITLE
fix(desktop): dismiss PR chip tooltip before browser handoff

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -433,6 +433,40 @@ describe("ThreadRow chip flow", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  it("dismisses the PR tooltip before opening the PR in the browser", () => {
+    const onOpenPullRequest = vi.fn();
+    renderRow({
+      onOpenPullRequest,
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "Retain thread pull request history",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    const prChip = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#123/,
+    });
+    fireEvent.mouseEnter(prChip);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    fireEvent.click(prChip);
+
+    expect(onOpenPullRequest).toHaveBeenCalledWith(
+      "https://github.com/pwrdrvr/PwrAgent/pull/123",
+    );
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("dismisses the PR tooltip when the thread list scrolls", () => {
     const { container } = renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -66,6 +66,7 @@ export function PrChip(props: PrChipProps) {
   ): void => {
     event.preventDefault();
     event.stopPropagation();
+    tooltipController.hide();
     props.onOpen(pr.url);
   };
 
@@ -85,6 +86,7 @@ export function PrChip(props: PrChipProps) {
           }
           event.preventDefault();
           event.stopPropagation();
+          tooltipController.hide();
           const rect = event.currentTarget.getBoundingClientRect();
           props.onOpenContextMenu(pr, {
             x: event.clientX,


### PR DESCRIPTION
## Summary

Clicking a PR chip now clears its hover tooltip before Electron hands the URL to the external browser, so returning to PwrAgent no longer leaves a stale tooltip floating over the thread list. The same cleanup runs before the PR chip context menu opens.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
