### PR TITLE
fix(desktop): reuse worktree branch status

### DIFF
--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -322,6 +322,37 @@ describe("GitDirectoryService", () => {
     );
   });
 
+  it("reuses branch inventory across worktrees that share a common git directory", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const worktreePath = path.join(repoDir, ".worktrees", "release");
+    await mkdir(path.dirname(worktreePath), { recursive: true });
+    runGit(repoDir, ["worktree", "add", worktreePath, "release"]);
+    let forEachRefCalls = 0;
+    const runGitWithCounts = async (cwd: string, args: string[]) => {
+      if (args[0] === "for-each-ref") {
+        forEachRefCalls += 1;
+      }
+      return execFileSync("git", ["-C", cwd, ...args], {
+        encoding: "utf8",
+      }).trim();
+    };
+    const service = new GitDirectoryService({
+      cacheTtlMs: 60_000,
+      runGit: runGitWithCounts,
+    });
+
+    const primaryStatus = await service.readDirectoryStatus({ path: repoDir });
+    const worktreeStatus = await service.readDirectoryStatus({ path: worktreePath });
+
+    expect(primaryStatus?.currentBranch).toBe("main");
+    expect(worktreeStatus?.currentBranch).toBe("release");
+    expect(worktreeStatus?.branches).toEqual(primaryStatus?.branches);
+    // One local-branch scan and one local+remote base-branch scan total, not
+    // once per worktree path.
+    expect(forEachRefCalls).toBe(2);
+  });
+
   it("streams directory status lookups with bounded concurrency", async () => {
     const service = new GitDirectoryService({
       statusConcurrency: 2,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -82,6 +82,21 @@ async function readGitRoot(
   }
 }
 
+async function readGitCommonDir(params: {
+  repoRoot: string;
+  runGit: GitCommandRunner;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string> {
+  const commonDir = await params
+    .runGit(params.repoRoot, ["rev-parse", "--git-common-dir"], params.env)
+    .catch(() => "");
+  const trimmed = commonDir.trim();
+  if (!trimmed) {
+    return path.resolve(params.repoRoot, ".git");
+  }
+  return path.resolve(params.repoRoot, trimmed);
+}
+
 export async function recordCodexWorktreeOwnerThread(params: {
   worktreePath: string;
   threadId: string;
@@ -584,6 +599,19 @@ type CachedDirectoryStatus = {
   status?: NavigationDirectoryGitStatus;
 };
 
+type BranchInventory = {
+  branchesOutput: string;
+  baseBranchesOutput: string;
+  remoteHead: string;
+  worktreeList: string;
+};
+
+type CachedBranchInventory = {
+  expiresAt: number;
+  inFlight?: Promise<BranchInventory>;
+  inventory?: BranchInventory;
+};
+
 export type DirectoryGitStatusEntry = {
   directoryKey: string;
   gitStatus?: NavigationDirectoryGitStatus;
@@ -604,6 +632,8 @@ type GitDirectoryServiceOptions = {
 
 export class GitDirectoryService {
   private readonly statusCache = new Map<string, CachedDirectoryStatus>();
+  private readonly branchInventoryCache = new Map<string, CachedBranchInventory>();
+  private readonly commonGitDirByCwd = new Map<string, string>();
   private readonly cacheTtlMs: number;
   private readonly statusConcurrency: number;
   private readonly statusMaxUnread: number;
@@ -711,6 +741,11 @@ export class GitDirectoryService {
     }
 
     this.statusCache.delete(normalizedPath);
+    const commonGitDir = this.commonGitDirByCwd.get(normalizedPath);
+    if (commonGitDir) {
+      this.branchInventoryCache.delete(commonGitDir);
+      this.commonGitDirByCwd.delete(normalizedPath);
+    }
   }
 
   private async loadDirectoryStatus(
@@ -723,46 +758,22 @@ export class GitDirectoryService {
       return undefined;
     }
 
+    const commonGitDir = await readGitCommonDir({
+      repoRoot,
+      runGit,
+      env: gitEnv,
+    });
+    this.commonGitDirByCwd.set(cwd, commonGitDir);
+
     const [
       rawCurrentBranch,
-      branchesOutput,
-      baseBranchesOutput,
-      remoteHead,
-      worktreeList,
+      branchInventory,
       recentCommitsOutput,
     ] = await Promise.all([
         runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
           () => "",
         ),
-        runGit(
-          repoRoot,
-          [
-            "for-each-ref",
-            "refs/heads",
-            "--sort=-committerdate",
-            "--format=%(refname:short)%09%(committerdate:unix)",
-          ],
-          gitEnv,
-        ).catch(() => ""),
-        runGit(
-          repoRoot,
-          [
-            "for-each-ref",
-            "refs/heads",
-            "refs/remotes",
-            "--sort=-committerdate",
-            "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
-          ],
-          gitEnv,
-        ).catch(() => ""),
-        runGit(
-          repoRoot,
-          ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
-          gitEnv,
-        ).catch(() => ""),
-        runGit(repoRoot, ["worktree", "list", "--porcelain"], gitEnv).catch(
-          () => "",
-        ),
+        this.readBranchInventory({ commonGitDir, repoRoot }),
         runGit(
           repoRoot,
           [
@@ -785,8 +796,12 @@ export class GitDirectoryService {
       ],
       gitEnv,
     ).catch(() => "");
-    const parsedBranchDetailsAll = parseGitBranchDetails(branchesOutput);
-    const parsedBaseBranchDetailsAll = parseGitBaseBranchDetails(baseBranchesOutput);
+    const parsedBranchDetailsAll = parseGitBranchDetails(
+      branchInventory.branchesOutput,
+    );
+    const parsedBaseBranchDetailsAll = parseGitBaseBranchDetails(
+      branchInventory.baseBranchesOutput,
+    );
     const recentCommits = parseGitCommitSummaries(recentCommitsOutput).slice(
       0,
       MAX_TRACKED_COMMITS,
@@ -795,20 +810,20 @@ export class GitDirectoryService {
     // `main` is still found, then cap everything we hold/persist downstream.
     const defaultBranch = resolveDefaultBranch({
       branches: parsedBranchDetailsAll.map((detail) => detail.name),
-      remoteHead,
+      remoteHead: branchInventory.remoteHead,
     });
     const parsedBranchDetails = capRecentBranchDetails(parsedBranchDetailsAll, {
       keep: [currentBranch, defaultBranch],
       limit: MAX_TRACKED_BRANCHES,
     });
     const parsedBaseBranchDetails = capRecentBranchDetails(parsedBaseBranchDetailsAll, {
-      keep: [currentBranch, defaultBranch, remoteHead.trim()],
+      keep: [currentBranch, defaultBranch, branchInventory.remoteHead.trim()],
       limit: MAX_TRACKED_BRANCHES,
     });
     const branches = parsedBranchDetails.map((detail) => detail.name);
     const baseBranches = parsedBaseBranchDetails.map((detail) => detail.name);
     const worktreeBranchNames = new Set(
-      parseGitWorktreeEntries(worktreeList)
+      parseGitWorktreeEntries(branchInventory.worktreeList)
         .map((entry) => entry.branch)
         .filter((branch): branch is string => Boolean(branch)),
     );
@@ -841,7 +856,7 @@ export class GitDirectoryService {
       branches,
       currentBranch,
       defaultBranch,
-      worktreeList,
+      worktreeList: branchInventory.worktreeList,
     });
 
     if (!upstreamBranch) {
@@ -890,6 +905,84 @@ export class GitDirectoryService {
       recentCommits,
       handoffBranches,
       syncState,
+    };
+  }
+
+  private async readBranchInventory(params: {
+    commonGitDir: string;
+    repoRoot: string;
+  }): Promise<BranchInventory> {
+    const cached = this.branchInventoryCache.get(params.commonGitDir);
+    const now = Date.now();
+    if (cached?.inFlight) {
+      return await cached.inFlight;
+    }
+
+    if (cached?.inventory && cached.expiresAt > now) {
+      return cached.inventory;
+    }
+
+    const inFlight = this.loadBranchInventory(params.repoRoot).then((inventory) => {
+      this.branchInventoryCache.set(params.commonGitDir, {
+        expiresAt: Date.now() + this.cacheTtlMs,
+        inventory,
+      });
+      return inventory;
+    });
+    this.branchInventoryCache.set(params.commonGitDir, {
+      expiresAt: cached?.expiresAt ?? 0,
+      inFlight,
+      inventory: cached?.inventory,
+    });
+
+    return await inFlight;
+  }
+
+  private async loadBranchInventory(repoRoot: string): Promise<BranchInventory> {
+    const runGit = this.runGitCommand;
+    const gitEnv = this.gitEnv;
+    const [
+      branchesOutput,
+      baseBranchesOutput,
+      remoteHead,
+      worktreeList,
+    ] = await Promise.all([
+      runGit(
+        repoRoot,
+        [
+          "for-each-ref",
+          "refs/heads",
+          "--sort=-committerdate",
+          "--format=%(refname:short)%09%(committerdate:unix)",
+        ],
+        gitEnv,
+      ).catch(() => ""),
+      runGit(
+        repoRoot,
+        [
+          "for-each-ref",
+          "refs/heads",
+          "refs/remotes",
+          "--sort=-committerdate",
+          "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
+        ],
+        gitEnv,
+      ).catch(() => ""),
+      runGit(
+        repoRoot,
+        ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+        gitEnv,
+      ).catch(() => ""),
+      runGit(repoRoot, ["worktree", "list", "--porcelain"], gitEnv).catch(
+        () => "",
+      ),
+    ]);
+
+    return {
+      branchesOutput,
+      baseBranchesOutput,
+      remoteHead,
+      worktreeList,
     };
   }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4694,6 +4694,134 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("inherits repo git status for new-worktree sub-thread branch pickers", async () => {
+    const repoPath = "/repo/app";
+    const parentWorktreePath = "/repo/app/.worktrees/parent/app";
+    const parentThread = {
+      id: "thread-parent",
+      title: "Worktree parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: parentWorktreePath,
+          label: "app",
+          path: repoPath,
+          worktreePath: parentWorktreePath,
+          kind: "worktree" as const,
+        },
+      ],
+      gitBranch: "feature/parent",
+      observedGitBranch: "feature/parent",
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:new-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: parentWorktreePath,
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey: "subthread:codex:thread-parent:new-worktree",
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: parentWorktreePath,
+        workMode: "worktree" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "feature/parent",
+        parentThreadId: "thread-parent",
+        parentThreadTitle: "Worktree parent",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const gitStatus = {
+      currentBranch: "feature/parent",
+      defaultBranch: "develop",
+      branches: ["feature/parent", "develop", "release"],
+      baseBranches: [
+        "feature/parent",
+        "develop",
+        "origin/develop",
+        "release",
+      ],
+      syncState: "untracked" as const,
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [
+        {
+          key: `directory:${repoPath}`,
+          kind: "directory" as const,
+          label: "app",
+          path: repoPath,
+          threadKeys: ["codex:thread-parent"],
+          needsAttentionCount: 0,
+          gitStatus,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "new-worktree");
+    });
+
+    expect(result.current.selectedDirectory?.key).toBe(
+      "subthread:codex:thread-parent:new-worktree",
+    );
+    expect(result.current.selectedDirectory?.gitStatus).toMatchObject({
+      currentBranch: "feature/parent",
+      defaultBranch: "develop",
+      baseBranches: expect.arrayContaining(["develop", "origin/develop"]),
+    });
+    expect(result.current.selectedDirectory?.threadKeys).toEqual([]);
+  });
+
   it("opens same-worktree sub-thread launchpads on the parent worktree branch", async () => {
     const parentThread = {
       id: "thread-parent",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -150,6 +150,7 @@ function selectThreadWorkspace(
   directoryKind: NavigationDirectorySummary["kind"];
   directoryLabel: string;
   directoryPath?: string;
+  gitStatusSourcePath?: string;
   workMode: NavigationLaunchpadDraft["workMode"];
   branchName?: string;
 } {
@@ -171,6 +172,7 @@ function selectThreadWorkspace(
       directoryKind: repository ? "directory" : "workspace",
       directoryLabel: preferred?.label ?? thread.title,
       directoryPath: repository,
+      gitStatusSourcePath: worktree?.path ?? local?.path ?? repository,
       workMode: "worktree",
     };
   }
@@ -186,6 +188,10 @@ function selectThreadWorkspace(
         ? local?.label ?? thread.title
         : preferred?.label ?? thread.title,
     directoryPath: sameWorkspacePath,
+    gitStatusSourcePath:
+      mode === "local"
+        ? local?.path ?? sameWorkspacePath
+        : worktree?.path ?? local?.path ?? sameWorkspacePath,
     workMode: "local",
     ...(mode === "same-worktree" && namedBranch ? { branchName: namedBranch } : {}),
   };
@@ -205,11 +211,48 @@ function sortNavigationDirectories(
   return [...directories].sort(compareNavigationDirectoriesByLabel);
 }
 
+function findLaunchpadSourceDirectory(
+  directories: NavigationSnapshot["directories"],
+  launchpad: NavigationLaunchpadDraft,
+  sourcePath?: string,
+): NavigationSnapshot["directories"][number] | undefined {
+  const normalizedSourcePath = sourcePath?.trim();
+  if (normalizedSourcePath) {
+    const sourceDirectory = directories.find(
+      (directory) =>
+        directory.key !== launchpad.directoryKey &&
+        directory.path?.trim() === normalizedSourcePath,
+    );
+    if (sourceDirectory) {
+      return sourceDirectory;
+    }
+  }
+
+  const launchpadPath = launchpad.directoryPath?.trim();
+  if (!launchpadPath) {
+    return undefined;
+  }
+
+  return directories.find(
+    (directory) =>
+      directory.key !== launchpad.directoryKey &&
+      directory.path?.trim() === launchpadPath,
+  );
+}
+
 function upsertLaunchpadDirectory(
   directories: NavigationSnapshot["directories"],
   launchpad: NavigationLaunchpadDraft,
+  options?: {
+    gitStatusSourcePath?: string;
+  },
 ): NavigationSnapshot["directories"] {
   let foundDirectory = false;
+  const sourceDirectory = findLaunchpadSourceDirectory(
+    directories,
+    launchpad,
+    options?.gitStatusSourcePath,
+  );
   const nextDirectories = directories.map((directory) => {
     if (directory.key !== launchpad.directoryKey) {
       return directory;
@@ -221,6 +264,11 @@ function upsertLaunchpadDirectory(
       kind: launchpad.directoryKind,
       label: launchpad.directoryLabel,
       path: launchpad.directoryPath ?? directory.path,
+      ...(directory.gitStatus
+        ? {}
+        : sourceDirectory?.gitStatus
+          ? { gitStatus: sourceDirectory.gitStatus }
+          : {}),
       launchpad,
     };
   });
@@ -237,6 +285,9 @@ function upsertLaunchpadDirectory(
             path: launchpad.directoryPath,
             threadKeys: [],
             needsAttentionCount: 0,
+            ...(sourceDirectory?.gitStatus
+              ? { gitStatus: sourceDirectory.gitStatus }
+              : {}),
             launchpad,
           },
         ],
@@ -1617,7 +1668,10 @@ function applyThreadExecutionModeQueueCleared(
 function applyLaunchpadUpdate(
   snapshot: NavigationSnapshot | undefined,
   launchpad: NavigationLaunchpadDraft,
-  defaults: NavigationSnapshot["launchpadDefaults"]
+  defaults: NavigationSnapshot["launchpadDefaults"],
+  options?: {
+    gitStatusSourcePath?: string;
+  },
 ): NavigationSnapshot | undefined {
   if (!snapshot) {
     return {
@@ -1626,14 +1680,14 @@ function applyLaunchpadUpdate(
       unchanged: false,
       threads: [],
       inboxThreadKeys: [],
-      directories: upsertLaunchpadDirectory([], launchpad),
+      directories: upsertLaunchpadDirectory([], launchpad, options),
       launchpadDefaults: defaults,
     };
   }
 
   return {
     ...snapshot,
-    directories: upsertLaunchpadDirectory(snapshot.directories, launchpad),
+    directories: upsertLaunchpadDirectory(snapshot.directories, launchpad, options),
     launchpadDefaults: defaults,
   };
 }
@@ -3832,7 +3886,9 @@ export function useThreadNavigation(
         }));
         setState((current) => ({
           ...current,
-          response: applyLaunchpadUpdate(current.response, launchpad, defaults),
+          response: applyLaunchpadUpdate(current.response, launchpad, defaults, {
+            gitStatusSourcePath: directory.gitStatusSourcePath,
+          }),
         }));
         setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
       } catch (error) {


### PR DESCRIPTION
## Summary

Grouped subthread branch pickers now open with the full known branch inventory instead of briefly showing only the parent thread branch while git status catches up. Branch-heavy repositories also avoid repeating the shared ref enumeration for each managed worktree; the branch inventory is cached at the common git directory while current branch, upstream state, and recent commits remain per worktree.

This keeps the parent branch selected by default, but still lets operators choose the repository default branch or any other discovered local/remote base branch immediately when starting a grouped new-worktree subthread.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx -- --runInBand`
- `pnpm lint:eslint -- apps/desktop/src/main/app-server/git-directory-service.ts apps/desktop/src/main/__tests__/git-directory-service.test.ts apps/desktop/src/renderer/src/lib/useThreadNavigation.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (existing warning baseline, no errors)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
