### PR TITLE
fix(desktop): stop a racing relaunch from aborting the update install

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -71,6 +71,12 @@ vi.mock("../update-install-state", () => ({
   markUpdateInstallInProgress: () => markUpdateInstallInProgressMock(),
 }));
 
+const writeUpdateHandoffMarkerMock = vi.fn();
+vi.mock("../update-handoff-marker", () => ({
+  writeUpdateHandoffMarker: (version: string) =>
+    writeUpdateHandoffMarkerMock(version),
+}));
+
 async function importAutoUpdater() {
   return await import("../auto-updater");
 }
@@ -149,6 +155,7 @@ describe("auto updater", () => {
     autoUpdaterMock.on.mockClear();
     autoUpdaterMock.quitAndInstall.mockReset();
     markUpdateInstallInProgressMock.mockReset();
+    writeUpdateHandoffMarkerMock.mockReset();
   });
 
   afterEach(() => {
@@ -379,6 +386,10 @@ describe("auto updater", () => {
     await expect(install?.()).resolves.toEqual({ status: "restarting" });
     expect(requestQuit).toHaveBeenCalledTimes(1);
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    // isForceRunAfter=true so ShipIt relaunches the updated app after the swap.
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(false, true);
+    // The cross-boot marker is persisted so a racing relaunch steps aside.
+    expect(writeUpdateHandoffMarkerMock).toHaveBeenCalledWith("1.0.0-beta.8");
   });
 
   it("latches update-install-in-progress before handing off to quitAndInstall", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -99,6 +99,7 @@ const getAppPathMock = vi.fn(() => "/test/app");
 const getVersionMock = vi.fn(() => "1.0.0-alpha.0");
 const whenReadyMock = vi.fn(() => Promise.resolve());
 const quitMock = vi.fn();
+const exitMock = vi.fn();
 const getAllWindowsMock = vi.fn(() => []);
 const dockSetIconMock = vi.fn();
 const protocolHandleMock = vi.fn();
@@ -155,6 +156,7 @@ vi.mock("electron", () => ({
       appEventHandlers.set(event, handler);
     }),
     quit: quitMock,
+    exit: exitMock,
   },
   BrowserWindow: {
     getAllWindows: getAllWindowsMock,
@@ -235,6 +237,11 @@ vi.mock("../auto-updater", () => ({
 const isUpdateInstallInProgressMock = vi.fn(() => false);
 vi.mock("../update-install-state", () => ({
   isUpdateInstallInProgress: () => isUpdateInstallInProgressMock(),
+}));
+
+const shouldStepAsideForUpdateInstallMock = vi.fn(() => false);
+vi.mock("../update-handoff-marker", () => ({
+  shouldStepAsideForUpdateInstall: () => shouldStepAsideForUpdateInstallMock(),
 }));
 
 vi.mock("../app-log-window", () => ({
@@ -533,6 +540,9 @@ describe("bootstrapApp", () => {
     whenReadyMock.mockReset();
     whenReadyMock.mockReturnValue(Promise.resolve());
     quitMock.mockReset();
+    exitMock.mockReset();
+    shouldStepAsideForUpdateInstallMock.mockReset();
+    shouldStepAsideForUpdateInstallMock.mockReturnValue(false);
     getAllWindowsMock.mockReset();
     getAllWindowsMock.mockReturnValue([]);
     protocolHandleMock.mockReset();
@@ -561,6 +571,20 @@ describe("bootstrapApp", () => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it("steps aside without opening a window while an update install is mid-flight", async () => {
+    shouldStepAsideForUpdateInstallMock.mockReturnValue(true);
+
+    await import("../index");
+    await flushMicrotasks();
+
+    // A ShipIt bundle swap can't run while any instance of the app is alive, so
+    // a launch that races the install must exit immediately and let ShipIt
+    // finish — booting a window would abort the update with "App Still Running".
+    expect(exitMock).toHaveBeenCalledWith(0);
+    expect(whenReadyMock).not.toHaveBeenCalled();
+    expect(createMainWindowMock).not.toHaveBeenCalled();
   });
 
   it("awaits startup CPU profiling before creating the first window", async () => {

--- a/apps/desktop/src/main/__tests__/update-handoff-marker.test.ts
+++ b/apps/desktop/src/main/__tests__/update-handoff-marker.test.ts
@@ -1,0 +1,78 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearUpdateHandoffMarker,
+  shouldStepAsideForUpdateInstall,
+  writeUpdateHandoffMarker,
+} from "../update-handoff-marker";
+
+const OLD_VERSION = "1.0.0-beta.1";
+const NEW_VERSION = "1.0.0-beta.2";
+
+let tmpHome: string;
+let priorHome: string | undefined;
+
+function markerFile(): string {
+  return path.join(tmpHome, "update-handoff.json");
+}
+
+beforeEach(() => {
+  priorHome = process.env.PWRAGENT_HOME;
+  tmpHome = mkdtempSync(path.join(os.tmpdir(), "pwragent-handoff-"));
+  process.env.PWRAGENT_HOME = tmpHome;
+});
+
+afterEach(() => {
+  if (priorHome === undefined) {
+    delete process.env.PWRAGENT_HOME;
+  } else {
+    process.env.PWRAGENT_HOME = priorHome;
+  }
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("update handoff marker", () => {
+  it("does not step aside when no marker exists", () => {
+    expect(shouldStepAsideForUpdateInstall(OLD_VERSION)).toBe(false);
+  });
+
+  it("steps aside on a fresh handoff while still on the old version", () => {
+    writeUpdateHandoffMarker(NEW_VERSION);
+    expect(existsSync(markerFile())).toBe(true);
+    expect(shouldStepAsideForUpdateInstall(OLD_VERSION)).toBe(true);
+  });
+
+  it("does not step aside — and clears the marker — once on the target version", () => {
+    writeUpdateHandoffMarker(NEW_VERSION);
+    expect(shouldStepAsideForUpdateInstall(NEW_VERSION)).toBe(false);
+    expect(existsSync(markerFile())).toBe(false);
+  });
+
+  it("does not step aside for a stale marker and clears it", () => {
+    // Hand-write an ancient timestamp so we exercise the TTL branch without
+    // mocking the clock.
+    writeFileSync(
+      markerFile(),
+      JSON.stringify({ targetVersion: NEW_VERSION, at: Date.now() - 60 * 60_000 }),
+      "utf8",
+    );
+    expect(shouldStepAsideForUpdateInstall(OLD_VERSION)).toBe(false);
+    expect(existsSync(markerFile())).toBe(false);
+  });
+
+  it("does not step aside for a corrupt marker and clears it", () => {
+    writeFileSync(markerFile(), "{ not valid json", "utf8");
+    expect(shouldStepAsideForUpdateInstall(OLD_VERSION)).toBe(false);
+    expect(existsSync(markerFile())).toBe(false);
+  });
+
+  it("clearUpdateHandoffMarker removes the file", () => {
+    writeUpdateHandoffMarker(NEW_VERSION);
+    clearUpdateHandoffMarker();
+    expect(existsSync(markerFile())).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -17,6 +17,7 @@ import type {
 } from "../shared/app-metadata";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
+import { writeUpdateHandoffMarker } from "./update-handoff-marker";
 import { markUpdateInstallInProgress } from "./update-install-state";
 
 const log = getMainLogger("pwragent:updater");
@@ -565,7 +566,14 @@ export async function installDownloadedAppUpdate(options?: {
       // so the app's own window-all-closed / before-quit handlers don't race it
       // with a competing app.quit() that would strand us on the old version.
       markUpdateInstallInProgress();
-      autoUpdater.quitAndInstall();
+      // Persist a cross-boot marker so a launch that races this install — the
+      // classic "user reopens the app during the install gap" — steps aside on
+      // boot instead of tripping ShipIt's "App Still Running" abort loop.
+      writeUpdateHandoffMarker(version);
+      // isForceRunAfter=true relaunches the updated app after the swap. Without
+      // it ShipIt leaves the app closed, which is exactly what prompts people to
+      // reopen it mid-install and trigger the failure the marker guards against.
+      autoUpdater.quitAndInstall(false, true);
     };
     if (options?.requestQuit) {
       const quitAccepted = await options.requestQuit(performQuit);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -132,6 +132,7 @@ import {
   type ProfileFocusRequestWatcher,
 } from "./profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "./settings/desktop-secret-store";
+import { shouldStepAsideForUpdateInstall } from "./update-handoff-marker";
 import { isUpdateInstallInProgress } from "./update-install-state";
 
 const APP_NAME = "PwrAgent";
@@ -675,6 +676,22 @@ export function bootstrapApp(): void {
   initializeMainLogger({
     profileName: resolveMainLogProfileName(bootDecision),
   });
+
+  // A Squirrel/ShipIt bundle swap won't run while any instance of the app is
+  // alive ("App Still Running Error"). If this launch is racing an in-flight
+  // install — most commonly the user reopening the app during the brief,
+  // feedback-less update gap — quit immediately so ShipIt can swap the bundle
+  // and relaunch the updated build. Done here, before any handler is registered
+  // or window opened, so the "running" instance ShipIt sees is as short-lived
+  // as possible. Fails open (see shouldStepAsideForUpdateInstall).
+  if (shouldStepAsideForUpdateInstall(app.getVersion())) {
+    mainLog.info(
+      "update install in progress; quitting to let ShipIt finish the bundle swap",
+    );
+    app.exit(0);
+    return;
+  }
+
   installProcessShutdownHandlers();
   installBootErrorHandlers();
 

--- a/apps/desktop/src/main/update-handoff-marker.ts
+++ b/apps/desktop/src/main/update-handoff-marker.ts
@@ -1,0 +1,125 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { readPwragentHome } from "./pwragent-home";
+
+/**
+ * Cross-boot marker recording that we just handed a bundle swap to
+ * Squirrel.Mac / ShipIt.
+ *
+ * A ShipIt install refuses to run while ANY instance of the target app is alive
+ * — it aborts with SQRLInstallerErrorDomain -9 "App Still Running Error". So if
+ * the app is reopened during the brief, feedback-less quit → install → relaunch
+ * gap (a user who thinks the update stalled and relaunches it), the reopened
+ * process strands the update in an abort/retry loop that only clears once the
+ * app happens to stay closed long enough.
+ *
+ * We drop this marker right before `quitAndInstall()` and read it on the next
+ * boot: if a swap is plausibly still in flight we step aside (quit immediately)
+ * so ShipIt can finish, and ShipIt relaunches the updated build — whose boot
+ * clears the marker via the version-match branch below.
+ *
+ * The marker is deliberately coarse and self-clearing (TTL + version match) so
+ * a crashed or aborted install can never wedge the app closed.
+ */
+
+const MARKER_FILE = "update-handoff.json";
+
+// A ShipIt swap can legitimately take a couple of minutes on a busy machine;
+// past this we assume the install failed and boot normally rather than block
+// launches indefinitely.
+const HANDOFF_TTL_MS = 5 * 60_000;
+
+type HandoffMarker = { targetVersion: string; at: number };
+
+function pwragentHomeDir(): string {
+  return readPwragentHome() ?? path.join(os.homedir(), ".pwragent");
+}
+
+function markerPath(): string {
+  return path.join(pwragentHomeDir(), MARKER_FILE);
+}
+
+/**
+ * Record that a Squirrel/ShipIt bundle swap for `targetVersion` is being handed
+ * off. Best effort: the guard is a resilience nicety, never load-bearing, so a
+ * write failure just falls back to today's behavior and must never throw into
+ * the quit path.
+ */
+export function writeUpdateHandoffMarker(targetVersion: string): void {
+  try {
+    mkdirSync(pwragentHomeDir(), { recursive: true });
+    const marker: HandoffMarker = { targetVersion, at: Date.now() };
+    writeFileSync(markerPath(), JSON.stringify(marker), "utf8");
+  } catch {
+    // Intentionally swallowed — see doc comment.
+  }
+}
+
+export function clearUpdateHandoffMarker(): void {
+  try {
+    rmSync(markerPath(), { force: true });
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Whether this freshly-launched instance should quit immediately to let an
+ * in-flight ShipIt bundle swap complete.
+ *
+ * Fails open: a missing, unreadable, corrupt, stale, or already-satisfied
+ * marker returns false (clearing the marker where it makes sense) so the app
+ * always boots when no install is actually underway.
+ */
+export function shouldStepAsideForUpdateInstall(
+  currentVersion: string,
+): boolean {
+  let raw: string;
+  try {
+    if (!existsSync(markerPath())) return false;
+    raw = readFileSync(markerPath(), "utf8");
+  } catch {
+    return false;
+  }
+
+  let marker: Partial<HandoffMarker>;
+  try {
+    marker = JSON.parse(raw) as Partial<HandoffMarker>;
+  } catch {
+    clearUpdateHandoffMarker();
+    return false;
+  }
+
+  const { targetVersion, at } = marker;
+  if (typeof targetVersion !== "string" || typeof at !== "number") {
+    clearUpdateHandoffMarker();
+    return false;
+  }
+
+  // The swap already landed — ShipIt relaunched us (or the user reopened after
+  // it finished) and we ARE the target build. Clear and boot normally.
+  if (currentVersion === targetVersion) {
+    clearUpdateHandoffMarker();
+    return false;
+  }
+
+  // Too old to still be installing: assume the install failed/aborted and boot
+  // rather than wedge the app closed forever.
+  if (Date.now() - at > HANDOFF_TTL_MS) {
+    clearUpdateHandoffMarker();
+    return false;
+  }
+
+  // Fresh handoff, still the old version: a ShipIt swap is very likely in
+  // flight. Step aside; ShipIt relaunches the updated build and that boot
+  // clears the marker via the version-match branch above.
+  return true;
+}


### PR DESCRIPTION
## Summary

- On macOS a Squirrel/ShipIt bundle swap refuses to run while any instance of the target app is alive — it aborts with `SQRLInstallerErrorDomain -9` "App Still Running Error". Reopening the app during the brief, feedback-less quit → install → relaunch gap (typically the user relaunching it because it looked stalled) strands the update in an abort/retry loop that only clears once the app happens to stay closed long enough.
- Add a cross-boot **handoff marker** (`update-handoff-marker.ts`) written just before `quitAndInstall()`. On the next boot, if a swap is plausibly still in flight (fresh marker, still on the old version), the freshly launched instance exits immediately so ShipIt can finish and relaunch the updated build. The marker **fails open** — missing / corrupt / stale / already-on-target all boot normally — with a 5-minute TTL so an aborted install can never wedge the app closed.
- Pass `isForceRunAfter=true` to `quitAndInstall()` so ShipIt relaunches the updated app after the swap. It was leaving the app closed, which is what prompted people to reopen it mid-install in the first place.

## Verification

- `pnpm test` on the 3 affected files — **60 passed** (8 new: the full marker decision matrix, `isForceRunAfter` + marker assertions on the install path, and a boot-guard test proving no window opens while an install is mid-flight).
- `pnpm typecheck` clean; `pnpm lint:eslint` — 0 errors, 0 findings on the changed files.
- The failure and the fix direction were reproduced by hand during diagnosis (a live instance blocks ShipIt; forcing the ShipIt spawn after the app stays closed completes the swap). A real Squirrel swap can't be exercised in CI without a signed release, so the logic is covered by unit/integration tests rather than a live run.

## Notes

- The marker lives at `~/.pwragent/update-handoff.json` — app-wide (not per-profile), since the update targets `/Applications/PwrAgent.app` regardless of profile.
- Only the explicit "Restart to update" path (`installDownloadedAppUpdate`) sets `isForceRunAfter=true`; the `autoInstallOnAppQuit` path is untouched, so a deliberate quit-with-pending-update doesn't force the app back open.
- **Deliberately not** adding a single-instance lock: the runtime-config contract guarantees multiple instances can share a profile safely (sqlite WAL), and dev + packaged builds are run together. A lock would break that.
- **Deliberately not** adding a speculative `launchctl kickstart` of the ShipIt job: the launchd spawn stall observed pre-reboot cleared on reboot, and a kickstart adds shell-out/timing risk for a transient condition.
