### PR TITLE
fix(desktop): respect fork boundary in edited files

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1543,9 +1543,18 @@ export function ThreadView(props: ThreadViewProps) {
       collectEditedFileGroups({
         entries: props.transcriptEntries,
         activeTurnId: props.activeTurnId,
+        forkCreatedAt: selectedThread?.forkSourceThreadId
+          ? selectedThread.createdAt
+          : undefined,
         livePendingEntry: pendingRailActivityEntry,
       }),
-    [props.transcriptEntries, props.activeTurnId, pendingRailActivityEntry],
+    [
+      props.transcriptEntries,
+      props.activeTurnId,
+      selectedThread?.createdAt,
+      selectedThread?.forkSourceThreadId,
+      pendingRailActivityEntry,
+    ],
   );
 
   // Git commit lifecycle per group, resolved against the live worktree.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts
@@ -49,6 +49,7 @@ function fileDiffDetail(params: {
 }
 
 function activityEntry(params: {
+  createdAt?: number;
   id: string;
   turnId?: string;
   details: AppServerThreadActivityDetail[];
@@ -56,6 +57,7 @@ function activityEntry(params: {
   return {
     type: "activity",
     id: params.id,
+    ...(params.createdAt !== undefined ? { createdAt: params.createdAt } : {}),
     summary: "activity",
     details: params.details,
     ...(params.turnId ? { turn: { id: params.turnId } } : {}),
@@ -200,6 +202,30 @@ describe("collectEditedFileGroups", () => {
       "turn-2",
       "turn-1",
     ]);
+  });
+
+  it("starts forked-thread edit history at the fork boundary", () => {
+    const groups = collectEditedFileGroups({
+      entries: [
+        activityEntry({
+          id: "ancestor-a1",
+          createdAt: 1_000,
+          turnId: "ancestor-turn-1",
+          details: [fileDiffDetail({ path: "src/ancestor.ts", additions: 3 })],
+        }),
+        activityEntry({
+          id: "fork-a1",
+          createdAt: 2_000,
+          turnId: "fork-turn-1",
+          details: [fileDiffDetail({ path: "src/fork.ts", additions: 5 })],
+        }),
+      ],
+      forkCreatedAt: 1_500,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("fork-turn-1");
+    expect(groups[0].details.map((detail) => detail.path)).toEqual(["src/fork.ts"]);
   });
 
   it("renders the live pending cumulative diff as the newest group", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/edited-file-groups.ts
@@ -139,11 +139,14 @@ function mergeFileDiffDetail(
 export function collectEditedFileGroups(params: {
   entries: readonly AppServerThreadEntry[];
   activeTurnId?: string;
+  forkCreatedAt?: number;
   livePendingEntry?: AppServerThreadActivityEntry;
 }): EditedFileGroup[] {
   const turnOrder: string[] = [];
   const orderIndexByKey = new Map<string, number>();
   const buckets = new Map<string, TurnBucket>();
+  const forkCreatedAt = params.forkCreatedAt;
+  let pastForkBoundary = typeof forkCreatedAt !== "number";
 
   const ensureTurnIndex = (key: string): number => {
     let index = orderIndexByKey.get(key);
@@ -177,6 +180,24 @@ export function collectEditedFileGroups(params: {
   };
 
   for (const entry of params.entries) {
+    if (typeof forkCreatedAt === "number" && !pastForkBoundary) {
+      // Forked Codex threads replay ancestor entries before their own turns.
+      // Start the edit history at the fork thread's creation boundary.
+      const entryCreatedAt =
+        typeof entry.createdAt === "number"
+          ? entry.createdAt
+          : typeof entry.turn?.completedAt === "number"
+            ? entry.turn.completedAt
+            : entry.turn?.startedAt;
+      if (
+        typeof entryCreatedAt !== "number" ||
+        entryCreatedAt < forkCreatedAt
+      ) {
+        continue;
+      }
+      pastForkBoundary = true;
+    }
+
     const turnKey = entry.turn?.id;
     if (entry.type !== "activity") {
       continue;

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -71,6 +71,62 @@ function buildAutomationSummary(
   };
 }
 
+describe("navigation fork metadata", () => {
+  it("materializes fork origin metadata from thread overlays", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          forkSourceThreadId: "thread-parent",
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread({ createdAt: 2_000 })],
+    });
+
+    expect(thread?.forkSourceThreadId).toBe("thread-parent");
+  });
+
+  it("includes fork origin metadata in the navigation snapshot hash", () => {
+    const [threadWithoutForkOrigin] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {},
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread({ createdAt: 2_000 })],
+    });
+    const [threadWithForkOrigin] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          forkSourceThreadId: "thread-parent",
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread({ createdAt: 2_000 })],
+    });
+
+    expect(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithoutForkOrigin!],
+      }),
+    ).not.toBe(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithForkOrigin!],
+      }),
+    );
+  });
+});
+
 describe("navigation automation summaries", () => {
   it("materializes compact automation summaries onto thread navigation rows", () => {
     const [thread] = materializeNavigationThreads({

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -209,6 +209,7 @@ export function materializeNavigationThreads(params: {
       subAgents: overlay?.subAgents ?? [],
       pinnedRank: overlay?.pinnedRank,
       parentThreadId,
+      forkSourceThreadId: overlay?.forkSourceThreadId,
       subthreadOrder: overlay?.subthreadOrder,
       subthreadsCollapsed: overlay?.subthreadsCollapsed,
       prs: overlay?.prs ?? [],
@@ -462,6 +463,7 @@ export function buildNavigationSnapshotHash(params: {
       reactions: thread.reactions ?? [],
       pinnedRank: thread.pinnedRank ?? null,
       parentThreadId: thread.parentThreadId ?? null,
+      forkSourceThreadId: thread.forkSourceThreadId ?? null,
       subthreadOrder: thread.subthreadOrder ?? [],
       subthreadsCollapsed: thread.subthreadsCollapsed ?? null,
       // Include prs in the hash so refreshThreadPullRequests writes to

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -62,6 +62,12 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
    * agent thread; this only controls sidebar grouping.
    */
   parentThreadId?: ThreadIdentifier;
+  /**
+   * Set only when this thread inherited copied context by forking another
+   * thread. Renderer surfaces use this to distinguish fork baseline history
+   * from edits made by the forked thread itself.
+   */
+  forkSourceThreadId?: ThreadIdentifier;
   /** User-curated child order, stored on the parent thread overlay. */
   subthreadOrder?: ThreadIdentifier[];
   /** Persisted disclosure state for the parent's child section. */


### PR DESCRIPTION
## Summary
Forked desktop threads now keep the Edits panel focused on work done after the fork. When Codex replays copied ancestor history before the fork's own turns, the Edited Files list starts at the fork boundary instead of aggregating pre-fork file changes into the current thread.

The fork-origin marker now reaches the renderer through navigation state, and the edited-file collector uses that marker plus the fork thread creation time only for forked threads. Normal grouped or child threads continue to show their full edit history.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/edited-file-groups.test.ts`
- `pnpm test packages/agent-core/src/__tests__/navigation-state.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm --filter @pwragent/agent-core typecheck`
- `pnpm --filter @pwragent/shared typecheck`
- `pnpm lint:eslint` (warnings only; no errors)
- `pnpm lint:boundaries`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5.5-000000)
