### PR TITLE
feat(desktop): classify pricing summaries by upstream attribution, not a token guess

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12782,9 +12782,69 @@ command = "pnpm dev"
       reasoningOutputTokens: 10,
       totalTokens: 1_060,
       turnId: "turn-2",
+      turnUsageAttributed: true,
       uncachedInputTokens: 800,
     });
     expect(pricing.lines[0]?.cumulativeTotalCostMicros).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("marks a whole-thread total with no per-request usage as unattributed", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    // Only a cumulative total, no per-request `last` snapshot to isolate the
+    // turn: the builder can't attribute this to the turn, so it records
+    // turnUsageAttributed: false and the row reads as a whole-thread summary.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-3",
+        tokenUsage: {
+          total_token_usage: {
+            input_tokens: 11_000,
+            cached_input_tokens: 10_200,
+            output_tokens: 500,
+            reasoning_output_tokens: 100,
+            total_tokens: 11_600,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      totalTokens: 11_600,
+      turnId: "turn-3",
+      turnUsageAttributed: false,
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -797,6 +797,102 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       totalCostMicros: 0,
     });
   });
+
+  it("round-trips the turnUsageAttributed flag through sqlite", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        turnId: "turn-attributed",
+        turnUsageAttributed: true,
+        usageLineId: "line-attributed",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        turnId: "turn-unattributed",
+        turnUsageAttributed: false,
+        usageLineId: "line-unattributed",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const byId = new Map(pricing.lines.map((line) => [line.usageLineId, line]));
+    expect(byId.get("line-attributed")?.turnUsageAttributed).toBe(true);
+    expect(byId.get("line-unattributed")?.turnUsageAttributed).toBe(false);
+    // A line that never set the flag stays undefined, not coerced to a boolean.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({ turnId: "turn-plain", usageLineId: "line-plain" }),
+    });
+    const after = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(
+      after.lines.find((line) => line.usageLineId === "line-plain")
+        ?.turnUsageAttributed,
+    ).toBeUndefined();
+  });
+
+  it("backfills legacy live summary rows to turnUsageAttributed=false on migration", async () => {
+    // Legacy whole-thread summary masquerading as a turn (no cumulative
+    // breakdown, >= 1M tokens), plus controls that must stay untouched.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-legacy",
+        usageLineId: "legacy-summary",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cumulativeTotalTokens: 2_000_000,
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 2_000_000,
+        turnId: "turn-modern",
+        usageLineId: "modern-turn",
+      }),
+    });
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 500_000,
+        turnId: "turn-small",
+        usageLineId: "small-live-turn",
+      }),
+    });
+
+    // Force the user_version 26 migration to run against the seeded rows, then
+    // reassign the module handle so afterEach closes the reopened db.
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.pragma("user_version = 25");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+
+    const flagById = new Map(
+      (
+        stateDb.raw
+          .prepare(
+            "SELECT usage_line_id, turn_usage_attributed FROM thread_usage_lines",
+          )
+          .all() as {
+          turn_usage_attributed: number | null;
+          usage_line_id: string;
+        }[]
+      ).map((row) => [row.usage_line_id, row.turn_usage_attributed]),
+    );
+    expect(flagById.get("legacy-summary")).toBe(0);
+    expect(flagById.get("modern-turn")).toBeNull();
+    expect(flagById.get("small-live-turn")).toBeNull();
+  });
 });
 
 function buildUsageLine(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3387,6 +3387,7 @@ function resolveLiveThreadUsageTiming(params: {
 }
 
 function buildLiveThreadUsageLine(params: {
+  attributed?: boolean;
   backend: AppServerBackendKind;
   cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
   completedAt?: number;
@@ -3489,6 +3490,9 @@ function buildLiveThreadUsageLine(params: {
     totalCostMicros: cost?.totalCostMicros ?? 0,
     totalTokens,
     ...(params.turnId ? { turnId: params.turnId } : {}),
+    ...(typeof params.attributed === "boolean"
+      ? { turnUsageAttributed: params.attributed }
+      : {}),
     uncachedInputCostMicros: cost?.uncachedInputCostMicros ?? 0,
     uncachedInputTokens,
     usageLineId: [
@@ -12861,6 +12865,11 @@ export class DesktopBackendRegistry {
     tokenUsage: unknown;
     turnId?: string;
   }): {
+    // Whether turnTokenUsage is a real measurement of this turn — a per-turn
+    // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
+    // total we couldn't decompose. Carried onto the persisted row so the
+    // renderer classifies summaries by fact, not a token-count guess.
+    attributed: boolean;
     cumulativeTokenUsage?: TaskMonitorTokenUsageBreakdown;
     turnTokenUsage: TaskMonitorTokenUsageBreakdown | unknown;
     /**
@@ -12873,11 +12882,14 @@ export class DesktopBackendRegistry {
   } {
     const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
     if (!records) {
-      return { turnTokenUsage: params.tokenUsage };
+      return { attributed: false, turnTokenUsage: params.tokenUsage };
     }
 
     if (!records.totalUsage || !params.turnId) {
       return {
+        // A "last" snapshot is this request's own usage; anything else here is
+        // a bare/whole payload we can't attribute to the turn.
+        attributed: Boolean(records.latestUsage),
         ...(records.totalUsage ? { cumulativeTokenUsage: records.totalUsage } : {}),
         turnTokenUsage:
           records.latestUsage ?? records.currentUsage ?? params.tokenUsage,
@@ -12907,6 +12919,9 @@ export class DesktopBackendRegistry {
       ? subtractTaskMonitorTokenUsage(records.totalUsage, baseline)
       : undefined;
     return {
+      // Attributed when we computed a per-turn delta or have this request's
+      // "last" snapshot; not when we fall back to the whole cumulative total.
+      attributed: Boolean(turnTokenUsage) || Boolean(records.latestUsage),
       cumulativeTokenUsage: records.totalUsage,
       turnTokenUsage:
         turnTokenUsage ??
@@ -13038,6 +13053,7 @@ export class DesktopBackendRegistry {
       turnId: notification.params.turnId ?? undefined,
     });
     const line = buildLiveThreadUsageLine({
+      attributed: derivedUsage.attributed,
       backend: event.backend,
       cumulativeTokenUsage: derivedUsage.cumulativeTokenUsage,
       ...usageTiming,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -748,6 +748,7 @@ export class SqliteOverlayStore {
             reasoning_effort,
             service_tier,
             fast_mode,
+            turn_usage_attributed,
             settings_source,
             settings_confidence,
             input_tokens,
@@ -796,6 +797,7 @@ export class SqliteOverlayStore {
             @reasoningEffort,
             @serviceTier,
             @fastMode,
+            @turnUsageAttributed,
             @settingsSource,
             @settingsConfidence,
             @inputTokens,
@@ -844,6 +846,7 @@ export class SqliteOverlayStore {
             reasoning_effort = excluded.reasoning_effort,
             service_tier = excluded.service_tier,
             fast_mode = excluded.fast_mode,
+            turn_usage_attributed = excluded.turn_usage_attributed,
             settings_source = excluded.settings_source,
             settings_confidence = excluded.settings_confidence,
             input_tokens = excluded.input_tokens,
@@ -2431,6 +2434,7 @@ type ThreadUsageLineRow = {
   reasoning_effort: string | null;
   service_tier: string | null;
   fast_mode: number | null;
+  turn_usage_attributed: number | null;
   settings_source: ThreadUsageLineRecord["settingsSource"] | null;
   settings_confidence: ThreadUsageLineRecord["settingsConfidence"] | null;
   input_tokens: number;
@@ -2704,6 +2708,12 @@ function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string,
     cumulativeUncachedInputTokens: line.cumulativeUncachedInputTokens ?? null,
     currency: line.currency,
     fastMode: typeof line.fastMode === "boolean" ? (line.fastMode ? 1 : 0) : null,
+    turnUsageAttributed:
+      typeof line.turnUsageAttributed === "boolean"
+        ? line.turnUsageAttributed
+          ? 1
+          : 0
+        : null,
     inputTokens: line.inputTokens,
     model: line.model ?? null,
     observedColdReplayCount: line.observedColdReplayCount ?? null,
@@ -2774,6 +2784,9 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
       : {}),
     currency: row.currency,
     ...(row.fast_mode !== null ? { fastMode: Boolean(row.fast_mode) } : {}),
+    ...(row.turn_usage_attributed !== null
+      ? { turnUsageAttributed: Boolean(row.turn_usage_attributed) }
+      : {}),
     inputTokens: row.input_tokens,
     ...(row.model ? { model: row.model } : {}),
     outputCostMicros: row.output_cost_micros,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 25;
+export const CURRENT_STATE_DB_USER_VERSION = 26;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -565,6 +565,7 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   reasoning_effort           TEXT,
   service_tier               TEXT,
   fast_mode                  INTEGER,
+  turn_usage_attributed      INTEGER,
   settings_source            TEXT,
   settings_confidence        TEXT,
   input_tokens               INTEGER NOT NULL,
@@ -854,6 +855,12 @@ export class StateDb {
         // THREAD_USAGE_PRICING_SCHEMA; the ALTERs are guarded by tableColumnExists
         // so a fresh db (schema already carries them) no-ops.
         ensureThreadUsageTurnObservedReplayColumns(db);
+        db.pragma("user_version = 25");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 26) {
+      db.transaction(() => {
+        ensureThreadUsageAttributedColumn(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1323,6 +1330,34 @@ function ensureThreadUsageTurnObservedReplayColumns(db: BetterSqlite3.Database):
       db.exec(column.sql);
     }
   }
+}
+
+// Adds the turn_usage_attributed column and backfills the finite set of legacy
+// pre-attribution rows. Live rows built before this field existed recorded no
+// attribution; the ones that were whole-thread summaries masquerading as turns
+// are the live/pending rows with no cumulative breakdown and a >= 1M-token
+// total. This one-shot backfill over already-persisted rows is the ONLY place
+// the old token-count guess still runs — new live rows record attribution
+// explicitly at build time, so the renderer never re-derives it.
+function ensureThreadUsageAttributedColumn(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_lines")) {
+    db.exec(THREAD_USAGE_PRICING_SCHEMA);
+    return;
+  }
+  if (!tableColumnExists(db, "thread_usage_lines", "turn_usage_attributed")) {
+    db.exec(
+      "ALTER TABLE thread_usage_lines ADD COLUMN turn_usage_attributed INTEGER",
+    );
+  }
+  db.exec(`
+UPDATE thread_usage_lines
+SET turn_usage_attributed = 0
+WHERE turn_usage_attributed IS NULL
+  AND source = 'live'
+  AND status = 'pending'
+  AND cumulative_total_tokens IS NULL
+  AND total_tokens >= 1000000
+`);
 }
 
 function ensureThreadSearchFtsThreadIdColumn(db: BetterSqlite3.Database): void {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1623,9 +1623,10 @@ describe("ThreadContextPanel", () => {
   });
 
   it("keeps the running duration on an active turn that trips the historical-summary heuristic", () => {
-    // A live turn whose first usage event carries no cumulative snapshot and
-    // whose own totalTokens is >= 1M satisfies isHistoricalUsageSummary. It is
-    // still the active turn, so it must keep its Live chip AND running clock.
+    // An active live turn the builder couldn't attribute (turnUsageAttributed
+    // false) classifies as a historical summary. It is still the active turn,
+    // so it must keep its Live chip AND running clock (guard-order in
+    // formatUsageLineDuration puts the active branch before the summary guard).
     const startedAt = 1_800_000_000_000;
     vi.useFakeTimers();
     vi.setSystemTime(startedAt + 65_000);
@@ -1656,6 +1657,7 @@ describe("ThreadContextPanel", () => {
             totalCostMicros: 1_000,
             totalTokens: 1_500_010,
             turnId: "turn-live",
+            turnUsageAttributed: false,
             uncachedInputCostMicros: 0,
             uncachedInputTokens: 0,
             usageLineId: "line-live-huge",
@@ -1868,7 +1870,7 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Sub-agent usage")).toBeInTheDocument();
   });
 
-  it("labels legacy live rows without cumulative context as historical summaries", () => {
+  it("labels unattributed live rows as historical summaries", () => {
     renderPanel({
       activeTab: "pricing",
       pinned: true,
@@ -1894,6 +1896,7 @@ describe("ThreadContextPanel", () => {
             totalCostMicros: 55_830_000,
             totalTokens: 73_473_538,
             turnId: "turn-legacy",
+            turnUsageAttributed: false,
             uncachedInputCostMicros: 6_830_000,
             uncachedInputTokens: 2_788_759,
             usageLineId: "line-legacy",
@@ -1925,6 +1928,50 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText("Historical usage summary")).toBeInTheDocument();
     expect(screen.getByText("$55.83 list price")).toBeInTheDocument();
     expect(screen.queryByText("$55.83 list price this turn")).not.toBeInTheDocument();
+  });
+
+  it("treats a large attributed live turn as a turn, not a summary", () => {
+    // Same size as the unattributed row above, but attributed to the turn — it
+    // must read as a normal (large) turn. No token-count threshold reclassifies it.
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [
+          {
+            backend: "codex",
+            cachedInputCostMicros: 7_000_000,
+            cachedInputTokens: 70_463_104,
+            createdAt: 1_800_000_000_000,
+            currency: "USD",
+            inputTokens: 73_251_863,
+            model: "gpt-5.5",
+            outputCostMicros: 42_000_000,
+            outputTokens: 221_675,
+            priceStatus: "priced",
+            provider: "openai",
+            reasoningOutputTokens: 37_030,
+            scope: "turn",
+            source: "live",
+            status: "pending",
+            threadId: "thread-1",
+            totalCostMicros: 55_830_000,
+            totalTokens: 73_473_538,
+            turnId: "turn-big",
+            turnUsageAttributed: true,
+            uncachedInputCostMicros: 6_830_000,
+            uncachedInputTokens: 2_788_759,
+            usageLineId: "line-big",
+          },
+        ],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("Turn usage")).toBeInTheDocument();
+    expect(screen.queryByText("Historical usage summary")).not.toBeInTheDocument();
+    expect(screen.getByText("$55.83 list price this turn")).toBeInTheDocument();
   });
 
   it("hides the hover rail when document mouse movement resumes outside the rail", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -953,15 +953,16 @@ function isForkBaselineLine(line: ThreadUsageLineRecord): boolean {
   return line.scope === "fork-baseline";
 }
 
+// A row is a whole-thread/historical summary when its scope says so, or when
+// the live builder recorded that it could not attribute the usage to this turn
+// (turnUsageAttributed === false) — e.g. a first observed event that carried a
+// whole-thread total we couldn't decompose. Legacy rows predating the flag are
+// backfilled by the state-db migration (user_version 26). No token-count guess.
 function isHistoricalUsageSummary(line: ThreadUsageLineRecord): boolean {
-  if (line.scope === "total" || line.scope === "backfill") {
-    return true;
-  }
   return (
-    line.source === "live" &&
-    line.status === "pending" &&
-    line.cumulativeTotalTokens === undefined &&
-    line.totalTokens >= 1_000_000
+    line.scope === "total" ||
+    line.scope === "backfill" ||
+    line.turnUsageAttributed === false
   );
 }
 

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -91,6 +91,14 @@ export type ThreadUsageLineRecord = {
   totalCostMicros: number;
   totalTokens: number;
   turnId?: string;
+  // Whether this row's token totals are a real measurement of THIS turn.
+  // Set by the live builder: `true` when usage was attributed to the turn (a
+  // per-turn delta or a per-request "last" snapshot), `false` when the builder
+  // had to fall back to a whole-thread/undecomposed total and the row is really
+  // a summary. `undefined` = not computed (hydration/backfill rows, or rows
+  // persisted before this field existed). The renderer treats `false` as a
+  // historical summary instead of guessing from raw token counts.
+  turnUsageAttributed?: boolean;
   uncachedInputCostMicros: number;
   uncachedInputTokens: number;
   usageLineId: string;


### PR DESCRIPTION
Stacked on #935 (base branch: `feat/pricing-turn-durations-active-indicator`). Review/merge #935 first.

## Why

`isHistoricalUsageSummary` decided whether a pricing row was a whole-thread **summary** or a real **turn** with a render-time guess:

```ts
line.source === "live" && line.status === "pending" &&
line.cumulativeTotalTokens === undefined && line.totalTokens >= 1_000_000
```

That magic number misfired both ways — it mislabeled a *legitimately large* live turn as "Historical usage summary" (the bug that surfaced in #935), and it missed *small* undecomposed blobs. And it was re-derived on every render, with less information than the builder had upstream.

## The fix: decide it where the fact is known

The main process already knows, when it builds a live row, whether it produced a **real per-turn measurement** — a per-turn delta (cumulative minus a stored baseline) or a per-request `last` snapshot — or had to **fall back to a whole-thread total it couldn't decompose**. That's the actual "is this a turn or a summary" signal. We were computing it and throwing it away.

Now `deriveLiveThreadTokenUsage` returns `attributed`, `buildLiveThreadUsageLine` records it as `turnUsageAttributed`, and it's persisted with the row. The renderer reads the field.

- **shared**: `ThreadUsageLineRecord.turnUsageAttributed?: boolean`
- **state-db**: `turn_usage_attributed` column + `user_version` 24 migration that adds the column and **backfills the finite set of legacy rows** using the old predicate — run **once** over already-persisted data. This is the only place the `1M` number survives, and it never runs at render.
- **overlay-store**: persist/read the flag (mirrors `fast_mode`)
- **backend-registry**: compute + record attribution on live rows
- **renderer**: `isHistoricalUsageSummary = scope total/backfill || turnUsageAttributed === false`; the `>= 1M` arithmetic is deleted

## Behavior change (intended)

- A large turn we **attributed** now reads as a **Turn** (fixes the mislabel).
- A whole-thread total we **couldn't decompose** reads as a **summary** regardless of size.
- The common path is unchanged: modern main-thread `thread/tokenUsage/updated` events carry both `last_token_usage` and `total_token_usage`, so they're attributed and render as turns exactly as before (locked by a backend-registry test asserting `turnUsageAttributed: true`).

This also resolves the question we couldn't answer earlier (does CAS ever emit a live event without a cumulative total?) — we no longer need to know. The builder records what it actually observed rather than the renderer guessing.

## Testing

- **backend-registry**: `last + total` event → `turnUsageAttributed: true`; a `total`-only event (no per-request `last`) → `false`. (345 pass)
- **overlay-store**: flag round-trips through sqlite (true/false/undefined preserved); the `user_version` 24 migration backfills a legacy live/pending/no-cumulative/≥1M row to `0` while leaving a cumulative-bearing modern turn and a sub-1M turn `NULL`.
- **renderer**: an unattributed live row → "Historical usage summary"; a large *attributed* live row → "Turn usage" / "list price this turn"; an active unattributed turn still keeps its Live chip + running clock (#935's guard-order).
- `typecheck` (desktop + shared), `lint:sql`, `lint:boundaries` pass. ESLint isn't on this branch's base (pre-adoption) — it'll apply once this rebases onto main after #935 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
