### PR TITLE
feat(desktop): make Messaging Activity window resizable and denser

### DIFF
--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -96,25 +96,43 @@ export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
     setCollapsed((current) => (current === pane ? null : pane));
   }, []);
 
-  const startDrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const container = containerRef.current;
-    if (!container) return;
-    event.preventDefault();
-    const rect = container.getBoundingClientRect();
-    const onMove = (move: PointerEvent) => {
-      if (rect.height <= 0) return;
-      const fraction = (move.clientY - rect.top) / rect.height;
-      setSplitFraction(Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, fraction)));
-    };
-    const onUp = () => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
-      document.body.style.cursor = "";
-    };
-    document.body.style.cursor = "row-resize";
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+  // Tracks the in-flight drag so an unmount mid-drag can tear down the
+  // window-level listeners and reset the body cursor (see the cleanup effect).
+  const dragAbortRef = useRef<AbortController | null>(null);
+  const endDrag = useCallback(() => {
+    dragAbortRef.current?.abort();
+    dragAbortRef.current = null;
+    document.body.style.cursor = "";
   }, []);
+
+  const startDrag = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const container = containerRef.current;
+      if (!container) return;
+      event.preventDefault();
+      endDrag(); // Guard against a leaked prior drag.
+      const controller = new AbortController();
+      dragAbortRef.current = controller;
+      const rect = container.getBoundingClientRect();
+      const onMove = (move: PointerEvent) => {
+        if (rect.height <= 0) return;
+        const fraction = (move.clientY - rect.top) / rect.height;
+        setSplitFraction(Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, fraction)));
+      };
+      document.body.style.cursor = "row-resize";
+      window.addEventListener("pointermove", onMove, {
+        signal: controller.signal,
+      });
+      window.addEventListener("pointerup", endDrag, {
+        signal: controller.signal,
+      });
+    },
+    [endDrag],
+  );
+
+  // Abort any drag still in flight when the screen unmounts so the
+  // window-level listeners and the row-resize cursor don't dangle.
+  useEffect(() => endDrag, [endDrag]);
 
   return (
     <section

--- a/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-activity/MessagingActivityScreen.tsx
@@ -1,10 +1,18 @@
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import type {
   MessagingActivityEntry,
   MessagingActivityKind,
 } from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { ChevronRightIcon } from "../../icons";
 import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
@@ -29,6 +37,13 @@ const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "mut
   binding: "ok",
   diagnostic: "warning",
 };
+/** Which pane, if any, is collapsed to header-only. */
+type CollapsedPane = "top" | "bottom" | null;
+
+const MIN_SPLIT = 0.15;
+const MAX_SPLIT = 0.85;
+const DEFAULT_SPLIT = 0.62;
+
 /**
  * Read-only view of the recent messaging activity log: routed inbound,
  * rejected inbound (unauthorized senders), ignored inbound (post-revoke),
@@ -37,25 +52,26 @@ const KIND_TONE: Record<MessagingActivityKind, "ok" | "warning" | "error" | "mut
  *
  * Polls every 5s while open. The renderer doesn't subscribe to a push
  * event because the activity log writes are best-effort and a dropped
- * tick is fine (we'll catch up on the next poll).
+ * tick is fine (we'll catch up on the next poll). No manual Refresh
+ * control — the 5s poll keeps the two panes current on its own.
+ *
+ * The body is two panes — "Bound activity" and "Attention" — split by a
+ * draggable divider; each pane header is a collapse toggle so the other
+ * pane can take the full height.
  */
 export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
   const desktopApi = props.desktopApi;
   const [entries, setEntries] = useState<MessagingActivityEntry[]>([]);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [loading, setLoading] = useState(false);
 
   const refresh = useCallback(async () => {
     if (!desktopApi?.listMessagingActivity) return;
-    setLoading(true);
     setError(undefined);
     try {
       const result = await desktopApi.listMessagingActivity({ limit: 200 });
       setEntries(result.entries);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : String(caught));
-    } finally {
-      setLoading(false);
     }
   }, [desktopApi]);
 
@@ -69,79 +85,137 @@ export function MessagingActivityScreen(props: { desktopApi?: DesktopApi }) {
 
   const groups = groupByKind(entries);
 
-  return (
-    <section className="messaging-activity" aria-label="Messaging activity">
-      {/* Pinned header card — eyebrow + title + helper paragraph + Refresh. */}
-      <section
-        className="settings-panel messaging-activity__head"
-        aria-labelledby="messaging-activity-title"
-      >
-        <div className="settings-panel__header">
-          <div>
-            <p className="eyebrow">Messaging</p>
-            <h2 id="messaging-activity-title">Activity</h2>
-          </div>
-          <button
-            className="button button--secondary"
-            disabled={loading || !desktopApi?.listMessagingActivity}
-            type="button"
-            onClick={() => void refresh()}
-          >
-            {loading ? "Loading…" : "Refresh"}
-          </button>
-        </div>
-        <p className="settings-panel__hint">
-          Last {entries.length} events across all configured messaging platforms.
-          Capped per-platform with FIFO eviction; older history is not retained.
-        </p>
-        {error ? (
-          <p className="settings-error" role="alert">
-            {error}
-          </p>
-        ) : null}
-      </section>
+  // Split between the two panes. `splitFraction` is the top pane's share of
+  // the container height when neither pane is collapsed; the divider drags it.
+  // Collapsing a pane pins it to header height and lets the other fill.
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [splitFraction, setSplitFraction] = useState(DEFAULT_SPLIT);
+  const [collapsed, setCollapsed] = useState<CollapsedPane>(null);
 
-      {/* Primary list — fills available height with internal scroll. */}
+  const toggleCollapse = useCallback((pane: Exclude<CollapsedPane, null>) => {
+    setCollapsed((current) => (current === pane ? null : pane));
+  }, []);
+
+  const startDrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) return;
+    event.preventDefault();
+    const rect = container.getBoundingClientRect();
+    const onMove = (move: PointerEvent) => {
+      if (rect.height <= 0) return;
+      const fraction = (move.clientY - rect.top) / rect.height;
+      setSplitFraction(Math.min(MAX_SPLIT, Math.max(MIN_SPLIT, fraction)));
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.cursor = "";
+    };
+    document.body.style.cursor = "row-resize";
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }, []);
+
+  return (
+    <section
+      className="messaging-activity"
+      aria-label="Messaging activity"
+      ref={containerRef}
+    >
+      {error ? (
+        <p className="settings-error messaging-activity__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {/* Primary list. */}
       <ActivitySection
-        className="messaging-activity__main"
+        className="messaging-activity__pane messaging-activity__pane--top"
+        style={paneStyleFor("top", collapsed, splitFraction)}
         title="Bound activity"
         emptyLabel="No bound conversations have sent messages recently."
         kinds={["binding", "inbound-routed", "outbound"]}
         groups={groups}
+        collapsed={collapsed === "top"}
+        onToggleCollapse={() => toggleCollapse("top")}
       />
 
-      {/* Secondary list — capped at ~5 rows tall; internal scroll if longer.
-          Stays pinned to the bottom of the pane. */}
+      {/* Draggable divider — only meaningful when both panes are open. */}
+      {collapsed === null ? (
+        <div
+          className="messaging-activity__divider"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize sections"
+          onPointerDown={startDrag}
+        >
+          <span className="messaging-activity__divider-grip" aria-hidden="true" />
+        </div>
+      ) : null}
+
+      {/* Secondary list — rejections, pairing, delivery diagnostics. */}
       <ActivitySection
-        className="messaging-activity__aside"
+        className="messaging-activity__pane messaging-activity__pane--bottom"
+        style={paneStyleFor("bottom", collapsed, splitFraction)}
         title="Attention"
         emptyLabel="No rejected messages, pairing attempts, or delivery diagnostics."
         kinds={["diagnostic", "inbound-rejected", "inbound-ignored", "pairing"]}
         groups={groups}
+        collapsed={collapsed === "bottom"}
+        onToggleCollapse={() => toggleCollapse("bottom")}
       />
     </section>
   );
 }
 
+/**
+ * Flex sizing for one pane given the collapse state:
+ * - this pane collapsed → header height only (`flex: 0 0 auto`).
+ * - the other pane collapsed → fill the remaining space.
+ * - neither collapsed → share the container by `splitFraction`.
+ */
+function paneStyleFor(
+  pane: Exclude<CollapsedPane, null>,
+  collapsed: CollapsedPane,
+  splitFraction: number,
+): CSSProperties {
+  if (collapsed === pane) return { flex: "0 0 auto" };
+  if (collapsed !== null) return { flexGrow: 1, flexBasis: 0, minHeight: 0 };
+  const grow = pane === "top" ? splitFraction : 1 - splitFraction;
+  return { flexGrow: grow, flexBasis: 0, minHeight: 0 };
+}
+
 function ActivitySection(props: {
   className?: string;
+  style?: CSSProperties;
   title: string;
   emptyLabel: string;
   kinds: MessagingActivityKind[];
   groups: Record<MessagingActivityKind, MessagingActivityEntry[]>;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
 }) {
   const entries = props.kinds.flatMap((kind) => props.groups[kind] ?? []);
   entries.sort((left, right) => right.createdAt - left.createdAt);
   const className = `settings-panel${props.className ? ` ${props.className}` : ""}`;
   return (
-    <section className={className} aria-label={props.title}>
-      <div className="settings-panel__header">
-        <div>
-          <p className="eyebrow">Messaging</p>
-          <h2>{props.title}</h2>
-        </div>
-      </div>
-      {entries.length === 0 ? (
+    <section className={className} style={props.style} aria-label={props.title}>
+      <button
+        type="button"
+        className="messaging-activity-pane__header"
+        aria-expanded={!props.collapsed}
+        onClick={props.onToggleCollapse}
+      >
+        <ChevronRightIcon
+          size={14}
+          className={`messaging-activity-pane__chevron${
+            props.collapsed ? "" : " messaging-activity-pane__chevron--open"
+          }`}
+        />
+        <h2>{props.title}</h2>
+        <span className="messaging-activity-pane__count">{entries.length}</span>
+      </button>
+      {props.collapsed ? null : entries.length === 0 ? (
         <p className="settings-empty messaging-activity-empty">{props.emptyLabel}</p>
       ) : (
         <ul className="messaging-activity-list">

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2228,15 +2228,6 @@ textarea,
   text-align: left;
 }
 
-.messaging-activity-pane__header h2 {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 15px;
-  font-weight: 700;
-  letter-spacing: -0.005em;
-  line-height: 1.2;
-}
-
 .messaging-activity-pane__header:hover .messaging-activity-pane__chevron {
   color: var(--text-secondary);
 }
@@ -5627,7 +5618,8 @@ textarea,
   text-transform: uppercase;
 }
 
-.settings-panel__header h2 {
+.settings-panel__header h2,
+.messaging-activity-pane__header h2 {
   margin: 0;
   color: var(--text-primary);
   font-size: 15px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2181,49 +2181,110 @@ textarea,
   color: var(--button-text);
 }
 
-/* Pinned head + filling middle + capped footer for the activity body. */
+/* Two resizable, collapsible panes with a draggable divider between them. */
 .messaging-activity {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
   min-height: 0;
   width: 100%;
 }
 
-.messaging-activity__head {
+.messaging-activity__error {
   flex: 0 0 auto;
+  margin: 0;
 }
 
-.messaging-activity__main {
+/* Each pane flexes to its assigned share (inline style, see paneStyleFor)
+   and scrolls its own list. `overflow: hidden` clips the list at the pane
+   edge so the internal scroll — not the window — absorbs overflow. */
+.messaging-activity__pane {
   display: flex;
-  flex: 1;
   flex-direction: column;
   min-height: 0;
+  overflow: hidden;
 }
 
-.messaging-activity__main .messaging-activity-list {
+.messaging-activity__pane .messaging-activity-list {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   padding: 0 18px 14px;
 }
 
-.messaging-activity__aside {
-  flex: 0 0 auto;
-  /* ~5 rows of meta + summary + 8px gap + 14px head. The list scrolls
-     internally if the cap is exceeded. */
-  max-height: 240px;
+/* Collapsible pane header — the whole strip is the collapse toggle. */
+.messaging-activity-pane__header {
   display: flex;
-  flex-direction: column;
-  min-height: 0;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  width: 100%;
+  padding: 14px 18px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
 }
 
-.messaging-activity__aside .messaging-activity-list {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 0 18px 14px;
+.messaging-activity-pane__header h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  line-height: 1.2;
+}
+
+.messaging-activity-pane__header:hover .messaging-activity-pane__chevron {
+  color: var(--text-secondary);
+}
+
+.messaging-activity-pane__header:focus-visible {
+  outline: none;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px var(--accent-shadow);
+}
+
+.messaging-activity-pane__chevron {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 120ms ease;
+}
+
+.messaging-activity-pane__chevron--open {
+  transform: rotate(90deg);
+}
+
+.messaging-activity-pane__count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Draggable split handle — rendered only when both panes are open. */
+.messaging-activity__divider {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 10px;
+  cursor: row-resize;
+  touch-action: none;
+}
+
+.messaging-activity__divider-grip {
+  width: 36px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--border-subtle);
+  transition: background 120ms ease;
+}
+
+.messaging-activity__divider:hover .messaging-activity__divider-grip {
+  background: var(--accent-border);
 }
 
 .messaging-activity-empty {


### PR DESCRIPTION
## What & why

The Messaging Activity window wasted vertical space on static chrome and gave the "Attention" list too little room. This reworks the body around operator control.

Addresses three points of feedback:

1. **Refresh button removed.** The screen already polls every 5s, so the button never did anything the poll didn't. Dropped it and its `loading` state. Errors now surface as a compact inline line instead of living inside a header card.
2. **Top "Activity" intro card removed entirely.** The eyebrow, "Activity" title, and the "Last 200 events / FIFO eviction" hint are gone — the window titlebar already reads `MESSAGING › Activity`, so the card was pure vertical waste. The body now starts straight into the two lists.
3. **Resizable + collapsible split.** The old fixed layout (Bound activity `flex:1`, Attention capped at 240px) is replaced with two equal-citizen panes:
   - **Draggable divider** between them — drag to rebalance, clamped 15–85%.
   - **Collapse chevron** on each pane header (the whole header strip is the toggle). Collapse one and the other fills; the divider hides while a pane is collapsed. Each header shows a live entry count so a collapsed pane still informs.

## Reviewer notes

- Chevron reuses the existing `ChevronRightIcon` (rotates to point down when open) to match app chrome.
- Split/collapse state is in-component — it resets when the window reopens (not persisted to config). Easy to persist later if wanted.
- Did **not** touch the `activity-titlebar` tokens, so the `theme-contract` brand/breadcrumb test is unaffected.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` — clean.
- The 4 `messaging-activity-screen.test.tsx` unit tests pass (both panes default to expanded, so copy-control assertions still hold).
- No live visual pass of the drag/collapse interaction yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)