### PR TITLE
docs: codify no-Prettier policy and how to use ESLint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,48 @@
 - To regenerate the README screenshots under `docs/assets/screenshots/`, run `pnpm --filter @pwragent/desktop screenshot:readme`. The full walkthrough (spec, fixtures, state-seeding helpers, native capture utilities) lives in [apps/desktop/AGENTS.md](apps/desktop/AGENTS.md) under "Capturing README Screenshots". macOS Screen Recording permission is required for whichever terminal/IDE runs the spec.
 - When focusing root Vitest runs through `pnpm test`, pass file paths or filters directly, for example `pnpm test packages/agent-core/src/__tests__/overlay-store.test.ts`. Do not insert a standalone `--` before the focus args; `pnpm test -- packages/...` makes Vitest run the full workspace suite.
 
+## Code Formatting & Linting
+
+**There is a linter (ESLint) but no autoformatter — and that split is
+deliberate. Run ESLint; hand-format; never run Prettier.**
+
+- **ESLint is adopted — as a correctness linter, not a formatter.** Run
+  `pnpm lint:eslint` (CI's `Lint` job runs it too, alongside `lint:sql`,
+  `lint:codex-storage`, `lint:colors`, `licenses:check`, `typecheck`, and
+  `lint:boundaries`). The config is [`eslint.config.mjs`](eslint.config.mjs):
+  typescript-eslint recommended + classic react-hooks (scoped to the renderer),
+  **no stylistic rules**. Fix the errors it reports. A block of pre-existing
+  findings (`no-explicit-any`, `exhaustive-deps`, and intentional patterns) is
+  set to `warn` as a burn-down baseline — CI blocks on errors, not warnings.
+  Do NOT add stylistic/whitespace rules and do NOT run `eslint --fix` to
+  reformat code: formatting is not ESLint's job here.
+- **Prettier is deliberately absent.** No dependency, no `.prettierrc`, no
+  `format` script, no CI formatting step. **Never run `npx prettier` or
+  `prettier --write` on repo files.** Because no config is committed, `npx`
+  downloads Prettier and applies its built-in defaults, which fight this repo's
+  hand-maintained house style and reformat large spans of untouched code. On
+  PR #934 a single `npx prettier --write` on one file rewrote ~90 unrelated
+  lines around a 3-line change, bloating the diff and muddying `git blame`. A
+  full-tree Prettier reformat was evaluated (it touched ~77% of files) and
+  declined; don't reintroduce it ad hoc.
+- **Match the surrounding code by hand.** The house style (verify against
+  neighbors, don't assume): double quotes, 2-space indent, semicolons, trailing
+  commas on multi-line literals, and **leading binary operators** on wrapped
+  expressions — the operator starts the continuation line:
+
+  ```ts
+  const ok =
+    isAllowed(char)
+    || SAFE_PUNCTUATION.has(char)
+    || isDigit(char);
+  ```
+
+  Prettier's default flips these to trailing operators; there are 500+ leading-
+  operator lines in the tree, so a default run is pure churn. Format new code to
+  look like its neighbors.
+- Keep diffs scoped to your actual change. If a file is already inconsistent,
+  leave the untouched lines alone rather than "tidying" them.
+
 ## Agent Instruction Files
 
 - Keep a sibling `CLAUDE.md` symlink next to every `AGENTS.md`, pointing at that `AGENTS.md`, so Codex and Claude read the same local guidance.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -24,6 +24,18 @@ The desktop style guide defines:
 - copy rules
 - anti-patterns
 
+## Code Formatting & Linting
+
+ESLint is the correctness linter — run `pnpm lint:eslint` (CI runs it too) and
+fix its errors; **don't run `eslint --fix` to reformat**. There is no
+autoformatter by design: **never run Prettier (`npx prettier` /
+`prettier --write`)** on a renderer or main-process file — no config is
+committed, so `npx` applies tool defaults that fight the hand-maintained house
+style (notably leading binary operators) and reformat untouched code. Match the
+surrounding file by hand. See "Code Formatting & Linting" in the
+[repo-root `AGENTS.md`](../../AGENTS.md) for the full rule and the house-style
+summary.
+
 ## Non-Negotiables
 
 - Inbox, Recents, and Directories live in one thread lens switch; Inbox is the


### PR DESCRIPTION
## What

Updates the agent guidance (root `AGENTS.md` + `apps/desktop/AGENTS.md`, mirrored via the `CLAUDE.md` symlinks) to reflect the decision the team actually landed on: **ESLint adopted as a correctness linter (#940, merged), Prettier deliberately declined.**

Originally this PR banned *both* Prettier and ESLint ("no autoformatter, don't run either"). Since #940 merged, that framing is factually wrong — there's now an `eslint.config.mjs`, an `eslint` dependency, a `lint:eslint` script, and an ESLint step in CI's `Lint` job. This rewrite corrects it.

## The policy now

- **ESLint (adopted, correctness-only):** run `pnpm lint:eslint` (CI runs it too), fix its errors, don't `eslint --fix` to reformat, don't add stylistic rules.
- **Prettier (declined):** never `npx prettier` / `prettier --write`; the full-tree reformat was evaluated (touched ~77% of files) and rejected. Hand-format to the house style — double quotes, 2-space indent, semicolons, trailing commas, **leading binary operators** (with the worked example kept from the original).
- Keeps the #934 anecdote (an `npx prettier --write` that rewrote ~90 unrelated lines) as the cautionary tale.

## Notes

- Docs-only; no tooling/CI change here (that shipped in #940).
- Rebased onto current `main` (post-#940). The `CLAUDE.md` symlinks are intact and pick up both edits.
- Supersedes the earlier "ban both" version of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)