### PR TITLE
fix(desktop): keep MSG status popover open when hovering onto it

### DIFF
--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -93,12 +93,11 @@ export function MessagingStatusBar(props: {
     () => withConfiguredSettingsStatuses(statuses, settingsSnapshot),
     [settingsSnapshot, statuses],
   );
-  const messagingOn =
-    sessionOverride ??
-    runtimeMessagingEnabled ??
-    inferMessagingEnabled(displayStatuses);
+  const messagingOn = sessionOverride
+    ?? runtimeMessagingEnabled
+    ?? inferMessagingEnabled(displayStatuses);
   const activePlatforms = displayStatuses.filter((status) =>
-    hasRecentActivity(status, activeAtByPlatform[status.platform]),
+    hasRecentActivity(status, activeAtByPlatform[status.platform])
   );
   const hasDegradation = displayStatuses.some(
     (status) => (status.degradationReasons ?? []).length > 0,
@@ -123,20 +122,17 @@ export function MessagingStatusBar(props: {
 
   useEffect(() => {
     if (
-      !props.desktopApi?.getMessagingPlatformStatuses ||
-      !props.desktopApi?.readSettings
+      !props.desktopApi?.getMessagingPlatformStatuses
+      || !props.desktopApi?.readSettings
     ) {
       return;
     }
     let cancelled = false;
-    void props.desktopApi
-      .readSettings({})
-      .then((response) => {
-        if (!cancelled) setSettingsSnapshot(response.snapshot);
-      })
-      .catch(() => {
-        // Settings screen owns user-facing errors; keep this controller quiet.
-      });
+    void props.desktopApi.readSettings({}).then((response) => {
+      if (!cancelled) setSettingsSnapshot(response.snapshot);
+    }).catch(() => {
+      // Settings screen owns user-facing errors; keep this controller quiet.
+    });
     return () => {
       cancelled = true;
     };
@@ -144,21 +140,18 @@ export function MessagingStatusBar(props: {
 
   useEffect(() => {
     if (
-      !open ||
-      !props.desktopApi?.getMessagingPlatformStatuses ||
-      !props.desktopApi?.readSettings
+      !open
+      || !props.desktopApi?.getMessagingPlatformStatuses
+      || !props.desktopApi?.readSettings
     ) {
       return;
     }
     let cancelled = false;
-    void props.desktopApi
-      .readSettings({})
-      .then((response) => {
-        if (!cancelled) setSettingsSnapshot(response.snapshot);
-      })
-      .catch(() => {
-        // Settings screen owns user-facing errors; keep this controller quiet.
-      });
+    void props.desktopApi.readSettings({}).then((response) => {
+      if (!cancelled) setSettingsSnapshot(response.snapshot);
+    }).catch(() => {
+      // Settings screen owns user-facing errors; keep this controller quiet.
+    });
     return () => {
       cancelled = true;
     };
@@ -171,9 +164,7 @@ export function MessagingStatusBar(props: {
       try {
         const response = await props.desktopApi!.getMessagingActivitySummary!();
         if (!cancelled) {
-          setActivityByPlatform(
-            summarizeActivityByPlatform(response.summaries),
-          );
+          setActivityByPlatform(summarizeActivityByPlatform(response.summaries));
         }
       } catch {
         // Activity is best-effort; the full Activity window surfaces errors.
@@ -231,9 +222,9 @@ export function MessagingStatusBar(props: {
       setSessionOverride(result.enabled);
       if (nextEnabled && !result.enabled) {
         setToggleError(
-          result.disabledReason ??
-            result.overrideReason ??
-            "Messaging could not be started.",
+          result.disabledReason
+            ?? result.overrideReason
+            ?? "Messaging could not be started.",
         );
       }
     } catch (error) {
@@ -326,10 +317,7 @@ export function MessagingStatusBar(props: {
             <PlatformGlyph
               key={status.platform}
               status={status}
-              active={hasRecentActivity(
-                status,
-                activeAtByPlatform[status.platform],
-              )}
+              active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
               forcedOff={!messagingOn}
             />
           ))}
@@ -366,9 +354,7 @@ export function MessagingStatusBar(props: {
                 <span aria-hidden="true" className="settings-switch__track">
                   <span className="settings-switch__thumb" />
                 </span>
-                <span>
-                  {togglePending ? "..." : messagingOn ? "On" : "Off"}
-                </span>
+                <span>{togglePending ? "..." : messagingOn ? "On" : "Off"}</span>
               </button>
             </div>
             <div className="messaging-status-popover__rows">
@@ -376,10 +362,7 @@ export function MessagingStatusBar(props: {
                 <PlatformStatusRow
                   key={status.platform}
                   status={status}
-                  active={hasRecentActivity(
-                    status,
-                    activeAtByPlatform[status.platform],
-                  )}
+                  active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
                   activity={activityByPlatform[status.platform]}
                   forcedOff={!messagingOn}
                   platformEnabled={platformEnabledFromSnapshot(
@@ -474,14 +457,13 @@ function PlatformStatusRow(props: {
   const configurable = configurablePlatform(status.platform)
     ? status.platform
     : undefined;
-  const platformEnabled =
-    props.platformEnabled ?? status.health !== "suspended";
-  const statusLabel =
-    forcedOff || platformEnabled === false
-      ? "Off"
-      : HEALTH_LABEL[status.health];
-  const stateHealth =
-    forcedOff || platformEnabled === false ? "suspended" : status.health;
+  const platformEnabled = props.platformEnabled ?? status.health !== "suspended";
+  const statusLabel = forcedOff || platformEnabled === false
+    ? "Off"
+    : HEALTH_LABEL[status.health];
+  const stateHealth = forcedOff || platformEnabled === false
+    ? "suspended"
+    : status.health;
   const subline = forcedOff
     ? "Globally disabled"
     : formatPlatformSubline(status, now);
@@ -496,7 +478,8 @@ function PlatformStatusRow(props: {
     ...formatPlatformActivity(props.activity, now),
     status.reason,
     ...formatDegradationReasons(status.degradationReasons ?? [], now),
-  ].filter((line): line is string => Boolean(line));
+  ]
+    .filter((line): line is string => Boolean(line));
 
   return (
     <div className="messaging-status-popover__row">
@@ -528,9 +511,7 @@ function PlatformStatusRow(props: {
             }`}
             aria-label={`${platformEnabled ? "Disable" : "Enable"} ${formatMessagingPlatformName(status.platform)}`}
             aria-pressed={platformEnabled}
-            disabled={
-              props.platformTogglePending || props.platformToggleDisabled
-            }
+            disabled={props.platformTogglePending || props.platformToggleDisabled}
             onClick={() => {
               void props.onTogglePlatform(configurable, !platformEnabled);
             }}
@@ -558,9 +539,8 @@ function withConfiguredSettingsStatuses(
 ): MessagingPlatformStatus[] {
   if (!snapshot) return [...runtimeStatuses];
   const seen = new Set(runtimeStatuses.map((status) => status.platform));
-  const configuredFromSettings = CONFIGURABLE_MESSAGING_PLATFORMS.filter(
-    (platform) => !seen.has(platform),
-  )
+  const configuredFromSettings = CONFIGURABLE_MESSAGING_PLATFORMS
+    .filter((platform) => !seen.has(platform))
     .filter((platform) => platformConfiguredFromSnapshot(snapshot, platform))
     .map((platform): MessagingPlatformStatus => ({
       platform,
@@ -635,8 +615,7 @@ function platformEnabledPatch(
 function summarizeActivityByPlatform(
   summaries: readonly MessagingPlatformActivitySummary[],
 ): Partial<Record<MessagingChannelKind, PlatformActivitySummary>> {
-  const next: Partial<Record<MessagingChannelKind, PlatformActivitySummary>> =
-    {};
+  const next: Partial<Record<MessagingChannelKind, PlatformActivitySummary>> = {};
   for (const summary of summaries) {
     next[summary.platform] = {
       lastRequestAt: summary.lastRequestAt,
@@ -730,13 +709,13 @@ function formatPlatformSubline(
   if (status.health === "enabled") {
     return status.lastActivityAt
       ? `Last activity ${formatRelativeTime(status.lastActivityAt, now)}`
-      : (status.detail ?? status.account ?? "Listening");
+      : status.detail ?? status.account ?? "Listening";
   }
   if (status.health === "degraded") {
     const firstReason = status.degradationReasons?.[0];
     return firstReason
       ? formatDegradationReason(firstReason, now)
-      : (status.reason ?? "Temporarily constrained");
+      : status.reason ?? "Temporarily constrained";
   }
   if (status.health === "errored") {
     return status.reason ?? "Connection error";
@@ -760,10 +739,9 @@ function formatDegradationReason(
 ): string {
   const scopeLabel = reason.scope?.label ? ` (${reason.scope.label})` : "";
   const started = `since ${formatClockTime(reason.startedAt)}`;
-  const remaining =
-    "expiresAt" in reason && reason.expiresAt
-      ? `, ${formatRemaining(reason.expiresAt, now)} remaining`
-      : "";
+  const remaining = "expiresAt" in reason && reason.expiresAt
+    ? `, ${formatRemaining(reason.expiresAt, now)} remaining`
+    : "";
   switch (reason.kind) {
     case "rate-limited":
       return `Rate limited${scopeLabel}; ${started}${remaining}${formatRetry(reason.retryAfterMs)}`;

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -93,11 +93,12 @@ export function MessagingStatusBar(props: {
     () => withConfiguredSettingsStatuses(statuses, settingsSnapshot),
     [settingsSnapshot, statuses],
   );
-  const messagingOn = sessionOverride
-    ?? runtimeMessagingEnabled
-    ?? inferMessagingEnabled(displayStatuses);
+  const messagingOn =
+    sessionOverride ??
+    runtimeMessagingEnabled ??
+    inferMessagingEnabled(displayStatuses);
   const activePlatforms = displayStatuses.filter((status) =>
-    hasRecentActivity(status, activeAtByPlatform[status.platform])
+    hasRecentActivity(status, activeAtByPlatform[status.platform]),
   );
   const hasDegradation = displayStatuses.some(
     (status) => (status.degradationReasons ?? []).length > 0,
@@ -122,17 +123,20 @@ export function MessagingStatusBar(props: {
 
   useEffect(() => {
     if (
-      !props.desktopApi?.getMessagingPlatformStatuses
-      || !props.desktopApi?.readSettings
+      !props.desktopApi?.getMessagingPlatformStatuses ||
+      !props.desktopApi?.readSettings
     ) {
       return;
     }
     let cancelled = false;
-    void props.desktopApi.readSettings({}).then((response) => {
-      if (!cancelled) setSettingsSnapshot(response.snapshot);
-    }).catch(() => {
-      // Settings screen owns user-facing errors; keep this controller quiet.
-    });
+    void props.desktopApi
+      .readSettings({})
+      .then((response) => {
+        if (!cancelled) setSettingsSnapshot(response.snapshot);
+      })
+      .catch(() => {
+        // Settings screen owns user-facing errors; keep this controller quiet.
+      });
     return () => {
       cancelled = true;
     };
@@ -140,18 +144,21 @@ export function MessagingStatusBar(props: {
 
   useEffect(() => {
     if (
-      !open
-      || !props.desktopApi?.getMessagingPlatformStatuses
-      || !props.desktopApi?.readSettings
+      !open ||
+      !props.desktopApi?.getMessagingPlatformStatuses ||
+      !props.desktopApi?.readSettings
     ) {
       return;
     }
     let cancelled = false;
-    void props.desktopApi.readSettings({}).then((response) => {
-      if (!cancelled) setSettingsSnapshot(response.snapshot);
-    }).catch(() => {
-      // Settings screen owns user-facing errors; keep this controller quiet.
-    });
+    void props.desktopApi
+      .readSettings({})
+      .then((response) => {
+        if (!cancelled) setSettingsSnapshot(response.snapshot);
+      })
+      .catch(() => {
+        // Settings screen owns user-facing errors; keep this controller quiet.
+      });
     return () => {
       cancelled = true;
     };
@@ -164,7 +171,9 @@ export function MessagingStatusBar(props: {
       try {
         const response = await props.desktopApi!.getMessagingActivitySummary!();
         if (!cancelled) {
-          setActivityByPlatform(summarizeActivityByPlatform(response.summaries));
+          setActivityByPlatform(
+            summarizeActivityByPlatform(response.summaries),
+          );
         }
       } catch {
         // Activity is best-effort; the full Activity window surfaces errors.
@@ -222,9 +231,9 @@ export function MessagingStatusBar(props: {
       setSessionOverride(result.enabled);
       if (nextEnabled && !result.enabled) {
         setToggleError(
-          result.disabledReason
-            ?? result.overrideReason
-            ?? "Messaging could not be started.",
+          result.disabledReason ??
+            result.overrideReason ??
+            "Messaging could not be started.",
         );
       }
     } catch (error) {
@@ -317,7 +326,10 @@ export function MessagingStatusBar(props: {
             <PlatformGlyph
               key={status.platform}
               status={status}
-              active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
+              active={hasRecentActivity(
+                status,
+                activeAtByPlatform[status.platform],
+              )}
               forcedOff={!messagingOn}
             />
           ))}
@@ -330,73 +342,80 @@ export function MessagingStatusBar(props: {
           role="dialog"
           aria-label="Messaging platforms"
         >
-          <div className="messaging-status-popover__head">
-            <div>
-              <div className="messaging-status-popover__title">
-                Messaging platforms
+          <div className="messaging-status-popover__panel">
+            <div className="messaging-status-popover__head">
+              <div>
+                <div className="messaging-status-popover__title">
+                  Messaging platforms
+                </div>
+                <div className="messaging-status-popover__summary">
+                  {summary}
+                </div>
               </div>
-              <div className="messaging-status-popover__summary">
-                {summary}
-              </div>
+              <button
+                type="button"
+                className={`settings-switch messaging-status-popover__switch${
+                  messagingOn ? " is-on" : ""
+                }`}
+                aria-pressed={messagingOn}
+                disabled={togglePending}
+                onClick={() => {
+                  void handleToggleMessaging();
+                }}
+              >
+                <span aria-hidden="true" className="settings-switch__track">
+                  <span className="settings-switch__thumb" />
+                </span>
+                <span>
+                  {togglePending ? "..." : messagingOn ? "On" : "Off"}
+                </span>
+              </button>
             </div>
-            <button
-              type="button"
-              className={`settings-switch messaging-status-popover__switch${
-                messagingOn ? " is-on" : ""
-              }`}
-              aria-pressed={messagingOn}
-              disabled={togglePending}
-              onClick={() => {
-                void handleToggleMessaging();
-              }}
-            >
-              <span aria-hidden="true" className="settings-switch__track">
-                <span className="settings-switch__thumb" />
-              </span>
-              <span>{togglePending ? "..." : messagingOn ? "On" : "Off"}</span>
-            </button>
+            <div className="messaging-status-popover__rows">
+              {displayStatuses.map((status) => (
+                <PlatformStatusRow
+                  key={status.platform}
+                  status={status}
+                  active={hasRecentActivity(
+                    status,
+                    activeAtByPlatform[status.platform],
+                  )}
+                  activity={activityByPlatform[status.platform]}
+                  forcedOff={!messagingOn}
+                  platformEnabled={platformEnabledFromSnapshot(
+                    settingsSnapshot,
+                    status.platform,
+                  )}
+                  platformTogglePending={
+                    configurablePlatform(status.platform)
+                      ? platformTogglePending[status.platform] === true
+                      : false
+                  }
+                  platformToggleDisabled={!messagingOn}
+                  now={now}
+                  onTogglePlatform={handleTogglePlatform}
+                />
+              ))}
+            </div>
+            {toggleError || platformToggleError ? (
+              <p className="messaging-status-popover__error" role="alert">
+                {toggleError ?? platformToggleError}
+              </p>
+            ) : null}
+            {props.onOpenActivity ? (
+              <button
+                type="button"
+                className="messaging-status-popover__activity"
+                onClick={() => {
+                  setOpen(false);
+                  setPinned(false);
+                  props.onOpenActivity?.();
+                }}
+              >
+                Open Messaging Activity
+              </button>
+            ) : null}
           </div>
-          <div className="messaging-status-popover__rows">
-            {displayStatuses.map((status) => (
-              <PlatformStatusRow
-                key={status.platform}
-                status={status}
-                active={hasRecentActivity(status, activeAtByPlatform[status.platform])}
-                activity={activityByPlatform[status.platform]}
-                forcedOff={!messagingOn}
-                platformEnabled={platformEnabledFromSnapshot(
-                  settingsSnapshot,
-                  status.platform,
-                )}
-                platformTogglePending={
-                  configurablePlatform(status.platform)
-                    ? platformTogglePending[status.platform] === true
-                    : false
-                }
-                platformToggleDisabled={!messagingOn}
-                now={now}
-                onTogglePlatform={handleTogglePlatform}
-              />
-            ))}
-          </div>
-          {toggleError || platformToggleError ? (
-            <p className="messaging-status-popover__error" role="alert">
-              {toggleError ?? platformToggleError}
-            </p>
-          ) : null}
-          {props.onOpenActivity ? (
-            <button
-              type="button"
-              className="messaging-status-popover__activity"
-              onClick={() => {
-                setOpen(false);
-                setPinned(false);
-                props.onOpenActivity?.();
-              }}
-            >
-              Open Messaging Activity
-            </button>
-          ) : null}
         </div>
       ) : null}
     </div>
@@ -455,13 +474,14 @@ function PlatformStatusRow(props: {
   const configurable = configurablePlatform(status.platform)
     ? status.platform
     : undefined;
-  const platformEnabled = props.platformEnabled ?? status.health !== "suspended";
-  const statusLabel = forcedOff || platformEnabled === false
-    ? "Off"
-    : HEALTH_LABEL[status.health];
-  const stateHealth = forcedOff || platformEnabled === false
-    ? "suspended"
-    : status.health;
+  const platformEnabled =
+    props.platformEnabled ?? status.health !== "suspended";
+  const statusLabel =
+    forcedOff || platformEnabled === false
+      ? "Off"
+      : HEALTH_LABEL[status.health];
+  const stateHealth =
+    forcedOff || platformEnabled === false ? "suspended" : status.health;
   const subline = forcedOff
     ? "Globally disabled"
     : formatPlatformSubline(status, now);
@@ -476,8 +496,7 @@ function PlatformStatusRow(props: {
     ...formatPlatformActivity(props.activity, now),
     status.reason,
     ...formatDegradationReasons(status.degradationReasons ?? [], now),
-  ]
-    .filter((line): line is string => Boolean(line));
+  ].filter((line): line is string => Boolean(line));
 
   return (
     <div className="messaging-status-popover__row">
@@ -509,7 +528,9 @@ function PlatformStatusRow(props: {
             }`}
             aria-label={`${platformEnabled ? "Disable" : "Enable"} ${formatMessagingPlatformName(status.platform)}`}
             aria-pressed={platformEnabled}
-            disabled={props.platformTogglePending || props.platformToggleDisabled}
+            disabled={
+              props.platformTogglePending || props.platformToggleDisabled
+            }
             onClick={() => {
               void props.onTogglePlatform(configurable, !platformEnabled);
             }}
@@ -537,8 +558,9 @@ function withConfiguredSettingsStatuses(
 ): MessagingPlatformStatus[] {
   if (!snapshot) return [...runtimeStatuses];
   const seen = new Set(runtimeStatuses.map((status) => status.platform));
-  const configuredFromSettings = CONFIGURABLE_MESSAGING_PLATFORMS
-    .filter((platform) => !seen.has(platform))
+  const configuredFromSettings = CONFIGURABLE_MESSAGING_PLATFORMS.filter(
+    (platform) => !seen.has(platform),
+  )
     .filter((platform) => platformConfiguredFromSnapshot(snapshot, platform))
     .map((platform): MessagingPlatformStatus => ({
       platform,
@@ -613,7 +635,8 @@ function platformEnabledPatch(
 function summarizeActivityByPlatform(
   summaries: readonly MessagingPlatformActivitySummary[],
 ): Partial<Record<MessagingChannelKind, PlatformActivitySummary>> {
-  const next: Partial<Record<MessagingChannelKind, PlatformActivitySummary>> = {};
+  const next: Partial<Record<MessagingChannelKind, PlatformActivitySummary>> =
+    {};
   for (const summary of summaries) {
     next[summary.platform] = {
       lastRequestAt: summary.lastRequestAt,
@@ -707,13 +730,13 @@ function formatPlatformSubline(
   if (status.health === "enabled") {
     return status.lastActivityAt
       ? `Last activity ${formatRelativeTime(status.lastActivityAt, now)}`
-      : status.detail ?? status.account ?? "Listening";
+      : (status.detail ?? status.account ?? "Listening");
   }
   if (status.health === "degraded") {
     const firstReason = status.degradationReasons?.[0];
     return firstReason
       ? formatDegradationReason(firstReason, now)
-      : status.reason ?? "Temporarily constrained";
+      : (status.reason ?? "Temporarily constrained");
   }
   if (status.health === "errored") {
     return status.reason ?? "Connection error";
@@ -737,9 +760,10 @@ function formatDegradationReason(
 ): string {
   const scopeLabel = reason.scope?.label ? ` (${reason.scope.label})` : "";
   const started = `since ${formatClockTime(reason.startedAt)}`;
-  const remaining = "expiresAt" in reason && reason.expiresAt
-    ? `, ${formatRemaining(reason.expiresAt, now)} remaining`
-    : "";
+  const remaining =
+    "expiresAt" in reason && reason.expiresAt
+      ? `, ${formatRemaining(reason.expiresAt, now)} remaining`
+      : "";
   switch (reason.kind) {
     case "rate-limited":
       return `Rate limited${scopeLabel}; ${started}${remaining}${formatRetry(reason.retryAfterMs)}`;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1396,17 +1396,29 @@ textarea,
 
 .messaging-status-popover {
   position: absolute;
-  top: calc(100% + 8px);
+  /* Anchor flush to the controller (top: 100%) and render the 8px visual gap
+     as transparent padding *inside* this element rather than as a positioning
+     offset. The offset version left an 8px dead zone the pointer crossed on its
+     way down, firing onPointerLeave and closing the popover before the cursor
+     reached it. Keeping the gap inside the box means the hover path stays
+     continuous — and, because this element matches `.messaging-status-bar *`,
+     the strip is already `-webkit-app-region: no-drag`, so it never falls back
+     to the OS title-bar drag region (see the .messaging-status-bar svg note). */
+  top: 100%;
   right: 0;
   z-index: 60;
   width: min(420px, calc(100vw - 32px));
+  padding-top: 8px;
+  text-align: left;
+}
+
+.messaging-status-popover__panel {
   padding: 10px;
   border: 1px solid var(--border-strong);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
   color: var(--text-primary);
-  text-align: left;
 }
 
 .messaging-status-popover__head {


### PR DESCRIPTION
## Problem

Hovering the **MSG** messaging-status control in the title bar opens the platforms popover, but moving the cursor straight down onto that popover closes it. Users can't reach the **Open Messaging Activity** button (or the per-platform toggles) by hover alone — they have to *click* MSG to pin the popover open first, then move down.

## Cause

The popover was positioned with `top: calc(100% + 8px)`, leaving an 8px gap between the controller button and the panel that belonged to **neither** element. `onPointerLeave` fires when the pointer leaves an element *and all its descendants*; the moment the cursor entered that empty 8px strip it was over nothing in the hover root's subtree, so `onPointerLeave` fired → `setOpen(false)` → the popover unmounted before the cursor arrived. Clicking worked only because it sets `pinned`, which makes `onPointerLeave` a no-op.

## Fix

Anchor the popover flush to the button (`top: 100%`) and render the 8px gap as transparent `padding-top` **inside** the popover element. The hover path is now continuous, so sliding onto the panel keeps it open — no pinning required.

Because the transparent strip lives inside the popover, it already matches `.messaging-status-bar *` and stays `-webkit-app-region: no-drag`, so it can't regress into the title-bar drag-region bug fixed in #925. The visual chrome (border, background, shadow, radius, inner padding) moved to a new `.messaging-status-popover__panel` wrapper, so the panel renders pixel-identically — same 8px gap, same 1px border, same shadow.

The TSX file also carries pre-existing prettier formatting normalization (operator wrapping, `.then().catch()` chains) that was already in the working tree; it's whitespace-only, no logic changes.

## Testing

- `MessagingStatusBar.test.tsx` — all 11 tests pass.
- Not yet verified live in the running app; the fix is a pointer-path/geometry change that unit tests don't exercise. Manual hover check recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)