### PR TITLE
refactor(desktop): replace the 1M-token pricing summary heuristic with an explicit scope

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -492,6 +492,61 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       }),
     ]);
   });
+
+  it("reclassifies legacy live summary rows to scope 'total' on migration", async () => {
+    // A pre-cumulative-snapshot whole-thread total that landed as a live/pending
+    // "turn" row. It should be reclassified; a modern turn (has cumulative) and a
+    // sub-1M live turn should not.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-legacy",
+        usageLineId: "legacy-summary",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cumulativeTotalTokens: 2_000_000,
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-modern",
+        usageLineId: "modern-turn",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 500_000,
+        turnId: "turn-small",
+        usageLineId: "small-live-turn",
+      }),
+    });
+
+    // Force the user_version 24 migration to run against the seeded rows, then
+    // reassign the module handle so afterEach closes the reopened db.
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.pragma("user_version = 23");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+
+    const scopeById = new Map(
+      (
+        stateDb.raw
+          .prepare("SELECT usage_line_id, scope FROM thread_usage_lines")
+          .all() as { usage_line_id: string; scope: string }[]
+      ).map((row) => [row.usage_line_id, row.scope]),
+    );
+    expect(scopeById.get("legacy-summary")).toBe("total");
+    expect(scopeById.get("modern-turn")).toBe("turn");
+    expect(scopeById.get("small-live-turn")).toBe("turn");
+  });
 });
 
 function buildUsageLine(

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 23;
+export const CURRENT_STATE_DB_USER_VERSION = 24;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -819,6 +819,12 @@ export class StateDb {
         // the same column/index also live in AUTOMATION_SCHEMA so
         // re-instantiated dbs converge.
         ensureAutomationRunSourceEventKey(db);
+        db.pragma("user_version = 23");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 24) {
+      db.transaction(() => {
+        reclassifyLegacyThreadUsageSummaries(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1353,6 +1359,31 @@ WHERE source = 'live'
     WHERE thread_usage_turns.usage_turn_id = thread_usage_lines.usage_turn_id
       AND thread_usage_turns.observed_at < thread_usage_lines.created_at
   )
+`);
+}
+
+// One-time reclassification of pre-cumulative-snapshot ledger rows. Before the
+// protocol carried per-turn cumulative breakdowns, a whole-thread usage total
+// could land as a single live/pending row scoped as a "turn". The renderer used
+// to re-detect these on every paint with a `total_tokens >= 1M` heuristic, which
+// also misfired on legitimately large modern turns. These legacy rows are a
+// finite, static set already in the ledger, so we fix the data once here: mark
+// them scope 'total' (the structural "historical summary" scope) and drop the
+// render-time guess. Modern turns carry cumulative_total_tokens and are left
+// untouched; the token threshold only ever runs against this closed legacy set.
+function reclassifyLegacyThreadUsageSummaries(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_lines")) {
+    return;
+  }
+
+  db.exec(`
+UPDATE thread_usage_lines
+SET scope = 'total'
+WHERE source = 'live'
+  AND status = 'pending'
+  AND scope = 'turn'
+  AND cumulative_total_tokens IS NULL
+  AND total_tokens >= 1000000
 `);
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1449,7 +1449,10 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Sub-agent usage")).toBeInTheDocument();
   });
 
-  it("labels legacy live rows without cumulative context as historical summaries", () => {
+  it("labels whole-thread total rows as historical summaries", () => {
+    // The scope 'total' shape a legacy live/pending summary is migrated into
+    // (state-db user_version 24), and the shape hydration emits for a
+    // whole-thread total. Classified as historical purely by scope.
     renderPanel({
       activeTab: "pricing",
       pinned: true,
@@ -1468,9 +1471,9 @@ describe("ThreadContextPanel", () => {
             priceStatus: "priced",
             provider: "openai",
             reasoningOutputTokens: 37_030,
-            scope: "turn",
-            source: "live",
-            status: "pending",
+            scope: "total",
+            source: "hydration",
+            status: "finalized",
             threadId: "thread-1",
             totalCostMicros: 55_830_000,
             totalTokens: 73_473_538,
@@ -1506,6 +1509,50 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Historical usage summary")).toBeInTheDocument();
     expect(screen.getByText("$55.83 list price")).toBeInTheDocument();
     expect(screen.queryByText("$55.83 list price this turn")).not.toBeInTheDocument();
+  });
+
+  it("treats a large live turn as a turn, not a historical summary", () => {
+    // A genuine turn-scoped live row is a turn regardless of size — no
+    // token-count heuristic reclassifies it. (Previously a >= 1M-token live
+    // row without cumulative context was mislabeled "Historical usage summary".)
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 7_000_000,
+            cachedInputTokens: 70_463_104,
+            createdAt: 1_800_000_000_000,
+            currency: "USD",
+            inputTokens: 73_251_863,
+            model: "gpt-5.5",
+            outputCostMicros: 42_000_000,
+            outputTokens: 221_675,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 37_030,
+            scope: "turn",
+            source: "live",
+            status: "pending",
+            threadId: "thread-1",
+            totalCostMicros: 55_830_000,
+            totalTokens: 73_473_538,
+            turnId: "turn-big-live",
+            uncachedInputCostMicros: 6_830_000,
+            uncachedInputTokens: 2_788_759,
+            usageLineId: "line-big-live",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("Turn usage")).toBeInTheDocument();
+    expect(screen.queryByText("Historical usage summary")).not.toBeInTheDocument();
+    expect(screen.getByText("$55.83 list price this turn")).toBeInTheDocument();
   });
 
   it("hides the hover rail when document mouse movement resumes outside the rail", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -941,16 +941,13 @@ function isEstimatedUsageGap(line: ThreadUsageLineRecord): boolean {
   return "estimatedUsageGap" in line && line.estimatedUsageGap === true;
 }
 
+// A usage line is a whole-thread/historical summary purely by its scope. Legacy
+// pre-cumulative live rows that once needed a `total_tokens >= 1M` heuristic are
+// reclassified to scope 'total' by the state-db migration (user_version 24), so
+// the renderer never re-guesses a summary from raw token counts — which would
+// also misclassify a legitimately large live turn.
 function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
-  if (line.scope === "total" || line.scope === "backfill") {
-    return true;
-  }
-  return (
-    line.source === "live" &&
-    line.status === "pending" &&
-    line.cumulativeTotalTokens === undefined &&
-    line.totalTokens >= 1_000_000
-  );
+  return line.scope === "total" || line.scope === "backfill";
 }
 
 function PricingUsageTimestamp(props: {


### PR DESCRIPTION
## Why

`isHistoricalUsageSummary` classified a pricing usage line as a whole-thread summary with a magic-number heuristic:

```ts
line.source === "live" && line.status === "pending" &&
line.cumulativeTotalTokens === undefined && line.totalTokens >= 1_000_000
```

Two problems:
1. **It re-guesses on every render.** The classification is derived from raw token counts each paint, forever.
2. **The threshold is aging badly.** It was safe when turns rarely crossed 1M tokens, but large cached contexts routinely push a *single legitimate turn* past 1M now — so an active turn could get labeled "Historical usage summary" (and, in the durations work, wear a Live chip with no clock).

The rows the heuristic actually exists for are **legacy**: they were persisted before the Codex protocol carried per-turn cumulative snapshots, so a whole-thread total landed as one `live`/`pending` row scoped as a `turn`. That's a **finite, static set already sitting in the sqlite ledger** — not something new writes produce (modern live rows carry `cumulative_total_tokens`).

## What changed

Fix the data once instead of guessing on every render:

- **`state-db` migration (`user_version` 24)** — `reclassifyLegacyThreadUsageSummaries` runs a one-shot `UPDATE` marking legacy rows (`source='live' AND status='pending' AND scope='turn' AND cumulative_total_tokens IS NULL AND total_tokens >= 1000000`) to `scope = 'total'`, the structural "historical summary" scope that already routes through the principled first branch. Modern turns (with cumulative) and sub-1M turns are untouched. The token threshold now runs **once, against a closed legacy set** — not on every paint.
- **`isHistoricalUsageSummary`** drops to `scope === "total" || scope === "backfill"`. No token arithmetic. A large live turn is now correctly a **Turn** (with its per-turn cost suffix), not a summary.

Net effect on display is unchanged for the legacy rows (still "Historical usage summary", still `$X list price` not `list price this turn`), because `scope: 'total'` produces exactly that. The behavior *change* is the intended one: a genuinely large live turn is no longer misclassified.

Reader for the constant-bump gotcha: the previous last migration step set `user_version` to `CURRENT_STATE_DB_USER_VERSION`; that's now pinned to a literal `23` so bumping the constant to 24 can't skip the new step.

## Testing

- New main-process test: migration reclassifies a legacy live/pending 2M-token summary row to `scope 'total'` while leaving a cumulative-bearing modern turn and a sub-1M live turn as `'turn'`.
- Renderer tests: a `scope: 'total'` row renders "Historical usage summary" / `$X list price`; a large `scope: 'turn'` live row now renders "Turn usage" / `$X list price this turn`.
- `typecheck`, `lint:eslint`, `lint:sql`, `lint:boundaries`, and the `state-db` / `state-migration` suites all pass.

## Relationship to #935

Independent and stacks cleanly. #935 (per-turn durations) added a guard-order fix so an active turn always shows its clock even when the old heuristic misfired; this PR removes the misfire at its root. Whichever merges second reconciles trivially — they touch different functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
