### PR TITLE
fix(messaging): stop trusting Slack channel-name prefix for group-DM gate

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -1462,6 +1462,55 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("does not treat a regular channel named mpdm-… as a group DM (no name-based gate bypass)", async () => {
+    const socket = fakeSocket();
+    // Lock the team/channel gates with empty allowlists and open group DMs, so
+    // a channel classified as a group DM would be accepted (authorized user)
+    // while a channel subject to the team/channel gates is rejected. The slash
+    // payload carries only a *name* — "mpdm-…" here — which is attacker-
+    // influenceable and must NOT drive classification: conversations.info
+    // (is_mpim: false) is authoritative, so this stays a channel and is gated.
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedTeamIds: [],
+        teamAuthorizationMode: "approved_only",
+        channelAuthorizationMode: "approved_only",
+        groupDmAccessMode: "authorized_users",
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slash_commands", {
+      ack: async () => undefined,
+      body: {
+        channel_id: "C0SPOOFCHAN",
+        channel_name: "mpdm-spoof-not-a-group-dm",
+        command: "/status",
+        team_id: "T012ABCDEF0",
+        text: "",
+        user_id: "U012ABCDEF0",
+        user_name: "alice",
+      },
+    });
+
+    expect(events).toEqual([]);
+    expect(rejected).toEqual([
+      expect.objectContaining({ reason: "unauthorized-conversation" }),
+    ]);
+  });
+
   it("ignores (does not reject) a non-mention group DM message from a non-authorized participant", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -845,7 +845,6 @@ export class SlackAdapter implements SlackProviderAdapter {
       kind: "callback",
       isGroupDm: await this.resolveIsGroupDm({
         channelId: ids.channelId,
-        channelName: body.channel?.name,
       }),
       routingState,
       teamId: ids.teamId,
@@ -914,7 +913,6 @@ export class SlackAdapter implements SlackProviderAdapter {
       kind: "command",
       isGroupDm: await this.resolveIsGroupDm({
         channelId: ids.channelId,
-        channelName: body.channel_name,
       }),
       routingState,
       teamId: ids.teamId,
@@ -1689,9 +1687,8 @@ export class SlackAdapter implements SlackProviderAdapter {
   private async resolveIsGroupDm(params: {
     channelId: string;
     channelType?: string;
-    channelName?: string;
   }): Promise<boolean> {
-    if (isSlackGroupDm({ channelType: params.channelType, channelName: params.channelName })) {
+    if (isSlackGroupDm({ channelType: params.channelType })) {
       return true;
     }
     const cached = this.conversationGroupDmCache.get(params.channelId);
@@ -2244,17 +2241,18 @@ function slackGroupDmAccessMode(
 }
 
 /**
- * Detect a Slack multi-person DM (mpim / "group DM"). Message events carry
- * `channel_type: "mpim"`; interactive (block action) and slash payloads carry
- * only a channel name, but Slack always names group DMs `mpdm-…`. Both signals
- * are checked so every inbound path (message, callback, slash) agrees.
+ * Detect a Slack multi-person DM (mpim / "group DM") from the one synchronous
+ * signal we can trust: message events carry `channel_type: "mpim"`. We do NOT
+ * classify on the channel *name*: interactive (block action) and slash payloads
+ * carry only a name, and a name is attacker-influenceable. Slack names group DMs
+ * `mpdm-…`, but nothing stops a regular channel from being named `mpdm-…` too —
+ * trusting that prefix would route such a channel through the looser group-DM
+ * gate (`groupDmAccessMode` + authorized user), letting an authorized user slip
+ * past the team/channel allowlists. Name-only paths resolve authoritatively via
+ * `conversations.info.is_mpim` in `resolveIsGroupDm` instead.
  */
-function isSlackGroupDm(params: {
-  channelType?: string;
-  channelName?: string;
-}): boolean {
-  if (params.channelType === "mpim") return true;
-  return params.channelName?.startsWith("mpdm") ?? false;
+function isSlackGroupDm(params: { channelType?: string }): boolean {
+  return params.channelType === "mpim";
 }
 
 function callbackBindingId(intent: MessagingSurfaceIntent): string | undefined {


### PR DESCRIPTION
## Summary

- Slack group-DM (mpim) classification short-circuited to `true` whenever the inbound `channel_name` started with `mpdm-`, **before** the authoritative `conversations.info.is_mpim` lookup.
- The group-DM gate bypasses the team/channel allowlists (it checks only `groupDmAccessMode` + authorized actor), so an authorized user could route a **non-allowlisted** channel through the looser gate by operating in a channel named `mpdm-…`. A channel name is attacker-influenceable, and nothing stops a regular channel from using that prefix. Slash-command and block-action payloads — which carry only a name, no `channel_type` — were the exposed paths.
- Fix: classify group DMs only from signals we can trust — `channel_type === "mpim"` synchronously (message events) and `conversations.info.is_mpim` for the name-less paths (that lookup was already implemented in `resolveIsGroupDm`). Dropped the name heuristic and the now-dead `channelName` argument from `resolveIsGroupDm` and both call sites.

## Verification

- Added a regression test: a slash command from a regular channel named `mpdm-spoof-not-a-group-dm`, with the team/channel gates locked (`approved_only`, empty allowlists) and group DMs open (`authorized_users`) from an authorized actor, is now rejected as `unauthorized-conversation` instead of slipping through. Confirmed the test **fails** against the pre-fix behavior and **passes** with the fix.
- Slack provider suite: 50/50 pass.
- `pnpm typecheck`: clean across all packages.
- `pnpm lint:eslint`: 0 errors; the two changed files add 0 warnings (tree was already at 140 baseline warnings on `main`).

## Notes

- **Behavior change (fails closed):** block actions and slash commands in *real* group DMs now always resolve via the cached `conversations.info` lookup, which needs `conversations.info` scope (already used for conversation titles). If that scope is ever absent, a real group DM is treated as a channel and gated by the allowlists — the safe direction — rather than being auto-allowed off its name.
- Practical exploitability of the original issue was narrow: it required an already-authorized actor, the operator having opted into group DMs (`groupDmAccessMode` defaults to `none`), and a channel named `mpdm-…`. Fixing it regardless removes an authorization decision based on an attacker-influenceable string when the authoritative signal was already on hand.
- Found during independent verification of an external review of the Slack authorization redesign (#916). This addresses the one finding that failed *open*; the other findings (fail-closed correctness/migration issues) are not included here.