### PR TITLE
feat(desktop): mark the live turn and add per-turn durations in Pricing

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12782,9 +12782,69 @@ command = "pnpm dev"
       reasoningOutputTokens: 10,
       totalTokens: 1_060,
       turnId: "turn-2",
+      turnUsageAttributed: true,
       uncachedInputTokens: 800,
     });
     expect(pricing.lines[0]?.cumulativeTotalCostMicros).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("marks a whole-thread total with no per-request usage as unattributed", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    // Only a cumulative total, no per-request `last` snapshot to isolate the
+    // turn: the builder can't attribute this to the turn, so it records
+    // turnUsageAttributed: false and the row reads as a whole-thread summary.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-3",
+        tokenUsage: {
+          total_token_usage: {
+            input_tokens: 11_000,
+            cached_input_tokens: 10_200,
+            output_tokens: 500,
+            reasoning_output_tokens: 100,
+            total_tokens: 11_600,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      totalTokens: 11_600,
+      turnId: "turn-3",
+      turnUsageAttributed: false,
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -797,6 +797,102 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       totalCostMicros: 0,
     });
   });
+
+  it("round-trips the turnUsageAttributed flag through sqlite", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        turnId: "turn-attributed",
+        turnUsageAttributed: true,
+        usageLineId: "line-attributed",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        turnId: "turn-unattributed",
+        turnUsageAttributed: false,
+        usageLineId: "line-unattributed",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const byId = new Map(pricing.lines.map((line) => [line.usageLineId, line]));
+    expect(byId.get("line-attributed")?.turnUsageAttributed).toBe(true);
+    expect(byId.get("line-unattributed")?.turnUsageAttributed).toBe(false);
+    // A line that never set the flag stays undefined, not coerced to a boolean.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({ turnId: "turn-plain", usageLineId: "line-plain" }),
+    });
+    const after = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(
+      after.lines.find((line) => line.usageLineId === "line-plain")
+        ?.turnUsageAttributed,
+    ).toBeUndefined();
+  });
+
+  it("backfills legacy live summary rows to turnUsageAttributed=false on migration", async () => {
+    // Legacy whole-thread summary masquerading as a turn (no cumulative
+    // breakdown, >= 1M tokens), plus controls that must stay untouched.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-legacy",
+        usageLineId: "legacy-summary",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cumulativeTotalTokens: 2_000_000,
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-modern",
+        usageLineId: "modern-turn",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 500_000,
+        turnId: "turn-small",
+        usageLineId: "small-live-turn",
+      }),
+    });
+
+    // Force the user_version 26 migration to run against the seeded rows, then
+    // reassign the module handle so afterEach closes the reopened db.
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.pragma("user_version = 25");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+
+    const flagById = new Map(
+      (
+        stateDb.raw
+          .prepare(
+            "SELECT usage_line_id, turn_usage_attributed FROM thread_usage_lines",
+          )
+          .all() as {
+          turn_usage_attributed: number | null;
+          usage_line_id: string;
+        }[]
+      ).map((row) => [row.usage_line_id, row.turn_usage_attributed]),
+    );
+    expect(flagById.get("legacy-summary")).toBe(0);
+    expect(flagById.get("modern-turn")).toBeNull();
+    expect(flagById.get("small-live-turn")).toBeNull();
+  });
 });
 
 function buildUsageLine(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3387,6 +3387,7 @@ function resolveLiveThreadUsageTiming(params: {
 }
 
 function buildLiveThreadUsageLine(params: {
+  attributed?: boolean;
   backend: AppServerBackendKind;
   cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
   completedAt?: number;
@@ -3489,6 +3490,9 @@ function buildLiveThreadUsageLine(params: {
     totalCostMicros: cost?.totalCostMicros ?? 0,
     totalTokens,
     ...(params.turnId ? { turnId: params.turnId } : {}),
+    ...(typeof params.attributed === "boolean"
+      ? { turnUsageAttributed: params.attributed }
+      : {}),
     uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
     uncachedInputTokens,
     usageLineId: [
@@ -12861,6 +12865,11 @@ export class DesktopBackendRegistry {
     tokenUsage: unknown;
     turnId?: string;
   }): {
+    // Whether turnTokenUsage is a real measurement of this turn — a per-turn
+    // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
+    // total we couldn't decompose. Carried onto the persisted row so the
+    // renderer classifies summaries by fact, not a token-count guess.
+    attributed: boolean;
     cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
     turnTokenUsage: TaskMonitorTokenUsageBreakdown | unknown;
     /**
@@ -12873,11 +12882,14 @@ export class DesktopBackendRegistry {
   } {
     const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
     if (!records) {
-      return { turnTokenUsage: params.tokenUsage };
+      return { attributed: false, turnTokenUsage: params.tokenUsage };
     }
 
     if (!records.totalUsage || !params.turnId) {
       return {
+        // A "last" snapshot is this request's own usage; anything else here is
+        // a bare/whole payload we can't attribute to the turn.
+        attributed: Boolean(records.latestUsage),
         ...(records.totalUsage ? { cumulativeTokenUsage: records.totalUsage } : {}),
         turnTokenUsage:
           records.latestUsage ?? records.currentUsage ?? params.tokenUsage,
@@ -12907,6 +12919,9 @@ export class DesktopBackendRegistry {
       ? subtractTaskMonitorTokenUsage(records.totalUsage, baseline)
       : undefined;
     return {
+      // Attributed when we computed a per-turn delta or have this request's
+      // "last" snapshot; not when we fall back to the whole cumulative total.
+      attributed: Boolean(turnTokenUsage) || Boolean(records.latestUsage),
       cumulativeTokenUsage: records.totalUsage,
       turnTokenUsage:
         turnTokenUsage ??
@@ -13038,6 +13053,7 @@ export class DesktopBackendRegistry {
       turnId: notification.params.turnId ?? undefined,
     });
     const line = buildLiveThreadUsageLine({
+      attributed: derivedUsage.attributed,
       backend: event.backend,
       cumulativeTokenUsage: derivedUsage.cumulativeTokenUsage,
       ...usageTiming,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -748,6 +748,7 @@ export class SqliteOverlayStore {
             reasoning_effort,
             service_tier,
             fast_mode,
+            turn_usage_attributed,
             settings_source,
             settings_confidence,
             input_tokens,
@@ -796,6 +797,7 @@ export class SqliteOverlayStore {
             @reasoningEffort,
             @serviceTier,
             @fastMode,
+            @turnUsageAttributed,
             @settingsSource,
             @settingsConfidence,
             @inputTokens,
@@ -844,6 +846,7 @@ export class SqliteOverlayStore {
             reasoning_effort = excluded.reasoning_effort,
             service_tier = excluded.service_tier,
             fast_mode = excluded.fast_mode,
+            turn_usage_attributed = excluded.turn_usage_attributed,
             settings_source = excluded.settings_source,
             settings_confidence = excluded.settings_confidence,
             input_tokens = excluded.input_tokens,
@@ -2431,6 +2434,7 @@ type ThreadUsageLineRow = {
   reasoning_effort: string | null;
   service_tier: string | null;
   fast_mode: number | null;
+  turn_usage_attributed: number | null;
   settings_source: ThreadUsageLineRecord["settingsSource"] | null;
   settings_confidence: ThreadUsageLineRecord["settingsConfidence"] | null;
   input_tokens: number;
@@ -2704,6 +2708,12 @@ function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string,
     cumulativeUncachedInputTokens: line.cumulativeUncachedInputTokens ?? null,
     currency: line.currency,
     fastMode: typeof line.fastMode === "boolean" ? (line.fastMode ? 1 : 0) : null,
+    turnUsageAttributed:
+      typeof line.turnUsageAttributed === "boolean"
+        ? line.turnUsageAttributed
+          ? 1
+          : 0
+        : null,
     inputTokens: line.inputTokens,
     model: line.model ?? null,
     observedColdReplayCount: line.observedColdReplayCount ?? null,
@@ -2774,6 +2784,9 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
       : {}),
     currency: row.currency,
     ...(row.fast_mode !== null ? { fastMode: Boolean(row.fast_mode) } : {}),
+    ...(row.turn_usage_attributed !== null
+      ? { turnUsageAttributed: Boolean(row.turn_usage_attributed) }
+      : {}),
     inputTokens: row.input_tokens,
     ...(row.model ? { model: row.model } : {}),
     outputCostMicros: row.output_cost_micros,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 25;
+export const CURRENT_STATE_DB_USER_VERSION = 26;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -565,6 +565,7 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   reasoning_effort           TEXT,
   service_tier               TEXT,
   fast_mode                  INTEGER,
+  turn_usage_attributed      INTEGER,
   settings_source            TEXT,
   settings_confidence        TEXT,
   input_tokens               INTEGER NOT NULL,
@@ -854,6 +855,12 @@ export class StateDb {
         // THREAD_USAGE_PRICING_SCHEMA; the ALTERs are guarded by tableColumnExists
         // so a fresh db (schema already carries them) no-ops.
         ensureThreadUsageTurnObservedReplayColumns(db);
+        db.pragma("user_version = 25");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 26) {
+      db.transaction(() => {
+        ensureThreadUsageAttributedColumn(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1323,6 +1330,34 @@ function ensureThreadUsageTurnObservedReplayColumns(db: BetterSqlite3.Database):
       db.exec(column.sql);
     }
   }
+}
+
+// Adds the turn_usage_attributed column and backfills the finite set of legacy
+// pre-attribution rows. Live rows built before this field existed recorded no
+// attribution; the ones that were whole-thread summaries masquerading as turns
+// are the live/pending rows with no cumulative breakdown and a >= 1M-token
+// total. This one-shot backfill over already-persisted rows is the ONLY place
+// the old token-count guess still runs — new live rows record attribution
+// explicitly at build time, so the renderer never re-derives it.
+function ensureThreadUsageAttributedColumn(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_lines")) {
+    db.exec(THREAD_USAGE_PRICING_SCHEMA);
+    return;
+  }
+  if (!tableColumnExists(db, "thread_usage_lines", "turn_usage_attributed")) {
+    db.exec(
+      "ALTER TABLE thread_usage_lines ADD COLUMN turn_usage_attributed INTEGER",
+    );
+  }
+  db.exec(`
+UPDATE thread_usage_lines
+SET turn_usage_attributed = 0
+WHERE turn_usage_attributed IS NULL
+  AND source = 'live'
+  AND status = 'pending'
+  AND cumulative_total_tokens IS NULL
+  AND total_tokens >= 1000000
+`);
 }
 
 function ensureThreadSearchFtsThreadIdColumn(db: BetterSqlite3.Database): void {

--- a/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EnvActionRunsView.tsx
@@ -8,6 +8,14 @@ import {
 } from "react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import {
+  formatDurationMs,
+  formatRunningDurationMs,
+} from "../../lib/format-duration";
+
+// Re-exported so existing importers (Composer + its tests) keep resolving the
+// duration helpers from here; the source of truth now lives in lib/format-duration.
+export { formatDurationMs, formatRunningDurationMs };
 
 const ENV_ACTION_OUTPUT_MAX_LINES = 500;
 
@@ -79,37 +87,6 @@ function elementContainsSelection(element: HTMLElement | null): boolean {
     }
   }
   return false;
-}
-
-export function formatDurationMs(
-  ms?: number,
-  options?: { coarseAfterMinute?: boolean },
-): string {
-  if (!ms || !Number.isFinite(ms)) return "";
-  if (ms < 1_000) return `${Math.round(ms)}ms`;
-  const totalSeconds = Math.round(ms / 1_000);
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (totalMinutes < 60) {
-    if (options?.coarseAfterMinute) return `${totalMinutes}m`;
-    return seconds ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`;
-  }
-  const totalHours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (totalHours < 24) {
-    return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
-  }
-  const days = Math.floor(totalHours / 24);
-  const hours = totalHours % 24;
-  return hours ? `${days}d ${hours}h` : `${days}d`;
-}
-
-export function formatRunningDurationMs(ms?: number): string {
-  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
-  const totalSeconds = Math.floor(ms / 1_000);
-  if (totalSeconds < 1) return "0s";
-  return formatDurationMs(totalSeconds * 1_000);
 }
 
 export function EnvActionRunsView(props: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -78,6 +78,7 @@ const CONTEXT_TABS: ContextTab[] = [
 ];
 
 type ThreadContextPanelProps = {
+  activeTurnId?: string;
   backendError?: string;
   backends: BackendSummary[];
   desktopApi?: DesktopApi;
@@ -665,6 +666,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       case "pricing":
         return (
           <PricingPanel
+            activeTurnId={props.activeTurnId}
             pricing={props.pricing}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -670,6 +670,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             pricing={props.pricing}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}
+            subAgents={props.thread.subAgents}
           />
         );
       case "actions":

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2709,6 +2709,7 @@ export function ThreadView(props: ThreadViewProps) {
 
         <ThreadContextPanel
           activeTab={activeContextTab}
+          activeTurnId={props.activeTurnId}
           backendError={props.backendError}
           backends={props.backends}
           desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1541,6 +1541,100 @@ describe("ThreadContextPanel", () => {
     expect(onScrollToTurn).toHaveBeenCalledWith("turn-1", 1_800_000_000_000);
   });
 
+  it("marks the active live turn with a Live chip and a running duration", () => {
+    const startedAt = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startedAt + 65_000);
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      activeTurnId: "turn-live",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 0,
+            cachedInputTokens: 0,
+            createdAt: startedAt,
+            currency: "USD",
+            inputTokens: 100,
+            outputCostMicros: 0,
+            outputTokens: 10,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 0,
+            scope: "turn",
+            source: "live",
+            startedAt,
+            status: "pending",
+            threadId: "thread-1",
+            totalCostMicros: 1_000,
+            totalTokens: 110,
+            turnId: "turn-live",
+            uncachedInputCostMicros: 0,
+            uncachedInputTokens: 100,
+            usageLineId: "line-live",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const activeRow = container.querySelector(".pricing-usage-row--active");
+    expect(activeRow).not.toBeNull();
+    expect(within(activeRow as HTMLElement).getByText("Live")).toBeInTheDocument();
+    const times = activeRow?.querySelector(".rail-card__times");
+    expect(times?.textContent).toContain("· 1m 5s ·");
+  });
+
+  it("shows a finished duration and no Live chip on a completed turn", () => {
+    const startedAt = 1_800_000_000_000;
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      activeTurnId: "turn-other",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 0,
+            cachedInputTokens: 0,
+            completedAt: startedAt + 125_000,
+            createdAt: startedAt,
+            currency: "USD",
+            inputTokens: 100,
+            outputCostMicros: 0,
+            outputTokens: 10,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 0,
+            scope: "turn",
+            source: "live",
+            startedAt,
+            status: "finalized",
+            threadId: "thread-1",
+            totalCostMicros: 1_000,
+            totalTokens: 110,
+            turnId: "turn-done",
+            uncachedInputCostMicros: 0,
+            uncachedInputTokens: 100,
+            usageLineId: "line-done",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+    const times = container.querySelector(".rail-card__times");
+    expect(times?.textContent).toContain("· 2m 5s ·");
+  });
+
   it("summarizes pricing rows when provider summaries are absent", () => {
     renderPanel({
       activeTab: "pricing",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1589,6 +1589,57 @@ describe("ThreadContextPanel", () => {
     expect(times?.textContent).toContain("· 1m 5s ·");
   });
 
+  it("keeps the running duration on an active turn that trips the historical-summary heuristic", () => {
+    // A live turn whose first usage event carries no cumulative snapshot and
+    // whose own totalTokens is >= 1M satisfies isHistoricalUsageSummary. It is
+    // still the active turn, so it must keep its Live chip AND running clock.
+    const startedAt = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startedAt + 65_000);
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      activeTurnId: "turn-live",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 0,
+            cachedInputTokens: 1_500_000,
+            createdAt: startedAt,
+            currency: "USD",
+            inputTokens: 1_500_000,
+            outputCostMicros: 0,
+            outputTokens: 10,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 0,
+            scope: "turn",
+            source: "live",
+            startedAt,
+            status: "pending",
+            threadId: "thread-1",
+            totalCostMicros: 1_000,
+            totalTokens: 1_500_010,
+            turnId: "turn-live",
+            uncachedInputCostMicros: 0,
+            uncachedInputTokens: 0,
+            usageLineId: "line-live-huge",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const activeRow = container.querySelector(".pricing-usage-row--active");
+    expect(activeRow).not.toBeNull();
+    expect(within(activeRow as HTMLElement).getByText("Live")).toBeInTheDocument();
+    const times = activeRow?.querySelector(".rail-card__times");
+    expect(times?.textContent).toContain("· 1m 5s ·");
+  });
+
   it("shows a finished duration and no Live chip on a completed turn", () => {
     const startedAt = 1_800_000_000_000;
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -45,6 +45,38 @@ const baseThread: NavigationThreadSummary = {
   },
 };
 
+// A monitor-scope pricing row for a sub-agent. `sourceItemId` is the join key
+// to a `ThreadSubAgentSummary.monitorId`.
+function buildMonitorLine(
+  overrides: Partial<ThreadUsageLineRecord> = {},
+): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_800_000_000_000,
+    currency: "USD",
+    inputTokens: 100,
+    model: "gpt-5.5",
+    outputCostMicros: 0,
+    outputTokens: 10,
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "monitor",
+    source: "monitor",
+    sourceItemId: "mon-1",
+    status: "finalized",
+    threadId: "thread-1",
+    totalCostMicros: 1_000,
+    totalTokens: 110,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 100,
+    usageLineId: "mon-line-1",
+    ...overrides,
+  };
+}
+
 const baseBackend: BackendSummary = {
   kind: "codex",
   label: "OpenAI",
@@ -1685,6 +1717,114 @@ describe("ThreadContextPanel", () => {
     expect(screen.queryByText("Live")).not.toBeInTheDocument();
     const times = container.querySelector(".rail-card__times");
     expect(times?.textContent).toContain("· 2m 5s ·");
+  });
+
+  it("marks a running sub-agent row live with its name and a running clock", () => {
+    const startedAt = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startedAt + 65_000);
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "mon-1",
+            task: "Review the diff",
+            status: "running",
+            agentName: "Reviewer",
+            createdAt: startedAt,
+            updatedAt: startedAt,
+          },
+        ],
+      },
+      pricing: {
+        lines: [buildMonitorLine({ createdAt: startedAt })],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    const activeRow = container.querySelector(".pricing-usage-row--active");
+    expect(activeRow).not.toBeNull();
+    expect(within(activeRow as HTMLElement).getByText("Live")).toBeInTheDocument();
+    expect(within(activeRow as HTMLElement).getByText("Reviewer")).toBeInTheDocument();
+    const times = activeRow?.querySelector(".rail-card__times");
+    expect(times?.textContent).toContain("· 1m 5s");
+  });
+
+  it("shows a terminal sub-agent's name but no Live chip", () => {
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "mon-1",
+            task: "Review the diff",
+            status: "success",
+            agentName: "Reviewer",
+            createdAt: 1_800_000_000_000,
+            updatedAt: 1_800_000_000_000,
+          },
+        ],
+      },
+      pricing: {
+        lines: [buildMonitorLine({})],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+    expect(screen.getByText("Reviewer")).toBeInTheDocument();
+  });
+
+  it("marks multiple concurrently-running sub-agents live", () => {
+    const startedAt = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startedAt + 5_000);
+
+    const { container } = renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "mon-1",
+            task: "A",
+            status: "running",
+            agentName: "Alpha",
+            createdAt: startedAt,
+            updatedAt: startedAt,
+          },
+          {
+            monitorId: "mon-2",
+            task: "B",
+            status: "pending",
+            agentName: "Beta",
+            createdAt: startedAt,
+            updatedAt: startedAt,
+          },
+        ],
+      },
+      pricing: {
+        lines: [
+          buildMonitorLine({ sourceItemId: "mon-1", usageLineId: "mon-line-1" }),
+          buildMonitorLine({ sourceItemId: "mon-2", usageLineId: "mon-line-2" }),
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(container.querySelectorAll(".pricing-usage-row--active")).toHaveLength(2);
+    expect(screen.getAllByText("Live")).toHaveLength(2);
   });
 
   it("summarizes pricing rows when provider summaries are absent", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1623,9 +1623,10 @@ describe("ThreadContextPanel", () => {
   });
 
   it("keeps the running duration on an active turn that trips the historical-summary heuristic", () => {
-    // A live turn whose first usage event carries no cumulative snapshot and
-    // whose own totalTokens is >= 1M satisfies isHistoricalUsageSummary. It is
-    // still the active turn, so it must keep its Live chip AND running clock.
+    // An active live turn the builder couldn't attribute (turnUsageAttributed
+    // false) classifies as a historical summary. It is still the active turn,
+    // so it must keep its Live chip AND running clock (guard-order in
+    // formatUsageLineDuration puts the active branch before the summary guard).
     const startedAt = 1_800_000_000_000;
     vi.useFakeTimers();
     vi.setSystemTime(startedAt + 65_000);
@@ -1656,6 +1657,7 @@ describe("ThreadContextPanel", () => {
             totalCostMicros: 1_000,
             totalTokens: 1_500_010,
             turnId: "turn-live",
+            turnUsageAttributed: false,
             uncachedInputCostMicros: 0,
             uncachedInputTokens: 0,
             usageLineId: "line-live-huge",
@@ -1868,7 +1870,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Sub-agent usage")).toBeInTheDocument();
   });
 
-  it("labels legacy live rows without cumulative context as historical summaries", () => {
+  it("labels unattributed live rows as historical summaries", () => {
     renderPanel({
       activeTab: "pricing",
       pinned: true,
@@ -1894,6 +1896,7 @@ describe("ThreadContextPanel", () => {
             totalCostMicros: 55_830_000,
             totalTokens: 73_473_538,
             turnId: "turn-legacy",
+            turnUsageAttributed: false,
             uncachedInputCostMicros: 6_830_000,
             uncachedInputTokens: 2_788_759,
             usageLineId: "line-legacy",
@@ -1925,6 +1928,50 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Historical usage summary")).toBeInTheDocument();
     expect(screen.getByText("$55.83 list price")).toBeInTheDocument();
     expect(screen.queryByText("$55.83 list price this turn")).not.toBeInTheDocument();
+  });
+
+  it("treats a large attributed live turn as a turn, not a summary", () => {
+    // Same size as the unattributed row above, but attributed to the turn — it
+    // must read as a normal (large) turn. No token-count threshold reclassifies it.
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 7_000_000,
+            cachedInputTokens: 70_463_104,
+            createdAt: 1_800_000_000_000,
+            currency: "USD",
+            inputTokens: 73_251_863,
+            model: "gpt-5.5",
+            outputCostMicros: 42_000_000,
+            outputTokens: 221_675,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 37_030,
+            scope: "turn",
+            source: "live",
+            status: "pending",
+            threadId: "thread-1",
+            totalCostMicros: 55_830_000,
+            totalTokens: 73_473_538,
+            turnId: "turn-big",
+            turnUsageAttributed: true,
+            uncachedInputCostMicros: 6_830_000,
+            uncachedInputTokens: 2_788_759,
+            usageLineId: "line-big",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("Turn usage")).toBeInTheDocument();
+    expect(screen.queryByText("Historical usage summary")).not.toBeInTheDocument();
+    expect(screen.getByText("$55.83 list price this turn")).toBeInTheDocument();
   });
 
   it("hides the hover rail when document mouse movement resumes outside the rail", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -108,6 +108,7 @@ type PanelOverrides = Partial<
   Pick<
     ComponentProps<typeof ThreadContextPanel>,
     | "activeTab"
+    | "activeTurnId"
     | "backends"
     | "desktopApi"
     | "pinned"

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -7,6 +7,11 @@ import {
   estimateOpenAiTokenUsageCost,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
+import { useEffect, useState } from "react";
+import {
+  formatDurationMs,
+  formatRunningDurationMs,
+} from "../../../lib/format-duration";
 import { formatTimestamp } from "./context-rail-shared";
 import { formatTokenCount } from "./subagent-format";
 
@@ -43,6 +48,13 @@ export function PricingPanel(props: PricingPanelProps) {
     aggregateSummaries(displaySummaries) ?? aggregateUsageLines(displayLines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   const pricingTotals = buildPricingRunningTotals(displayLines);
+  const activeTurnId = props.activeTurnId;
+  const hasActiveTurn = displayLines.some((line) =>
+    isActiveLiveTurnUsageLine({ activeTurnId, line }),
+  );
+  // Only tick while a turn is actually live, so completed threads render
+  // static and never spin a 1s interval in the background.
+  const now = useNowWhileActive(hasActiveTurn);
 
   return (
     <section className="context-panel__section">
@@ -134,12 +146,30 @@ export function PricingPanel(props: PricingPanelProps) {
               line,
             });
             const runningTokens = formatUsageLineRunningTokens(line);
+            const isActive = isActiveLiveTurnUsageLine({ activeTurnId, line });
+            const duration = formatUsageLineDuration({ isActive, line, now });
 
             return (
-              <li key={line.usageLineId} className="rail-card pricing-usage-row">
-                <p className="rail-card__title">
-                  {formatUsageLineTitle(line)}
-                </p>
+              <li
+                key={line.usageLineId}
+                className={`rail-card pricing-usage-row${
+                  isActive ? " pricing-usage-row--active" : ""
+                }`}
+              >
+                <div className="pricing-usage-row__header">
+                  <p className="rail-card__title">
+                    {formatUsageLineTitle(line)}
+                  </p>
+                  {isActive ? (
+                    <span className="rail-chip pricing-usage-row__live">
+                      <span
+                        className="rail-chip__dot rail-chip__dot--active"
+                        aria-hidden="true"
+                      />
+                      Live
+                    </span>
+                  ) : null}
+                </div>
                 <p className="rail-card__model">
                   {line.model ?? "Unknown model"}
                   {line.reasoningEffort ? ` · ${line.reasoningEffort}` : ""}
@@ -154,6 +184,7 @@ export function PricingPanel(props: PricingPanelProps) {
                     : ""}
                 </p>
                 <PricingUsageTimestamp
+                  duration={duration}
                   line={line}
                   onScrollToTurn={props.onScrollToTurn}
                 />
@@ -905,6 +936,7 @@ function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
 }
 
 function PricingUsageTimestamp(props: {
+  duration?: string;
   line: ThreadUsageLineRecord;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
 }) {
@@ -929,9 +961,66 @@ function PricingUsageTimestamp(props: {
       ) : (
         timestamp
       )}
+      {props.duration ? ` · ${props.duration}` : ""}
       {props.line.turnId ? ` · ${props.line.turnId}` : ""}
     </p>
   );
+}
+
+/**
+ * The start-anchored timestamp on each card carries the "when", so the card
+ * pairs it with a single duration rather than a second minute-resolution stop
+ * stamp (two coarse stamps can't reconstruct a sub-minute turn anyway).
+ *
+ * - Live turn: elapsed since start, ticking once per second.
+ * - Finished turn: completedAt − start, in the coarse `2h 3m 4s` style.
+ * - Estimates / historical summaries / sub-agent rollups: no duration — the
+ *   span isn't a single measurable turn.
+ */
+function formatUsageLineDuration(params: {
+  isActive: boolean;
+  line: PricingUsageLine;
+  now: number;
+}): string {
+  const { isActive, line, now } = params;
+  if (
+    line.scope === "monitor" ||
+    isEstimatedUsageGap(line) ||
+    isHistoricalUsageSummary(line)
+  ) {
+    return "";
+  }
+  const start = line.startedAt ?? line.createdAt;
+  if (isActive) {
+    return formatRunningDurationMs(Math.max(0, now - start));
+  }
+  const end = line.completedAt;
+  if (end === undefined || end <= start) {
+    return "";
+  }
+  return formatDurationMs(end - start);
+}
+
+/**
+ * `Date.now()` that re-renders once per second, but only while a live turn is
+ * present. When nothing is active the interval is torn down, so a settled
+ * pricing panel never keeps a timer running.
+ */
+function useNowWhileActive(enabled: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1_000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [enabled]);
+  return now;
 }
 
 function aggregateSummaries(

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -1,5 +1,7 @@
 import type {
   ThreadPricingSummary,
+  ThreadSubAgentStatus,
+  ThreadSubAgentSummary,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -23,7 +25,22 @@ type PricingPanelProps = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
+  /**
+   * Durable sub-agent (task-monitor) summaries for this thread, joined to
+   * monitor-scope usage rows by `monitorId` === the row's `sourceItemId`.
+   * Supplies each sub-agent row's name and its live/terminal status.
+   */
+  subAgents?: ThreadSubAgentSummary[];
 };
+
+// Terminal sub-agent statuses — a sub-agent in any other status is still
+// running, so its usage row reads as live. Mirrors the main process
+// `codexNativeSubAgentIsTerminal`.
+const SUBAGENT_TERMINAL_STATUSES: ReadonlySet<ThreadSubAgentStatus> = new Set([
+  "success",
+  "failure",
+  "cancelled",
+]);
 
 type PricingDisplayOptions = {
   codexCredits: boolean;
@@ -50,12 +67,15 @@ export function PricingPanel(props: PricingPanelProps) {
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   const pricingTotals = buildPricingRunningTotals(displayLines);
   const activeTurnId = props.activeTurnId;
-  const hasActiveTurn = displayLines.some((line) =>
-    isActiveLiveTurnUsageLine({ activeTurnId, line }),
+  const subAgentsById = new Map(
+    (props.subAgents ?? []).map((subAgent) => [subAgent.monitorId, subAgent]),
   );
-  // Only tick while a turn is actually live, so completed threads render
-  // static and never spin a 1s interval in the background.
-  const now = useNowWhileActive(hasActiveTurn);
+  const hasActiveRow = displayLines.some((line) =>
+    isActiveUsageLine({ activeTurnId, line, subAgentsById }),
+  );
+  // Tick while any row is live — the main turn or any still-running sub-agent —
+  // so completed threads render static and never spin a 1s interval.
+  const now = useNowWhileActive(hasActiveRow);
 
   return (
     <section className="context-panel__section">
@@ -147,7 +167,11 @@ export function PricingPanel(props: PricingPanelProps) {
               line,
             });
             const runningTokens = formatUsageLineRunningTokens(line);
-            const isActive = isActiveLiveTurnUsageLine({ activeTurnId, line });
+            const subAgent =
+              line.scope === "monitor" && line.sourceItemId
+                ? subAgentsById.get(line.sourceItemId)
+                : undefined;
+            const isActive = isActiveUsageLine({ activeTurnId, line, subAgentsById });
             const duration = formatUsageLineDuration({ isActive, line, now });
 
             return (
@@ -171,6 +195,11 @@ export function PricingPanel(props: PricingPanelProps) {
                     </span>
                   ) : null}
                 </div>
+                {subAgent?.agentName ? (
+                  <p className="rail-card__agent-name" title={subAgent.agentName}>
+                    {subAgent.agentName}
+                  </p>
+                ) : null}
                 <p className="rail-card__model">
                   {line.model ?? "Unknown model"}
                   {line.reasoningEffort ? ` · ${line.reasoningEffort}` : ""}
@@ -948,6 +977,29 @@ function isActiveLiveTurnUsageLine(params: {
     Boolean(params.activeTurnId) &&
     params.line.turnId === params.activeTurnId
   );
+}
+
+// A row is live if it's the main active turn OR a monitor row whose sub-agent
+// is still running. Sub-agents run concurrently, so more than one row can be
+// live at once (e.g. a fan-out of spawn_agent calls in a single turn).
+function isActiveUsageLine(params: {
+  activeTurnId?: string;
+  line: PricingUsageLine;
+  subAgentsById: Map<string, ThreadSubAgentSummary>;
+}): boolean {
+  if (
+    isActiveLiveTurnUsageLine({
+      activeTurnId: params.activeTurnId,
+      line: params.line,
+    })
+  ) {
+    return true;
+  }
+  if (params.line.scope !== "monitor" || !params.line.sourceItemId) {
+    return false;
+  }
+  const subAgent = params.subAgentsById.get(params.line.sourceItemId);
+  return Boolean(subAgent && !SUBAGENT_TERMINAL_STATUSES.has(subAgent.status));
 }
 
 function PricingUsageTimestamp(props: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -953,15 +953,16 @@ function isForkBaselineLine(line: ThreadUsageLineRecord): boolean {
   return line.scope === "fork-baseline";
 }
 
+// A row is a whole-thread/historical summary when its scope says so, or when
+// the live builder recorded that it could not attribute the usage to this turn
+// (turnUsageAttributed === false) — e.g. a first observed event that carried a
+// whole-thread total we couldn't decompose. Legacy rows predating the flag are
+// backfilled by the state-db migration (user_version 26). No token-count guess.
 function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
-  if (line.scope === "total" || line.scope === "backfill") {
-    return true;
-  }
   return (
-    line.source === "live" &&
-    line.status === "pending" &&
-    line.cumulativeTotalTokens === undefined &&
-    line.totalTokens >= 1_000_000
+    line.scope === "total" ||
+    line.scope === "backfill" ||
+    line.turnUsageAttributed === false
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -16,6 +16,7 @@ import { formatTimestamp } from "./context-rail-shared";
 import { formatTokenCount } from "./subagent-format";
 
 type PricingPanelProps = {
+  activeTurnId?: string;
   displayOptions?: PricingDisplayOptions;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   pricing?: {
@@ -932,6 +933,20 @@ function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
     line.status === "pending" &&
     line.cumulativeTotalTokens === undefined &&
     line.totalTokens >= 1_000_000
+  );
+}
+
+// The in-progress turn: the live, still-pending turn row whose id matches the
+// session's active turn. Drives the Live chip + running duration.
+function isActiveLiveTurnUsageLine(params: {
+  activeTurnId?: string;
+  line: PricingUsageLine;
+}): boolean {
+  return (
+    params.line.scope === "turn" &&
+    params.line.source === "live" &&
+    Boolean(params.activeTurnId) &&
+    params.line.turnId === params.activeTurnId
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -983,16 +983,21 @@ function formatUsageLineDuration(params: {
   now: number;
 }): string {
   const { isActive, line, now } = params;
+  const start = line.startedAt ?? line.createdAt;
+  // The active turn always shows its running clock: if it's wearing the Live
+  // chip, the duration must agree. Checked before the scope/estimate/historical
+  // guards because a live turn can trip isHistoricalUsageSummary (a >= 1M-token
+  // request with no cumulative snapshot yet), which would otherwise strand the
+  // Live chip with no ticking duration.
+  if (isActive) {
+    return formatRunningDurationMs(Math.max(0, now - start));
+  }
   if (
     line.scope === "monitor" ||
     isEstimatedUsageGap(line) ||
     isHistoricalUsageSummary(line)
   ) {
     return "";
-  }
-  const start = line.startedAt ?? line.createdAt;
-  if (isActive) {
-    return formatRunningDurationMs(Math.max(0, now - start));
   }
   const end = line.completedAt;
   if (end === undefined || end <= start) {

--- a/apps/desktop/src/renderer/src/lib/format-duration.ts
+++ b/apps/desktop/src/renderer/src/lib/format-duration.ts
@@ -1,0 +1,42 @@
+/**
+ * Human-readable duration formatting shared across the renderer.
+ *
+ * `formatDurationMs` renders a finished duration in the coarse
+ * `2h 3m 4s` / `1d 1h` style used on action-run cards and pricing
+ * turn-usage cards. `formatRunningDurationMs` is the live variant that
+ * floors to whole seconds (so a ticking clock never shows sub-second
+ * jitter) and renders `0s` at rest instead of an empty string.
+ *
+ * Lifted out of `EnvActionRunsView.tsx` so the pricing panel can reuse
+ * the exact same duration vocabulary without a feature-to-feature import.
+ */
+export function formatDurationMs(
+  ms?: number,
+  options?: { coarseAfterMinute?: boolean },
+): string {
+  if (!ms || !Number.isFinite(ms)) return "";
+  if (ms < 1_000) return `${Math.round(ms)}ms`;
+  const totalSeconds = Math.round(ms / 1_000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) {
+    if (options?.coarseAfterMinute) return `${totalMinutes}m`;
+    return seconds ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`;
+  }
+  const totalHours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (totalHours < 24) {
+    return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
+  }
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours ? `${days}d ${hours}h` : `${days}d`;
+}
+
+export function formatRunningDurationMs(ms?: number): string {
+  if (ms === undefined || !Number.isFinite(ms) || ms < 0) return "";
+  const totalSeconds = Math.floor(ms / 1_000);
+  if (totalSeconds < 1) return "0s";
+  return formatDurationMs(totalSeconds * 1_000);
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13000,6 +13000,32 @@ textarea,
   user-select: text;
 }
 
+/* The in-progress turn: a calm accent left-stripe + slightly firmer border,
+   reading as "live" without the background wash that would look like a
+   hover/selection state. Pairs with the Live chip in the card header. */
+.pricing-usage-row--active {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
+  box-shadow: inset 2px 0 0 0 var(--accent);
+}
+
+/* Title + Live chip share the top row; the title wraps/clamps while the
+   chip stays pinned to the right at its natural width. */
+.pricing-usage-row__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.pricing-usage-row__header .rail-card__title {
+  min-width: 0;
+}
+
+.pricing-usage-row__live {
+  flex: 0 0 auto;
+}
+
 .pricing-running-total {
   margin: 0;
   color: var(--text-secondary);

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -91,6 +91,14 @@ export type ThreadUsageLineRecord = {
   totalCostMicros: number;
   totalTokens: number;
   turnId?: string;
+  // Whether this row's token totals are a real measurement of THIS turn.
+  // Set by the live builder: `true` when usage was attributed to the turn (a
+  // per-turn delta or a per-request "last" snapshot), `false` when the builder
+  // had to fall back to a whole-thread/undecomposed total and the row is really
+  // a summary. `undefined` = not computed (hydration/backfill rows, or rows
+  // persisted before this field existed). The renderer treats `false` as a
+  // historical summary instead of guessing from raw token counts.
+  turnUsageAttributed?: boolean;
   uncachedInputCostMicros: number;
   uncachedInputTokens: number;
   usageLineId: string;


### PR DESCRIPTION
## Why

In the Pricing panel, the turn-usage card for the turn currently being billed looked identical to every settled card — nothing signaled "this is the active turn." And the cards showed *when* a turn happened but never *how long* it took. Two minute-resolution timestamps (start + stop) can't reconstruct a sub-minute turn anyway, so a duration is the thing that actually answers "how long."

## What changed

All three land on the turn-usage cards in `PricingPanel`:

1. **Active turn indicator.** The in-progress turn now renders a **Live** chip (accent dot, reusing the existing `.rail-chip` / `.rail-chip__dot--active` primitive) in the card header, plus a calm accent left-stripe on the card. It reads as "live" without a background wash that would look like a hover/selection state. This rides on the already-computed `activeTurnId` — no new data plumbing.

2. **Durations.** Each card shows a duration next to its start timestamp in the coarse `2h 3m 4s` vocabulary already used on action-run cards:
   - Finished turn → `completedAt − start`.
   - Live turn → a running clock that ticks once per second. The 1s interval only runs while a turn is actually active, so a settled panel never spins a timer.
   - Estimates / historical summaries / sub-agent rollups get no duration — those spans aren't a single measurable turn.

3. **One stamp, not two.** The card keeps a single start-anchored timestamp paired with the duration rather than adding a redundant stop stamp.

A card's time line now reads e.g. `Jul 4, 9:00 AM · 1m 47s · 019f2d36…`, and the live turn's duration ticks next to the Live chip.

## Refactor

`formatDurationMs` / `formatRunningDurationMs` moved from `EnvActionRunsView.tsx` into a new `lib/format-duration.ts` so the pricing panel reuses the exact same duration vocabulary without a feature-to-feature import. `EnvActionRunsView` re-exports them, so Composer and its tests are untouched.

## Testing

- `pnpm --filter @pwragent/desktop typecheck` — clean
- New `ThreadContextPanel` tests: one asserts the Live chip + running `1m 5s` on the active turn (fake-timer controlled), one asserts a finished `2m 5s` duration and *no* Live chip on a completed turn. Existing 41 pricing tests + 30 `EnvActionAnchorEntry` helper tests still pass (43 + 30 green).
- `pnpm lint:boundaries`, `pnpm lint:colors`, theme-contract test — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
