### PR TITLE
fix(desktop): make MSG status bar hover work over text and icons

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1298,6 +1298,18 @@ textarea,
   -webkit-app-region: no-drag;
 }
 
+/* Chromium ignores `-webkit-app-region` on inline-level boxes, so the
+   no-drag rule above silently fails for the plain-`inline` label span and
+   the replaced-`inline` <svg> icons. Those children then fall back to the
+   title bar's inherited drag region, which makes the OS swallow
+   pointerenter/click events over them — the popover only opened over the
+   button's bare padding. Forcing a non-inline display lets the no-drag
+   above take effect across the whole control. (The button, chips, and
+   platforms wrapper are already `inline-flex`, which is why they worked.) */
+.messaging-status-bar svg {
+  display: block;
+}
+
 .messaging-status-chip {
   position: relative;
   display: inline-flex;
@@ -1316,6 +1328,8 @@ textarea,
 }
 
 .messaging-status-chip__fallback {
+  /* Non-inline so no-drag applies — see .messaging-status-bar svg note. */
+  display: inline-flex;
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -1365,6 +1379,10 @@ textarea,
 }
 
 .messaging-status-controller__label {
+  /* inline-flex (not the default `inline`) so `-webkit-app-region: no-drag`
+     applies — see the .messaging-status-bar svg note above. */
+  display: inline-flex;
+  align-items: center;
   font: 700 10px/1 var(--font-sans, sans-serif);
   letter-spacing: 0.08em;
   text-transform: uppercase;


### PR DESCRIPTION
## What

The messaging status controller (the **MSG** pill in the window title bar) only opened its popover when hovering the button's *bare gray padding* — hovering directly over the "Msg" label or the platform icons did nothing. This fixes it so the whole control is hoverable/clickable.

## Why

Same class of bug we previously hit on the settings gear: Electron's `-webkit-app-region` drag region swallowing pointer events over child elements.

The component already tries to neutralize this with:

```css
.messaging-status-bar * { -webkit-app-region: no-drag; }
```

…but **Chromium silently ignores `-webkit-app-region` on `inline`-level boxes.** The elements split cleanly along that line:

- ✅ The button, the platforms wrapper, and each chip are `display: inline-flex` → no-drag honored → the button padding worked.
- ❌ The `.messaging-status-controller__label` span (default `inline`) and the platform icons (replaced `inline` `<svg>`) were **not** honored, so they fell back to the title bar's inherited **drag** region. The OS swallows `pointerover`/click events over drag regions, so hovering the text or icons never fired `onPointerEnter` → popover stayed closed.

## The change

Force the offending inline children to a non-inline display so the existing subtree-wide `no-drag` actually applies:

- `.messaging-status-bar svg` → `display: block` (the icons)
- `.messaging-status-controller__label` → `display: inline-flex` (the "Msg"/"Off" text)
- `.messaging-status-chip__fallback` → `display: inline-flex` (the 2-letter fallback for icon-less platforms)

Each carries a comment explaining the inline/app-region gotcha so it isn't "tidied" away later. No visual/layout impact — the SVGs were already centered in flex chips and the label is a single token.

## Reviewer notes

- CSS-only change, one file (`apps/desktop/src/renderer/src/styles/app.css`).
- This is a real-Electron drag-region interaction, so it isn't meaningfully covered by the automated harness (it depends on hovering over OS drag regions). To eyeball: `pnpm dev:no-messaging` from repo root, then hover the MSG control directly over the text and each icon — the popover should open from anywhere on the button.