### PR TITLE
fix(desktop): stop window-all-closed from racing the update relaunch

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -66,6 +66,11 @@ vi.mock("../log", () => ({
   })),
 }));
 
+const markUpdateInstallInProgressMock = vi.fn();
+vi.mock("../update-install-state", () => ({
+  markUpdateInstallInProgress: () => markUpdateInstallInProgressMock(),
+}));
+
 async function importAutoUpdater() {
   return await import("../auto-updater");
 }
@@ -143,6 +148,7 @@ describe("auto updater", () => {
     autoUpdaterMock.logger = undefined;
     autoUpdaterMock.on.mockClear();
     autoUpdaterMock.quitAndInstall.mockReset();
+    markUpdateInstallInProgressMock.mockReset();
   });
 
   afterEach(() => {
@@ -373,6 +379,43 @@ describe("auto updater", () => {
     await expect(install?.()).resolves.toEqual({ status: "restarting" });
     expect(requestQuit).toHaveBeenCalledTimes(1);
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("latches update-install-in-progress before handing off to quitAndInstall", async () => {
+    const updater = await importAutoUpdater();
+    const callOrder: string[] = [];
+    markUpdateInstallInProgressMock.mockImplementation(() => {
+      callOrder.push("mark");
+    });
+    autoUpdaterMock.quitAndInstall.mockImplementation(() => {
+      callOrder.push("quitAndInstall");
+    });
+    const requestQuit = vi.fn(async (performQuit: () => void) => {
+      performQuit();
+      return true;
+    });
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    const install = ipcHandlers.get("app:install-update");
+
+    await expect(install?.()).resolves.toEqual({ status: "restarting" });
+    // The latch must be set before quitAndInstall so window-all-closed sees it.
+    expect(callOrder).toEqual(["mark", "quitAndInstall"]);
+  });
+
+  it("does not latch update-install-in-progress when quit is cancelled", async () => {
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async () => false);
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    const install = ipcHandlers.get("app:install-update");
+
+    await install?.();
+    expect(markUpdateInstallInProgressMock).not.toHaveBeenCalled();
   });
 
   it("does not install a downloaded update when quit confirmation is cancelled", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -232,6 +232,11 @@ vi.mock("../auto-updater", () => ({
   initAutoUpdater: initAutoUpdaterMock,
 }));
 
+const isUpdateInstallInProgressMock = vi.fn(() => false);
+vi.mock("../update-install-state", () => ({
+  isUpdateInstallInProgress: () => isUpdateInstallInProgressMock(),
+}));
+
 vi.mock("../app-log-window", () => ({
   showAppLogWindow: showAppLogWindowMock,
 }));
@@ -476,6 +481,8 @@ describe("bootstrapApp", () => {
     allowImmediateQuitMock.mockReset();
     isQuitAllowedMock.mockReset();
     isQuitAllowedMock.mockReturnValue(true);
+    isUpdateInstallInProgressMock.mockReset();
+    isUpdateInstallInProgressMock.mockReturnValue(false);
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
     mainLogErrorMock.mockReset();
@@ -731,6 +738,24 @@ describe("bootstrapApp", () => {
     expect(requestQuitMock).toHaveBeenLastCalledWith({
       source: "window-all-closed",
     });
+  });
+
+  it("lets the updater drive relaunch when window-all-closed fires during an update install", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    // quitAndInstall() closes every window as the first step of the Squirrel.Mac
+    // relaunch. If we answered that window-all-closed with our own app.quit()
+    // we would race the native teardown and strand the app on the old version.
+    isUpdateInstallInProgressMock.mockReturnValue(true);
+    requestQuitMock.mockClear();
+
+    appEventHandlers.get("window-all-closed")?.();
+    await flushMicrotasks();
+
+    expect(requestQuitMock).not.toHaveBeenCalled();
   });
 
   it("creates a main window when a profile focus request arrives without one", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1018,6 +1018,23 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not recreate a window from Dock activation during an update install", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    // The update install closes every window without flipping quitInProgress;
+    // window creation must still be blocked so a Dock click can't boot a fresh
+    // window while Squirrel is swapping the bundle.
+    isUpdateInstallInProgressMock.mockReturnValue(true);
+    getAllWindowsMock.mockReturnValue([]);
+
+    appEventHandlers.get("activate")?.();
+
+    expect(createMainWindowMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not recreate a window from profile focus after quit begins", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -17,6 +17,7 @@ import type {
 } from "../shared/app-metadata";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
+import { markUpdateInstallInProgress } from "./update-install-state";
 
 const log = getMainLogger("pwragent:updater");
 const GITHUB_RELEASES_URL =
@@ -560,6 +561,10 @@ export async function installDownloadedAppUpdate(options?: {
   try {
     log.info("installing downloaded update", { version });
     const performQuit = (): void => {
+      // Hand the quit + relaunch to the native Squirrel.Mac updater. Latch first
+      // so the app's own window-all-closed / before-quit handlers don't race it
+      // with a competing app.quit() that would strand us on the old version.
+      markUpdateInstallInProgress();
       autoUpdater.quitAndInstall();
     };
     if (options?.requestQuit) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -132,6 +132,7 @@ import {
   type ProfileFocusRequestWatcher,
 } from "./profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "./settings/desktop-secret-store";
+import { isUpdateInstallInProgress } from "./update-install-state";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -875,6 +876,17 @@ export function bootstrapApp(): void {
   });
 
   app.on("window-all-closed", () => {
+    if (isUpdateInstallInProgress()) {
+      // The auto updater's quitAndInstall() closes every window as the first
+      // step of staging the Squirrel.Mac relaunch, then calls app.quit()
+      // itself once ShipIt is armed. Do NOT quit here — a competing app.quit()
+      // races that teardown and strands the app on the old version (it exits,
+      // or relaunches un-updated). Let the updater drive the quit + relaunch.
+      mainLog.info(
+        "window-all-closed during update install; letting the updater relaunch",
+      );
+      return;
+    }
     if (quitInProgress) {
       if (appQuitManager.isQuitAllowed()) {
         mainLog.info("quitting after windows closed during shutdown");

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -442,7 +442,14 @@ function beginQuitWithRelease(source: QuitRequestSource): void {
 }
 
 function isWindowCreationBlocked(): boolean {
-  return quitInProgress || mainProcessResourcesDisposed;
+  // An update install closes every window as it hands off to the updater but
+  // deliberately does NOT flip quitInProgress (see the window-all-closed
+  // handler). Block window creation here too, so a dock activate or
+  // profile-focus request in the teardown window can't boot a fresh window
+  // while Squirrel is swapping the bundle.
+  return (
+    quitInProgress || mainProcessResourcesDisposed || isUpdateInstallInProgress()
+  );
 }
 
 /**

--- a/apps/desktop/src/main/update-install-state.ts
+++ b/apps/desktop/src/main/update-install-state.ts
@@ -1,0 +1,26 @@
+/**
+ * One-way latch that records when the app has handed control to the auto
+ * updater's `quitAndInstall()` flow.
+ *
+ * On macOS, `autoUpdater.quitAndInstall()` (electron-updater's MacUpdater →
+ * Electron's native Squirrel.Mac updater) closes every window first and only
+ * then calls `app.quit()` itself, once the ShipIt relaunch has been armed.
+ * Any code that reacts to `window-all-closed` (or `before-quit`) by calling
+ * `app.quit()` on its own races that native teardown: the process can exit
+ * before ShipIt finishes swapping the bundle, so the app relaunches into the
+ * OLD version — or fails to relaunch at all. See the update-install quit path
+ * in `auto-updater.ts` and the `window-all-closed` handler in `index.ts`.
+ *
+ * Once the install is underway there is no valid path back to a running app, so
+ * this latch is intentionally never reset: the process is on its way down and
+ * the updater owns the quit + relaunch.
+ */
+let updateInstallInProgress = false;
+
+export function markUpdateInstallInProgress(): void {
+  updateInstallInProgress = true;
+}
+
+export function isUpdateInstallInProgress(): boolean {
+  return updateInstallInProgress;
+}


### PR DESCRIPTION
## Summary

- Beta auto-updates download fine but never actually apply: on install the app either relaunches into the **old** version or just exits. Root cause is our own regression from #716 ("quit the app when the main window is closed").
- On macOS, `autoUpdater.quitAndInstall()` closes every window first, then calls `app.quit()` itself once Squirrel.Mac/ShipIt has staged the new bundle and armed the relaunch. The update-install quit path runs straight through the quit manager and never sets `quitInProgress`, so when `quitAndInstall()` closes the windows our `window-all-closed` handler treats it as a fresh user quit and calls `app.quit()` **reentrantly** — before ShipIt finishes swapping the bundle. The process dies out from under the updater, so it relaunches the un-swapped old app (or fails to relaunch).
- Fix: a one-way update-install latch set the instant we hand off to `quitAndInstall()` (the single chokepoint both the renderer "Restart to update" button and the agent-tool restart path funnel through). `window-all-closed` returns early while the latch is set and lets the native updater drive the quit + relaunch. `before-quit` and the main-window `close` handler already no-op in this state, so `window-all-closed` was the only offender.

Files:
- `apps/desktop/src/main/update-install-state.ts` (new) — `markUpdateInstallInProgress()` / `isUpdateInstallInProgress()` latch.
- `apps/desktop/src/main/auto-updater.ts` — set the latch in `performQuit` immediately before `quitAndInstall()`.
- `apps/desktop/src/main/index.ts` — guard `window-all-closed` on the latch.

## Verification

Diagnosed from the on-device logs (`~/Library/Logs/PwrAgent/profile-default.main.log`). Both failed beta.41 installs show the same signature:

```
(updater) installing downloaded update version=1.0.0-beta.41
(quit)    quit requested with no in-progress threads source=update-install   ← quitAndInstall() fired
(main)    quit in progress source=window-all-closed                          ← our handler fired app.quit()
(updater) Proxy server for native Squirrel.Mac is closed
(main)    boot decision: open   ← relaunched as beta.40, immediately re-downloads beta.41
```

- `pnpm test` for `auto-updater`, `index`, `quit-manager`: **57 passed**. New coverage: latch is set *before* `quitAndInstall` (ordering asserted), not set on a cancelled quit, and `window-all-closed` during an install no longer calls `requestQuit`.
- `pnpm --filter @pwragent/desktop typecheck`: clean.

## Notes

- Auto-update is disabled in dev, so the end-to-end confirmation (beta.N → beta.N+1 actually installs and relaunches into the new version) can only be verified on a real signed build. This change removes the racing `app.quit()`, which is the only anomaly between `quitAndInstall()` and the broken relaunch; everything up to process exit is now correct.
- Covers both install entry points (renderer restart button + `manage_pwragent` agent tool) since both go through `installDownloadedAppUpdate`'s `performQuit`.