### PR TITLE
fix(desktop): preserve markdown rules in thread composer

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -291,9 +291,14 @@ function matchMarkdownBulletListItem(line: string): RegExpMatchArray | null {
   return line.match(/^\s{0,3}[-*]\s+(.+)$/);
 }
 
+function isMarkdownThematicBreak(line: string): boolean {
+  return /^\s{0,3}(?:-{3,}|\*{3,}|_{3,})\s*$/.test(line);
+}
+
 function isMarkdownBlockStart(line: string): boolean {
   return (
     parseBacktickFenceLine(line) !== undefined ||
+    isMarkdownThematicBreak(line) ||
     matchMarkdownOrderedListItem(line) !== null ||
     matchMarkdownBulletListItem(line) !== null
   );
@@ -386,6 +391,7 @@ function isHtmlStructuredBlockElement(element: HTMLElement): boolean {
   return (
     isHtmlListElement(element) ||
     tagName === "blockquote" ||
+    tagName === "hr" ||
     tagName === "pre" ||
     tagName === "p" ||
     tagName === "div" ||
@@ -523,6 +529,10 @@ function parseHtmlStructuredBlockElement(element: HTMLElement): JSONContent[] {
         content: content.length > 0 ? content : undefined,
       },
     ];
+  }
+
+  if (tagName === "hr") {
+    return [{ type: "horizontalRule" }];
   }
 
   if (tagName === "pre") {
@@ -676,6 +686,12 @@ function buildMarkdownTiptapContent(value: string): JSONContent {
           ? [{ type: "text", text: codeLines.join("\n") }]
           : undefined,
       });
+      continue;
+    }
+
+    if (isMarkdownThematicBreak(line)) {
+      content.push({ type: "horizontalRule" });
+      index += 1;
       continue;
     }
 
@@ -1003,6 +1019,11 @@ function appendMarkdownBlock(
     return;
   }
 
+  if (node.type.name === "horizontalRule") {
+    state.value += "---";
+    return;
+  }
+
   if (node.type.name === "bulletList") {
     node.forEach((child, _offset, listIndex) => {
       if (listIndex > 0) {
@@ -1244,6 +1265,9 @@ function htmlNodeToPlainText(node: Node): string {
   if (tagName === "br") {
     return "\n";
   }
+  if (tagName === "hr") {
+    return "\n---\n";
+  }
   if (tagName === "pre") {
     return node.textContent ?? "";
   }
@@ -1445,6 +1469,16 @@ function getDraftIndexAtPosition(
       if (childIndex > 0) {
         index += mode === "markdown" ? 2 : 1;
       }
+      if (mode === "markdown" && node.type.name === "horizontalRule") {
+        const nodeEnd = pos + node.nodeSize;
+        if (position <= nodeEnd) {
+          index += Math.min(3, Math.max(0, position - pos));
+          found = true;
+          return false;
+        }
+        index += 3;
+        return false;
+      }
       if (mode === "markdown" && node.type.name === "codeBlock") {
         const codeBlock = getCodeBlockMarkdownParts(node);
         const nodeEnd = pos + node.nodeSize;
@@ -1555,6 +1589,15 @@ function getPositionAtDraftIndex(
           return false;
         }
         index += codeBlock.totalLength;
+        return false;
+      }
+      if (mode === "markdown" && node.type.name === "horizontalRule") {
+        if (draftIndex <= index + 3) {
+          position = pos + node.nodeSize;
+          found = true;
+          return false;
+        }
+        index += 3;
         return false;
       }
     }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -887,6 +887,117 @@ describe("ComposerTiptapInput", () => {
     expect(container.querySelector("code")).toHaveTextContent("inline code");
   });
 
+  it("round-trips thematic breaks as markdown horizontal rules", async () => {
+    const original = [
+      "- One",
+      "- Two",
+      "---",
+      "- Second List - One",
+      "- Second List - Two",
+    ].join("\n");
+    const inputRef = createRef<ComposerInputHandle>();
+    const { container } = render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={original}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    expect(container.querySelector("hr")).toBeInTheDocument();
+    expect(inputRef.current?.value).toBe(
+      [
+        "- One",
+        "- Two",
+        "",
+        "---",
+        "",
+        "- Second List - One",
+        "- Second List - Two",
+      ].join("\n"),
+    );
+  });
+
+  it("serializes restored horizontalRule editor nodes instead of dropping them", async () => {
+    const inputRef = createRef<ComposerInputHandle>();
+
+    render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        editorDocument={{
+          type: "doc",
+          content: [
+            {
+              type: "bulletList",
+              content: [
+                {
+                  type: "listItem",
+                  content: [{ type: "paragraph", content: [{ type: "text", text: "One" }] }],
+                },
+              ],
+            },
+            { type: "horizontalRule" },
+            {
+              type: "bulletList",
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Second List - One" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }}
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={"- One\n\n---\n\n- Second List - One"}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    expect(inputRef.current?.value).toBe("- One\n\n---\n\n- Second List - One");
+  });
+
+  it("keeps hyphen-only bullet items as list text", async () => {
+    const original = ["- One", "- Two", "- --", "- Three"].join("\n");
+    const inputRef = createRef<ComposerInputHandle>();
+    const { container } = render(
+      <ComposerTiptapInput
+        ref={inputRef}
+        id="reply"
+        label="Reply"
+        markdownConversion
+        onChange={() => undefined}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value={original}
+      />,
+    );
+
+    await screen.findByRole("textbox", { name: "Reply" });
+
+    expect(container.querySelector("hr")).toBeNull();
+    expect(container.querySelectorAll("li")).toHaveLength(4);
+    expect(inputRef.current?.value).toBe(original);
+  });
+
   it("serializes marked trailing spaces outside delimiters before plain text", async () => {
     const boldText = "Allow detaching the only attached project - ";
     const plainText =

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -51,7 +51,10 @@ type MarkdownViewerTarget = LocalFileTarget & {
 };
 
 export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdownProps) {
-  const markdownText = useMemo(() => repairNestedLanguageFences(props.text), [props.text]);
+  const markdownText = useMemo(
+    () => protectComposerHyphenListItems(repairNestedLanguageFences(props.text)),
+    [props.text]
+  );
   const [markdownViewerTarget, setMarkdownViewerTarget] =
     useState<MarkdownViewerTarget>();
   const editorApplication = useMemo(
@@ -252,6 +255,9 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       },
       h6(headingProps) {
         return <h6 className="transcript-message__heading">{headingProps.children}</h6>;
+      },
+      hr() {
+        return <hr className="transcript-message__rule" />;
       },
       img(imageProps) {
         const altText = typeof imageProps.alt === "string" ? imageProps.alt : "";
@@ -601,6 +607,43 @@ function MarkdownDocumentModal(props: {
     </div>,
     document.body,
   );
+}
+
+function protectComposerHyphenListItems(markdown: string): string {
+  const lines = markdown.split("\n");
+  let fence: { marker: "`" | "~"; length: number } | undefined;
+
+  return lines
+    .map((line) => {
+      const fenceLine = line.match(/^\s{0,3}(`{3,}|~{3,})(.*)$/);
+      if (fenceLine) {
+        const sequence = fenceLine[1] ?? "";
+        const marker = sequence[0] as "`" | "~";
+        const trailing = fenceLine[2] ?? "";
+        if (!fence) {
+          fence = { marker, length: sequence.length };
+        } else if (
+          marker === fence.marker &&
+          sequence.length >= fence.length &&
+          trailing.trim() === ""
+        ) {
+          fence = undefined;
+        }
+        return line;
+      }
+
+      if (fence) {
+        return line;
+      }
+
+      const hyphenOnlyListItem = line.match(/^(\s{0,3})-\s+(-+)(\s*)$/);
+      if (!hyphenOnlyListItem || (hyphenOnlyListItem[2]?.length ?? 0) < 2) {
+        return line;
+      }
+
+      return `${hyphenOnlyListItem[1]}- \\${hyphenOnlyListItem[2]}${hyphenOnlyListItem[3]}`;
+    })
+    .join("\n");
 }
 
 const normalizeMarkdownUrl: UrlTransform = (url) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -336,6 +336,48 @@ describe("ThreadMarkdown", () => {
     expect(container).toHaveTextContent("Built by xAI.");
   });
 
+  it("renders thematic breaks between separate lists", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={[
+          "- One",
+          "- Two",
+          "---",
+          "- Second List - One",
+          "- Second List - Two",
+          "---",
+          "- Third List - One",
+          "- Third List - Two",
+        ].join("\n")}
+      />
+    );
+
+    expect(container.querySelectorAll("hr.transcript-message__rule")).toHaveLength(2);
+    expect(container.querySelectorAll("ul.transcript-message__list")).toHaveLength(3);
+    expect(screen.getByText("Second List - One")).toBeInTheDocument();
+  });
+
+  it("keeps composer-style hyphen-only bullet items visible", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={[
+          "- One",
+          "- Two",
+          "- --",
+          "- Three",
+          "- Four",
+          "- --",
+          "- Five",
+          "- Six",
+        ].join("\n")}
+      />
+    );
+
+    expect(container.querySelector("hr")).toBeNull();
+    expect(container.querySelectorAll("ul.transcript-message__list")).toHaveLength(1);
+    expect(screen.getAllByText("--")).toHaveLength(2);
+  });
+
   it("renders html-looking transcript text literally", () => {
     const { container } = render(
       <ThreadMarkdown
@@ -374,6 +416,28 @@ describe("ThreadMarkdown", () => {
     expect(container.querySelector("pre strong")).toBeNull();
     expect(container.querySelector("pre .skill-chip")).toBeNull();
     expect(container.querySelector("pre img")).toBeNull();
+  });
+
+  it("does not escape hyphen-only lines after shorter nested code fences", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={[
+          "````md",
+          "```ts",
+          "const marker = true;",
+          "```",
+          "- --",
+          "````",
+        ].join("\n")}
+      />
+    );
+
+    const codeBlock = container.querySelector("pre code");
+    expect(codeBlock).not.toBeNull();
+    expect(codeBlock?.textContent).toContain("```ts");
+    expect(codeBlock?.textContent).toContain("- --");
+    expect(codeBlock?.textContent).not.toContain("- \\--");
+    expect(container.querySelector("hr")).toBeNull();
   });
 
   it("keeps malformed handoff messages grouped when they contain language fences", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8402,6 +8402,13 @@ textarea,
   font-weight: 650;
 }
 
+.transcript-message__rule {
+  width: 100%;
+  height: 1px;
+  border: 0;
+  background: var(--border-subtle);
+}
+
 .thread-header__summary .transcript-message__heading {
   font-size: 14px;
   line-height: 1.45;


### PR DESCRIPTION
## Summary
Thread messages that use Markdown horizontal rules now keep those separators when they render, when a queued message is edited, and when rendered content is copied back into the composer. Composer-authored `- --` list items also stay visible as list text instead of disappearing during the thread render round-trip.

The fix preserves `horizontalRule` nodes as `---` in the Tiptap composer serializer, imports copied `<hr>` blocks back into the editor, and gives the transcript renderer explicit HR styling.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
