### PR TITLE
fix(desktop): track branches for attached worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4023,6 +4023,73 @@ describe("app server ipc", () => {
     });
   });
 
+  it("refreshes post-turn pull requests for a scoped linked worktree branch", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/primary",
+        linkedDirectories: [
+          {
+            id: "directory:/repo/primary",
+            label: "primary",
+            path: "/repo/primary",
+            kind: "local",
+          },
+          {
+            id: "directory:/repo/kube-manifests",
+            label: "kube-manifests",
+            path: "/repo/kube-manifests",
+            kind: "worktree",
+            worktreePath: "/worktrees/kube-manifests",
+            gitBranch: "fix/channelsv2-live-pods",
+          },
+        ],
+        gitBranch: "main",
+        observedGitBranch: "main",
+        updatedAt: 2000,
+      },
+    ] as never);
+    detectPullRequestsForThread.mockResolvedValue([]);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    detectPullRequestsForThread.mockClear();
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "main",
+        directoryPaths: ["/repo/primary"],
+      });
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "fix/channelsv2-live-pods",
+        directoryPaths: ["/worktrees/kube-manifests"],
+      });
+    });
+  });
+
   it("ignores a completed non-git command for working-state refresh", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -19857,6 +19857,143 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("records the observed branch on an attached managed worktree", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-attach-worktree-"));
+    const repoPath = path.join(root, "kube-manifests");
+    const worktreePath = path.join(root, "worktrees", "kube-manifests");
+    await mkdir(repoPath, { recursive: true });
+    try {
+      await git(repoPath, ["init", "-b", "master"]);
+    } catch {
+      await git(repoPath, ["init"]);
+      await git(repoPath, ["checkout", "-b", "master"]);
+    }
+    await writeFile(path.join(repoPath, "README.md"), "kube manifests\n", "utf8");
+    await git(repoPath, ["add", "README.md"]);
+    await git(repoPath, [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=tests@pwragent.local",
+      "commit",
+      "-m",
+      "initial",
+    ]);
+    await mkdir(path.dirname(worktreePath), { recursive: true });
+    await git(repoPath, [
+      "worktree",
+      "add",
+      "-b",
+      "fix/channelsv2-live-pods",
+      worktreePath,
+      "master",
+    ]);
+
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:agent-thread": {
+          ...createAgentOverlay(),
+          executionMode: "full-access",
+          gitBranch: "HEAD",
+          observedGitBranch: "HEAD",
+        },
+      },
+    });
+    const prepareLaunchpadWorkspace = vi.fn(async () => ({
+      cwd: worktreePath,
+      repositoryPath: repoPath,
+      rollback: vi.fn(async () => undefined),
+      workMode: "worktree" as const,
+    }));
+    const recordCodexWorktreeOwnerThread = vi.fn(async () => undefined);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace,
+        recordCodexWorktreeOwnerThread,
+        resolvePrimaryWorkspacePath: vi.fn(async () => repoPath),
+      } as never,
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    try {
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "agent-thread",
+            turnId: "turn-1",
+            turn: { id: "turn-1" },
+          },
+        },
+      });
+
+      const response = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          callId: "call-1",
+          requestId: "call-1",
+          namespace: "pwragent",
+          tool: "attach_thread_directory",
+          arguments: {
+            path: repoPath,
+            workspaceMode: "new_worktree",
+            branchName: "master",
+            worktreeBranchMode: "attached",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(response).toMatchObject({ success: true });
+      const payload = JSON.parse(
+        (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+      );
+      expect(payload).toMatchObject({
+        branch: "fix/channelsv2-live-pods",
+      });
+      const overlay = await overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "agent-thread",
+      });
+      expect(overlay).toMatchObject({
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+      });
+      expect(overlay?.extraLinkedDirectories).toEqual([
+        expect.objectContaining({
+          gitBranch: "fix/channelsv2-live-pods",
+          kind: "worktree",
+          path: expectedDir(repoPath),
+          worktreePath: expectedDir(worktreePath),
+        }),
+      ]);
+      expect(
+        events.some(
+          (event) =>
+            event.notification.method === "thread/branch/updated" &&
+            event.notification.params.threadId === "agent-thread" &&
+            event.notification.params.branch === "fix/channelsv2-live-pods",
+        ),
+      ).toBe(false);
+    } finally {
+      unsubscribe();
+      await registry.close();
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
   it("requires confirmation before attaching an untrusted directory in Default Access", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -16127,7 +16127,7 @@ export class DesktopBackendRegistry {
         return trustFailure;
       }
 
-      const directory =
+      let directory =
         workspaceMode === "new_worktree"
           ? await this.createAttachedWorktreeDirectory({
               backend,
@@ -16139,6 +16139,17 @@ export class DesktopBackendRegistry {
               return result.directory;
             })
           : await this.createAttachedLocalDirectory(repositoryPath);
+      const branchSource = directory.worktreePath ?? directory.path;
+      const branch = branchSource
+        ? await readCurrentGitBranch(branchSource).catch(() => undefined)
+        : undefined;
+      const normalizedBranch = branch?.trim() || undefined;
+      if (workspaceMode === "new_worktree" && normalizedBranch) {
+        directory = {
+          ...directory,
+          gitBranch: normalizedBranch,
+        };
+      }
 
       const overlay = await this.overlayStore.addLinkedDirectory({
         backend,
@@ -16157,10 +16168,6 @@ export class DesktopBackendRegistry {
         },
       });
 
-      const branchSource = directory.worktreePath ?? directory.path;
-      const branch = branchSource
-        ? await readCurrentGitBranch(branchSource).catch(() => undefined)
-        : undefined;
       return {
         ok: true,
         data: {
@@ -16170,7 +16177,7 @@ export class DesktopBackendRegistry {
             (current) => current.id === directory.id,
           ) ?? directory,
           workspaceMode,
-          ...(branch ? { branch } : {}),
+          ...(normalizedBranch ? { branch: normalizedBranch } : {}),
           message:
             workspaceMode === "new_worktree"
               ? "Attached a managed worktree directory to this thread."

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -218,6 +218,15 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "readThreadGitWorkingStateCache"
     | "writeThreadGitWorkingStateCacheEntry"
   >;
+
+type ThreadPrRefreshContext = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  branch: string;
+  directoryPaths: string[];
+  branchScoped: boolean;
+};
+
 const appServerLog = getMainLogger("pwragent:app-server");
 
 /**
@@ -794,12 +803,7 @@ class DesktopAppServerService {
   private readonly worktreePathByThreadKey = new Map<string, string>();
   private readonly prRefreshContextByThreadKey = new Map<
     string,
-    {
-      backend: AppServerBackendKind;
-      threadId: string;
-      branch: string;
-      directoryPaths: string[];
-    }
+    ThreadPrRefreshContext[]
   >();
   // Merged PR commits are accepted as "pushed" even when the PR head branch
   // has been deleted and no remote ref still contains those SHAs locally.
@@ -1291,19 +1295,12 @@ class DesktopAppServerService {
   ): void {
     for (const thread of threads) {
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-      const branch =
-        thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || "";
-      const directoryPaths = resolveThreadPullRequestDirectoryPaths(thread);
-      if (!branch || directoryPaths.length === 0) {
+      const contexts = resolveThreadPullRequestContexts(thread);
+      if (contexts.length === 0) {
         this.prRefreshContextByThreadKey.delete(threadKey);
         continue;
       }
-      this.prRefreshContextByThreadKey.set(threadKey, {
-        backend: thread.source,
-        threadId: thread.id,
-        branch,
-        directoryPaths,
-      });
+      this.prRefreshContextByThreadKey.set(threadKey, contexts);
     }
   }
 
@@ -1892,12 +1889,14 @@ class DesktopAppServerService {
     const threadKey = buildThreadIdentityKey(event.backend, threadId);
     if (method === "thread/branch/updated") {
       const branch = params.branch?.trim();
-      const existingContext = this.prRefreshContextByThreadKey.get(threadKey);
-      if (branch && existingContext) {
-        this.prRefreshContextByThreadKey.set(threadKey, {
-          ...existingContext,
-          branch,
-        });
+      const existingContexts = this.prRefreshContextByThreadKey.get(threadKey);
+      if (branch && existingContexts) {
+        this.prRefreshContextByThreadKey.set(
+          threadKey,
+          existingContexts.map((context) =>
+            context.branchScoped ? context : { ...context, branch },
+          ),
+        );
       }
     }
 
@@ -1914,18 +1913,20 @@ class DesktopAppServerService {
     }
 
     if (method === "turn/completed") {
-      const prContext = this.prRefreshContextByThreadKey.get(threadKey);
-      if (prContext) {
-        void this.refreshThreadPullRequests({
-          ...prContext,
-          provider: "github.com",
-          trigger: "post-turn",
-        }).catch((error) => {
-          appServerLog.warn("post-turn PR refresh failed", {
-            threadId,
-            error: error instanceof Error ? error.message : String(error),
+      const prContexts = this.prRefreshContextByThreadKey.get(threadKey);
+      if (prContexts?.length) {
+        for (const prContext of prContexts) {
+          void this.refreshThreadPullRequests({
+            ...prContext,
+            provider: "github.com",
+            trigger: "post-turn",
+          }).catch((error) => {
+            appServerLog.warn("post-turn PR refresh failed", {
+              threadId,
+              error: error instanceof Error ? error.message : String(error),
+            });
           });
-        });
+        }
       }
     }
   }
@@ -3515,17 +3516,61 @@ function isFreshWorktreeWorkingStateCacheEntry(
   return Date.now() - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
 }
 
+function resolveThreadPullRequestContexts(
+  thread: Pick<
+    AppServerThreadSummary,
+    "gitBranch" | "id" | "linkedDirectories" | "observedGitBranch" | "source"
+  >,
+): ThreadPrRefreshContext[] {
+  const contexts: ThreadPrRefreshContext[] = [];
+  const threadBranch =
+    thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || "";
+  const unscopedDirectoryPaths = resolveThreadPullRequestDirectoryPaths({
+    linkedDirectories: (thread.linkedDirectories ?? []).filter(
+      (directory) => !directory.gitBranch?.trim(),
+    ),
+  });
+  if (threadBranch && unscopedDirectoryPaths.length > 0) {
+    contexts.push({
+      backend: thread.source,
+      threadId: thread.id,
+      branch: threadBranch,
+      directoryPaths: unscopedDirectoryPaths,
+      branchScoped: false,
+    });
+  }
+
+  const seenScopedKeys = new Set<string>();
+  for (const directory of thread.linkedDirectories ?? []) {
+    const branch = directory.gitBranch?.trim();
+    const directoryPath = resolvePullRequestDirectoryPath(directory);
+    if (!branch || branch === "HEAD" || !directoryPath) {
+      continue;
+    }
+    const key = `${branch}\0${directoryPath}`;
+    if (seenScopedKeys.has(key)) {
+      continue;
+    }
+    seenScopedKeys.add(key);
+    contexts.push({
+      backend: thread.source,
+      threadId: thread.id,
+      branch,
+      directoryPaths: [directoryPath],
+      branchScoped: true,
+    });
+  }
+
+  return contexts;
+}
+
 function resolveThreadPullRequestDirectoryPaths(
   thread: Pick<AppServerThreadSummary, "linkedDirectories">,
 ): string[] {
   const seen = new Set<string>();
   const paths: string[] = [];
   for (const directory of thread.linkedDirectories ?? []) {
-    const candidate =
-      directory.kind === "worktree"
-        ? directory.worktreePath ?? directory.path
-        : directory.path;
-    const normalized = candidate?.trim();
+    const normalized = resolvePullRequestDirectoryPath(directory);
     if (!normalized || seen.has(normalized)) {
       continue;
     }
@@ -3533,6 +3578,16 @@ function resolveThreadPullRequestDirectoryPaths(
     paths.push(normalized);
   }
   return paths;
+}
+
+function resolvePullRequestDirectoryPath(
+  directory: AppServerThreadSummary["linkedDirectories"][number],
+): string | undefined {
+  const candidate =
+    directory.kind === "worktree"
+      ? directory.worktreePath ?? directory.path
+      : directory.path;
+  return candidate?.trim() || undefined;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -2194,6 +2194,37 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByLabelText("Path for PwrAgent Other")).toBeInTheDocument();
   });
 
+  it("shows scoped linked-project branches before the thread branch", () => {
+    renderPanel({
+      activeTab: "projects",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        gitBranch: "main",
+        linkedDirectories: [
+          {
+            id: "primary-dir",
+            kind: "local",
+            label: "PwrAgent",
+            path: "/Users/huntharo/github/PwrAgent",
+          },
+          {
+            id: "kube-dir",
+            kind: "worktree",
+            label: "kube-manifests",
+            path: "/Users/huntharo/github/kube-manifests",
+            worktreePath:
+              "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+            gitBranch: "fix/channelsv2-live-pods",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByText("fix/channelsv2-live-pods")).toBeInTheDocument();
+  });
+
   it("detaches a secondary linked project from the Linked Projects tab", async () => {
     const detachDirectoryFromThread = vi.fn(async () => ({
       ok: true as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -36,7 +36,6 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
   const [detachingDirectoryId, setDetachingDirectoryId] = useState<string>();
   const directories = dedupeLinkedProjectDirectories(props.thread.linkedDirectories);
   const prs = props.thread.prs ?? [];
-  const branch = props.thread.gitBranch;
   const canAttachDirectory = Boolean(
     props.desktopApi?.pickDirectoryFromDisk && props.desktopApi.attachDirectoryToThread,
   );
@@ -120,6 +119,7 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
         <ul className="context-list linked-projects-list">
           {directories.map((directory, index) => {
             const worktreePath = directory.worktreePath ?? directory.path;
+            const branch = directory.gitBranch ?? props.thread.gitBranch;
             const canDetachDirectory = Boolean(
               props.desktopApi?.detachDirectoryFromThread
                 && directories.length > 1

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -441,8 +441,10 @@ export function buildNavigationSnapshotHash(params: {
       ),
       linkedDirectories: thread.linkedDirectories.map((directory) => ({
         id: directory.id,
+        gitBranch: directory.gitBranch ?? null,
         kind: directory.kind,
         path: directory.path,
+        worktreePath: directory.worktreePath ?? null,
       })),
       worktreeSnapshots: (thread.worktreeSnapshots ?? []).map((snapshot) => ({
         id: snapshot.id,

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -107,6 +107,8 @@ export type LinkedDirectorySummary = {
    * commands, VS Code, and terminal launches should prefer this over path.
    */
   worktreePath?: string;
+  /** Best-effort branch observed for this linked directory/worktree. */
+  gitBranch?: string;
   kind: "local" | "worktree";
 };
 


### PR DESCRIPTION
## Summary
Managed worktrees attached through `attach_thread_directory` now keep their observed branch on the linked-directory record instead of promoting it to the thread-wide branch. That lets Linked Projects show a secondary worktree on `fix/channelsv2-live-pods` while the primary thread can remain on `main` or `HEAD`, avoiding false branch drift and stale branch chips.

Post-turn PR discovery now builds branch/path contexts per thread: the primary workspace still uses the thread branch, while any linked directory with its own branch gets a scoped lookup against its own worktree path. That gives secondary attached worktrees a path to automatic PR attachment without corrupting the primary workspace metadata.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "records the observed branch on an attached managed worktree"`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts -t "refreshes pull requests for the rendered branch when a turn completes|refreshes post-turn pull requests for a scoped linked worktree branch|refreshes post-turn pull requests for an adopted branch instead of stale snapshot context"`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx -t "shows scoped linked-project branches before the thread branch"`
- `pnpm typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
