### PR TITLE
fix(desktop): stop rejecting generated titles missing refs

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -91,7 +91,7 @@ describe("ThreadTitleGenerationService", () => {
     expect(codexGenerator.generateTitle).not.toHaveBeenCalled();
   });
 
-  it("preserves recognized issue and PR references", async () => {
+  it("accepts recognized issue and PR references in generated titles", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {
         codex: makeGenerator({ title: "PR 456 issue 123 followup" }),
@@ -146,7 +146,7 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
-  it("rejects titles that drop ticket references from the prompt", async () => {
+  it("accepts titles that drop ticket references from the prompt", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {
         codex: makeGenerator({ title: "Checkout crash followup" }),
@@ -158,13 +158,13 @@ describe("ThreadTitleGenerationService", () => {
         backend: "codex",
         userPrompt: "PROJECT-123 investigate checkout crash",
       })
-    ).resolves.toEqual({
-      status: "invalid",
-      reason: "ticket_reference_missing",
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "Checkout crash followup",
     });
   });
 
-  it("rejects titles that preserve only one of multiple references", async () => {
+  it("accepts titles that preserve only one of multiple references", async () => {
     const service = new ThreadTitleGenerationService({
       generators: {
         codex: makeGenerator({ title: "Issue 123 rename followup" }),
@@ -176,9 +176,28 @@ describe("ThreadTitleGenerationService", () => {
         backend: "codex",
         userPrompt: "In issue 123 and PR 456, why does rename fail?",
       })
-    ).resolves.toEqual({
-      status: "invalid",
-      reason: "ticket_reference_missing",
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "Issue 123 rename followup",
+    });
+  });
+
+  it("accepts generated titles that omit GitHub PR references from quoted context", async () => {
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({ title: "PR attachment API mismatch" }),
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt:
+          "> PRs created: > - #12998: https://github.com/Giphy/giphy-services/pull/12998 > - #12999 stacked on it: https://github.com/Giphy/giphy-services/pull/12999 Why could the agent not attach the PR to the thread?",
+      })
+    ).resolves.toMatchObject({
+      status: "generated",
+      title: "PR attachment API mismatch",
     });
   });
 

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -143,7 +143,7 @@ export class ThreadTitleGenerationService {
       return result;
     }
 
-    const normalized = normalizeThreadTitleObject(result.object, userPrompt);
+    const normalized = normalizeThreadTitleObject(result.object);
     if (!normalized.title) {
       return {
         status: "invalid",
@@ -215,8 +215,7 @@ export class GrokThreadTitleGenerator implements ThreadTitleGenerator {
 }
 
 function normalizeThreadTitleObject(
-  object: unknown,
-  userPrompt: string
+  object: unknown
 ): { title?: string; reason: string } {
   if (!object || typeof object !== "object" || Array.isArray(object)) {
     return { reason: "title_payload_must_be_object" };
@@ -236,9 +235,6 @@ function normalizeThreadTitleObject(
   }
   if (countWords(cleaned) > MAX_TITLE_WORDS) {
     return { reason: "title_too_many_words" };
-  }
-  if (!preservesTicketReferences(userPrompt, cleaned)) {
-    return { reason: "ticket_reference_missing" };
   }
 
   return {
@@ -272,48 +268,4 @@ function stripMatchingQuotes(value: string): string {
 
 function countWords(value: string): number {
   return value.split(/\s+/).filter(Boolean).length;
-}
-
-function preservesTicketReferences(userPrompt: string, title: string): boolean {
-  const promptRefs = extractTicketReferences(userPrompt);
-  if (promptRefs.length === 0) {
-    return true;
-  }
-
-  const normalizedTitle = normalizeReferenceText(title);
-  return promptRefs.every((reference) =>
-    normalizedTitle.includes(normalizeReferenceText(reference))
-  );
-}
-
-function extractTicketReferences(value: string): string[] {
-  const references: string[] = [];
-  const contextualPatterns = [
-    /\b[A-Z][A-Z0-9]+-\d+\b/g,
-    /\b(?:issue|pr|pull request)\s+#?\d+\b/gi,
-  ];
-
-  for (const pattern of contextualPatterns) {
-    for (const match of value.matchAll(pattern)) {
-      references.push(match[0]);
-    }
-  }
-
-  for (const match of value.matchAll(/#\d+\b/g)) {
-    const index = match.index;
-    if (typeof index !== "number" || isBareHashTicketReference(value, index)) {
-      references.push(match[0]);
-    }
-  }
-
-  return references;
-}
-
-function isBareHashTicketReference(value: string, index: number): boolean {
-  const context = value.slice(Math.max(0, index - 32), index).toLowerCase();
-  return !/\b(?:agent|item|option|step|subagent|task|turn)\s*$/.test(context);
-}
-
-function normalizeReferenceText(value: string): string {
-  return value.toLowerCase().replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary
Generated thread titles no longer fail just because they omit ticket or PR references from the first prompt. The title prompt still asks the helper to preserve useful references, but validation now only rejects structurally invalid, empty, overlong, or too-wordy titles instead of turning a good title into `ticket_reference_missing`.

This fixes the case where quoted context containing refs like `#12998` and `#12999` could prevent an otherwise useful generated title from being applied.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.5](https://img.shields.io/badge/GPT_5.5-000000)
