### PR TITLE
fix(desktop): preserve subthread branch picker status

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4822,6 +4822,156 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedDirectory?.threadKeys).toEqual([]);
   });
 
+  it("keeps launchpad git status streamed before the sub-thread directory exists", async () => {
+    const repoPath = "/repo/app";
+    const parentWorktreePath = "/repo/app/.worktrees/parent/app";
+    const directoryKey = "subthread:codex:thread-parent:new-worktree";
+    type AgentEvent = Parameters<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >[0];
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const parentThread = {
+      id: "thread-parent",
+      title: "Worktree parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: parentWorktreePath,
+          label: "app",
+          path: repoPath,
+          worktreePath: parentWorktreePath,
+          kind: "worktree" as const,
+        },
+      ],
+      gitBranch: "feature/parent",
+      observedGitBranch: "feature/parent",
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const gitStatus = {
+      currentBranch: "feature/parent",
+      defaultBranch: "develop",
+      baseBranches: [
+        "feature/parent",
+        "develop",
+        "origin/develop",
+        "release",
+      ],
+      syncState: "untracked" as const,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "navigation/directoryGitStatus/updated",
+            params: {
+              directoryKey,
+              gitStatus,
+              fetchedAt: Date.now(),
+            },
+          },
+        } as unknown as AgentEvent);
+      }
+      return {
+        launchpad: {
+          directoryKey,
+          directoryKind: "directory" as const,
+          directoryLabel: "app",
+          directoryPath: parentWorktreePath,
+          workMode: "local" as const,
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          prompt: "",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        defaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      };
+    });
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey,
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: parentWorktreePath,
+        workMode: "worktree" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "feature/parent",
+        parentThreadId: "thread-parent",
+        parentThreadTitle: "Worktree parent",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [
+        {
+          key: `directory:${repoPath}`,
+          kind: "directory" as const,
+          label: "app",
+          path: repoPath,
+          threadKeys: ["codex:thread-parent"],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "new-worktree");
+    });
+
+    expect(result.current.selectedDirectory?.key).toBe(directoryKey);
+    expect(result.current.selectedDirectory?.gitStatus).toMatchObject({
+      currentBranch: "feature/parent",
+      defaultBranch: "develop",
+      baseBranches: expect.arrayContaining(["develop", "origin/develop"]),
+    });
+  });
+
   it("opens same-worktree sub-thread launchpads on the parent worktree branch", async () => {
     const parentThread = {
       id: "thread-parent",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -10,6 +10,7 @@ import type {
   HandoffThreadWorkspaceRequest,
   LinkedDirectorySummary,
   NavigationBrowseMode,
+  NavigationDirectoryGitStatus,
   NavigationDirectoryGitStatusUpdatedNotification,
   NavigationDirectorySummary,
   NavigationLaunchpadDefaults,
@@ -244,6 +245,7 @@ function upsertLaunchpadDirectory(
   directories: NavigationSnapshot["directories"],
   launchpad: NavigationLaunchpadDraft,
   options?: {
+    gitStatus?: NavigationDirectoryGitStatus | null;
     gitStatusSourcePath?: string;
   },
 ): NavigationSnapshot["directories"] {
@@ -253,24 +255,34 @@ function upsertLaunchpadDirectory(
     launchpad,
     options?.gitStatusSourcePath,
   );
+  const hasGitStatusOverride =
+    options && Object.prototype.hasOwnProperty.call(options, "gitStatus");
+  const inheritedGitStatus = hasGitStatusOverride
+    ? options.gitStatus ?? undefined
+    : sourceDirectory?.gitStatus;
   const nextDirectories = directories.map((directory) => {
     if (directory.key !== launchpad.directoryKey) {
       return directory;
     }
 
     foundDirectory = true;
-    return {
+    const next: NavigationSnapshot["directories"][number] = {
       ...directory,
       kind: launchpad.directoryKind,
       label: launchpad.directoryLabel,
       path: launchpad.directoryPath ?? directory.path,
-      ...(directory.gitStatus
-        ? {}
-        : sourceDirectory?.gitStatus
-          ? { gitStatus: sourceDirectory.gitStatus }
-          : {}),
       launchpad,
     };
+    if (hasGitStatusOverride) {
+      if (inheritedGitStatus) {
+        next.gitStatus = inheritedGitStatus;
+      } else {
+        delete next.gitStatus;
+      }
+    } else if (!directory.gitStatus && inheritedGitStatus) {
+      next.gitStatus = inheritedGitStatus;
+    }
+    return next;
   });
 
   return sortNavigationDirectories(
@@ -285,8 +297,8 @@ function upsertLaunchpadDirectory(
             path: launchpad.directoryPath,
             threadKeys: [],
             needsAttentionCount: 0,
-            ...(sourceDirectory?.gitStatus
-              ? { gitStatus: sourceDirectory.gitStatus }
+            ...(inheritedGitStatus
+              ? { gitStatus: inheritedGitStatus }
               : {}),
             launchpad,
           },
@@ -1670,6 +1682,7 @@ function applyLaunchpadUpdate(
   launchpad: NavigationLaunchpadDraft,
   defaults: NavigationSnapshot["launchpadDefaults"],
   options?: {
+    gitStatus?: NavigationDirectoryGitStatus | null;
     gitStatusSourcePath?: string;
   },
 ): NavigationSnapshot | undefined {
@@ -2304,6 +2317,9 @@ export function useThreadNavigation(
   const backgroundRefreshIdleRef = useRef(false);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
   const pendingPickedLaunchpadRef = useRef(new Map<string, NavigationLaunchpadDraft>());
+  const pendingDirectoryGitStatusRef = useRef(
+    new Map<string, NavigationDirectoryGitStatus | null>(),
+  );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
 
@@ -2539,6 +2555,18 @@ export function useThreadNavigation(
   const refreshNavigation = useCallback(async (): Promise<void> => {
     await refresh();
   }, [refresh]);
+
+  const takePendingDirectoryGitStatus = useCallback(
+    (directoryKey: string): NavigationDirectoryGitStatus | null | undefined => {
+      if (!pendingDirectoryGitStatusRef.current.has(directoryKey)) {
+        return undefined;
+      }
+      const gitStatus = pendingDirectoryGitStatusRef.current.get(directoryKey);
+      pendingDirectoryGitStatusRef.current.delete(directoryKey);
+      return gitStatus ?? null;
+    },
+    [],
+  );
 
   const scheduleRefresh = useCallback(
     (
@@ -2795,10 +2823,28 @@ export function useThreadNavigation(
       if (method === "navigation/directoryGitStatus/updated") {
         const params = event.notification
           .params as NavigationDirectoryGitStatusUpdatedNotification["params"];
-        setState((current) => ({
-          ...current,
-          response: applyDirectoryGitStatusUpdate(current.response, params),
-        }));
+        const hasDirectoryNow = stateRef.current.response?.directories.some(
+          (directory) => directory.key === params.directoryKey,
+        ) ?? false;
+        if (!hasDirectoryNow) {
+          pendingDirectoryGitStatusRef.current.set(
+            params.directoryKey,
+            params.gitStatus,
+          );
+        }
+        setState((current) => {
+          const hasDirectory = current.response?.directories.some(
+            (directory) => directory.key === params.directoryKey,
+          ) ?? false;
+          if (!hasDirectory) {
+            return current;
+          }
+          pendingDirectoryGitStatusRef.current.delete(params.directoryKey);
+          return {
+            ...current,
+            response: applyDirectoryGitStatusUpdate(current.response, params),
+          };
+        });
         return;
       }
 
@@ -3672,9 +3718,17 @@ export function useThreadNavigation(
           ...current,
           [directoryKey]: launchpad,
         }));
+        const pendingGitStatus = takePendingDirectoryGitStatus(directoryKey);
         setState((current) => ({
           ...current,
-          response: applyLaunchpadUpdate(current.response, launchpad, defaults),
+          response: applyLaunchpadUpdate(
+            current.response,
+            launchpad,
+            defaults,
+            pendingGitStatus !== undefined
+              ? { gitStatus: pendingGitStatus }
+              : undefined,
+          ),
         }));
         const selectionKey = buildLaunchpadSelectionKey(directoryKey);
         pendingPickedLaunchpadRef.current.set(directoryKey, launchpad);
@@ -3704,7 +3758,14 @@ export function useThreadNavigation(
         setCreatingThread(undefined);
       }
     },
-    [desktopApi, directories, refresh, selectedDirectory, selectedThreadKey]
+    [
+      desktopApi,
+      directories,
+      refresh,
+      selectedDirectory,
+      selectedThreadKey,
+      takePendingDirectoryGitStatus,
+    ]
   );
 
   /**
@@ -3884,9 +3945,13 @@ export function useThreadNavigation(
           ...current,
           [directoryKey]: launchpad,
         }));
+        const pendingGitStatus = takePendingDirectoryGitStatus(directoryKey);
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(current.response, launchpad, defaults, {
+            ...(pendingGitStatus !== undefined
+              ? { gitStatus: pendingGitStatus }
+              : {}),
             gitStatusSourcePath: directory.gitStatusSourcePath,
           }),
         }));
@@ -3897,7 +3962,7 @@ export function useThreadNavigation(
         setCreatingThread(undefined);
       }
     },
-    [desktopApi, resolveGroupRoot],
+    [desktopApi, resolveGroupRoot, takePendingDirectoryGitStatus],
   );
 
   const forkThread = useCallback(


### PR DESCRIPTION
## Summary
Creating a grouped subthread in a new worktree no longer opens a branch picker with only the parent branch when the branch inventory arrives before the synthetic launchpad row exists. The renderer now buffers that early git-status event and applies it when the launchpad directory is inserted, so the picker can show the full base branch list immediately.

## Validation
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec eslint apps/desktop/src/renderer/src/lib/useThreadNavigation.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (existing warnings only)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
