### PR TITLE
fix(desktop): preserve thread selection during launch

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3004,6 +3004,140 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.id).toBe("thread-existing");
   });
 
+  it("does not let a pending materialized thread override a newer user thread selection", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey,
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/github/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "Start the pending focus thread",
+      workMode: "worktree",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const defaults: NavigationLaunchpadDefaults = {
+      backend: "codex",
+      executionMode: "default",
+    };
+    const materializeResponse = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      executionMode: "default";
+      workMode: "worktree";
+    }>();
+    const initialSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-existing",
+          title: "Existing thread",
+          titleSource: "explicit",
+          summary: "Existing thread summary",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 1_000,
+        },
+        {
+          id: "thread-stay-put",
+          title: "Stay put thread",
+          titleSource: "explicit",
+          summary: "Thread selected while the launchpad is starting",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+          updatedAt: 900,
+        },
+      ],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: ["codex:thread-existing", "codex:thread-stay-put"],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: defaults,
+    };
+    const getNavigationSnapshot = vi.fn(async () => initialSnapshot);
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad,
+      defaults,
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(
+      async () => await materializeResponse.promise
+    );
+
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-existing");
+    });
+
+    await act(async () => {
+      await result.current.openDirectoryLaunchpad(result.current.directories[0]!);
+    });
+
+    expect(result.current.selectedLaunchpad?.directoryKey).toBe(directoryKey);
+
+    let materializePromise: Promise<void> | undefined;
+    act(() => {
+      materializePromise = result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    await waitFor(() => {
+      expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+        directoryKey,
+        launchpad: expect.objectContaining({
+          directoryKey,
+        }),
+        input: undefined,
+        collaborationMode: undefined,
+        reviewTarget: undefined,
+      });
+    });
+
+    act(() => {
+      result.current.selectThread(
+        result.current.threads.find((thread) => thread.id === "thread-stay-put")!,
+      );
+    });
+    expect(result.current.selectedThread?.id).toBe("thread-stay-put");
+
+    await act(async () => {
+      materializeResponse.resolve({
+        backend: "codex",
+        threadId: "thread-new",
+        executionMode: "default",
+        workMode: "worktree",
+      });
+      await materializePromise;
+    });
+
+    expect(result.current.threads.map((thread) => thread.id)).toContain("thread-new");
+    expect(result.current.selectedThread?.id).toBe("thread-stay-put");
+  });
+
   it("does not keep a directory launchpad selected when a thread in that directory is selected", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3138,6 +3138,170 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.id).toBe("thread-stay-put");
   });
 
+  it("does not let an older launchpad completion replace a newer optimistic selection", async () => {
+    const firstDirectoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const secondDirectoryKey = "directory:/Users/huntharo/github/OtherApp";
+    const defaults: NavigationLaunchpadDefaults = {
+      backend: "codex",
+      executionMode: "default",
+    };
+    const firstMaterialize = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      executionMode: "default";
+      workMode: "worktree";
+    }>();
+    const secondMaterialize = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      executionMode: "default";
+      workMode: "worktree";
+    }>();
+    const launchpadsByDirectory = new Map<string, NavigationLaunchpadDraft>(
+      [firstDirectoryKey, secondDirectoryKey].map((directoryKey) => [
+        directoryKey,
+        {
+          directoryKey,
+          directoryKind: "directory",
+          directoryLabel: directoryKey === firstDirectoryKey ? "PwrAgent" : "OtherApp",
+          directoryPath:
+            directoryKey === firstDirectoryKey
+              ? "/Users/huntharo/github/PwrAgent"
+              : "/Users/huntharo/github/OtherApp",
+          backend: "codex",
+          executionMode: "default",
+          prompt:
+            directoryKey === firstDirectoryKey
+              ? "Start the older pending launchpad"
+              : "Start the newer optimistic launchpad",
+          workMode: "worktree",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ])
+    );
+    const initialSnapshot: NavigationSnapshot = {
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: firstDirectoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+        {
+          key: secondDirectoryKey,
+          kind: "directory",
+          label: "OtherApp",
+          path: "/Users/huntharo/github/OtherApp",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: defaults,
+    };
+    const getNavigationSnapshot = vi.fn(async () => initialSnapshot);
+    const ensureDirectoryLaunchpad = vi.fn(
+      async ({ directoryKey }: { directoryKey: string }) => ({
+        launchpad: launchpadsByDirectory.get(directoryKey)!,
+        defaults,
+      })
+    );
+    const materializeDirectoryLaunchpad = vi.fn(
+      async ({ directoryKey }: { directoryKey: string }) =>
+        await (directoryKey === firstDirectoryKey
+          ? firstMaterialize.promise
+          : secondMaterialize.promise)
+    );
+
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.openDirectoryLaunchpad(
+        result.current.directories.find(
+          (directory) => directory.key === firstDirectoryKey,
+        )!,
+      );
+    });
+
+    let firstMaterializePromise: Promise<void> | undefined;
+    act(() => {
+      firstMaterializePromise =
+        result.current.materializeDirectoryLaunchpad(firstDirectoryKey);
+    });
+
+    await waitFor(() => {
+      expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
+        directoryKey: firstDirectoryKey,
+        launchpad: expect.objectContaining({
+          directoryKey: firstDirectoryKey,
+        }),
+        input: undefined,
+        collaborationMode: undefined,
+        reviewTarget: undefined,
+      });
+    });
+
+    await act(async () => {
+      await result.current.openDirectoryLaunchpad(
+        result.current.directories.find(
+          (directory) => directory.key === secondDirectoryKey,
+        )!,
+      );
+    });
+
+    let secondMaterializePromise: Promise<void> | undefined;
+    act(() => {
+      secondMaterializePromise =
+        result.current.materializeDirectoryLaunchpad(secondDirectoryKey);
+    });
+
+    await act(async () => {
+      secondMaterialize.resolve({
+        backend: "codex",
+        threadId: "thread-newer",
+        executionMode: "default",
+        workMode: "worktree",
+      });
+      await secondMaterializePromise;
+    });
+
+    expect(result.current.selectedThread?.id).toBe("thread-newer");
+
+    await act(async () => {
+      firstMaterialize.resolve({
+        backend: "codex",
+        threadId: "thread-older",
+        executionMode: "default",
+        workMode: "worktree",
+      });
+      await firstMaterializePromise;
+    });
+
+    expect(result.current.selectedThread?.id).toBe("thread-newer");
+    expect(result.current.threads.map((thread) => thread.id)).toContain(
+      "thread-newer"
+    );
+  });
+
   it("does not keep a directory launchpad selected when a thread in that directory is selected", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4476,10 +4476,16 @@ export function useThreadNavigation(
         delete next[directoryKey];
         return next;
       });
-      setOptimisticThread(optimisticMaterializedThread);
       const shouldSelectMaterializedThread =
         selectionKeyAtMaterializationStart !== launchpadSelectionKey ||
         selectedItemKeyRef.current === launchpadSelectionKey;
+      const shouldProjectOptimisticThread =
+        shouldSelectMaterializedThread || !optimisticThreadRef.current;
+      setOptimisticThread((current) =>
+        shouldSelectMaterializedThread || !current
+          ? optimisticMaterializedThread
+          : current
+      );
       if (shouldSelectMaterializedThread) {
         setSelectedItemKey(nextThreadKey);
         setPendingSeenThreadKey(nextThreadKey);
@@ -4500,7 +4506,7 @@ export function useThreadNavigation(
       try {
         await refresh(
           shouldSelectMaterializedThread ? nextThreadKey : undefined,
-          optimisticMaterializedThread,
+          shouldProjectOptimisticThread ? optimisticMaterializedThread : undefined,
         );
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2276,6 +2276,7 @@ export function useThreadNavigation(
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
   const retainedUnreadThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
+  const selectedItemKeyRef = useRef<string | undefined>(undefined);
   const manuallySelectedThreadKeysRef = useRef(new Set<string>());
   const submittedSeenUpdatedAtByThreadKeyRef = useRef(new Map<string, number | undefined>());
   const refreshInFlightRef = useRef(false);
@@ -2309,6 +2310,7 @@ export function useThreadNavigation(
 
   optimisticThreadRef.current = optimisticThread;
   retainedUnreadThreadRef.current = retainedUnreadThread;
+  selectedItemKeyRef.current = selectedItemKey;
   stateRef.current = state;
 
   useEffect(() => {
@@ -4405,6 +4407,8 @@ export function useThreadNavigation(
       // The draft carries the group root (sub-threading a child re-parents to
       // the root); prefer it over the key-parsed source so the new thread links
       // to the root and renders one level deep.
+      const launchpadSelectionKey = buildLaunchpadSelectionKey(directoryKey);
+      const selectionKeyAtMaterializationStart = selectedItemKeyRef.current;
       const materializeParentThreadId =
         parentThreadId ??
         launchpad.parentThreadId ??
@@ -4473,8 +4477,13 @@ export function useThreadNavigation(
         return next;
       });
       setOptimisticThread(optimisticMaterializedThread);
-      setSelectedItemKey(nextThreadKey);
-      setPendingSeenThreadKey(nextThreadKey);
+      const shouldSelectMaterializedThread =
+        selectionKeyAtMaterializationStart !== launchpadSelectionKey ||
+        selectedItemKeyRef.current === launchpadSelectionKey;
+      if (shouldSelectMaterializedThread) {
+        setSelectedItemKey(nextThreadKey);
+        setPendingSeenThreadKey(nextThreadKey);
+      }
       if (response.turnStartFailure) {
         setLaunchpadError(response.turnStartFailure.message);
       }
@@ -4489,7 +4498,10 @@ export function useThreadNavigation(
           : current.response,
       }));
       try {
-        await refresh(nextThreadKey, optimisticMaterializedThread);
+        await refresh(
+          shouldSelectMaterializedThread ? nextThreadKey : undefined,
+          optimisticMaterializedThread,
+        );
       } catch (error) {
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }


### PR DESCRIPTION
## Summary
Starting a directory launchpad no longer yanks the main thread view back to the newly materialized thread if the operator selected another thread while setup was still pending. The new thread is still created optimistically and added to navigation, but the late async materialization response only takes focus when the launchpad is still the active selection.

## Validation
- Added a failing regression test first: `useThreadNavigation` now covers selecting another thread before a pending directory launchpad materialization resolves.
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx`
- `pnpm lint:eslint` (passes with the existing warning baseline)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
