### PR TITLE
test(desktop): de-flake transcript temporal-order E2E turn-completed race

### DIFF
--- a/apps/desktop/e2e/transcript-temporal-order.spec.ts
+++ b/apps/desktop/e2e/transcript-temporal-order.spec.ts
@@ -52,6 +52,10 @@ test("transcript preserves temporal order across live activity and hydration", a
     await app.advance({ stepId: "turn-completed-1" });
 
     await expect(transcript.getByText("I added the controller hook")).toBeVisible();
+    // Turn completion introduces the work-group summary labels; wait for them to
+    // render before the synchronous innerText() snapshot so we don't race the DOM.
+    await expect(transcript).toContainText("Worked for 1m 10s");
+    await expect(transcript).toContainText("More work");
     transcriptText = await transcript.innerText();
     assertOrdered(transcriptText, [
       "Show the temporal transcript order.",


### PR DESCRIPTION
## Summary

- Fixes intermittent CI failures in `apps/desktop/e2e/transcript-temporal-order.spec.ts` ("transcript preserves temporal order across live activity and hydration").
- Root cause: after `await app.advance({ stepId: "turn-completed-1" })`, the test gated the synchronous `transcript.innerText()` snapshot only on `getByText("I added the controller hook")` — a message that was **already visible before** turn completion. So the read raced the render of the new turn-completed work-group summary labels, intermittently failing `assertOrdered` with `Expected "Worked for 1m 10s" after index 88 ... Received: -1`.
- Fix: add web-first retrying assertions (`await expect(transcript).toContainText(...)`) for the newly-appeared labels `"Worked for 1m 10s"` and `"More work"` before the `innerText()` snapshot, so Playwright waits for the DOM to settle. The ordering assertions themselves are unchanged.

This is a test-timing bug, not a product bug — the render code (`workGroupLabel` in `apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts`, gated on turn `durationMs > 60_000`) is correct.

## Verification

- `pnpm --filter @pwragent/desktop run pretest:e2e` — clean build.
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/transcript-temporal-order.spec.ts --repeat-each=10` — **10/10 passed**.

## Notes

- The third `assertOrdered` block was already safe — it gates on its own newly-appeared labels (`"Read useThreadSessionState.ts"`, `"Searched thread-detail"`) before its snapshot.
- Independent of PR #935 (that PR does not touch the transcript path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)