### PR TITLE
fix(desktop): find threads by id

### DIFF
--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -891,6 +891,20 @@ describe("StateDb", () => {
         .map((result) => result.threadId),
     ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
   });
+
+  it("advances stale thread search FTS tables from intervening user versions", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "intervening-version-thread-search-fts.db");
+    createLegacyThreadSearchFtsDb(dbPath, 24);
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+    expect(columnNames("thread_search_fts")).toContain("thread_id");
+  });
 });
 
 function createLegacyThreadSearchFtsDb(

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -892,17 +892,15 @@ describe("StateDb", () => {
     ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
   });
 
-  it("advances stale thread search FTS tables from intervening user versions", () => {
+  it("repairs stale thread search FTS tables without downgrading newer versions", () => {
     stateDb.close();
 
-    const dbPath = path.join(tempDir, "intervening-version-thread-search-fts.db");
+    const dbPath = path.join(tempDir, "newer-version-thread-search-fts.db");
     createLegacyThreadSearchFtsDb(dbPath, 24);
 
     stateDb = StateDb.open(dbPath);
 
-    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
-      CURRENT_STATE_DB_USER_VERSION,
-    );
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(24);
     expect(columnNames("thread_search_fts")).toContain("thread_id");
   });
 });

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -11,6 +11,7 @@ import {
   STATE_DB_WAL_AUTOCHECKPOINT_PAGES,
   StateDb,
 } from "../state/state-db";
+import { ThreadSearchStore } from "../thread-search/thread-search-store";
 
 let stateDb: StateDb;
 let tempDir: string;
@@ -858,6 +859,79 @@ describe("StateDb", () => {
       CURRENT_STATE_DB_USER_VERSION,
     );
   });
+
+  it("migrates thread search FTS rows to include thread ids", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "legacy-thread-search-fts-state.db");
+    const raw = openRawDb(dbPath);
+    raw.exec(`
+      PRAGMA user_version = 22;
+      CREATE TABLE thread_search_documents (
+        identity_key            TEXT PRIMARY KEY,
+        backend                 TEXT NOT NULL,
+        thread_id               TEXT NOT NULL,
+        title                   TEXT NOT NULL,
+        title_source            TEXT,
+        summary                 TEXT,
+        project_key             TEXT,
+        created_at              INTEGER,
+        updated_at              INTEGER,
+        archived_at             INTEGER,
+        git_branch              TEXT,
+        git_origin_url          TEXT,
+        model                   TEXT,
+        linked_directories_json TEXT NOT NULL,
+        display_json            TEXT NOT NULL,
+        indexed_at              INTEGER NOT NULL
+      );
+      CREATE VIRTUAL TABLE thread_search_fts USING fts5(
+        identity_key UNINDEXED,
+        title,
+        summary,
+        project_key,
+        directory_labels,
+        directory_paths,
+        git_branch,
+        git_origin_url,
+        model,
+        backend,
+        tokenize = "unicode61 remove_diacritics 2 tokenchars '-_./:'"
+      );
+      INSERT INTO thread_search_documents (
+        identity_key, backend, thread_id, title, title_source, summary,
+        project_key, created_at, updated_at, archived_at, git_branch,
+        git_origin_url, model, linked_directories_json, display_json, indexed_at
+      ) VALUES (
+        'codex:7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84',
+        'codex',
+        '7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84',
+        'Release notes',
+        'derived',
+        'Prepared release copy',
+        'PwrAgent',
+        1000,
+        1000,
+        NULL,
+        'feat/release',
+        NULL,
+        'gpt-5.5',
+        '[{"id":"dir-1","label":"PwrAgent","path":"/repo/PwrAgent","kind":"local"}]',
+        '{}',
+        1000
+      );
+    `);
+    raw.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(columnNames("thread_search_fts")).toContain("thread_id");
+    expect(
+      new ThreadSearchStore(stateDb)
+        .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
+  });
 });
 
 function openRawDb(dbPath: string): BetterSqlite3.Database {
@@ -884,6 +958,7 @@ function columnNames(
     | "pr_lookup_cache"
     | "pr_status_cache"
     | "thread_pricing_summaries"
+    | "thread_search_fts"
     | "thread_usage_lines",
 ): string[] {
   const rows = readTableInfo(tableName);
@@ -915,6 +990,7 @@ function readTableInfo(
     | "pr_lookup_cache"
     | "pr_status_cache"
     | "thread_pricing_summaries"
+    | "thread_search_fts"
     | "thread_usage_lines",
 ): Array<{ name: string }> {
   switch (tableName) {
@@ -929,6 +1005,10 @@ function readTableInfo(
     case "thread_pricing_summaries":
       return stateDb.raw
         .prepare("PRAGMA table_info(thread_pricing_summaries)")
+        .all() as Array<{ name: string }>;
+    case "thread_search_fts":
+      return stateDb.raw
+        .prepare("PRAGMA table_info(thread_search_fts)")
         .all() as Array<{ name: string }>;
     case "thread_usage_lines":
       return stateDb.raw

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -874,6 +874,11 @@ describe("StateDb", () => {
         .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
         .map((result) => result.threadId),
     ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
+    expect(
+      new ThreadSearchStore(stateDb)
+        .search({ query: "e31f5e66", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d"]);
   });
 
   it("repairs stale thread search FTS tables even at current user_version", () => {
@@ -952,6 +957,23 @@ function createLegacyThreadSearchFtsDb(
         'codex',
         '7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84',
         'Release notes',
+        'derived',
+        'Prepared release copy',
+        'PwrAgent',
+        1000,
+        1000,
+        NULL,
+        'feat/release',
+        NULL,
+        'gpt-5.5',
+        '[{"id":"dir-1","label":"PwrAgent","path":"/repo/PwrAgent","kind":"local"}]',
+        '{}',
+        1000
+      ), (
+        'codex:session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d',
+        'codex',
+        'session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d',
+        'Kimi session',
         'derived',
         'Prepared release copy',
         'PwrAgent',

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -864,8 +864,41 @@ describe("StateDb", () => {
     stateDb.close();
 
     const dbPath = path.join(tempDir, "legacy-thread-search-fts-state.db");
-    const raw = openRawDb(dbPath);
-    raw.exec(`
+    createLegacyThreadSearchFtsDb(dbPath, 22);
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(columnNames("thread_search_fts")).toContain("thread_id");
+    expect(
+      new ThreadSearchStore(stateDb)
+        .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
+  });
+
+  it("repairs stale thread search FTS tables even at current user_version", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "current-version-stale-thread-search-fts.db");
+    createLegacyThreadSearchFtsDb(dbPath, CURRENT_STATE_DB_USER_VERSION);
+
+    stateDb = StateDb.open(dbPath);
+
+    expect(columnNames("thread_search_fts")).toContain("thread_id");
+    expect(
+      new ThreadSearchStore(stateDb)
+        .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
+  });
+});
+
+function createLegacyThreadSearchFtsDb(
+  dbPath: string,
+  userVersion: number,
+): void {
+  const raw = openRawDb(dbPath);
+  raw.exec(`
       PRAGMA user_version = 22;
       CREATE TABLE thread_search_documents (
         identity_key            TEXT PRIMARY KEY,
@@ -921,18 +954,9 @@ describe("StateDb", () => {
         1000
       );
     `);
-    raw.close();
-
-    stateDb = StateDb.open(dbPath);
-
-    expect(columnNames("thread_search_fts")).toContain("thread_id");
-    expect(
-      new ThreadSearchStore(stateDb)
-        .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
-        .map((result) => result.threadId),
-    ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
-  });
-});
+  raw.pragma(`user_version = ${userVersion}`);
+  raw.close();
+}
 
 function openRawDb(dbPath: string): BetterSqlite3.Database {
   const nativeBinding = getNativeBinding();

--- a/apps/desktop/src/main/__tests__/thread-search-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-search-store.test.ts
@@ -81,6 +81,26 @@ describe("ThreadSearchStore", () => {
     ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
   });
 
+  it("searches by prefixed ACP thread ids and their embedded UUIDs", () => {
+    store.upsertThread(
+      threadSummary({
+        id: "session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d",
+        title: "Kimi session",
+      }),
+    );
+
+    expect(
+      store
+        .search({ query: "session_e31f5e66", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d"]);
+    expect(
+      store
+        .search({ query: "e31f5e66", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d"]);
+  });
+
   it("falls back to recent projection rows for filter-only searches", () => {
     store.upsertThread(
       threadSummary({ id: "old", title: "Old", updatedAt: 1_000 }),

--- a/apps/desktop/src/main/__tests__/thread-search-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-search-store.test.ts
@@ -65,6 +65,22 @@ describe("ThreadSearchStore", () => {
     expect(results[0]?.snippets[0]?.scope).toBe("projection");
   });
 
+  it("searches by thread id", () => {
+    store.upsertThread(
+      threadSummary({
+        id: "7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84",
+        title: "Release notes",
+        summary: "Prepared release copy",
+      }),
+    );
+
+    expect(
+      store
+        .search({ query: "7f2f4bd1-8e7b-4d3b-92e5", limit: 10 })
+        .map((result) => result.threadId),
+    ).toEqual(["7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84"]);
+  });
+
   it("falls back to recent projection rows for filter-only searches", () => {
     store.upsertThread(
       threadSummary({ id: "old", title: "Old", updatedAt: 1_000 }),

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 22;
+export const CURRENT_STATE_DB_USER_VERSION = 23;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -451,6 +451,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS thread_search_fts USING fts5(
   git_origin_url,
   model,
   backend,
+  thread_id,
   tokenize = "unicode61 remove_diacritics 2 tokenchars '-_./:'"
 );
 `;
@@ -803,6 +804,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 22) {
       db.transaction(() => {
         repairOpenAiThreadUsagePricing(db);
+        db.pragma("user_version = 22");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 23) {
+      db.transaction(() => {
+        ensureThreadSearchFtsThreadIdColumn(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1205,6 +1212,104 @@ function ensureThreadUsagePricingCumulativeColumns(db: BetterSqlite3.Database): 
   }
 }
 
+function ensureThreadSearchFtsThreadIdColumn(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_search_documents")) {
+    db.exec(THREAD_SEARCH_SCHEMA);
+    return;
+  }
+  if (
+    tableExists(db, "thread_search_fts") &&
+    tableColumnExists(db, "thread_search_fts", "thread_id")
+  ) {
+    return;
+  }
+
+  db.exec("DROP TABLE IF EXISTS thread_search_fts");
+  db.exec(THREAD_SEARCH_SCHEMA);
+
+  const rows = db
+    .prepare(
+      `SELECT
+         identity_key,
+         backend,
+         thread_id,
+         title,
+         summary,
+         project_key,
+         git_branch,
+         git_origin_url,
+         model,
+         linked_directories_json
+       FROM thread_search_documents`,
+    )
+    .all() as Array<{
+    backend: string;
+    git_branch: string | null;
+    git_origin_url: string | null;
+    identity_key: string;
+    linked_directories_json: string;
+    model: string | null;
+    project_key: string | null;
+    summary: string | null;
+    thread_id: string;
+    title: string;
+  }>;
+  const insert = db.prepare(
+    `INSERT INTO thread_search_fts (
+       identity_key, title, summary, project_key, directory_labels,
+       directory_paths, git_branch, git_origin_url, model, backend, thread_id
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  for (const row of rows) {
+    const directories = parseThreadSearchLinkedDirectories(
+      row.linked_directories_json,
+    );
+    insert.run(
+      row.identity_key,
+      row.title,
+      row.summary ?? "",
+      row.project_key ?? "",
+      directories.map((directory) => directory.label).join(" "),
+      directories
+        .flatMap((directory) => [directory.path, directory.worktreePath].filter(Boolean))
+        .join(" "),
+      row.git_branch ?? "",
+      row.git_origin_url ?? "",
+      row.model ?? "",
+      row.backend,
+      row.thread_id,
+    );
+  }
+}
+
+function parseThreadSearchLinkedDirectories(value: string): Array<{
+  label?: string;
+  path?: string;
+  worktreePath?: string;
+}> {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .filter(
+        (entry): entry is Record<string, unknown> =>
+          Boolean(entry) && typeof entry === "object",
+      )
+      .map((entry) => ({
+        ...(typeof entry.label === "string" ? { label: entry.label } : {}),
+        ...(typeof entry.path === "string" ? { path: entry.path } : {}),
+        ...(typeof entry.worktreePath === "string"
+          ? { worktreePath: entry.worktreePath }
+          : {}),
+      }));
+  } catch {
+    return [];
+  }
+}
+
 function repairThreadUsageLineCreatedAt(db: BetterSqlite3.Database): void {
   if (
     !tableExists(db, "thread_usage_lines") ||
@@ -1538,6 +1643,7 @@ function tableColumnExists(
     | "pr_lookup_cache"
     | "pr_status_cache"
     | "thread_pricing_summaries"
+    | "thread_search_fts"
     | "thread_usage_lines",
   columnName: string,
 ): boolean {
@@ -1552,6 +1658,7 @@ function readTableInfo(
     | "pr_lookup_cache"
     | "pr_status_cache"
     | "thread_pricing_summaries"
+    | "thread_search_fts"
     | "thread_usage_lines",
 ): Array<{ name: string }> {
   switch (tableName) {
@@ -1569,6 +1676,10 @@ function readTableInfo(
       }>;
     case "thread_pricing_summaries":
       return db.prepare("PRAGMA table_info(thread_pricing_summaries)").all() as Array<{
+        name: string;
+      }>;
+    case "thread_search_fts":
+      return db.prepare("PRAGMA table_info(thread_search_fts)").all() as Array<{
         name: string;
       }>;
     case "thread_usage_lines":

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -962,6 +962,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);
+    ensureThreadSearchFtsThreadIdColumn(db);
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1272,9 +1272,19 @@ function ensureThreadSearchFtsThreadIdColumn(db: BetterSqlite3.Database): void {
       row.git_origin_url ?? "",
       row.model ?? "",
       row.backend,
-      row.thread_id,
+      buildThreadSearchFtsThreadIdText(row.thread_id),
     );
   }
+}
+
+function buildThreadSearchFtsThreadIdText(threadId: string): string {
+  const variants = new Set([threadId]);
+  for (const match of threadId.matchAll(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+  )) {
+    variants.add(match[0]);
+  }
+  return [...variants].join(" ");
 }
 
 function parseThreadSearchLinkedDirectories(value: string): Array<{

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 23;
+export const CURRENT_STATE_DB_USER_VERSION = 25;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -807,7 +807,7 @@ export class StateDb {
         db.pragma("user_version = 22");
       })();
     }
-    if ((db.pragma("user_version", { simple: true }) as number) < 23) {
+    if ((db.pragma("user_version", { simple: true }) as number) < 25) {
       db.transaction(() => {
         ensureThreadSearchFtsThreadIdColumn(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 25;
+export const CURRENT_STATE_DB_USER_VERSION = 22;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -807,13 +807,6 @@ export class StateDb {
         db.pragma("user_version = 22");
       })();
     }
-    if ((db.pragma("user_version", { simple: true }) as number) < 25) {
-      db.transaction(() => {
-        ensureThreadSearchFtsThreadIdColumn(db);
-        db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
-      })();
-    }
-
     return new StateDb(db);
   }
 

--- a/apps/desktop/src/main/thread-search/thread-search-store.ts
+++ b/apps/desktop/src/main/thread-search/thread-search-store.ts
@@ -130,7 +130,7 @@ export class ThreadSearchStore {
           thread.gitOriginUrl ?? "",
           thread.model ?? "",
           thread.source,
-          thread.id,
+          buildThreadIdSearchText(thread.id),
         );
     });
 
@@ -282,6 +282,16 @@ function queryMatchesIdentifier(query: string | undefined, identifier: string): 
   return needle !== undefined && needle.length > 0
     ? identifier.toLowerCase().includes(needle)
     : false;
+}
+
+function buildThreadIdSearchText(threadId: string): string {
+  const variants = new Set([threadId]);
+  for (const match of threadId.matchAll(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+  )) {
+    variants.add(match[0]);
+  }
+  return [...variants].join(" ");
 }
 
 function buildFilterWhereClause(filters: ThreadSearchFilters | undefined): {

--- a/apps/desktop/src/main/thread-search/thread-search-store.ts
+++ b/apps/desktop/src/main/thread-search/thread-search-store.ts
@@ -115,8 +115,9 @@ export class ThreadSearchStore {
         .prepare(
           `INSERT INTO thread_search_fts (
              identity_key, title, summary, project_key, directory_labels,
-             directory_paths, git_branch, git_origin_url, model, backend
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             directory_paths, git_branch, git_origin_url, model, backend,
+             thread_id
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           identityKey,
@@ -129,6 +130,7 @@ export class ThreadSearchStore {
           thread.gitOriginUrl ?? "",
           thread.model ?? "",
           thread.source,
+          thread.id,
         );
     });
 
@@ -231,6 +233,7 @@ export class ThreadSearchStore {
           ftsRow,
           typeof ftsRow.rank_value === "number" ? -ftsRow.rank_value : 0,
           ftsRow.snippet_text,
+          request.query,
         );
       });
   }
@@ -239,7 +242,9 @@ export class ThreadSearchStore {
     row: ThreadSearchDocumentRow,
     score: number,
     snippetText: string | null | undefined,
+    query?: string,
   ): ThreadSearchResult {
+    const threadIdMatch = queryMatchesIdentifier(query, row.thread_id);
     return {
       backend: row.backend,
       threadId: row.thread_id,
@@ -256,13 +261,27 @@ export class ThreadSearchStore {
       ...(row.git_branch ? { gitBranch: row.git_branch } : {}),
       ...(row.model ? { model: row.model } : {}),
       score,
-      confidence: score > 0 ? "medium" : "low",
-      matchReasons: score > 0 ? [{ kind: "summary_match", field: "projection" }] : [],
+      confidence: threadIdMatch ? "high" : score > 0 ? "medium" : "low",
+      matchReasons:
+        score > 0
+          ? [
+              threadIdMatch
+                ? { kind: "thread_id_match", field: "thread_id" }
+                : { kind: "summary_match", field: "projection" },
+            ]
+          : [],
       snippets: snippetText
         ? [{ scope: "projection", field: "summary", text: snippetText }]
         : [],
     };
   }
+}
+
+function queryMatchesIdentifier(query: string | undefined, identifier: string): boolean {
+  const needle = query?.trim().toLowerCase();
+  return needle !== undefined && needle.length > 0
+    ? identifier.toLowerCase().includes(needle)
+    : false;
 }
 
 function buildFilterWhereClause(filters: ThreadSearchFilters | undefined): {

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -96,6 +96,7 @@ const MATCH_REASON_LABELS: Record<ThreadSearchMatchReasonKind, string> = {
   directory_match: "Directory match",
   path_match: "Path match",
   branch_match: "Branch match",
+  thread_id_match: "Thread ID match",
   backend_match: "Backend match",
   model_match: "Model match",
   pr_number_match: "PR match",

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
@@ -111,13 +111,15 @@ describe("mergePrNumberMatches", () => {
 
 describe("threadMatchesQuery", () => {
   const t = thread({
+    id: "7f2f4bd1-8e7b-4d3b-92e5-0e9ef15c9c84",
     title: "Messaging bug",
     gitBranch: "fix/messaging",
     prs: [pr(779)],
     linkedDirectories: [{ id: "d", label: "PwrAgent", path: "/x", kind: "local" }],
   });
 
-  it("matches title, branch, PR number (with or without #), and directory", () => {
+  it("matches id, title, branch, PR number (with or without #), and directory", () => {
+    expect(threadMatchesQuery(t, "7f2f4bd1-8e7b")).toBe(true);
     expect(threadMatchesQuery(t, "messaging")).toBe(true);
     expect(threadMatchesQuery(t, "fix/")).toBe(true);
     expect(threadMatchesQuery(t, "779")).toBe(true);

--- a/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts
@@ -127,6 +127,54 @@ describe("threadMatchesQuery", () => {
     expect(threadMatchesQuery(t, "pwragent")).toBe(true);
   });
 
+  it("matches common thread id shapes", () => {
+    expect(
+      threadMatchesQuery(
+        thread({ id: "bd3381bd-d3a2-458c-9a9b-69819930354f" }),
+        "bd3381bd",
+      ),
+    ).toBe(true);
+    expect(
+      threadMatchesQuery(
+        thread({ id: "session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d" }),
+        "session_e31f5e66",
+      ),
+    ).toBe(true);
+    expect(
+      threadMatchesQuery(
+        thread({ id: "session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d" }),
+        "e31f5e66",
+      ),
+    ).toBe(true);
+    expect(
+      threadMatchesQuery(
+        thread({ id: "019f23aa-7673-7950-b077-107f5bf4777c" }),
+        "019f23aa",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match short accidental thread id fragments", () => {
+    const idOnly = thread({
+      id: "bd3381bd-d3a2-458c-9a9b-69819930354f",
+      title: "Echo",
+      gitBranch: undefined,
+      prs: [],
+      linkedDirectories: [],
+    });
+    const sessionIdOnly = thread({
+      id: "session_e31f5e66-7410-4235-aa19-3bbb63ee8c3d",
+      title: "Echo",
+      gitBranch: undefined,
+      prs: [],
+      linkedDirectories: [],
+    });
+
+    expect(threadMatchesQuery(idOnly, "b")).toBe(false);
+    expect(threadMatchesQuery(idOnly, "1")).toBe(false);
+    expect(threadMatchesQuery(sessionIdOnly, "session_")).toBe(false);
+  });
+
   it("returns false for non-matches and empty queries", () => {
     expect(threadMatchesQuery(t, "zzz")).toBe(false);
     expect(threadMatchesQuery(t, "   ")).toBe(false);

--- a/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
@@ -5,6 +5,9 @@ import {
   type ThreadSearchResult,
 } from "@pwragent/shared";
 
+const MIN_LONG_THREAD_ID_QUERY_LENGTH = 10;
+const MIN_UUID_FRAGMENT_HEX_CHARS = 8;
+
 /**
  * Parse a "bare PR number" query — "779" or "#779" — into its number, or
  * `null` when the query is anything else. Bounded to 7 digits so a long digit
@@ -21,6 +24,21 @@ export function parsePrNumberQuery(query: string): number | null {
 
 function threadPrNumbers(thread: NavigationThreadSummary): number[] {
   return (thread.prs ?? []).map((pr) => pr.number);
+}
+
+function threadIdMatchesQuery(threadId: string, query: string): boolean {
+  const id = threadId.toLowerCase();
+  if (!id.includes(query)) {
+    return false;
+  }
+  const hexChars = query.match(/[0-9a-f]/g)?.length ?? 0;
+  const uuidFragment =
+    /^[0-9a-f][0-9a-f-]{7,}$/i.test(query) &&
+    hexChars >= MIN_UUID_FRAGMENT_HEX_CHARS;
+  if (uuidFragment) {
+    return true;
+  }
+  return query.length >= MIN_LONG_THREAD_ID_QUERY_LENGTH;
 }
 
 /** Threads linked to the given PR number (via persisted overlay PRs). */
@@ -88,8 +106,9 @@ export function mergePrNumberMatches(
 
 /**
  * Client-side relevance test for the thread-list quick search: matches title,
- * linked PR number, git branch, and linked-directory label. PR numbers match
- * with or without the leading "#".
+ * thread id, linked PR number, git branch, and linked-directory label. PR
+ * numbers match with or without the leading "#"; thread ids only match
+ * sufficiently deliberate UUID-like fragments or longer pasted ids.
  */
 export function threadMatchesQuery(
   thread: NavigationThreadSummary,
@@ -102,7 +121,7 @@ export function threadMatchesQuery(
   if (thread.title.toLowerCase().includes(needle)) {
     return true;
   }
-  if (thread.id.toLowerCase().includes(needle)) {
+  if (threadIdMatchesQuery(thread.id, needle)) {
     return true;
   }
   if ((thread.gitBranch ?? "").toLowerCase().includes(needle)) {

--- a/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
+++ b/apps/desktop/src/renderer/src/features/thread-search/thread-match.ts
@@ -102,6 +102,9 @@ export function threadMatchesQuery(
   if (thread.title.toLowerCase().includes(needle)) {
     return true;
   }
+  if (thread.id.toLowerCase().includes(needle)) {
+    return true;
+  }
   if ((thread.gitBranch ?? "").toLowerCase().includes(needle)) {
     return true;
   }

--- a/packages/shared/src/contracts/thread-search.ts
+++ b/packages/shared/src/contracts/thread-search.ts
@@ -53,6 +53,7 @@ export const THREAD_SEARCH_MATCH_REASON_KINDS = [
   "directory_match",
   "path_match",
   "branch_match",
+  "thread_id_match",
   "backend_match",
   "model_match",
   "pr_number_match",


### PR DESCRIPTION
## Summary
Thread search now finds a thread when the operator pastes that thread's UUID into either the sidebar quick search or the global Search screen. The quick matcher checks the navigation thread id directly, while the persisted FTS projection now indexes `thread_id` and labels those hits as thread ID matches.

Existing profile databases migrate their thread-search FTS table to include `thread_id` and repopulate the index from the durable thread-search document table, so users do not need to reset local state.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/thread-search/__tests__/thread-match.test.ts packages/shared/src/contracts/__tests__/thread-search.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/thread-search-store.test.ts apps/desktop/src/main/__tests__/state-db.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/thread-search-service.test.ts apps/desktop/src/main/__tests__/thread-search-provider-adapters.test.ts apps/desktop/src/renderer/src/features/thread-search/__tests__/ThreadSearchPanel.test.tsx`
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
