### PR TITLE
feat(messaging): Working Updates dial + default-off streaming gate

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -44,6 +44,7 @@ describe("DesktopSettingsService", () => {
         'full_access_warning = "always"',
         "input_debounce_ms = 750",
         'tool_update_mode = "show_more"',
+        "show_streaming_option = true",
         "",
         "[image_uploads]",
         "pasted_image_max_patches = 4096",
@@ -109,6 +110,10 @@ describe("DesktopSettingsService", () => {
     });
     expect(snapshot.messaging.toolUpdateMode).toEqual({
       value: "show_more",
+      source: "config",
+    });
+    expect(snapshot.messaging.showStreamingOption).toEqual({
+      value: true,
       source: "config",
     });
     expect(snapshot.messaging.inputDebounceMs).toEqual({
@@ -705,6 +710,7 @@ describe("DesktopSettingsService", () => {
     await service.writeConfigPatch({
       messaging: {
         toolUpdateMode: "show_all",
+        showStreamingOption: true,
       },
     });
 
@@ -714,6 +720,7 @@ describe("DesktopSettingsService", () => {
     );
     expect(contents).toContain('chat_reply_composer = "custom-widget-chips"');
     expect(contents).toContain('tool_update_mode = "show_all"');
+    expect(contents).toContain("show_streaming_option = true");
   });
 
   it("reads authorized contacts from TOML array-of-tables", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -66,6 +66,7 @@ describe("desktop messaging config", () => {
       "inputDebounceMs",
       "line",
       "mattermost",
+      "showStreamingOption",
       "slack",
       "telegram",
       "toolUpdateDefaultMode",
@@ -499,6 +500,7 @@ describe("desktop messaging config", () => {
       enabled: true,
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
+      showStreamingOption: false,
       attachmentPolicy: {
         imageProfile: "medium",
         maxAttachmentBytes: 10485760,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -978,7 +978,6 @@ describe("MessagingController", () => {
           id: "browse:new:working-updates",
           label: "Working Updates: Some",
         }),
-        expect.objectContaining({ id: "browse:new:streaming" }),
         expect.objectContaining({ id: "browse:new:model" }),
         expect.objectContaining({ id: "browse:new:reasoning" }),
       ]),
@@ -993,9 +992,14 @@ describe("MessagingController", () => {
         expect.objectContaining({ id: "browse:new:workspace:worktree" }),
       ]),
     });
+    // Streaming is default-off/advanced, so the wizard hides it (button + body
+    // line) unless the operator opts in globally.
     expect(readyIntent).toMatchObject({
-      body: expect.stringContaining("Streaming: off"),
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:streaming" }),
+      ]),
     });
+    expect(JSON.stringify(readyIntent)).not.toContain("Streaming:");
     expect(readyIntent).toMatchObject({
       browseSessionId: expect.stringMatching(/^browse:/),
     });
@@ -2403,16 +2407,17 @@ describe("MessagingController", () => {
           label: "Working Updates: Some",
           fallbackText: "tools",
         }),
-        expect.objectContaining({
-          id: "status:streaming",
-          label: "Stream: Off",
-          fallbackText: "stream",
-        }),
       ]),
     });
-    expect(harness.delivered.at(-1)).toMatchObject({
-      text: expect.stringContaining("Streaming: Off"),
-    });
+    // Streaming is an advanced, default-off control: with the global
+    // show-streaming-option off and no per-binding override, it is hidden from
+    // both the status card actions and the overview text.
+    const boundStatus = harness.delivered.at(-1);
+    expect(boundStatus).toMatchObject({ kind: "status" });
+    expect(
+      (boundStatus as Extract<MessagingSurfaceIntent, { kind: "status" }>).actions,
+    ).not.toContainEqual(expect.objectContaining({ id: "status:streaming" }));
+    expect(JSON.stringify(boundStatus)).not.toContain("Streaming:");
   });
 
   it("uses the provider conversation-input profile for shared-chat mention instructions", async () => {
@@ -2458,7 +2463,7 @@ describe("MessagingController", () => {
   });
 
   it("cycles per-binding streaming mode from the status card", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({ showStreamingOption: true });
     await bindThread(harness);
 
     await harness.controller.handleInboundEvent(
@@ -2511,7 +2516,10 @@ describe("MessagingController", () => {
   });
 
   it("shows and toggles the effective streaming default from the new-thread screen", async () => {
-    const harness = await createHarness({ streamingResponsesDefault: true });
+    const harness = await createHarness({
+      streamingResponsesDefault: true,
+      showStreamingOption: true,
+    });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
     await harness.controller.handleInboundEvent(
@@ -14552,6 +14560,7 @@ async function createHarness(options?: {
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
   startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
+  showStreamingOption?: boolean;
 }): Promise<{
   controller: MessagingController;
   compactThread: ReturnType<typeof vi.fn>;
@@ -14957,6 +14966,7 @@ async function createHarness(options?: {
     store,
     responseModeForConversation: options?.responseModeForConversation,
     streamingResponsesDefault: options?.streamingResponsesDefault,
+    showStreamingOption: options?.showStreamingOption,
     toolUpdateDefaultMode: options?.toolUpdateDefaultMode,
   });
   controllerRef = controller;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -10605,6 +10605,124 @@ describe("MessagingController", () => {
     });
   });
 
+  it("flushes the agent's setup prose before an elicitation even at None", async () => {
+    const harness = await createHarness({ toolUpdateDefaultMode: "show_none" });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    // Agent narrates the options mid-turn (non-final prose). At None this is
+    // suppressed from the channel by the Working Updates dial...
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "msg-setup",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Do you want Option A or Option B?",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    // ...but when the questionnaire arrives, the setup prose is flushed first so
+    // the terse question carries the context the agent just wrote.
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-1",
+        questions: [
+          {
+            id: "q1",
+            header: "Choice",
+            question: "Which one?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              { label: "Option A", description: "A" },
+              { label: "Option B", description: "B" },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    const sequence = harness.delivered.map((intent) => JSON.stringify(intent));
+    const proseIndex = sequence.findIndex(
+      (entry) =>
+        entry.includes("Do you want Option A or Option B?") &&
+        entry.includes('"role":"assistant"'),
+    );
+    const questionnaireIndex = sequence.findIndex((entry) =>
+      entry.includes('"kind":"questionnaire"'),
+    );
+    expect(proseIndex).toBeGreaterThanOrEqual(0);
+    expect(questionnaireIndex).toBeGreaterThanOrEqual(0);
+    expect(proseIndex).toBeLessThan(questionnaireIndex);
+  });
+
+  it("does not re-post setup prose the dial already delivered", async () => {
+    const harness = await createHarness({ toolUpdateDefaultMode: "show_all" });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    // At All the prose is bridged individually as it arrives...
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "msg-setup",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Do you want Option A or Option B?",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "request-1",
+        questions: [
+          {
+            id: "q1",
+            header: "Choice",
+            question: "Which one?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              { label: "Option A", description: "A" },
+              { label: "Option B", description: "B" },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    // ...so the elicitation flush must not re-post it — exactly one prose message.
+    const proseMessages = harness.delivered.filter((intent) => {
+      const entry = JSON.stringify(intent);
+      return (
+        entry.includes("Do you want Option A or Option B?") &&
+        entry.includes('"role":"assistant"')
+      );
+    });
+    expect(proseMessages).toHaveLength(1);
+  });
+
   it("stops typing while presenting a Plan questionnaire for an active turn", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2539,6 +2539,32 @@ describe("MessagingController", () => {
     });
   });
 
+  it("sticks the streaming-control reveal once a thread has enabled streaming", async () => {
+    const harness = await createHarness({ showStreamingOption: true });
+    await bindThread(harness);
+
+    // Enable streaming on the thread (inherit -> enabled).
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:streaming" }),
+    );
+    const afterEnable = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(afterEnable?.preferences?.streamingResponses).toBe("enabled");
+    expect(afterEnable?.preferences?.streamingControlRevealed).toBe(true);
+
+    // Turn it back off (enabled -> disabled). The sticky reveal flag persists so
+    // the control stays reachable even though the current mode is off.
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:streaming" }),
+    );
+    const afterDisable = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/resume").channel,
+    );
+    expect(afterDisable?.preferences?.streamingResponses).toBe("disabled");
+    expect(afterDisable?.preferences?.streamingControlRevealed).toBe(true);
+  });
+
   it("shows and toggles the effective streaming default from the new-thread screen", async () => {
     const harness = await createHarness({
       streamingResponsesDefault: true,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1076,10 +1076,34 @@ describe("MessagingController", () => {
       }),
     );
 
-    // Cycle the Working Updates dial (default Some -> More) before sending the
-    // first instruction, so the setting is chosen before the thread is born.
+    // Open the Working Updates picker before sending the first instruction, so
+    // the setting is chosen before the thread is born.
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "browse:new:working-updates" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Working Updates",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:set-working-updates",
+          label: "Some (current)",
+          value: { toolUpdateMode: "show_some" },
+        }),
+        expect.objectContaining({
+          id: "browse:new:set-working-updates",
+          label: "More",
+          value: { toolUpdateMode: "show_more" },
+        }),
+      ]),
+    });
+
+    // Pick "More", which returns to the ready gate reflecting the choice.
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-working-updates",
+        value: { toolUpdateMode: "show_more" },
+      }),
     );
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -10747,6 +10747,145 @@ describe("MessagingController", () => {
     expect(proseIndex).toBeLessThan(questionnaireIndex);
   });
 
+  it("only flushes setup prose captured under the elicitation's own turn", async () => {
+    const harness = await createHarness({ toolUpdateDefaultMode: "show_none" });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    // Prose is captured under turn-1...
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "msg-setup",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Setup context for turn one.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    // ...but the elicitation belongs to a different turn, so its flush must not
+    // surface turn-1's prose (correlation is by turnId).
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/tool/requestUserInput",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-2",
+        requestId: "request-1",
+        questions: [
+          {
+            id: "q1",
+            header: "Choice",
+            question: "Which one?",
+            isOther: false,
+            isSecret: false,
+            options: [
+              { label: "Option A", description: "A" },
+              { label: "Option B", description: "B" },
+            ],
+          },
+        ],
+      },
+    } satisfies AppServerPendingRequestNotification);
+
+    expect(
+      harness.delivered.some((intent) => intent.kind === "questionnaire"),
+    ).toBe(true);
+    expect(JSON.stringify(harness.delivered)).not.toContain(
+      "Setup context for turn one.",
+    );
+  });
+
+  it("does not permanently mark setup prose delivered when its flush is skipped", async () => {
+    let dropNextProse = true;
+    const delivered: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      toolUpdateDefaultMode: "show_none",
+      deliver: async (intent) => {
+        // Simulate a budget skip (no surface) for the FIRST setup-prose flush.
+        if (intent.id.startsWith("assistant-prose") && dropNextProse) {
+          dropNextProse = false;
+          return {
+            channel: "telegram" as const,
+            deliveredAt: 1000,
+            outcome: "discarded" as const,
+          };
+        }
+        delivered.push(intent);
+        return {
+          channel: "telegram" as const,
+          deliveredAt: 1000,
+          outcome: "presented" as const,
+          surface: { channel: "telegram" as const, id: `surface:${intent.id}` },
+        };
+      },
+    });
+    await bindThread(harness);
+    delivered.length = 0;
+    dropNextProse = true;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "msg-setup",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Setup context needing a retry.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    // First elicitation: the prose flush is budget-skipped and must be rolled
+    // back (not recorded as delivered)...
+    for (const requestId of ["request-1", "request-2"] as const) {
+      await harness.controller.handleBackendPendingRequest("codex", {
+        method: "item/tool/requestUserInput",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId,
+          questions: [
+            {
+              id: "q1",
+              header: "Choice",
+              question: "Which one?",
+              isOther: false,
+              isSecret: false,
+              options: [
+                { label: "Option A", description: "A" },
+                { label: "Option B", description: "B" },
+              ],
+            },
+          ],
+        },
+      } satisfies AppServerPendingRequestNotification);
+    }
+
+    // ...so the second elicitation's flush retries and the setup prose reaches
+    // the channel exactly once. Without the rollback it would be marked
+    // delivered on the skipped attempt and never sent at all.
+    const proseDeliveries = delivered.filter((intent) => {
+      const entry = JSON.stringify(intent);
+      return (
+        entry.includes("Setup context needing a retry.") &&
+        entry.includes('"role":"assistant"')
+      );
+    });
+    expect(proseDeliveries).toHaveLength(1);
+  });
+
   it("does not re-post setup prose the dial already delivered", async () => {
     const harness = await createHarness({ toolUpdateDefaultMode: "show_all" });
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -974,10 +974,17 @@ describe("MessagingController", () => {
       actions: expect.arrayContaining([
         expect.objectContaining({ id: "browse:new:permissions" }),
         expect.objectContaining({ id: "browse:new:fast" }),
+        expect.objectContaining({
+          id: "browse:new:working-updates",
+          label: "Working Updates: Some",
+        }),
         expect.objectContaining({ id: "browse:new:streaming" }),
         expect.objectContaining({ id: "browse:new:model" }),
         expect.objectContaining({ id: "browse:new:reasoning" }),
       ]),
+    });
+    expect(readyIntent).toMatchObject({
+      body: expect.stringContaining("Working Updates: Some"),
     });
     expect(readyIntent).toMatchObject({
       actions: expect.not.arrayContaining([
@@ -1047,6 +1054,47 @@ describe("MessagingController", () => {
     );
     expect(harness.delivered.at(-1)).toMatchObject({
       text: expect.stringContaining("Directory: /repo/pwragent"),
+    });
+  });
+
+  it("sets Working Updates in the /new wizard before the thread is created", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    // Cycle the Working Updates dial (default Some -> More) before sending the
+    // first instruction, so the setting is chosen before the thread is born.
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:working-updates" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:working-updates",
+          label: "Working Updates: More",
+        }),
+      ]),
+      body: expect.stringContaining("Working Updates: More"),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Fix bug"));
+
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toMatchObject({
+      preferences: expect.objectContaining({ toolUpdateMode: "show_more" }),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -9638,6 +9638,7 @@ describe("MessagingController", () => {
   it("suppresses non-final commentary completions so a turn posts one message", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({
+      toolUpdateDefaultMode: "show_none",
       deliver: async (intent) => {
         delivered.push(intent);
         return {
@@ -9652,8 +9653,9 @@ describe("MessagingController", () => {
     delivered.length = 0;
 
     // A regular (non-automation) turn where the backend emits intermediate
-    // "commentary" agentMessage completions before the final answer. Each of
-    // these used to post its own message — the multi-message channel flood.
+    // "commentary" agentMessage completions before the final answer. With the
+    // Working Updates dial at None (the agent-personality case), the commentary
+    // prose is suppressed — only the final answer and any elicitation post.
     for (const [phase, text] of [
       ["commentary", "I'll check the weather for 07747."],
       ["commentary", "Pulling current conditions now."],
@@ -9694,8 +9696,8 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
-    // Only the final answer is posted — the commentary phases are dropped, so
-    // the turn lands as a single message instead of a burst.
+    // Only the final answer is posted — the commentary phases are suppressed by
+    // the None dial, so the turn lands as a single message instead of a burst.
     expect(
       delivered.filter((intent) => intent.kind === "message" && intent.role === "assistant"),
     ).toEqual([
@@ -9711,6 +9713,53 @@ describe("MessagingController", () => {
     ]);
     expect(JSON.stringify(delivered)).not.toContain("I'll check the weather");
     expect(JSON.stringify(delivered)).not.toContain("Pulling current conditions");
+  });
+
+  it("posts intermediate prose through the Working Updates dial at Show All", async () => {
+    const delivered: MessagingSurfaceIntent[] = [];
+    const harness = await createHarness({
+      toolUpdateDefaultMode: "show_all",
+      deliver: async (intent) => {
+        delivered.push(intent);
+        return {
+          channel: "telegram" as const,
+          deliveredAt: 1000,
+          outcome: "presented" as const,
+          surface: { channel: "telegram" as const, id: `surface:${intent.id}` },
+        };
+      },
+    });
+    await bindThread(harness);
+    delivered.length = 0;
+
+    // With the dial at All, the agent's in-turn prose is bridged individually
+    // (still subject to the rate budget) rather than suppressed.
+    for (const [phase, text] of [
+      ["commentary", "I'll check the weather for 07747."],
+      ["commentary", "Pulling current conditions now."],
+      ["final", "For 07747 / Matawan, NJ: sunny and very hot."],
+    ] as const) {
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: { id: `msg-${phase}-${text.length}`, type: "agentMessage", phase, text },
+          },
+        },
+      } satisfies AgentEvent);
+    }
+
+    const assistantTexts = delivered
+      .filter(
+        (intent): intent is Extract<MessagingSurfaceIntent, { kind: "message" }> =>
+          intent.kind === "message" && intent.role === "assistant",
+      )
+      .flatMap((intent) => intent.parts.map((part) => ("text" in part ? part.text : "")));
+    expect(assistantTexts).toContain("I'll check the weather for 07747.");
+    expect(assistantTexts).toContain("Pulling current conditions now.");
   });
 
   it("does not re-post buffered text when deltas arrive after the turn is terminal", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2348,11 +2348,11 @@ describe("MessagingController", () => {
       text: expect.stringContaining("Binding: Thread one"),
     });
     expect(harness.delivered.at(-1)).toMatchObject({
-      text: expect.stringContaining("Tool updates: Some"),
+      text: expect.stringContaining("Working Updates: Some"),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "status:tool-updates",
-          label: "Tools: Some",
+          label: "Working Updates: Some",
           fallbackText: "tools",
         }),
         expect.objectContaining({
@@ -13716,7 +13716,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Tool updates: Few"),
+      text: expect.stringContaining("Working Updates: Few"),
     });
 
     await harness.controller.handleInboundEvent(
@@ -13725,7 +13725,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "single_select",
-      prompt: "Select Tools",
+      prompt: expect.stringContaining("Working Updates"),
       choices: expect.arrayContaining([
         expect.objectContaining({
           id: "status:set-tool-updates",
@@ -13743,7 +13743,7 @@ describe("MessagingController", () => {
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "status",
-      text: expect.stringContaining("Tool updates: Some"),
+      text: expect.stringContaining("Working Updates: Some"),
     });
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/status").channel),
@@ -13771,7 +13771,7 @@ describe("MessagingController", () => {
       );
       expect(harness.delivered.at(-1)).toMatchObject({
         kind: "single_select",
-        prompt: "Select Tools",
+        prompt: expect.stringContaining("Working Updates"),
       });
       await harness.controller.handleInboundEvent(
         buildCallbackEvent({
@@ -13781,7 +13781,7 @@ describe("MessagingController", () => {
       );
       expect(harness.delivered.at(-1)).toMatchObject({
         kind: "status",
-        text: expect.stringContaining(`Tool updates: ${expected}`),
+        text: expect.stringContaining(`Working Updates: ${expected}`),
       });
     }
   });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -476,6 +476,43 @@ describe("buildBindingStatusIntent", () => {
     );
   });
 
+  it("keeps the streaming control on a thread that had it on, after it is turned off with the global setting off", () => {
+    const binding = {
+      id: "binding-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: {
+        channel: "telegram",
+        conversation: { id: "chat-1", kind: "dm" },
+      },
+      createdAt: 1000,
+      threadId: "thread-1",
+      updatedAt: 1000,
+      // Streaming was enabled here before and later turned back off, but the
+      // sticky reveal flag persists.
+      preferences: {
+        streamingResponses: "disabled" as const,
+        streamingControlRevealed: true,
+        updatedAt: 1000,
+      },
+    } satisfies MessagingBindingRecord;
+    const navigation = buildNavigationSnapshot();
+    const intent = buildBindingStatusIntent({
+      id: "status-1",
+      createdAt: 1000,
+      binding,
+      // Global setting is OFF...
+      showStreamingOption: false,
+      threadState: resolveMessagingThreadState({ binding, navigation }),
+    });
+
+    // ...but the control stays reachable so the user can toggle streaming back on.
+    expect(intent.text).toContain("Streaming: Off");
+    expect(intent.actions).toContainEqual(
+      expect.objectContaining({ id: "status:streaming" }),
+    );
+  });
+
   it("targets an existing status surface for updates", () => {
     const binding = {
       id: "binding-1",

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -47,6 +47,7 @@ describe("buildBindingStatusIntent", () => {
     const navigation = buildNavigationSnapshot();
     const intent = buildBindingStatusIntent({
       id: "status-1",
+      showStreamingOption: true,
       backendSummary: {
         kind: "codex",
         label: "Codex",
@@ -462,6 +463,7 @@ describe("buildBindingStatusIntent", () => {
       createdAt: 1000,
       binding,
       streamingResponsesDefault: true,
+      showStreamingOption: true,
       threadState: resolveMessagingThreadState({ binding, navigation }),
     });
 

--- a/apps/desktop/src/main/__tests__/messaging-streaming-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-streaming-visibility.test.ts
@@ -20,4 +20,17 @@ describe("shouldShowStreamingControl", () => {
   it("shows the control when the binding already enabled streaming (anti-stranding)", () => {
     expect(shouldShowStreamingControl("enabled", false)).toBe(true);
   });
+
+  it("keeps the control visible for a thread that had streaming on, after it is turned off", () => {
+    // streamingControlRevealed sticks once streaming has been enabled, so the
+    // control stays reachable even when the current mode is off/inherit and the
+    // global setting is off.
+    expect(shouldShowStreamingControl("disabled", false, true)).toBe(true);
+    expect(shouldShowStreamingControl("inherit", false, true)).toBe(true);
+  });
+
+  it("does not reveal the control for a thread that never had streaming on", () => {
+    expect(shouldShowStreamingControl("disabled", false, false)).toBe(false);
+    expect(shouldShowStreamingControl("inherit", false, undefined)).toBe(false);
+  });
 });

--- a/apps/desktop/src/main/__tests__/messaging-streaming-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-streaming-visibility.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowStreamingControl } from "../messaging/core/messaging-status-card.js";
+
+describe("shouldShowStreamingControl", () => {
+  it("hides the control by default (global off, binding inherits)", () => {
+    expect(shouldShowStreamingControl("inherit", false)).toBe(false);
+    expect(shouldShowStreamingControl("inherit", undefined)).toBe(false);
+  });
+
+  it("hides the control when the binding explicitly disabled streaming", () => {
+    expect(shouldShowStreamingControl("disabled", false)).toBe(false);
+  });
+
+  it("shows the control when the global option is enabled", () => {
+    expect(shouldShowStreamingControl("inherit", true)).toBe(true);
+    expect(shouldShowStreamingControl("disabled", true)).toBe(true);
+  });
+
+  it("shows the control when the binding already enabled streaming (anti-stranding)", () => {
+    expect(shouldShowStreamingControl("enabled", false)).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-tool-update-renderer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { MessagingToolActivity } from "../messaging/core/messaging-tool-activity.js";
+import {
+  buildToolUpdateBatchMessageIntent,
+  buildToolUpdateMessageIntent,
+} from "../messaging/core/messaging-renderer.js";
+
+const tool = (id: string, title: string): MessagingToolActivity => ({
+  id,
+  kind: "tool",
+  status: "completed",
+  title,
+});
+
+const prose = (id: string, text: string): MessagingToolActivity => ({
+  id,
+  kind: "prose",
+  status: "completed",
+  title: text,
+});
+
+describe("tool-update renderer prose handling", () => {
+  it("renders an individual tool activity as a system tool-update line", () => {
+    const intent = buildToolUpdateMessageIntent({
+      activity: tool("t1", "Ran tests"),
+      bindingId: "b1",
+      createdAt: 1,
+      id: "i1",
+    });
+    expect(intent.role).toBe("system");
+    expect(intent.parts[0]).toMatchObject({
+      text: "Tool update: Ran tests",
+      markdown: "light",
+    });
+  });
+
+  it("renders individual prose verbatim as an assistant markdown message", () => {
+    const intent = buildToolUpdateMessageIntent({
+      activity: prose("p1", "Let me check the config first."),
+      bindingId: "b1",
+      createdAt: 1,
+      id: "i2",
+    });
+    expect(intent.role).toBe("assistant");
+    expect(intent.parts[0]).toMatchObject({
+      text: "Let me check the config first.",
+      markdown: "markdown",
+    });
+  });
+
+  it("keeps the tool-only batch header and format unchanged", () => {
+    const intent = buildToolUpdateBatchMessageIntent({
+      activities: [tool("t1", "Ran tests"), tool("t2", "Edited app.ts")],
+      bindingId: "b1",
+      createdAt: 1,
+      id: "i3",
+    });
+    expect(intent.role).toBe("system");
+    const part = intent.parts[0];
+    expect("text" in part ? part.text : "").toBe(
+      "Tool updates: ran 2 tools\n- Ran tests\n- Edited app.ts",
+    );
+  });
+
+  it("renders a mixed prose+tool batch as assistant with prose above the tool summary", () => {
+    const intent = buildToolUpdateBatchMessageIntent({
+      activities: [
+        prose("p1", "Looking into the failing test."),
+        tool("t1", "Ran tests"),
+      ],
+      bindingId: "b1",
+      createdAt: 1,
+      id: "i4",
+    });
+    expect(intent.role).toBe("assistant");
+    const part = intent.parts[0];
+    const text = "text" in part ? part.text : "";
+    expect(text).toBe(
+      "Looking into the failing test.\n\nTool updates: ran 1 tool\n- Ran tests",
+    );
+    expect(part).toMatchObject({ markdown: "markdown" });
+  });
+});

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -245,7 +245,13 @@ const DEFAULT_INPUT_DEBOUNCE_MS = 500;
 // that completed long ago so a long-lived controller does not grow without
 // bound (one entry per automation run).
 const MAX_DELIVERED_AUTOMATION_KEYS = 1_000;
+const MAX_TRACKED_TURN_PROSE = 256;
 const MESSAGING_ENVIRONMENT_SETUP_PROGRESS_INTERVAL_MS = 15_000;
+
+type MessagingTurnProseState = {
+  latest?: { activityId: string; text: string };
+  deliveredIds: Set<string>;
+};
 const DEFAULT_MESSAGING_AGENT_NAME = "Messaging Agent";
 const DEFAULT_MESSAGING_AGENT_INSTRUCTIONS =
   "You are an Agent thread created from messaging. Keep shared context for the attached messaging surfaces and use available Agent tools when they are relevant.";
@@ -574,7 +580,7 @@ export type MessagingControllerOptions = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
   streamingResponsesDefault?: boolean;
-  showStreamingOption?: boolean;
+  showStreamingOption?: boolean | (() => boolean | Promise<boolean>);
   responseModeForConversation?: (
     channel: MessagingChannelRef,
   ) => Promise<MessagingResponseMode> | MessagingResponseMode;
@@ -632,19 +638,21 @@ export class MessagingController {
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
-  private readonly showStreamingOption: boolean;
+  private readonly showStreamingOptionConfig:
+    | boolean
+    | (() => boolean | Promise<boolean>);
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
-  // Un-gated per-turn capture of the agent's most recent in-turn (non-final)
-  // prose, keyed by `${bindingId}\0${turnId}`. Written before the Working
-  // Updates dial decides delivery, so an elicitation can flush its setup
-  // message (U7) even when the dial suppressed it. `deliveredProseIds` tracks
-  // which prose activity ids already reached the channel so the flush stays
-  // idempotent.
-  private readonly turnProseCapture = new Map<
-    string,
-    { activityId: string; text: string }
-  >();
-  private readonly deliveredProseIds = new Map<string, Set<string>>();
+  // Per-turn in-turn (non-final) prose bookkeeping, keyed by
+  // `${bindingId}\0${turnId}`:
+  //   - `latest` is the most-recent captured prose block, written before the
+  //     Working Updates dial decides delivery so U7 can flush an elicitation's
+  //     setup message even when the dial (None) suppressed it.
+  //   - `deliveredIds` records which prose activity ids already reached the
+  //     channel (individually, in a batch, or via the flush) so the flush stays
+  //     idempotent and a later batch does not re-post pre-flushed prose.
+  // Bounded so a turn that ends without a clean terminal event to clear it
+  // cannot grow the map without limit.
+  private readonly turnProse = new Map<string, MessagingTurnProseState>();
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
   private readonly pendingFullAccessNewThreadPrompts = new Map<
@@ -691,7 +699,7 @@ export class MessagingController {
     this.deliveryBudget = options.deliveryBudget;
     this.logger = options.logger ?? messagingControllerLog;
     this.streamingResponsesDefault = options.streamingResponsesDefault ?? false;
-    this.showStreamingOption = options.showStreamingOption ?? false;
+    this.showStreamingOptionConfig = options.showStreamingOption ?? false;
     this.turnAdmission = new MessagingTurnAdmission({
       debounceMs: options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS,
       now: this.now,
@@ -4998,7 +5006,7 @@ export class MessagingController {
       (await this.resolveToolUpdateDefaultMode());
     const showStreaming = shouldShowStreamingControl(
       effectiveSession.preferences?.streamingResponses ?? "inherit",
-      this.showStreamingOption,
+      await this.resolveShowStreamingOption(),
     );
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
@@ -9898,6 +9906,24 @@ export class MessagingController {
     }
   }
 
+  /**
+   * Resolve the global "show streaming option on thread cards" setting. Resolved
+   * live (like {@link resolveToolUpdateDefaultMode}) rather than snapshotted at
+   * construction, so toggling it in Settings takes effect on the next status
+   * render instead of only after a messaging restart.
+   */
+  private async resolveShowStreamingOption(): Promise<boolean> {
+    const configured = this.showStreamingOptionConfig;
+    try {
+      return typeof configured === "function" ? await configured() : configured;
+    } catch (error) {
+      this.logger.debug?.("messaging show-streaming-option resolution failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
   private async retireBindingStatus(
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent | undefined,
@@ -10006,7 +10032,7 @@ export class MessagingController {
         ? handoffContextForBinding(binding, snapshot)
         : undefined,
       streamingResponsesDefault: this.streamingResponsesDefault,
-      showStreamingOption: this.showStreamingOption,
+      showStreamingOption: await this.resolveShowStreamingOption(),
       threadState: resolveMessagingThreadState({
         activeTurn,
         binding,
@@ -11405,10 +11431,10 @@ export class MessagingController {
       status: "completed",
       title: assistantText,
     };
-    this.turnProseCapture.set(this.turnProseKey(binding.id, turnId), {
+    this.ensureTurnProseState(this.turnProseKey(binding.id, turnId)).latest = {
       activityId: activity.id,
       text: assistantText,
-    });
+    };
 
     const mode = resolveMessagingToolUpdateMode(
       binding,
@@ -11429,6 +11455,24 @@ export class MessagingController {
     return `${bindingId}\0${turnId}`;
   }
 
+  private ensureTurnProseState(key: string): MessagingTurnProseState {
+    let state = this.turnProse.get(key);
+    if (!state) {
+      state = { deliveredIds: new Set() };
+      this.turnProse.set(key, state);
+      // Backstop the terminal-event cleanup: evict the oldest turn(s) so a run
+      // that ends without a clean terminal event cannot grow the map unbounded.
+      while (this.turnProse.size > MAX_TRACKED_TURN_PROSE) {
+        const oldest = this.turnProse.keys().next().value;
+        if (oldest === undefined) {
+          break;
+        }
+        this.turnProse.delete(oldest);
+      }
+    }
+    return state;
+  }
+
   private markProseActivitiesDelivered(
     delivery: MessagingToolUpdatePolicyDelivery,
   ): void {
@@ -11438,21 +11482,16 @@ export class MessagingController {
     if (proseIds.length === 0) {
       return;
     }
-    const key = this.turnProseKey(delivery.bindingId, delivery.turnId);
-    let delivered = this.deliveredProseIds.get(key);
-    if (!delivered) {
-      delivered = new Set();
-      this.deliveredProseIds.set(key, delivered);
-    }
+    const state = this.ensureTurnProseState(
+      this.turnProseKey(delivery.bindingId, delivery.turnId),
+    );
     for (const id of proseIds) {
-      delivered.add(id);
+      state.deliveredIds.add(id);
     }
   }
 
   private clearTurnProse(bindingId: string, turnId: string): void {
-    const key = this.turnProseKey(bindingId, turnId);
-    this.turnProseCapture.delete(key);
-    this.deliveredProseIds.delete(key);
+    this.turnProse.delete(this.turnProseKey(bindingId, turnId));
   }
 
   private async flushToolUpdatesForBinding(
@@ -11509,14 +11548,15 @@ export class MessagingController {
   private filterUndeliveredProseActivities(
     delivery: MessagingToolUpdatePolicyDelivery,
   ): MessagingToolActivity[] {
-    const delivered = this.deliveredProseIds.get(
+    const state = this.turnProse.get(
       this.turnProseKey(delivery.bindingId, delivery.turnId),
     );
-    if (!delivered) {
+    if (!state) {
       return delivery.activities;
     }
     return delivery.activities.filter(
-      (activity) => activity.kind !== "prose" || !delivered.has(activity.id),
+      (activity) =>
+        activity.kind !== "prose" || !state.deliveredIds.has(activity.id),
     );
   }
 
@@ -11534,33 +11574,31 @@ export class MessagingController {
     if (!turnId) {
       return;
     }
-    const key = this.turnProseKey(binding.id, turnId);
-    const captured = this.turnProseCapture.get(key);
-    if (!captured) {
+    const state = this.turnProse.get(this.turnProseKey(binding.id, turnId));
+    const latest = state?.latest;
+    if (!state || !latest || state.deliveredIds.has(latest.activityId)) {
       return;
-    }
-    let delivered = this.deliveredProseIds.get(key);
-    if (delivered?.has(captured.activityId)) {
-      return;
-    }
-    if (!delivered) {
-      delivered = new Set();
-      this.deliveredProseIds.set(key, delivered);
     }
     // Mark before delivering so a re-entrant elicitation for the same turn does
-    // not double-post the setup message.
-    delivered.add(captured.activityId);
-    await this.deliver(
+    // not double-post the setup message...
+    state.deliveredIds.add(latest.activityId);
+    const result = await this.deliver(
       {
         id: this.newIntentId("assistant-prose"),
         kind: "message",
         bindingId: binding.id,
         createdAt: this.now(),
         role: "assistant",
-        parts: [{ type: "text", text: captured.text, markdown: "markdown" }],
+        parts: [{ type: "text", text: latest.text, markdown: "markdown" }],
       },
       binding,
     );
+    // ...but if the delivery was skipped (e.g. budget-exhausted), roll the mark
+    // back so the setup prose can still ride the turn's coalesced batch rather
+    // than being silently recorded as delivered and filtered out.
+    if (!result.surface) {
+      state.deliveredIds.delete(latest.activityId);
+    }
   }
 
   private async attachThreadHereFromAgentMessagingOrigin(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -167,12 +167,14 @@ import {
   buildStatusReasoningPickerIntent,
   buildStatusToolUpdateModePickerIntent,
   formatExecutionModeLabel,
+  formatMessagingToolUpdateModeLabel,
   formatPermissionsActionDisplayLabel,
   formatPermissionsLineDisplayLabel,
   handoffRequestFromValue,
   messagingStreamingResponsesEnabled,
   messagingToolUpdateModeChoices,
   nextMessagingStreamingResponseMode,
+  nextMessagingToolUpdateMode,
   resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
   type MessagingWorkspaceHandoffContext,
@@ -4346,6 +4348,25 @@ export class MessagingController {
       );
       return;
     }
+    if (actionId === "browse:new:working-updates") {
+      const currentMode =
+        nextSession.preferences?.toolUpdateMode ??
+        (await this.resolveToolUpdateDefaultMode());
+      const toolUpdateMode = nextMessagingToolUpdateMode(currentMode);
+      await this.presentNewThreadPromptGate(
+        {
+          ...nextSession,
+          preferences: {
+            ...nextSession.preferences,
+            toolUpdateMode,
+            updatedAt: this.now(),
+          },
+        },
+        event,
+        navigation,
+      );
+      return;
+    }
     if (actionId === "browse:new:backend") {
       await this.presentNewThreadBackendPicker(nextSession, event, navigation);
       return;
@@ -4957,6 +4978,9 @@ export class MessagingController {
     const supportsEnvironment =
       options.codexEnvironmentOptions.length > 0 ||
       Boolean(options.codexEnvironmentId);
+    const toolUpdateMode =
+      effectiveSession.preferences?.toolUpdateMode ??
+      (await this.resolveToolUpdateDefaultMode());
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -4970,7 +4994,12 @@ export class MessagingController {
           }
         : undefined,
       title: "Ready to start",
-      body: newThreadPromptGateBody(effectiveSession, options, selectedBackend),
+      body: newThreadPromptGateBody(
+        effectiveSession,
+        options,
+        selectedBackend,
+        toolUpdateMode,
+      ),
       fallbackText: "Send your first instruction, or use the option buttons before sending it.",
       targetSurface: effectiveSession.surface,
       actions: [
@@ -5039,6 +5068,12 @@ export class MessagingController {
               },
             ]
           : []),
+        {
+          id: "browse:new:working-updates",
+          label: `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
+          style: "secondary",
+          fallbackText: "working updates",
+        },
         {
           id: "browse:new:streaming",
           label: options.streamingResponses ? "Stream: on" : "Stream: off",
@@ -12944,6 +12979,7 @@ function newThreadPromptGateBody(
   session: MessagingBrowseSessionRecord,
   options: NewThreadOptionsSummary,
   backend: BackendSummary,
+  toolUpdateMode: MessagingToolUpdateMode,
 ): string {
   const acpRuntimeMode = isAcpBackendId(options.backend)
     ? buildMessagingAcpRuntimeModeSummary({
@@ -12975,6 +13011,7 @@ function newThreadPromptGateBody(
       ? `Reasoning: ${options.reasoningEffort}`
       : undefined,
     options.supportsFast ? `Fast mode: ${options.fastMode ? "on" : "off"}` : undefined,
+    `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
     `Streaming: ${options.streamingResponses ? "on" : "off"}`,
   ]
     .filter((line): line is string => Boolean(line))

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1353,6 +1353,10 @@ export class MessagingController {
         }
       }
       const pendingIntent = await this.storePendingIntent(intent, binding);
+      await this.flushPendingTurnProseBeforeElicitation(
+        binding,
+        request.params.turnId,
+      );
       const delivery = await this.deliver(intent, binding);
       let deliveredPendingIntent = pendingIntent;
       if (delivery.surface) {
@@ -11365,22 +11369,86 @@ export class MessagingController {
       return;
     }
 
+    // Drop prose already delivered out-of-band (e.g. flushed ahead of an
+    // elicitation by U7) so a later coalesced batch does not re-post it.
+    const activities = this.filterUndeliveredProseActivities(delivery);
+    if (activities.length === 0) {
+      return;
+    }
+
     const intent =
       delivery.kind === "individual"
         ? buildToolUpdateMessageIntent({
-            activity: delivery.activities[0]!,
+            activity: activities[0]!,
             bindingId: binding.id,
             createdAt: this.now(),
             id: this.newIntentId("tool-update"),
           })
         : buildToolUpdateBatchMessageIntent({
-            activities: delivery.activities,
+            activities,
             bindingId: binding.id,
             createdAt: this.now(),
             id: this.newIntentId("tool-update-batch"),
           });
-    this.markProseActivitiesDelivered(delivery);
+    this.markProseActivitiesDelivered({ ...delivery, activities });
     await this.deliver(intent, binding);
+  }
+
+  private filterUndeliveredProseActivities(
+    delivery: MessagingToolUpdatePolicyDelivery,
+  ): MessagingToolActivity[] {
+    const delivered = this.deliveredProseIds.get(
+      this.turnProseKey(delivery.bindingId, delivery.turnId),
+    );
+    if (!delivered) {
+      return delivery.activities;
+    }
+    return delivery.activities.filter(
+      (activity) => activity.kind !== "prose" || !delivered.has(activity.id),
+    );
+  }
+
+  /**
+   * Deliver the agent's captured in-turn setup prose immediately before an
+   * elicitation (U7), so a questionnaire like "Option A or Option B?" carries
+   * the message that described the options — even when the Working Updates dial
+   * (None) would otherwise suppress it. Idempotent: prose already delivered this
+   * turn (individually, in a batch, or by a prior elicitation) is not re-sent.
+   */
+  private async flushPendingTurnProseBeforeElicitation(
+    binding: MessagingBindingRecord,
+    turnId: string | null | undefined,
+  ): Promise<void> {
+    if (!turnId) {
+      return;
+    }
+    const key = this.turnProseKey(binding.id, turnId);
+    const captured = this.turnProseCapture.get(key);
+    if (!captured) {
+      return;
+    }
+    let delivered = this.deliveredProseIds.get(key);
+    if (delivered?.has(captured.activityId)) {
+      return;
+    }
+    if (!delivered) {
+      delivered = new Set();
+      this.deliveredProseIds.set(key, delivered);
+    }
+    // Mark before delivering so a re-entrant elicitation for the same turn does
+    // not double-post the setup message.
+    delivered.add(captured.activityId);
+    await this.deliver(
+      {
+        id: this.newIntentId("assistant-prose"),
+        kind: "message",
+        bindingId: binding.id,
+        createdAt: this.now(),
+        role: "assistant",
+        parts: [{ type: "text", text: captured.text, markdown: "markdown" }],
+      },
+      binding,
+    );
   }
 
   private async attachThreadHereFromAgentMessagingOrigin(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4345,12 +4345,20 @@ export class MessagingController {
         nextSession.preferences?.streamingResponses ?? "inherit",
         this.streamingResponsesDefault,
       );
+      // Sticky-reveal so the control stays in the gate once enabled here, and
+      // carries onto the created binding.
+      const streamingControlRevealed =
+        nextSession.preferences?.streamingControlRevealed ||
+        streamingResponses === "enabled";
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
           preferences: {
             ...nextSession.preferences,
             streamingResponses,
+            ...(streamingControlRevealed
+              ? { streamingControlRevealed: true }
+              : {}),
             updatedAt: this.now(),
           },
         },
@@ -5007,6 +5015,7 @@ export class MessagingController {
     const showStreaming = shouldShowStreamingControl(
       effectiveSession.preferences?.streamingResponses ?? "inherit",
       await this.resolveShowStreamingOption(),
+      effectiveSession.preferences?.streamingControlRevealed,
     );
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
@@ -9671,11 +9680,20 @@ export class MessagingController {
     event: MessagingInboundEvent,
   ): Promise<void> {
     const currentMode = resolveMessagingStreamingResponseMode(binding);
+    const nextMode = nextMessagingStreamingResponseMode(
+      currentMode,
+      this.streamingResponsesDefault,
+    );
+    // Sticky-reveal: once streaming has been enabled on this thread (now, or by
+    // this toggle), keep the control visible so it can be turned back on/off
+    // even after the global setting hides it for other threads.
+    const streamingControlRevealed =
+      binding.preferences?.streamingControlRevealed ||
+      currentMode === "enabled" ||
+      nextMode === "enabled";
     const updatedBinding = await this.updateBindingPreferences(binding, {
-      streamingResponses: nextMessagingStreamingResponseMode(
-        currentMode,
-        this.streamingResponsesDefault,
-      ),
+      streamingResponses: nextMode,
+      ...(streamingControlRevealed ? { streamingControlRevealed: true } : {}),
     });
     await this.renderBindingStatus(updatedBinding, event);
   }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -177,6 +177,7 @@ import {
   nextMessagingToolUpdateMode,
   resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
+  shouldShowStreamingControl,
   type MessagingWorkspaceHandoffContext,
 } from "./messaging-status-card.js";
 import {
@@ -574,6 +575,7 @@ export type MessagingControllerOptions = {
   attachmentPolicy?: Partial<MessagingAttachmentPolicy>;
   store: MessagingStoreLike;
   streamingResponsesDefault?: boolean;
+  showStreamingOption?: boolean;
   responseModeForConversation?: (
     channel: MessagingChannelRef,
   ) => Promise<MessagingResponseMode> | MessagingResponseMode;
@@ -631,6 +633,7 @@ export class MessagingController {
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
+  private readonly showStreamingOption: boolean;
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
   // Un-gated per-turn capture of the agent's most recent in-turn (non-final)
   // prose, keyed by `${bindingId}\0${turnId}`. Written before the Working
@@ -689,6 +692,7 @@ export class MessagingController {
     this.deliveryBudget = options.deliveryBudget;
     this.logger = options.logger ?? messagingControllerLog;
     this.streamingResponsesDefault = options.streamingResponsesDefault ?? false;
+    this.showStreamingOption = options.showStreamingOption ?? false;
     this.turnAdmission = new MessagingTurnAdmission({
       debounceMs: options.inputDebounceMs ?? DEFAULT_INPUT_DEBOUNCE_MS,
       now: this.now,
@@ -4981,6 +4985,10 @@ export class MessagingController {
     const toolUpdateMode =
       effectiveSession.preferences?.toolUpdateMode ??
       (await this.resolveToolUpdateDefaultMode());
+    const showStreaming = shouldShowStreamingControl(
+      effectiveSession.preferences?.streamingResponses ?? "inherit",
+      this.showStreamingOption,
+    );
     await this.options.store.upsertBrowseSession(effectiveSession);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("new-thread-ready"),
@@ -4999,6 +5007,7 @@ export class MessagingController {
         options,
         selectedBackend,
         toolUpdateMode,
+        showStreaming,
       ),
       fallbackText: "Send your first instruction, or use the option buttons before sending it.",
       targetSurface: effectiveSession.surface,
@@ -5074,12 +5083,16 @@ export class MessagingController {
           style: "secondary",
           fallbackText: "working updates",
         },
-        {
-          id: "browse:new:streaming",
-          label: options.streamingResponses ? "Stream: on" : "Stream: off",
-          style: "secondary",
-          fallbackText: "stream",
-        },
+        ...(showStreaming
+          ? [
+              {
+                id: "browse:new:streaming",
+                label: options.streamingResponses ? "Stream: on" : "Stream: off",
+                style: "secondary" as const,
+                fallbackText: "stream",
+              },
+            ]
+          : []),
         ...(supportsModel
           ? [
               {
@@ -9930,6 +9943,7 @@ export class MessagingController {
         ? handoffContextForBinding(binding, snapshot)
         : undefined,
       streamingResponsesDefault: this.streamingResponsesDefault,
+      showStreamingOption: this.showStreamingOption,
       threadState: resolveMessagingThreadState({
         activeTurn,
         binding,
@@ -12980,6 +12994,7 @@ function newThreadPromptGateBody(
   options: NewThreadOptionsSummary,
   backend: BackendSummary,
   toolUpdateMode: MessagingToolUpdateMode,
+  showStreaming: boolean,
 ): string {
   const acpRuntimeMode = isAcpBackendId(options.backend)
     ? buildMessagingAcpRuntimeModeSummary({
@@ -13012,7 +13027,9 @@ function newThreadPromptGateBody(
       : undefined,
     options.supportsFast ? `Fast mode: ${options.fastMode ? "on" : "off"}` : undefined,
     `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
-    `Streaming: ${options.streamingResponses ? "on" : "off"}`,
+    showStreaming
+      ? `Streaming: ${options.streamingResponses ? "on" : "off"}`
+      : undefined,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -174,7 +174,6 @@ import {
   messagingStreamingResponsesEnabled,
   messagingToolUpdateModeChoices,
   nextMessagingStreamingResponseMode,
-  nextMessagingToolUpdateMode,
   resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
   shouldShowStreamingControl,
@@ -4356,7 +4355,19 @@ export class MessagingController {
       const currentMode =
         nextSession.preferences?.toolUpdateMode ??
         (await this.resolveToolUpdateDefaultMode());
-      const toolUpdateMode = nextMessagingToolUpdateMode(currentMode);
+      await this.presentNewThreadWorkingUpdatesPicker(
+        nextSession,
+        event,
+        currentMode,
+      );
+      return;
+    }
+    if (actionId === "browse:new:set-working-updates") {
+      const toolUpdateMode = readMessagingToolUpdateModeValue(event.value);
+      if (!toolUpdateMode) {
+        await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
       await this.presentNewThreadPromptGate(
         {
           ...nextSession,
@@ -5833,6 +5844,58 @@ export class MessagingController {
           fallbackText: String(index + 1),
           priority: 10 + index,
           value: { reasoningEffort: effort },
+        })),
+        {
+          id: session.workMode === "worktree"
+            ? "browse:new:workspace:worktree"
+            : "browse:new:workspace:local",
+          label: "Back",
+          style: "secondary" as const,
+          fallbackText: "back",
+          priority: 1,
+        },
+      ],
+    });
+    await this.storePendingIntent(intent, undefined, event);
+    const result = await this.deliver(intent, undefined, event);
+    if (result.surface) {
+      await this.options.store.upsertBrowseSession({
+        ...session,
+        surface: result.surface,
+        updatedAt: this.now(),
+      });
+    }
+  }
+
+  private async presentNewThreadWorkingUpdatesPicker(
+    session: MessagingBrowseSessionRecord,
+    event: MessagingInboundEvent,
+    currentMode: MessagingToolUpdateMode,
+  ): Promise<void> {
+    const intent = buildConfirmationIntent({
+      id: this.newIntentId("new-thread-working-updates"),
+      capabilityProfile: this.capabilityProfile,
+      browseSessionId: session.id,
+      createdAt: this.now(),
+      delivery: session.surface
+        ? { mode: "update", replaceMarkup: true }
+        : undefined,
+      title: "Working Updates",
+      body:
+        "How much of the agent's in-progress work is bridged to this chat.\n\n"
+        + "None: only final answers and questions.\n"
+        + "Less / Some / More: coalesced batches that respect platform rate limits.\n"
+        + "All: the most (the rate budget may still hold some back).",
+      fallbackText: "Choose a Working Updates option, or reply back.",
+      targetSurface: session.surface,
+      actions: [
+        ...messagingToolUpdateModeChoices(currentMode).map((choice, index) => ({
+          id: "browse:new:set-working-updates",
+          label: `${choice.label}${choice.current ? " (current)" : ""}`,
+          style: "secondary" as const,
+          fallbackText: String(index + 1),
+          priority: 10 + index,
+          value: { toolUpdateMode: choice.mode },
         })),
         {
           id: session.workMode === "worktree"

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -199,6 +199,7 @@ import {
   type MessagingResolvedThreadState,
 } from "./messaging-thread-state.js";
 import { summarizeToolActivityFromBackendEvent } from "./messaging-tool-activity.js";
+import type { MessagingToolActivity } from "./messaging-tool-activity.js";
 import {
   MessagingToolUpdatePolicy,
   type MessagingToolUpdatePolicyDelivery,
@@ -629,6 +630,17 @@ export class MessagingController {
   private readonly logger: MessagingControllerLogger;
   private readonly streamingResponsesDefault: boolean;
   private readonly toolUpdatePolicy: MessagingToolUpdatePolicy;
+  // Un-gated per-turn capture of the agent's most recent in-turn (non-final)
+  // prose, keyed by `${bindingId}\0${turnId}`. Written before the Working
+  // Updates dial decides delivery, so an elicitation can flush its setup
+  // message (U7) even when the dial suppressed it. `deliveredProseIds` tracks
+  // which prose activity ids already reached the channel so the flush stays
+  // idempotent.
+  private readonly turnProseCapture = new Map<
+    string,
+    { activityId: string; text: string }
+  >();
+  private readonly deliveredProseIds = new Map<string, Set<string>>();
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
   private readonly pendingFullAccessNewThreadPrompts = new Map<
@@ -1120,10 +1132,14 @@ export class MessagingController {
         (isTerminalTurnLifecycle(lifecycle) ||
           (isThreadStatusIdleEvent(event) && activeTurn))
       ) {
+        const terminalTurnId = turnIdForBackendEvent(event) ?? activeTurn?.turnId;
         await this.flushToolUpdatesForBinding(binding, {
           clear: true,
-          turnId: turnIdForBackendEvent(event) ?? activeTurn?.turnId,
+          turnId: terminalTurnId,
         });
+        if (terminalTurnId) {
+          this.clearTurnProse(binding.id, terminalTurnId);
+        }
       }
 
       const assistantDelta = assistantDeltaForBackendEvent(event);
@@ -1135,14 +1151,6 @@ export class MessagingController {
 
       const assistantText = assistantTextForBackendEvent(event);
       if (assistantText) {
-        // Suppress NON-final agentMessage completions (e.g. Codex "commentary"
-        // phases the agent emits while thinking) on every turn, not just
-        // automation ones. Each such `item/completed` otherwise posts its own
-        // message, so a single turn fans out into a burst of separate messages
-        // on the channel — the "pinged a dozen times" flood. Messaging shows
-        // the agent's final answer (streamed into one message when streaming is
-        // on); intermediate commentary stays on the desktop transcript. Items
-        // with no phase, or phase "final"/"final_answer", still post.
         if (!isNonFinalAssistantTextForBackendEvent(event)) {
           const deliveredFinalStream = await this.flushAssistantStreamForEvent(
             event,
@@ -1154,6 +1162,20 @@ export class MessagingController {
           } else {
             await this.deliverAssistantMessage(assistantText, event, binding);
           }
+        } else if (!automationTurnEvent) {
+          // NON-final agentMessage completions (e.g. Codex "commentary" phases
+          // the agent emits while thinking) are the agent's in-turn prose. They
+          // flow through the Working Updates dial: suppressed at None, coalesced
+          // into batches at Less/Some/More, sent individually at All — the same
+          // policy that governs tool activity. This replaces the old outright
+          // drop that was added to stop the "pinged a dozen times" flood; the
+          // coalescing preserves that anti-flood intent at low dial settings.
+          await this.deliverAssistantProseForBackendEvent(
+            event,
+            binding,
+            assistantText,
+            activeTurn?.turnId,
+          );
         }
       } else if (isTerminalTurnLifecycle(activeTurn) && !assistantDelta) {
         // Only flush buffered stream text on a genuine terminal event (e.g.
@@ -11240,6 +11262,83 @@ export class MessagingController {
     }
   }
 
+  /**
+   * Route the agent's in-turn (non-final) prose through the Working Updates
+   * dial, mirroring {@link deliverToolActivityForBackendEvent} for tools. The
+   * prose is captured un-gated first (so U7's elicitation flush can surface a
+   * suppressed setup message), then handed to the same coalescing policy so it
+   * is dropped at None, batched at Less/Some/More, or sent individually at All.
+   */
+  private async deliverAssistantProseForBackendEvent(
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+    assistantText: string,
+    activeTurnId?: string,
+  ): Promise<void> {
+    const turnId = turnIdForBackendEvent(event) ?? activeTurnId;
+    if (!turnId) {
+      return;
+    }
+    if (this.isAutomationTurnEvent(event, binding, activeTurnId)) {
+      return;
+    }
+
+    const activity: MessagingToolActivity = {
+      id: proseActivityIdForBackendEvent(event, turnId, assistantText),
+      kind: "prose",
+      status: "completed",
+      title: assistantText,
+    };
+    this.turnProseCapture.set(this.turnProseKey(binding.id, turnId), {
+      activityId: activity.id,
+      text: assistantText,
+    });
+
+    const mode = resolveMessagingToolUpdateMode(
+      binding,
+      await this.resolveToolUpdateDefaultMode(),
+    );
+    const deliveries = this.toolUpdatePolicy.processActivity({
+      activity,
+      bindingId: binding.id,
+      mode,
+      turnId,
+    });
+    for (const delivery of deliveries) {
+      await this.deliverToolUpdateDelivery(delivery, binding);
+    }
+  }
+
+  private turnProseKey(bindingId: string, turnId: string): string {
+    return `${bindingId}\0${turnId}`;
+  }
+
+  private markProseActivitiesDelivered(
+    delivery: MessagingToolUpdatePolicyDelivery,
+  ): void {
+    const proseIds = delivery.activities
+      .filter((activity) => activity.kind === "prose")
+      .map((activity) => activity.id);
+    if (proseIds.length === 0) {
+      return;
+    }
+    const key = this.turnProseKey(delivery.bindingId, delivery.turnId);
+    let delivered = this.deliveredProseIds.get(key);
+    if (!delivered) {
+      delivered = new Set();
+      this.deliveredProseIds.set(key, delivered);
+    }
+    for (const id of proseIds) {
+      delivered.add(id);
+    }
+  }
+
+  private clearTurnProse(bindingId: string, turnId: string): void {
+    const key = this.turnProseKey(bindingId, turnId);
+    this.turnProseCapture.delete(key);
+    this.deliveredProseIds.delete(key);
+  }
+
   private async flushToolUpdatesForBinding(
     binding: MessagingBindingRecord,
     options: { clear: boolean; turnId?: string },
@@ -11280,6 +11379,7 @@ export class MessagingController {
             createdAt: this.now(),
             id: this.newIntentId("tool-update-batch"),
           });
+    this.markProseActivitiesDelivered(delivery);
     await this.deliver(intent, binding);
   }
 
@@ -13487,6 +13587,32 @@ function isNonFinalAssistantTextForBackendEvent(event: AgentEvent): boolean {
   }
   const phase = typeof params.item.phase === "string" ? params.item.phase : undefined;
   return Boolean(phase && phase !== "final" && phase !== "final_answer");
+}
+
+/**
+ * Stable id for an in-turn prose activity so the coalescing policy dedups
+ * re-emitted events. Prefers the backend item id; falls back to a
+ * turn-scoped signature of the text (distinct prose blocks differ, and verbatim
+ * repeats are intentionally deduped).
+ */
+function proseActivityIdForBackendEvent(
+  event: AgentEvent,
+  turnId: string,
+  text: string,
+): string {
+  if (event.notification.method === "item/completed") {
+    const item = (event.notification.params as { item?: Record<string, unknown> })
+      .item;
+    const rawId =
+      (typeof item?.id === "string" && item.id) ||
+      (typeof item?.itemId === "string" && item.itemId) ||
+      (typeof item?.item_id === "string" && item.item_id) ||
+      undefined;
+    if (rawId) {
+      return `prose:${rawId}`;
+    }
+  }
+  return `prose:${turnId}:${text.length}:${text.slice(0, 24)}`;
 }
 
 function isTerminalTurnLifecycle(

--- a/apps/desktop/src/main/messaging/core/messaging-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-renderer.ts
@@ -93,6 +93,22 @@ export function buildToolUpdateMessageIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingMessageIntent {
+  if (params.activity.kind === "prose") {
+    return {
+      id: params.id,
+      kind: "message",
+      bindingId: params.bindingId,
+      createdAt: params.createdAt,
+      role: "assistant",
+      parts: [
+        {
+          type: "text",
+          text: params.activity.title,
+          markdown: "markdown",
+        },
+      ],
+    };
+  }
   return {
     id: params.id,
     kind: "message",
@@ -115,21 +131,39 @@ export function buildToolUpdateBatchMessageIntent(params: {
   createdAt: number;
   id: string;
 }): MessagingMessageIntent {
-  const count = params.activities.length;
+  // A coalesced batch can blend the agent's in-turn prose with tool activity.
+  // Render the prose blocks verbatim (they are assistant markdown) and summarize
+  // the tool activity under its own header so prose is never mislabeled as a
+  // "ran N tools" line. Tool-only batches keep the original header/format so
+  // existing tool-update behavior is unchanged.
+  const proseActivities = params.activities.filter(
+    (activity) => activity.kind === "prose",
+  );
+  const toolActivities = params.activities.filter(
+    (activity) => activity.kind !== "prose",
+  );
+  const segments: string[] = proseActivities.map((activity) => activity.title);
+  if (toolActivities.length > 0) {
+    const count = toolActivities.length;
+    segments.push(
+      [
+        `Tool updates: ran ${count} tool${count === 1 ? "" : "s"}`,
+        ...toolActivities.map((activity) => `- ${formatToolActivityLine(activity)}`),
+      ].join("\n"),
+    );
+  }
+  const hasProse = proseActivities.length > 0;
   return {
     id: params.id,
     kind: "message",
     bindingId: params.bindingId,
     createdAt: params.createdAt,
-    role: "system",
+    role: hasProse ? "assistant" : "system",
     parts: [
       {
         type: "text",
-        text: [
-          `Tool updates: ran ${count} tool${count === 1 ? "" : "s"}`,
-          ...params.activities.map((activity) => `- ${formatToolActivityLine(activity)}`),
-        ].join("\n"),
-        markdown: "light",
+        text: segments.join("\n\n"),
+        markdown: hasProse ? "markdown" : "light",
       },
     ],
   };

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -165,7 +165,7 @@ export function buildBindingStatusIntent(params: {
       supportsFastMode ? `Fast mode: ${fastMode ? "on" : "off"}` : undefined,
       planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
-      `Tool updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
+      `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       `Streaming: ${streamingLabel}`,
       params.binding.pendingSkillSelection
         ? `Pending skill: $${params.binding.pendingSkillSelection.name}`
@@ -493,7 +493,7 @@ function buildStatusActions(params: {
       : []),
     {
       id: "status:tool-updates",
-      label: `Tools: ${formatMessagingToolUpdateModeLabel(params.toolUpdateMode)}`,
+      label: `Working Updates: ${formatMessagingToolUpdateModeLabel(params.toolUpdateMode)}`,
       style: "secondary",
       fallbackText: "tools",
       priority: 9,
@@ -1313,8 +1313,12 @@ export function buildStatusToolUpdateModePickerIntent(params: {
       fallback: "present_new",
     },
     targetSurface: params.binding.statusSurface,
-    fallbackText: "Reply with a tools option number, Back, or Cancel.",
-    prompt: "Select Tools",
+    fallbackText: "Reply with a Working Updates option number, Back, or Cancel.",
+    prompt:
+      "Working Updates — how much of the agent's in-progress work is bridged here.\n\n"
+      + "None: only final answers and questions.\n"
+      + "Less / Some / More: coalesced batches that respect platform rate limits.\n"
+      + "All: the most (the rate budget may still hold some back).",
     choices: applyActionCapabilityLimits(
       [
         ...params.choices.map((choice, index) => ({

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -51,6 +51,20 @@ export type MessagingWorkspaceHandoffContext = {
 export const BRANCH_PICKER_PAGE_SIZE = 8;
 export const HANDOFF_BRANCH_PAGE_SIZE = BRANCH_PICKER_PAGE_SIZE;
 
+/**
+ * The per-thread streaming control is an advanced, default-off feature. Show it
+ * only when the operator opted in globally (`showStreamingOption`) OR the
+ * binding already has streaming explicitly enabled — the anti-stranding case so
+ * a pre-existing streaming binding can still be turned off after the default
+ * hides the control.
+ */
+export function shouldShowStreamingControl(
+  streamingMode: MessagingStreamingResponseMode,
+  showStreamingOption?: boolean,
+): boolean {
+  return Boolean(showStreamingOption) || streamingMode === "enabled";
+}
+
 export function buildBindingStatusIntent(params: {
   allowFullAccessEscalation?: boolean;
   backendSummary?: BackendSummary;
@@ -61,6 +75,7 @@ export function buildBindingStatusIntent(params: {
   handoff?: MessagingWorkspaceHandoffContext;
   id: string;
   streamingResponsesDefault?: boolean;
+  showStreamingOption?: boolean;
   threadState: MessagingResolvedThreadState;
   toolUpdateMode?: MessagingToolUpdateMode;
 }): MessagingStatusIntent {
@@ -166,7 +181,9 @@ export function buildBindingStatusIntent(params: {
       planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
       `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
-      `Streaming: ${streamingLabel}`,
+      shouldShowStreamingControl(streamingMode, params.showStreamingOption)
+        ? `Streaming: ${streamingLabel}`
+        : undefined,
       params.binding.pendingSkillSelection
         ? `Pending skill: $${params.binding.pendingSkillSelection.name}`
         : undefined,
@@ -195,6 +212,7 @@ export function buildBindingStatusIntent(params: {
       supportsReasoning,
       streamingMode,
       streamingResponsesDefault: params.streamingResponsesDefault,
+      showStreamingOption: params.showStreamingOption,
       toolUpdateMode,
     }),
   };
@@ -426,6 +444,7 @@ function buildStatusActions(params: {
   supportsReasoning: boolean;
   streamingMode: MessagingStreamingResponseMode;
   streamingResponsesDefault?: boolean;
+  showStreamingOption?: boolean;
   toolUpdateMode: MessagingToolUpdateMode;
 }): MessagingSurfaceAction[] {
   const profile = params.capabilityProfile;
@@ -498,16 +517,20 @@ function buildStatusActions(params: {
       fallbackText: "tools",
       priority: 9,
     },
-    {
-      id: "status:streaming",
-      label: `Stream: ${formatMessagingStreamingResponseModeLabel(
-        params.streamingMode,
-        params.streamingResponsesDefault,
-      )}`,
-      style: "secondary",
-      fallbackText: "stream",
-      priority: 10,
-    },
+    ...(shouldShowStreamingControl(params.streamingMode, params.showStreamingOption)
+      ? [
+          {
+            id: "status:streaming",
+            label: `Stream: ${formatMessagingStreamingResponseModeLabel(
+              params.streamingMode,
+              params.streamingResponsesDefault,
+            )}`,
+            style: "secondary" as const,
+            fallbackText: "stream",
+            priority: 10,
+          },
+        ]
+      : []),
     {
       id: "status:compact",
       label: "Compact",

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -53,16 +53,25 @@ export const HANDOFF_BRANCH_PAGE_SIZE = BRANCH_PICKER_PAGE_SIZE;
 
 /**
  * The per-thread streaming control is an advanced, default-off feature. Show it
- * only when the operator opted in globally (`showStreamingOption`) OR the
- * binding already has streaming explicitly enabled — the anti-stranding case so
- * a pre-existing streaming binding can still be turned off after the default
- * hides the control.
+ * when any of:
+ * - the operator opted in globally (`showStreamingOption`) — governs threads
+ *   that never had streaming on, and all new threads;
+ * - this thread has streaming enabled *right now* (`streamingMode === "enabled"`)
+ *   — covers pre-existing enabled bindings before the sticky flag was recorded;
+ * - this thread has had streaming enabled before (`streamingControlRevealed`) —
+ *   the sticky anti-stranding case, so a thread that turned streaming off can
+ *   always toggle it back even while the global setting is off.
  */
 export function shouldShowStreamingControl(
   streamingMode: MessagingStreamingResponseMode,
   showStreamingOption?: boolean,
+  streamingControlRevealed?: boolean,
 ): boolean {
-  return Boolean(showStreamingOption) || streamingMode === "enabled";
+  return (
+    Boolean(showStreamingOption) ||
+    Boolean(streamingControlRevealed) ||
+    streamingMode === "enabled"
+  );
 }
 
 export function buildBindingStatusIntent(params: {
@@ -181,7 +190,11 @@ export function buildBindingStatusIntent(params: {
       planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
       `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
-      shouldShowStreamingControl(streamingMode, params.showStreamingOption)
+      shouldShowStreamingControl(
+        streamingMode,
+        params.showStreamingOption,
+        params.binding.preferences?.streamingControlRevealed,
+      )
         ? `Streaming: ${streamingLabel}`
         : undefined,
       params.binding.pendingSkillSelection
@@ -213,6 +226,7 @@ export function buildBindingStatusIntent(params: {
       streamingMode,
       streamingResponsesDefault: params.streamingResponsesDefault,
       showStreamingOption: params.showStreamingOption,
+      streamingControlRevealed: params.binding.preferences?.streamingControlRevealed,
       toolUpdateMode,
     }),
   };
@@ -445,6 +459,7 @@ function buildStatusActions(params: {
   streamingMode: MessagingStreamingResponseMode;
   streamingResponsesDefault?: boolean;
   showStreamingOption?: boolean;
+  streamingControlRevealed?: boolean;
   toolUpdateMode: MessagingToolUpdateMode;
 }): MessagingSurfaceAction[] {
   const profile = params.capabilityProfile;
@@ -517,7 +532,11 @@ function buildStatusActions(params: {
       fallbackText: "tools",
       priority: 9,
     },
-    ...(shouldShowStreamingControl(params.streamingMode, params.showStreamingOption)
+    ...(shouldShowStreamingControl(
+      params.streamingMode,
+      params.showStreamingOption,
+      params.streamingControlRevealed,
+    )
       ? [
           {
             id: "status:streaming",

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -7,6 +7,7 @@ export type MessagingToolActivityKind =
   | "command"
   | "file"
   | "mcp"
+  | "prose"
   | "search"
   | "tool";
 

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -176,6 +176,7 @@ export type DesktopMessagingConfig = {
   slack?: SlackMessagingConfig;
   telegram?: TelegramMessagingConfig;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
+  showStreamingOption?: boolean;
 };
 
 export type DesktopMessagingFullAccessControls = {
@@ -211,6 +212,7 @@ export const DESKTOP_MESSAGING_ROOT_CONFIG_FIELD_IMPACTS = {
   slack: "connection",
   telegram: "connection",
   toolUpdateDefaultMode: "irrelevant",
+  showStreamingOption: "irrelevant",
 } as const satisfies Record<
   keyof DesktopMessagingConfig,
   DesktopMessagingConfigFieldImpact
@@ -1130,6 +1132,7 @@ export async function loadDesktopMessagingConfigFromSettings(
     },
     inputDebounceMs: snapshot.messaging.inputDebounceMs.value,
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
+    showStreamingOption: snapshot.messaging.showStreamingOption.value,
     attachmentPolicy,
     ...telegramConfig,
     ...discordConfig,

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1003,7 +1003,8 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         config,
         adapter.channel,
       ),
-      showStreamingOption: config.showStreamingOption ?? false,
+      showStreamingOption: async () =>
+        (await this.loadConfig()).showStreamingOption ?? false,
       responseModeForConversation: async (channel) =>
         responseModeForChannel(
           await this.loadConfig(),

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1003,6 +1003,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         config,
         adapter.channel,
       ),
+      showStreamingOption: config.showStreamingOption ?? false,
       responseModeForConversation: async (channel) =>
         responseModeForChannel(
           await this.loadConfig(),

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -136,6 +136,7 @@ export type DesktopSettingsConfig = {
     fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    showStreamingOption?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;
       maxAttachmentBytes?: number;
@@ -872,6 +873,9 @@ export function desktopSettingsPatchToEdits(
   if (patch.messaging?.toolUpdateMode !== undefined) {
     set(["messaging", "tool_update_mode"], patch.messaging.toolUpdateMode);
   }
+  if (patch.messaging?.showStreamingOption !== undefined) {
+    set(["messaging", "show_streaming_option"], patch.messaging.showStreamingOption);
+  }
 
   const attachments = patch.messaging?.attachments;
   if (attachments?.imageProfile !== undefined) {
@@ -1361,6 +1365,7 @@ function normalizeDesktopConfig(
       ),
       inputDebounceMs: readNumber(messaging?.input_debounce_ms),
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
+      showStreamingOption: readBoolean(messaging?.show_streaming_option),
       attachments: {
         imageProfile: readImageProfile(attachments?.image_profile),
         maxAttachmentBytes: readNumber(attachments?.max_attachment_bytes),
@@ -1667,6 +1672,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const allowFullAccessThreadResume = config.messaging?.allowFullAccessThreadResume;
   const fullAccessWarning = config.messaging?.fullAccessWarning;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
+  const showStreamingOption = config.messaging?.showStreamingOption;
   if (
     enabled !== undefined ||
     allowFullAccessEscalation !== undefined ||
@@ -1674,6 +1680,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     fullAccessWarning !== undefined ||
     inputDebounceMs !== undefined ||
     toolUpdateMode !== undefined ||
+    showStreamingOption !== undefined ||
     (attachments && hasDefinedValue(attachments))
     || (telegram && hasDefinedValue(telegram))
     || (discord && hasDefinedValue(discord))
@@ -1697,6 +1704,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (inputDebounceMs !== undefined) {
       pruned.messaging.inputDebounceMs = inputDebounceMs;
+    }
+    if (showStreamingOption !== undefined) {
+      pruned.messaging.showStreamingOption = showStreamingOption;
     }
     if (toolUpdateMode !== undefined) {
       pruned.messaging.toolUpdateMode = toolUpdateMode;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -683,6 +683,10 @@ export class DesktopSettingsService {
         toolUpdateMode: this.resolveToolUpdateMode(
           config.messaging?.toolUpdateMode,
         ),
+        showStreamingOption: this.resolveConfigBoolean(
+          config.messaging?.showStreamingOption,
+          false,
+        ),
         attachments: {
           imageProfile: this.resolveMessagingImageProfile(
             config.messaging?.attachments?.imageProfile,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -479,6 +479,7 @@ describe("App", () => {
         fullAccessWarning: { value: "dismissable", source: "default" },
         inputDebounceMs: { value: 500, source: "default" },
         toolUpdateMode: { value: "show_some", source: "default" },
+        showStreamingOption: { value: false, source: "default" },
         telegram: {
           enabled: { value: false, source: "default" },
           responseMode: { value: "every_message", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -121,6 +121,33 @@ export function MessagingSettings(props: {
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
   const showStreamingOption = props.snapshot.messaging.showStreamingOption;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
+  const [streamingNudgeProvider, setStreamingNudgeProvider] = useState<
+    string | null
+  >(null);
+  // When an operator turns on provider-level streaming, offer once to reveal the
+  // per-thread streaming control (the global show-option, default off). Guarded
+  // by shouldOfferStreamingNudge so it doesn't nag: skip if the global option is
+  // already on, or if another provider already streams (choice already made).
+  const maybeNudgeForStreaming = (
+    providerKey: string,
+    providerLabel: string,
+  ): void => {
+    const offer = shouldOfferStreamingNudge({
+      showStreamingOption: showStreamingOption.value,
+      enabledProviderKey: providerKey,
+      providerStreaming: {
+        telegram: telegram.streamingResponses.value,
+        discord: discord.streamingResponses.value,
+        mattermost: mattermost.streamingResponses.value,
+        slack: slack.streamingResponses.value,
+        feishu: feishu.streamingResponses.value,
+        line: line.streamingResponses.value,
+      },
+    });
+    if (offer) {
+      setStreamingNudgeProvider(providerLabel);
+    }
+  };
   const imageProfile = props.snapshot.messaging.attachments.imageProfile;
   const runtimeMessaging = props.snapshot.runtime.messaging;
   const masterEnabled = runtimeMessaging.overrideActive
@@ -221,6 +248,45 @@ export function MessagingSettings(props: {
               void props.onShowStreamingOptionChange(enabled);
             }}
           />
+          {streamingNudgeProvider ? (
+            <section
+              className="settings-panel settings-panel--warning"
+              role="status"
+            >
+              <div className="settings-panel__header">
+                <div>
+                  <p className="eyebrow">Streaming enabled</p>
+                  <h2>Show the streaming option on thread cards?</h2>
+                </div>
+              </div>
+              <p className="settings-row__description">
+                You turned on streaming for {streamingNudgeProvider}. Show the
+                per-thread streaming toggle in chat status cards and the New
+                Thread menu so you can pick it per thread? It stays an advanced
+                option — most people leave it off.
+              </p>
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--secondary"
+                  disabled={props.saving}
+                  onClick={() => {
+                    setStreamingNudgeProvider(null);
+                    void props.onShowStreamingOptionChange(true);
+                  }}
+                  type="button"
+                >
+                  Show it on thread cards
+                </button>
+                <button
+                  className="button button--ghost"
+                  onClick={() => setStreamingNudgeProvider(null)}
+                  type="button"
+                >
+                  Not now
+                </button>
+              </div>
+            </section>
+          ) : null}
           <NumberField
             disabled={props.saving}
             label="Input debounce"
@@ -353,6 +419,7 @@ export function MessagingSettings(props: {
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(telegram.streamingResponses)}
             onChange={(streamingResponses) => {
+              if (streamingResponses) maybeNudgeForStreaming("telegram", "Telegram");
               void props.onSaveTelegram({
                 ...telegram,
                 streamingResponses: {
@@ -470,6 +537,7 @@ export function MessagingSettings(props: {
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(discord.streamingResponses)}
             onChange={(streamingResponses) => {
+              if (streamingResponses) maybeNudgeForStreaming("discord", "Discord");
               void props.onSaveDiscord({
                 ...discord,
                 streamingResponses: {
@@ -623,6 +691,7 @@ export function MessagingSettings(props: {
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(mattermost.streamingResponses)}
             onChange={(streamingResponses) => {
+              if (streamingResponses) maybeNudgeForStreaming("mattermost", "Mattermost");
               void props.onSaveMattermost({
                 ...mattermost,
                 streamingResponses: {
@@ -1103,6 +1172,7 @@ export function MessagingSettings(props: {
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(slack.streamingResponses)}
             onChange={(streamingResponses) => {
+              if (streamingResponses) maybeNudgeForStreaming("slack", "Slack");
               void props.onSaveSlack({
                 ...slack,
                 streamingResponses: {
@@ -1265,6 +1335,7 @@ export function MessagingSettings(props: {
             help={STREAMING_RESPONSES_WARNING}
             source={sourceBadge(feishu.streamingResponses)}
             onChange={(streamingResponses) => {
+              if (streamingResponses) maybeNudgeForStreaming("feishu", "Feishu");
               void props.onSaveFeishu({
                 ...feishu,
                 streamingResponses: {
@@ -1652,6 +1723,26 @@ const FEISHU_INBOUND_MODE_OPTIONS: Array<{
   { label: "Persistent", value: "persistent" },
   { label: "Webhook", value: "webhook" },
 ];
+
+/**
+ * Whether to offer the "show streaming option on thread cards" nudge when a
+ * provider's streaming is switched on. Skips when the global option is already
+ * on, or when any OTHER provider already streams (the operator has made this
+ * choice before, so a repeat prompt would nag).
+ */
+export function shouldOfferStreamingNudge(params: {
+  showStreamingOption: boolean;
+  enabledProviderKey: string;
+  providerStreaming: Record<string, boolean>;
+}): boolean {
+  if (params.showStreamingOption) {
+    return false;
+  }
+  const anyOtherStreaming = Object.entries(params.providerStreaming).some(
+    ([key, enabled]) => key !== params.enabledProviderKey && enabled,
+  );
+  return !anyOtherStreaming;
+}
 
 const STREAMING_RESPONSES_WARNING =
   "Advanced. Leave this off unless you specifically need live message edits. It does not make turns finish sooner; it repeatedly edits the same platform message, which can break voice readers and reach platform rate limits much sooner.";

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -238,55 +238,6 @@ export function MessagingSettings(props: {
               void props.onToolUpdateModeChange(mode);
             }}
           />
-          <ToggleField
-            checked={showStreamingOption.value}
-            disabled={props.saving}
-            label="Show streaming option on thread cards"
-            sub="Advanced. Reveals a per-thread streaming toggle in chat status cards and the New Thread menu. Streaming does not send in-turn messages — it repeatedly edits one message as tokens arrive, which burns platform rate limits fast and usually ends up throttled. Most people should leave this off."
-            source={sourceBadge(showStreamingOption)}
-            onChange={(enabled) => {
-              void props.onShowStreamingOptionChange(enabled);
-            }}
-          />
-          {streamingNudgeProvider ? (
-            <section
-              className="settings-panel settings-panel--warning"
-              role="status"
-            >
-              <div className="settings-panel__header">
-                <div>
-                  <p className="eyebrow">Streaming enabled</p>
-                  <h2>Show the streaming option on thread cards?</h2>
-                </div>
-              </div>
-              <p className="settings-row__description">
-                You turned on streaming for {streamingNudgeProvider}. Show the
-                per-thread streaming toggle in chat status cards and the New
-                Thread menu so you can pick it per thread? It stays an advanced
-                option — most people leave it off.
-              </p>
-              <div className="settings-inline-actions">
-                <button
-                  className="button button--secondary"
-                  disabled={props.saving}
-                  onClick={() => {
-                    setStreamingNudgeProvider(null);
-                    void props.onShowStreamingOptionChange(true);
-                  }}
-                  type="button"
-                >
-                  Show it on thread cards
-                </button>
-                <button
-                  className="button button--ghost"
-                  onClick={() => setStreamingNudgeProvider(null)}
-                  type="button"
-                >
-                  Not now
-                </button>
-              </div>
-            </section>
-          ) : null}
           <NumberField
             disabled={props.saving}
             label="Input debounce"
@@ -341,6 +292,57 @@ export function MessagingSettings(props: {
               void props.onImageProfileChange(profile);
             }}
           />
+
+          <SettingsGroupLabel>Advanced</SettingsGroupLabel>
+          <ToggleField
+            checked={showStreamingOption.value}
+            disabled={props.saving}
+            label="Show streaming option on thread cards"
+            sub="Advanced. Reveals a per-thread streaming toggle in chat status cards and the New Thread menu. Streaming does not send in-turn messages — it repeatedly edits one message as tokens arrive, which burns platform rate limits fast and usually ends up throttled. Most people should leave this off."
+            source={sourceBadge(showStreamingOption)}
+            onChange={(enabled) => {
+              void props.onShowStreamingOptionChange(enabled);
+            }}
+          />
+          {streamingNudgeProvider ? (
+            <section
+              className="settings-panel settings-panel--warning"
+              role="status"
+            >
+              <div className="settings-panel__header">
+                <div>
+                  <p className="eyebrow">Streaming enabled</p>
+                  <h2>Show the streaming option on thread cards?</h2>
+                </div>
+              </div>
+              <p className="settings-row__description">
+                You turned on streaming for {streamingNudgeProvider}. Show the
+                per-thread streaming toggle in chat status cards and the New
+                Thread menu so you can pick it per thread? It stays an advanced
+                option — most people leave it off.
+              </p>
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--secondary"
+                  disabled={props.saving}
+                  onClick={() => {
+                    setStreamingNudgeProvider(null);
+                    void props.onShowStreamingOptionChange(true);
+                  }}
+                  type="button"
+                >
+                  Show it on thread cards
+                </button>
+                <button
+                  className="button button--ghost"
+                  onClick={() => setStreamingNudgeProvider(null)}
+                  type="button"
+                >
+                  Not now
+                </button>
+              </div>
+            </section>
+          ) : null}
         </div>
       </SettingsSection>
 

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -77,6 +77,7 @@ export function MessagingSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onToolUpdateModeChange: (mode: MessagingToolUpdateMode) => Promise<void>;
+  onShowStreamingOptionChange: (enabled: boolean) => Promise<void>;
   onImageProfileChange: (profile: DesktopMessagingImageProfile) => Promise<void>;
   onInputDebounceMsChange: (value: number) => Promise<void>;
   onMessagingEnabledChange: (enabled: boolean) => Promise<void>;
@@ -118,6 +119,7 @@ export function MessagingSettings(props: {
     props.snapshot.messaging.allowFullAccessThreadResume;
   const fullAccessWarning = props.snapshot.messaging.fullAccessWarning;
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
+  const showStreamingOption = props.snapshot.messaging.showStreamingOption;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
   const imageProfile = props.snapshot.messaging.attachments.imageProfile;
   const runtimeMessaging = props.snapshot.runtime.messaging;
@@ -207,6 +209,16 @@ export function MessagingSettings(props: {
             value={toolUpdateMode.value}
             onChange={(mode) => {
               void props.onToolUpdateModeChange(mode);
+            }}
+          />
+          <ToggleField
+            checked={showStreamingOption.value}
+            disabled={props.saving}
+            label="Show streaming option on thread cards"
+            sub="Advanced. Reveals a per-thread streaming toggle in chat status cards and the New Thread menu. Streaming does not send in-turn messages — it repeatedly edits one message as tokens arrive, which burns platform rate limits fast and usually ends up throttled. Most people should leave this off."
+            source={sourceBadge(showStreamingOption)}
+            onChange={(enabled) => {
+              void props.onShowStreamingOptionChange(enabled);
             }}
           />
           <NumberField

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -200,8 +200,8 @@ export function MessagingSettings(props: {
           />
           <SegmentedField
             disabled={props.saving}
-            label="Tool usage notifications"
-            sub="How chatty bridged messages are when the agent runs tools."
+            label="Working Updates"
+            sub="How much of the agent's in-progress work — tool activity and in-turn messages — is bridged. None sends only final answers and questions; higher settings send coalesced batches that respect platform rate limits."
             options={TOOL_UPDATE_MODE_OPTIONS}
             source={sourceBadge(toolUpdateMode)}
             value={toolUpdateMode.value}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -459,6 +459,13 @@ function SettingsSectionBody(props: {
             },
           });
         }}
+        onShowStreamingOptionChange={async (showStreamingOption) => {
+          await props.settings.writeConfig({
+            messaging: {
+              showStreamingOption,
+            },
+          });
+        }}
         onInputDebounceMsChange={async (inputDebounceMs) => {
           await props.settings.writeConfig({
             messaging: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -190,6 +190,7 @@ function createSnapshot(
       fullAccessWarning: { value: "dismissable", source: "default" },
       inputDebounceMs: { value: 500, source: "default" },
       toolUpdateMode: { value: "show_some", source: "default" },
+      showStreamingOption: { value: false, source: "default" },
       telegram: {
         enabled: { value: false, source: "default" },
         responseMode: { value: "every_message", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/streaming-nudge.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/streaming-nudge.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldOfferStreamingNudge } from "../MessagingSettings.js";
+
+const allOff = {
+  telegram: false,
+  discord: false,
+  mattermost: false,
+  slack: false,
+  feishu: false,
+  line: false,
+};
+
+describe("shouldOfferStreamingNudge", () => {
+  it("offers the nudge when enabling the first provider with the global option off", () => {
+    expect(
+      shouldOfferStreamingNudge({
+        showStreamingOption: false,
+        enabledProviderKey: "telegram",
+        providerStreaming: allOff,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not nudge when the global option is already on", () => {
+    expect(
+      shouldOfferStreamingNudge({
+        showStreamingOption: true,
+        enabledProviderKey: "telegram",
+        providerStreaming: allOff,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not nudge when another provider already streams", () => {
+    expect(
+      shouldOfferStreamingNudge({
+        showStreamingOption: false,
+        enabledProviderKey: "discord",
+        providerStreaming: { ...allOff, telegram: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("still offers when only the provider being enabled shows as streaming", () => {
+    // The excluded key is the one being toggled; its snapshot value may already
+    // read true depending on timing, so it must not suppress its own nudge.
+    expect(
+      shouldOfferStreamingNudge({
+        showStreamingOption: false,
+        enabledProviderKey: "telegram",
+        providerStreaming: { ...allOff, telegram: true },
+      }),
+    ).toBe(true);
+  });
+});

--- a/docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md
+++ b/docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md
@@ -1,0 +1,231 @@
+---
+title: Messaging output verbosity, coalescing, and streaming — concepts and requirements
+type: requirements
+status: draft
+date: 2026-07-04
+tags: [messaging, telegram, discord, tool-updates, streaming, rate-budget, coalescing, elicitation]
+related_code:
+  - packages/shared/src/contracts/messaging.ts
+  - packages/messaging/interface/src/index.ts
+  - apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts
+  - apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts
+  - apps/desktop/src/main/messaging/core/messaging-controller.ts
+  - apps/desktop/src/main/messaging/core/messaging-status-card.ts
+  - apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+---
+
+# Messaging output verbosity, coalescing, and streaming
+
+> **Why this doc exists.** The messaging bridge has four different kinds of
+> agent output and (at least) three overlapping controls governing what
+> reaches the phone. The terminology has drifted — "tool updates,"
+> "streaming," "in-turn messages," and "rate budget" get conflated, and even
+> careful readers (human and agent) mix them up. This doc pins down what each
+> thing *is*, what's wrong today, and the decisions we've made for the next
+> iteration. It is a concept reference first and a requirements list second.
+
+## The four output streams (glossary)
+
+Everything the agent emits during a turn falls into exactly one of these
+structural categories. This taxonomy is *structural* on purpose — we do not
+try to judge whether a given line of prose is "important." We can't do that
+reliably, so we classify by shape, not by meaning.
+
+| # | Stream | What it is | Reader's mental bucket |
+|---|--------|-----------|------------------------|
+| 1 | **Tool activity** | `item/completed` events for tool / command / MCP / file / search items. "Read X", "ran `git status`", "edited Y". | "the agent working" |
+| 2 | **In-turn (intermediate) prose** | *Completed* assistant text blocks emitted mid-turn, before the final answer. The agent thinking out loud ("Let me check the config…", "I found the issue in…"). | "the agent working" |
+| 3 | **Final response** | The terminal assistant message for the turn — the actual answer. | "the answer" |
+| 4 | **Elicitation / questionnaire** | A structured, *blocking* prompt: approval, confirmation, questionnaire. The run stalls until it's answered. | "it needs me" |
+
+The key reader-side insight: **streams 1 and 2 are the same thing to the
+person on their phone** — both are "the agent working." Streams 3 and 4 are
+"the answer" and "it needs me." That collapse is what drives the single-dial
+decision below.
+
+## The controls today (and what's wrong with each)
+
+### `toolUpdateMode` — the Activity dial (governs stream 1 only)
+
+- Values: `show_none`, `show_less`, `show_some`, `show_more`, `show_all`
+  ([packages/shared/src/contracts/messaging.ts](../../packages/shared/src/contracts/messaging.ts)).
+- A real graduated dial with batching windows: `show_all` sends individually;
+  `show_more` up to 5 individual then batch (15s window); `show_some` up to 3
+  then batch (30s); `show_less` always batch (60s); `show_none` never
+  ([messaging-tool-update-policy.ts](../../apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts)).
+- Per-binding override with a global default fallback
+  (`MessagingBindingPreferences.toolUpdateMode`,
+  `resolveMessagingToolUpdateMode`).
+- **Problem 1:** it governs *tool activity only*. Stream 2 (in-turn prose) is
+  not on this dial at all.
+- **Problem 2:** it is **not settable in the `/new` wizard** — only after the
+  thread/binding exists, via the status card.
+
+### `streamingResponses` — the misnamed trap (partially governs stream 2)
+
+- Values: `inherit`, `enabled`, `disabled`.
+- **What operators think it means:** whether the bot sends in-turn messages.
+  **Wrong.**
+- **What it actually means:** whether a *single bridged message* gets
+  progressively **edited/replaced** as tokens arrive from the agent. It is a
+  *messaging-only, message-edit* behavior.
+- **It does NOT control desktop streaming.** Responses always stream inside
+  the desktop app regardless of this setting. This only affects the messaging
+  bridge.
+- **It is a rate-limit trap.** Every message edit counts as a *send* against
+  the provider's rate limit. Telegram allows roughly **20 msgs/min in a
+  group** and **60 msgs/min in a DM**; token-by-token editing blows through
+  that in a few seconds. The result: you get a few early tokens, then
+  everything throttles — and because throttling drops low-priority traffic,
+  it *also* kills your tool and status updates.
+- Today, in-turn prose is only surfaced when `streamingResponses` is
+  `enabled`, which couples "do I see narration at all" to "do I want
+  token-by-token editing." Those are different questions.
+- **Consensus: most people do NOT want this on. It is a poor experience and
+  should be treated as an advanced escape hatch, off by default.**
+
+### Rate budget — the final gate
+
+- [messaging-delivery-budget.ts](../../apps/desktop/src/main/messaging/core/messaging-delivery-budget.ts):
+  default sliding window 60 messages / 60s, 1 reserved slot, 2s safety buffer,
+  slow-mode floor 5s, slow-mode recovery 5min after a 429 cool-off.
+- Priority tiers: `critical_interactive` (elicitations) and `final_turn`
+  (final answers) are deferrable but never dropped; `routine_status`,
+  `tool_progress`, and `stream_partial` are dropped in slow mode.
+- **Consequence:** even `show_all` is not literally "all" — the budget can and
+  will hold progress back. Any user-facing copy must set that expectation.
+
+## Decisions
+
+### D1 — One dial for streams 1 + 2 ("Activity updates")
+
+Rescope and rename `toolUpdateMode` so it governs **tool activity *and*
+in-turn prose** as one blended, coalesced stream. Rename the surface from
+"Tool usage notifications" to **"Activity updates"** (or "Working updates").
+
+- **None** — only final answers + elicitations. In-turn prose and tool
+  activity are suppressed. *(This is the "agent personality" mode that is
+  impossible to express today.)*
+- **Less / Some / More** — increasing density of **coalesced** progress
+  (tools + prose blended, batched).
+- **All** — the most, still subject to the rate budget.
+
+"Intermediate prose" surfaced by this dial means *completed* mid-turn
+assistant messages, coalesced — **not** live token deltas. It works with
+streaming **off** (the normal case).
+
+Route stream 2 through the **same** `MessagingToolUpdatePolicy` that already
+batches stream 1, so both share one coalescing buffer and one budget lane.
+
+**Rationale for one dial, not two:** to the reader, tools and narration are
+the same "progress" bucket, and the motivating personality-thread case wants
+both gone together (= one dial at its floor, not two dials turned down).
+One → two is a cheap future move (ship an "unlink" advanced toggle if evidence
+ever demands it); two → one is a migration. Build the widenable thing.
+
+### D2 — Elicitations and final responses are never on the dial
+
+Streams 3 and 4 always send (`final_turn` / `critical_interactive`,
+deferrable-but-never-dropped). The dial only governs the *optional* progress
+stream, which is why **None is safe** — it can never starve or stall a run.
+
+### D3 — Streaming becomes a gated, default-off advanced feature (Option 4)
+
+Do **not** fold streaming into the Activity dial. Keep it a separate concept
+and hide it by default behind a single global **Messaging → "Show streaming
+option on thread cards"** setting, default **Off**, with an advisory note.
+
+- Rejected: the "hide unless a provider has streaming enabled" heuristic —
+  it keys off an unrelated concern and fires backwards (streaming here is
+  messaging-only; it has nothing to do with provider/desktop streaming).
+- Rejected: full removal — orphans anyone who already has it enabled, with no
+  card control to turn it back off.
+- Rejected: per-card "Advanced ▸" disclosure — too heavy for one row.
+- **Safety rule:** show the per-thread streaming control if the global setting
+  is On **OR** any binding currently has streaming enabled, so nobody who
+  already flipped it on gets stranded.
+
+### D4 — A questionnaire must carry its preceding in-turn message
+
+When we surface an elicitation/questionnaire, the agent has often described
+the options in the *preceding in-turn message* ("So which do you want — Option
+A or Option B?") while the elicitation prompt itself is terse. **If that
+preceding in-turn message has not already been sent** (e.g. because the
+Activity dial suppressed or was still coalescing it), send it immediately
+*before* the elicitation so the question has its context. Elicitation delivery
+must flush any pending buffered prose that belongs to the same turn.
+
+### D5 — Coalescing with exponential backoff (streaming AND slow mode)
+
+This is spun off to its own worktree (see below) but is captured here because
+it's part of the same conceptual model.
+
+- Streaming must **not** emit one edit per agent delta. Debounce per in-flight
+  message using a stored **"next allowed release time"**, not a proliferation
+  of timers: on each incoming delta, if the timestamp hasn't passed and the
+  message isn't final, **coalesce** (buffer) instead of sending.
+- Backoff schedule for a single message: wait ~**250–500ms** after first
+  receipt, send a coalesced block; then **1s**, **2s**, **4s**, **8s**, up to
+  a **~16s cap** between edits. The **final** message flushes immediately
+  (bypasses the timer).
+- Apply the same coalescing to **non-streaming** updates whenever **slow mode**
+  is active. We don't do any of this today.
+
+## Explanatory copy
+
+**Activity dial editor (picker header):**
+
+> Controls how much of the agent's in-progress work is bridged here.
+> **None** — only final answers and questions. Intermediate "thinking out
+> loud" messages and tool activity are suppressed.
+> **Some / More** — those get coalesced into occasional batched updates to
+> stay under platform rate limits.
+> **All** — sends the most, though the rate budget may still hold some back.
+
+**Streaming toggle (advisory):**
+
+> **Advanced.** This does **not** control whether the bot sends in-turn
+> messages — it controls whether a single message is repeatedly edited /
+> replaced as tokens come in. Each edit counts as a message send, so it burns
+> through platform rate limits fast (≈20/min in groups, ≈60/min in DMs) and
+> usually ends up throttled — which then slows or drops your tool and status
+> updates too. You may see slightly earlier tokens, but most people should
+> leave this **off**.
+
+## Requirements checklist
+
+- [ ] Rename/rescope `toolUpdateMode` → "Activity updates"; None suppresses,
+      Less/Some/More coalesce, All = most. (D1)
+- [ ] Feed in-turn prose (stream 2) into `MessagingToolUpdatePolicy` so tools
+      and prose share one coalescing buffer / budget lane. (D1)
+- [ ] Decouple in-turn prose visibility from `streamingResponses`. (D1/D3)
+- [ ] Add the Activity dial to the `/new` wizard picker sequence in
+      [messaging-resume-browser.ts](../../apps/desktop/src/main/messaging/core/messaging-resume-browser.ts);
+      collect into the preferences already passed to `updateBindingPreferences`
+      at thread creation. Infra (per-binding override + global fallback)
+      already exists — this is a picker + one collected field. (Concern A)
+- [ ] Add global Messaging setting "Show streaming option on thread cards"
+      (default Off) gating the per-thread streaming control, with the
+      "OR any binding has it enabled" safety rule. (D3)
+- [ ] Attach the two explanatory notes to the respective editors.
+- [ ] Flush the preceding in-turn message before an elicitation if unsent. (D4)
+- [ ] **[separate worktree]** Streaming/slow-mode coalescing with exponential
+      backoff via next-release timestamps. (D5)
+
+## Open questions / deferrals
+
+- Exact label: "Activity updates" vs "Working updates" vs "Progress." TBD.
+- Whether `show_less` vs `show_some` vs `show_more` thresholds need retuning
+  now that prose shares the buffer (more content per window).
+- Migration for existing bindings with `streamingResponses: enabled` once the
+  card control is hidden by default (the safety rule covers discoverability;
+  no data migration needed).
+
+## Code map
+
+See the file list in frontmatter. Entry points:
+`toolUpdateMode` enum → `messaging.ts`; batching policy →
+`messaging-tool-update-policy.ts`; budget/slow-mode →
+`messaging-delivery-budget.ts`; delivery-priority routing + stream buffering →
+`messaging-controller.ts`; status-card pickers → `messaging-status-card.ts`;
+`/new` wizard sequence → `messaging-resume-browser.ts`.

--- a/docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md
+++ b/docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md
@@ -171,6 +171,19 @@ it's part of the same conceptual model.
 - Apply the same coalescing to **non-streaming** updates whenever **slow mode**
   is active. We don't do any of this today.
 
+### D6 — Nudge to reveal the streaming control when a provider enables streaming
+
+The global "show streaming option on thread cards" setting (D3) defaults off, so
+an operator who turns on provider-level streaming would otherwise have no way to
+pick it per-thread. When provider-level streaming is switched on in Settings, and
+the global show-option is off **and** no other provider already has streaming
+enabled, prompt once offering to turn the global show-option on. Suppress the
+prompt if the global option is already on or another provider already streams —
+this surfaces the advanced control to operators who signal interest without
+nagging repeat-togglers. Complements the D3 anti-stranding rule; it does not
+reintroduce the rejected "hide unless a provider streams" heuristic — the control
+stays gated by the explicit global setting, this only *offers* to flip it.
+
 ## Explanatory copy
 
 **Activity dial editor (picker header):**
@@ -207,6 +220,8 @@ it's part of the same conceptual model.
 - [ ] Add global Messaging setting "Show streaming option on thread cards"
       (default Off) gating the per-thread streaming control, with the
       "OR any binding has it enabled" safety rule. (D3)
+- [ ] Prompt once to offer flipping that global setting on when a provider
+      enables streaming, guarded so it doesn't nag. (D6)
 - [ ] Attach the two explanatory notes to the respective editors.
 - [ ] Flush the preceding in-turn message before an elicitation if unsent. (D4)
 - [ ] **[separate worktree]** Streaming/slow-mode coalescing with exponential
@@ -214,7 +229,9 @@ it's part of the same conceptual model.
 
 ## Open questions / deferrals
 
-- Exact label: "Activity updates" vs "Working updates" vs "Progress." TBD.
+- Label resolved: the dial is named **"Working Updates"** (chosen over "Activity
+  updates" / "Progress"). Prose above predates the decision and still reads
+  "Activity dial" in places; "Working Updates" is authoritative for shipped copy.
 - Whether `show_less` vs `show_some` vs `show_more` thresholds need retuning
   now that prose shares the buffer (more content per window).
 - Migration for existing bindings with `streamingResponses: enabled` once the

--- a/docs/plans/2026-07-04-001-feat-messaging-working-updates-dial-plan.md
+++ b/docs/plans/2026-07-04-001-feat-messaging-working-updates-dial-plan.md
@@ -1,0 +1,525 @@
+---
+title: "feat: Messaging Working Updates dial + streaming gate"
+type: feat
+status: active
+date: 2026-07-04
+origin: docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md
+---
+
+# feat: Messaging Working Updates dial + streaming gate
+
+## Summary
+
+Consolidate the messaging output-verbosity controls: rescope the existing
+tool-update dial into a single **"Working Updates"** dial that governs both
+tool activity and the agent's in-turn (non-final) prose, coalesced through one
+policy; make it settable in the `/new` thread-creation wizard; demote messaging
+"streaming" to a default-off advanced control gated by a new global setting
+(with a one-time nudge when a provider enables streaming); and flush a
+questionnaire's preceding setup message before the elicitation is delivered.
+
+## Problem Frame
+
+Today the messaging bridge exposes a 5-position tool-update dial that governs
+*only* tool activity, while the agent's in-turn narration is governed by a
+separate, cruder `streamingResponses` toggle that is unbatched, rate-limit
+hostile, and mislabeled. To a reader on their phone, tool activity and
+narration are the same "the agent is working" stream, and some threads
+(agent-personality threads especially) want only final answers and questions.
+The dial also can't be set when a thread is born from messaging — only after.
+And a questionnaire often lands without the in-turn message that described its
+options. See origin: `docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md`.
+
+The exponential-backoff coalescing of streaming/slow-mode edits (origin
+decision D5) is **out of scope here** — it is already in flight on a separate
+branch. This plan delivers origin decisions D1–D4.
+
+---
+
+## Requirements
+
+### Working Updates dial
+
+- R1. A single dial ("Working Updates") governs both tool activity and
+  intermediate (non-final) assistant prose. `None` suppresses both;
+  `Less` / `Some` / `More` coalesce both at increasing density; `All` sends the
+  most, still subject to the rate budget. (origin D1)
+- R2. Intermediate prose is coalesced through the same policy as tool activity
+  (shared thresholds/windows) and is decoupled from the streaming setting.
+  (origin D1)
+- R3. Final responses and elicitations are never gated by the dial; `None`
+  never stalls or starves a run. (origin D2)
+- R4. The persisted preference key (`toolUpdateMode`) and its enum values
+  (`show_none`…`show_all`) are unchanged. Changes are behavior + labels only —
+  no config-file migration and no stored-data change. (KTD1)
+- R5. The dial is settable in the `/new` wizard before the thread is created,
+  defaulting to the global messaging default, persisted as a per-binding
+  preference, and remembered (sticky) for the next `/new`. (origin "Concern A")
+- R6. The dial editor shows explanatory copy describing what None / Some / More
+  / All do, including that the budget may still hold some back. (origin D1 copy)
+
+### Streaming control gating
+
+- R7. A new global Messaging setting, "Show streaming option on thread cards,"
+  defaults **Off** and gates visibility of the per-thread streaming control in
+  both the status card and the `/new` wizard. (origin D3, Option 4)
+- R8. As an anti-stranding safety, the streaming control is also shown when the
+  current binding already has `streamingResponses` explicitly set to `enabled`,
+  so a user who turned it on before this change can still turn it off.
+- R9. When a user enables provider-level streaming in Settings, and the global
+  show-option is Off **and** no other provider currently has streaming enabled,
+  prompt once offering to turn the global show-option on. Suppress the prompt if
+  the global option is already on or another provider already streams. (origin D6)
+- R10. The streaming control carries advisory copy clarifying it does **not**
+  control whether in-turn messages are sent, and warning that each edit is a
+  rate-limited send. (origin D3 copy)
+
+### Elicitation context
+
+- R11. Delivering an elicitation/questionnaire first flushes any pending
+  buffered in-turn prose for that turn, so the question carries the setup
+  context the agent wrote just before it. (origin D4)
+
+---
+
+## Key Technical Decisions
+
+- KTD1. **Keep `toolUpdateMode` key and enum stable; rescope + relabel only.**
+  Binding preferences persist as JSON (`messaging-store.ts`), and the global
+  default is a single TOML scalar (`[messaging] tool_update_mode`). Renaming the
+  key would trigger the full `docs/config-file-evolution.md` legacy-shape dance
+  for zero user benefit. Instead the enum and key stay; only behavior (now also
+  governs prose) and user-facing labels ("Tool usage notifications" → "Working
+  Updates") change. This removes migration risk entirely.
+- KTD2. **Route non-final assistant prose through the existing
+  `MessagingToolUpdatePolicy`.** Treat intermediate prose as a new activity kind
+  fed to `processActivity()` so it shares the mode thresholds and batch windows
+  already defined for tools (`show_more` 15s, `show_some` 30s, `show_less` 60s,
+  `show_none` suppress). This gives one coalescing buffer and one budget lane for
+  the blended stream, and decouples prose visibility from `streamingResponses`.
+  The **final** assistant message keeps its existing terminal (`final_turn`,
+  never-dropped) delivery path untouched — only non-terminal prose is diverted.
+  Note the current `MessagingToolActivity` shape is tool-specific, so this adds a
+  prose activity variant that threads through the delivery type and both
+  renderers (see U2). It also re-opens the exact code path (the line-1146 drop
+  guard) that was deliberately added to stop mid-turn flooding — the coalescing
+  is what preserves that anti-flood intent at low dial settings, so it must not
+  regress it.
+- KTD3. **Streaming visibility = global `showStreamingOption` OR current binding
+  `streamingResponses === "enabled"`.** A per-binding check (no cross-binding
+  scan) satisfies the anti-stranding safety cheaply. Rejected: full removal
+  (strands existing users), and the "hide unless a provider has streaming"
+  heuristic (fires backwards — messaging streaming is unrelated to provider/
+  desktop streaming). (origin D3)
+- KTD4. **Nudge-to-enable, guarded** (origin D6). The prompt to flip the global option on
+  fires from the renderer Settings screen when a provider-level streaming toggle
+  is switched on, guarded by (global option currently Off) AND (no other provider
+  currently has streaming enabled). This surfaces the advanced control to users
+  who signal interest without nagging repeat-togglers.
+- KTD5. **Elicitation prose-flush at the delivery seam.** Inject the flush in
+  `handleBackendPendingRequest()` (`messaging-controller.ts:1291`) immediately
+  before `this.deliver(intent, binding)` (~1334), correlating buffered prose to
+  the elicitation by `binding.id` + turn id (`request.params.turnId`, ~1313).
+  Because `None` drops prose without buffering it (see U7), the flush reads from
+  an un-gated per-turn last-prose capture, not the policy's coalescing buffer.
+- KTD6. **New global setting is an additive TOML key** (`[messaging]
+  show_streaming_option`, default `false`) — no migration, no collision with
+  existing keys.
+
+---
+
+## High-Level Technical Design
+
+The core move is reclassifying the agent's output streams and routing the two
+"progress" streams through one coalescing policy, while the two "always-on"
+streams bypass it (and elicitation triggers a prose flush on the way out).
+
+```mermaid
+flowchart TB
+  subgraph out[Agent turn output]
+    T[Tool activity]
+    P[Intermediate non-final prose]
+    F[Final response]
+    E[Elicitation / questionnaire]
+  end
+
+  T --> POL[MessagingToolUpdatePolicy<br/>coalesce by Working Updates mode]
+  P --> POL
+  POL -->|None: drop| X[(suppressed)]
+  POL -->|Less/Some/More: batch| BUD
+  POL -->|All: individual| BUD
+
+  F --> BUD[Rate budget gate]
+  E --> FLUSH{Pending prose<br/>for this turn?}
+  FLUSH -->|yes| POLFLUSH[flush buffered prose first] --> BUD
+  FLUSH -->|no| BUD
+
+  BUD --> SEND[Deliver to platform]
+
+  classDef always fill:#1f6f43,stroke:#2ec77e,color:#fff;
+  class F,E always;
+```
+
+Final responses and elicitations are `final_turn` / `critical_interactive`
+(deferrable, never dropped), so `None` only ever silences the two progress
+streams — it can never stall a run.
+
+---
+
+## Implementation Units
+
+### U1. Rescope and relabel the dial to "Working Updates"
+
+- Goal: Rename all user-facing surfaces of the tool-update dial to "Working
+  Updates" and refresh the picker copy, without touching the stored key or enum.
+- Requirements: R4, R6.
+- Dependencies: none.
+- Files:
+  - `apps/desktop/src/main/messaging/core/messaging-status-card.ts` — status
+    action label (~line 495, `"Tools: …"` → `"Working Updates: …"`), picker
+    `prompt` and `fallbackText` in `buildStatusToolUpdateModePickerIntent`
+    (~lines 1299–1341), and any `formatMessagingToolUpdateModeLabel` helper.
+  - `apps/desktop/src/renderer/src/**` — the Settings → Messaging "Tool usage
+    notifications" row label + description (locate the renderer settings section
+    that renders the `messaging.toolUpdateMode` control).
+  - Test file: colocated with whichever helper formats the label (e.g.
+    `apps/desktop/src/main/messaging/core/__tests__/messaging-status-card.test.ts`).
+- Approach: Copy/label-only. Keep enum values and the `toolUpdateMode` key
+  everywhere. Render the R6 explanatory copy (verbatim text in the
+  [Copy strings](#copy-strings) section) for the dial editor. Note: the existing
+  `MessagingSingleSelectIntent` exposes a short `prompt` + one-line `fallbackText`
+  and no multi-paragraph description field — confirm at implementation whether the
+  copy goes in `prompt`, as a message sent immediately before the picker, or
+  requires a small intent-shape addition; do not silently truncate it away.
+  Confirm the renderer reads the setting via the IPC bridge (renderer may only
+  import `@pwragent/shared`).
+- Patterns to follow: existing `buildStatusReasoningPickerIntent`
+  (`messaging-status-card.ts` ~1159–1202) for prompt/description shape.
+- Test scenarios:
+  - Status-card action renders "Working Updates: <mode>" for each mode value.
+  - Picker prompt includes the None/Some/More/All explanatory copy.
+  - Persisted/read value still round-trips through the unchanged
+    `toolUpdateMode` key (guard against accidental key rename).
+- Verification: Settings screen, status card, and picker all read "Working
+  Updates"; stored config still uses `tool_update_mode`.
+
+### U2. Route intermediate prose through the coalescing policy
+
+- Goal: Feed non-final assistant prose into `MessagingToolUpdatePolicy` so it is
+  coalesced/suppressed by the Working Updates mode, independent of
+  `streamingResponses`.
+- Requirements: R1, R2, R3.
+- Dependencies: none (core plumbing; U1 is cosmetic and can land in parallel).
+- Files:
+  - `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts` —
+    extend the activity type (or add a sibling kind) so prose items flow through
+    the same threshold/window logic; ensure batch rendering can represent prose.
+  - `apps/desktop/src/main/messaging/core/messaging-controller.ts` — the
+    interception point is the non-final-prose **drop guard** at ~line 1136–1157
+    (`if (!isNonFinalAssistantTextForBackendEvent(event)) { … }`, comment
+    "intermediate commentary stays on the desktop transcript"). Today non-final
+    `agentMessage` completions are discarded here even though `assistantText` is
+    already in hand. Route that text into the policy at this guard. This is
+    **not** the delta stream-buffer path (~3274–3404), which handles token
+    deltas + the terminal accumulated message and never holds non-final prose —
+    do not touch it; the terminal/final delivery path stays intact.
+  - `apps/desktop/src/main/messaging/core/messaging-renderer.ts` — the batch
+    renderer `buildToolUpdateBatchMessageIntent` (~112–136) hardcodes a
+    "Tool updates: ran N tool(s)" header and formats each entry via
+    `formatToolActivityLine`. It must **branch on activity kind** so a mixed
+    prose+tool batch does not render prose under a "ran N tools" header, and so a
+    prose-only batch gets prose-appropriate framing.
+  - Test file:
+    `apps/desktop/src/main/messaging/core/__tests__/messaging-tool-update-policy.test.ts`
+    (extend) and controller-level messaging tests.
+- Approach: Non-final vs final is **already classified by the code**, not a
+  look-ahead problem: `isNonFinalAssistantTextForBackendEvent`
+  (`messaging-controller.ts:13475`) keys off `item/completed` +
+  `type === "agentMessage"` + a non-final `phase`, and that discrete event
+  carries the full text. Feed that text to `processActivity()` as a prose
+  activity so it shares the mode thresholds/windows. The prose variant must
+  thread end-to-end through `MessagingToolActivity` (today tool-shaped:
+  `kind`/`title`/`status`/`pathBasename`/`durationMs`),
+  `MessagingToolUpdatePolicyDelivery`, and both the individual and batch
+  renderers. Keep `None` = drop, matching `show_none` for tools. One extra
+  responsibility for U2: when prose is intercepted at the line-1146 guard, record
+  it in a small **un-gated per-turn last-prose capture** (keyed by `binding.id` +
+  `turnId`) *before* the dial decides delivery, so U7 can flush the setup message
+  ahead of an elicitation even when the dial is `None`.
+- Execution note: Start with a failing policy test that asserts prose activities
+  coalesce with tool activities under `show_some`, then wire the controller path.
+- Patterns to follow: existing tool-activity flow through `processActivity()`
+  and the batch-intent renderer.
+- Test scenarios:
+  - `show_none`: intermediate prose is suppressed; final response still sends.
+  - `show_some`: 4 prose items within the window coalesce into one batched
+    message; tool + prose activity in the same turn batch together.
+  - `show_all`: prose delivered individually (subject to budget).
+  - Streaming off (the default): a turn with narration + a final answer still
+    delivers the final answer via the terminal path exactly once.
+  - Covers AE: `None` on a personality thread yields only final answer +
+    elicitation, no intermediate messages.
+- Verification: With streaming off and dial at `Some`, a multi-step turn
+  produces coalesced progress plus one final message; at `None`, only the final
+  message and any elicitation.
+
+### U3. Add the Working Updates picker to the `/new` wizard
+
+- Goal: Expose the dial in the new-thread prompt gate so it is chosen before the
+  thread is born.
+- Requirements: R5.
+- Dependencies: U1 (shared label/copy), reuses U2's semantics but not its code.
+- Files:
+  - `apps/desktop/src/main/messaging/core/messaging-controller.ts` — add a
+    `browse:new:working-updates` button in `presentNewThreadPromptGate()`
+    (~4950–5054, alongside the existing streaming/fast/model/reasoning buttons),
+    a handler that presents the picker, a `browse:new:set-working-updates`
+    handler that writes `session.preferences.toolUpdateMode` and calls
+    `updateNewThreadStickySettings()`, then re-renders the gate. The collected
+    value already flows to `updateBindingPreferences(binding, session.preferences)`
+    at creation (~4467–4480).
+  - Test file: controller new-thread wizard tests (colocated
+    `__tests__`).
+- Approach: Clone the streaming/reasoning wizard-button pattern
+  (`browse:new:streaming` handler ~4304–4321; `browse:new:reasoning` ~4394–4423).
+  Reuse `buildStatusToolUpdateModePickerIntent` (or a new-thread variant) for the
+  picker surface. Default the displayed value to the resolved global default when
+  the session has no override yet.
+- Patterns to follow: `browse:new:reasoning` → `presentNewThreadReasoningPicker`
+  → `browse:new:set-reasoning` chain.
+- Test scenarios:
+  - The prompt gate renders a "Working Updates: <mode>" row.
+  - Selecting a value updates the session and persists to the binding at thread
+    creation.
+  - With no explicit choice, the created binding inherits the global default.
+  - The chosen value is remembered (sticky) for the next `/new`.
+- Verification: `/new` shows a Working Updates row; a thread created with a
+  non-default choice starts with that per-binding preference.
+
+### U4. Add the global "Show streaming option on thread cards" setting
+
+- Goal: Introduce the additive global setting (default Off) and its Settings UI,
+  with the streaming advisory copy.
+- Requirements: R7, R10.
+- Dependencies: none.
+- Files:
+  - `packages/shared/src/contracts/settings.ts` — add
+    `messaging.showStreamingOption` to the settings snapshot (near the `messaging`
+    block ~550–611) and to the config-patch type (~765–794).
+  - `apps/desktop/src/main/settings/desktop-config.ts` — parse/serialize
+    `[messaging] show_streaming_option` (mirror the `tool_update_mode`
+    read/write at ~872–873); default `false`.
+  - `apps/desktop/src/renderer/src/**` — a toggle in Settings → Messaging with
+    the R10 advisory copy. The renderer already ships a
+    `STREAMING_RESPONSES_WARNING` constant applied via `help={…}` on each
+    provider's streaming `ToggleField` (`MessagingSettings.tsx`) — R10 should
+    update that single source (or reference it) rather than introduce duplicate
+    or conflicting help text. Reconcile its current wording against the
+    [Copy strings](#copy-strings) streaming advisory.
+  - Test file:
+    `apps/desktop/src/main/settings/__tests__/desktop-config.test.ts` (extend).
+- Approach: Additive scalar, default false. No migration. Advisory copy verbatim
+  in the [Copy strings](#copy-strings) section.
+- Test scenarios:
+  - Missing key parses to `false`.
+  - Round-trip: setting `true` serializes to `[messaging] show_streaming_option
+    = true` and reads back.
+  - Unrelated messaging keys/comments preserved on write.
+- Verification: Toggle appears in Settings, defaults Off, persists across
+  restart.
+
+### U5. Gate the streaming control visibility
+
+- Goal: Hide the per-thread streaming control unless the global setting is on or
+  the binding already has streaming explicitly enabled.
+- Requirements: R7, R8.
+- Dependencies: U4.
+- Files:
+  - `apps/desktop/src/main/messaging/core/messaging-status-card.ts` — guard the
+    `status:streaming` action (~502) behind `showStreamingOption ||
+    binding.preferences?.streamingResponses === "enabled"`.
+  - `apps/desktop/src/main/messaging/core/messaging-controller.ts` — apply the
+    same guard to the `browse:new:streaming` wizard button (~5017–5021).
+  - Test files: status-card and controller `__tests__`.
+- Approach: Single shared predicate (e.g. `shouldShowStreamingControl(binding,
+  settings)`) used by both surfaces to avoid drift.
+- Test scenarios:
+  - Global Off + binding streaming inherit/disabled → control hidden in both card
+    and wizard.
+  - Global On → control visible in both.
+  - Global Off + binding streaming `enabled` → control visible (anti-stranding).
+- Verification: Fresh install shows no streaming control; enabling the global
+  setting reveals it; a pre-existing streaming-enabled binding still shows it.
+
+### U6. Nudge to enable the global option when a provider enables streaming
+
+- Goal: When provider-level streaming is switched on, offer (once, guarded) to
+  turn the global show-option on.
+- Requirements: R9.
+- Dependencies: U4.
+- Files:
+  - `apps/desktop/src/renderer/src/**` — in the Settings → Messaging provider
+    section, on toggling a provider `streamingResponses` to on, if
+    `showStreamingOption` is Off and no other provider currently has streaming
+    enabled, show a confirm prompt; on accept, set `showStreamingOption = true`
+    via the settings IPC path.
+  - Test file: renderer settings component test.
+- Approach: Guard = `!showStreamingOption && countProvidersWithStreamingEnabled()
+  === 0` (evaluated before applying the new toggle, or excluding the one being
+  toggled). Reuse an existing Settings confirm-dialog primitive rather than
+  inventing one. Decline is a **one-time dismissal with no re-nag** — the guard
+  already ensures the prompt won't re-fire once any provider streams or the global
+  option is on. Final offer/accept/decline wording is design-owned (tracked in
+  Open Questions); the prompt frames streaming as advanced/optional.
+- Test scenarios:
+  - Enabling the first provider's streaming with global Off → prompt shown;
+    accept sets global On.
+  - Enabling a second provider's streaming → no prompt (another already on).
+  - Enabling provider streaming when global already On → no prompt.
+  - Declining the prompt leaves global Off.
+- Verification: Turning on Telegram streaming from a clean state prompts;
+  accepting flips the global setting and reveals the per-thread control.
+
+### U7. Flush preceding in-turn prose before elicitation delivery
+
+- Goal: Ensure a questionnaire/approval carries the in-turn message that
+  described its options.
+- Requirements: R11.
+- Dependencies: U2 (defines the prose-capture introduced below).
+- Files:
+  - `apps/desktop/src/main/messaging/core/messaging-controller.ts` — in
+    `handleBackendPendingRequest()` (`messaging-controller.ts:1291`), immediately
+    before `await this.deliver(intent, binding)` (~1334), flush the pending
+    in-turn prose for the correlated turn.
+  - Test file: controller elicitation-delivery `__tests__`.
+- Approach: The flush cannot read from the policy's coalescing buffer, because at
+  `None` the policy returns `[]` immediately (`messaging-tool-update-policy.ts`
+  ~89–91) and buffers nothing — yet R11 requires the setup prose to precede the
+  question *even at* `None`. So U2 must retain a small **un-gated per-turn
+  last-prose capture** keyed by `binding.id` + `turnId` (written when the
+  non-final prose is intercepted at the line-1146 guard, before the dial decides
+  delivery). U7 flushes from that capture. Correlate by `binding.id` + turn id
+  (`request.params.turnId` ~1313). Flush is idempotent — do not re-send prose the
+  dial already delivered this turn.
+- Test scenarios:
+  - Questionnaire preceded by un-sent buffered prose → prose delivered first,
+    then the questionnaire.
+  - Prose already delivered (dial `All`) → no duplicate; questionnaire delivered
+    once.
+  - Elicitation with no preceding prose → questionnaire delivered alone.
+  - `None` dial: the setup prose that would otherwise be suppressed is still
+    flushed before the elicitation (the question needs its context regardless of
+    the dial).
+- Verification: An agent turn that narrates options then asks a questionnaire
+  delivers the narration immediately before the question on the platform.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Exponential-backoff coalescing of streaming and slow-mode edits (origin D5) —
+  in flight on a separate branch/worktree (spawned task
+  `Coalesce messaging streaming with exponential backoff`). This plan must not
+  re-implement or conflict with it; U5 touches streaming *visibility* only, not
+  the send/edit timing path.
+- Retuning the `show_less`/`show_some`/`show_more` thresholds now that prose
+  shares the buffer (more content per window) — revisit after U2 lands and real
+  volume is observable.
+
+### Out of Scope
+
+- Renaming the persisted `toolUpdateMode` key or its enum values (KTD1).
+- Splitting Working Updates into two independent knobs (tools vs prose) — origin
+  explicitly chose one dial; a future "unlink" toggle stays a non-breaking
+  superset if ever needed.
+- Folding streaming into the Working Updates dial — origin D3 keeps it separate.
+
+---
+
+## Risks & Dependencies
+
+- Coordination with the streaming-coalescing branch: both touch streaming-
+  adjacent code, but in different seams (this plan: visibility gating in
+  status-card/wizard/settings; the other: send/edit timing in the buffer/budget
+  path). Land order is independent; watch for merge overlap in
+  `messaging-controller.ts` around the stream-buffer region.
+- U2 reintroduces delivery of prose at the exact line-1146 drop guard that was
+  deliberately added to stop mid-turn flooding ("pinged a dozen times"). The
+  coalescing is what preserves that anti-flood intent at low dial settings —
+  regression risk lives precisely in the code the flood fix protects, so the
+  low-dial suppression paths need explicit test coverage.
+- Rate budget still caps everything: even `All` is not literally all. Copy (R6)
+  must set that expectation; tests should not assert unconditional delivery of
+  progress items.
+
+---
+
+## Open Questions
+
+- Does routing prose through the tool-update policy's single budget lane risk
+  one stream starving the other within a turn (prose crowding out tool activity
+  or vice versa) now that they share one coalescing buffer? Threshold retuning is
+  already deferred; this intra-turn contention question is the sharper edge of it
+  and should be watched once U2 lands.
+- Should the U6 "other provider has streaming enabled" guard count provider-
+  global streaming settings only, or also per-binding `enabled` overrides? Lean
+  provider-global for the nudge signal; confirm during U6.
+- Exact copy for the U6 confirm prompt (offer text, accept/decline button
+  labels) — design-owned; U6 pins the behavior (one-time, no re-nag) but not the
+  final wording.
+
+Resolved during review: intermediate prose **is** observable as a discrete
+`item/completed` `agentMessage` event with a non-final `phase`
+(`isNonFinalAssistantTextForBackendEvent`, `messaging-controller.ts:13475`),
+carrying full text — not only as streaming deltas. U2 intercepts at the
+line-1146 drop guard accordingly.
+
+---
+
+## Copy strings
+
+Final label: **Working Updates** — this resolves the origin's open label question
+("Activity updates" vs "Working updates" vs "Progress"). The origin doc uses
+"Activity updates" in its draft prose; wherever implementation copy is written,
+"Working Updates" is authoritative.
+
+Working Updates dial editor (R6):
+
+> Controls how much of the agent's in-progress work is bridged here.
+> **None** — only final answers and questions. Intermediate "thinking out loud"
+> messages and tool activity are suppressed.
+> **Some / More** — those get coalesced into occasional batched updates to stay
+> under platform rate limits.
+> **All** — sends the most, though the rate budget may still hold some back.
+
+Streaming control advisory (R10):
+
+> **Advanced.** This does **not** control whether the bot sends in-turn
+> messages — it controls whether a single message is repeatedly edited/replaced
+> as tokens come in. Each edit counts as a message send, so it burns through
+> platform rate limits fast (≈20/min in groups, ≈60/min in DMs) and usually ends
+> up throttled — which then slows or drops your tool and status updates too. You
+> may see slightly earlier tokens, but most people should leave this **off**.
+
+---
+
+## Sources / Research
+
+- Origin requirements: `docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md`.
+- Config-shape rules (why KTD1 avoids a rename): `docs/config-file-evolution.md`.
+- Messaging boundaries / where settings vs picker vs wizard logic lives:
+  `packages/messaging/AGENTS.md`, `apps/desktop/AGENTS.md`,
+  `docs/messaging-architecture.md`, `docs/messaging-adapter-contract.md`.
+- Prior tool-update coalescing pattern being extended:
+  `apps/desktop/src/main/messaging/core/messaging-tool-update-policy.ts`
+  (`MODE_POLICIES` ~30–54, `processActivity` ~83–136).
+- Binding preferences shape + JSON persistence:
+  `packages/messaging/interface/src/index.ts` (~1225–1245),
+  `apps/desktop/src/main/messaging/core/messaging-store.ts` (`upsertBinding`
+  ~32–51).
+- Elicitation delivery seam: `messaging-controller.ts`
+  `handleBackendPendingRequest` (`:1291`, deliver at ~1334).
+- Non-final prose drop guard (U2 interception point): `messaging-controller.ts`
+  `isNonFinalAssistantTextForBackendEvent` (`:13475`) and the drop guard ~1136–1157.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1240,6 +1240,15 @@ export type MessagingBindingPreferences = {
   reasoningEffort?: string;
   serviceTier?: string;
   streamingResponses?: MessagingStreamingResponseMode;
+  /**
+   * Sticky once true: set when streaming has been enabled on this binding at
+   * least once (observed by the desktop app). Keeps the per-thread streaming
+   * control visible on this thread even after streaming is turned back off and
+   * while the global "show streaming option" setting is off — so a thread that
+   * had streaming on can always toggle it back. The global setting still governs
+   * threads that never had streaming enabled.
+   */
+  streamingControlRevealed?: boolean;
   toolUpdateMode?: MessagingToolUpdateMode;
   updatedAt: number;
 };

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -149,6 +149,7 @@ describe("desktop settings contracts", () => {
           value: "show_some",
           source: "default",
         },
+        showStreamingOption: { value: false, source: "default" },
         attachments: {
           imageProfile: { value: "medium", source: "default" },
           maxAttachmentBytes: { value: 10485760, source: "default" },

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -554,6 +554,7 @@ export type DesktopSettingsSnapshot = {
     fullAccessWarning: DesktopSettingsValue<DesktopMessagingFullAccessWarningGlobalPolicy>;
     inputDebounceMs: DesktopSettingsValue<number>;
     toolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
+    showStreamingOption: DesktopSettingsValue<boolean>;
     attachments: DesktopMessagingAttachmentSettingsSnapshot;
     telegram: {
       enabled: DesktopSettingsValue<boolean>;
@@ -769,6 +770,7 @@ export type DesktopSettingsConfigPatch = {
     fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    showStreamingOption?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;
       maxAttachmentBytes?: number;


### PR DESCRIPTION
## Summary

Consolidates the messaging output-verbosity controls behind a single **Working Updates** dial and demotes messaging "streaming" to a default-off advanced feature. Implements decisions D1–D4 + D6 from the [requirements brainstorm](docs/brainstorms/2026-07-04-messaging-output-verbosity-and-streaming-requirements.md); executed against the [plan](docs/plans/2026-07-04-001-feat-messaging-working-updates-dial-plan.md).

Problem it solves: the old dial governed *only* tool activity, while the agent's in-turn narration was governed by a separate, cruder `streamingResponses` toggle that was unbatched, rate-limit hostile, and mislabeled. To a reader on their phone, tool activity and narration are the same "the agent is working" stream — and some threads (agent-personality threads) want only final answers and questions. The dial also couldn't be set when a thread was born from messaging, and questionnaires often landed without the in-turn message that set them up.

What changed, by implementation unit:

- **U1 — Relabel the dial to "Working Updates"** across the status card, picker copy, and Settings row. The persisted `toolUpdateMode` key and its enum are unchanged, so there is **no config migration**.
- **U2 — Route in-turn prose through the coalescing policy.** Non-final `agentMessage` completions (previously dropped outright to avoid channel flooding) now flow through the same `MessagingToolUpdatePolicy` as tool activity: suppressed at None, coalesced at Less/Some/More, sent individually at All. Adds a `prose` activity kind that threads through the delivery type and both renderers (individual + mixed batch) so prose is never mislabeled as a "ran N tools" line. Decoupled from `streamingResponses`.
- **U3 — Working Updates in the `/new` wizard.** A cycling control (next to Fast/Stream) plus a summary line, chosen before the thread is born and persisted into the binding's preferences at creation.
- **U4 — Global "Show streaming option on thread cards" setting** (additive `[messaging] show_streaming_option` TOML key, default off) with a Settings toggle whose advisory copy clarifies streaming does **not** send in-turn messages and burns platform rate limits.
- **U5 — Gate the per-thread streaming control** (status card + wizard) behind that global setting **OR** a per-binding `streamingResponses = enabled` (anti-stranding, so anyone who already turned it on can still turn it off). Shared `shouldShowStreamingControl` predicate drives both surfaces.
- **U6 — One-time nudge** when a provider enables streaming: an inline banner offers to reveal the per-thread control, guarded so it won't nag (skips if the global option is already on or another provider already streams; declining dismisses with no re-nag).
- **U7 — Flush the setup prose before an elicitation** so a terse question ("Option A or Option B?") carries the message that described the options — even at None. Idempotent, so prose already delivered by the dial isn't re-posted.

## Verification

- **Full workspace test suite: 4454 tests pass** (357 files), including new coverage for prose routing (None/All), renderer prose branching (individual + mixed batch), the elicitation flush (ordering at None + no-double-post at All), the wizard control (cycle + persist-to-binding), the `show_streaming_option` config round-trip, the `shouldShowStreamingControl` predicate (incl. anti-stranding), and the `shouldOfferStreamingNudge` guard.
- **`pnpm typecheck`** clean across all packages.
- **`pnpm lint`** clean — SQL, codex-storage, colors, licenses, typecheck, and **dependency boundaries** (997 modules, 0 violations).

## Notes

- **Streaming coalescing (brainstorm D5) is intentionally out of scope** and is being handled on a separate branch. This PR only touches streaming *visibility* (status card / wizard / settings), never the send/edit timing path, so the two don't collide.
- **U3 sticky deviation from plan R5:** the wizard's Working Updates choice is **per-session**, not sticky across `/new` invocations — matching the sibling streaming control exactly. True stickiness would require extending the launchpad sticky-settings patch (cross-package); left as an easy follow-up.
- The requirements/plan docs are included in this PR (`docs/brainstorms/`, `docs/plans/`). The brainstorm was updated on this branch to record the label decision ("Working Updates") and the nudge (D6).
- No new first-party dependencies; no TOML shape migration (both new/changed keys are additive or unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
