### PR TITLE
fix(desktop): mark Codex thread starts as user sourced

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -34,6 +34,7 @@ import type {
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
 import type { MessagingBindingRecord } from "@pwragent/messaging-interface";
+import type { ThreadSource as CodexThreadSource } from "@pwrdrvr/codex-app-server-protocol/v2";
 import { buildNavigationSnapshot } from "@pwragent/agent-core";
 import {
   buildCodexFastModeMismatchNotificationParams,
@@ -848,6 +849,7 @@ class MockBackendClient {
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     defaultModeRequestUserInput?: boolean;
+    threadSource?: CodexThreadSource;
   };
   lastForkThreadParams?: {
     threadId: string;
@@ -1158,6 +1160,7 @@ class MockBackendClient {
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     defaultModeRequestUserInput?: boolean;
+    threadSource?: CodexThreadSource;
   }): Promise<{ threadId: string }> {
     this.lastStartThreadParams = params;
     return this.options.startThreadResult ?? { threadId: "thread-1" };
@@ -13011,6 +13014,7 @@ command = "pnpm dev"
       ephemeral: true,
       sandbox: "workspace-write",
     });
+    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
     expect(codexClient.lastStartTurnParams).toMatchObject({
       approvalPolicy: "never",
       sandbox: "workspace-write",
@@ -13142,6 +13146,7 @@ command = "pnpm dev"
       ephemeral: true,
       sandbox: "danger-full-access",
     });
+    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
     expect(codexClient.lastStartTurnParams).toMatchObject({
       approvalPolicy: "never",
       cwd: "/tmp/full-access-project",
@@ -14030,6 +14035,7 @@ command = "pnpm dev"
       fastMode: true,
       approvalPolicy: "never",
       sandbox: "danger-full-access",
+      threadSource: "user",
     });
     expect(codexClient.lastRenameThreadParams).toEqual({
       threadId: "thread-1",
@@ -17640,6 +17646,7 @@ script = "printf setup"
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
     });
+    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
     expect(
       (codexClient.lastStartThreadParams?.dynamicTools as Array<{ name: string }> | undefined)
         ?.map((tool) => tool.name),
@@ -17875,6 +17882,7 @@ script = "printf setup"
       ephemeral: true,
       model: "gpt-5.4-mini",
     });
+    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
     expect(codexClient.startTurnCallCount).toBe(1);
 
     await registry.close();
@@ -17954,6 +17962,7 @@ script = "printf setup"
       ephemeral: true,
       sandbox: "danger-full-access",
     });
+    expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
     expect(codexClient.lastStartTurnParams).toMatchObject({
       approvalPolicy: "never",
       codexEnvironmentRuntime,

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5316,7 +5316,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("starts Codex threads as user-sourced sessions", async () => {
+  it("passes explicit user source classification when starting Codex threads", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -5326,6 +5326,7 @@ describe("CodexAppServerClient", () => {
 
     await client.startThread({
       cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+      threadSource: "user",
     });
 
     const request = MockTransport.instances[0]?.sentMessages
@@ -6107,6 +6108,18 @@ describe("CodexAppServerClient", () => {
           },
         }),
       })
+    );
+    const threadStartRequests = requests.filter(
+      (request) => request.method === "thread/start",
+    );
+    expect(threadStartRequests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.not.objectContaining({
+            threadSource: expect.anything(),
+          }),
+        }),
+      ]),
     );
     expect(requests).toContainEqual(
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5316,6 +5316,29 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("starts Codex threads as user-sourced sessions", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+    });
+
+    const request = MockTransport.instances[0]?.sentMessages
+      .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
+      .find((payload) => payload.method === "thread/start");
+    expect(request?.params).toMatchObject({
+      cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
+      threadSource: "user",
+    });
+
+    await client.close();
+  });
+
   it("forks a Codex thread through thread/fork with workspace and permission overrides", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4,7 +4,10 @@ import { randomUUID } from "node:crypto";
 import { stat } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { DynamicToolSpec as CodexDynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
+import type {
+  DynamicToolSpec as CodexDynamicToolSpec,
+  ThreadSource as CodexThreadSource,
+} from "@pwrdrvr/codex-app-server-protocol/v2";
 import type {
   MessagingApprovalDecision,
   MessagingBindingRecord,
@@ -471,6 +474,7 @@ type BackendClient = {
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
+    threadSource?: CodexThreadSource;
   }): Promise<{ threadId: string }>;
   forkThread?(params: {
     threadId: string;
@@ -7116,6 +7120,7 @@ export class DesktopBackendRegistry {
               ? {
                   defaultModeRequestUserInput:
                     this.resolveCodexDefaultModeRequestUserInputFn(),
+                  threadSource: "user" as CodexThreadSource,
                 }
               : {}),
             dynamicTools,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4719,6 +4719,7 @@ function buildThreadStartPayload(params: {
   const base: CodexThreadStartParams = {
     experimentalRawEvents: false,
     persistExtendedHistory: false,
+    threadSource: "user",
   };
 
   if (params.cwd?.trim()) {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4715,11 +4715,11 @@ function buildThreadStartPayload(params: {
   config?: CodexThreadStartParams["config"];
   defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
+  threadSource?: CodexThreadStartParams["threadSource"];
 }): CodexThreadStartParams {
   const base: CodexThreadStartParams = {
     experimentalRawEvents: false,
     persistExtendedHistory: false,
-    threadSource: "user",
   };
 
   if (params.cwd?.trim()) {
@@ -4745,6 +4745,9 @@ function buildThreadStartPayload(params: {
   }
   if (params.ephemeral !== undefined) {
     base.ephemeral = params.ephemeral;
+  }
+  if (params.threadSource) {
+    base.threadSource = params.threadSource;
   }
   const config = mergeCodexShellEnvironmentPolicyConfig(
     mergeCodexDefaultModeRequestUserInputConfig(
@@ -6038,6 +6041,7 @@ export class CodexAppServerClient {
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     defaultModeRequestUserInput?: boolean;
     dynamicTools?: CodexDynamicToolSpec[];
+    threadSource?: CodexThreadStartParams["threadSource"];
   }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
 


### PR DESCRIPTION
## Summary

Clean Codex handoffs now create sessions with the same user-source classification as other PwrAgent-created threads, so they stay inside the interactive thread list that the sidebar searches and scrolls against. Before this, a clean `handoff_task` child could be persisted and searchable by title while missing from `thread/list`, leaving the search result with no sidebar row to reveal. The Codex client now sends `threadSource: "user"` on `thread/start`, matching the existing `thread/fork` behavior instead of widening list filters to every agent/subagent source.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
