### PR TITLE
fix(desktop): stop forked threads re-billing inherited parent history

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12981,6 +12981,103 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("does not capture a fork baseline when an earlier turn was already observed", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-fork": {
+          backend: "codex",
+          threadId: "thread-fork",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+          forkSourceThreadId: "thread-parent",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    // Simulate turn-1 already having been observed (a persisted turn line)
+    // WITHOUT the fork baseline having been captured (e.g. the latch write was
+    // lost). The first turn we now observe is turn-2, whose total−latest folds
+    // turn-1's own usage — so no fork baseline may be fabricated.
+    await overlayStore.upsertThreadUsageLine({
+      line: {
+        backend: "codex",
+        usageLineId: "codex:thread-fork:turn-1:live-token-usage",
+        threadId: "thread-fork",
+        turnId: "turn-1",
+        scope: "turn",
+        source: "live",
+        status: "finalized",
+        model: "gpt-5.5",
+        currency: "USD",
+        inputTokens: 160_000,
+        cachedInputTokens: 159_104,
+        uncachedInputTokens: 896,
+        outputTokens: 6,
+        reasoningOutputTokens: 0,
+        totalTokens: 160_006,
+        priceStatus: "priced",
+        provider: "openai",
+        cachedInputCostMicros: 0,
+        uncachedInputCostMicros: 0,
+        outputCostMicros: 0,
+        totalCostMicros: 0,
+        createdAt: 1_800_000_000_000,
+      },
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-fork",
+        turnId: "turn-2",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 5_000,
+            cached_input_tokens: 4_992,
+            output_tokens: 7,
+            reasoning_output_tokens: 0,
+            total_tokens: 5_007,
+          },
+          total_token_usage: {
+            input_tokens: 18_966_393,
+            cached_input_tokens: 17_792_768,
+            output_tokens: 46_007,
+            reasoning_output_tokens: 9_979,
+            total_tokens: 19_022_379,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-fork",
+    });
+    expect(
+      pricing.lines.filter((line) => line.scope === "fork-baseline"),
+    ).toHaveLength(0);
+    // The guard latches so it will not keep re-checking on later turns.
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-fork",
+    });
+    expect(overlay?.forkBaselineCaptured).toBe(true);
+
+    await registry.close();
+  });
+
   it("persists Codex reviews as sub-agent summaries on the parent thread", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -478,6 +478,31 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadForkOrigin: async (settings: {
+      backend: "codex" | "grok";
+      threadId: string;
+      forkSourceThreadId?: string;
+      forkBaselineCaptured?: boolean;
+    }) => {
+      const key = `${settings.backend}:${settings.threadId}`;
+      const current = overlays.get(key) ?? {
+        backend: settings.backend,
+        threadId: settings.threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const forkSourceThreadId =
+        settings.forkSourceThreadId?.trim() || current.forkSourceThreadId;
+      const next = {
+        ...current,
+        ...(forkSourceThreadId ? { forkSourceThreadId } : {}),
+        ...(settings.forkBaselineCaptured !== undefined
+          ? { forkBaselineCaptured: settings.forkBaselineCaptured }
+          : {}),
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     setThreadCodexEnvironmentRuntime: async (settings: {
       backend: "codex" | "grok";
       threadId: string;
@@ -12760,6 +12785,198 @@ command = "pnpm dev"
       uncachedInputTokens: 800,
     });
     expect(pricing.lines[0]?.cumulativeTotalCostMicros).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("records inherited fork context as a zero-cost fork-baseline line, once", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-fork": {
+          backend: "codex",
+          threadId: "thread-fork",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+          // Marks this thread as a fork of thread-parent: its first observed
+          // `total` already includes the copied-in parent context.
+          forkSourceThreadId: "thread-parent",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    // First observed turn of the fork. `last` is this turn; `total` = inherited
+    // fork context + this turn.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-fork",
+        turnId: "turn-1",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 160_000,
+            cached_input_tokens: 159_104,
+            output_tokens: 6,
+            reasoning_output_tokens: 0,
+            total_tokens: 160_006,
+          },
+          total_token_usage: {
+            input_tokens: 18_961_393,
+            cached_input_tokens: 17_787_776,
+            output_tokens: 46_000,
+            reasoning_output_tokens: 9_979,
+            total_tokens: 19_017_372,
+          },
+        },
+      },
+    });
+
+    const afterTurn1 = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-fork",
+    });
+
+    const forkLines = afterTurn1.lines.filter(
+      (line) => line.scope === "fork-baseline",
+    );
+    expect(forkLines).toHaveLength(1);
+    // Inherited = total − last, priced at $0 (billed on the parent thread).
+    expect(forkLines[0]).toMatchObject({
+      scope: "fork-baseline",
+      source: "backfill",
+      status: "finalized",
+      priceStatus: "priced",
+      model: "gpt-5.5",
+      uncachedInputTokens: 1_172_721,
+      cachedInputTokens: 17_628_672,
+      outputTokens: 45_994,
+      reasoningOutputTokens: 9_979,
+      totalCostMicros: 0,
+      uncachedInputCostMicros: 0,
+      cachedInputCostMicros: 0,
+      outputCostMicros: 0,
+    });
+    expect(forkLines[0]?.cumulativeCachedInputTokens).toBeUndefined();
+
+    // The live turn line still records only this turn's own usage.
+    const turnLine = afterTurn1.lines.find((line) => line.scope === "turn");
+    expect(turnLine).toMatchObject({
+      turnId: "turn-1",
+      uncachedInputTokens: 896,
+      cachedInputTokens: 159_104,
+      outputTokens: 6,
+    });
+
+    const forkOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-fork",
+    });
+    expect(forkOverlay?.forkBaselineCaptured).toBe(true);
+
+    // A later turn must not create a second fork-baseline line.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-fork",
+        turnId: "turn-2",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 5_000,
+            cached_input_tokens: 4_992,
+            output_tokens: 7,
+            reasoning_output_tokens: 0,
+            total_tokens: 5_007,
+          },
+          total_token_usage: {
+            input_tokens: 18_966_393,
+            cached_input_tokens: 17_792_768,
+            output_tokens: 46_007,
+            reasoning_output_tokens: 9_979,
+            total_tokens: 19_022_379,
+          },
+        },
+      },
+    });
+
+    const afterTurn2 = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-fork",
+    });
+    expect(
+      afterTurn2.lines.filter((line) => line.scope === "fork-baseline"),
+    ).toHaveLength(1);
+
+    await registry.close();
+  });
+
+  it("does not record a fork-baseline line for non-fork threads", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    // A non-fork thread observed late: `total` far exceeds `last`, but there is
+    // no fork origin, so no fork-baseline line is invented.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-2",
+        tokenUsage: {
+          last_token_usage: {
+            input_tokens: 1_000,
+            cached_input_tokens: 200,
+            output_tokens: 50,
+            reasoning_output_tokens: 10,
+            total_tokens: 1_060,
+          },
+          total_token_usage: {
+            input_tokens: 11_000,
+            cached_input_tokens: 10_200,
+            output_tokens: 500,
+            reasoning_output_tokens: 100,
+            total_tokens: 11_600,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(
+      pricing.lines.filter((line) => line.scope === "fork-baseline"),
+    ).toHaveLength(0);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -492,6 +492,67 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       }),
     ]);
   });
+
+  it("persists the fork origin marker and round-trips a fork-baseline line", async () => {
+    await store.setThreadForkOrigin({
+      backend: "codex",
+      threadId: "thread-1",
+      forkSourceThreadId: "thread-parent",
+    });
+    let overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.forkSourceThreadId).toBe("thread-parent");
+    expect(overlay?.forkBaselineCaptured).toBeUndefined();
+
+    await store.setThreadForkOrigin({
+      backend: "codex",
+      threadId: "thread-1",
+      forkBaselineCaptured: true,
+    });
+    overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    // The fork source must survive a later capture-flag write.
+    expect(overlay?.forkSourceThreadId).toBe("thread-parent");
+    expect(overlay?.forkBaselineCaptured).toBe(true);
+
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        usageLineId: "codex:thread-1:fork-baseline",
+        scope: "fork-baseline",
+        source: "backfill",
+        sourceItemId: "fork-baseline",
+        turnId: undefined,
+        cachedInputTokens: 17_628_672,
+        uncachedInputTokens: 1_172_721,
+        inputTokens: 18_801_393,
+        outputTokens: 46_199,
+        reasoningOutputTokens: 9_979,
+        totalTokens: 18_847_592,
+        cachedInputCostMicros: 0,
+        uncachedInputCostMicros: 0,
+        outputCostMicros: 0,
+        totalCostMicros: 0,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const forkLine = pricing.lines.find(
+      (line) => line.scope === "fork-baseline",
+    );
+    expect(forkLine).toMatchObject({
+      scope: "fork-baseline",
+      cachedInputTokens: 17_628_672,
+      uncachedInputTokens: 1_172_721,
+      totalCostMicros: 0,
+    });
+  });
 });
 
 function buildUsageLine(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3330,6 +3330,78 @@ function buildLiveThreadUsageLine(params: {
   };
 }
 
+/**
+ * Build the zero-cost `scope: "fork-baseline"` line representing the context a
+ * thread inherited at its fork point. Carries the inherited token counts (so the
+ * renderer can show what was copied in and absorb it into accounted tokens,
+ * suppressing the invented "Historical usage estimate" gap) but no cost and no
+ * `cumulative*` fields — its cost was billed on the parent thread, not here.
+ * Returns undefined when there are no inherited tokens to attribute.
+ */
+function buildForkBaselineUsageLine(params: {
+  backend: AppServerBackendKind;
+  fastMode?: boolean;
+  inheritedTokenUsage: TaskMonitorTokenUsageBreakdown;
+  model?: string;
+  serviceTier?: string;
+  threadId: string;
+  usageTiming: { completedAt?: number; createdAt?: number; startedAt?: number };
+}): ThreadUsageLineRecord | undefined {
+  const {
+    cachedInputTokens,
+    inputTokens,
+    outputTokens,
+    reasoningOutputTokens,
+    totalTokens,
+    uncachedInputTokens,
+  } = normalizeTaskMonitorPricingTokens(params.inheritedTokenUsage);
+  if (
+    cachedInputTokens <= 0 &&
+    uncachedInputTokens <= 0 &&
+    outputTokens <= 0 &&
+    reasoningOutputTokens <= 0
+  ) {
+    return undefined;
+  }
+  // Sort just before the first live turn so the Fork point card renders at the
+  // base of the panel and its tokens are accounted before any turn's gap check.
+  const anchorAt =
+    params.usageTiming.startedAt ??
+    params.usageTiming.createdAt ??
+    params.usageTiming.completedAt ??
+    Date.now();
+  return {
+    backend: params.backend,
+    cachedInputCostMicros: 0,
+    cachedInputTokens,
+    createdAt: Math.max(0, anchorAt - 1),
+    currency: "USD",
+    ...(params.fastMode !== undefined ? { fastMode: params.fastMode } : {}),
+    inputTokens,
+    ...(params.model ? { model: params.model } : {}),
+    outputCostMicros: 0,
+    outputTokens,
+    // Known cost: $0 to this thread (billed on the parent). "priced" keeps it
+    // out of the unpriced-rows warning.
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens,
+    scope: "fork-baseline",
+    ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
+    settingsConfidence: params.model ? "fallback" : "unknown",
+    settingsSource: "thread-overlay",
+    source: "backfill",
+    sourceItemId: "fork-baseline",
+    status: "finalized",
+    threadId: params.threadId,
+    totalCostMicros: 0,
+    totalTokens,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens,
+    usageLineId: [params.backend, params.threadId, "fork-baseline"].join(":"),
+  };
+}
+
 function readTurnStatus(value: unknown): string | undefined {
   if (!value || typeof value !== "object" || !("status" in value)) {
     return undefined;
@@ -7903,6 +7975,16 @@ export class DesktopBackendRegistry {
               parentThreadId: request.parentThreadId,
             },
           },
+        });
+      }
+      // Record the fork origin so live-usage pricing knows this thread inherited
+      // a copied-in history from `sourceThreadId` and must not re-bill it. This
+      // is distinct from `parentThreadId` (an overloaded UI grouping marker).
+      if (request.sourceThreadId?.trim()) {
+        await this.overlayStore.setThreadForkOrigin?.({
+          backend,
+          threadId: result.threadId,
+          forkSourceThreadId: request.sourceThreadId,
         });
       }
       await this.updateThreadGitBranchMetadata({
@@ -12575,6 +12657,13 @@ export class DesktopBackendRegistry {
   }): {
     cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
     turnTokenUsage: TaskMonitorTokenUsageBreakdown | unknown;
+    /**
+     * The `total − latest` baseline, set only on the call that first seeds it
+     * for a `(thread, turn)`. For a fork's first observed turn this equals the
+     * context copied in at the fork point, which pricing captures as the
+     * inherited (never re-billed) fork baseline.
+     */
+    seededBaselineTokenUsage?: TaskMonitorTokenUsageBreakdown;
   } {
     const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
     if (!records) {
@@ -12596,6 +12685,7 @@ export class DesktopBackendRegistry {
       "live-token-usage",
     ].join(":");
     let baseline = this.liveThreadUsageBaselines.get(key);
+    let seededBaselineTokenUsage: TaskMonitorTokenUsageBreakdown | undefined;
     if (!baseline && records.latestUsage) {
       baseline = subtractTaskMonitorTokenUsage(
         records.totalUsage,
@@ -12603,6 +12693,7 @@ export class DesktopBackendRegistry {
       );
       if (baseline) {
         this.liveThreadUsageBaselines.set(key, baseline);
+        seededBaselineTokenUsage = baseline;
       }
     }
 
@@ -12616,6 +12707,7 @@ export class DesktopBackendRegistry {
         records.latestUsage ??
         records.currentUsage ??
         records.totalUsage,
+      ...(seededBaselineTokenUsage ? { seededBaselineTokenUsage } : {}),
     };
   }
 
@@ -12697,11 +12789,79 @@ export class DesktopBackendRegistry {
     if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
       logUnpricedThreadUsageLine(line);
       await this.overlayStore.upsertThreadUsageLine({ line });
+      await this.captureForkBaselineUsageLine({
+        backend: event.backend,
+        fastMode,
+        inheritedTokenUsage: derivedUsage.seededBaselineTokenUsage,
+        model,
+        overlay,
+        serviceTier,
+        threadId,
+        usageTiming,
+      });
       await this.emitThreadPricingUpdated({
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
       });
     }
+  }
+
+  /**
+   * On a fork's first observed turn, persist the context copied in at the fork
+   * point as a zero-cost `scope: "fork-baseline"` usage line. That inherited
+   * history was already billed on the parent thread; recording it as a real
+   * (but $0) line stops the renderer from inventing a priced "Historical usage
+   * estimate" gap for it and gives it an explicit "Fork point" card instead.
+   *
+   * Guarded to run at most once per fork via `forkBaselineCaptured`, and only
+   * for threads with a recorded `forkSourceThreadId` — non-fork threads (whose
+   * cumulative-vs-observed gaps are genuinely their own unobserved usage) are
+   * left untouched.
+   */
+  private async captureForkBaselineUsageLine(params: {
+    backend: AppServerBackendKind;
+    fastMode?: boolean;
+    inheritedTokenUsage?: TaskMonitorTokenUsageBreakdown;
+    model?: string;
+    overlay?: ThreadOverlayState;
+    serviceTier?: string;
+    threadId: string;
+    usageTiming: { completedAt?: number; createdAt?: number; startedAt?: number };
+  }): Promise<void> {
+    if (
+      !params.overlay?.forkSourceThreadId ||
+      params.overlay.forkBaselineCaptured ||
+      !params.inheritedTokenUsage ||
+      typeof this.overlayStore.upsertThreadUsageLine !== "function"
+    ) {
+      return;
+    }
+    const forkLine = buildForkBaselineUsageLine({
+      backend: params.backend,
+      fastMode: params.fastMode,
+      inheritedTokenUsage: params.inheritedTokenUsage,
+      model: params.model,
+      serviceTier: params.serviceTier,
+      threadId: params.threadId,
+      usageTiming: params.usageTiming,
+    });
+    if (!forkLine) {
+      // No inherited tokens to attribute (e.g. a fork with an empty parent
+      // context): nothing to show, but still latch the guard so we don't
+      // re-check every subsequent turn.
+      await this.overlayStore.setThreadForkOrigin?.({
+        backend: params.backend,
+        threadId: params.threadId,
+        forkBaselineCaptured: true,
+      });
+      return;
+    }
+    await this.overlayStore.upsertThreadUsageLine({ line: forkLine });
+    await this.overlayStore.setThreadForkOrigin?.({
+      backend: params.backend,
+      threadId: params.threadId,
+      forkBaselineCaptured: true,
+    });
   }
 
   private async recordCodexNativeSubAgentUsage(event: AgentEvent): Promise<void> {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12789,16 +12789,27 @@ export class DesktopBackendRegistry {
     if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
       logUnpricedThreadUsageLine(line);
       await this.overlayStore.upsertThreadUsageLine({ line });
-      await this.captureForkBaselineUsageLine({
-        backend: event.backend,
-        fastMode,
-        inheritedTokenUsage: derivedUsage.seededBaselineTokenUsage,
-        model,
-        overlay,
-        serviceTier,
-        threadId,
-        usageTiming,
-      });
+      // Best-effort: a failure here must never block the load-bearing pricing
+      // push below (the turn line is already persisted).
+      try {
+        await this.captureForkBaselineUsageLine({
+          backend: event.backend,
+          fastMode,
+          inheritedTokenUsage: derivedUsage.seededBaselineTokenUsage,
+          model,
+          overlay,
+          serviceTier,
+          threadId,
+          turnId: notification.params.turnId ?? undefined,
+          usageTiming,
+        });
+      } catch (error) {
+        backendRegistryLog.warn("fork-baseline usage capture failed", {
+          backend: event.backend,
+          threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       await this.emitThreadPricingUpdated({
         backend: event.backend,
         threadId: line.parentThreadId ?? line.threadId,
@@ -12826,6 +12837,7 @@ export class DesktopBackendRegistry {
     overlay?: ThreadOverlayState;
     serviceTier?: string;
     threadId: string;
+    turnId?: string;
     usageTiming: { completedAt?: number; createdAt?: number; startedAt?: number };
   }): Promise<void> {
     if (
@@ -12836,6 +12848,26 @@ export class DesktopBackendRegistry {
     ) {
       return;
     }
+
+    // The seeded baseline (`total − latest`) only equals the inherited fork
+    // context on the fork's FIRST observed turn. If this thread already has an
+    // observed turn line for a different turn, the baseline has folded this
+    // thread's own earlier usage into the "inherited" amount — capturing it
+    // would under-bill. Skip and latch (capturing on a later turn would be
+    // wrong too). This catches the observed-earlier-turn window; a fork whose
+    // first turn was never seen live still mis-attributes (known limitation).
+    if (
+      params.turnId &&
+      (await this.threadHasObservedTurnBefore({
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId: params.turnId,
+      }))
+    ) {
+      await this.latchForkBaselineCaptured(params.backend, params.threadId);
+      return;
+    }
+
     const forkLine = buildForkBaselineUsageLine({
       backend: params.backend,
       fastMode: params.fastMode,
@@ -12845,23 +12877,52 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       usageTiming: params.usageTiming,
     });
-    if (!forkLine) {
-      // No inherited tokens to attribute (e.g. a fork with an empty parent
-      // context): nothing to show, but still latch the guard so we don't
-      // re-check every subsequent turn.
-      await this.overlayStore.setThreadForkOrigin?.({
-        backend: params.backend,
-        threadId: params.threadId,
-        forkBaselineCaptured: true,
-      });
-      return;
+    // Persist the fork-baseline line when there are inherited tokens to
+    // attribute; a fork of an empty-context parent has none, but we still latch
+    // the guard below so we don't re-check every subsequent turn.
+    if (forkLine) {
+      await this.overlayStore.upsertThreadUsageLine({ line: forkLine });
     }
-    await this.overlayStore.upsertThreadUsageLine({ line: forkLine });
+    await this.latchForkBaselineCaptured(params.backend, params.threadId);
+  }
+
+  private async latchForkBaselineCaptured(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): Promise<void> {
     await this.overlayStore.setThreadForkOrigin?.({
-      backend: params.backend,
-      threadId: params.threadId,
+      backend,
+      threadId,
       forkBaselineCaptured: true,
     });
+  }
+
+  /**
+   * True when this thread already has a persisted turn usage line for a turn
+   * OTHER than `turnId`. Used to detect that a fork's first turn is not the one
+   * being observed now, so its inherited-context baseline can't be trusted.
+   * Only the thread's own lines count — rolled-up child/monitor lines
+   * (different `threadId`) are ignored.
+   */
+  private async threadHasObservedTurnBefore(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+  }): Promise<boolean> {
+    if (typeof this.overlayStore.readThreadPricing !== "function") {
+      return false;
+    }
+    const { lines } = await this.overlayStore.readThreadPricing({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    return lines.some(
+      (line) =>
+        line.threadId === params.threadId &&
+        line.scope === "turn" &&
+        Boolean(line.turnId) &&
+        line.turnId !== params.turnId,
+    );
   }
 
   private async recordCodexNativeSubAgentUsage(event: AgentEvent): Promise<void> {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2508,10 +2508,19 @@ function repriceOpenAiUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRec
   }
   // Fork-baseline lines carry inherited context that was billed on the parent
   // thread. Their cost is $0 to this thread by definition — never re-price them
-  // from their (large) inherited token counts.
+  // from their (large) inherited token counts. Strip catalog/rate/reason fields
+  // (as the normal repricing path does) so a $0 "priced" line never carries a
+  // stale rate id or priceUnavailableReason.
   if (line.scope === "fork-baseline") {
+    const {
+      priceUnavailableReason: _forkPriceUnavailableReason,
+      pricingCatalogId: _forkPricingCatalogId,
+      pricingCatalogVersion: _forkPricingCatalogVersion,
+      pricingRateId: _forkPricingRateId,
+      ...forkBaseLine
+    } = line;
     return {
-      ...line,
+      ...forkBaseLine,
       cachedInputCostMicros: 0,
       outputCostMicros: 0,
       priceStatus: "priced",

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1037,6 +1037,40 @@ export class SqliteOverlayStore {
   }
 
   /**
+   * Record that this thread was created by forking `forkSourceThreadId`, and/or
+   * flip the one-time `forkBaselineCaptured` guard once the fork-point
+   * inherited-usage line has been persisted. Pricing reads `forkSourceThreadId`
+   * as the authoritative "this thread inherited a copied-in history" signal so
+   * the fork-point context is never re-billed on the fork. See
+   * `ThreadOverlayState.forkSourceThreadId`.
+   */
+  async setThreadForkOrigin(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    forkSourceThreadId?: string;
+    forkBaselineCaptured?: boolean;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const forkSourceThreadId =
+      params.forkSourceThreadId?.trim() || current.forkSourceThreadId;
+    const nextState: ThreadOverlayState = {
+      ...current,
+      ...(forkSourceThreadId ? { forkSourceThreadId } : {}),
+      ...(params.forkBaselineCaptured !== undefined
+        ? { forkBaselineCaptured: params.forkBaselineCaptured }
+        : {}),
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  /**
    * Reorder pinned threads globally across backends. `threadKeys` is the
    * complete pinned order (thread identity keys); ranks are assigned by global
    * index so Codex and ACP pins interleave in any order. Unparseable keys are
@@ -2472,6 +2506,19 @@ function repriceOpenAiUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRec
   if (line.provider !== "openai") {
     return line;
   }
+  // Fork-baseline lines carry inherited context that was billed on the parent
+  // thread. Their cost is $0 to this thread by definition — never re-price them
+  // from their (large) inherited token counts.
+  if (line.scope === "fork-baseline") {
+    return {
+      ...line,
+      cachedInputCostMicros: 0,
+      outputCostMicros: 0,
+      priceStatus: "priced",
+      totalCostMicros: 0,
+      uncachedInputCostMicros: 0,
+    };
+  }
 
   const cost = estimateOpenAiTokenUsageCost({
     at: line.createdAt,
@@ -2684,6 +2731,7 @@ export type OverlayStoreLike = Pick<
   | "setThreadParent"
   | "setThreadAgent"
   | "setThreadHandoffOrigin"
+  | "setThreadForkOrigin"
   | "reorderThreadPins"
   | "updateSubthreadOrder"
   | "setSubthreadsCollapsed"

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -878,6 +878,153 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Running total: $0.049 list price · 1.2 Codex Credits")).toBeInTheDocument();
   });
 
+  it("shows a Fork point card and does not re-bill inherited fork context", () => {
+    // Inherited context copied in at the fork point. Its cost was billed on the
+    // parent thread — recorded here as a zero-cost fork-baseline line.
+    const forkBaselineLine: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-fork-baseline",
+      threadId: "thread-1",
+      scope: "fork-baseline",
+      source: "backfill",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 18_801_393,
+      uncachedInputTokens: 1_172_721,
+      cachedInputTokens: 17_628_672,
+      outputTokens: 46_199,
+      reasoningOutputTokens: 9_979,
+      totalTokens: 18_847_592,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 0,
+      cachedInputCostMicros: 0,
+      outputCostMicros: 0,
+      totalCostMicros: 0,
+      provider: "openai",
+      createdAt: 1_799_999_999_999,
+    };
+    const forkTurn1: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-fork-turn-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 159_821,
+      uncachedInputTokens: 717,
+      cachedInputTokens: 159_104,
+      outputTokens: 6,
+      reasoningOutputTokens: 0,
+      totalTokens: 159_827,
+      priceStatus: "priced",
+      currency: "USD",
+      // Cumulative already includes the inherited fork context.
+      cumulativeUncachedInputTokens: 1_173_438,
+      cumulativeCachedInputTokens: 17_787_776,
+      cumulativeInputTokens: 18_961_214,
+      cumulativeOutputTokens: 46_205,
+      cumulativeReasoningOutputTokens: 9_979,
+      cumulativeTotalTokens: 19_007_419,
+      uncachedInputCostMicros: 80_000,
+      cachedInputCostMicros: 4_000,
+      outputCostMicros: 6_000,
+      totalCostMicros: 90_000,
+      provider: "openai",
+      createdAt: 1_800_000_030_000,
+    };
+    const forkTurn2: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "line-fork-turn-2",
+      threadId: "thread-1",
+      turnId: "turn-2",
+      scope: "turn",
+      source: "live",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 159_802,
+      uncachedInputTokens: 154_810,
+      cachedInputTokens: 4_992,
+      outputTokens: 7,
+      reasoningOutputTokens: 0,
+      totalTokens: 159_809,
+      priceStatus: "priced",
+      currency: "USD",
+      cumulativeUncachedInputTokens: 1_328_248,
+      cumulativeCachedInputTokens: 17_792_768,
+      cumulativeInputTokens: 19_121_016,
+      cumulativeOutputTokens: 46_212,
+      cumulativeReasoningOutputTokens: 9_979,
+      cumulativeTotalTokens: 19_167_228,
+      uncachedInputCostMicros: 770_000,
+      cachedInputCostMicros: 2_000,
+      outputCostMicros: 8_000,
+      totalCostMicros: 780_000,
+      provider: "openai",
+      createdAt: 1_800_000_060_000,
+    };
+    // Persisted summary rolls the inherited tokens into INPUT (context size) but
+    // its $0 cost keeps the running total to the two real turns only.
+    const summary: ThreadPricingSummary = {
+      backend: "codex",
+      threadId: "thread-1",
+      currency: "USD",
+      inputTokens: 19_121_016,
+      uncachedInputTokens: 1_328_248,
+      cachedInputTokens: 17_792_768,
+      outputTokens: 46_212,
+      reasoningOutputTokens: 9_979,
+      totalTokens: 19_167_228,
+      totalCostMicros: 870_000,
+      usageLineCount: 3,
+      pricedUsageLineCount: 3,
+      unpricedUsageLineCount: 0,
+      provider: "openai",
+      updatedAt: 1_800_000_060_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [forkBaselineLine, forkTurn1, forkTurn2],
+        summaries: [summary],
+      },
+      pricingDisplayOptions: {
+        codexCredits: false,
+        usd: true,
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    // The inherited context renders as a "Fork point" card, not a priced
+    // "Historical usage estimate".
+    expect(screen.getByText("Fork point")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Historical usage estimate"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Inherited from parent thread — billed there, not re-charged here",
+      ),
+    ).toBeInTheDocument();
+    // The inherited token counts are still shown (attributed, not re-charged).
+    expect(
+      screen.getByText(
+        "1,172,721 uncached in · 17,628,672 cached · 46,199 out (9,979 reasoning)",
+      ),
+    ).toBeInTheDocument();
+    // INPUT reflects the full context, including inherited tokens.
+    expect(
+      screen.getByText("1,328,248 uncached, 17,792,768 cached"),
+    ).toBeInTheDocument();
+    // No fabricated cost for the inherited history anywhere in the panel.
+    expect(screen.queryByText(/estimated list price/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/includes estimates/)).not.toBeInTheDocument();
+  });
+
   it("inserts estimated historical gap rows from unexplained cumulative token jumps", () => {
     const firstObservedLine: ThreadUsageLineRecord = {
       backend: "codex",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -586,6 +586,11 @@ function formatUsageLineEstimates(params: {
   line: PricingUsageLine;
   lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
+  // Inherited fork context was billed on the parent thread — show the
+  // attribution, never a dollar figure, so it reads as not-re-charged here.
+  if (isForkBaselineLine(params.line)) {
+    return "Inherited from parent thread — billed there, not re-charged here";
+  }
   const estimates: string[] = [];
   if (params.displayOptions.usd) {
     estimates.push(
@@ -612,6 +617,11 @@ function formatUsageLineRunningTotal(params: {
   line: PricingUsageLine;
   lineTotals: PricingRunningLineTotals | undefined;
 }): string | undefined {
+  // The fork-point card carries no incremental cost, so a running-total row on
+  // it is noise — the attribution line already says it isn't charged here.
+  if (isForkBaselineLine(params.line)) {
+    return undefined;
+  }
   const estimates: string[] = [];
   if (params.displayOptions.usd && params.lineTotals?.runningCostMicros !== undefined) {
     estimates.push(
@@ -899,6 +909,9 @@ function formatUsageLineTitle(line: PricingUsageLine): string {
   if (line.scope === "monitor") {
     return "Sub-agent usage";
   }
+  if (isForkBaselineLine(line)) {
+    return "Fork point";
+  }
   if (isEstimatedUsageGap(line)) {
     return "Historical usage estimate";
   }
@@ -939,6 +952,10 @@ function formatUsageLineCreditSuffix(line: PricingUsageLine): string {
 
 function isEstimatedUsageGap(line: ThreadUsageLineRecord): boolean {
   return "estimatedUsageGap" in line && line.estimatedUsageGap === true;
+}
+
+function isForkBaselineLine(line: ThreadUsageLineRecord): boolean {
+  return line.scope === "fork-baseline";
 }
 
 function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
@@ -1075,6 +1092,11 @@ function estimateCodexCreditsForLine(line: PricingUsageLine):
     }
   | undefined {
   if (line.provider !== "openai") {
+    return undefined;
+  }
+  // Inherited fork context was billed on the parent thread; never estimate
+  // (and never accumulate) credits for it on the fork.
+  if (isForkBaselineLine(line)) {
     return undefined;
   }
   const estimate = estimateOpenAiCodexCreditUsage({

--- a/docs/plans/2026-07-04-001-fix-forked-thread-inherited-usage-pricing-plan.md
+++ b/docs/plans/2026-07-04-001-fix-forked-thread-inherited-usage-pricing-plan.md
@@ -169,6 +169,31 @@ into the persisted summary). Fixed by exempting `scope: "fork-baseline"` lines
 from repricing (always $0, priced). Caught by the sqlite round-trip test; the
 main-process test uses a non-repricing mock store and did not surface it.
 
+## Review follow-ups (applied)
+
+Multi-agent review of PR #936 surfaced fixes applied in a follow-up commit:
+
+- **First-turn guard.** `captureForkBaselineUsageLine` now skips (and latches)
+  when the thread already has an observed turn line for a *different* turn
+  (`threadHasObservedTurnBefore`) — the seeded `total − latest` baseline only
+  equals the inherited context on the fork's genuine first turn. Covers the
+  observed-earlier-turn-but-latch-not-yet-written window; the never-observed
+  first turn remains a limitation (below).
+- **Capture can't block the emit.** The capture call in `recordLiveThreadUsage`
+  is wrapped in try/catch so a fork-line persist failure no longer suppresses
+  the load-bearing `thread/pricing/updated` push for the already-persisted turn.
+- **Repricing strip parity.** The `scope: "fork-baseline"` exemption in
+  `repriceOpenAiUsageLine` now strips `pricingCatalogId`/`pricingRateId`/
+  `pricingCatalogVersion`/`priceUnavailableReason` like the normal path, so a
+  $0 "priced" line never carries a stale rate id or unavailable-reason.
+- **Latch dedupe.** The `forkBaselineCaptured` write is a single
+  `latchForkBaselineCaptured` helper instead of a copy-pasted branch.
+
+Deferred (not fragile enough to warrant the churn now): generalizing the
+scattered `isForkBaselineLine` renderer dispatch + scope-literal reprice gate
+into one `carriesOwnCost`/`noReprice` predicate; the persisted-summary token
+inflation (no consumer beyond PricingPanel reads those fields today).
+
 ## Known limitation
 
 If the app first observes a fork at turn N>1 (fork's earlier turns never watched

--- a/docs/plans/2026-07-04-001-fix-forked-thread-inherited-usage-pricing-plan.md
+++ b/docs/plans/2026-07-04-001-fix-forked-thread-inherited-usage-pricing-plan.md
@@ -1,0 +1,177 @@
+# Fix: forked threads must not re-bill inherited parent history
+
+- **Date:** 2026-07-04
+- **Status:** implemented (tests green: typecheck, boundaries, sql/color/codex-storage lints, backend-registry + overlay-store-usage-pricing + ThreadContextPanel suites)
+- **Branch:** `claude/pensive-bohr-428965`
+- **Area:** `desktop` / `agent-core` pricing (`PricingPanel`, `BackendRegistry` live token usage)
+
+## Problem
+
+A thread forked from another thread shows a fabricated **"Historical usage
+estimate"** cost for the context copied in at the fork point. Real screenshot
+(codex backend, `gpt-5.5`):
+
+- `Historical usage estimate` — `1,172,721 uncached in · 17,628,672 cached ·
+  46,199 out (9,979 reasoning)` — **`$16.37 estimated list price`** — running
+  total `$16.37 (includes estimates)`.
+- Two genuine live `Turn usage` rows for the two turns actually run in the fork
+  (`$0.084` and `$0.78`).
+
+That `$16.37` block is the **parent thread's history copied into the fork at the
+fork point**. It was already billed on the original thread. We must not invent a
+cost for it on the fork.
+
+Repro thread id: `019f2d5a-c460-73f0-9f50-fba94f37eb1c` (forked, then ran 2
+turns). Protocol capture (PII — do **not** commit):
+`apps/desktop/.local/protocol-captures/2026-07-04T13-38-46-782Z-codex-default.jsonl`.
+
+Math that confirms it: the fork's first observed cumulative `total.input` ≈
+19,121,016, `total.cached` = 17,792,768. The "historical estimate" gap =
+cumulative total − the two observed live turns:
+`1,328,248 − 717 − 154,810 = 1,172,721` uncached;
+`17,792,768 − 159,104 − 4,992 = 17,628,672` cached — exactly the forked-in
+parent history.
+
+## Root cause
+
+Two collaborating facts:
+
+1. **Main process** (`apps/desktop/src/main/app-server/backend-registry.ts`,
+   `deriveLiveThreadTokenUsage` ~L12570): the per-turn baseline is seeded as
+   `total − latest` on the first observed `thread/tokenUsage/updated`. For a
+   fork, the very first `total` already contains the whole copied-in parent
+   context, so the per-turn split is *correct* but the cumulative `total`
+   stamped onto the live usage line (`cumulative*` fields) is inflated by the
+   inherited history.
+2. **Renderer** (`.../context-panels/PricingPanel.tsx`,
+   `buildPricingDisplayLines` ~L204): for the first main-thread line it computes
+   `gapTokens = cumulativeTokens − (accountedMainTokens + lineTokens)` and, when
+   non-empty, prices it via `buildEstimatedHistoricalGapLine` (~L499) tagged
+   `estimatedUsageGap` → "Historical usage estimate". For a fork the gap is the
+   entire inherited history, and it gets priced as this thread's cost.
+
+The renderer cannot tell "history this thread paid for but we didn't watch live"
+(keep estimating) from "history inherited at a fork point" (do not charge). It
+has no fork signal, and `parentThreadId` on the thread is **overloaded**
+(fork, `startThread` grouping, manual reparent, sub-agent rollup), so it is not
+a reliable fork discriminator on its own.
+
+## Fix strategy — mark the fork baseline as data
+
+Prefer fixing the data over a renderer heuristic. Persist the fork-point
+inherited context as a real, **zero-cost** usage line so the renderer both (a)
+stops inventing a priced gap and (b) has an explicit thing to render as a "Fork
+point" card.
+
+### 1. Persist a fork-origin marker on the forked thread
+
+`ThreadOverlayState` is stored as a JSON `payload` blob (no column migration
+needed). Add:
+
+- `forkSourceThreadId?: ThreadIdentifier` — the thread this fork was created
+  from. Set **only** by `forkThread` (unambiguous fork signal, distinct from the
+  overloaded grouping `parentThreadId`).
+- `forkBaselineCaptured?: boolean` — set true once we've persisted the
+  fork-baseline line, so we capture it exactly once and it survives restart.
+
+`BackendRegistry.forkThread` (~L7891) already writes several overlay fields
+after the Codex `thread/fork` RPC; add one write recording
+`forkSourceThreadId = request.sourceThreadId`.
+
+### 2. Capture the inherited baseline from the fork's own first turn
+
+Measuring from the fork's own first `total − latest` is more robust than reading
+the parent's cumulative (which may be missing/untracked, and Codex compacts
+history on fork with `excludeTurns`/`persistExtendedHistory:false`).
+
+- `deriveLiveThreadTokenUsage` returns the freshly-seeded baseline
+  (`total − latest`) when — and only when — it seeds it on this call.
+- In `recordLiveThreadUsage`, when the thread overlay has `forkSourceThreadId`
+  and **not** `forkBaselineCaptured`, and a baseline was just seeded, build and
+  upsert a **fork-baseline usage line** and mark `forkBaselineCaptured`.
+
+Fork-baseline line shape (`buildForkBaselineUsageLine`):
+- `scope: "fork-baseline"` (new union value; `scope` is plain `TEXT`, no CHECK —
+  round-trips with no migration).
+- `source: "backfill"`, `status: "finalized"`, stable
+  `usageLineId: "fork-baseline:<threadId>"`.
+- token fields = inherited breakdown (`total − latest`), **no `cumulative*`
+  fields** (so the renderer computes no gap for it).
+- all cost micros `0`, `priceStatus: "priced"` (known cost = $0 to this thread;
+  keeps it out of the unpriced warning).
+- `parentThreadId` left **unset** so the line rolls up under the fork's own id,
+  not into the fork's grouping parent.
+- `createdAt` = just before the first turn so it sorts oldest.
+
+### 3. Renderer: render the fork-baseline line, stop inventing the gap
+
+Because the fork-baseline line is a real "main" line whose tokens land in
+`accountedMainTokens` before the first live turn, the first turn's
+`gapTokens` collapses to 0 → no "Historical usage estimate". Then:
+
+- `formatUsageLineTitle` → `"Fork point"` for `scope === "fork-baseline"`
+  (checked before the historical-summary/estimate branches).
+- `formatUsageLineEstimates` → attribution copy for fork-baseline lines instead
+  of a `$` figure, e.g. *"Inherited from parent thread — billed there, not
+  re-charged here."* The token breakdown line already prints the inherited
+  `… uncached in · … cached · … out` counts (requirement 3).
+- Suppress the running-total row for the fork-baseline line (its incremental
+  cost is $0).
+
+### 4. Non-fork threads unaffected
+
+Non-fork threads never get `forkSourceThreadId`, so no fork-baseline line is
+persisted, so a genuine cumulative-vs-observed gap still surfaces as today's
+"Historical usage estimate". (Requirement 4.)
+
+## Files to touch
+
+- `packages/shared/src/token-usage-pricing.ts` — add `"fork-baseline"` to
+  `ThreadUsageLineScope`.
+- `packages/shared/src/contracts/navigation.ts` — add `forkSourceThreadId`,
+  `forkBaselineCaptured` to `ThreadOverlayState`.
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts` +
+  `OverlayStoreLike` interface — `recordThreadForkOrigin` /
+  `setThreadForkBaselineCaptured` (JSON payload writes; optional methods).
+- `apps/desktop/src/main/app-server/backend-registry.ts` — set fork origin in
+  `forkThread`; surface seeded baseline from `deriveLiveThreadTokenUsage`; build
+  + persist fork-baseline line in `recordLiveThreadUsage`;
+  `buildForkBaselineUsageLine` helper.
+- `apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx`
+  — fork-baseline title / estimate / running-total handling.
+
+## Tests (synthetic fixtures only — no PII capture)
+
+- **Renderer** (`ThreadContextPanel.test.tsx` pricing tab): a fork-baseline line
+  + two turn lines whose cumulative totals include the inherited block →
+  asserts a "Fork point" card, **no** "Historical usage estimate", running total
+  excludes the inherited cost, INPUT still reflects inherited tokens.
+- **Renderer regression**: a non-fork thread with a real cumulative-vs-observed
+  gap still renders "Historical usage estimate" (requirement 4).
+- **Main process** (`backend-registry.test.ts`): drive `thread/fork` then a
+  synthetic `thread/tokenUsage/updated` carrying `total`/`last` shaped like the
+  capture; assert exactly one persisted `scope: "fork-baseline"` line with the
+  inherited breakdown, zero cost, and `forkBaselineCaptured` set; a second turn
+  does not create a second fork-baseline line.
+
+## Coordination
+
+Sibling branch `plan/observed-context-replay-counting` also edits `PricingPanel`
+(cold/hot replay bucket). This fork fix is independent; keep edits localized to
+the fork-baseline title/estimate/running-total helpers to minimize conflict.
+
+## Resolved during implementation
+
+`OverlayStoreSqlite.upsertThreadUsageLine` runs every openai line through
+`repriceOpenAiUsageLine`, which recomputes cost from token counts — it would
+have re-inflated the fork-baseline line's $0 back to ~$16 on persist (and thus
+into the persisted summary). Fixed by exempting `scope: "fork-baseline"` lines
+from repricing (always $0, priced). Caught by the sqlite round-trip test; the
+main-process test uses a non-repricing mock store and did not surface it.
+
+## Known limitation
+
+If the app first observes a fork at turn N>1 (fork's earlier turns never watched
+live), the captured baseline folds those earlier own-turns into the inherited
+amount (under-billing them). Forks normally run immediately after creation, so
+turn 1 is observed; documented, not handled.

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1130,6 +1130,21 @@ export type ThreadOverlayState = {
    * access to the parent transcript or state.
    */
   parentThreadId?: ThreadIdentifier;
+  /**
+   * Set only when this thread was created by forking another thread
+   * (`thread/fork`). Records the source thread the fork inherited its context
+   * from. Distinct from `parentThreadId`, which is an overloaded UI grouping
+   * marker also set by `startThread` grouping, manual reparent, and sub-agent
+   * rollup. Pricing uses this as the authoritative "this thread inherited a
+   * copied-in history" signal so the fork-point context is not re-billed here.
+   */
+  forkSourceThreadId?: ThreadIdentifier;
+  /**
+   * True once the fork-point inherited-usage line (`scope: "fork-baseline"`)
+   * has been persisted for this fork. Guards one-time capture of the inherited
+   * baseline across restarts. Only meaningful when `forkSourceThreadId` is set.
+   */
+  forkBaselineCaptured?: boolean;
   /** Child thread ids in user-curated order, stored on the parent. */
   subthreadOrder?: ThreadIdentifier[];
   /** Persisted disclosure state for the parent's child section. */

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -33,7 +33,11 @@ export type ThreadUsageLineScope =
   | "latest-request"
   | "total"
   | "monitor"
-  | "backfill";
+  | "backfill"
+  // Context a thread inherited at a fork point. Its cost was already billed on
+  // the parent thread, so a fork-baseline line carries the inherited token
+  // counts but zero cost — it is shown as a "Fork point" card, never re-charged.
+  | "fork-baseline";
 
 export type ThreadUsageLineStatus = "pending" | "finalized" | "superseded";
 


### PR DESCRIPTION
## What & why

A thread forked from another thread showed a fabricated **"Historical usage estimate"** cost (e.g. `$16.37`) for the context copied in at the fork point. That history was already billed on the parent thread — the fork must not re-charge it.

**Root cause.** `PricingPanel` prices the gap between a thread's cumulative `total` and its observed live turns. On a fork the first `total` already contains the whole inherited parent context, so `gap = all of parent history` and it gets priced as this thread's cost. The renderer had no fork signal, and `parentThreadId` is overloaded (UI grouping, manual reparent, sub-agent rollup) so it can't discriminate forks.

The arithmetic matches the real (PII, not committed) capture: `1,328,248 − 717 − 154,810 = 1,172,721` uncached and `17,792,768 − 159,104 − 4,992 = 17,628,672` cached — exactly the forked-in parent history.

## The fix — mark the fork baseline as data, don't guess in the renderer

1. **Record the fork origin.** `forkThread` writes `forkSourceThreadId` on the fork's overlay (the unambiguous fork signal) plus a one-time `forkBaselineCaptured` guard. Overlay state is a JSON blob → **no sqlite migration**.
2. **Persist the inherited context as a real, zero-cost line.** On the fork's first observed turn, the main process persists `total − latest` as a new `scope: "fork-baseline"` usage line: inherited token counts, **$0 cost**, priced. Its tokens absorb the renderer's gap so no estimate is invented. The new scope value round-trips as plain `TEXT` → **no migration**.
3. **Don't let the store re-price it.** Exempted `scope: "fork-baseline"` lines from `repriceOpenAiUsageLine`, which otherwise re-derives ~$16 from the inherited tokens on persist (caught by the sqlite round-trip test).
4. **Render a "Fork point" card.** Shows the inherited tokens attributed to the parent (*"billed there, not re-charged here"*), with no dollar figure, running total, or Codex-credit estimate.

**Non-fork threads are unaffected** — a genuine cumulative-vs-observed gap still surfaces as today's "Historical usage estimate" (existing renderer tests still pass).

## Files

- `packages/shared/src/token-usage-pricing.ts` — add `"fork-baseline"` scope
- `packages/shared/src/contracts/navigation.ts` — `forkSourceThreadId`, `forkBaselineCaptured` on `ThreadOverlayState`
- `apps/desktop/src/main/app-server/backend-registry.ts` — record fork origin; surface seeded baseline; capture + build the fork-baseline line
- `apps/desktop/src/main/state/overlay-store-sqlite.ts` — `setThreadForkOrigin`; repricing exemption
- `apps/desktop/src/renderer/.../PricingPanel.tsx` — Fork-point title / attribution / suppress cost + credits

## Tests (synthetic fixtures, no PII capture)

- Main process: fork captures exactly one zero-cost fork-baseline line, once; a non-fork thread with a large gap gets none.
- Sqlite: fork marker persists and the fork-baseline line round-trips at $0.
- Renderer: "Fork point" card renders, no "Historical usage estimate", no fabricated cost, INPUT still reflects inherited tokens.

Verified: `typecheck` (shared + desktop), `lint:boundaries`, `lint:sql`, `lint:colors`, `lint:codex-storage`, and the three affected suites (402 tests) all green.

## Reviewer notes

- **Known limitation:** if a fork's *first* turn is never observed live (app started watching at turn N>1), the captured baseline folds those earlier own-turns into the inherited amount. Forks normally run immediately after creation, so this is rare — documented in the plan.
- Sibling branch `plan/observed-context-replay-counting` also edits `PricingPanel` (cold/hot replay bucket). This fix is independent; edits were kept confined to the fork-baseline title/estimate/running-total/credits helpers to minimize conflict.
- Plan doc: `docs/plans/2026-07-04-001-fix-forked-thread-inherited-usage-pricing-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)