### PR TITLE
feat(desktop): count observed context replays on sub-agent threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13418,6 +13418,166 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("counts observed context replays on review sub-agent usage lines", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-parent",
+        reviewThreadId: "thread-review",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "detached",
+    });
+
+    // First request: 160k of input on a cold cache — one cold replay.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-review",
+        turnId: "turn-review-1",
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: { inputTokens: 160_000, cachedInputTokens: 8_000, outputTokens: 500 },
+          last: { inputTokens: 160_000, cachedInputTokens: 8_000, outputTokens: 500 },
+        },
+      },
+    });
+    // Second request replays the grown context mostly cache-served — one hot
+    // replay on the same review turn.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-review",
+        turnId: "turn-review-1",
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: { inputTokens: 325_000, cachedInputTokens: 168_000, outputTokens: 1_200 },
+          last: { inputTokens: 165_000, cachedInputTokens: 160_000, outputTokens: 700 },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const pricing = await overlayStore.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-parent",
+        });
+        return pricing.lines[0];
+      })
+      .toMatchObject({
+        scope: "monitor",
+        threadId: "thread-review",
+        turnId: "turn-review-1",
+        observedColdReplayCount: 1,
+        // The review thread's first observed request has no prior context
+        // snapshot, so cold attribution falls back to its full uncached amount.
+        observedColdReplayUncachedTokens: 152_000,
+        observedHotReplayCount: 1,
+        observedHotReplayCachedTokens: 160_000,
+      });
+
+    await registry.close();
+  });
+
+  it("counts observed context replays on Codex native sub-agent usage lines", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    const nativeThreadId = "019ebb70-2c58-7143-850e-0a699607c799";
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-spawn-1",
+          type: "collabAgentToolCall",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: [nativeThreadId],
+          prompt: "You are the correctness reviewer. Inspect the diff.",
+          model: "gpt-5.4-mini",
+          agentsStates: {
+            [nativeThreadId]: {
+              status: "running",
+              message: "Inspecting the diff.",
+            },
+          },
+        },
+      },
+    } as AppServerNotification);
+
+    // Two cache-served context replays on the agent's own thread.
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: nativeThreadId,
+        turnId: "turn-native-1",
+        model: "gpt-5.4-mini",
+        tokenUsage: {
+          total: { inputTokens: 65_000, cachedInputTokens: 60_000, outputTokens: 1_000 },
+          last: { inputTokens: 65_000, cachedInputTokens: 60_000, outputTokens: 1_000 },
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: nativeThreadId,
+        turnId: "turn-native-1",
+        model: "gpt-5.4-mini",
+        tokenUsage: {
+          total: { inputTokens: 131_000, cachedInputTokens: 124_000, outputTokens: 1_800 },
+          last: { inputTokens: 66_000, cachedInputTokens: 64_000, outputTokens: 800 },
+        },
+      },
+    });
+
+    await expect
+      .poll(async () => {
+        const pricing = await overlayStore.readThreadPricing({
+          backend: "codex",
+          threadId: "thread-parent",
+        });
+        return pricing.lines[0];
+      })
+      .toMatchObject({
+        scope: "monitor",
+        threadId: nativeThreadId,
+        turnId: "turn-native-1",
+        observedColdReplayCount: 0,
+        observedColdReplayUncachedTokens: 0,
+        observedHotReplayCount: 2,
+        observedHotReplayCachedTokens: 124_000,
+      });
+
+    await registry.close();
+  });
+
   it("persists Codex native spawnAgent calls as sub-agent summaries", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -209,6 +209,61 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("round-trips a parent-scoped monitor line's observed tally through the turn record", async () => {
+    const monitorLine: Partial<ThreadUsageLineRecord> = {
+      parentThreadId: "thread-1",
+      scope: "monitor",
+      source: "monitor",
+      sourceItemId: "review:turn-review-1",
+      threadId: "monitor-thread-1",
+      turnId: "turn-review-1",
+      usageLineId:
+        "codex:thread-1:review:turn-review-1:monitor-thread-1:turn-review-1:monitor",
+    };
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        ...monitorLine,
+        observedColdReplayCount: 1,
+        observedColdReplayUncachedTokens: 152_000,
+        observedHotReplayCount: 8,
+        observedHotReplayCachedTokens: 4_207_616,
+      }),
+    });
+
+    // The parent-thread read picks the monitor line up through the
+    // parent_thread_id branch and must join the tally back from its
+    // child-thread-scoped turn record.
+    let pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      scope: "monitor",
+      threadId: "monitor-thread-1",
+      usageTurnId: "openai:codex:monitor-thread-1:turn-review-1",
+      observedColdReplayCount: 1,
+      observedColdReplayUncachedTokens: 152_000,
+      observedHotReplayCount: 8,
+      observedHotReplayCachedTokens: 4_207_616,
+    });
+
+    // A later tally-less re-upsert of the same monitor line (e.g. a duplicate
+    // usage emission after restart) must not wipe the persisted counts.
+    await store.upsertThreadUsageLine({ line: buildUsageLine(monitorLine) });
+    pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      observedColdReplayCount: 1,
+      observedColdReplayUncachedTokens: 152_000,
+      observedHotReplayCount: 8,
+      observedHotReplayCachedTokens: 4_207_616,
+    });
+  });
+
   it("keeps the observed tally on the turn record when hydration supersedes the live line", async () => {
     // Live turn we observed replays for.
     await store.upsertThreadUsageLine({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3175,6 +3175,7 @@ function buildTaskMonitorUsageLine(params: {
   monitorId: string;
   monitorThreadId: string;
   monitorTurnId?: string;
+  observedReplays?: ObservedContextReplayTally;
   parentThreadId: string;
   serviceTier?: string;
   source: ThreadUsageLineRecord["source"];
@@ -3228,6 +3229,16 @@ function buildTaskMonitorUsageLine(params: {
     ...(params.fastMode !== undefined ? { fastMode: params.fastMode } : {}),
     inputTokens,
     ...(model ? { model } : {}),
+    ...(params.observedReplays
+      ? {
+          observedColdReplayCount: params.observedReplays.coldReplayCount,
+          observedColdReplayUncachedTokens:
+            params.observedReplays.coldReplayUncachedTokens,
+          observedHotReplayCachedTokens:
+            params.observedReplays.hotReplayCachedTokens,
+          observedHotReplayCount: params.observedReplays.hotReplayCount,
+        }
+      : {}),
     outputCostMicros: cost?.outputCostMicros ?? 0,
     outputTokens,
     parentThreadId: params.parentThreadId,
@@ -12719,6 +12730,12 @@ export class DesktopBackendRegistry {
       }
       if (reviewRecord) {
         reviewRecord.latestUsage = usageSnapshot;
+        const observedReplays = this.observeLiveThreadContextReplay({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+          tokenUsage: notification.params.tokenUsage,
+          turnId: notification.params.turnId,
+        });
         await this.persistReviewSubAgent(reviewRecord, {
           monitorUsage: usageSnapshot,
         });
@@ -12730,6 +12747,7 @@ export class DesktopBackendRegistry {
             monitorId: reviewSubAgentId(reviewRecord.turnId),
             monitorThreadId: reviewRecord.reviewThreadId,
             monitorTurnId: reviewRecord.turnId,
+            observedReplays,
             parentThreadId: reviewRecord.parentThreadId,
             serviceTier,
             source: "monitor",
@@ -12754,6 +12772,12 @@ export class DesktopBackendRegistry {
         usage: usageSnapshot,
       });
       if (reviewUsagePersisted) {
+        const observedReplays = this.observeLiveThreadContextReplay({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+          tokenUsage: notification.params.tokenUsage,
+          turnId: notification.params.turnId,
+        });
         if (typeof this.overlayStore.upsertThreadUsageLine === "function") {
           const line = buildTaskMonitorUsageLine({
             backend: event.backend,
@@ -12763,6 +12787,7 @@ export class DesktopBackendRegistry {
             monitorThreadId:
               completedReviewRecord?.reviewThreadId ?? notification.params.threadId,
             monitorTurnId: notification.params.turnId,
+            observedReplays,
             parentThreadId:
               completedReviewRecord?.parentThreadId ?? notification.params.threadId,
             serviceTier,
@@ -12799,6 +12824,12 @@ export class DesktopBackendRegistry {
     });
     if (usageSnapshot) {
       monitorRecord.latestUsage = usageSnapshot;
+      const observedReplays = this.observeLiveThreadContextReplay({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        tokenUsage: notification.params.tokenUsage,
+        turnId: notification.params.turnId ?? monitorRecord.monitorTurnId,
+      });
       await this.persistTaskMonitorSubAgent(monitorRecord, {
         monitorUsage: usageSnapshot,
       });
@@ -12809,6 +12840,7 @@ export class DesktopBackendRegistry {
           monitorId: monitorRecord.monitorId,
           monitorThreadId: monitorRecord.monitorThreadId ?? notification.params.threadId,
           monitorTurnId: monitorRecord.monitorTurnId,
+          observedReplays,
           parentThreadId: monitorRecord.parentThreadId,
           source: "monitor",
           usage: usageSnapshot,
@@ -13209,6 +13241,15 @@ export class DesktopBackendRegistry {
     if (!usageSnapshot) {
       return;
     }
+    const monitorTurnId =
+      readOptionalString(notificationParams, ["turnId", "turn_id"]) ??
+      existing.monitorTurnId;
+    const observedReplays = this.observeLiveThreadContextReplay({
+      backend: "codex",
+      threadId: event.notification.params.threadId,
+      tokenUsage: event.notification.params.tokenUsage,
+      turnId: monitorTurnId,
+    });
 
     await this.overlayStore.upsertThreadSubAgent({
       backend: "codex",
@@ -13236,9 +13277,8 @@ export class DesktopBackendRegistry {
         model,
         monitorId,
         monitorThreadId: event.notification.params.threadId,
-        monitorTurnId:
-          readOptionalString(notificationParams, ["turnId", "turn_id"]) ??
-          existing.monitorTurnId,
+        monitorTurnId,
+        observedReplays,
         parentThreadId,
         serviceTier,
         source: "monitor",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1194,6 +1194,62 @@ describe("ThreadContextPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders observed replay counts on sub-agent monitor pricing cards", () => {
+    const line: ThreadUsageLineRecord = {
+      backend: "codex",
+      usageLineId: "monitor-line-context-replays",
+      threadId: "monitor-thread-1",
+      parentThreadId: "thread-1",
+      turnId: "turn-review-1",
+      scope: "monitor",
+      source: "monitor",
+      status: "finalized",
+      model: "gpt-5.5",
+      inputTokens: 550_000,
+      uncachedInputTokens: 100_000,
+      cachedInputTokens: 450_000,
+      outputTokens: 2_000,
+      reasoningOutputTokens: 500,
+      totalTokens: 552_500,
+      priceStatus: "priced",
+      currency: "USD",
+      uncachedInputCostMicros: 500_000,
+      cachedInputCostMicros: 225_000,
+      outputCostMicros: 75_000,
+      totalCostMicros: 800_000,
+      observedColdReplayCount: 1,
+      observedColdReplayUncachedTokens: 100_000,
+      observedHotReplayCount: 5,
+      observedHotReplayCachedTokens: 450_000,
+      provider: "openai",
+      createdAt: 1_800_000_000_000,
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      pricing: {
+        lines: [line],
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    // Sub-agent ("monitor") lines carry the tally observed on the agent's own
+    // thread and render the same replay estimates as turn lines.
+    expect(screen.getByText("Sub-agent usage")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated cold context replays: 1 (100,000 uncached · $0.50)",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Estimated hot context replays: 5 (~90,000 cached avg; 450,000 cached bucket · $0.23)",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("shows observed replay counts on a completed turn (no active turn needed)", () => {
     // Regression guard for the #871 complaint: a finished turn keeps the counts
     // it observed live rather than losing them once it is no longer active.

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -639,11 +639,12 @@ function formatContextReplayEstimate(params: {
   displayOptions: PricingDisplayOptions;
   line: PricingUsageLine;
 }): string[] {
-  // Context replays are a per-turn concept; only turn-scoped lines carry the
-  // observed tally. Guarding on scope keeps monitor/total/backfill rows from
-  // ever rendering replay estimates even if they somehow carried the fields.
+  // Context replays are observed per turn: turn-scoped lines and sub-agent
+  // ("monitor") lines both carry the tally the main process accumulated live.
+  // Guarding on scope keeps total/backfill/gap rows from ever rendering replay
+  // estimates even if they somehow carried the fields.
   if (
-    params.line.scope !== "turn" ||
+    (params.line.scope !== "turn" && params.line.scope !== "monitor") ||
     isEstimatedUsageGap(params.line) ||
     isHistoricalUsageSummary(params.line)
   ) {


### PR DESCRIPTION
Extends observed context-replay counting (#933) to sub-agent threads, resolving open question **O3** of `docs/plans/2026-07-04-001-feat-observed-context-replay-counting-plan.md` (plan doc left untouched per `docs/plans/AGENTS.md` — it belongs to the merged #933 branch; the resolution is recorded here instead).

## Problem

Spawned agents (codex native sub-agents, review fan-out, task monitors) display "Sub-agent usage" cards with full cost and cached/uncached token breakdowns, but no "Estimated cold/hot context replays" lines. Example: a review thread showing 588,282 input / 525,952 cached — roughly 8 uncounted hot replays of a ~65k context — rendered no replay estimate.

Two gates hid them:
- `recordLiveThreadUsage` is the only caller of `observeLiveThreadContextReplay`, and it early-returns for all three sub-agent flavors before the fold runs.
- The renderer's `formatContextReplayEstimate` returned `[]` for `scope !== "turn"`.

The protocol data was always there — sub-agent threads emit the same `thread/tokenUsage/updated` with `total`/`last`.

## Changes

- **Fold sub-agent usage**: each of the three sub-agent usage paths (review sub-agent — both the active-record and usage-after-completion branches — task-monitor delegation, codex native sub-agent) now calls `observeLiveThreadContextReplay` with the **agent's own** `threadId`/`turnId` before building its usage line. The pure fold (`foldObservedContextReplay`) is unchanged; its per-thread cursor makes agent threads compose cleanly. `forgetCompletedTurnReplayObservations` already covers agent turns — their `turn/completed` flows through the same dispatch and the cleanup is keyed on the notification's own thread/turn ids.
- **`buildTaskMonitorUsageLine`** gains `observedReplays?: ObservedContextReplayTally` and spreads the four `observed*` fields exactly like `buildLiveThreadUsageLine`.
- **Renderer**: `formatContextReplayEstimate` now allows `scope === "monitor"` alongside `"turn"`; gap/summary exclusions unchanged. Monitor cards render the same "Estimated cold/hot context replays" lines as turn cards.
- **Persistence (verified, no code change needed)**: after #945, the tally lives on `thread_usage_turns`. Monitor lines derive a child-thread-scoped `usage_turn_id` (`provider:backend:<agentThreadId>:<monitorTurnId>`), the turn row carries `parent_thread_id`, and `readThreadPricing`'s parent-scoped branch (`parent_thread_id = ? AND thread_id != ?`) already joins the tally back onto displayed monitor lines. Locked with a round-trip test, including COALESCE-preservation when a tally-less re-upsert of the same monitor line lands later. The deprecated dual-write to `thread_usage_lines` (#947) is untouched and still open.
- **No backfill**: historical monitor rows were never observed live; absent fields keep meaning "not observed" and render nothing.

## Tests

- `backend-registry.test.ts`: two end-to-end tests (usage notification → tally on the persisted monitor line) — review sub-agent path (cold first request + hot replay of the grown context) and codex native sub-agent path (two hot replays).
- `overlay-store-usage-pricing.test.ts`: parent-scoped monitor line round-trips its tally through the turn record via the parent-thread read, and survives a tally-less re-upsert.
- `ThreadContextPanel.test.tsx`: a monitor-scope line with observed fields renders both replay-estimate lines on the "Sub-agent usage" card.

`pnpm test` (registry 349 ✓, pricing store ✓, fold ✓, renderer panel 42 ✓), `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:sql`, `pnpm lint:boundaries` — all green under Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)