### PR TITLE
refactor(desktop): store context-replay tally on the turn record

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -99,7 +99,7 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
-  it("round-trips observed context-replay tallies on usage lines", async () => {
+  it("round-trips observed context-replay tallies through the turn record", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
         observedColdReplayCount: 2,
@@ -114,11 +114,58 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       threadId: "thread-1",
     });
 
+    // The tally is stored on thread_usage_turns and re-attached to the displayed
+    // line at read time.
     expect(pricing.lines[0]).toMatchObject({
       observedColdReplayCount: 2,
       observedColdReplayUncachedTokens: 322_900,
       observedHotReplayCachedTokens: 672_200,
       observedHotReplayCount: 4,
+    });
+    const turn = stateDb.raw
+      .prepare(
+        `SELECT observed_cold_replay_count,
+                observed_cold_replay_uncached_tokens,
+                observed_hot_replay_cached_tokens,
+                observed_hot_replay_count
+         FROM thread_usage_turns
+         WHERE usage_turn_id = ?`,
+      )
+      .get(pricing.lines[0]?.usageTurnId) as {
+        observed_cold_replay_count: number | null;
+        observed_cold_replay_uncached_tokens: number | null;
+        observed_hot_replay_cached_tokens: number | null;
+        observed_hot_replay_count: number | null;
+      };
+    expect(turn).toEqual({
+      observed_cold_replay_count: 2,
+      observed_cold_replay_uncached_tokens: 322_900,
+      observed_hot_replay_cached_tokens: 672_200,
+      observed_hot_replay_count: 4,
+    });
+    // DEPRECATED dual-write (issue #947): the tally is also mirrored onto
+    // thread_usage_lines so older locally-run builds keep displaying it. Remove
+    // this assertion when the dual-write is dropped.
+    const line = stateDb.raw
+      .prepare(
+        `SELECT observed_cold_replay_count,
+                observed_cold_replay_uncached_tokens,
+                observed_hot_replay_cached_tokens,
+                observed_hot_replay_count
+         FROM thread_usage_lines
+         WHERE usage_line_id = ?`,
+      )
+      .get(pricing.lines[0]?.usageLineId) as {
+        observed_cold_replay_count: number | null;
+        observed_cold_replay_uncached_tokens: number | null;
+        observed_hot_replay_cached_tokens: number | null;
+        observed_hot_replay_count: number | null;
+      };
+    expect(line).toEqual({
+      observed_cold_replay_count: 2,
+      observed_cold_replay_uncached_tokens: 322_900,
+      observed_hot_replay_cached_tokens: 672_200,
+      observed_hot_replay_count: 4,
     });
     // Observation-derived tallies must not leak into the priced summary totals.
     expect(pricing.summaries[0]).not.toHaveProperty("observedColdReplayCount");
@@ -138,7 +185,8 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
 
     // Same usageLineId re-upserts (e.g. accumulator reset after restart) with no
-    // observed fields — the persisted tally must not be erased.
+    // observed fields — the turn-record COALESCE must not erase the persisted
+    // tally.
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
         source: "live",
@@ -161,24 +209,31 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
-  it("keeps an observed live line when transcript hydration arrives for the turn", async () => {
+  it("keeps the observed tally on the turn record when hydration supersedes the live line", async () => {
     // Live turn we observed replays for.
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
+        completedAt: undefined,
+        model: "gpt-5.5",
         observedColdReplayCount: 1,
         observedColdReplayUncachedTokens: 150_000,
         observedHotReplayCount: 4,
         observedHotReplayCachedTokens: 600_000,
+        serviceTier: "standard",
         source: "live",
         status: "pending",
         usageLineId: "live:thread-1:turn-1",
       }),
     });
 
-    // Transcript hydration for the same turn (no observed tally, different id) —
-    // this is what readThread persists on every thread open.
+    // Transcript hydration for the same turn (no observed tally, different id,
+    // distinct turn metadata) — this is what readThread persists on every thread
+    // open. It now supersedes the live line normally.
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
+        completedAt: 55_000,
+        model: "gpt-5.5-codex",
+        serviceTier: "priority",
         source: "hydration",
         status: "finalized",
         usageLineId: "codex:thread-1:turn-1:total:item-9",
@@ -190,17 +245,47 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       threadId: "thread-1",
     });
 
-    // Exactly one line for the turn — ours — with the observed tally intact.
+    // Exactly one line survives — the hydration line — and the observed tally,
+    // stored on the turn record, is re-attached to it.
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({
-      usageLineId: "live:thread-1:turn-1",
-      source: "live",
+      usageLineId: "codex:thread-1:turn-1:total:item-9",
+      source: "hydration",
+      model: "gpt-5.5-codex",
       observedColdReplayCount: 1,
+      observedColdReplayUncachedTokens: 150_000,
       observedHotReplayCount: 4,
       observedHotReplayCachedTokens: 600_000,
     });
-    // No double-counting: the hydration copy was ignored, not added.
+    // No double-counting: hydration superseded the live line, not added to it.
     expect(pricing.summaries[0]?.usageLineCount).toBe(1);
+
+    // Turn metadata now reflects the hydration line (COALESCE let it win), while
+    // the observed tally is preserved.
+    const turn = stateDb.raw
+      .prepare(
+        `SELECT model,
+                service_tier,
+                completed_at,
+                observed_cold_replay_count,
+                observed_hot_replay_count
+         FROM thread_usage_turns
+         WHERE usage_turn_id = ?`,
+      )
+      .get(pricing.lines[0]?.usageTurnId) as {
+        model: string | null;
+        service_tier: string | null;
+        completed_at: number | null;
+        observed_cold_replay_count: number | null;
+        observed_hot_replay_count: number | null;
+      };
+    expect(turn).toEqual({
+      model: "gpt-5.5-codex",
+      service_tier: "priority",
+      completed_at: 55_000,
+      observed_cold_replay_count: 1,
+      observed_hot_replay_count: 4,
+    });
   });
 
   it("keeps the original usage line timestamp when live usage is updated", async () => {

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -86,6 +86,34 @@ describe("StateDb", () => {
     ]);
   });
 
+  it("carries observed context-replay columns on both the turn and the line", () => {
+    // The tally's source of truth is thread_usage_turns. The line columns are a
+    // DEPRECATED dual-write (issue #947) kept so older locally-run builds — which
+    // read the tally off the usage line — keep working against a shared profile
+    // DB. Every build must find the columns it expects on a fresh DB.
+    const observedColumns = [
+      "observed_cold_replay_count",
+      "observed_cold_replay_uncached_tokens",
+      "observed_hot_replay_cached_tokens",
+      "observed_hot_replay_count",
+    ];
+    const turnColumns = (
+      stateDb.raw
+        .prepare("PRAGMA table_info(thread_usage_turns)")
+        .all() as Array<{ name: string }>
+    ).map((column) => column.name);
+    const lineColumns = (
+      stateDb.raw
+        .prepare("PRAGMA table_info(thread_usage_lines)")
+        .all() as Array<{ name: string }>
+    ).map((column) => column.name);
+
+    for (const column of observedColumns) {
+      expect(turnColumns).toContain(column);
+      expect(lineColumns).toContain(column);
+    }
+  });
+
   it("sets explicit WAL checkpoint and journal size bounds", () => {
     expect(stateDb.raw.pragma("journal_mode", { simple: true })).toBe("wal");
     expect(stateDb.raw.pragma("wal_autocheckpoint", { simple: true })).toBe(
@@ -901,11 +929,14 @@ describe("StateDb", () => {
     stateDb.close();
 
     const dbPath = path.join(tempDir, "newer-version-thread-search-fts.db");
-    createLegacyThreadSearchFtsDb(dbPath, 24);
+    const newerVersion = CURRENT_STATE_DB_USER_VERSION + 1;
+    createLegacyThreadSearchFtsDb(dbPath, newerVersion);
 
     stateDb = StateDb.open(dbPath);
 
-    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(24);
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      newerVersion,
+    );
     expect(columnNames("thread_search_fts")).toContain("thread_id");
   });
 });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -620,34 +620,6 @@ export class SqliteOverlayStore {
     const now = Date.now();
     let line = repriceOpenAiUsageLine(normalizeThreadUsageLine(params.line, now));
     const upsert = this.stateDb.raw.transaction(() => {
-      // Keep observed context-replay data: a transcript-hydration/backfill line
-      // for a turn we already watched live carries no observed replay tally (the
-      // tally is derived data the Codex transcript can't reproduce). Letting it
-      // through would supersede our live line and drop the tally, so when an
-      // observed live line already exists for this turn we ignore the transcript
-      // copy and keep ours. This is what makes observed counts survive a thread
-      // re-read / app restart.
-      if (
-        (line.source === "hydration" || line.source === "backfill") &&
-        line.turnId
-      ) {
-        const preserved = this.readLiveTurnLineWithObservedReplaysSync({
-          backend: line.backend,
-          provider: line.provider,
-          threadId: line.threadId,
-          turnId: line.turnId,
-        });
-        if (preserved) {
-          line = preserved;
-          return this.recomputeThreadPricingSummarySync({
-            backend: preserved.backend,
-            currency: preserved.currency,
-            provider: preserved.provider,
-            threadId: preserved.parentThreadId ?? preserved.threadId,
-            updatedAt: now,
-          });
-        }
-      }
       const existing = this.readThreadUsageLineSync(line.usageLineId);
       if (existing) {
         line = mergeThreadUsageLineForUpsert(line, existing);
@@ -694,6 +666,10 @@ export class SqliteOverlayStore {
             started_at,
             completed_at,
             observed_at,
+            observed_cold_replay_count,
+            observed_cold_replay_uncached_tokens,
+            observed_hot_replay_cached_tokens,
+            observed_hot_replay_count,
             updated_at
           ) VALUES (
             @usageTurnId,
@@ -711,6 +687,10 @@ export class SqliteOverlayStore {
             @startedAt,
             @completedAt,
             @createdAt,
+            @observedColdReplayCount,
+            @observedColdReplayUncachedTokens,
+            @observedHotReplayCachedTokens,
+            @observedHotReplayCount,
             @updatedAt
           )
           ON CONFLICT(usage_turn_id) DO UPDATE SET
@@ -736,6 +716,14 @@ export class SqliteOverlayStore {
             started_at = COALESCE(thread_usage_turns.started_at, excluded.started_at),
             completed_at = excluded.completed_at,
             observed_at = MIN(thread_usage_turns.observed_at, excluded.observed_at),
+            -- Observation-derived tallies are absent on transcript-hydration
+            -- lines (the Codex transcript can't reproduce them). COALESCE keeps a
+            -- previously-observed tally when a hydration line (NULL params) later
+            -- refreshes the turn metadata, so the count survives thread re-read.
+            observed_cold_replay_count = COALESCE(excluded.observed_cold_replay_count, thread_usage_turns.observed_cold_replay_count),
+            observed_cold_replay_uncached_tokens = COALESCE(excluded.observed_cold_replay_uncached_tokens, thread_usage_turns.observed_cold_replay_uncached_tokens),
+            observed_hot_replay_cached_tokens = COALESCE(excluded.observed_hot_replay_cached_tokens, thread_usage_turns.observed_hot_replay_cached_tokens),
+            observed_hot_replay_count = COALESCE(excluded.observed_hot_replay_count, thread_usage_turns.observed_hot_replay_count),
             updated_at = excluded.updated_at`,
         )
         .run(toThreadUsageLineRowParams(line));
@@ -881,10 +869,14 @@ export class SqliteOverlayStore {
             output_cost_micros = excluded.output_cost_micros,
             total_cost_micros = excluded.total_cost_micros,
             cumulative_total_cost_micros = excluded.cumulative_total_cost_micros,
-            observed_cold_replay_count = excluded.observed_cold_replay_count,
-            observed_cold_replay_uncached_tokens = excluded.observed_cold_replay_uncached_tokens,
-            observed_hot_replay_cached_tokens = excluded.observed_hot_replay_cached_tokens,
-            observed_hot_replay_count = excluded.observed_hot_replay_count,
+            -- DEPRECATED (see issue #947): dual-written for older builds; the new
+            -- build reads the tally from thread_usage_turns. COALESCE mirrors the
+            -- turn-record preserve so a tally-less re-upsert of the same line
+            -- (e.g. accumulator reset) does not wipe the persisted values.
+            observed_cold_replay_count = COALESCE(excluded.observed_cold_replay_count, thread_usage_lines.observed_cold_replay_count),
+            observed_cold_replay_uncached_tokens = COALESCE(excluded.observed_cold_replay_uncached_tokens, thread_usage_lines.observed_cold_replay_uncached_tokens),
+            observed_hot_replay_cached_tokens = COALESCE(excluded.observed_hot_replay_cached_tokens, thread_usage_lines.observed_hot_replay_cached_tokens),
+            observed_hot_replay_count = COALESCE(excluded.observed_hot_replay_count, thread_usage_lines.observed_hot_replay_count),
             updated_at = excluded.updated_at`,
         )
         .run(toThreadUsageLineRowParams(line));
@@ -958,10 +950,85 @@ export class SqliteOverlayStore {
       )
       .all(params.backend, params.threadId) as ThreadPricingSummaryRow[];
 
+    const lines = lineRows.map(threadUsageLineFromRow);
+    this.attachObservedReplayTalliesSync(params.backend, params.threadId, lines);
+
     return {
-      lines: lineRows.map(threadUsageLineFromRow),
+      lines,
       summaries: summaryRows.map(threadPricingSummaryFromRow),
     };
+  }
+
+  // The observed context-replay tally lives on the per-turn record
+  // (thread_usage_turns), not on the usage line — the turn record is refreshed
+  // via COALESCE and is immune to the line supersession lifecycle, so a
+  // transcript-hydration line can supersede the live line without dropping the
+  // tally. Attach it back onto the displayed line at read time so the renderer
+  // keeps reading the observed fields off ThreadUsageLineRecord. Deliberately
+  // NOT summed into pricing summaries.
+  private attachObservedReplayTalliesSync(
+    backend: string,
+    threadId: string,
+    lines: ThreadUsageLineRecord[],
+  ): void {
+    if (lines.length === 0) {
+      return;
+    }
+    const turnRows = this.stateDb.raw
+      .prepare(
+        `SELECT usage_turn_id,
+                observed_cold_replay_count,
+                observed_cold_replay_uncached_tokens,
+                observed_hot_replay_cached_tokens,
+                observed_hot_replay_count
+           FROM thread_usage_turns
+          WHERE backend = ?
+            AND thread_id = ?
+          UNION ALL
+         SELECT usage_turn_id,
+                observed_cold_replay_count,
+                observed_cold_replay_uncached_tokens,
+                observed_hot_replay_cached_tokens,
+                observed_hot_replay_count
+           FROM thread_usage_turns
+          WHERE backend = ?
+            AND parent_thread_id = ?
+            AND thread_id != ?`,
+      )
+      .all(backend, threadId, backend, threadId, threadId) as Array<{
+      usage_turn_id: string;
+      observed_cold_replay_count: number | null;
+      observed_cold_replay_uncached_tokens: number | null;
+      observed_hot_replay_cached_tokens: number | null;
+      observed_hot_replay_count: number | null;
+    }>;
+    if (turnRows.length === 0) {
+      return;
+    }
+    const byTurnId = new Map(turnRows.map((row) => [row.usage_turn_id, row]));
+    for (const line of lines) {
+      if (!line.usageTurnId) {
+        continue;
+      }
+      const turn = byTurnId.get(line.usageTurnId);
+      if (!turn) {
+        continue;
+      }
+      if (turn.observed_cold_replay_count !== null) {
+        line.observedColdReplayCount = turn.observed_cold_replay_count;
+      }
+      if (turn.observed_cold_replay_uncached_tokens !== null) {
+        line.observedColdReplayUncachedTokens =
+          turn.observed_cold_replay_uncached_tokens;
+      }
+      if (turn.observed_hot_replay_cached_tokens !== null) {
+        line.observedHotReplayCachedTokens =
+          turn.observed_hot_replay_cached_tokens;
+      }
+      if (turn.observed_hot_replay_count !== null) {
+        line.observedHotReplayCount = turn.observed_hot_replay_count;
+      }
+    }
   }
 
   async upsertThreadSubAgent(params: {
@@ -2126,39 +2193,6 @@ export class SqliteOverlayStore {
     return row ? threadUsageLineFromRow(row) : undefined;
   }
 
-  // The active (non-superseded) live usage line for a turn that carries an
-  // observed context-replay tally, if any. Used to keep observed data when
-  // transcript hydration would otherwise supersede the live line.
-  private readLiveTurnLineWithObservedReplaysSync(params: {
-    backend: string;
-    provider: string;
-    threadId: string;
-    turnId: string;
-  }): ThreadUsageLineRecord | undefined {
-    const row = this.stateDb.raw
-      .prepare(
-        `SELECT *
-           FROM thread_usage_lines
-          WHERE provider = ?
-            AND backend = ?
-            AND thread_id = ?
-            AND turn_id = ?
-            AND source = 'live'
-            AND status != 'superseded'
-            AND (COALESCE(observed_cold_replay_count, 0) > 0
-                 OR COALESCE(observed_hot_replay_count, 0) > 0)
-          ORDER BY created_at DESC, usage_line_id DESC
-          LIMIT 1`,
-      )
-      .get(
-        params.provider,
-        params.backend,
-        params.threadId,
-        params.turnId,
-      ) as ThreadUsageLineRow | undefined;
-    return row ? threadUsageLineFromRow(row) : undefined;
-  }
-
   private recomputeThreadPricingSummarySync(params: {
     backend: string;
     currency: string;
@@ -2388,10 +2422,6 @@ type ThreadUsageLineRow = {
   output_cost_micros: number;
   total_cost_micros: number;
   cumulative_total_cost_micros: number | null;
-  observed_cold_replay_count: number | null;
-  observed_cold_replay_uncached_tokens: number | null;
-  observed_hot_replay_cached_tokens: number | null;
-  observed_hot_replay_count: number | null;
   updated_at: number;
 };
 
@@ -2498,21 +2528,6 @@ function mergeThreadUsageLineForUpsert(
   const merged: ThreadUsageLineRecord = {
     ...line,
     createdAt: Math.min(existing.createdAt, line.createdAt),
-    // Observation-derived tallies are never present on transcript-sourced
-    // lines, and a live re-upsert can momentarily omit them (e.g. the in-memory
-    // accumulator was reset). Never let an incoming line without a tally erase a
-    // previously-persisted one. `?? existing` (not `||`) preserves a legitimate
-    // observed count of 0.
-    observedColdReplayCount:
-      line.observedColdReplayCount ?? existing.observedColdReplayCount,
-    observedColdReplayUncachedTokens:
-      line.observedColdReplayUncachedTokens ??
-      existing.observedColdReplayUncachedTokens,
-    observedHotReplayCachedTokens:
-      line.observedHotReplayCachedTokens ??
-      existing.observedHotReplayCachedTokens,
-    observedHotReplayCount:
-      line.observedHotReplayCount ?? existing.observedHotReplayCount,
     ...(line.fastMode !== undefined
       ? { fastMode: line.fastMode }
       : existing.fastMode !== undefined
@@ -2705,23 +2720,6 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
     ...(row.fast_mode !== null ? { fastMode: Boolean(row.fast_mode) } : {}),
     inputTokens: row.input_tokens,
     ...(row.model ? { model: row.model } : {}),
-    ...(row.observed_cold_replay_count !== null
-      ? { observedColdReplayCount: row.observed_cold_replay_count }
-      : {}),
-    ...(row.observed_cold_replay_uncached_tokens !== null
-      ? {
-          observedColdReplayUncachedTokens:
-            row.observed_cold_replay_uncached_tokens,
-        }
-      : {}),
-    ...(row.observed_hot_replay_cached_tokens !== null
-      ? {
-          observedHotReplayCachedTokens: row.observed_hot_replay_cached_tokens,
-        }
-      : {}),
-    ...(row.observed_hot_replay_count !== null
-      ? { observedHotReplayCount: row.observed_hot_replay_count }
-      : {}),
     outputCostMicros: row.output_cost_micros,
     outputTokens: row.output_tokens,
     ...(row.parent_thread_id ? { parentThreadId: row.parent_thread_id } : {}),

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 24;
+export const CURRENT_STATE_DB_USER_VERSION = 25;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -536,6 +536,10 @@ CREATE TABLE IF NOT EXISTS thread_usage_turns (
   started_at          INTEGER,
   completed_at        INTEGER,
   observed_at         INTEGER NOT NULL,
+  observed_cold_replay_count   INTEGER,
+  observed_cold_replay_uncached_tokens INTEGER,
+  observed_hot_replay_cached_tokens    INTEGER,
+  observed_hot_replay_count    INTEGER,
   updated_at          INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_thread_usage_turns_thread
@@ -586,6 +590,11 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   output_cost_micros         INTEGER NOT NULL,
   total_cost_micros          INTEGER NOT NULL,
   cumulative_total_cost_micros INTEGER,
+  -- DEPRECATED (see issue #947): the observed context-replay tally now lives on
+  -- thread_usage_turns. These columns are dual-written only so older locally-run
+  -- builds (which read the tally off the usage line) keep working against a
+  -- shared profile DB during the transition. Remove after the new build is
+  -- stable (~1 week post-merge).
   observed_cold_replay_count   INTEGER,
   observed_cold_replay_uncached_tokens INTEGER,
   observed_hot_replay_cached_tokens    INTEGER,
@@ -828,10 +837,23 @@ export class StateDb {
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 24) {
       db.transaction(() => {
-        // Observed context-replay tallies on live turn usage lines. Additive
-        // columns; the same columns also live in THREAD_USAGE_PRICING_SCHEMA so
-        // re-instantiated dbs converge.
+        // Observed context-replay tallies on the usage line. DEPRECATED (see
+        // issue #947): the tally has since moved to thread_usage_turns (v25), but
+        // these columns are still dual-written during the transition so older
+        // locally-run builds keep working. Additive; the same columns also live
+        // in THREAD_USAGE_PRICING_SCHEMA so re-instantiated dbs converge.
         ensureThreadUsageObservedReplayColumns(db);
+        db.pragma("user_version = 24");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 25) {
+      db.transaction(() => {
+        // Relocate the observed context-replay tally onto thread_usage_turns —
+        // the per-turn record hydration refreshes via COALESCE, immune to the
+        // usage *line* supersession lifecycle. Additive columns that also live in
+        // THREAD_USAGE_PRICING_SCHEMA; the ALTERs are guarded by tableColumnExists
+        // so a fresh db (schema already carries them) no-ops.
+        ensureThreadUsageTurnObservedReplayColumns(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1057,6 +1079,10 @@ CREATE TABLE IF NOT EXISTS thread_usage_turns (
   started_at          INTEGER,
   completed_at        INTEGER,
   observed_at         INTEGER NOT NULL,
+  observed_cold_replay_count   INTEGER,
+  observed_cold_replay_uncached_tokens INTEGER,
+  observed_hot_replay_cached_tokens    INTEGER,
+  observed_hot_replay_count    INTEGER,
   updated_at          INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_thread_usage_turns_thread
@@ -1234,6 +1260,9 @@ function ensureThreadUsagePricingCumulativeColumns(db: BetterSqlite3.Database): 
   }
 }
 
+// DEPRECATED (see issue #947): observed context-replay tally on the usage line.
+// Kept only to dual-write the columns so older locally-run builds keep working
+// during the transition to thread_usage_turns. Remove with the dual-write.
 function ensureThreadUsageObservedReplayColumns(db: BetterSqlite3.Database): void {
   if (!tableExists(db, "thread_usage_lines")) {
     db.exec(THREAD_USAGE_PRICING_SCHEMA);
@@ -1260,6 +1289,37 @@ function ensureThreadUsageObservedReplayColumns(db: BetterSqlite3.Database): voi
   ];
   for (const column of columns) {
     if (!tableColumnExists(db, "thread_usage_lines", column.name)) {
+      db.exec(column.sql);
+    }
+  }
+}
+
+function ensureThreadUsageTurnObservedReplayColumns(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_turns")) {
+    db.exec(THREAD_USAGE_PRICING_SCHEMA);
+    return;
+  }
+
+  const columns: Array<{ name: string; sql: string }> = [
+    {
+      name: "observed_cold_replay_count",
+      sql: "ALTER TABLE thread_usage_turns ADD COLUMN observed_cold_replay_count INTEGER",
+    },
+    {
+      name: "observed_cold_replay_uncached_tokens",
+      sql: "ALTER TABLE thread_usage_turns ADD COLUMN observed_cold_replay_uncached_tokens INTEGER",
+    },
+    {
+      name: "observed_hot_replay_cached_tokens",
+      sql: "ALTER TABLE thread_usage_turns ADD COLUMN observed_hot_replay_cached_tokens INTEGER",
+    },
+    {
+      name: "observed_hot_replay_count",
+      sql: "ALTER TABLE thread_usage_turns ADD COLUMN observed_hot_replay_count INTEGER",
+    },
+  ];
+  for (const column of columns) {
+    if (!tableColumnExists(db, "thread_usage_turns", column.name)) {
       db.exec(column.sql);
     }
   }
@@ -1717,7 +1777,8 @@ function tableColumnExists(
     | "pr_status_cache"
     | "thread_pricing_summaries"
     | "thread_search_fts"
-    | "thread_usage_lines",
+    | "thread_usage_lines"
+    | "thread_usage_turns",
   columnName: string,
 ): boolean {
   const rows = readTableInfo(db, tableName);
@@ -1733,7 +1794,8 @@ function readTableInfo(
     | "pr_status_cache"
     | "thread_pricing_summaries"
     | "thread_search_fts"
-    | "thread_usage_lines",
+    | "thread_usage_lines"
+    | "thread_usage_turns",
 ): Array<{ name: string }> {
   switch (tableName) {
     case "app_runtime_instances":
@@ -1762,6 +1824,10 @@ function readTableInfo(
       }>;
     case "thread_usage_lines":
       return db.prepare("PRAGMA table_info(thread_usage_lines)").all() as Array<{
+        name: string;
+      }>;
+    case "thread_usage_turns":
+      return db.prepare("PRAGMA table_info(thread_usage_turns)").all() as Array<{
         name: string;
       }>;
   }

--- a/docs/plans/2026-07-04-001-feat-observed-context-replay-counting-plan.md
+++ b/docs/plans/2026-07-04-001-feat-observed-context-replay-counting-plan.md
@@ -342,8 +342,17 @@ Reviewed and consciously deferred (documented, not fixed):
 - **Declined:** a fast-out for the per-line guard `SELECT` — it is an indexed
   point lookup with negligible cost, and the obvious in-memory fast-out would
   break cross-restart durability (persisted-but-not-yet-read observed rows).
-- **Follow-ups:** (a) the tally would live more naturally on `thread_usage_turns`
-  (removes the supersede guard entirely) — larger refactor; (b) the private
+- **Follow-ups:** (a) **DONE** (stacked refactor
+  `refactor/context-replay-tally-on-turn-record`): the tally now lives on
+  `thread_usage_turns` (`user_version` 25), refreshed via COALESCE and immune to
+  the usage-*line* supersession lifecycle, and re-attached to the displayed line
+  at read time in `readThreadPricing`. This removed the `upsertThreadUsageLine`
+  preserve guard, `readLiveTurnLineWithObservedReplaysSync`, and the
+  `mergeThreadUsageLineForUpsert` `?? existing` observed-field preservation
+  entirely; hydration now supersedes the live line normally. The tally is
+  temporarily **dual-written** to the (now deprecated) `thread_usage_lines`
+  columns so older locally-run builds sharing the profile DB keep working during
+  the transition; removal tracked in issue #947. (b) the private
   `observeLiveThreadContextReplay` map-keying is only covered transitively via
   the fixture test's re-implemented bookkeeping; (c) a narrow race where
   hydration arriving before a turn's first ≥32k request supersedes the


### PR DESCRIPTION
## Stacked on #933

Base: `plan/observed-context-replay-counting` (the #933 branch), **not** `main`.
This is an exploratory follow-up refactor — reviewable or discardable without
touching #933.

## What & why

#933 persisted the observed cold/hot context-replay tally (4 numbers per turn)
as four columns on `thread_usage_lines`. But `readThread` re-persists
transcript-**hydration** usage lines on every thread open, and those *supersede*
the `source:"live"` line that carries the tally — which is derived data the Codex
transcript can't reproduce. #933 worked around it with a special-case guard in
`upsertThreadUsageLine` (`readLiveTurnLineWithObservedReplaysSync`) plus
`?? existing` preservation in `mergeThreadUsageLineForUpsert`. Review flagged this
as a band-aid on the generic supersede path (plan §8b follow-up (a)).

This makes the per-turn record **`thread_usage_turns`** (PK `usage_turn_id`) the
source of truth. Hydration already refreshes it via `COALESCE` and it's immune to
the *line* supersession lifecycle. The live line and every hydration line for a
turn map to the **same** turn row
(`usage_turn_id = provider:backend:threadId:turnId`), so a hydration line with
NULL observed params `COALESCE`-preserves the existing tally.

## Cross-version dual-write (temporary — issue #947)

Desktop builds share a per-profile sqlite DB (WAL). Because this repo is under
active local development across branches, the tally is **dual-written** to the
now-**deprecated** `thread_usage_lines.observed_*` columns so older builds — which
read the tally off the usage line — keep working against a shared/fresh DB instead
of hitting "no such column". The new build reads **only** from
`thread_usage_turns`. Removal of the dual-write + line columns is tracked in
**#947** (target ~1 week post-merge). The tally is derived, self-healing data, so
there is **no data backfill** at any step.

## Changes

- **Schema/migration** (`state-db.ts`): 4 observed columns added to
  `thread_usage_turns`; `user_version` 24 → 25 with an idempotent
  `ensureThreadUsageTurnObservedReplayColumns` migration. The `thread_usage_lines`
  columns are retained (marked deprecated) for the dual-write.
- **Write** (`overlay-store-sqlite.ts`): the turns `INSERT` persists the 4 columns
  with `ON CONFLICT ... COALESCE(excluded.x, thread_usage_turns.x)` so hydration
  preserves the live tally; the lines `INSERT` mirrors the same COALESCE for the
  deprecated dual-write.
- **Removed the band-aid**: deleted the `upsertThreadUsageLine` preserve guard,
  `readLiveTurnLineWithObservedReplaysSync`, and the observed `?? existing` lines
  in `mergeThreadUsageLineForUpsert`. Hydration now supersedes the live line
  normally.
- **Read/join** (`readThreadPricing`): looks the tally up per `usage_turn_id`
  from `thread_usage_turns` and re-attaches it to the displayed line, so the
  renderer keeps reading observed fields off `ThreadUsageLineRecord` unchanged.
  The fields stay **off** pricing summaries (no leak into totals).
- **Backend accumulator** (`backend-registry.ts`) and **renderer**: unchanged.

## Tests

- `overlay-store-usage-pricing.test.ts`: the hydration test now asserts hydration
  supersedes the live line while the tally survives on the turn record and turn
  metadata (model/service_tier/completed_at) reflects the hydration line;
  round-trip test asserts the tally lands on both `thread_usage_turns` and (dual-
  write) `thread_usage_lines`; COALESCE-preserve and summary-leak guards retained.
- `state-db.test.ts`: new test locks the cross-version contract (observed columns
  present on **both** tables in a fresh DB); forward-compat FTS-repair test made
  version-agnostic.
- Accumulator/fold and renderer tests unaffected.

## Verify (Node 24, sqlite ABI-pinned)

`pnpm test` (store/migration/replay/backend-registry/renderer), `pnpm --filter
@pwragent/desktop typecheck`, `pnpm lint:sql`, `pnpm lint:boundaries` — all green.

Plan doc §8b follow-up (a) marked done (with the dual-write note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
