### PR TITLE
fix(desktop): review from selected workspace and base

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -204,6 +204,7 @@ type WorkingStateEntry = {
     dirtyDeletions: number;
     untrackedFiles: number;
     unpushedCommits: number;
+    baseBranch?: string;
   };
 };
 const readWorktreeWorkingStateEntries = vi.fn(
@@ -3480,6 +3481,65 @@ describe("app server ipc", () => {
           gitWorkingState,
         }),
       },
+    });
+  });
+
+  it("hydrates working state from linked worktrees when the thread has no project key", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    const worktreePath =
+      "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services";
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "develop",
+    };
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [
+          {
+            id: worktreePath,
+            label: "giphy-services",
+            path: "/Users/huntharo/GIPHY/giphy-services",
+            worktreePath,
+            kind: "worktree",
+          },
+        ],
+        updatedAt: 2000,
+      },
+    ] as never);
+    readThreadGitWorkingStateCache.mockResolvedValueOnce({
+      [worktreePath]: {
+        worktreePath,
+        fetchedAt: 1000,
+        gitWorkingState,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+    const snapshot = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(snapshot).toMatchObject({
+      threads: [
+        expect.objectContaining({
+          id: "thread-1",
+          gitWorkingState,
+        }),
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledWith(
+        [worktreePath],
+        expect.any(Object),
+      );
     });
   });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6886,6 +6886,7 @@ describe("CodexAppServerClient", () => {
           threadId: "thread-2",
           target: { type: "baseBranch", branch: "main" },
           delivery: "inline",
+          cwd: "/Users/example/project",
         },
       })
     );

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -136,6 +136,10 @@ const SUPPORTED_CODEX_MODEL_ORDER = [
 const SUPPORTED_CODEX_MODELS = new Set<string>(SUPPORTED_CODEX_MODEL_ORDER);
 const MAX_INLINE_FILE_DIFF_CHARS = 512 * 1024;
 
+type CodexReviewStartPayload = CodexReviewStartParams & {
+  cwd?: string;
+};
+
 type CodexClientOptions = {
   command?: string;
   args?: string[];
@@ -5115,12 +5119,18 @@ function buildReviewStartPayload(params: {
   threadId: string;
   target: AppServerReviewTarget;
   delivery?: AppServerReviewDelivery;
-}): CodexReviewStartParams {
-  return {
+  cwd?: string;
+}): CodexReviewStartPayload {
+  const payload: CodexReviewStartPayload = {
     threadId: params.threadId,
     target: params.target,
     delivery: params.delivery ?? "inline",
   };
+  const cwd = params.cwd?.trim();
+  if (cwd) {
+    payload.cwd = cwd;
+  }
+  return payload;
 }
 
 function buildThreadSettingsUpdatePayload(params: {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1264,7 +1264,7 @@ class DesktopAppServerService {
   ): string[] {
     const paths = new Set<string>();
     for (const thread of threads) {
-      const worktreePath = thread.projectKey?.trim();
+      const worktreePath = this.resolveThreadWorkingStatePath(thread);
       if (worktreePath) {
         paths.add(worktreePath);
       }
@@ -1277,7 +1277,7 @@ class DesktopAppServerService {
   ): void {
     for (const thread of threads) {
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      const worktreePath = thread.projectKey?.trim();
+      const worktreePath = this.resolveThreadWorkingStatePath(thread);
       if (worktreePath) {
         this.worktreePathByThreadKey.set(threadKey, worktreePath);
       } else {
@@ -1346,7 +1346,7 @@ class DesktopAppServerService {
       this.rememberMergedPrCommitShasForThread({
         backend: thread.source,
         threadId: thread.id,
-        worktreePath: thread.projectKey,
+        worktreePath: this.resolveThreadWorkingStatePath(thread),
         prs: [
           ...(thread.prs ?? []),
           ...(detachedPrsByThreadKey.get(threadKey) ?? []),
@@ -1405,7 +1405,7 @@ class DesktopAppServerService {
   private applyCachedWorktreeWorkingState(
     thread: NavigationSnapshot["threads"][number],
   ): NavigationSnapshot["threads"][number] {
-    const worktreePath = thread.projectKey?.trim();
+    const worktreePath = this.resolveThreadWorkingStatePath(thread);
     const cached = worktreePath
       ? this.workingStateByWorktree.get(worktreePath)
       : undefined;
@@ -1416,6 +1416,37 @@ class DesktopAppServerService {
       return { ...thread, gitWorkingState: cached.gitWorkingState };
     }
     return thread;
+  }
+
+  private resolveThreadWorkingStatePath(
+    thread: Pick<
+      NavigationSnapshot["threads"][number],
+      "projectKey" | "linkedDirectories"
+    >,
+  ): string | undefined {
+    const projectKey = thread.projectKey?.trim();
+    if (projectKey) {
+      return projectKey;
+    }
+
+    for (const directory of thread.linkedDirectories ?? []) {
+      const worktreePath = directory.worktreePath?.trim();
+      if (worktreePath) {
+        return worktreePath;
+      }
+    }
+
+    for (const directory of thread.linkedDirectories ?? []) {
+      if (directory.kind !== "local") {
+        continue;
+      }
+      const directoryPath = directory.path?.trim();
+      if (directoryPath) {
+        return directoryPath;
+      }
+    }
+
+    return undefined;
   }
 
   async refreshDirectoryGitStatusesForKeys(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -326,6 +326,7 @@ const CONTEXT_MOON_PHASES = [
 
 type ReviewConfigState = {
   branch: string;
+  branchSource?: "auto" | "user";
   commit: string;
   customInstructions: string;
   target?: ReviewTargetChoice;
@@ -618,6 +619,7 @@ function createReviewConfig(params: {
   const workspaceOptions = buildReviewWorkspaceOptions(params.thread);
   const config: ReviewConfigState = {
     branch: buildReviewBranchOptions(params)[0] ?? "main",
+    branchSource: "auto",
     commit: "",
     customInstructions: "",
     target: "baseBranch",
@@ -633,7 +635,12 @@ function createReviewConfig(params: {
     return { ...config, target: "uncommittedChanges" };
   }
   if (target.type === "baseBranch") {
-    return { ...config, branch: target.branch, target: "baseBranch" };
+    return {
+      ...config,
+      branch: target.branch,
+      branchSource: "user",
+      target: "baseBranch",
+    };
   }
   if (target.type === "commit") {
     return { ...config, commit: target.sha, target: "commit" };
@@ -3059,6 +3066,14 @@ export function Composer(props: ComposerProps) {
       }),
     [props.directory, props.thread],
   );
+  const defaultReviewBranch = useMemo(
+    () =>
+      buildReviewBranchOptions({
+        directory: props.directory,
+        thread: props.thread,
+      })[0] ?? "main",
+    [props.directory, props.thread],
+  );
   const reviewCommitOptions = useMemo(
     () => buildReviewCommitOptions(props.directory),
     [props.directory],
@@ -3091,6 +3106,38 @@ export function Composer(props: ComposerProps) {
       setReviewConfig(undefined);
     }
   }, [reviewConfig, supportsReview]);
+
+  useEffect(() => {
+    if (
+      !isReviewComposerOpen ||
+      reviewConfig?.target !== "baseBranch" ||
+      reviewConfig.branchSource !== "auto" ||
+      reviewConfig.branch === defaultReviewBranch
+    ) {
+      return;
+    }
+
+    setReviewConfig((current) => {
+      if (
+        current?.target !== "baseBranch" ||
+        current.branchSource !== "auto" ||
+        current.branch === defaultReviewBranch
+      ) {
+        return current;
+      }
+
+      return {
+        ...current,
+        branch: defaultReviewBranch,
+      };
+    });
+  }, [
+    defaultReviewBranch,
+    isReviewComposerOpen,
+    reviewConfig?.branch,
+    reviewConfig?.branchSource,
+    reviewConfig?.target,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -6194,6 +6241,7 @@ export function Composer(props: ComposerProps) {
                           thread: props.thread,
                         })),
                       branch,
+                      branchSource: "user",
                       target: "baseBranch",
                     }));
                     setSendError(undefined);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -571,11 +571,11 @@ function buildReviewBranchOptions(params: {
 
   pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
   pushDirectoryDefault();
-  pushIfKnown(upstreamBranch);
   for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
     pushPreferredDefault(branch);
   }
   push("main", { allowCurrent: true });
+  pushIfKnown(upstreamBranch);
   for (const candidate of baseBranches) {
     push(candidate);
   }
@@ -1776,7 +1776,7 @@ function ReviewBranchPicker(props: {
       }
       return;
     }
-    if (event.key === "Escape" && open && visibleOptions.length > 0) {
+    if (event.key === "Escape" && open) {
       event.preventDefault();
       event.stopPropagation();
       setOpen(false);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1783,8 +1783,8 @@ function ReviewBranchPicker(props: {
     }
   };
 
-  const shouldShowMenu = open && visibleOptions.length > 0;
-  const activeOptionId = shouldShowMenu
+  const shouldShowMenu = open && props.options.length > 0;
+  const activeOptionId = shouldShowMenu && visibleOptions.length > 0
     ? `${listboxId}-option-${activeIndex}`
     : undefined;
 
@@ -1817,80 +1817,101 @@ function ReviewBranchPicker(props: {
         onKeyDown={handleKeyDown}
       />
       {shouldShowMenu ? (
-        <div
-          aria-label={props.ariaLabel}
-          className="branch-picker__menu review-branch-picker__menu"
-          id={listboxId}
-          role="listbox"
-        >
-          <div className="branch-picker__list">
-            {visibleOptions.map((option, index) => {
-              const isSelected = option.name === props.value.trim();
-              const relativeTime = formatBranchRelativeTime(
-                option.lastCommitAt,
-                nowMs,
-              );
-              return (
-                <button
-                  aria-label={option.name}
-                  aria-selected={isSelected}
-                  className={[
-                    "branch-picker__option",
-                    index === activeIndex ? "is-active" : "",
-                    isSelected ? "is-selected" : "",
-                  ]
-                    .filter(Boolean)
-                    .join(" ")}
-                  id={`${listboxId}-option-${index}`}
-                  key={option.name}
-                  ref={(element) => {
-                    optionRefs.current[index] = element;
-                  }}
-                  role="option"
-                  tabIndex={-1}
-                  type="button"
-                  onClick={() => commit(option.name)}
-                  onMouseEnter={() => setActiveIndex(index)}
-                >
-                  <span aria-hidden="true" className="branch-picker__option-check">
-                    {isSelected ? "✓" : ""}
-                  </span>
-                  <span aria-hidden="true" className="branch-picker__option-icon">
-                    <BranchIcon size={12} />
-                  </span>
-                  <span className="branch-picker__option-name">{option.name}</span>
-                  {option.current ? (
-                    <span
-                      aria-hidden="true"
-                      className="branch-picker__badge branch-picker__badge--current"
-                    >
-                      Current
+        <div className="branch-picker__menu review-branch-picker__menu">
+          <div className="branch-picker__search">
+            <span aria-hidden="true" className="branch-picker__search-icon">
+              <SearchIcon size={13} />
+            </span>
+            <input
+              aria-label="Find a branch"
+              className="branch-picker__search-input"
+              placeholder="Find a branch"
+              type="text"
+              value={filterText}
+              onChange={(event) => {
+                setFilterText(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={handleKeyDown}
+            />
+          </div>
+          <div
+            aria-label={`${props.ariaLabel} options`}
+            className="branch-picker__list"
+            id={listboxId}
+            role="listbox"
+          >
+            {visibleOptions.length === 0 ? (
+              <p className="branch-picker__empty">No branches match your filter.</p>
+            ) : (
+              visibleOptions.map((option, index) => {
+                const isSelected = option.name === props.value.trim();
+                const relativeTime = formatBranchRelativeTime(
+                  option.lastCommitAt,
+                  nowMs,
+                );
+                return (
+                  <button
+                    aria-label={option.name}
+                    aria-selected={isSelected}
+                    className={[
+                      "branch-picker__option",
+                      index === activeIndex ? "is-active" : "",
+                      isSelected ? "is-selected" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    id={`${listboxId}-option-${index}`}
+                    key={option.name}
+                    ref={(element) => {
+                      optionRefs.current[index] = element;
+                    }}
+                    role="option"
+                    tabIndex={-1}
+                    type="button"
+                    onClick={() => commit(option.name)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                  >
+                    <span aria-hidden="true" className="branch-picker__option-check">
+                      {isSelected ? "✓" : ""}
                     </span>
-                  ) : null}
-                  {option.isDefault ? (
-                    <span
-                      aria-hidden="true"
-                      className="branch-picker__badge branch-picker__badge--default"
-                    >
-                      Default
+                    <span aria-hidden="true" className="branch-picker__option-icon">
+                      <BranchIcon size={12} />
                     </span>
-                  ) : null}
-                  {option.inUse ? (
-                    <span
-                      aria-hidden="true"
-                      className="branch-picker__badge branch-picker__badge--in-use"
-                    >
-                      In use
-                    </span>
-                  ) : null}
-                  {relativeTime ? (
-                    <span aria-hidden="true" className="branch-picker__option-time">
-                      {relativeTime}
-                    </span>
-                  ) : null}
-                </button>
-              );
-            })}
+                    <span className="branch-picker__option-name">{option.name}</span>
+                    {option.current ? (
+                      <span
+                        aria-hidden="true"
+                        className="branch-picker__badge branch-picker__badge--current"
+                      >
+                        Current
+                      </span>
+                    ) : null}
+                    {option.isDefault ? (
+                      <span
+                        aria-hidden="true"
+                        className="branch-picker__badge branch-picker__badge--default"
+                      >
+                        Default
+                      </span>
+                    ) : null}
+                    {option.inUse ? (
+                      <span
+                        aria-hidden="true"
+                        className="branch-picker__badge branch-picker__badge--in-use"
+                      >
+                        In use
+                      </span>
+                    ) : null}
+                    {relativeTime ? (
+                      <span aria-hidden="true" className="branch-picker__option-time">
+                        {relativeTime}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
           </div>
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -519,24 +519,16 @@ function buildReviewBranchOptions(params: {
     pushIfKnown(value);
   };
 
-  const reportedDefaultBranch = params.directory?.gitStatus?.defaultBranch
-    ?.trim()
-    .replace(/^origin\//, "");
-  if (
-    reportedDefaultBranch &&
-    REVIEW_PREFERRED_BASE_BRANCHES.includes(reportedDefaultBranch)
-  ) {
-    pushPreferredDefault(reportedDefaultBranch);
-  }
+  push(params.thread?.gitWorkingState?.baseBranch);
+  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
+  pushIfKnown(upstreamBranch);
   for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
     pushPreferredDefault(branch);
   }
   push("main", { allowCurrent: true });
-  pushIfKnown(upstreamBranch);
   for (const candidate of baseBranches) {
     push(candidate);
   }
-  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
   push(params.thread?.gitBranch);
   push(params.thread?.observedGitBranch);
   push(params.directory?.gitStatus?.currentBranch);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -457,11 +457,18 @@ function buildReviewBranchOptions(params: {
   directory?: NavigationDirectorySummary;
   thread?: NavigationThreadSummary;
 }): string[] {
+  const threadCurrentBranches = [
+    params.thread?.gitBranch,
+    params.thread?.observedGitBranch,
+  ]
+    .map((branch) => branch?.trim())
+    .filter((branch): branch is string => Boolean(branch));
   const currentBranches = new Set(
     [
-      params.thread?.gitBranch,
-      params.thread?.observedGitBranch,
-      params.directory?.gitStatus?.currentBranch,
+      ...threadCurrentBranches,
+      ...(threadCurrentBranches.length === 0
+        ? [params.directory?.gitStatus?.currentBranch]
+        : []),
     ]
       .map((branch) => branch?.trim())
       .filter((branch): branch is string => Boolean(branch)),
@@ -483,6 +490,12 @@ function buildReviewBranchOptions(params: {
     /^origin\//,
     "",
   );
+  const directoryCurrentBranch = params.directory?.gitStatus?.currentBranch
+    ?.trim()
+    .replace(/^origin\//, "");
+  const directoryDefaultBranch = params.directory?.gitStatus?.defaultBranch
+    ?.trim()
+    .replace(/^origin\//, "");
   const baseBranches = params.directory?.gitStatus?.baseBranches ?? [];
   const knownBranches = new Set(
     [
@@ -521,6 +534,19 @@ function buildReviewBranchOptions(params: {
     pushIfKnown(`origin/${value}`);
     pushIfKnown(value);
   };
+  const pushDirectoryDefault = (): void => {
+    if (!directoryDefaultBranch) {
+      return;
+    }
+    if (
+      threadCurrentBranches.length > 0 &&
+      directoryDefaultBranch === directoryCurrentBranch &&
+      !REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(directoryDefaultBranch)
+    ) {
+      return;
+    }
+    pushPreferredDefault(directoryDefaultBranch);
+  };
   const pushInferredBaseBranch = (candidate?: string): void => {
     const value = candidate?.trim();
     if (!value) {
@@ -544,7 +570,7 @@ function buildReviewBranchOptions(params: {
   };
 
   pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
-  pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
+  pushDirectoryDefault();
   pushIfKnown(upstreamBranch);
   for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
     pushPreferredDefault(branch);
@@ -572,9 +598,9 @@ function buildReviewBranchPickerOptions(params: {
     [];
   const detailByName = new Map(details.map((detail) => [detail.name, detail]));
   const currentBranch = normalizeSelectableLaunchpadBranch(
-    params.directory?.gitStatus?.currentBranch ??
-      params.thread?.gitBranch ??
-      params.thread?.observedGitBranch,
+    params.thread?.gitBranch ??
+      params.thread?.observedGitBranch ??
+      params.directory?.gitStatus?.currentBranch,
   );
   const defaultBranch = normalizeSelectableLaunchpadBranch(
     params.directory?.gitStatus?.defaultBranch,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -423,6 +423,8 @@ const REVIEW_TARGET_OPTIONS: Array<{
 ];
 
 const REVIEW_PREFERRED_BASE_BRANCHES = ["main", "master", "develop", "trunk"];
+const REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN =
+  /^(main|master|develop|development|trunk)$|^(release|releases|stable|support|maintenance)\//;
 
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
@@ -518,8 +520,29 @@ function buildReviewBranchOptions(params: {
     pushIfKnown(`origin/${value}`);
     pushIfKnown(value);
   };
+  const pushInferredBaseBranch = (candidate?: string): void => {
+    const value = candidate?.trim();
+    if (!value) {
+      return;
+    }
 
-  push(params.thread?.gitWorkingState?.baseBranch);
+    const optionCount = options.size;
+    if (value.startsWith("origin/")) {
+      pushIfKnown(value);
+      pushIfKnown(value.slice("origin/".length));
+    } else if (REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(value)) {
+      pushIfKnown(`origin/${value}`);
+      pushIfKnown(value);
+    } else {
+      pushIfKnown(value);
+    }
+
+    if (options.size === optionCount) {
+      push(value);
+    }
+  };
+
+  pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
   pushPreferredDefault(params.directory?.gitStatus?.defaultBranch);
   pushIfKnown(upstreamBranch);
   for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5266,6 +5266,62 @@ describe("Composer", () => {
     });
   });
 
+  it("filters review base branch options without replacing the selected branch text", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "release", "main"],
+            baseBranches: ["main", "release", "hotfix"],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    const baseBranchInput = screen.getByLabelText("Base branch");
+    expect(baseBranchInput).toHaveValue("main");
+    fireEvent.click(baseBranchInput);
+    fireEvent.change(screen.getByLabelText("Find a branch"), {
+      target: { value: "rel" },
+    });
+
+    expect(baseBranchInput).toHaveValue("main");
+    expect(screen.getByRole("option", { name: "release" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "hotfix" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "release" }));
+    expect(baseBranchInput).toHaveValue("release");
+  });
+
   it("accepts a custom review base ref that is not in the branch picker options", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5322,6 +5322,60 @@ describe("Composer", () => {
     expect(baseBranchInput).toHaveValue("release");
   });
 
+  it("closes an empty review branch filter menu with Escape", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/PwrAgent",
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "feature/review",
+            defaultBranch: "main",
+            branches: ["feature/review", "release", "main"],
+            baseBranches: ["main", "release", "hotfix"],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+    const filterInput = screen.getByLabelText("Find a branch");
+    fireEvent.change(filterInput, { target: { value: "no-such-branch" } });
+
+    expect(screen.getByText("No branches match your filter.")).toBeInTheDocument();
+
+    fireEvent.keyDown(filterInput, { key: "Escape" });
+
+    expect(
+      screen.queryByText("No branches match your filter."),
+    ).not.toBeInTheDocument();
+  });
+
   it("accepts a custom review base ref that is not in the branch picker options", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
@@ -5503,6 +5557,60 @@ describe("Composer", () => {
     await clickButton("Send");
 
     expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+  });
+
+  it("keeps an unrelated directory upstream behind safe review bases", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/GIPHY/giphy-services",
+          kind: "directory",
+          label: "giphy-services",
+          path: "/Users/huntharo/GIPHY/giphy-services",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "search-gha-deploy-cutover",
+            defaultBranch: "search-gha-deploy-cutover",
+            upstreamBranch: "origin/search-gha-deploy-cutover",
+            branches: [
+              "search-gha-deploy-cutover",
+              "main",
+            ],
+            baseBranches: [
+              "search-gha-deploy-cutover",
+              "origin/search-gha-deploy-cutover",
+              "origin/main",
+              "main",
+            ],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "channelsv2",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "fix-channels-tagged-magic-tags-table",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
   });
 
   it("prefers the thread git-derived worktree base branch over main for reviews", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5586,6 +5586,67 @@ describe("Composer", () => {
     });
   });
 
+  it("does not exclude the default review base just because the local directory is on it", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(),
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/GIPHY/giphy-services",
+          kind: "directory",
+          label: "giphy-services",
+          path: "/Users/huntharo/GIPHY/giphy-services",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "develop",
+            defaultBranch: "develop",
+            branches: [
+              "develop",
+              "fix-channels-tagged-magic-tags-table",
+            ],
+            baseBranches: [
+              "develop",
+              "origin/develop",
+              "origin/master",
+            ],
+            syncState: "in-sync",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "channelsv2",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "fix-channels-tagged-magic-tags-table",
+          executionMode: "default",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services",
+              kind: "worktree",
+              label: "giphy-services",
+              path: "/Users/huntharo/GIPHY/giphy-services",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+  });
+
   it("updates an auto-selected review base when directory branch metadata hydrates", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5586,6 +5586,176 @@ describe("Composer", () => {
     });
   });
 
+  it("updates an auto-selected review base when directory branch metadata hydrates", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const desktopApi = {
+      onAgentEvent: () => () => undefined,
+      startReview,
+    };
+    const thread = {
+      id: "thread-1",
+      title: "channelsv2",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      gitBranch: "fix-channels-tagged-magic-tags-table",
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services",
+          kind: "worktree" as const,
+          label: "giphy-services",
+          path: "/Users/huntharo/GIPHY/giphy-services",
+          worktreePath:
+            "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services",
+        },
+      ],
+      inbox: { inInbox: false },
+    };
+    const hydratedDirectory = {
+      key: "directory:/Users/huntharo/GIPHY/giphy-services",
+      kind: "directory" as const,
+      label: "giphy-services",
+      path: "/Users/huntharo/GIPHY/giphy-services",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "fix-channels-tagged-magic-tags-table",
+        defaultBranch: "develop",
+        branches: [
+          "fix-channels-tagged-magic-tags-table",
+          "develop",
+        ],
+        baseBranches: [
+          "fix-channels-tagged-magic-tags-table",
+          "origin/fix-channels-tagged-magic-tags-table",
+          "develop",
+          "origin/develop",
+          "origin/master",
+        ],
+        syncState: "untracked" as const,
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        desktopApi={desktopApi}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("main");
+
+    rerender(
+      <Composer
+        desktopApi={desktopApi}
+        directory={hydratedDirectory}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/develop" },
+        delivery: "inline",
+        cwd:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mr3qwmcx/giphy-services",
+      });
+    });
+  });
+
+  it("keeps a user-entered review base when directory branch metadata hydrates", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const desktopApi = {
+      onAgentEvent: () => () => undefined,
+      startReview,
+    };
+    const thread = {
+      id: "thread-1",
+      title: "channelsv2",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      gitBranch: "fix-channels-tagged-magic-tags-table",
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const hydratedDirectory = {
+      key: "directory:/Users/huntharo/GIPHY/giphy-services",
+      kind: "directory" as const,
+      label: "giphy-services",
+      path: "/Users/huntharo/GIPHY/giphy-services",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "fix-channels-tagged-magic-tags-table",
+        defaultBranch: "develop",
+        branches: ["fix-channels-tagged-magic-tags-table", "develop"],
+        baseBranches: ["origin/develop", "develop"],
+        syncState: "untracked" as const,
+      },
+    };
+
+    const { rerender } = render(
+      <Composer
+        desktopApi={desktopApi}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    const baseBranchInput = screen.getByLabelText("Base branch");
+    fireEvent.change(baseBranchInput, {
+      target: { value: "origin/release-candidate" },
+    });
+
+    rerender(
+      <Composer
+        desktopApi={desktopApi}
+        directory={hydratedDirectory}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue(
+      "origin/release-candidate",
+    );
+  });
+
   it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5508,6 +5508,84 @@ describe("Composer", () => {
     });
   });
 
+  it("resolves a remote-agnostic git-derived review base to a known remote ref", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={{
+          key: "directory:/Users/huntharo/GIPHY/giphy-services",
+          kind: "directory",
+          label: "giphy-services",
+          path: "/Users/huntharo/GIPHY/giphy-services",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          gitStatus: {
+            currentBranch: "channelsv2-get-tagged-channels-by-asset-id",
+            defaultBranch: "develop",
+            branches: [
+              "channelsv2-get-tagged-channels-by-asset-id",
+              "main",
+            ],
+            baseBranches: [
+              "channelsv2-get-tagged-channels-by-asset-id",
+              "origin/main",
+              "origin/develop",
+            ],
+            syncState: "untracked",
+          },
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "channelsv2",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "channelsv2-get-tagged-channels-by-asset-id",
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 1,
+            baseBranch: "develop",
+          },
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/develop" },
+        delivery: "inline",
+      });
+    });
+  });
+
   it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5449,6 +5449,65 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Base branch")).toHaveValue("main");
   });
 
+  it("prefers the thread git-derived worktree base branch over main for reviews", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "channelsv2",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "channelsv2-get-tagged-channels-by-asset-id",
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 1,
+            baseBranch: "origin/develop",
+          },
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    const form = reviewTarget.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/develop" },
+        delivery: "inline",
+      });
+    });
+  });
+
   it("suggests recent commits for commit reviews and caps the list at twenty", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/packages/agent-core/src/__tests__/review-start.test.ts
+++ b/packages/agent-core/src/__tests__/review-start.test.ts
@@ -1,6 +1,12 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { readReviewPrompt } from "../app-server/review-prompt.js";
-import { createTestHarness, FakeProvider } from "../testing/test-harness.js";
+import { createTemporaryTestDirectory, createTestHarness, FakeProvider } from "../testing/test-harness.js";
+
+const execFileAsync = promisify(execFile);
 
 async function flushAsync(): Promise<void> {
   await Promise.resolve();
@@ -29,6 +35,20 @@ const reviewOutput = {
   overall_explanation: "The patch has one review issue.",
   overall_confidence_score: 0.88,
 } as const;
+
+async function git(cwd: string, args: string[]): Promise<{ stdout: string }> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_AUTHOR_NAME: "PwrAgent Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "PwrAgent Test",
+    },
+  });
+  return { stdout };
+}
 
 describe("Codex review start", () => {
   it("keeps the committed review prompt aligned with the Codex review schema", () => {
@@ -409,6 +429,59 @@ describe("Codex review start", () => {
         },
       },
     });
+  });
+
+  it("runs base-branch reviews from the requested cwd without changing thread metadata", async () => {
+    const temp = await createTemporaryTestDirectory();
+    try {
+      const originalCwd = path.join(temp.path, "giphy-services");
+      const selectedCwd = path.join(temp.path, "svc-infra");
+      await fs.mkdir(originalCwd);
+      await fs.mkdir(selectedCwd);
+
+      await git(selectedCwd, ["init"]);
+      await git(selectedCwd, ["checkout", "-b", "main"]);
+      await fs.writeFile(path.join(selectedCwd, "iam.tf"), "resource = \"base\"\n");
+      await git(selectedCwd, ["add", "iam.tf"]);
+      await git(selectedCwd, ["commit", "-m", "base"]);
+      const { stdout } = await git(selectedCwd, ["rev-parse", "HEAD"]);
+      const mergeBase = stdout.trim();
+      await git(selectedCwd, ["checkout", "-b", "feature"]);
+      await fs.writeFile(path.join(selectedCwd, "iam.tf"), "resource = \"feature\"\n");
+      await git(selectedCwd, ["add", "iam.tf"]);
+      await git(selectedCwd, ["commit", "-m", "feature"]);
+
+      const provider = new FakeProvider();
+      const { server } = createTestHarness({ provider });
+      await server.request("thread/start", { cwd: originalCwd });
+
+      await server.request("review/start", {
+        threadId: "thread-1",
+        cwd: selectedCwd,
+        target: { type: "baseBranch", branch: "main" },
+        delivery: "inline",
+      });
+
+      expect(provider.runs[0]?.thread.cwd).toBe(selectedCwd);
+      expect(provider.runs[0]?.input[0]).toEqual({
+        type: "text",
+        text: expect.stringContaining(
+          `The merge base commit for this comparison is ${mergeBase}.`,
+        ),
+      });
+
+      const replay = await server.request("thread/read", {
+        threadId: "thread-1",
+      });
+      expect(replay).toMatchObject({
+        thread: {
+          threadId: "thread-1",
+          cwd: originalCwd,
+        },
+      });
+    } finally {
+      await temp.cleanup();
+    }
   });
 
   it("emits a failed turn when the provider review run rejects", async () => {

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -330,10 +330,12 @@ export class CodexAppServer {
     if (!thread) {
       throw new AppServerProtocolError(`Unknown thread: ${threadId}`);
     }
+    const cwd = asOptionalString(params.cwd);
+    const reviewThread = cwd ? { ...thread, cwd } : thread;
     const turnId = this.createTurnId();
     const itemId = `${turnId}-item`;
     const result = await this.reviewRunner.start({
-      thread,
+      thread: reviewThread,
       turnId,
       itemId,
       target: params.target,


### PR DESCRIPTION
## Summary
- forward the selected review cwd through the Codex `review/start` payload
- have agent-core run review prompt construction and provider execution from that requested cwd
- prefer the thread git-derived base branch before repository defaults or hard-coded `main`/`master` guesses
- add regression coverage for a thread whose primary cwd differs from the selected review repo and for thread-only review defaulting to the derived base

## Tests
- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
- pnpm test packages/agent-core/src/__tests__/review-start.test.ts
- pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts
- pnpm typecheck
- pnpm lint:eslint -- apps/desktop/src/renderer/src/features/composer/Composer.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/codex-app-server/client.ts apps/desktop/src/main/__tests__/codex-client.test.ts packages/agent-core/src/app-server/codex-app-server.ts packages/agent-core/src/__tests__/review-start.test.ts
- git diff --check