### PR TITLE
fix(desktop): require project selection for ambiguous reviews

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12560,6 +12560,35 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("passes the selected review cwd to the Codex client", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["review/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      cwd: "/repo/selected-worktree",
+    });
+
+    expect(codexClient.lastStartReviewParams).toMatchObject({
+      threadId: "thread-1",
+      cwd: "/repo/selected-worktree",
+      target: { type: "baseBranch", branch: "main" },
+    });
+
+    await registry.close();
+  });
+
   it("rejects Codex reviews with a selected model that is not in the discovered model list", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start", "review/start"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8633,14 +8633,16 @@ export class DesktopBackendRegistry {
               threadId: params.threadId,
             })
           : undefined;
-      const cwd =
-        params.backend === "codex"
-          ? await this.resolveThreadEnvironmentCwd(
-              params.backend,
-              params.threadId,
-              overlay,
-            )
-          : undefined;
+      let cwd: string | undefined;
+      if (params.backend === "codex") {
+        cwd =
+          params.cwd?.trim()
+          || await this.resolveThreadEnvironmentCwd(
+            params.backend,
+            params.threadId,
+            overlay,
+          );
+      }
 
       const startWithClient = async (
         client: BackendClient,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -260,6 +260,7 @@ type QueuedTurnDraft = {
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
   reviewCommand?: {
+    cwd?: string;
     displayText: string;
     target: AppServerReviewTarget;
   };
@@ -328,6 +329,14 @@ type ReviewConfigState = {
   commit: string;
   customInstructions: string;
   target?: ReviewTargetChoice;
+  workspaceCwd?: string;
+};
+
+type ReviewWorkspaceOption = {
+  cwd: string;
+  key: string;
+  label: string;
+  path: string;
 };
 
 const DEFAULT_REASONING_EFFORT = "medium";
@@ -586,24 +595,81 @@ function getThreadComposerScopeKey(backend: string, threadId: string): string {
 function createReviewConfig(params: {
   directory?: NavigationDirectorySummary;
   thread?: NavigationThreadSummary;
+  reviewCommand?: {
+    cwd?: string;
+    target: AppServerReviewTarget;
+  };
 }): ReviewConfigState {
-  return {
+  const workspaceOptions = buildReviewWorkspaceOptions(params.thread);
+  const config: ReviewConfigState = {
     branch: buildReviewBranchOptions(params)[0] ?? "main",
     commit: "",
     customInstructions: "",
     target: "baseBranch",
+    workspaceCwd: params.reviewCommand?.cwd ?? (
+      workspaceOptions.length === 1 ? workspaceOptions[0]?.cwd : undefined
+    ),
   };
+  const target = params.reviewCommand?.target;
+  if (!target) {
+    return config;
+  }
+  if (target.type === "uncommittedChanges") {
+    return { ...config, target: "uncommittedChanges" };
+  }
+  if (target.type === "baseBranch") {
+    return { ...config, branch: target.branch, target: "baseBranch" };
+  }
+  if (target.type === "commit") {
+    return { ...config, commit: target.sha, target: "commit" };
+  }
+  return {
+    ...config,
+    customInstructions: target.instructions,
+    target: "custom",
+  };
+}
+
+function linkedDirectoryReviewCwd(
+  directory: NavigationThreadSummary["linkedDirectories"][number],
+): string | undefined {
+  const cwd = (directory.worktreePath ?? directory.path).trim();
+  return cwd || undefined;
+}
+
+function buildReviewWorkspaceOptions(
+  thread?: NavigationThreadSummary,
+): ReviewWorkspaceOption[] {
+  const options: ReviewWorkspaceOption[] = [];
+  const seen = new Set<string>();
+  for (const directory of thread?.linkedDirectories ?? []) {
+    const cwd = linkedDirectoryReviewCwd(directory);
+    if (!cwd || seen.has(cwd)) {
+      continue;
+    }
+    seen.add(cwd);
+    const label = directory.label.trim() || cwd;
+    options.push({
+      cwd,
+      key: `${directory.id}:${cwd}`,
+      label,
+      path: cwd,
+    });
+  }
+  return options;
 }
 
 function buildConfiguredReviewCommand(
   config: ReviewConfigState | undefined
-): { displayText: string; target: AppServerReviewTarget } | undefined {
+): { cwd?: string; displayText: string; target: AppServerReviewTarget } | undefined {
   if (!config?.target) {
     return undefined;
   }
+  const cwd = config.workspaceCwd?.trim() || undefined;
 
   if (config.target === "uncommittedChanges") {
     return {
+      ...(cwd ? { cwd } : {}),
       target: { type: "uncommittedChanges" },
       displayText: "Review current changes",
     };
@@ -613,6 +679,7 @@ function buildConfiguredReviewCommand(
     const branch = config.branch.trim();
     return branch
       ? {
+          ...(cwd ? { cwd } : {}),
           target: { type: "baseBranch", branch },
           displayText: `Review changes against ${branch}`,
         }
@@ -623,6 +690,7 @@ function buildConfiguredReviewCommand(
     const sha = config.commit.trim();
     return sha
       ? {
+          ...(cwd ? { cwd } : {}),
           target: { type: "commit", sha, title: null },
           displayText: `Review commit ${sha}`,
         }
@@ -632,6 +700,7 @@ function buildConfiguredReviewCommand(
   const instructions = config.customInstructions.trim();
   return instructions
     ? {
+        ...(cwd ? { cwd } : {}),
         target: { type: "custom", instructions },
         displayText: "Review custom instructions",
       }
@@ -919,6 +988,7 @@ function parseStaleInterruptError(error: unknown): boolean {
 }
 
 function reviewCommandToDraftText(command: {
+  cwd?: string;
   target: AppServerReviewTarget;
 }): string {
   const target = command.target;
@@ -935,18 +1005,20 @@ function reviewCommandToDraftText(command: {
 }
 
 function reviewSubmissionKey(command: {
+  cwd?: string;
   target: AppServerReviewTarget;
 }): string {
+  const cwdPart = command.cwd ? `:${command.cwd}` : "";
   const target = command.target;
   switch (target.type) {
     case "baseBranch":
-      return `review:baseBranch:${target.branch}`;
+      return `review:baseBranch${cwdPart}:${target.branch}`;
     case "commit":
-      return `review:commit:${target.sha}:${target.title ?? ""}`;
+      return `review:commit${cwdPart}:${target.sha}:${target.title ?? ""}`;
     case "custom":
-      return `review:custom:${target.instructions}`;
+      return `review:custom${cwdPart}:${target.instructions}`;
     default:
-      return `review:${JSON.stringify(target)}`;
+      return `review${cwdPart}:${JSON.stringify(target)}`;
   }
 }
 
@@ -2976,10 +3048,16 @@ export function Composer(props: ComposerProps) {
     () => buildReviewCommitOptions(props.directory),
     [props.directory],
   );
+  const reviewWorkspaceOptions = useMemo(
+    () => buildReviewWorkspaceOptions(props.thread),
+    [props.thread],
+  );
+  const reviewWorkspaceSelectionRequired = reviewWorkspaceOptions.length > 1;
+  const parsedReviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
   const isBareReviewCommand = draft.trim() === "/review";
   const isCompactCommand = supportsCompactCommand && draft.trim() === "/compact";
   const isReviewComposerOpen = Boolean(
-    supportsReview && reviewConfig && isBareReviewCommand
+    supportsReview && reviewConfig && parsedReviewCommand
   );
 
   useEffect(() => {
@@ -3504,6 +3582,7 @@ export function Composer(props: ComposerProps) {
   ]);
 
   const submitReviewCommand = async (reviewCommand: {
+    cwd?: string;
     displayText: string;
     target: AppServerReviewTarget;
   }, options?: {
@@ -3532,6 +3611,21 @@ export function Composer(props: ComposerProps) {
     }
     if (!options?.queued && imageAttachments.length > 0) {
       setSendError("/review does not accept image attachments.");
+      return;
+    }
+    if (
+      !options?.queued &&
+      reviewWorkspaceSelectionRequired &&
+      !reviewCommand.cwd
+    ) {
+      setReviewConfig(
+        createReviewConfig({
+          directory: props.directory,
+          reviewCommand,
+          thread: props.thread,
+        })
+      );
+      setSendError("Choose a project to review.");
       return;
     }
     if (!options?.queued && shouldQueueThreadSubmit()) {
@@ -3598,6 +3692,7 @@ export function Composer(props: ComposerProps) {
         threadId: props.thread.id,
         target: reviewCommand.target,
         delivery: "inline",
+        ...(reviewCommand.cwd ? { cwd: reviewCommand.cwd } : {}),
         ...(selectedModelOption?.id ? { model: selectedModelOption.id } : {}),
         ...(supportsReasoning && selectedReasoningEffort
           ? { reasoningEffort: selectedReasoningEffort }
@@ -4100,6 +4195,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const queueReviewCommand = (reviewCommand: {
+    cwd?: string;
     displayText: string;
     target: AppServerReviewTarget;
   }): void => {
@@ -4255,7 +4351,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
-    const reviewCommand = supportsReview ? parseReviewCommand(draft) : undefined;
+    const reviewCommand = parsedReviewCommand;
     if (
       reviewCommand &&
       sendingRef.current &&
@@ -4283,6 +4379,17 @@ export function Composer(props: ComposerProps) {
       } else if (reviewCommand) {
         if (imageAttachments.length > 0) {
           setSendError("/review does not accept image attachments.");
+          return;
+        }
+        if (reviewWorkspaceSelectionRequired) {
+          setReviewConfig(
+            createReviewConfig({
+              directory: props.directory,
+              reviewCommand,
+              thread: props.thread,
+            })
+          );
+          setSendError("Choose a project to review.");
           return;
         }
         queueReviewCommand(reviewCommand);
@@ -6002,6 +6109,36 @@ export function Composer(props: ComposerProps) {
             onKeyDown={handleReviewConfigKeyDown}
           >
             <legend>Review target</legend>
+            {reviewWorkspaceSelectionRequired ? (
+              <label className="composer__review-field">
+                <span>Project</span>
+                <select
+                  aria-label="Review project"
+                  className="composer__review-input"
+                  value={reviewConfig?.workspaceCwd ?? ""}
+                  onChange={(event) => {
+                    setReviewConfig((current) => ({
+                      ...(current ??
+                        createReviewConfig({
+                          directory: props.directory,
+                          thread: props.thread,
+                        })),
+                      workspaceCwd: event.target.value,
+                    }));
+                    setSendError(undefined);
+                  }}
+                >
+                  <option value="" disabled>
+                    Choose project
+                  </option>
+                  {reviewWorkspaceOptions.map((option) => (
+                    <option key={option.key} value={option.cwd}>
+                      {option.label} - {option.path}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
             <div className="composer__review-options">
               {REVIEW_TARGET_OPTIONS.map((option, index) => (
                 <button
@@ -6106,7 +6243,10 @@ export function Composer(props: ComposerProps) {
               <button
                 type="button"
                 className="composer__primary-action"
-                disabled={!buildConfiguredReviewCommand(reviewConfig)}
+                disabled={
+                  !buildConfiguredReviewCommand(reviewConfig) ||
+                  (reviewWorkspaceSelectionRequired && !reviewConfig?.workspaceCwd)
+                }
                 onClick={() => {
                   void submitConfiguredReviewComposer();
                 }}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4215,6 +4215,79 @@ describe("Composer", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("requires a project choice before reviewing a thread with multiple worktrees", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/GIPHY/giphy-services",
+              kind: "worktree",
+              label: "giphy-services",
+              path: "/Users/huntharo/GIPHY/giphy-services",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mr9mnf9z/giphy-services",
+            },
+            {
+              id: "/Users/huntharo/GIPHY/gif-recommendations",
+              kind: "worktree",
+              label: "gif-recommendations",
+              path: "/Users/huntharo/GIPHY/gif-recommendations",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mr9motar/gif-recommendations",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review main" },
+    });
+    await clickButton("Send");
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Review project")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start review" })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Review project"), {
+      target: {
+        value:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mr9motar/gif-recommendations",
+      },
+    });
+    await clickButton("Start review");
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+        cwd: "/Users/huntharo/.codex/profiles/sstk/worktrees/mr9motar/gif-recommendations",
+      });
+    });
+  });
+
   it("starts slash reviews with the current composer model settings", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -23,6 +23,7 @@ export type ComposerQueuedTurnSnapshot = {
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
   reviewCommand?: {
+    cwd?: string;
     displayText: string;
     target: AppServerReviewTarget;
   };

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -384,6 +384,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/selected-worktree",
         displayText: "Review changes against main",
         target: {
           type: "baseBranch",
@@ -442,6 +443,7 @@ describe("useQueuedTurnRelease", () => {
           branch: "main",
         },
         delivery: "inline",
+        cwd: "/repo/selected-worktree",
         model: "gpt-5.5",
         reasoningEffort: "high",
         serviceTier: "priority",
@@ -714,6 +716,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/background-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -755,6 +758,7 @@ describe("useQueuedTurnRelease", () => {
         threadId: "thread-a",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        cwd: "/repo/background-worktree",
       });
     });
     expect(startTurn).not.toHaveBeenCalled();
@@ -796,6 +800,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -875,6 +880,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/retained-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -955,6 +961,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/retained-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -1008,6 +1015,7 @@ describe("useQueuedTurnRelease", () => {
         threadId: "thread-a",
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
+        cwd: "/repo/retained-worktree",
       });
     });
     expect(
@@ -1043,6 +1051,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -1446,6 +1455,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -1503,6 +1513,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -1589,6 +1600,7 @@ describe("useQueuedTurnRelease", () => {
       text: "/review main",
       imageAttachments: [],
       reviewCommand: {
+        cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
         target: { type: "baseBranch", branch: "main" },
       },
@@ -1618,6 +1630,7 @@ describe("useQueuedTurnRelease", () => {
       threadId: "thread-a",
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
+      cwd: "/repo/polled-worktree",
     });
     expect(
       composerDraftStore.getQueuedTurn("thread:codex:thread-a")

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -299,6 +299,7 @@ export function useQueuedTurnRelease(params: {
             threadId: releaseThread.id,
             target: reviewCommand.target,
             delivery: "inline",
+            ...(reviewCommand.cwd ? { cwd: reviewCommand.cwd } : {}),
             ...(releaseThread.model ? { model: releaseThread.model } : {}),
             ...(releaseThread.reasoningEffort
               ? { reasoningEffort: releaseThread.reasoningEffort }

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -245,6 +245,7 @@ export type StartReviewRequest = {
   threadId: ThreadIdentifier;
   target: AppServerReviewTarget;
   delivery?: AppServerReviewDelivery;
+  cwd?: string;
   model?: string;
   serviceTier?: string;
   reasoningEffort?: string;


### PR DESCRIPTION
## Summary

Starting a `/review` from a thread with multiple linked worktrees no longer silently reviews whichever workspace the thread resolver picks first. The review composer now requires a project choice in that ambiguous state, and the selected worktree cwd is passed through to Codex `review/start`.

This covers both bare `/review` and explicit targets like `/review main`, so a thread that has both `giphy-services` and `gif-recommendations` linked can start the review in the intended project.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint -- packages/shared/src/contracts/agent.ts apps/desktop/src/main/app-server/backend-registry.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/composer/Composer.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (passes with existing warning baseline)
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
