### PR TITLE
fix(desktop): guard terminal shutdown during quit

### DIFF
--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -198,6 +198,64 @@ describe("resolveTerminalShell", () => {
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(webContents.once).toHaveBeenCalledTimes(1);
   });
+
+  it("reports running terminal sessions for quit confirmation", async () => {
+    const pty = fakePty();
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+    });
+
+    const response = await service.createOrAttach(
+      {
+        threadKey: "codex:thread-a",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 1,
+      sessionIds: [response.sessionId],
+      threadKeys: ["codex:thread-a"],
+    });
+  });
+
+  it("removes pty listeners before killing sessions during shutdown", async () => {
+    const disposable = { dispose: vi.fn() };
+    const pty = fakePty({
+      onData: vi.fn(() => disposable),
+      onExit: vi.fn(() => disposable),
+    });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+    });
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-a",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    service.dispose();
+
+    expect(disposable.dispose).toHaveBeenCalledTimes(2);
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 0,
+      sessionIds: [],
+      threadKeys: [],
+    });
+  });
 });
 
 function fakeWebContents(): WebContents & {
@@ -214,7 +272,7 @@ function fakeWebContents(): WebContents & {
   };
 }
 
-function fakePty(): IPty {
+function fakePty(overrides: Partial<IPty> = {}): IPty {
   return {
     pid: 123,
     cols: 80,
@@ -229,5 +287,6 @@ function fakePty(): IPty {
     resume: vi.fn(),
     resize: vi.fn(),
     write: vi.fn(),
+    ...overrides,
   };
 }

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -15,6 +15,14 @@ vi.mock("../app-server/backend-registry", () => ({
   })),
 }));
 
+vi.mock("../ipc/integrated-terminal", () => ({
+  getIntegratedTerminalQuitSnapshot: vi.fn(() => ({
+    count: 0,
+    sessionIds: [],
+    threadKeys: [],
+  })),
+}));
+
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: vi.fn(() => ({
     resolveConfirmQuitWithInProgressThreads: () => true,
@@ -36,7 +44,12 @@ describe("createQuitManager", () => {
     const manager = createQuitManager({
       confirm,
       getConfirmationEnabled: () => true,
-      getInProgressThreads: () => ({ count: 0, threadIds: [] }),
+      getQuitBlockers: () => ({
+        count: 0,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
+        threadIds: [],
+      }),
       log: {},
       performQuit,
     });
@@ -55,8 +68,10 @@ describe("createQuitManager", () => {
     const manager = createQuitManager({
       confirm,
       getConfirmationEnabled: () => true,
-      getInProgressThreads: () => ({
+      getQuitBlockers: () => ({
         count: 2,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
         threadIds: ["acp:grok:thread-2", "codex:thread-1"],
       }),
       log: { warn },
@@ -71,12 +86,52 @@ describe("createQuitManager", () => {
       expect.objectContaining({
         countdownSeconds: 10,
         inProgressThreadCount: 2,
+        terminalSessionCount: 0,
       }),
     );
     expect(performQuit).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      "quit requested with in-progress threads",
+      "quit requested with active work",
       expect.objectContaining({ count: 2 }),
+    );
+  });
+
+  it("shows confirmation when integrated terminals are running", async () => {
+    const { createQuitManager } = await import("../quit-manager");
+    const performQuit = vi.fn();
+    const warn = vi.fn();
+    const confirm = vi.fn(async () => "manual-confirm" as const);
+    const manager = createQuitManager({
+      confirm,
+      getConfirmationEnabled: () => true,
+      getQuitBlockers: () => ({
+        count: 1,
+        terminalSessionCount: 1,
+        terminalThreadKeys: ["codex:thread-terminal"],
+        threadIds: [],
+      }),
+      log: { warn },
+      performQuit,
+    });
+
+    await expect(manager.requestQuit({ source: "menu" })).resolves.toBe(true);
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        countdownSeconds: 10,
+        inProgressThreadCount: 0,
+        terminalSessionCount: 1,
+      }),
+    );
+    expect(performQuit).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      "quit requested with active work",
+      expect.objectContaining({
+        count: 1,
+        terminalSessionCount: 1,
+        terminalThreadKeys: ["codex:thread-terminal"],
+        threadIds: [],
+      }),
     );
   });
 
@@ -87,8 +142,10 @@ describe("createQuitManager", () => {
     const manager = createQuitManager({
       confirm,
       getConfirmationEnabled: () => true,
-      getInProgressThreads: () => ({
+      getQuitBlockers: () => ({
         count: 1,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
         threadIds: ["codex:thread-1"],
       }),
       log: {},
@@ -114,8 +171,10 @@ describe("createQuitManager", () => {
     const manager = createQuitManager({
       confirm,
       getConfirmationEnabled: () => true,
-      getInProgressThreads: () => ({
+      getQuitBlockers: () => ({
         count: 1,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
         threadIds: ["codex:thread-1"],
       }),
       log: {},
@@ -143,8 +202,10 @@ describe("createQuitManager", () => {
     const manager = createQuitManager({
       confirm,
       getConfirmationEnabled: () => false,
-      getInProgressThreads: () => ({
+      getQuitBlockers: () => ({
         count: 1,
+        terminalSessionCount: 0,
+        terminalThreadKeys: [],
         threadIds: ["codex:thread-1"],
       }),
       log: {},

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -13,6 +13,7 @@ import type {
   IntegratedTerminalWriteRequest,
 } from "../../shared/integrated-terminal";
 import { IntegratedTerminalService } from "../terminal/integrated-terminal-service";
+import type { IntegratedTerminalQuitSnapshot } from "../terminal/integrated-terminal-service";
 
 let service: IntegratedTerminalService | undefined;
 
@@ -61,4 +62,14 @@ export function disposeIntegratedTerminalIpcHandlers(): void {
   ipcMain.removeHandler(INTEGRATED_TERMINAL_CLOSE_CHANNEL);
   service?.dispose();
   service = undefined;
+}
+
+export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnapshot {
+  return (
+    service?.getQuitSnapshot() ?? {
+      count: 0,
+      sessionIds: [],
+      threadKeys: [],
+    }
+  );
 }

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -9,6 +9,7 @@ export type QuitConfirmationDialogResult =
 export type QuitConfirmationDialogOptions = {
   countdownSeconds: number;
   inProgressThreadCount: number;
+  terminalSessionCount: number;
   parent?: BrowserWindow | null;
 };
 
@@ -87,7 +88,7 @@ export async function showQuitConfirmationDialog(
   const palette = QUIT_DIALOG_PALETTES[colorScheme];
   const window = new BrowserWindow({
     width: 460,
-    height: 320,
+    height: 340,
     resizable: false,
     minimizable: false,
     maximizable: false,
@@ -154,6 +155,7 @@ export async function showQuitConfirmationDialog(
         buildQuitConfirmationHtml({
           countdownSeconds: options.countdownSeconds,
           inProgressThreadCount: options.inProgressThreadCount,
+          terminalSessionCount: options.terminalSessionCount,
           navigationPrefix,
           colorScheme,
           palette,
@@ -170,14 +172,19 @@ export async function showQuitConfirmationDialog(
 function buildQuitConfirmationHtml(options: {
   countdownSeconds: number;
   inProgressThreadCount: number;
+  terminalSessionCount: number;
   navigationPrefix: string;
   colorScheme: "dark" | "light";
   palette: QuitDialogPalette;
 }): string {
-  const countText =
-    options.inProgressThreadCount === 1
-      ? "1 thread has an agent turn in progress."
-      : `${options.inProgressThreadCount} threads have agent turns in progress.`;
+  const countText = describeQuitBlockers({
+    inProgressThreadCount: options.inProgressThreadCount,
+    terminalSessionCount: options.terminalSessionCount,
+  });
+  const interruptionText = describeQuitImpact({
+    inProgressThreadCount: options.inProgressThreadCount,
+    terminalSessionCount: options.terminalSessionCount,
+  });
   const p = options.palette;
   return `<!doctype html>
 <html lang="en">
@@ -345,7 +352,7 @@ function buildQuitConfirmationHtml(options: {
     <main class="content">
       <h1>Quit PwrAgent?</h1>
       <p>${escapeHtml(countText)}</p>
-      <p>If you quit now, those turns will be interrupted. You'll need to find each thread when you restart and tell them to continue.</p>
+      <p>${escapeHtml(interruptionText)}</p>
       <p class="countdown" id="countdown"></p>
       <div class="actions">
         <button id="stay" class="secondary" type="button">Stay Open</button>
@@ -383,6 +390,43 @@ function buildQuitConfirmationHtml(options: {
     </script>
   </body>
 </html>`;
+}
+
+function describeQuitBlockers(options: {
+  inProgressThreadCount: number;
+  terminalSessionCount: number;
+}): string {
+  const parts: string[] = [];
+  if (options.inProgressThreadCount === 1) {
+    parts.push("1 thread has an agent turn in progress");
+  } else if (options.inProgressThreadCount > 1) {
+    parts.push(`${options.inProgressThreadCount} threads have agent turns in progress`);
+  }
+  if (options.terminalSessionCount === 1) {
+    parts.push("1 integrated terminal is running");
+  } else if (options.terminalSessionCount > 1) {
+    parts.push(`${options.terminalSessionCount} integrated terminals are running`);
+  }
+  if (parts.length === 0) {
+    return "PwrAgent is ready to quit.";
+  }
+  if (parts.length === 1) {
+    return `${parts[0]}.`;
+  }
+  return `${parts[0]}, and ${parts[1]}.`;
+}
+
+function describeQuitImpact(options: {
+  inProgressThreadCount: number;
+  terminalSessionCount: number;
+}): string {
+  if (options.inProgressThreadCount > 0 && options.terminalSessionCount > 0) {
+    return "If you quit now, those turns will be interrupted and terminal processes will be killed. You'll need to reopen the threads and restart any terminal work.";
+  }
+  if (options.terminalSessionCount > 0) {
+    return "If you quit now, terminal processes will be killed. You'll need to restart any terminal work after reopening PwrAgent.";
+  }
+  return "If you quit now, those turns will be interrupted. You'll need to find each thread when you restart and tell them to continue.";
 }
 
 function escapeHtml(value: string): string {

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow } from "electron";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
+import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
 import {
@@ -24,15 +25,23 @@ export type RequestQuitOptions = {
   source: QuitRequestSource;
 };
 
+export type QuitBlockerSnapshot = {
+  count: number;
+  terminalSessionCount: number;
+  terminalThreadKeys: string[];
+  threadIds: string[];
+};
+
 export type QuitManagerDependencies = {
   confirm?: (params: {
     countdownSeconds: number;
     inProgressThreadCount: number;
+    terminalSessionCount: number;
     parent?: BrowserWindow | null;
   }) => Promise<QuitConfirmationDialogResult>;
   getConfirmationEnabled: () => boolean;
   getFocusedWindow?: () => BrowserWindow | null;
-  getInProgressThreads: () => { count: number; threadIds: string[] };
+  getQuitBlockers: () => QuitBlockerSnapshot;
   log: {
     info?: (message: string, meta?: Record<string, unknown>) => void;
     warn?: (message: string, meta?: Record<string, unknown>) => void;
@@ -59,9 +68,9 @@ export function createQuitManager(
       return true;
     }
 
-    const snapshot = dependencies.getInProgressThreads();
+    const snapshot = dependencies.getQuitBlockers();
     if (snapshot.count <= 0) {
-      dependencies.log.info?.("quit requested with no in-progress threads", {
+      dependencies.log.info?.("quit requested with no active work", {
         source: options.source,
       });
       quitAllowed = true;
@@ -71,10 +80,12 @@ export function createQuitManager(
 
     if (!dependencies.getConfirmationEnabled()) {
       dependencies.log.warn?.(
-        "quit requested with in-progress threads; confirmation disabled",
+        "quit requested with active work; confirmation disabled",
         {
           count: snapshot.count,
           source: options.source,
+          terminalSessionCount: snapshot.terminalSessionCount,
+          terminalThreadKeys: snapshot.terminalThreadKeys,
           threadIds: snapshot.threadIds,
         },
       );
@@ -90,9 +101,11 @@ export function createQuitManager(
       return await promptPromise;
     }
 
-    dependencies.log.warn?.("quit requested with in-progress threads", {
+    dependencies.log.warn?.("quit requested with active work", {
       count: snapshot.count,
       source: options.source,
+      terminalSessionCount: snapshot.terminalSessionCount,
+      terminalThreadKeys: snapshot.terminalThreadKeys,
       threadIds: snapshot.threadIds,
     });
 
@@ -100,13 +113,16 @@ export function createQuitManager(
     promptPromise = (async () => {
       const resolution = await (dependencies.confirm ?? showQuitConfirmationDialog)({
         countdownSeconds: QUIT_CONFIRMATION_COUNTDOWN_SECONDS,
-        inProgressThreadCount: snapshot.count,
+        inProgressThreadCount: snapshot.threadIds.length,
+        terminalSessionCount: snapshot.terminalSessionCount,
         parent: dependencies.getFocusedWindow?.(),
       });
       dependencies.log.warn?.("quit confirmation resolved", {
         count: snapshot.count,
         resolution,
         source: options.source,
+        terminalSessionCount: snapshot.terminalSessionCount,
+        terminalThreadKeys: snapshot.terminalThreadKeys,
         threadIds: snapshot.threadIds,
       });
       if (resolution === "manual-cancel") {
@@ -133,14 +149,37 @@ export function createQuitManager(
   };
 }
 
+export function buildQuitBlockerSnapshot(params: {
+  inProgressThreads: {
+    count: number;
+    threadIds: string[];
+  };
+  terminalSessions: {
+    count: number;
+    threadKeys: string[];
+  };
+}): QuitBlockerSnapshot {
+  const threadIds = [...params.inProgressThreads.threadIds].sort();
+  return {
+    count: threadIds.length + params.terminalSessions.count,
+    terminalSessionCount: params.terminalSessions.count,
+    terminalThreadKeys: [...params.terminalSessions.threadKeys].sort(),
+    threadIds,
+  };
+}
+
 const quitLog = getMainLogger("pwragent:quit");
 
 export const appQuitManager = createQuitManager({
   getConfirmationEnabled: () =>
     getDesktopSettingsService().resolveConfirmQuitWithInProgressThreads(),
   getFocusedWindow: () => BrowserWindow.getFocusedWindow(),
-  getInProgressThreads: () =>
-    getDesktopBackendRegistry().getInProgressThreadSnapshotForQuit(),
+  getQuitBlockers: () =>
+    buildQuitBlockerSnapshot({
+      inProgressThreads:
+        getDesktopBackendRegistry().getInProgressThreadSnapshotForQuit(),
+      terminalSessions: getIntegratedTerminalQuitSnapshot(),
+    }),
   log: quitLog,
   performQuit: () => {
     app.quit();

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -39,6 +39,12 @@ type TerminalSession = {
 
 type NodePtyModule = typeof import("node-pty");
 
+export type IntegratedTerminalQuitSnapshot = {
+  count: number;
+  sessionIds: string[];
+  threadKeys: string[];
+};
+
 type IntegratedTerminalServiceOptions = {
   loadNodePty?: () => Promise<Pick<NodePtyModule, "spawn">>;
 };
@@ -48,6 +54,7 @@ export class IntegratedTerminalService {
   private readonly sessionsByThread = new Map<string, TerminalSession>();
   private readonly sessionsById = new Map<string, TerminalSession>();
   private readonly loadNodePty: () => Promise<Pick<NodePtyModule, "spawn">>;
+  private disposing = false;
 
   constructor(options: IntegratedTerminalServiceOptions = {}) {
     this.loadNodePty = options.loadNodePty ?? loadNodePty;
@@ -148,9 +155,19 @@ export class IntegratedTerminalService {
   }
 
   dispose(): void {
+    this.disposing = true;
     for (const session of Array.from(this.sessionsById.values())) {
-      this.killSession(session);
+      this.disposeSessionForShutdown(session);
     }
+  }
+
+  getQuitSnapshot(): IntegratedTerminalQuitSnapshot {
+    const sessions = [...this.sessionsById.values()];
+    return {
+      count: sessions.length,
+      sessionIds: sessions.map((session) => session.sessionId).sort(),
+      threadKeys: sessions.map((session) => session.threadKey).sort(),
+    };
   }
 
   private toCreateResponse(
@@ -180,6 +197,9 @@ export class IntegratedTerminalService {
   }
 
   private handleOutput(session: TerminalSession, data: string): void {
+    if (this.disposing || this.sessionsById.get(session.sessionId) !== session) {
+      return;
+    }
     session.buffer = trimBufferedOutput(session.buffer + data);
     this.send(session, INTEGRATED_TERMINAL_OUTPUT_CHANNEL, {
       sessionId: session.sessionId,
@@ -192,6 +212,9 @@ export class IntegratedTerminalService {
     exitCode: number | undefined,
     signal: number | undefined,
   ): void {
+    if (this.disposing || this.sessionsById.get(session.sessionId) !== session) {
+      return;
+    }
     this.send(session, INTEGRATED_TERMINAL_EXIT_CHANNEL, {
       sessionId: session.sessionId,
       exitCode: exitCode ?? null,
@@ -217,12 +240,35 @@ export class IntegratedTerminalService {
   }
 
   private deleteSession(session: TerminalSession): void {
-    for (const disposable of session.disposables) {
-      disposable.dispose();
-    }
+    this.disposeSessionListeners(session);
     this.sessionsByThread.delete(session.threadKey);
     this.sessionsById.delete(session.sessionId);
     session.subscribers.clear();
+  }
+
+  private disposeSessionForShutdown(session: TerminalSession): void {
+    this.deleteSession(session);
+    try {
+      session.pty.kill();
+    } catch (error) {
+      this.logger.warn("shutdown-kill-failed", {
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: session.sessionId,
+      });
+    }
+  }
+
+  private disposeSessionListeners(session: TerminalSession): void {
+    for (const disposable of session.disposables.splice(0)) {
+      try {
+        disposable.dispose();
+      } catch (error) {
+        this.logger.warn("listener-dispose-failed", {
+          error: error instanceof Error ? error.message : String(error),
+          sessionId: session.sessionId,
+        });
+      }
+    }
   }
 
   private send(session: TerminalSession, channel: string, payload: unknown): void {

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -421,14 +421,14 @@ export function GeneralSettings(props: {
       >
         <div className="settings-fields">
           <SettingsField
-            label="Confirm quit when threads are in progress"
-            sub="Warn before quitting while agent turns are running. The prompt auto-quits after a short countdown so shutdown can continue."
+            label="Confirm quit when threads or terminals are active"
+            sub="Warn before quitting while agent turns or integrated terminal sessions are running. The prompt auto-quits after a short countdown so shutdown can continue."
             source={sourceBadge(confirmQuitWithInProgressThreads)}
             control={
               <SettingsSwitch
                 checked={confirmQuitWithInProgressThreads.value}
                 disabled={props.saving}
-                label="Confirm quit when threads are in progress"
+                label="Confirm quit when threads or terminals are active"
                 onChange={(next) => {
                   void props.onConfirmQuitWithInProgressThreadsChange(next);
                 }}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -514,12 +514,12 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("switch", {
-        name: "Confirm quit when threads are in progress",
+        name: "Confirm quit when threads or terminals are active",
       }),
     ).toHaveAttribute("aria-checked", "true");
     fireEvent.click(
       screen.getByRole("switch", {
-        name: "Confirm quit when threads are in progress",
+        name: "Confirm quit when threads or terminals are active",
       }),
     );
     await waitFor(() => {


### PR DESCRIPTION
## Summary

Quitting PwrAgent now treats integrated terminal sessions as active work, so operators get the same confirmation prompt for running terminals that they already get for in-progress agent turns. The dialog separates agent turns from terminal sessions and makes the terminal consequence explicit: quitting will kill those terminal processes.

Terminal service shutdown also now enters a disposal mode before killing ptys, removes pty listeners first, and ignores late output or exit callbacks during teardown. That reduces the shutdown-time `node-pty` callback path that matched the local crash report after upgrading from another profile.

## Tests

- `pnpm test apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
