### PR TITLE
fix(messaging): allow Slack delivery bursts within the rate window

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-delivery-budget.test.ts
@@ -197,6 +197,86 @@ describe("MessagingDeliveryBudget", () => {
     });
   });
 
+  it("admits a normal Slack turn burst without slow mode but throttles at the minute total", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    // The Slack channel budget shape produced by rateLimitScopeForTarget.
+    const scope: MessagingDeliveryScope = {
+      platform: "slack",
+      id: "slack:channel:C012ABCDEF0",
+      kind: "channel",
+      budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
+    };
+
+    // A single agent turn's burst: status update, streaming partial, then the
+    // final assistant message — all within ~1s. None should trip slow mode.
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+    now = 1_200;
+    expect(budget.admit({ scope, priority: "stream_partial" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+    now = 1_400;
+    expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
+      outcome: "admitted",
+      slowMode: false,
+    });
+    expect(budget.isScopeInSlowMode(scope)).toBe(false);
+
+    // Fill the non-reserved capacity (25 = limit 30 - reserved 5) with chatter.
+    for (let sent = 3; sent < 25; sent += 1) {
+      now += 100;
+      expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+        outcome: "admitted",
+      });
+    }
+
+    // Chatter beyond the non-reserved capacity is dropped and arms slow mode,
+    // but the reserved slots still admit the final answer.
+    now += 100;
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "dropped",
+      reason: "budget-exhausted",
+    });
+    expect(budget.admit({ scope, priority: "final_turn" })).toMatchObject({
+      outcome: "admitted",
+    });
+  });
+
+  it("defers to the next window, not the slow-mode floor, when capacity frees sooner", () => {
+    let now = 1_000;
+    const budget = new MessagingDeliveryBudget({ now: () => now });
+    // A short 1s window frees capacity well before the 5s slow-mode floor.
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:group:short-window",
+      kind: "group",
+      budget: { limit: 1, intervalMs: 1_000, reserved: 0 },
+    };
+
+    expect(budget.admit({ scope, priority: "routine_status" })).toMatchObject({
+      outcome: "admitted",
+    });
+
+    // Deferred retry points at the next window (2_000 = oldest 1_000 + 1_000),
+    // even though slow mode is armed for the full 5s floor.
+    expect(budget.admit({ scope, priority: "final_turn" })).toEqual({
+      outcome: "deferred",
+      reason: "budget-exhausted",
+      retryAt: 2_000,
+      slowMode: true,
+    });
+
+    // Slow mode still holds until the 5s floor (1_000 + 5_000).
+    now = 4_999;
+    expect(budget.isScopeInSlowMode(scope)).toBe(true);
+    now = 6_001;
+    expect(budget.isScopeInSlowMode(scope)).toBe(false);
+  });
+
   it("keeps independent scopes from throttling each other", () => {
     const budget = new MessagingDeliveryBudget({ now: () => 1_000 });
     const first = testScope({ id: "telegram:group:1", limit: 1, reserved: 0 });

--- a/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
@@ -100,17 +100,19 @@ export class MessagingDeliveryBudget {
     }
 
     if (!this.hasCapacity(request.scope, state, request.priority)) {
-      const slowModeUntil = Math.max(
-        nextWindowAt(request.scope, state, now),
-        now + SLOW_MODE_MINIMUM_MS,
-      );
+      // Local budget (not a provider 429): capacity frees at the next sliding
+      // window, so a deferrable message should retry then rather than waiting
+      // the full slow-mode floor. Slow mode itself still arms at the floor so
+      // low-priority chatter stays suppressed for at least SLOW_MODE_MINIMUM_MS.
+      const nextWindow = nextWindowAt(request.scope, state, now);
+      const slowModeUntil = Math.max(nextWindow, now + SLOW_MODE_MINIMUM_MS);
       state.slowModeUntil = Math.max(state.slowModeUntil ?? 0, slowModeUntil);
       slowMode = true;
       if (DEFERABLE_PRIORITIES.has(request.priority)) {
         return {
           outcome: "deferred",
           reason: "budget-exhausted",
-          retryAt: slowModeUntil,
+          retryAt: nextWindow,
           slowMode,
         };
       }

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -676,7 +676,11 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       kind: rootId ? "thread" : "channel",
       label: rootId ? "Mattermost thread" : "Mattermost channel",
       ...(rootId ? { parentId: channelId } : {}),
-      budget: { limit: 1, intervalMs: 1_000, reserved: 0 },
+      // Budget deliveries per channel/thread over a sliding minute so a single
+      // agent turn's normal burst is admitted instead of tripping slow mode on
+      // the 2nd send. Mirrors Discord/Slack channels (30/min, 5 reserved for
+      // the final answer).
+      budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
     };
   }
 

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -366,6 +366,10 @@ describe("SlackAdapter", () => {
         retryable: true,
         scope: {
           id: "slack:channel:C012ABCDEF0",
+          kind: "channel",
+          // Per-minute sliding window (not the legacy 1/sec) so an agent turn's
+          // burst is admitted. Channels mirror Discord: 30/min, 5 reserved.
+          budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
         },
       },
     });
@@ -375,9 +379,54 @@ describe("SlackAdapter", () => {
         retryable: true,
         scope: expect.objectContaining({
           id: "slack:channel:C012ABCDEF0",
+          budget: { limit: 30, intervalMs: 60_000, reserved: 5 },
         }),
       }),
     ]);
+  });
+
+  it("budgets Slack DMs over a per-minute window like Telegram DMs", async () => {
+    const rateLimitError = Object.assign(new Error("rate_limited"), {
+      retryAfter: 3,
+    });
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: {
+        ...fakeApi({}),
+        postMessage: async () => {
+          throw rateLimitError;
+        },
+      },
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await expect(adapter.deliver({
+      id: "message-1",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [{ type: "text", text: "Final answer" }],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: { id: "D012ABCDEF0", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    })).resolves.toMatchObject({
+      outcome: "failed",
+      rateLimit: {
+        scope: {
+          id: "slack:channel:D012ABCDEF0",
+          kind: "dm",
+          budget: { limit: 60, intervalMs: 60_000, reserved: 0 },
+        },
+      },
+    });
   });
 
   it("marks Slack file-upload rate limits non-retryable after posting the message", async () => {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -961,12 +961,21 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   private rateLimitScopeForTarget(target: { channelId: string }): MessagingDeliveryScope {
+    const isDm = target.channelId.startsWith("D");
     return {
       platform: this.channel,
       id: `slack:channel:${target.channelId}`,
-      kind: target.channelId.startsWith("D") ? "dm" : "channel",
-      label: target.channelId.startsWith("D") ? "Slack DM" : "Slack channel",
-      budget: { limit: 1, intervalMs: 1_000, reserved: 0 },
+      kind: isDm ? "dm" : "channel",
+      label: isDm ? "Slack DM" : "Slack channel",
+      // Slack budgets deliveries per channel over a sliding minute so a single
+      // agent turn's normal burst (status update + final stream + assistant
+      // message) is admitted instead of tripping slow mode on the 2nd send.
+      // Channels mirror Discord (30/min, 5 reserved for the final answer);
+      // DMs mirror Telegram DMs (60/min). Both stay comfortably under Slack's
+      // ~1 msg/sec/channel sustained limit while tolerating in-turn bursts.
+      budget: isDm
+        ? { limit: 60, intervalMs: 60_000, reserved: 0 }
+        : { limit: 30, intervalMs: 60_000, reserved: 5 },
     };
   }
 


### PR DESCRIPTION
## The bug

Slack deliveries were budgeted per channel at **1 delivery / 1 second**. A single agent turn normally emits a burst — a status update, a streaming partial, and the final assistant message — all within ~1s. The 2nd delivery in a second tripped `budget-exhausted`, which arms a 5-second slow mode (`SLOW_MODE_MINIMUM_MS`). During those 5s, `routine_status` / `tool_progress` / `stream_partial` intents were **dropped** and the final assistant message was **deferred**, so every Slack turn lost its progress/stream updates and the final reply landed ~5s late (observed: a one-word "hey goat" reply deferred with `retryDelayMs=5000`).

Root cause: `rateLimitScopeForTarget` in `packages/messaging/providers/slack/src/slack-adapter.ts` set `budget: { limit: 1, intervalMs: 1_000, reserved: 0 }`. A 1/sec window can't absorb a burst. Telegram and Discord already use per-minute sliding windows, which naturally permit bursts and only throttle once the minute's total is hit.

## The fix

Switched the Slack scope (and the identical Mattermost anti-pattern) from a 1/sec window to a per-minute sliding window, distinguishing DM from channel the way Telegram does:

| Scope | Budget | Mirrors |
|---|---|---|
| Slack channel | `{ limit: 30, intervalMs: 60_000, reserved: 5 }` | Discord channels |
| Slack DM (`D…`) | `{ limit: 60, intervalMs: 60_000, reserved: 0 }` | Telegram DMs |
| Mattermost channel/thread | `{ limit: 30, intervalMs: 60_000, reserved: 5 }` | Discord channels |

### Why these numbers
- Slack's `chat.postMessage` is roughly **1 msg/sec/channel sustained** but tolerates short bursts; `chat.update` and other Web API methods are Tier-based (~50/min). A per-minute total of 30 for channels averages 0.5 msg/sec — well under the sustained ceiling — while letting a whole turn's burst through instantly. 60/min for DMs matches Telegram's DM budget (1/sec average).
- `reserved: 5` on channels holds back slots that only deferrable priorities (`final_turn`, `critical_interactive`, `user_command`) may use, so the final answer never gets starved behind low-priority status chatter at saturation. DMs mirror Telegram's `reserved: 0` since the 60/min budget is generous enough that chatter won't exhaust it in a single turn.

### Mattermost
**Included in this PR** — it had the exact same `{ limit: 1, intervalMs: 1_000, reserved: 0 }` and the same failure mode.

### Secondary latency fix (included)
In `apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts`, when a deferrable priority hit `budget-exhausted`, the returned `retryAt` was the slow-mode floor (`max(nextWindow, now + 5000)`), so an important deferred message waited the full 5s even though local capacity frees at the next window. It now defers to `nextWindowAt(...)`; slow mode still arms at the 5s floor to keep suppressing low-priority chatter. The real-429 path (`recordRateLimit` → `coolOffUntil` + 5-minute slow mode) is **unchanged** so genuine Slack 429s still back off hard.

## Tests
- `messaging-delivery-budget.test.ts`: new test that a Slack channel scope admits a normal multi-delivery turn burst without entering slow mode and still throttles once the per-minute non-reserved total is exceeded (reserved slots keep admitting the final answer); new test that a deferred `retryAt` points at the next window rather than the 5s floor when capacity frees sooner.
- `slack-adapter.test.ts`: rate-limit feedback now asserts the windowed channel budget; new test locks in the per-minute DM budget.

## Validation
- `pnpm --filter @pwragent/messaging-provider-slack typecheck` ✅
- `pnpm --filter @pwragent/messaging-provider-mattermost typecheck` ✅
- `pnpm --filter @pwragent/desktop typecheck` ✅
- `pnpm test` for `messaging-delivery-budget` (10), `slack-adapter` (27), `messaging-controller` (257) ✅
- `pnpm lint:boundaries` ✅ (no violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)