### PR TITLE
fix(desktop): skip disabled ACP discovery

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AcpAgentInstance } from "@pwragent/shared";
+import type { LocalAcpDiscoveryOptions } from "@pwrdrvr/agent-acp";
 import { resolveActiveAcpInstance } from "../acp/acp-instance-resolver";
 import {
   discoverAcpAgentInstances,
@@ -121,6 +122,25 @@ describe("discoverAcpAgentInstances", () => {
     expect(discover).toHaveBeenCalledWith(expect.not.objectContaining({ overrides: expect.anything() }));
   });
 
+  it("passes only enabled strategies to the kit", async () => {
+    const discover = vi.fn(
+      async (_options?: LocalAcpDiscoveryOptions) => [
+        group("kimi", [instance("/Users/me/.kimi-code/bin/kimi", "fallback")]),
+      ],
+    );
+
+    await discoverAcpAgentInstances({
+      discover,
+      enabledRegistryIds: ["kimi", "qwen"],
+    });
+
+    const options = discover.mock.calls[0]?.[0];
+    expect(options?.strategies?.map((strategy) => strategy.id)).toEqual([
+      "kimi",
+      "qwen",
+    ]);
+  });
+
   it("omits agents with no installed instances", async () => {
     const discover = vi.fn(async () => [group("gemini", [])]);
     const result = await discoverAcpAgentInstances({ discover });
@@ -166,5 +186,14 @@ describe("discoverLocalAcpAgentRecords", () => {
     const discover = vi.fn(async () => [group("gemini", [])]);
     const records = await discoverLocalAcpAgentRecords({ discover });
     expect(records).toEqual([]);
+  });
+
+  it("passes an empty strategy list when every provider is disabled", async () => {
+    const discover = vi.fn(async () => []);
+    await discoverLocalAcpAgentRecords({
+      discover,
+      enabledRegistryIds: [],
+    });
+    expect(discover).toHaveBeenCalledWith(expect.objectContaining({ strategies: [] }));
   });
 });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2505,6 +2505,60 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("filters disabled ACP agents before default backend discovery", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-backend-registry-"),
+    );
+    const previousHome = process.env.PWRAGENT_HOME;
+    const profileDir = path.join(tempRoot, "profiles", "default");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      path.join(profileDir, "config.toml"),
+      [
+        "[acp_agents.gemini]",
+        "enabled = false",
+        "",
+        "[acp_agents.kimi]",
+        "cli_path = \"/opt/pwragent/bin/kimi\"",
+        "",
+      ].join("\n"),
+    );
+    process.env.PWRAGENT_HOME = tempRoot;
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockReset();
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([]);
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+    });
+
+    try {
+      await registry.listBackends({ includeUnavailable: true });
+
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabledRegistryIds: ["grok", "kimi", "qwen"],
+          preferences: {
+            kimi: { overridePath: "/opt/pwragent/bin/kimi" },
+          },
+        }),
+      );
+    } finally {
+      await registry.close();
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockReset();
+      localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([]);
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("lists persisted ACP sessions as thread summaries", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -897,18 +897,128 @@ describe("settings ipc", () => {
 
       expect(
         localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
-      ).toHaveBeenCalledWith({
-        preferences: {
-          grok: { overridePath: "/opt/pwragent/bin/grok" },
-          qwen: { overridePath: "/opt/pwragent/bin/qwen" },
-        },
-      });
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabledRegistryIds: ["gemini", "grok", "kimi", "qwen"],
+          preferences: {
+            grok: { overridePath: "/opt/pwragent/bin/grok" },
+            qwen: { overridePath: "/opt/pwragent/bin/qwen" },
+          },
+        }),
+      );
     } finally {
       disposeAppState();
     }
     // Dynamic `import()` of the main app-state graph + IPC discovery round-trip
     // runs right at the 5s default under CI load; give it headroom so the slow
     // setup doesn't flake the suite.
+  }, 20_000);
+
+  it("skips local discovery and runtime probes for disabled ACP agents", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const profileConfigPath = path.join(
+      tempRoot,
+      "profiles",
+      "default",
+      "config.toml",
+    );
+    fs.mkdirSync(path.dirname(profileConfigPath), { recursive: true });
+    fs.writeFileSync(
+      profileConfigPath,
+      [
+        "[acp_agents.gemini]",
+        "enabled = false",
+        "",
+        "[acp_agents.kimi]",
+        "cli_path = \"/opt/pwragent/bin/kimi\"",
+        "",
+      ].join("\n"),
+    );
+    localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockImplementation(
+      async () => [],
+    );
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState();
+    try {
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        backendId: "acp:gemini",
+        registryId: "gemini",
+        name: "Gemini CLI",
+        version: "0.42.0",
+        distributionKind: "local",
+        distributionSource: "gemini --acp --skip-trust",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-gemini-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        launchDescriptor: {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          distributionKind: "local",
+          command: "gemini",
+          args: ["--acp", "--skip-trust"],
+          env: {},
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      const refreshed = (await handlers
+        .get(ACP_AGENTS_LIST_CHANNEL)
+        ?.({}, { refresh: true, force: true })) as
+        | { entries?: Array<{ registryId: string; installed: boolean }> }
+        | undefined;
+
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabledRegistryIds: ["grok", "kimi", "qwen"],
+          preferences: {
+            kimi: { overridePath: "/opt/pwragent/bin/kimi" },
+          },
+        }),
+      );
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          preferences: expect.objectContaining({
+            gemini: expect.anything(),
+          }),
+        }),
+      );
+      expect(
+        acpRuntimeDiscoveryMock.discoverAcpRuntimeCapabilities,
+      ).not.toHaveBeenCalled();
+      expect(refreshed?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            registryId: "gemini",
+            installed: true,
+          }),
+        ]),
+      );
+    } finally {
+      disposeAppState();
+    }
   }, 20_000);
 
   it("reuses cached ACP capabilities across refreshes and re-probes only when forced", async () => {

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -9,8 +9,10 @@
 // via the shared instance resolver.
 
 import {
+  BUILT_IN_ACP_STRATEGIES,
   discoverLocalAcpAgentInstances,
   strategyById,
+  type AcpAgentStrategy,
   type DiscoveredAcpAgentGroup,
   type LocalAcpDiscoveryOptions,
 } from "@pwrdrvr/agent-acp";
@@ -37,6 +39,8 @@ export type AcpInstanceDiscovery = {
 export type DiscoverAcpAgentInstancesOptions = {
   /** Per-agent (registryId) path preferences (override + picked). */
   preferences?: Record<string, AcpAgentPreference>;
+  /** Registry ids to discover. Undefined means all built-in strategies. */
+  enabledRegistryIds?: readonly string[];
   /** Env used for PATH enumeration + (default probe) spawns. */
   env?: NodeJS.ProcessEnv;
   /** Injectable clock (tests). */
@@ -58,6 +62,7 @@ export async function discoverAcpAgentInstances(
   options?: DiscoverAcpAgentInstancesOptions,
 ): Promise<Map<string, AcpInstanceDiscovery>> {
   const preferences = options?.preferences ?? {};
+  const strategies = strategiesForEnabledRegistryIds(options?.enabledRegistryIds);
 
   const overrides: Record<string, string> = {};
   for (const [registryId, pref] of Object.entries(preferences)) {
@@ -69,6 +74,7 @@ export async function discoverAcpAgentInstances(
 
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
   const groups = await discover({
+    ...(strategies !== undefined ? { strategies } : {}),
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
@@ -108,6 +114,7 @@ export async function discoverLocalAcpAgentRecords(
   options?: DiscoverAcpAgentInstancesOptions,
 ): Promise<AcpInstalledAgentRecord[]> {
   const preferences = options?.preferences ?? {};
+  const strategies = strategiesForEnabledRegistryIds(options?.enabledRegistryIds);
 
   const overrides: Record<string, string> = {};
   for (const [registryId, pref] of Object.entries(preferences)) {
@@ -119,6 +126,7 @@ export async function discoverLocalAcpAgentRecords(
 
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
   const groups = await discover({
+    ...(strategies !== undefined ? { strategies } : {}),
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
@@ -188,4 +196,14 @@ export async function discoverLocalAcpAgentRecords(
     });
   }
   return records;
+}
+
+function strategiesForEnabledRegistryIds(
+  enabledRegistryIds: readonly string[] | undefined,
+): readonly AcpAgentStrategy[] | undefined {
+  if (enabledRegistryIds === undefined) {
+    return undefined;
+  }
+  const enabled = new Set(enabledRegistryIds);
+  return BUILT_IN_ACP_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
 }

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -729,20 +729,20 @@ export class AcpBackendAdapter {
         // not once per lookup.
         const config = readDesktopSettingsConfigSafe();
         const preferences: Record<string, AcpAgentPreference> = {};
-        for (const registryId of ["gemini", "grok", "kimi", "qwen"]) {
+        const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+          (registryId) => acpAgentEnabledFor(config, registryId),
+        );
+        for (const registryId of enabledRegistryIds) {
           const override = acpCliPathOverrideFor(config, registryId);
           if (override) {
             preferences[registryId] = { overridePath: override };
           }
         }
         const records = await discoverLocalAcpAgentRecords({
+          enabledRegistryIds,
           ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
         });
-        // Drop agents the user disabled in Settings → AI Providers so they
-        // never surface as launchable chat backends. Defaults to enabled.
-        return records.filter((record) =>
-          acpAgentEnabledFor(config, record.registryId),
-        );
+        return records;
       });
     this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -55,6 +55,7 @@ import {
 import type { DesktopSettingsService } from "../settings/desktop-settings-service";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import {
+  acpAgentEnabledFor,
   acpCliPathOverrideFor,
   readDesktopSettingsConfigSafe,
 } from "../settings/desktop-config";
@@ -295,13 +296,17 @@ async function listInstalledAndLocalAcpAgents(
     try {
       const config = readDesktopSettingsConfigSafe();
       const preferences: Record<string, AcpAgentPreference> = {};
-      for (const registryId of ["gemini", "grok", "kimi", "qwen"]) {
+      const enabledRegistryIds = ["gemini", "grok", "kimi", "qwen"].filter(
+        (registryId) => acpAgentEnabledFor(config, registryId),
+      );
+      for (const registryId of enabledRegistryIds) {
         const override = acpCliPathOverrideFor(config, registryId);
         if (override) {
           preferences[registryId] = { overridePath: override };
         }
       }
       discovered = await discoverLocalAcpAgentRecords({
+        enabledRegistryIds,
         ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
       });
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -277,7 +277,7 @@ function AcpAgentSection(props: {
 
         <SettingsField
           label="Re-probe"
-          sub="Re-run discovery for every agent (versions, installs, capabilities)."
+          sub="Re-run discovery for enabled agents (versions, installs, capabilities)."
           control={
             <div className="settings-inline-actions">
               <button


### PR DESCRIPTION
## Summary
Disabled ACP providers no longer get probed during AI Providers refresh or backend discovery. A disabled Gemini install can stay visible from cache, but PwrAgent will not hand Gemini to the ACP discovery kit or runtime capability probe, so Settings navigation and Refresh do not trigger its browser login flow.

The Refresh row now describes the narrower behavior as discovery for enabled agents.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t "filters disabled ACP agents before default backend discovery"`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (passes with existing warning baseline)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
