### PR TITLE
fix(desktop): clear PR chip focus before browser handoff

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -467,6 +467,43 @@ describe("ThreadRow chip flow", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  it("removes PR chip focus before opening the browser so refocus cannot restore its tooltip", () => {
+    const onOpenPullRequest = vi.fn();
+    renderRow({
+      onOpenPullRequest,
+      thread: {
+        ...baseThread,
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "Retain thread pull request history",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    const prChip = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#123/,
+    });
+    prChip.focus();
+    fireEvent.focus(prChip);
+    expect(prChip).toHaveFocus();
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    fireEvent.click(prChip);
+
+    expect(onOpenPullRequest).toHaveBeenCalledWith(
+      "https://github.com/pwrdrvr/PwrAgent/pull/123",
+    );
+    expect(prChip).not.toHaveFocus();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("dismisses the PR tooltip when the thread list scrolls", () => {
     const { container } = renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -67,6 +67,7 @@ export function PrChip(props: PrChipProps) {
     event.preventDefault();
     event.stopPropagation();
     tooltipController.hide();
+    event.currentTarget.blur();
     props.onOpen(pr.url);
   };
 


### PR DESCRIPTION
## Summary

Returning to PwrAgent after opening a PR no longer restores the old PR chip tooltip through retained chip focus. The previous fix hid the tooltip before browser handoff, but the activated chip could stay focused and run its focus tooltip path again when the window became active; activation now clears that focus before opening the external URL.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

Related: #920

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
