### PR TITLE
fix(desktop): reload review project metadata

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -707,6 +707,77 @@ function buildReviewWorkspaceOptions(
   return options;
 }
 
+function normalizeReviewWorkspacePath(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function reviewWorkspacePathMatches(
+  left?: string,
+  right?: string,
+): boolean {
+  const normalizedLeft = normalizeReviewWorkspacePath(left);
+  const normalizedRight = normalizeReviewWorkspacePath(right);
+  return Boolean(
+    normalizedLeft &&
+      normalizedRight &&
+      normalizedLeft === normalizedRight,
+  );
+}
+
+function findReviewDirectoryForWorkspace(params: {
+  directories?: NavigationDirectorySummary[];
+  directory?: NavigationDirectorySummary;
+  thread?: NavigationThreadSummary;
+  workspaceCwd?: string;
+}): NavigationDirectorySummary | undefined {
+  const workspaceCwd = normalizeReviewWorkspacePath(params.workspaceCwd);
+  if (!workspaceCwd) {
+    return params.directory;
+  }
+
+  const directories = [
+    params.directory,
+    ...(params.directories ?? []),
+  ].filter((directory): directory is NavigationDirectorySummary =>
+    Boolean(directory)
+  );
+  const directMatch = directories.find((directory) =>
+    reviewWorkspacePathMatches(directory.path, workspaceCwd) ||
+      reviewWorkspacePathMatches(
+        directory.key.startsWith("directory:")
+          ? directory.key.slice("directory:".length)
+          : directory.key,
+        workspaceCwd,
+      )
+  );
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const linkedDirectory = params.thread?.linkedDirectories.find((directory) =>
+    reviewWorkspacePathMatches(directory.worktreePath, workspaceCwd) ||
+      reviewWorkspacePathMatches(directory.path, workspaceCwd)
+  );
+  if (!linkedDirectory) {
+    return params.directory;
+  }
+
+  return directories.find((directory) =>
+    reviewWorkspacePathMatches(directory.path, linkedDirectory.path) ||
+      reviewWorkspacePathMatches(directory.path, linkedDirectory.worktreePath) ||
+      reviewWorkspacePathMatches(
+        directory.key.startsWith("directory:")
+          ? directory.key.slice("directory:".length)
+          : directory.key,
+        linkedDirectory.path,
+      )
+  ) ?? params.directory;
+}
+
 function buildConfiguredReviewCommand(
   config: ReviewConfigState | undefined
 ): { cwd?: string; displayText: string; target: AppServerReviewTarget } | undefined {
@@ -3105,25 +3176,40 @@ export function Composer(props: ComposerProps) {
     autocompleteListboxId && autocompleteKind
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
+  const reviewDirectory = useMemo(
+    () =>
+      findReviewDirectoryForWorkspace({
+        directories: props.directories,
+        directory: props.directory,
+        thread: props.thread,
+        workspaceCwd: reviewConfig?.workspaceCwd,
+      }),
+    [
+      props.directories,
+      props.directory,
+      props.thread,
+      reviewConfig?.workspaceCwd,
+    ],
+  );
   const reviewBranchPickerOptions = useMemo(
     () =>
       buildReviewBranchPickerOptions({
-        directory: props.directory,
+        directory: reviewDirectory,
         thread: props.thread,
       }),
-    [props.directory, props.thread],
+    [reviewDirectory, props.thread],
   );
   const defaultReviewBranch = useMemo(
     () =>
       buildReviewBranchOptions({
-        directory: props.directory,
+        directory: reviewDirectory,
         thread: props.thread,
       })[0] ?? "main",
-    [props.directory, props.thread],
+    [reviewDirectory, props.thread],
   );
   const reviewCommitOptions = useMemo(
-    () => buildReviewCommitOptions(props.directory),
-    [props.directory],
+    () => buildReviewCommitOptions(reviewDirectory),
+    [reviewDirectory],
   );
   const reviewWorkspaceOptions = useMemo(
     () => buildReviewWorkspaceOptions(props.thread),
@@ -6226,13 +6312,27 @@ export function Composer(props: ComposerProps) {
                   className="composer__review-input"
                   value={reviewConfig?.workspaceCwd ?? ""}
                   onChange={(event) => {
+                    const workspaceCwd = event.target.value;
+                    const directory = findReviewDirectoryForWorkspace({
+                      directories: props.directories,
+                      directory: props.directory,
+                      thread: props.thread,
+                      workspaceCwd,
+                    });
+                    const branch =
+                      buildReviewBranchOptions({
+                        directory,
+                        thread: props.thread,
+                      })[0] ?? "main";
                     setReviewConfig((current) => ({
                       ...(current ??
                         createReviewConfig({
-                          directory: props.directory,
+                          directory,
                           thread: props.thread,
                         })),
-                      workspaceCwd: event.target.value,
+                      branch,
+                      branchSource: "auto",
+                      workspaceCwd,
                     }));
                     setSendError(undefined);
                   }}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5,6 +5,7 @@ import type {
   BackendSummary,
   CompactThreadRequest,
   ComposerDraftRecoveryCandidate,
+  NavigationDirectorySummary,
   NavigationThreadSummary,
   NavigationLaunchpadDraft,
   StartReviewRequest,
@@ -4284,6 +4285,261 @@ describe("Composer", () => {
         target: { type: "baseBranch", branch: "main" },
         delivery: "inline",
         cwd: "/Users/huntharo/.codex/profiles/sstk/worktrees/mr9motar/gif-recommendations",
+      });
+    });
+  });
+
+  it("reloads review base branches when the review project changes", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const giphyDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/GIPHY/giphy-services",
+      kind: "directory",
+      label: "giphy-services",
+      path: "/Users/huntharo/GIPHY/giphy-services",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "fix-channels-tagged-magic-tags-table",
+        defaultBranch: "main",
+        branches: ["fix-channels-tagged-magic-tags-table", "main"],
+        baseBranches: [
+          "origin/main",
+          "main",
+          "fix-channels-tagged-magic-tags-table",
+        ],
+        syncState: "untracked",
+      },
+    };
+    const kubeDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/infra/kube-manifests",
+      kind: "directory",
+      label: "kube-manifests",
+      path: "/Users/huntharo/infra/kube-manifests",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "deploy/search-grpc",
+        defaultBranch: "develop",
+        branches: ["deploy/search-grpc", "develop"],
+        baseBranches: [
+          "origin/develop",
+          "develop",
+          "deploy/search-grpc",
+        ],
+        syncState: "untracked",
+      },
+    };
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={giphyDirectory}
+        directories={[giphyDirectory, kubeDirectory]}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Search gRPC",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "deploy/search-grpc",
+          executionMode: "default",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/GIPHY/giphy-services",
+              kind: "worktree",
+              label: "giphy-services",
+              path: "/Users/huntharo/GIPHY/giphy-services",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/giphy-services",
+            },
+            {
+              id: "/Users/huntharo/infra/kube-manifests",
+              kind: "worktree",
+              label: "kube-manifests",
+              path: "/Users/huntharo/infra/kube-manifests",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
+
+    fireEvent.change(screen.getByLabelText("Review project"), {
+      target: {
+        value:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+    });
+
+    fireEvent.click(screen.getByLabelText("Base branch"));
+    expect(
+      screen.getByRole("option", { name: "origin/develop" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "origin/main" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/develop" },
+        delivery: "inline",
+        cwd:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+      });
+    });
+  });
+
+  it("reloads review commit suggestions when the review project changes", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const giphyCommit = {
+      sha: "1111111111111111111111111111111111111111",
+      shortSha: "1111111",
+      committedAt: 1_700_000_000,
+      subject: "Update giphy service",
+    };
+    const kubeCommit = {
+      sha: "2222222222222222222222222222222222222222",
+      shortSha: "2222222",
+      committedAt: 1_700_000_500,
+      subject: "Update kube manifest",
+    };
+    const giphyDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/GIPHY/giphy-services",
+      kind: "directory",
+      label: "giphy-services",
+      path: "/Users/huntharo/GIPHY/giphy-services",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "fix-channels-tagged-magic-tags-table",
+        defaultBranch: "main",
+        branches: ["fix-channels-tagged-magic-tags-table", "main"],
+        recentCommits: [giphyCommit],
+        syncState: "untracked",
+      },
+    };
+    const kubeDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/infra/kube-manifests",
+      kind: "directory",
+      label: "kube-manifests",
+      path: "/Users/huntharo/infra/kube-manifests",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "deploy/search-grpc",
+        defaultBranch: "develop",
+        branches: ["deploy/search-grpc", "develop"],
+        recentCommits: [kubeCommit],
+        syncState: "untracked",
+      },
+    };
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={giphyDirectory}
+        directories={[giphyDirectory, kubeDirectory]}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Search gRPC",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "deploy/search-grpc",
+          executionMode: "default",
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/GIPHY/giphy-services",
+              kind: "worktree",
+              label: "giphy-services",
+              path: "/Users/huntharo/GIPHY/giphy-services",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/giphy-services",
+            },
+            {
+              id: "/Users/huntharo/infra/kube-manifests",
+              kind: "worktree",
+              label: "kube-manifests",
+              path: "/Users/huntharo/infra/kube-manifests",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.change(screen.getByLabelText("Review project"), {
+      target: {
+        value:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /2222222 Update kube manifest/i }))
+        .toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("option", { name: /1111111 Update giphy service/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: /2222222 Update kube manifest/i }));
+    expect(commitInput).toHaveValue(kubeCommit.sha);
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "commit", sha: kubeCommit.sha, title: null },
+        delivery: "inline",
+        cwd:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2637,6 +2637,7 @@ export function ThreadView(props: ThreadViewProps) {
             composerImplementation={props.composerImplementation}
             draftStore={props.composerDraftStore}
             directory={props.selectedDirectory}
+            directories={props.directories}
             disabled={props.composerDisabled}
             unavailableReason={selectedThreadBackend?.unavailableReason}
             contextWindow={props.contextWindow}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -11,6 +11,7 @@ import type {
   NavigationDirectorySummary,
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
+  StartReviewRequest,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import type { PendingMcpInteractionState } from "../mcp-elicitation";
@@ -357,6 +358,141 @@ describe("ThreadView", () => {
     expect(screen.getByRole("tab", { name: "Provider status" })).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("passes directory summaries to the thread review composer for project switching", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const giphyDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/GIPHY/giphy-services",
+      kind: "directory",
+      label: "giphy-services",
+      path: "/Users/huntharo/GIPHY/giphy-services",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "fix-channels-tagged-magic-tags-table",
+        defaultBranch: "main",
+        branches: ["fix-channels-tagged-magic-tags-table", "main"],
+        baseBranches: [
+          "origin/main",
+          "main",
+          "fix-channels-tagged-magic-tags-table",
+        ],
+        syncState: "untracked",
+      },
+    };
+    const kubeDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/infra/kube-manifests",
+      kind: "directory",
+      label: "kube-manifests",
+      path: "/Users/huntharo/infra/kube-manifests",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "deploy/search-grpc",
+        defaultBranch: "develop",
+        branches: ["deploy/search-grpc", "develop"],
+        baseBranches: [
+          "origin/develop",
+          "develop",
+          "deploy/search-grpc",
+        ],
+        syncState: "untracked",
+      },
+    };
+
+    render(
+      <ThreadView
+        addOptimisticReviewEntry={(_text) => "optimistic-review-1"}
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directories={[giphyDirectory, kubeDirectory]}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedDirectory={giphyDirectory}
+        selectedThread={{
+          id: "thread-1",
+          title: "Build Search gRPC",
+          titleSource: "explicit",
+          source: "codex",
+          gitBranch: "deploy/search-grpc",
+          executionMode: "default",
+          updatedAt: Date.now(),
+          linkedDirectories: [
+            {
+              id: "/Users/huntharo/GIPHY/giphy-services",
+              kind: "worktree",
+              label: "giphy-services",
+              path: "/Users/huntharo/GIPHY/giphy-services",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/giphy-services",
+            },
+            {
+              id: "/Users/huntharo/infra/kube-manifests",
+              kind: "worktree",
+              label: "kube-manifests",
+              path: "/Users/huntharo/infra/kube-manifests",
+              worktreePath:
+                "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+            },
+          ],
+          inbox: { inInbox: true },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByLabelText("Base branch")).toHaveValue("origin/main");
+
+    fireEvent.change(screen.getByLabelText("Review project"), {
+      target: {
+        value:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Base branch")).toHaveValue("origin/develop");
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "origin/develop" },
+        delivery: "inline",
+        cwd:
+          "/Users/huntharo/.codex/profiles/sstk/worktrees/mrctwp7f/kube-manifests",
+      });
+    });
   });
 
   it("keeps the integrated terminal open state per selected thread", async () => {


### PR DESCRIPTION
## Summary
Changing the project inside the `/review` target picker now changes the review metadata with it. A thread linked to multiple worktrees no longer keeps the previous project's base branch list, default branch, commit suggestions, or review cwd after the operator selects a different project such as `kube-manifests`.

The review composer now resolves the selected workspace path back to the matching directory summary, including managed worktree paths, and uses that directory's git metadata for base-branch and commit-review choices. Switching projects resets the auto-selected base branch to the newly selected project's best review base so the submitted review target matches the visible project.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm lint:eslint` (passes with existing warning baseline)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
