### PR TITLE
fix(desktop): correct edits diff stats

### DIFF
--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -282,6 +282,47 @@ describe("probeWorktreeWorkingState", () => {
       await rm(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it("expands collapsed untracked directories before computing dirty totals", async () => {
+    const tmpRoot = await mkdtemp(makeTempPrefix());
+    try {
+      const skillRoot = path.join(tmpRoot, ".codex", "skills", "diagnose-jvm-memory");
+      await mkdir(path.join(skillRoot, "agents"), { recursive: true });
+      await mkdir(path.join(skillRoot, "references"), { recursive: true });
+      await writeFile(path.join(skillRoot, "SKILL.md"), "one\ntwo\n", "utf8");
+      await writeFile(path.join(skillRoot, "agents", "openai.yaml"), "agent\n", "utf8");
+      await writeFile(
+        path.join(skillRoot, "references", "giphy-jvm-memory.md"),
+        "alpha\nbeta\ngamma\n",
+        "utf8",
+      );
+      const { runGit } = fakeGit((args) => {
+        if (args.includes("--numstat")) return "";
+        if (args.includes("status")) return "?? .codex/skills/\0";
+        if (args.includes("ls-files")) {
+          return [
+            ".codex/skills/diagnose-jvm-memory/SKILL.md",
+            ".codex/skills/diagnose-jvm-memory/agents/openai.yaml",
+            ".codex/skills/diagnose-jvm-memory/references/giphy-jvm-memory.md",
+          ].join("\0");
+        }
+        if (args[args.length - 1] === "remote") return "";
+        return undefined;
+      });
+
+      const state = await probeWorktreeWorkingState(tmpRoot, { runGit });
+
+      expect(state).toEqual({
+        dirtyFiles: 3,
+        dirtyAdditions: 6,
+        dirtyDeletions: 0,
+        untrackedFiles: 3,
+        unpushedCommits: 0,
+      });
+    } finally {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("GitWorkingStateService", () => {

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -710,14 +710,49 @@ async function expandUntrackedDirectoryEntry(
 async function summarizeUntrackedChanges(
   cwd: string,
   statusOutput: string,
+  runGit: GitCommandRunner,
+  gitEnv?: NodeJS.ProcessEnv,
 ): Promise<{ files: number; additions: number }> {
   const untrackedEntries = parseStatusPorcelain(statusOutput, cwd).filter(
     (entry) => entry.status === "untracked",
   );
-  const visibleEntries = untrackedEntries.slice(0, DEFAULT_OTHER_CHANGES_MAX_FILES);
+  const visibleEntries: WorktreeOtherChangeEntry[] = [];
+  let files = 0;
+  for (const entry of untrackedEntries) {
+    if (isCollapsedUntrackedDirectoryEntry(entry)) {
+      const remaining = Math.max(
+        0,
+        DEFAULT_OTHER_CHANGES_MAX_FILES - visibleEntries.length,
+      );
+      const expanded = await expandUntrackedDirectoryEntry(
+        cwd,
+        entry,
+        remaining,
+        () => true,
+        runGit,
+        gitEnv,
+      );
+      files += expanded.changes.length;
+      if (expanded.truncated || expanded.changes.length === 0) {
+        files += 1;
+      }
+      visibleEntries.push(
+        ...expanded.changes.slice(
+          0,
+          Math.max(0, DEFAULT_OTHER_CHANGES_MAX_FILES - visibleEntries.length),
+        ),
+      );
+      continue;
+    }
+
+    files += 1;
+    if (visibleEntries.length < DEFAULT_OTHER_CHANGES_MAX_FILES) {
+      visibleEntries.push(entry);
+    }
+  }
   await Promise.all(visibleEntries.map((entry) => enrichUntrackedChangeStats(entry)));
   return {
-    files: untrackedEntries.length,
+    files,
     additions: visibleEntries.reduce(
       (sum, entry) => sum + (entry.additions ?? 0),
       0,
@@ -807,7 +842,12 @@ export async function probeWorktreeWorkingState(
   }
 
   const numstat = parseNumstat(numstatOutput ?? "");
-  const untracked = await summarizeUntrackedChanges(worktreePath, statusOutput ?? "");
+  const untracked = await summarizeUntrackedChanges(
+    worktreePath,
+    statusOutput ?? "",
+    runGit,
+    gitEnv,
+  );
 
   // "Unpushed" means reachable from HEAD but on no remote ref. With no
   // remotes configured, every commit would count — meaningless for a

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -31,19 +31,27 @@ export function ThreadMetaChips({
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const gitWorking = thread.gitWorkingState;
-  const hasDirtySummary = Boolean(
+  const hasDirtyState = Boolean(
     gitWorking &&
       (gitWorking.dirtyFiles > 0 ||
         gitWorking.dirtyAdditions > 0 ||
         gitWorking.dirtyDeletions > 0),
   );
+  const hasDirtyLineStats = Boolean(
+    gitWorking &&
+      (gitWorking.dirtyAdditions > 0 || gitWorking.dirtyDeletions > 0),
+  );
   const hasUntracked = Boolean(gitWorking && gitWorking.untrackedFiles > 0);
   const dirtyTooltip = gitWorking
     ? [
-        hasDirtySummary
-          ? `Uncommitted changes: ${gitWorking.dirtyFiles} file${
-              gitWorking.dirtyFiles === 1 ? "" : "s"
-            }, +${gitWorking.dirtyAdditions.toLocaleString()}, -${gitWorking.dirtyDeletions.toLocaleString()}`
+        hasDirtyState
+          ? hasDirtyLineStats
+            ? `Uncommitted changes: ${gitWorking.dirtyFiles} file${
+                gitWorking.dirtyFiles === 1 ? "" : "s"
+              }, +${gitWorking.dirtyAdditions.toLocaleString()}, -${gitWorking.dirtyDeletions.toLocaleString()}`
+            : `Uncommitted changes: ${gitWorking.dirtyFiles} file${
+                gitWorking.dirtyFiles === 1 ? "" : "s"
+              }`
           : undefined,
         hasUntracked
           ? `${gitWorking.untrackedFiles} untracked file${
@@ -195,7 +203,7 @@ export function ThreadMetaChips({
         </CopyableThreadChip>
       ) : null}
 
-      {hasDirtySummary || hasUntracked ? (
+      {hasDirtyState || hasUntracked ? (
         <span
           aria-label={dirtyTooltip.replace(/\n/g, "; ")}
           role="img"
@@ -205,7 +213,7 @@ export function ThreadMetaChips({
           }
           onMouseLeave={gitStateTooltip.hide}
         >
-          {hasDirtySummary ? (
+          {hasDirtyLineStats ? (
             <>
               <span className="thread-row__chip-stat thread-row__chip-stat--added">
                 +{gitWorking!.dirtyAdditions.toLocaleString()}
@@ -216,7 +224,7 @@ export function ThreadMetaChips({
             </>
           ) : (
             <span className="thread-row__chip-stat">
-              {gitWorking!.untrackedFiles} new
+              {formatDirtyFileFallback(gitWorking!)}
             </span>
           )}
         </span>
@@ -238,6 +246,18 @@ export function ThreadMetaChips({
       {gitStateTooltip.tooltipNode}
     </>
   );
+}
+
+function formatDirtyFileFallback(
+  gitWorking: NonNullable<NavigationThreadSummary["gitWorkingState"]>,
+): string {
+  if (
+    gitWorking.untrackedFiles > 0 &&
+    gitWorking.dirtyFiles <= gitWorking.untrackedFiles
+  ) {
+    return `${gitWorking.untrackedFiles.toLocaleString()} new`;
+  }
+  return `${gitWorking.dirtyFiles.toLocaleString()} changed`;
 }
 
 function formatBranchCopyLabel(params: {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -666,6 +666,26 @@ describe("ThreadRow chip flow", () => {
     expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
   });
 
+  it("does not render degenerate +0/-0 dirty stats", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitWorkingState: {
+          dirtyFiles: 1,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 1,
+          unpushedCommits: 0,
+        },
+      },
+    });
+
+    const dirtyChip = container.querySelector(".thread-row__chip--dirty");
+    expect(dirtyChip).toHaveTextContent("1 new");
+    expect(dirtyChip).not.toHaveTextContent("+0");
+    expect(dirtyChip).not.toHaveTextContent("-0");
+  });
+
   it("renders no git working-state chips when the tree is clean and pushed", () => {
     const { container } = renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/EditedFileGroupList.tsx
@@ -91,6 +91,12 @@ type EditedFileGroupListProps = {
   /** Scroll the transcript to a group's turn (clickable timestamp). */
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   /**
+   * Optional exact current-worktree details for the flat All files view. When
+   * absent, the list falls back to the accumulated historical transcript
+   * details.
+   */
+  flatDetailsOverride?: AppServerThreadActivityDetail[];
+  /**
    * Keep the per-turn group header when there is only one group. The
    * above-composer rail already carries the single-group summary in its outer
    * header, but the sidebar Edits panel needs the group header for timestamp
@@ -238,7 +244,10 @@ export function EditedFileGroupList(props: EditedFileGroupListProps) {
           );
         })()
       ) : (
-        <EditedFileFlatSection groups={props.groups} />
+        <EditedFileFlatSection
+          groups={props.groups}
+          detailsOverride={props.flatDetailsOverride}
+        />
       );
   }
 }
@@ -247,10 +256,15 @@ function formatEditedFileCount(count: number): string {
   return `Edited ${count.toLocaleString()} ${count === 1 ? "file" : "files"}`;
 }
 
-function EditedFileFlatSection(props: { groups: EditedFileGroup[] }) {
+function EditedFileFlatSection(props: {
+  groups: EditedFileGroup[];
+  detailsOverride?: AppServerThreadActivityDetail[];
+}) {
+  const headerRef = useRef<HTMLDivElement>(null);
+  const headerHeight = useMeasuredHeight(headerRef);
   const details = useMemo(
-    () => flattenEditedFileGroups(props.groups),
-    [props.groups],
+    () => props.detailsOverride ?? flattenEditedFileGroups(props.groups),
+    [props.groups, props.detailsOverride],
   );
   const totals = details.reduce(
     (sum, detail) => ({
@@ -261,8 +275,20 @@ function EditedFileFlatSection(props: { groups: EditedFileGroup[] }) {
   );
 
   return (
-    <>
-      <div className="edited-file-groups__group-header edited-file-groups__flat-header">
+    <section
+      className="edited-file-groups__group edited-file-groups__flat-section"
+      style={
+        headerHeight != null
+          ? ({
+              "--edits-group-header-height": `${headerHeight}px`,
+            } as CSSProperties)
+          : undefined
+      }
+    >
+      <div
+        ref={headerRef}
+        className="edited-file-groups__group-header edited-file-groups__flat-header"
+      >
         <div className="edited-file-groups__flat-summary">
           <span className="edited-file-groups__group-summary">
             {formatEditedFileCount(details.length)}
@@ -275,7 +301,7 @@ function EditedFileFlatSection(props: { groups: EditedFileGroup[] }) {
         />
       </div>
       <EditedFileList details={details} />
-    </>
+    </section>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx
@@ -104,10 +104,15 @@ describe("EditedFileGroupList Show more / Show less", () => {
       },
     ];
 
-    render(<EditedFileGroupList groups={flatGroups} view="files" />);
+    const { container } = render(
+      <EditedFileGroupList groups={flatGroups} view="files" />,
+    );
 
     expect(screen.getByText("Edited 2 files")).toBeInTheDocument();
     expect(screen.getByLabelText("+5 -4")).toBeInTheDocument();
+    expect(
+      container.querySelector(".edited-file-groups__flat-section"),
+    ).not.toBeNull();
   });
 
   it("renders the git status badge only for the newest turn group", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -16,7 +16,10 @@ import {
   type EditedFileGroupView,
 } from "../EditedFileGroupList";
 import { TranscriptDiff } from "../TranscriptDiff";
-import type { EditedFileGroup } from "../edited-file-groups";
+import {
+  flattenEditedFileGroups,
+  type EditedFileGroup,
+} from "../edited-file-groups";
 import type { EditedFilesDock } from "./context-tab";
 
 type EditsPanelProps = {
@@ -46,6 +49,10 @@ const OTHER_CHANGE_DIFF_MAX_BYTES = 200_000;
 
 function isAbsolutePathLike(value: string): boolean {
   return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
 }
 
 function toWorktreeAbsolutePath(
@@ -155,6 +162,108 @@ function useOtherWorktreeChanges(params: {
   return state;
 }
 
+function useCurrentEditedFileDetails(params: {
+  desktopApi?: Pick<DesktopApi, "getWorktreeOtherChangeDiff">;
+  enabled: boolean;
+  groups: readonly EditedFileGroup[];
+  refreshKey?: string;
+  worktreeRoot?: string;
+}) {
+  const fallbackDetails = useMemo(
+    () => flattenEditedFileGroups(params.groups),
+    [params.groups],
+  );
+  const editedPaths = useMemo(
+    () => collectEditedPaths(params.groups, params.worktreeRoot).sort(),
+    [params.groups, params.worktreeRoot],
+  );
+  const editedPathSignature = useMemo(
+    () => JSON.stringify(editedPaths),
+    [editedPaths],
+  );
+  const [details, setDetails] = useState<
+    AppServerThreadActivityDetail[] | undefined
+  >();
+
+  useEffect(() => {
+    const getDiff = params.desktopApi?.getWorktreeOtherChangeDiff;
+    const worktreePath = params.worktreeRoot?.trim();
+    if (!params.enabled || !getDiff || !worktreePath || editedPaths.length === 0) {
+      setDetails(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    setDetails([]);
+    void Promise.all(
+      editedPaths.map(async (filePath) => ({
+        filePath,
+        response: await getDiff({
+          worktreePath,
+          path: filePath,
+          maxBytes: OTHER_CHANGE_DIFF_MAX_BYTES,
+        }).catch(() => ({ detail: undefined })),
+      })),
+    ).then((results) => {
+      if (cancelled) {
+        return;
+      }
+
+      const currentByPath = new Map<string, AppServerThreadActivityDetail>();
+      for (const result of results) {
+        const detail = result.response.detail;
+        if (detail?.fileDiff) {
+          currentByPath.set(normalizePath(result.filePath), detail);
+        }
+      }
+      if (currentByPath.size === 0) {
+        setDetails([]);
+        return;
+      }
+
+      setDetails(
+        fallbackDetails.flatMap((detail) => {
+          const detailPath = detail.path?.trim();
+          if (!detailPath) {
+            return [];
+          }
+          const absolutePath = toWorktreeAbsolutePath(
+            detailPath,
+            params.worktreeRoot,
+          );
+          const current = absolutePath
+            ? currentByPath.get(normalizePath(absolutePath))
+            : undefined;
+          return current?.fileDiff
+            ? [
+                {
+                  ...detail,
+                  path: current.path ?? detail.path,
+                  status: current.status ?? detail.status,
+                  fileDiff: current.fileDiff,
+                },
+              ]
+            : [];
+        }),
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    editedPathSignature,
+    editedPaths,
+    fallbackDetails,
+    params.desktopApi?.getWorktreeOtherChangeDiff,
+    params.enabled,
+    params.refreshKey,
+    params.worktreeRoot,
+  ]);
+
+  return details;
+}
+
 function statusAction(status: WorktreeOtherChangeStatus): string {
   switch (status) {
     case "added":
@@ -246,6 +355,13 @@ export function EditsPanel(props: EditsPanelProps) {
     editedPaths,
     refreshKey: props.workingStateRefreshKey,
   });
+  const currentEditedFileDetails = useCurrentEditedFileDetails({
+    desktopApi: props.desktopApi,
+    enabled: view === "files",
+    groups: props.groups,
+    refreshKey: props.workingStateRefreshKey,
+    worktreeRoot: props.worktreeRoot,
+  });
   const hasOtherChanges = otherChanges.changes.length > 0;
 
   return (
@@ -295,6 +411,7 @@ export function EditsPanel(props: EditsPanelProps) {
             onOpenFile={props.onOpenFile}
             preferredEditor={props.preferredEditor}
             onScrollToTurn={props.onScrollToTurn}
+            flatDetailsOverride={currentEditedFileDetails}
             showSingleGroupHeader
           />
         ) : (

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx
@@ -1,6 +1,10 @@
 import "@testing-library/jest-dom/vitest";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type {
+  GetWorktreeOtherChangeDiffRequest,
+  GetWorktreeOtherChangeDiffResponse,
+} from "@pwragent/shared";
 import { EditsPanel } from "../EditsPanel";
 import type { EditedFileGroup } from "../../edited-file-groups";
 
@@ -211,5 +215,238 @@ describe("EditsPanel", () => {
     });
     expect(screen.getByText("docs/design.md")).toBeInTheDocument();
     expect(await screen.findByText("new")).toBeInTheDocument();
+  });
+
+  it("uses current worktree diffs for the All files view instead of summing historical edits", async () => {
+    const listWorktreeOtherChanges = vi.fn(async () => ({
+      changes: [],
+      totalChanges: 0,
+      truncated: false,
+      maxFiles: 50,
+    }));
+    const getWorktreeOtherChangeDiff = vi.fn(async () => ({
+      detail: {
+        id: "other-change:/repo/src/MemoryDumpMonitor.scala",
+        kind: "write" as const,
+        label: "MemoryDumpMonitor.scala",
+        path: "/repo/src/MemoryDumpMonitor.scala",
+        fileDiff: {
+          kind: "add" as const,
+          diff: "--- /dev/null\n+++ b/src/MemoryDumpMonitor.scala\n@@ -0,0 +1,194 @@\n+final file\n",
+          additions: 194,
+          removals: 0,
+        },
+      },
+    }));
+    const groups: EditedFileGroup[] = [
+      {
+        key: "turn-2",
+        turn: { id: "turn-2", completedAt: 1_718_000_000_002 },
+        details: [
+          {
+            id: "detail-update",
+            kind: "write",
+            label: "Update MemoryDumpMonitor.scala",
+            path: "/repo/src/MemoryDumpMonitor.scala",
+            fileDiff: {
+              kind: "update",
+              diff: "@@ -1 +1 @@\n-old\n+new\n",
+              additions: 203,
+              removals: 25,
+            },
+          },
+        ],
+        summary: "Edited 1 file",
+        additions: 203,
+        removals: 25,
+        live: false,
+      },
+      {
+        key: "turn-1",
+        turn: { id: "turn-1", completedAt: 1_718_000_000_001 },
+        details: [
+          {
+            id: "detail-add",
+            kind: "write",
+            label: "Add MemoryDumpMonitor.scala",
+            path: "/repo/src/MemoryDumpMonitor.scala",
+            fileDiff: {
+              kind: "add",
+              diff: "--- /dev/null\n+++ b/src/MemoryDumpMonitor.scala\n@@ -0,0 +1,194 @@\n+initial file\n",
+              additions: 194,
+              removals: 0,
+            },
+          },
+        ],
+        summary: "Edited 1 file",
+        additions: 194,
+        removals: 0,
+        live: false,
+      },
+    ];
+
+    render(
+      <EditsPanel
+        groups={groups}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        desktopApi={{ listWorktreeOtherChanges, getWorktreeOtherChangeDiff }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "All files" }));
+
+    await waitFor(() => {
+      expect(getWorktreeOtherChangeDiff).toHaveBeenCalledWith({
+        worktreePath: "/repo",
+        path: "/repo/src/MemoryDumpMonitor.scala",
+        maxBytes: 200000,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Edited 1 file")).toBeInTheDocument();
+      expect(screen.getAllByLabelText("+194 -0")).toHaveLength(2);
+    });
+    expect(screen.queryByLabelText("+397 -25")).not.toBeInTheDocument();
+  });
+
+  it("drops edited files that no longer have a current worktree diff", async () => {
+    const listWorktreeOtherChanges = vi.fn(async () => ({
+      changes: [],
+      totalChanges: 0,
+      truncated: false,
+      maxFiles: 50,
+    }));
+    const getWorktreeOtherChangeDiff = vi.fn(async (request) => ({
+      detail: request.path.endsWith("clean.ts")
+        ? undefined
+        : {
+            id: "other-change:/repo/src/dirty.ts",
+            kind: "write" as const,
+            label: "dirty.ts",
+            path: "/repo/src/dirty.ts",
+            fileDiff: {
+              kind: "update" as const,
+              diff: "@@ -1 +1 @@\n+dirty\n",
+              additions: 7,
+              removals: 0,
+            },
+          },
+    }));
+    const dirtyGroup: EditedFileGroup = {
+      ...editedGroup(2),
+      details: [
+        {
+          id: "dirty",
+          kind: "write",
+          label: "Update dirty.ts",
+          path: "/repo/src/dirty.ts",
+          fileDiff: {
+            kind: "update",
+            diff: "@@ -1 +1 @@\n+dirty\n",
+            additions: 7,
+            removals: 0,
+          },
+        },
+      ],
+      additions: 7,
+      removals: 0,
+    };
+    const cleanGroup: EditedFileGroup = {
+      ...editedGroup(1),
+      details: [
+        {
+          id: "clean",
+          kind: "write",
+          label: "Update clean.ts",
+          path: "/repo/src/clean.ts",
+          fileDiff: {
+            kind: "update",
+            diff: "@@ -1 +1 @@\n+clean\n",
+            additions: 11,
+            removals: 3,
+          },
+        },
+      ],
+      additions: 11,
+      removals: 3,
+    };
+
+    render(
+      <EditsPanel
+        groups={[dirtyGroup, cleanGroup]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        desktopApi={{ listWorktreeOtherChanges, getWorktreeOtherChangeDiff }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "All files" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("+7 -0")).toHaveLength(2);
+    });
+    expect(screen.getByText("Edited 1 file")).toBeInTheDocument();
+    expect(screen.getByText("Update dirty.ts")).toBeInTheDocument();
+    expect(screen.queryByText("Update clean.ts")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("+18 -3")).not.toBeInTheDocument();
+  });
+
+  it("refreshes current All files diffs when the worktree refresh key changes", async () => {
+    const listWorktreeOtherChanges = vi.fn(async () => ({
+      changes: [],
+      totalChanges: 0,
+      truncated: false,
+      maxFiles: 50,
+    }));
+    let currentAdditions = 5;
+    const getWorktreeOtherChangeDiff = vi.fn(
+      async (
+        request: GetWorktreeOtherChangeDiffRequest,
+      ): Promise<GetWorktreeOtherChangeDiffResponse> => {
+        return {
+          detail: request.path.endsWith("file-1.ts")
+            ? {
+                id: "other-change:/repo/apps/desktop/src/main/file-1.ts",
+                kind: "write" as const,
+                label: "file-1.ts",
+                path: "/repo/apps/desktop/src/main/file-1.ts",
+                fileDiff: {
+                  kind: "update" as const,
+                  diff: "@@ -1 +1 @@\n+live\n",
+                  additions: currentAdditions,
+                  removals: 0,
+                },
+              }
+            : undefined,
+        };
+      },
+    );
+    const panel = (refreshKey: string) => (
+      <EditsPanel
+        groups={[editedGroup(2), editedGroup(1)]}
+        dock="sidebar"
+        onDockChange={vi.fn()}
+        worktreeRoot="/repo"
+        workingStateRefreshKey={refreshKey}
+        desktopApi={{ listWorktreeOtherChanges, getWorktreeOtherChangeDiff }}
+      />
+    );
+    const { rerender } = render(panel("first"));
+
+    fireEvent.click(screen.getByRole("button", { name: "All files" }));
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("+5 -0")).toHaveLength(2);
+    });
+
+    currentAdditions = 9;
+    rerender(panel("second"));
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("+9 -0")).toHaveLength(2);
+    });
+    expect(getWorktreeOtherChangeDiff).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Summary
The desktop Edits surfaces now show current, explainable diff stats instead of leaking implementation artifacts into the UI. Thread dirty chips expand collapsed untracked directories before computing totals, and zero-line dirty states fall back to file-count labels instead of `+0 -0`.

The Edits sidebar `All files` view now prefers the live worktree diff for each edited file, so a new file edited multiple times reports the net current patch rather than a historical sum. Its flat header also uses the same measured sticky offset as turn headers, keeping expanded file rows pinned flush under the header while scrolling.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/EditedFileGroupList.test.tsx`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/EditsPanel.test.tsx`
- `pnpm exec eslint ...touched files...`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5.5](https://img.shields.io/badge/GPT--5.5-000000)
