### PR TITLE
fix(desktop): update Codex discovery package

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -64,7 +64,7 @@ MIT
 - @pwrdrvr/agent-transport@0.1.6 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/codex-app-server-protocol@0.133.0 | https://github.com/pwrdrvr/codex-app-server-protocol
 - @pwrdrvr/codex-app-server-protocol@0.135.0 | https://github.com/pwrdrvr/codex-app-server-protocol
-- @pwrdrvr/codex-discovery@0.1.3 | https://github.com/pwrdrvr/agent-kit
+- @pwrdrvr/codex-discovery@0.1.4 | https://github.com/pwrdrvr/agent-kit
 - @shutterstock/p-map-iterable@1.1.2 | https://github.com/shutterstock/p-map-iterable
 - @tiptap/core@3.27.1 | https://github.com/ueberdosis/tiptap
 - @tiptap/extension-blockquote@3.27.1 | https://github.com/ueberdosis/tiptap
@@ -328,7 +328,7 @@ Applies to:
 - @pwrdrvr/agent-transport@0.1.6 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.133.0 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.135.0 (MIT)
-- @pwrdrvr/codex-discovery@0.1.3 (MIT)
+- @pwrdrvr/codex-discovery@0.1.4 (MIT)
 
 Representative file: @pwrdrvr/agent-acp@0.12.2/LICENSE
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,7 +61,7 @@
     "@pwrdrvr/agent-core": "^0.2.0",
     "@pwrdrvr/agent-transport": "^0.1.6",
     "@pwrdrvr/codex-app-server-protocol": "0.135.0",
-    "@pwrdrvr/codex-discovery": "^0.1.2",
+    "@pwrdrvr/codex-discovery": "^0.1.4",
     "@shutterstock/p-map-iterable": "^1.1.2",
     "@tiptap/extension-mention": "^3.22.5",
     "@tiptap/react": "^3.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: 0.135.0
         version: 0.135.0
       '@pwrdrvr/codex-discovery':
-        specifier: ^0.1.2
-        version: 0.1.3
+        specifier: ^0.1.4
+        version: 0.1.4
       '@shutterstock/p-map-iterable':
         specifier: ^1.1.2
         version: 1.1.2(aggregate-error@3.1.0)
@@ -958,8 +958,8 @@ packages:
     resolution: {integrity: sha512-lmebPpbmaE7yfe0EDqcT2MPRtKurUc1o9NinHAVdA3lBdF3c8ZK3okiHIw6r6GEQLqOTd+7dpEuPsk4a1dEpkw==}
     engines: {node: '>=20'}
 
-  '@pwrdrvr/codex-discovery@0.1.3':
-    resolution: {integrity: sha512-9i6ZuDujKougP3JP+KRFf/V/wLmCxd73vLVwld4YTPqihQtlygjFHyqMCopTcDoIhMkSPogFcv5jzBxyAcX8qg==}
+  '@pwrdrvr/codex-discovery@0.1.4':
+    resolution: {integrity: sha512-jCk4LtJJFret0o8Mlzb53X8zrllA6dX1XX0Gvut+05bYjKRzXF/x9Y7mV3yfO1B5xdyp7ftw6FN8+qzxb1vH0w==}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -4875,7 +4875,7 @@ snapshots:
       '@pwrdrvr/agent-core': 0.2.0
       '@pwrdrvr/agent-transport': 0.1.6
       '@pwrdrvr/codex-app-server-protocol': 0.133.0
-      '@pwrdrvr/codex-discovery': 0.1.3
+      '@pwrdrvr/codex-discovery': 0.1.4
       zod: 4.3.6
 
   '@pwrdrvr/agent-core@0.2.0': {}
@@ -4888,7 +4888,7 @@ snapshots:
 
   '@pwrdrvr/codex-app-server-protocol@0.135.0': {}
 
-  '@pwrdrvr/codex-discovery@0.1.3':
+  '@pwrdrvr/codex-discovery@0.1.4':
     dependencies:
       '@pwrdrvr/agent-core': 0.2.0
 


### PR DESCRIPTION
## Summary
PwrAgent Settings can now use the published Codex discovery fix that finds Codex from renamed ChatGPT.app bundles and Homebrew installs even when the desktop app launches with a sparse macOS PATH.

This bumps `@pwrdrvr/codex-discovery` to `0.1.4` so AI Providers discovery no longer depends on the shell-only `/opt/homebrew/bin` PATH entry being present.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts`
- Direct discovery probe with `PATH=/usr/bin:/bin:/usr/sbin:/sbin` selected `/opt/homebrew/bin/codex` via `@pwrdrvr/codex-discovery@0.1.4`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt-5.5](https://img.shields.io/badge/gpt--5.5-000000)
