### PR TITLE
fix(desktop): preserve completed turn usage durations

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3478,6 +3478,7 @@ describe("CodexAppServerClient", () => {
             id: "turn-gpt-55",
             status: "completed",
             startedAt: 1_781_616_000,
+            completedAt: 1_781_616_020,
             items: [
               {
                 type: "turn_context",
@@ -3502,6 +3503,7 @@ describe("CodexAppServerClient", () => {
             id: "turn-gpt-54",
             status: "completed",
             startedAt: 1_781_616_060,
+            completedAt: 1_781_616_085,
             items: [
               {
                 type: "turn_context",
@@ -3546,6 +3548,21 @@ describe("CodexAppServerClient", () => {
     expect(usageEntries.map((entry) => entry.usageLine?.totalCostMicros)).toEqual([
       5_000_000,
       2_500_000,
+    ]);
+    expect(
+      usageEntries.map((entry) => ({
+        completedAt: entry.usageLine?.completedAt,
+        startedAt: entry.usageLine?.startedAt,
+      })),
+    ).toEqual([
+      {
+        completedAt: 1_781_616_020_000,
+        startedAt: 1_781_616_000_000,
+      },
+      {
+        completedAt: 1_781_616_085_000,
+        startedAt: 1_781_616_060_000,
+      },
     ]);
     expect(usageEntries.map((entry) => entry.details.at(-1)?.label)).toEqual([
       "Cost: $5.00 list price for GPT-5.5 Standard",

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -414,6 +414,27 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("returns usage line start time for completed turn durations", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        completedAt: 20_000,
+        createdAt: 20_100,
+        startedAt: 10_000,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      completedAt: 20_000,
+      createdAt: 20_100,
+      startedAt: 10_000,
+    });
+  });
+
   it("does not erase known turn settings when usage updates omit them", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -435,6 +435,55 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("lets hydration replace a live fallback start time with the turn start", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        completedAt: undefined,
+        createdAt: 20_000,
+        source: "live",
+        status: "pending",
+        usageLineId: "live:thread-1:turn-1",
+      }),
+    });
+
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        completedAt: 20_100,
+        createdAt: 20_100,
+        source: "hydration",
+        startedAt: 10_000,
+        status: "finalized",
+        usageLineId: "codex:thread-1:turn-1:latest-request:item-1",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const turn = stateDb.raw
+      .prepare(
+        `SELECT started_at, completed_at
+         FROM thread_usage_turns
+         WHERE usage_turn_id = ?`,
+      )
+      .get(pricing.lines[0]?.usageTurnId) as {
+        completed_at: number | null;
+        started_at: number | null;
+      };
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      completedAt: 20_100,
+      startedAt: 10_000,
+      usageLineId: "codex:thread-1:turn-1:latest-request:item-1",
+    });
+    expect(turn).toMatchObject({
+      completed_at: 20_100,
+      started_at: 10_000,
+    });
+  });
+
   it("does not erase known turn settings when usage updates omit them", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2930,6 +2930,7 @@ function summarizeTokenUsageActivity(
         settingsSource: "turn-context",
         source: "hydration",
         sourceItemId,
+        ...(typeof turn?.startedAt === "number" ? { startedAt: turn.startedAt } : {}),
         status: "finalized",
         threadId,
         totalCostMicros: cost?.totalCostMicros ?? 0,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -954,7 +954,7 @@ export class SqliteOverlayStore {
       .all(params.backend, params.threadId) as ThreadPricingSummaryRow[];
 
     const lines = lineRows.map(threadUsageLineFromRow);
-    this.attachObservedReplayTalliesSync(params.backend, params.threadId, lines);
+    this.attachUsageTurnMetadataSync(params.backend, params.threadId, lines);
 
     return {
       lines,
@@ -962,14 +962,14 @@ export class SqliteOverlayStore {
     };
   }
 
-  // The observed context-replay tally lives on the per-turn record
-  // (thread_usage_turns), not on the usage line — the turn record is refreshed
+  // Per-turn metadata lives on thread_usage_turns. The turn record is refreshed
   // via COALESCE and is immune to the line supersession lifecycle, so a
-  // transcript-hydration line can supersede the live line without dropping the
-  // tally. Attach it back onto the displayed line at read time so the renderer
-  // keeps reading the observed fields off ThreadUsageLineRecord. Deliberately
-  // NOT summed into pricing summaries.
-  private attachObservedReplayTalliesSync(
+  // transcript-hydration line can supersede the live line without dropping
+  // start timing or observed replay tallies. Attach it back onto displayed
+  // lines at read time so the renderer can compute finished durations and keep
+  // reading observed fields off ThreadUsageLineRecord. Deliberately NOT summed
+  // into pricing summaries.
+  private attachUsageTurnMetadataSync(
     backend: string,
     threadId: string,
     lines: ThreadUsageLineRecord[],
@@ -980,6 +980,8 @@ export class SqliteOverlayStore {
     const turnRows = this.stateDb.raw
       .prepare(
         `SELECT usage_turn_id,
+                started_at,
+                completed_at,
                 observed_cold_replay_count,
                 observed_cold_replay_uncached_tokens,
                 observed_hot_replay_cached_tokens,
@@ -989,6 +991,8 @@ export class SqliteOverlayStore {
             AND thread_id = ?
           UNION ALL
          SELECT usage_turn_id,
+                started_at,
+                completed_at,
                 observed_cold_replay_count,
                 observed_cold_replay_uncached_tokens,
                 observed_hot_replay_cached_tokens,
@@ -999,6 +1003,8 @@ export class SqliteOverlayStore {
             AND thread_id != ?`,
       )
       .all(backend, threadId, backend, threadId, threadId) as Array<{
+      completed_at: number | null;
+      started_at: number;
       usage_turn_id: string;
       observed_cold_replay_count: number | null;
       observed_cold_replay_uncached_tokens: number | null;
@@ -1016,6 +1022,10 @@ export class SqliteOverlayStore {
       const turn = byTurnId.get(line.usageTurnId);
       if (!turn) {
         continue;
+      }
+      line.startedAt = turn.started_at;
+      if (line.completedAt === undefined && turn.completed_at !== null) {
+        line.completedAt = turn.completed_at;
       }
       if (turn.observed_cold_replay_count !== null) {
         line.observedColdReplayCount = turn.observed_cold_replay_count;

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -713,7 +713,11 @@ export class SqliteOverlayStore {
                 THEN thread_usage_turns.settings_confidence
               ELSE excluded.settings_confidence
             END,
-            started_at = COALESCE(thread_usage_turns.started_at, excluded.started_at),
+            started_at = CASE
+              WHEN thread_usage_turns.started_at IS NULL THEN excluded.started_at
+              WHEN excluded.started_at IS NULL THEN thread_usage_turns.started_at
+              ELSE MIN(thread_usage_turns.started_at, excluded.started_at)
+            END,
             completed_at = excluded.completed_at,
             observed_at = MIN(thread_usage_turns.observed_at, excluded.observed_at),
             -- Observation-derived tallies are absent on transcript-hydration


### PR DESCRIPTION
## Summary

Completed turn usage cards now keep their elapsed duration after the turn settles or the thread is reopened. The pricing ledger already stored per-turn start timing, but the read path only reattached replay tallies, so some completed cards fell back to their usage-row timestamp and lost the duration while others kept it.

This preserves turn start metadata from both replay hydration and sqlite pricing reads, so the renderer receives a consistent `startedAt`/`completedAt` pair for completed turn usage rows.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
