### PR TITLE
feat(desktop): inbound-automation follow-ups (rate limit, throttle visibility, destination picker)

### DIFF
--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ThreadTurnQueueEntry } from "../app-server/thread-turn-queue";
 import { ThreadQueueAutomationRunner } from "../automations/automation-runner";
-import { AutomationScheduler } from "../automations/automation-scheduler";
+import {
+  AutomationScheduler,
+  RATE_LIMIT_SKIP_MESSAGE,
+} from "../automations/automation-scheduler";
 import { AutomationStore } from "../automations/automation-store";
 import type { AutomationGateRunner } from "../automations/automation-gate-runner";
 import { StateDb } from "../state/state-db";
@@ -621,7 +624,7 @@ describe("AutomationScheduler", () => {
     ]);
   });
 
-  it("caps inbound run starts at the per-hour token bucket", async () => {
+  it("caps inbound run starts at the per-hour rolling limit", async () => {
     const automation = store.createAutomation({
       id: "automation-rl",
       backend: "codex",
@@ -651,20 +654,78 @@ describe("AutomationScheduler", () => {
       message: { text: "ERROR" },
     });
 
-    // 10 distinct messages at the same instant; capacity == rate == 5.
+    // Count only runs that actually started; throttled drops record a separate
+    // skipped marker (asserted in its own test below).
+    const started = () =>
+      store
+        .listRunsForAutomation("automation-rl")
+        .filter((run) => run.status !== "skipped");
+
+    // 10 distinct messages at the same instant; the hourly cap is 5.
     now = 1_000;
     for (let i = 0; i < 10; i += 1) {
       await scheduler.runFromInboundEvent({ automation, source: src(`k${i}`), now });
     }
-    expect(store.listRunsForAutomation("automation-rl")).toHaveLength(5);
+    expect(started()).toHaveLength(5);
 
-    // Bucket refills 1 token after 1/5 hour (12 min); one more run starts.
+    // Still capped 12 minutes later — all 5 runs are within the rolling hour,
+    // so this is not a burstable/refilling bucket.
     now = 1_000 + 12 * 60 * 1000;
-    await scheduler.runFromInboundEvent({ automation, source: src("k-refill"), now });
-    expect(store.listRunsForAutomation("automation-rl")).toHaveLength(6);
+    await scheduler.runFromInboundEvent({ automation, source: src("k-12min"), now });
+    expect(started()).toHaveLength(5);
+
+    // Once the first runs age out of the rolling hour, a new run is allowed.
+    now = 1_000 + 60 * 60 * 1000 + 1;
+    await scheduler.runFromInboundEvent({ automation, source: src("k-aged"), now });
+    expect(started()).toHaveLength(6);
   });
 
-  it("does not spend rate tokens on idempotent redeliveries or duplicate-trigger matches", async () => {
+  it("records one coalesced skipped run for throttled inbound messages", async () => {
+    const automation = store.createAutomation({
+      id: "automation-rl",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Rate limited",
+      taskPrompt: "Triage.",
+      inboundCoalesceWindowMs: 0,
+      maxRunsPerHour: 1,
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      now: 0,
+    });
+    const scheduler = buildScheduler();
+    const src = (key: string) => ({
+      kind: "messaging" as const,
+      sourceEventKey: key,
+      receivedAt: now,
+      matchedTriggerId: "t",
+      actor: { platformUserId: "B123", isBot: true },
+      conversation: { channel: "slack" as const, conversationId: "C123" },
+      message: { text: "ERROR" },
+    });
+
+    // One run fits the cap; the next four are throttled.
+    now = 1_000;
+    for (let i = 0; i < 5; i += 1) {
+      await scheduler.runFromInboundEvent({ automation, source: src(`k${i}`), now });
+    }
+
+    const runs = store.listRunsForAutomation("automation-rl");
+    const skipped = runs.filter((run) => run.status === "skipped");
+    // The four drops collapse onto a single throttle marker, not four rows.
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.errorMessage).toBe(RATE_LIMIT_SKIP_MESSAGE);
+    // Exactly one started run plus the single throttle marker.
+    expect(runs).toHaveLength(2);
+  });
+
+  it("does not count idempotent redeliveries or duplicate-trigger matches toward the rate", async () => {
     const automation = store.createAutomation({
       id: "automation-rl2",
       backend: "codex",
@@ -695,13 +756,13 @@ describe("AutomationScheduler", () => {
     });
 
     now = 1_000;
-    // First message starts a run (1 token spent, 1 left).
+    // First message starts a run (1 of 2 used).
     await scheduler.runFromInboundEvent({ automation, source: src("k1"), now });
-    // Three redeliveries of the same key are idempotent: no run, no token spent.
+    // Three redeliveries of the same key are idempotent: no run, nothing counted.
     for (let i = 0; i < 3; i += 1) {
       await scheduler.runFromInboundEvent({ automation, source: src("k1"), now });
     }
-    // A genuinely new message still has its token and starts/queues a run.
+    // A genuinely new message is still under the cap and starts/queues a run.
     await scheduler.runFromInboundEvent({ automation, source: src("k2"), now });
 
     // 2 real runs (k1, k2); the bucket was not drained by the redeliveries. If

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -4,10 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ThreadTurnQueueEntry } from "../app-server/thread-turn-queue";
 import { ThreadQueueAutomationRunner } from "../automations/automation-runner";
-import {
-  AutomationScheduler,
-  RATE_LIMIT_SKIP_MESSAGE,
-} from "../automations/automation-scheduler";
+import { AutomationScheduler } from "../automations/automation-scheduler";
 import { AutomationStore } from "../automations/automation-store";
 import type { AutomationGateRunner } from "../automations/automation-gate-runner";
 import { StateDb } from "../state/state-db";
@@ -718,17 +715,17 @@ describe("AutomationScheduler", () => {
 
     const runs = store.listRunsForAutomation("automation-rl");
     const skipped = runs.filter((run) => run.status === "skipped");
-    // The four drops collapse onto a single throttle marker, not four rows.
+    // The four drops collapse onto a single throttle marker carrying the count.
     expect(skipped).toHaveLength(1);
-    expect(skipped[0]?.errorMessage).toBe(RATE_LIMIT_SKIP_MESSAGE);
     expect(skipped[0]?.skipReason).toBe("rate_limited");
+    expect(skipped[0]?.coalescedCount).toBe(4);
     // Exactly one started run plus the single throttle marker.
     expect(runs).toHaveLength(2);
   });
 
   it("keeps coalescing throttle drops after a real run finishes", async () => {
-    // A finished real run has a newer updated_at than the throttle marker, so
-    // coalescing must find the marker by skipReason, not by "newest run".
+    // The marker is keyed by the wall-clock hour, so an intervening finished run
+    // never causes a second marker within the same hour.
     const automation = store.createAutomation({
       id: "automation-rl",
       backend: "codex",
@@ -782,56 +779,7 @@ describe("AutomationScheduler", () => {
       .listRunsForAutomation("automation-rl")
       .filter((run) => run.status === "skipped");
     expect(skipped).toHaveLength(1);
-  });
-
-  it("keeps a redelivered coalesced throttle drop idempotent", async () => {
-    // A coalesced drop never gets its own row, but its key is recorded on the
-    // marker so a redelivery (even after the cap frees up) does not start a run.
-    const automation = store.createAutomation({
-      id: "automation-rl",
-      backend: "codex",
-      threadId: "thread-1",
-      name: "Rate limited",
-      taskPrompt: "Triage.",
-      inboundCoalesceWindowMs: 0,
-      maxRunsPerHour: 1,
-      triggers: [
-        {
-          id: "t",
-          kind: "inbound_message",
-          conversation: { channel: "slack", conversationId: "C123" },
-          textFilter: { mode: "contains", text: "ERROR" },
-        },
-      ],
-      now: 0,
-    });
-    const scheduler = buildScheduler();
-    const src = (key: string) => ({
-      kind: "messaging" as const,
-      sourceEventKey: key,
-      receivedAt: now,
-      matchedTriggerId: "t",
-      actor: { platformUserId: "B123", isBot: true },
-      conversation: { channel: "slack" as const, conversationId: "C123" },
-      message: { text: "ERROR" },
-    });
-
-    now = 1_000;
-    await scheduler.runFromInboundEvent({ automation, source: src("real"), now });
-    await scheduler.runFromInboundEvent({ automation, source: src("drop-1"), now });
-    await scheduler.runFromInboundEvent({ automation, source: src("drop-2"), now });
-    const startedBefore = store
-      .listRunsForAutomation("automation-rl")
-      .filter((run) => run.status !== "skipped").length;
-
-    // Advance past the rolling hour so the cap has freed up, then redeliver the
-    // coalesced drop. Without the coalesced-key check it would start a run.
-    now = 1_000 + 60 * 60 * 1000 + 1;
-    await scheduler.runFromInboundEvent({ automation, source: src("drop-2"), now });
-    const startedAfter = store
-      .listRunsForAutomation("automation-rl")
-      .filter((run) => run.status !== "skipped").length;
-    expect(startedAfter).toBe(startedBefore);
+    expect(skipped[0]?.coalescedCount).toBe(2);
   });
 
   it("does not count idempotent redeliveries or duplicate-trigger matches toward the rate", async () => {

--- a/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-scheduler.test.ts
@@ -721,8 +721,117 @@ describe("AutomationScheduler", () => {
     // The four drops collapse onto a single throttle marker, not four rows.
     expect(skipped).toHaveLength(1);
     expect(skipped[0]?.errorMessage).toBe(RATE_LIMIT_SKIP_MESSAGE);
+    expect(skipped[0]?.skipReason).toBe("rate_limited");
     // Exactly one started run plus the single throttle marker.
     expect(runs).toHaveLength(2);
+  });
+
+  it("keeps coalescing throttle drops after a real run finishes", async () => {
+    // A finished real run has a newer updated_at than the throttle marker, so
+    // coalescing must find the marker by skipReason, not by "newest run".
+    const automation = store.createAutomation({
+      id: "automation-rl",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Rate limited",
+      taskPrompt: "Triage.",
+      inboundCoalesceWindowMs: 0,
+      maxRunsPerHour: 1,
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      now: 0,
+    });
+    const scheduler = buildScheduler();
+    const src = (key: string) => ({
+      kind: "messaging" as const,
+      sourceEventKey: key,
+      receivedAt: now,
+      matchedTriggerId: "t",
+      actor: { platformUserId: "B123", isBot: true },
+      conversation: { channel: "slack" as const, conversationId: "C123" },
+      message: { text: "ERROR" },
+    });
+
+    now = 1_000;
+    await scheduler.runFromInboundEvent({ automation, source: src("real"), now });
+    await scheduler.runFromInboundEvent({ automation, source: src("drop-1"), now });
+
+    // The real run finishes, bumping its updated_at above the throttle marker.
+    const [realRun] = store
+      .listRunsForAutomation("automation-rl")
+      .filter((run) => run.status !== "skipped");
+    now = 2_000;
+    store.markRunTerminal({
+      runId: realRun.id,
+      status: "completed",
+      completedAt: now,
+      now,
+    });
+
+    // A later drop must still coalesce onto the existing marker, not spawn a new
+    // one just because the finished real run is now the newest row.
+    now = 3_000;
+    await scheduler.runFromInboundEvent({ automation, source: src("drop-2"), now });
+    const skipped = store
+      .listRunsForAutomation("automation-rl")
+      .filter((run) => run.status === "skipped");
+    expect(skipped).toHaveLength(1);
+  });
+
+  it("keeps a redelivered coalesced throttle drop idempotent", async () => {
+    // A coalesced drop never gets its own row, but its key is recorded on the
+    // marker so a redelivery (even after the cap frees up) does not start a run.
+    const automation = store.createAutomation({
+      id: "automation-rl",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Rate limited",
+      taskPrompt: "Triage.",
+      inboundCoalesceWindowMs: 0,
+      maxRunsPerHour: 1,
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C123" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      now: 0,
+    });
+    const scheduler = buildScheduler();
+    const src = (key: string) => ({
+      kind: "messaging" as const,
+      sourceEventKey: key,
+      receivedAt: now,
+      matchedTriggerId: "t",
+      actor: { platformUserId: "B123", isBot: true },
+      conversation: { channel: "slack" as const, conversationId: "C123" },
+      message: { text: "ERROR" },
+    });
+
+    now = 1_000;
+    await scheduler.runFromInboundEvent({ automation, source: src("real"), now });
+    await scheduler.runFromInboundEvent({ automation, source: src("drop-1"), now });
+    await scheduler.runFromInboundEvent({ automation, source: src("drop-2"), now });
+    const startedBefore = store
+      .listRunsForAutomation("automation-rl")
+      .filter((run) => run.status !== "skipped").length;
+
+    // Advance past the rolling hour so the cap has freed up, then redeliver the
+    // coalesced drop. Without the coalesced-key check it would start a run.
+    now = 1_000 + 60 * 60 * 1000 + 1;
+    await scheduler.runFromInboundEvent({ automation, source: src("drop-2"), now });
+    const startedAfter = store
+      .listRunsForAutomation("automation-rl")
+      .filter((run) => run.status !== "skipped").length;
+    expect(startedAfter).toBe(startedBefore);
   });
 
   it("does not count idempotent redeliveries or duplicate-trigger matches toward the rate", async () => {

--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -589,6 +589,52 @@ describe("AutomationStore", () => {
     expect(store.findActiveRunForAutomation("automation-1")).toBeUndefined();
   });
 
+  it("countRecentInboundRuns counts inbound runs in the window, excluding skipped", () => {
+    // The shared store keeps only runHistoryLimit (3) runs, so keep to 3.
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Rate",
+      taskPrompt: "Triage.",
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C1" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      now: 0,
+    });
+    const inbound = (id: string, createdAt: number) =>
+      store.createRun({
+        id,
+        automationId: "automation-1",
+        trigger: "inbound_message",
+        now: createdAt,
+      });
+    inbound("r-old", 1_000);
+    inbound("r-mid", 5_000);
+    inbound("r-skip", 6_000);
+    store.markRunTerminal({
+      runId: "r-skip",
+      status: "skipped",
+      completedAt: 6_000,
+      now: 6_000,
+    });
+
+    // From 4_000: only r-mid (r-old is before the window; r-skip is skipped and
+    // never started).
+    expect(
+      store.countRecentInboundRuns({ automationId: "automation-1", sinceMs: 4_000 }),
+    ).toBe(1);
+    // From 0: r-old + r-mid count; the skipped run stays excluded.
+    expect(
+      store.countRecentInboundRuns({ automationId: "automation-1", sinceMs: 0 }),
+    ).toBe(2);
+  });
+
   it("reconciles stale local runs on startup without creating catch-up rows", () => {
     store.createAutomation({
       id: "automation-1",

--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -635,6 +635,85 @@ describe("AutomationStore", () => {
     ).toBe(2);
   });
 
+  it("round-trips skip metadata and finds throttle markers by reason and coalesced key", () => {
+    store.createAutomation({
+      id: "automation-1",
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Rate",
+      taskPrompt: "Triage.",
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C1" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      now: 0,
+    });
+    store.createRun({
+      id: "r1",
+      automationId: "automation-1",
+      trigger: "inbound_message",
+      source: {
+        kind: "messaging",
+        sourceEventKey: "first",
+        receivedAt: 1_000,
+        matchedTriggerId: "t",
+        actor: { platformUserId: "B", isBot: true },
+        conversation: { channel: "slack", conversationId: "C1" },
+        message: { text: "ERROR" },
+      },
+      now: 1_000,
+    });
+    store.markRunTerminal({
+      runId: "r1",
+      status: "skipped",
+      skipReason: "rate_limited",
+      errorMessage: "throttled",
+      coalescedEventKeys: ["first", "second"],
+      completedAt: 1_000,
+      now: 1_000,
+    });
+
+    // skipReason + coalescedEventKeys survive the JSON payload round-trip.
+    const stored = store.getRun("r1");
+    expect(stored?.skipReason).toBe("rate_limited");
+    expect(stored?.coalescedEventKeys).toEqual(["first", "second"]);
+
+    // Found structurally by reason, not by matching display copy.
+    expect(
+      store.findRecentInboundSkip({
+        automationId: "automation-1",
+        skipReason: "rate_limited",
+        sinceMs: 0,
+      })?.id,
+    ).toBe("r1");
+    expect(
+      store.findRecentInboundSkip({
+        automationId: "automation-1",
+        skipReason: "lane_busy",
+        sinceMs: 0,
+      }),
+    ).toBeUndefined();
+
+    // A coalesced key (not the row's own source_event_key) resolves via the
+    // fallback, so a redelivery of that drop stays idempotent.
+    expect(
+      store.findRunBySourceEventKey({
+        automationId: "automation-1",
+        sourceEventKey: "second",
+      })?.id,
+    ).toBe("r1");
+    expect(
+      store.findRunBySourceEventKey({
+        automationId: "automation-1",
+        sourceEventKey: "unknown",
+      }),
+    ).toBeUndefined();
+  });
+
   it("reconciles stale local runs on startup without creating catch-up rows", () => {
     store.createAutomation({
       id: "automation-1",

--- a/apps/desktop/src/main/__tests__/automation-store.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-store.test.ts
@@ -635,7 +635,7 @@ describe("AutomationStore", () => {
     ).toBe(2);
   });
 
-  it("round-trips skip metadata and finds throttle markers by reason and coalesced key", () => {
+  it("round-trips skip metadata through the run payload", () => {
     store.createAutomation({
       id: "automation-1",
       backend: "codex",
@@ -656,15 +656,6 @@ describe("AutomationStore", () => {
       id: "r1",
       automationId: "automation-1",
       trigger: "inbound_message",
-      source: {
-        kind: "messaging",
-        sourceEventKey: "first",
-        receivedAt: 1_000,
-        matchedTriggerId: "t",
-        actor: { platformUserId: "B", isBot: true },
-        conversation: { channel: "slack", conversationId: "C1" },
-        message: { text: "ERROR" },
-      },
       now: 1_000,
     });
     store.markRunTerminal({
@@ -672,46 +663,15 @@ describe("AutomationStore", () => {
       status: "skipped",
       skipReason: "rate_limited",
       errorMessage: "throttled",
-      coalescedEventKeys: ["first", "second"],
+      coalescedCount: 7,
       completedAt: 1_000,
       now: 1_000,
     });
 
-    // skipReason + coalescedEventKeys survive the JSON payload round-trip.
+    // skipReason + coalescedCount survive the JSON payload round-trip.
     const stored = store.getRun("r1");
     expect(stored?.skipReason).toBe("rate_limited");
-    expect(stored?.coalescedEventKeys).toEqual(["first", "second"]);
-
-    // Found structurally by reason, not by matching display copy.
-    expect(
-      store.findRecentInboundSkip({
-        automationId: "automation-1",
-        skipReason: "rate_limited",
-        sinceMs: 0,
-      })?.id,
-    ).toBe("r1");
-    expect(
-      store.findRecentInboundSkip({
-        automationId: "automation-1",
-        skipReason: "lane_busy",
-        sinceMs: 0,
-      }),
-    ).toBeUndefined();
-
-    // A coalesced key (not the row's own source_event_key) resolves via the
-    // fallback, so a redelivery of that drop stays idempotent.
-    expect(
-      store.findRunBySourceEventKey({
-        automationId: "automation-1",
-        sourceEventKey: "second",
-      })?.id,
-    ).toBe("r1");
-    expect(
-      store.findRunBySourceEventKey({
-        automationId: "automation-1",
-        sourceEventKey: "unknown",
-      }),
-    ).toBeUndefined();
+    expect(stored?.coalescedCount).toBe(7);
   });
 
   it("reconciles stale local runs on startup without creating catch-up rows", () => {

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -1,6 +1,7 @@
 import type {
   AutomationRunSourceBatchedEntry,
   AutomationGateRunResult,
+  AutomationRunSkipReason,
   AutomationRunSourceMetadata,
   AutomationRunStatus,
   AutomationRunSummary,
@@ -185,19 +186,14 @@ export class AutomationScheduler {
       });
 
     // drop_missed + busy lane records a visible skipped run but starts no
-    // headless turn, so it must NOT consume a rate-limit token.
+    // headless turn, so it must NOT count toward the rate.
     if (active && params.automation.backlogPolicy === "drop_missed") {
-      const dropped = createInboundRun();
-      if (dropped) {
-        this.options.store.markRunTerminal({
-          runId: dropped.id,
-          status: "skipped",
-          completedAt: now,
-          errorMessage:
-            "The automation execution lane was busy when this inbound message arrived.",
-          now,
-        });
-      }
+      this.recordInboundSkip(createInboundRun, {
+        skipReason: "lane_busy",
+        errorMessage:
+          "The automation execution lane was busy when this inbound message arrived.",
+        now,
+      });
       return undefined;
     }
 
@@ -207,7 +203,12 @@ export class AutomationScheduler {
     // record a skipped run so the drop is visible in the run list; because it is
     // skipped it does not count toward the rate (see countRecentInboundRuns).
     if (!this.isInboundRunWithinRate(params.automation, now)) {
-      this.noteThrottledInboundRun(params.automation, createInboundRun, now);
+      this.noteThrottledInboundRun(
+        params.automation,
+        params.source,
+        createInboundRun,
+        now,
+      );
       return undefined;
     }
 
@@ -289,6 +290,7 @@ export class AutomationScheduler {
 
   private noteThrottledInboundRun(
     automation: AutomationRecord,
+    source: AutomationRunSourceMetadata,
     createInboundRun: () => AutomationRunSummary | undefined,
     now: number,
   ): void {
@@ -298,37 +300,68 @@ export class AutomationScheduler {
       maxRunsPerHour: resolveAutomationRunsPerHour(automation.maxRunsPerHour),
     });
 
-    // Surface the drop in the run list. Coalesce onto the automation's most
-    // recent run when it is already an in-window throttle marker so a burst of
-    // dropped messages collapses to a single, freshly-timestamped row instead
-    // of evicting real run history.
-    const latest = this.options.store.getLatestRunForAutomation(automation.id);
-    if (
-      latest &&
-      latest.status === "skipped" &&
-      latest.errorMessage === RATE_LIMIT_SKIP_MESSAGE &&
-      (latest.completedAt ?? 0) >= now - HOUR_MS
-    ) {
+    const eventKey = source.sourceEventKey;
+    // Surface the drop in the run list, coalescing onto the automation's active
+    // in-window throttle marker. The marker is found structurally by skipReason
+    // (not by matching display copy) and independently of the newest run overall
+    // (a real run finishing bumps its updated_at above the marker), so a burst
+    // collapses to one freshly-timestamped row rather than spawning a new marker
+    // each time a concurrent run transitions. The marker accumulates every
+    // coalesced message's key so a redelivery of any of them stays idempotent.
+    const marker = this.options.store.findRecentInboundSkip({
+      automationId: automation.id,
+      skipReason: "rate_limited",
+      sinceMs: now - HOUR_MS,
+    });
+    if (marker) {
+      const keys = new Set(marker.coalescedEventKeys ?? []);
+      if (eventKey) keys.add(eventKey);
       this.options.store.markRunTerminal({
-        runId: latest.id,
+        runId: marker.id,
         status: "skipped",
-        completedAt: now,
+        skipReason: "rate_limited",
         errorMessage: RATE_LIMIT_SKIP_MESSAGE,
+        completedAt: now,
+        coalescedEventKeys: [...keys],
         now,
       });
       return;
     }
 
+    this.recordInboundSkip(createInboundRun, {
+      skipReason: "rate_limited",
+      errorMessage: RATE_LIMIT_SKIP_MESSAGE,
+      coalescedEventKeys: eventKey ? [eventKey] : undefined,
+      now,
+    });
+  }
+
+  /**
+   * Record a dropped inbound message as a visible `skipped` run (which never
+   * started a headless turn, so it does not count toward the hourly rate). The
+   * structured `skipReason` lets callers tell drop kinds apart without matching
+   * display copy.
+   */
+  private recordInboundSkip(
+    createInboundRun: () => AutomationRunSummary | undefined,
+    opts: {
+      skipReason: AutomationRunSkipReason;
+      errorMessage: string;
+      coalescedEventKeys?: string[];
+      now: number;
+    },
+  ): void {
     const dropped = createInboundRun();
-    if (dropped) {
-      this.options.store.markRunTerminal({
-        runId: dropped.id,
-        status: "skipped",
-        completedAt: now,
-        errorMessage: RATE_LIMIT_SKIP_MESSAGE,
-        now,
-      });
-    }
+    if (!dropped) return;
+    this.options.store.markRunTerminal({
+      runId: dropped.id,
+      status: "skipped",
+      completedAt: opts.now,
+      errorMessage: opts.errorMessage,
+      skipReason: opts.skipReason,
+      coalescedEventKeys: opts.coalescedEventKeys,
+      now: opts.now,
+    });
   }
 
   async handleTurnQueueUpdate(params: {

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -3,6 +3,7 @@ import type {
   AutomationGateRunResult,
   AutomationRunSourceMetadata,
   AutomationRunStatus,
+  AutomationRunSummary,
   AutomationRunWindow,
 } from "@pwragent/shared";
 import {
@@ -35,25 +36,23 @@ type InboundCoalesceWindow = {
   totalChars: number;
 };
 
-/**
- * Per-automation token bucket gating inbound run STARTS. `tokens` refills
- * continuously toward the configured hourly rate; capacity equals the rate, so
- * an idle automation can burst up to one hour's allowance and then settles to
- * the steady rate.
- */
-type RunStartTokenBucket = { tokens: number; lastRefillAt: number };
-
 const MAX_COALESCED_EVENTS = 100;
 const COALESCE_TOTAL_CHAR_BUDGET = 16_000;
 const COALESCE_SUMMARY_CHARS = 500;
 const HOUR_MS = 60 * 60 * 1000;
+
+// Sentinel error message stamped on the skipped run we record when an inbound
+// message is throttled by the hourly rate limit. Consecutive throttled drops
+// coalesce onto a single run carrying this exact message (matched below), so a
+// chatty channel cannot flood the run history and evict real runs.
+export const RATE_LIMIT_SKIP_MESSAGE =
+  "The automation hit its hourly run limit, so new inbound messages are being dropped.";
 
 export class AutomationScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
   private readonly sessionStartedAt: number;
   private readonly coalesceWindows = new Map<string, InboundCoalesceWindow>();
-  private readonly runStartTokenBuckets = new Map<string, RunStartTokenBucket>();
 
   constructor(private readonly options: AutomationSchedulerOptions) {
     this.sessionStartedAt = this.now();
@@ -203,11 +202,12 @@ export class AutomationScheduler {
     }
 
     // The run will start now (lane free) or queue (coalesce backlog) and start
-    // later — either way it consumes exactly one token. Gate here, AFTER the
-    // idempotency and drop_missed checks, so only runs that actually start are
-    // counted, and throttled messages leave no run row.
-    if (!this.tryConsumeRunStartToken(params.automation, now)) {
-      this.noteThrottledInboundRun(params.automation);
+    // later. Gate here, AFTER the idempotency and drop_missed checks, so only
+    // runs that actually start count toward the hourly rate. Throttled messages
+    // record a skipped run so the drop is visible in the run list; because it is
+    // skipped it does not count toward the rate (see countRecentInboundRuns).
+    if (!this.isInboundRunWithinRate(params.automation, now)) {
+      this.noteThrottledInboundRun(params.automation, createInboundRun, now);
       return undefined;
     }
 
@@ -266,12 +266,13 @@ export class AutomationScheduler {
   }
 
   /**
-   * Consume one token from the automation's inbound run-start bucket. Returns
-   * false (and starts no run) when the bucket is empty. Unlimited automations
-   * always succeed. The bucket is in-memory: a process restart resets it to
-   * full, which is acceptable for a cost backstop (not a security boundary).
+   * Whether starting an inbound run for this automation now stays within its
+   * configured hourly cap. Counts inbound runs from the last hour in the run
+   * history (excluding skipped runs, which never started a headless turn), so
+   * the limit is a true rolling-hour cap that survives process restarts.
+   * Unlimited automations always pass.
    */
-  private tryConsumeRunStartToken(
+  private isInboundRunWithinRate(
     automation: AutomationRecord,
     now: number,
   ): boolean {
@@ -279,34 +280,55 @@ export class AutomationScheduler {
     if (ratePerHour === null) {
       return true;
     }
-    const capacity = ratePerHour;
-    const existing = this.runStartTokenBuckets.get(automation.id);
-    const bucket: RunStartTokenBucket = existing ?? {
-      tokens: capacity,
-      lastRefillAt: now,
-    };
-    if (existing) {
-      const elapsed = Math.max(0, now - existing.lastRefillAt);
-      bucket.tokens = Math.min(
-        capacity,
-        existing.tokens + (elapsed / HOUR_MS) * ratePerHour,
-      );
-      bucket.lastRefillAt = now;
-    }
-    this.runStartTokenBuckets.set(automation.id, bucket);
-    if (bucket.tokens >= 1) {
-      bucket.tokens -= 1;
-      return true;
-    }
-    return false;
+    const recent = this.options.store.countRecentInboundRuns({
+      automationId: automation.id,
+      sinceMs: now - HOUR_MS,
+    });
+    return recent < ratePerHour;
   }
 
-  private noteThrottledInboundRun(automation: AutomationRecord): void {
+  private noteThrottledInboundRun(
+    automation: AutomationRecord,
+    createInboundRun: () => AutomationRunSummary | undefined,
+    now: number,
+  ): void {
     automationSchedulerLog.info("inbound automation run throttled by rate limit", {
       automationId: automation.id,
       automationName: automation.name,
       maxRunsPerHour: resolveAutomationRunsPerHour(automation.maxRunsPerHour),
     });
+
+    // Surface the drop in the run list. Coalesce onto the automation's most
+    // recent run when it is already an in-window throttle marker so a burst of
+    // dropped messages collapses to a single, freshly-timestamped row instead
+    // of evicting real run history.
+    const latest = this.options.store.getLatestRunForAutomation(automation.id);
+    if (
+      latest &&
+      latest.status === "skipped" &&
+      latest.errorMessage === RATE_LIMIT_SKIP_MESSAGE &&
+      (latest.completedAt ?? 0) >= now - HOUR_MS
+    ) {
+      this.options.store.markRunTerminal({
+        runId: latest.id,
+        status: "skipped",
+        completedAt: now,
+        errorMessage: RATE_LIMIT_SKIP_MESSAGE,
+        now,
+      });
+      return;
+    }
+
+    const dropped = createInboundRun();
+    if (dropped) {
+      this.options.store.markRunTerminal({
+        runId: dropped.id,
+        status: "skipped",
+        completedAt: now,
+        errorMessage: RATE_LIMIT_SKIP_MESSAGE,
+        now,
+      });
+    }
   }
 
   async handleTurnQueueUpdate(params: {

--- a/apps/desktop/src/main/automations/automation-scheduler.ts
+++ b/apps/desktop/src/main/automations/automation-scheduler.ts
@@ -42,12 +42,20 @@ const COALESCE_TOTAL_CHAR_BUDGET = 16_000;
 const COALESCE_SUMMARY_CHARS = 500;
 const HOUR_MS = 60 * 60 * 1000;
 
-// Sentinel error message stamped on the skipped run we record when an inbound
-// message is throttled by the hourly rate limit. Consecutive throttled drops
-// coalesce onto a single run carrying this exact message (matched below), so a
-// chatty channel cannot flood the run history and evict real runs.
-export const RATE_LIMIT_SKIP_MESSAGE =
-  "The automation hit its hourly run limit, so new inbound messages are being dropped.";
+// Throttled inbound drops coalesce onto one visible skipped run per automation
+// per wall-clock hour. The run id is derived deterministically from the hour
+// bucket so a burst is found with an O(1) primary-key lookup (no scan) and can
+// never flood the run history: at most one marker per automation per hour.
+const THROTTLE_MARKER_PREFIX = "automation-throttle:";
+
+function throttleMarkerId(automationId: string, now: number): string {
+  return `${THROTTLE_MARKER_PREFIX}${automationId}:${Math.floor(now / HOUR_MS)}`;
+}
+
+export function throttleSkipMessage(droppedCount: number): string {
+  const noun = droppedCount === 1 ? "message" : "messages";
+  return `The automation hit its hourly run limit; ${droppedCount} inbound ${noun} dropped this hour.`;
+}
 
 export class AutomationScheduler {
   private timer: ReturnType<typeof setTimeout> | null = null;
@@ -203,12 +211,7 @@ export class AutomationScheduler {
     // record a skipped run so the drop is visible in the run list; because it is
     // skipped it does not count toward the rate (see countRecentInboundRuns).
     if (!this.isInboundRunWithinRate(params.automation, now)) {
-      this.noteThrottledInboundRun(
-        params.automation,
-        params.source,
-        createInboundRun,
-        now,
-      );
+      this.noteThrottledInboundRun(params.automation, params.source, now);
       return undefined;
     }
 
@@ -291,7 +294,6 @@ export class AutomationScheduler {
   private noteThrottledInboundRun(
     automation: AutomationRecord,
     source: AutomationRunSourceMetadata,
-    createInboundRun: () => AutomationRunSummary | undefined,
     now: number,
   ): void {
     automationSchedulerLog.info("inbound automation run throttled by rate limit", {
@@ -300,38 +302,31 @@ export class AutomationScheduler {
       maxRunsPerHour: resolveAutomationRunsPerHour(automation.maxRunsPerHour),
     });
 
-    const eventKey = source.sourceEventKey;
-    // Surface the drop in the run list, coalescing onto the automation's active
-    // in-window throttle marker. The marker is found structurally by skipReason
-    // (not by matching display copy) and independently of the newest run overall
-    // (a real run finishing bumps its updated_at above the marker), so a burst
-    // collapses to one freshly-timestamped row rather than spawning a new marker
-    // each time a concurrent run transitions. The marker accumulates every
-    // coalesced message's key so a redelivery of any of them stays idempotent.
-    const marker = this.options.store.findRecentInboundSkip({
-      automationId: automation.id,
-      skipReason: "rate_limited",
-      sinceMs: now - HOUR_MS,
-    });
-    if (marker) {
-      const keys = new Set(marker.coalescedEventKeys ?? []);
-      if (eventKey) keys.add(eventKey);
-      this.options.store.markRunTerminal({
-        runId: marker.id,
-        status: "skipped",
-        skipReason: "rate_limited",
-        errorMessage: RATE_LIMIT_SKIP_MESSAGE,
-        completedAt: now,
-        coalescedEventKeys: [...keys],
+    // Coalesce every drop in this wall-clock hour onto one deterministic marker,
+    // found by primary key (no scan). A bounded count — not a per-message key
+    // list — records the size of the drop. The provider adapters already ack and
+    // dedupe inbound events, so a throttled message is not redelivered to the
+    // scheduler and no per-drop idempotency is needed here.
+    const markerId = throttleMarkerId(automation.id, now);
+    const existing = this.options.store.getRun(markerId);
+    const droppedCount = (existing?.coalescedCount ?? 0) + 1;
+    if (!existing) {
+      const created = this.options.store.createRun({
+        id: markerId,
+        automationId: automation.id,
+        trigger: "inbound_message",
+        source,
         now,
       });
-      return;
+      if (!created) return;
     }
-
-    this.recordInboundSkip(createInboundRun, {
+    this.options.store.markRunTerminal({
+      runId: markerId,
+      status: "skipped",
       skipReason: "rate_limited",
-      errorMessage: RATE_LIMIT_SKIP_MESSAGE,
-      coalescedEventKeys: eventKey ? [eventKey] : undefined,
+      errorMessage: throttleSkipMessage(droppedCount),
+      completedAt: now,
+      coalescedCount: droppedCount,
       now,
     });
   }
@@ -347,7 +342,6 @@ export class AutomationScheduler {
     opts: {
       skipReason: AutomationRunSkipReason;
       errorMessage: string;
-      coalescedEventKeys?: string[];
       now: number;
     },
   ): void {
@@ -359,7 +353,6 @@ export class AutomationScheduler {
       completedAt: opts.now,
       errorMessage: opts.errorMessage,
       skipReason: opts.skipReason,
-      coalescedEventKeys: opts.coalescedEventKeys,
       now: opts.now,
     });
   }

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -207,7 +207,7 @@ type AutomationRunPayload = {
   backendThreadId?: string;
   errorMessage?: string;
   skipReason?: AutomationRunSkipReason;
-  coalescedEventKeys?: string[];
+  coalescedCount?: number;
   source?: AutomationRunSourceMetadata;
 };
 
@@ -581,50 +581,7 @@ export class AutomationStore {
       .get(params.automationId, params.sourceEventKey) as
       | AutomationRunRow
       | undefined;
-    if (row) return this.runFromRow(row);
-    // Fallback: a rate_limited throttle marker may have coalesced this key from
-    // a drop that never got its own row, so a redelivery must still resolve to
-    // it and stay idempotent. Scan the (few, because coalesced) recent skipped
-    // inbound rows and match the coalesced-key list in JS.
-    const skips = this.stateDb.raw
-      .prepare(
-        "SELECT * FROM automation_runs WHERE automation_id = ? AND trigger = 'inbound_message' AND status = 'skipped' ORDER BY updated_at DESC, rowid DESC LIMIT 50",
-      )
-      .all(params.automationId) as AutomationRunRow[];
-    for (const skip of skips) {
-      const run = this.runFromRow(skip);
-      if (run?.coalescedEventKeys?.includes(params.sourceEventKey)) {
-        return run;
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Most recently-updated in-window `skipped` inbound run for this automation
-   * carrying `skipReason`. Backs throttle-drop coalescing: it finds the active
-   * rate_limit marker regardless of what the automation's newest run overall is
-   * (a real run finishing bumps its `updated_at` above the marker), so a burst
-   * of drops collapses onto one row instead of spawning a fresh marker each
-   * time a concurrent run transitions.
-   */
-  findRecentInboundSkip(params: {
-    automationId: string;
-    skipReason: AutomationRunSkipReason;
-    sinceMs: number;
-  }): AutomationRunSummary | undefined {
-    const rows = this.stateDb.raw
-      .prepare(
-        "SELECT * FROM automation_runs WHERE automation_id = ? AND trigger = 'inbound_message' AND status = 'skipped' AND updated_at >= ? ORDER BY updated_at DESC, rowid DESC LIMIT 50",
-      )
-      .all(params.automationId, params.sinceMs) as AutomationRunRow[];
-    for (const row of rows) {
-      const run = this.runFromRow(row);
-      if (run?.skipReason === params.skipReason) {
-        return run;
-      }
-    }
-    return undefined;
+    return row ? this.runFromRow(row) : undefined;
   }
 
   /**
@@ -692,7 +649,7 @@ export class AutomationStore {
     completedAt?: number;
     errorMessage?: string;
     skipReason?: AutomationRunSkipReason;
-    coalescedEventKeys?: string[];
+    coalescedCount?: number;
     now?: number;
   }): AutomationRunSummary | undefined {
     const completedAt = params.completedAt ?? params.now ?? Date.now();
@@ -701,7 +658,7 @@ export class AutomationStore {
       completedAt,
       errorMessage: params.errorMessage,
       skipReason: params.skipReason,
-      coalescedEventKeys: params.coalescedEventKeys,
+      coalescedCount: params.coalescedCount,
       now: params.now,
     });
     if (!run) return undefined;
@@ -935,7 +892,7 @@ export class AutomationStore {
       queueEntryId?: string;
       errorMessage?: string;
       skipReason?: AutomationRunSkipReason;
-      coalescedEventKeys?: string[];
+      coalescedCount?: number;
       now?: number;
     },
   ): AutomationRunSummary | undefined {
@@ -954,7 +911,7 @@ export class AutomationStore {
       backendTurnId: input.backendTurnId ?? current.backendTurnId,
       errorMessage: input.errorMessage ?? current.errorMessage,
       skipReason: input.skipReason ?? current.skipReason,
-      coalescedEventKeys: input.coalescedEventKeys ?? current.coalescedEventKeys,
+      coalescedCount: input.coalescedCount ?? current.coalescedCount,
     };
     this.upsertRun(nextRun, {
       backend: row.backend,
@@ -1056,7 +1013,7 @@ export class AutomationStore {
       backendThreadId: run.backendThreadId,
       errorMessage: run.errorMessage,
       skipReason: run.skipReason,
-      coalescedEventKeys: run.coalescedEventKeys,
+      coalescedCount: run.coalescedCount,
       source: run.source,
     };
     this.stateDb.raw
@@ -1232,7 +1189,7 @@ export class AutomationStore {
       backendTurnId: row.backend_turn_id ?? undefined,
       errorMessage: payload.errorMessage,
       skipReason: payload.skipReason,
-      coalescedEventKeys: payload.coalescedEventKeys,
+      coalescedCount: payload.coalescedCount,
     };
   }
 

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -581,6 +581,26 @@ export class AutomationStore {
     return row ? this.runFromRow(row) : undefined;
   }
 
+  /**
+   * Count inbound-triggered runs created for this automation at or after
+   * `sinceMs` that consumed (or will consume) a headless turn — everything
+   * except `skipped` runs (a busy-lane / drop_missed skip never started).
+   * Backs the per-automation inbound run-rate limit: a rolling-hour count from
+   * the run history survives process restarts (unlike an in-memory bucket) and
+   * makes "N per hour" a hard cap rather than a burstable token bucket.
+   */
+  countRecentInboundRuns(params: {
+    automationId: string;
+    sinceMs: number;
+  }): number {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT COUNT(*) AS count FROM automation_runs WHERE automation_id = ? AND trigger = 'inbound_message' AND status != 'skipped' AND created_at >= ?",
+      )
+      .get(params.automationId, params.sinceMs) as { count: number };
+    return row.count;
+  }
+
   findPendingRunForAutomation(automationId: string): AutomationRunSummary | undefined {
     const row = this.stateDb.raw
       .prepare(

--- a/apps/desktop/src/main/automations/automation-store.ts
+++ b/apps/desktop/src/main/automations/automation-store.ts
@@ -10,6 +10,7 @@ import type {
   AutomationOutputActionResult,
   AutomationRunArtifact,
   AutomationRunOutputDecision,
+  AutomationRunSkipReason,
   AutomationRunSourceMetadata,
   AutomationRunStatus,
   AutomationRunSummary,
@@ -205,6 +206,8 @@ type AutomationRunPayload = {
   scheduledWindows: AutomationRunWindow[];
   backendThreadId?: string;
   errorMessage?: string;
+  skipReason?: AutomationRunSkipReason;
+  coalescedEventKeys?: string[];
   source?: AutomationRunSourceMetadata;
 };
 
@@ -578,7 +581,50 @@ export class AutomationStore {
       .get(params.automationId, params.sourceEventKey) as
       | AutomationRunRow
       | undefined;
-    return row ? this.runFromRow(row) : undefined;
+    if (row) return this.runFromRow(row);
+    // Fallback: a rate_limited throttle marker may have coalesced this key from
+    // a drop that never got its own row, so a redelivery must still resolve to
+    // it and stay idempotent. Scan the (few, because coalesced) recent skipped
+    // inbound rows and match the coalesced-key list in JS.
+    const skips = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND trigger = 'inbound_message' AND status = 'skipped' ORDER BY updated_at DESC, rowid DESC LIMIT 50",
+      )
+      .all(params.automationId) as AutomationRunRow[];
+    for (const skip of skips) {
+      const run = this.runFromRow(skip);
+      if (run?.coalescedEventKeys?.includes(params.sourceEventKey)) {
+        return run;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Most recently-updated in-window `skipped` inbound run for this automation
+   * carrying `skipReason`. Backs throttle-drop coalescing: it finds the active
+   * rate_limit marker regardless of what the automation's newest run overall is
+   * (a real run finishing bumps its `updated_at` above the marker), so a burst
+   * of drops collapses onto one row instead of spawning a fresh marker each
+   * time a concurrent run transitions.
+   */
+  findRecentInboundSkip(params: {
+    automationId: string;
+    skipReason: AutomationRunSkipReason;
+    sinceMs: number;
+  }): AutomationRunSummary | undefined {
+    const rows = this.stateDb.raw
+      .prepare(
+        "SELECT * FROM automation_runs WHERE automation_id = ? AND trigger = 'inbound_message' AND status = 'skipped' AND updated_at >= ? ORDER BY updated_at DESC, rowid DESC LIMIT 50",
+      )
+      .all(params.automationId, params.sinceMs) as AutomationRunRow[];
+    for (const row of rows) {
+      const run = this.runFromRow(row);
+      if (run?.skipReason === params.skipReason) {
+        return run;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -645,6 +691,8 @@ export class AutomationStore {
     status: Extract<AutomationRunStatus, "completed" | "failed" | "cancelled" | "skipped">;
     completedAt?: number;
     errorMessage?: string;
+    skipReason?: AutomationRunSkipReason;
+    coalescedEventKeys?: string[];
     now?: number;
   }): AutomationRunSummary | undefined {
     const completedAt = params.completedAt ?? params.now ?? Date.now();
@@ -652,6 +700,8 @@ export class AutomationStore {
       status: params.status,
       completedAt,
       errorMessage: params.errorMessage,
+      skipReason: params.skipReason,
+      coalescedEventKeys: params.coalescedEventKeys,
       now: params.now,
     });
     if (!run) return undefined;
@@ -884,6 +934,8 @@ export class AutomationStore {
       backendTurnId?: string;
       queueEntryId?: string;
       errorMessage?: string;
+      skipReason?: AutomationRunSkipReason;
+      coalescedEventKeys?: string[];
       now?: number;
     },
   ): AutomationRunSummary | undefined {
@@ -901,6 +953,8 @@ export class AutomationStore {
       backendThreadId: input.backendThreadId ?? current.backendThreadId,
       backendTurnId: input.backendTurnId ?? current.backendTurnId,
       errorMessage: input.errorMessage ?? current.errorMessage,
+      skipReason: input.skipReason ?? current.skipReason,
+      coalescedEventKeys: input.coalescedEventKeys ?? current.coalescedEventKeys,
     };
     this.upsertRun(nextRun, {
       backend: row.backend,
@@ -1001,6 +1055,8 @@ export class AutomationStore {
       scheduledWindows: run.scheduledWindows,
       backendThreadId: run.backendThreadId,
       errorMessage: run.errorMessage,
+      skipReason: run.skipReason,
+      coalescedEventKeys: run.coalescedEventKeys,
       source: run.source,
     };
     this.stateDb.raw
@@ -1175,6 +1231,8 @@ export class AutomationStore {
       backendThreadId: payload.backendThreadId,
       backendTurnId: row.backend_turn_id ?? undefined,
       errorMessage: payload.errorMessage,
+      skipReason: payload.skipReason,
+      coalescedEventKeys: payload.coalescedEventKeys,
     };
   }
 

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -366,6 +366,26 @@ export function AutomationEditor(props: AutomationEditorProps) {
     (group) => group.id === destGroupSelection,
   );
 
+  const destSelectionReconciledRef = useRef(false);
+  const initialDestGroupId = initialTargetIsTopic
+    ? initialTargetSnapshot?.parentId
+    : initialTargetSnapshot?.conversationId;
+  useEffect(() => {
+    // On edit, once the provider's authorized groups load, preselect the saved
+    // destination in the dropdown when it matches one. Otherwise
+    // destGroupSelection stays at MANUAL_GROUP_VALUE, selectedDestGroup is
+    // undefined, and the group's friendly title is dropped on re-save. Runs
+    // once (guarded by the ref) and only while still on the saved provider, so
+    // it never overrides a deliberate manual entry or a provider switch.
+    if (destSelectionReconciledRef.current) return;
+    if (!initialTargetSnapshot || !initialDestGroupId) return;
+    if (destProvider !== initialTargetSnapshot.channel) return;
+    if (destGroups.length === 0) return;
+    const match = destGroups.find((group) => group.id === initialDestGroupId);
+    if (match) setDestGroupSelection(match.id);
+    destSelectionReconciledRef.current = true;
+  }, [destGroups, destProvider, initialDestGroupId, initialTargetSnapshot]);
+
   const [topicOptions, setTopicOptions] = useState<InboundTopicOption[]>([]);
   const [topicSelection, setTopicSelection] = useState<string>(
     initialIsTopic ? MANUAL_GROUP_VALUE : "",

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -1652,9 +1652,12 @@ export function AutomationEditor(props: AutomationEditorProps) {
                     ))}
                   </select>
                 </label>
-                {destProvider === "telegram" && destGroups.length > 0 ? (
+                {destGroups.length > 0 ? (
                   <label className="automation-field">
-                    <span>Destination group</span>
+                    <span>
+                      Destination{" "}
+                      {conversationPickerLabel(destProvider).toLowerCase()}
+                    </span>
                     <select
                       value={destGroupSelection}
                       onChange={(event) => {
@@ -1664,37 +1667,28 @@ export function AutomationEditor(props: AutomationEditorProps) {
                         setValidationError(undefined);
                       }}
                     >
-                      <option value="">Choose a group</option>
+                      <option value="">
+                        Choose a{" "}
+                        {conversationPickerLabel(destProvider).toLowerCase()}
+                      </option>
                       {destGroups.map((group) => (
                         <option key={group.id} value={group.id}>
                           {group.title}
                         </option>
                       ))}
                       <option value={MANUAL_GROUP_VALUE}>
-                        Enter group ID manually...
+                        Enter {conversationLabel(destProvider)} manually...
                       </option>
                     </select>
                   </label>
                 ) : null}
               </div>
-              {destProvider === "telegram" ? (
-                destGroups.length === 0 ||
-                destGroupSelection === MANUAL_GROUP_VALUE ? (
-                  <label className="automation-field">
-                    <span>Destination group ID</span>
-                    <input
-                      placeholder="e.g. -1001234567890"
-                      value={destGroupId}
-                      onChange={(event) => {
-                        setDestGroupId(event.currentTarget.value);
-                        setValidationError(undefined);
-                      }}
-                    />
-                  </label>
-                ) : null
-              ) : (
+              {destGroups.length === 0 ||
+              destGroupSelection === MANUAL_GROUP_VALUE ? (
                 <label className="automation-field">
-                  <span>Destination {conversationLabel(destProvider).toLowerCase()}</span>
+                  <span>
+                    Destination {lowerLead(conversationLabel(destProvider))}
+                  </span>
                   <input
                     placeholder={conversationPlaceholder(destProvider)}
                     value={destGroupId}
@@ -1704,7 +1698,7 @@ export function AutomationEditor(props: AutomationEditorProps) {
                     }}
                   />
                 </label>
-              )}
+              ) : null}
               {destProvider === "telegram" ? (
                 <label className="automation-field">
                   <span>Destination topic ID (optional)</span>
@@ -2458,6 +2452,13 @@ function conversationPickerLabel(provider: MessagingChannelKind): string {
   if (provider === "telegram") return "Group";
   if (provider === "slack" || provider === "discord") return "Channel";
   return "Conversation";
+}
+
+// Lowercase only the leading word so "Group ID" reads as "group ID" after a
+// "Destination " prefix, keeping the "ID" suffix capitalized like the inbound
+// field's "Group ID"/"Channel ID" labels.
+function lowerLead(label: string): string {
+  return label.charAt(0).toLowerCase() + label.slice(1);
 }
 
 function conversationLabel(provider: MessagingChannelKind): string {

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -371,20 +371,29 @@ export function AutomationEditor(props: AutomationEditorProps) {
     ? initialTargetSnapshot?.parentId
     : initialTargetSnapshot?.conversationId;
   useEffect(() => {
-    // On edit, once the provider's authorized groups load, preselect the saved
-    // destination in the dropdown when it matches one. Otherwise
-    // destGroupSelection stays at MANUAL_GROUP_VALUE, selectedDestGroup is
-    // undefined, and the group's friendly title is dropped on re-save. Runs
-    // once (guarded by the ref) and only while still on the saved provider, so
-    // it never overrides a deliberate manual entry or a provider switch.
+    // On edit, preselect the saved destination in the dropdown once it appears
+    // in the provider's authorized groups (which can arrive after mount, or when
+    // the operator authorizes the group via the in-editor capture flow).
+    // Otherwise destGroupSelection stays at MANUAL_GROUP_VALUE, selectedDestGroup
+    // is undefined, and the group's friendly title is dropped on re-save. We only
+    // mark reconciliation done once we actually match, and bail the moment the
+    // user has changed the destination id, so we never override a deliberate
+    // manual entry or a provider switch.
     if (destSelectionReconciledRef.current) return;
     if (!initialTargetSnapshot || !initialDestGroupId) return;
     if (destProvider !== initialTargetSnapshot.channel) return;
-    if (destGroups.length === 0) return;
+    if (destGroupId !== initialDestGroupId) return;
     const match = destGroups.find((group) => group.id === initialDestGroupId);
-    if (match) setDestGroupSelection(match.id);
+    if (!match) return;
+    setDestGroupSelection(match.id);
     destSelectionReconciledRef.current = true;
-  }, [destGroups, destProvider, initialDestGroupId, initialTargetSnapshot]);
+  }, [
+    destGroups,
+    destGroupId,
+    destProvider,
+    initialDestGroupId,
+    initialTargetSnapshot,
+  ]);
 
   const [topicOptions, setTopicOptions] = useState<InboundTopicOption[]>([]);
   const [topicSelection, setTopicSelection] = useState<string>(

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -850,6 +850,86 @@ describe("AutomationEditor", () => {
     });
   });
 
+  it("preselects a saved destination channel on edit so its title survives re-save", async () => {
+    const onSubmit = vi.fn(async () => undefined);
+    const automation: AutomationDetail = {
+      backend: "codex",
+      threadId: "thread-1",
+      id: "auto-1",
+      name: "Slack alerts",
+      status: "enabled",
+      triggers: [
+        {
+          id: "t",
+          kind: "inbound_message",
+          conversation: { channel: "slack", conversationId: "C0IN" },
+          textFilter: { mode: "contains", text: "ERROR" },
+        },
+      ],
+      scheduleSummary: "On inbound message",
+      backlogPolicy: "coalesce",
+      updatedAt: 1,
+      createdAt: 1,
+      taskPrompt: "Investigate.",
+      outputActions: [
+        { id: "agent-context", kind: "agent_context" },
+        {
+          id: "messaging-target",
+          kind: "messaging_target",
+          target: {
+            channel: "slack",
+            conversationId: "C0ALERTS",
+            conversationKind: "channel",
+            title: "Alerts",
+          },
+        },
+      ],
+    };
+
+    render(
+      <AutomationEditor
+        desktopApi={fakeDesktopApi(
+          fakeSettings({
+            enabled: { slack: true },
+            slackChannels: [{ displayName: "Alerts", id: "C0ALERTS" }],
+          }),
+        )}
+        mode={{ kind: "edit", automation }}
+        onCancel={() => undefined}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Once channels load, the saved destination is preselected in the dropdown
+    // (not "Enter manually"), so selectedDestGroup resolves.
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText("Destination channel") as HTMLSelectElement).value,
+      ).toBe("C0ALERTS"),
+    );
+
+    // Re-saving without touching the destination must keep its friendly title.
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "update",
+        request: expect.objectContaining({
+          outputActions: expect.arrayContaining([
+            expect.objectContaining({
+              kind: "messaging_target",
+              target: expect.objectContaining({
+                channel: "slack",
+                conversationId: "C0ALERTS",
+                title: "Alerts",
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
   it("offers Agents first and regular threads on the Threads tab", async () => {
     const onSubmit = vi.fn(async () => undefined);
 

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -427,6 +427,14 @@ export type AutomationRunWindow = {
   scheduledFor: number;
 };
 
+/**
+ * Why a run was recorded as `skipped` without starting a headless turn. Used to
+ * tell the two inbound-skip kinds apart structurally (rather than by matching
+ * display copy): `lane_busy` is a drop_missed busy-lane drop; `rate_limited` is
+ * an hourly-cap throttle drop.
+ */
+export type AutomationRunSkipReason = "lane_busy" | "rate_limited";
+
 export type AutomationRunSummary = {
   id: string;
   automationId: string;
@@ -441,6 +449,14 @@ export type AutomationRunSummary = {
   backendThreadId?: string;
   backendTurnId?: string;
   errorMessage?: string;
+  /** Set on `skipped` runs to explain the skip without matching display copy. */
+  skipReason?: AutomationRunSkipReason;
+  /**
+   * Source-event keys a `rate_limited` throttle marker has absorbed by
+   * coalescing. Lets a redelivery of any coalesced drop stay idempotent even
+   * though it never got its own run row.
+   */
+  coalescedEventKeys?: string[];
   source?: AutomationRunSourceMetadata;
 };
 

--- a/packages/shared/src/contracts/automations.ts
+++ b/packages/shared/src/contracts/automations.ts
@@ -452,11 +452,11 @@ export type AutomationRunSummary = {
   /** Set on `skipped` runs to explain the skip without matching display copy. */
   skipReason?: AutomationRunSkipReason;
   /**
-   * Source-event keys a `rate_limited` throttle marker has absorbed by
-   * coalescing. Lets a redelivery of any coalesced drop stay idempotent even
-   * though it never got its own run row.
+   * How many inbound messages a `rate_limited` throttle marker has absorbed by
+   * coalescing (a bounded count, not a per-message list). Surfaced in the run
+   * list so the operator sees the size of the drop, e.g. "N messages dropped".
    */
-  coalescedEventKeys?: string[];
+  coalescedCount?: number;
   source?: AutomationRunSourceMetadata;
 };
 


### PR DESCRIPTION
Follow-ups from the merged inbound-message-triggered automations feature (#847). Three of the four documented follow-ups; #3 is intentionally deferred (see below). Hardened through two adversarial review rounds on this branch — the final design is simpler than the first cut.

## #1 — Store-backed inbound rate limit
The per-automation run-rate limiter was an in-memory token bucket. It reset to full on every process restart (so a crash-loop defeated the cap), the backing `Map` grew unbounded, and it was burstable (an idle automation could fire a full hour's allowance at once).

Replaced with a rolling-hour count of *started* inbound runs read from the run history (`AutomationStore.countRecentInboundRuns`, which excludes `skipped` runs since a skip never started a headless turn). Survives restarts, needs no in-memory state, and makes "N per hour" a true hard cap rather than a burstable bucket.

## #2 — Throttled drops are now visible
Previously a throttled message was only logged, so an operator whose automation went quiet had no signal why. Now throttled drops surface in the run history as a `skipped` run, and the mechanism is structurally bounded:

- **One marker per automation per wall-clock hour.** The marker's run id is derived from the automation id + hour bucket, so coalescing a drop is an O(1) primary-key `getRun` — no scans, and a chatty channel can never flood the run history.
- The marker carries a structured `skipReason: "rate_limited" | "lane_busy"` (persisted in the existing run payload JSON — **no schema migration**) plus a bounded `coalescedCount`, rendered as "hit its hourly run limit; N inbound messages dropped this hour."
- The existing run-history UI renders it with zero renderer changes.

Scheduler-level per-message idempotency for *dropped* messages was deliberately removed after verifying both adapters already ack + dedupe upstream (Telegram advances the grammy long-poll offset; Slack `ack()`s the Socket Mode envelope immediately and keeps its own inbound dedupe), so a throttled message is not redelivered to the scheduler.

## #4 — Provider-aware destination picker
The "send to a different conversation" picker only offered a dropdown of paired conversations for Telegram; Slack (and others) fell back to a raw ID text field even when authorized channels were available. The dropdown now works for any provider with authorized groups, with provider-aware labels.

Also fixed in review: editing an automation and re-saving used to silently drop the destination's friendly title (the saved conversation was never re-matched against the authorized list, so "#alerts" degraded to `C0123ABCD` on any edit). The editor now preselects the saved destination once the provider's groups load — including when the group is authorized mid-session via the in-editor capture flow — without overriding a deliberate manual entry.

## #3 — Deferred (not in this PR)
Group-DM automations still fire on @mention-ed messages only (main drops ambient group-DM messages at the adapter, below our carve-out). This matches the accepted behavior for group-DM pairing, so it's intentionally left as-is.

## Testing
- Scheduler + store suites (40 tests): rolling-hour cap semantics, per-hour marker coalescing across intervening real-run transitions, `coalescedCount` accumulation, skip-metadata payload round-trip, `countRecentInboundRuns` window/skip exclusion.
- Automation editor renderer suite (22 tests), including a regression test asserting the saved destination is preselected on edit and its title survives re-save.
- Broad main-process automation + messaging suites (630 passing).
- Full `pnpm lint` (sql, codex-storage boundary, renderer colors, licenses, typecheck, dependency-cruiser boundaries) and full CI including Desktop E2E and Windows build+test — green.

No DB migration; new run fields are optional members of the existing payload JSON, and old rows read fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)