### PR TITLE
fix(desktop): keep handoff subthreads under root parent

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16038,7 +16038,7 @@ script = "printf setup"
     await rm(root, { recursive: true, force: true });
   });
 
-  it("groups handoffs from a subthread under the root parent", async () => {
+  it("groups handoffs from a persisted grandchild under the root parent", async () => {
     const rootDirectory = {
       id: expectedDir("/repo/app"),
       kind: "local" as const,
@@ -16052,14 +16052,22 @@ script = "printf setup"
           threadId: "root-thread",
           executionMode: "default",
           extraLinkedDirectories: [rootDirectory],
-          subthreadOrder: ["older-child", "source-child"],
+          subthreadOrder: ["older-child", "intermediate-child"],
         },
-        "codex:source-child": {
+        "codex:intermediate-child": {
           backend: "codex",
-          threadId: "source-child",
+          threadId: "intermediate-child",
           executionMode: "default",
           extraLinkedDirectories: [rootDirectory],
           parentThreadId: "root-thread",
+          subthreadOrder: ["source-grandchild"],
+        },
+        "codex:source-grandchild": {
+          backend: "codex",
+          threadId: "source-grandchild",
+          executionMode: "default",
+          extraLinkedDirectories: [rootDirectory],
+          parentThreadId: "intermediate-child",
         },
       },
     });
@@ -16075,12 +16083,20 @@ script = "printf setup"
           updatedAt: 1000,
         },
         {
-          id: "source-child",
-          title: "Source Child",
+          id: "intermediate-child",
+          title: "Intermediate Child",
           titleSource: "explicit",
           source: "codex",
           linkedDirectories: [rootDirectory],
           updatedAt: 2000,
+        },
+        {
+          id: "source-grandchild",
+          title: "Source Grandchild",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [rootDirectory],
+          updatedAt: 3000,
         },
       ],
     });
@@ -16097,7 +16113,7 @@ script = "printf setup"
       notification: {
         method: "turn/started",
         params: {
-          threadId: "source-child",
+          threadId: "source-grandchild",
           turnId: "turn-1",
           turn: { id: "turn-1" },
         },
@@ -16107,7 +16123,7 @@ script = "printf setup"
     const response = await codexClient.emitRequest({
       method: "item/tool/call",
       params: {
-        threadId: "source-child",
+        threadId: "source-grandchild",
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
@@ -16130,7 +16146,7 @@ script = "printf setup"
       threadId: "thread-1",
       groupedUnderThreadId: "root-thread",
       origin: {
-        sourceThreadId: "source-child",
+        sourceThreadId: "source-grandchild",
       },
     });
     await expect(
@@ -16147,7 +16163,12 @@ script = "printf setup"
         threadId: "root-thread",
       }),
     ).resolves.toMatchObject({
-      subthreadOrder: ["older-child", "source-child", "thread-1"],
+      subthreadOrder: [
+        "older-child",
+        "intermediate-child",
+        "source-grandchild",
+        "thread-1",
+      ],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -440,6 +440,29 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    updateSubthreadOrder: async ({
+      backend,
+      parentThreadId,
+      threadIds,
+    }: {
+      backend: "codex" | "grok";
+      parentThreadId: string;
+      threadIds: string[];
+    }) => {
+      const key = `${backend}:${parentThreadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId: parentThreadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        subthreadOrder: threadIds,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return threadIds;
+    },
     setThreadAgent: async (settings: {
       backend: "codex" | "grok";
       threadId: string;
@@ -16013,6 +16036,121 @@ script = "printf setup"
 
     await registry.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it("groups handoffs from a subthread under the root parent", async () => {
+    const rootDirectory = {
+      id: expectedDir("/repo/app"),
+      kind: "local" as const,
+      label: "app",
+      path: expectedDir("/repo/app"),
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:root-thread": {
+          backend: "codex",
+          threadId: "root-thread",
+          executionMode: "default",
+          extraLinkedDirectories: [rootDirectory],
+          subthreadOrder: ["older-child", "source-child"],
+        },
+        "codex:source-child": {
+          backend: "codex",
+          threadId: "source-child",
+          executionMode: "default",
+          extraLinkedDirectories: [rootDirectory],
+          parentThreadId: "root-thread",
+        },
+      },
+    });
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "root-thread",
+          title: "Root Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [rootDirectory],
+          updatedAt: 1000,
+        },
+        {
+          id: "source-child",
+          title: "Source Child",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [rootDirectory],
+          updatedAt: 2000,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "source-child",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "source-child",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Investigate the follow-up.",
+          title: "Follow-up",
+          groupingMode: "subthread",
+          workspaceMode: "none",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload).toMatchObject({
+      threadId: "thread-1",
+      groupedUnderThreadId: "root-thread",
+      origin: {
+        sourceThreadId: "source-child",
+      },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "root-thread",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "root-thread",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["older-child", "source-child", "thread-1"],
+    });
+
+    await registry.close();
   });
 
   it("queues same-thread workspace moves from a live dynamic tool call", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -175,6 +175,7 @@ import {
   applyCodexEnvironmentActionRunUpdate,
   buildPendingRequestResponse,
   buildThreadIdentityKey,
+  insertSubthreadIdAfter,
   isAcpBackendId,
   isAppServerBackendKind,
   normalizePullRequestProvider,
@@ -16936,6 +16937,10 @@ export class DesktopBackendRegistry {
     const seedMode: HandoffTaskSeedMode = request.args.seedMode ?? "clean";
     const groupingMode: HandoffTaskGroupingMode =
       request.args.groupingMode ?? "none";
+    const groupedParentThreadId =
+      groupingMode === "subthread"
+        ? sourceOverlay.parentThreadId?.trim() || sourceThreadId
+        : undefined;
     const workspaceMode: HandoffTaskWorkspaceMode =
       request.args.workspaceMode === "same"
         ? "same_workspace"
@@ -17151,8 +17156,8 @@ export class DesktopBackendRegistry {
         const forked = await this.forkThread({
           backend,
           sourceThreadId,
-          ...(groupingMode === "subthread"
-            ? { parentThreadId: sourceThreadId }
+          ...(groupedParentThreadId
+            ? { parentThreadId: groupedParentThreadId }
             : {}),
           executionMode,
           directoryLabel:
@@ -17208,13 +17213,29 @@ export class DesktopBackendRegistry {
         this.updatePendingThreadHandoff(handoffId, { threadId });
         inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
-        if (groupingMode === "subthread") {
+        if (groupedParentThreadId) {
           await this.overlayStore.setThreadParent?.({
             backend,
             threadId,
-            parentThreadId: sourceThreadId,
+            parentThreadId: groupedParentThreadId,
           });
         }
+      }
+      if (groupedParentThreadId && this.overlayStore.updateSubthreadOrder) {
+        const parentOverlay = await this.overlayStore.getThreadOverlayState({
+          backend,
+          threadId: groupedParentThreadId,
+        });
+        const nextOrder = insertSubthreadIdAfter(
+          parentOverlay?.subthreadOrder ?? [],
+          sourceThreadId,
+          threadId,
+        );
+        await this.overlayStore.updateSubthreadOrder({
+          backend,
+          parentThreadId: groupedParentThreadId,
+          threadIds: nextOrder,
+        });
       }
       await this.renameThread({ backend, threadId, name: title }).catch(
         (error) => {
@@ -17345,8 +17366,8 @@ export class DesktopBackendRegistry {
         title,
         seedMode,
         groupingMode,
-        ...(groupingMode === "subthread"
-          ? { groupedUnderThreadId: sourceThreadId }
+        ...(groupedParentThreadId
+          ? { groupedUnderThreadId: groupedParentThreadId }
           : {}),
         inheritedSettings,
         origin,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -15909,6 +15909,34 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async resolveHandoffGroupParentThreadId(params: {
+    backend: AppServerBackendKind;
+    sourceOverlay: ThreadOverlayState;
+    sourceThreadId: string;
+  }): Promise<string> {
+    const directParentThreadId = params.sourceOverlay.parentThreadId?.trim();
+    if (!directParentThreadId) {
+      return params.sourceThreadId;
+    }
+
+    let parentThreadId = directParentThreadId;
+    const seen = new Set([params.sourceThreadId]);
+    while (!seen.has(parentThreadId)) {
+      seen.add(parentThreadId);
+      const parentOverlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: parentThreadId,
+      });
+      const nextParentThreadId = parentOverlay?.parentThreadId?.trim();
+      if (!nextParentThreadId) {
+        return parentThreadId;
+      }
+      parentThreadId = nextParentThreadId;
+    }
+
+    return directParentThreadId;
+  }
+
   private startPendingThreadWorkspaceMove(
     move: PendingThreadWorkspaceMoveSummary,
   ): PendingThreadWorkspaceMoveSummary {
@@ -16939,7 +16967,11 @@ export class DesktopBackendRegistry {
       request.args.groupingMode ?? "none";
     const groupedParentThreadId =
       groupingMode === "subthread"
-        ? sourceOverlay.parentThreadId?.trim() || sourceThreadId
+        ? await this.resolveHandoffGroupParentThreadId({
+            backend: sourceBackend,
+            sourceOverlay,
+            sourceThreadId,
+          })
         : undefined;
     const workspaceMode: HandoffTaskWorkspaceMode =
       request.args.workspaceMode === "same"
@@ -17227,7 +17259,10 @@ export class DesktopBackendRegistry {
           threadId: groupedParentThreadId,
         });
         const nextOrder = insertSubthreadIdAfter(
-          parentOverlay?.subthreadOrder ?? [],
+          groupedParentThreadId === sourceThreadId ||
+          parentOverlay?.subthreadOrder?.includes(sourceThreadId)
+            ? (parentOverlay?.subthreadOrder ?? [])
+            : [...(parentOverlay?.subthreadOrder ?? []), sourceThreadId],
           sourceThreadId,
           threadId,
         );

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -25,6 +25,40 @@ function buildThread(
   };
 }
 
+describe("materializeNavigationThreads — subthread grouping", () => {
+  it("flattens persisted nested subthreads to the root parent", () => {
+    const threads = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:source-child": {
+          backend: "codex",
+          threadId: "source-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "root-thread",
+        },
+        "codex:nested-child": {
+          backend: "codex",
+          threadId: "nested-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "source-child",
+        },
+      },
+      previousKnownThreadKeys: [],
+      threads: [
+        buildThread({ id: "root-thread" }),
+        buildThread({ id: "source-child" }),
+        buildThread({ id: "nested-child" }),
+      ],
+    });
+
+    expect(
+      threads.find((thread) => thread.id === "nested-child")?.parentThreadId,
+    ).toBe("root-thread");
+  });
+});
+
 describe("buildDirectorySummaries", () => {
   it("groups linked threads under stable directory rows and counts needs-attention threads", () => {
     const directories = buildDirectorySummaries({

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -120,6 +120,35 @@ function resolveNavigationObservedBranch(params: {
   return params.thread.observedGitBranch ?? params.overlay?.observedGitBranch;
 }
 
+function resolveNavigationParentThreadId(params: {
+  overlay?: ThreadOverlayState;
+  overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
+  source: AppServerThreadSummary["source"];
+  threadId: string;
+}): string | undefined {
+  const directParentThreadId = params.overlay?.parentThreadId?.trim();
+  if (!directParentThreadId) {
+    return undefined;
+  }
+
+  let parentThreadId = directParentThreadId;
+  const seen = new Set([params.threadId]);
+  while (!seen.has(parentThreadId)) {
+    seen.add(parentThreadId);
+    const parentOverlay =
+      params.overlayByThreadKey[
+        buildThreadIdentityKey(params.source, parentThreadId)
+      ];
+    const nextParentThreadId = parentOverlay?.parentThreadId?.trim();
+    if (!nextParentThreadId) {
+      return parentThreadId;
+    }
+    parentThreadId = nextParentThreadId;
+  }
+
+  return directParentThreadId;
+}
+
 export function materializeNavigationThreads(params: {
   firstSnapshot: boolean;
   now?: number;
@@ -146,6 +175,12 @@ export function materializeNavigationThreads(params: {
     ]);
     const gitBranch = resolveNavigationGitBranch({ overlay, thread });
     const observedGitBranch = resolveNavigationObservedBranch({ overlay, thread });
+    const parentThreadId = resolveNavigationParentThreadId({
+      overlay,
+      overlayByThreadKey: params.overlayByThreadKey,
+      source: thread.source,
+      threadId: thread.id,
+    });
     const messagingBindings = params.messagingBindingsByThreadKey?.[threadKey];
     const automationSummary = params.automationsByThreadKey?.[threadKey];
 
@@ -173,7 +208,7 @@ export function materializeNavigationThreads(params: {
       reactions: overlay?.reactions ?? [],
       subAgents: overlay?.subAgents ?? [],
       pinnedRank: overlay?.pinnedRank,
-      parentThreadId: overlay?.parentThreadId,
+      parentThreadId,
       subthreadOrder: overlay?.subthreadOrder,
       subthreadsCollapsed: overlay?.subthreadsCollapsed,
       prs: overlay?.prs ?? [],


### PR DESCRIPTION
## Summary

Handoffs started from an existing sub-thread now appear as siblings under the same root thread instead of becoming hidden grandchildren. This prevents a delegated thread from vanishing from the Directories lens while still being reachable from Search.

The handoff tool now resolves grouped handoffs to the root parent, inserts the new child after the invoking sub-thread in the root order, and reports the root in `groupedUnderThreadId`. Navigation also flattens already-persisted nested subthread state so existing affected threads reappear without manual state repair.

## Validation

- `pnpm test packages/agent-core/src/__tests__/directory-navigation.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts -- --runInBand`
- `pnpm lint:eslint`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
