### PR TITLE
feat(desktop): schedule composer sends

### DIFF
--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -129,7 +129,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     const composer = app.window.locator(".composer");
     const activeLens = app.window.locator(".lens-switch__button.is-active");
     const selectedRow = app.window.locator(".thread-row.is-selected").first();
-    const primaryButton = app.window.locator(".button--primary").first();
+    const primaryButton = app.window.locator(".composer__send-split-pill").first();
     const composerInput = app.window.getByLabel("Reply");
     const sendButton = app.window.getByRole("button", { name: "Send" });
 
@@ -148,7 +148,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     await expect(activeLens).toHaveCSS("background-color", "rgb(18, 8, 0)");
     await expect(activeLens).toHaveCSS("color", "rgb(255, 179, 92)");
     await expect(primaryButton).toHaveCSS("background-color", "rgb(18, 8, 0)");
-    await expect(primaryButton).toHaveCSS("color", "rgb(255, 179, 92)");
+    await expect(sendButton).toHaveCSS("color", "rgb(255, 179, 92)");
     // --accent-border now derives via color-mix(in srgb, var(--accent) 42%,
     // transparent). Chromium serializes the computed value as either
     // `rgba(...)` (older versions) or `color(srgb r g b / a)` (newer
@@ -192,7 +192,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
     await assertTangerineFocusRing(composerInput);
     await composerInput.fill("Focus ring check");
     await expect(sendButton).toBeEnabled();
-    await assertTangerineFocusRing(sendButton);
+    await assertTangerineFocusRing(primaryButton, sendButton);
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -38,8 +38,8 @@ import type {
 } from "@pwragent/shared";
 import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
 import {
-  ArrowUpIcon,
   BranchIcon,
+  ChevronUpIcon,
   CloseIcon,
   FileCodeIcon,
   FolderIcon,
@@ -84,6 +84,7 @@ import {
   formatRunningDurationMs,
 } from "../thread-detail/EnvActionRunsView";
 import {
+  getNextReleasableQueuedTurn,
   useComposerDraftStore,
   type ComposerDraftSnapshot,
   type ComposerDraftStore,
@@ -2617,6 +2618,7 @@ export function Composer(props: ComposerProps) {
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
   const queuedTurn = queuedTurns[0];
+  const nextReleasableQueuedTurn = getNextReleasableQueuedTurn(queuedTurns);
   const futureScheduledDraftSendAt = getFutureScheduledSendAt(
     scheduledDraftSendAt,
     scheduleTick,
@@ -4447,31 +4449,30 @@ export function Composer(props: ComposerProps) {
       return;
     }
     if (
-      !queuedTurn ||
+      !nextReleasableQueuedTurn ||
       globalQueuedTurnReleaseScopeKeys.has(composerScopeKey) ||
       props.threadBusy ||
       activeTurnId ||
       serverQueuedTurnEntryId ||
       sending ||
       props.launchpad ||
-      props.disabled ||
-      getFutureScheduledSendAt(queuedTurn.scheduledSendAt, scheduleTick)
+      props.disabled
     ) {
       return;
     }
-    if (queuedAutoReleaseAttemptIdRef.current === queuedTurn.id) {
+    if (queuedAutoReleaseAttemptIdRef.current === nextReleasableQueuedTurn.id) {
       return;
     }
 
-    queuedAutoReleaseAttemptIdRef.current = queuedTurn.id;
+    queuedAutoReleaseAttemptIdRef.current = nextReleasableQueuedTurn.id;
     globalQueuedTurnReleaseScopeKeys.add(composerScopeKey);
     updateSending(true);
-    void sendQueuedTurn(queuedTurn).finally(() => {
+    void sendQueuedTurn(nextReleasableQueuedTurn).finally(() => {
       updateSending(false);
     });
   }, [
     activeTurnId,
-    queuedTurn,
+    nextReleasableQueuedTurn,
     serverQueuedTurnEntryId,
     scheduleTick,
     sending,
@@ -5526,6 +5527,12 @@ export function Composer(props: ComposerProps) {
     Boolean(props.launchpad) ||
     !props.thread ||
     isCompactCommand;
+  // Only surface the schedule caret where scheduling actually applies. In the
+  // launchpad, compact command, or a thread-less composer there is nothing to
+  // schedule, so the split collapses to a plain Send pill instead of parking a
+  // permanently-dimmed half-button next to it.
+  const scheduleAffordanceVisible =
+    Boolean(props.thread) && !props.launchpad && !isCompactCommand;
   const submitButtonLabel = futureScheduledDraftSendAt
     ? `Send in ${formatScheduledSendCountdown(
         futureScheduledDraftSendAt,
@@ -7508,28 +7515,39 @@ export function Composer(props: ComposerProps) {
               .join(" ")}
             ref={scheduleMenuRef}
           >
-            <button
-              aria-expanded={scheduleMenuOpen}
-              aria-haspopup="menu"
-              aria-label="Schedule message"
-              className="button button--primary composer__send-schedule-button"
-              disabled={scheduleButtonDisabled}
-              type="button"
-              onClick={() => {
-                setScheduleTick(Date.now());
-                setScheduleMenuOpen((current) => !current);
-              }}
+            <div
+              className={[
+                "composer__send-split-pill",
+                sendButtonDisabled ? "is-disabled" : "",
+              ]
+                .filter(Boolean)
+                .join(" ")}
             >
-              <ArrowUpIcon size={13} />
-            </button>
-            <button
-              className="button button--primary composer__send-submit-button"
-              disabled={sendButtonDisabled}
-              type="submit"
-            >
-              {submitButtonLabel}
-            </button>
-            {scheduleMenuOpen ? (
+              {scheduleAffordanceVisible ? (
+                <button
+                  aria-expanded={scheduleMenuOpen}
+                  aria-haspopup="menu"
+                  aria-label="Schedule message"
+                  className="button composer__send-schedule-button"
+                  disabled={scheduleButtonDisabled}
+                  type="button"
+                  onClick={() => {
+                    setScheduleTick(Date.now());
+                    setScheduleMenuOpen((current) => !current);
+                  }}
+                >
+                  <ChevronUpIcon size={14} />
+                </button>
+              ) : null}
+              <button
+                className="button composer__send-submit-button"
+                disabled={sendButtonDisabled}
+                type="submit"
+              >
+                {submitButtonLabel}
+              </button>
+            </div>
+            {scheduleAffordanceVisible && scheduleMenuOpen ? (
               <div className="composer__schedule-menu" role="menu">
                 {scheduledSendOptions.map((option) => (
                   <button

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -38,6 +38,7 @@ import type {
 } from "@pwragent/shared";
 import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
 import {
+  ArrowUpIcon,
   BranchIcon,
   CloseIcon,
   FileCodeIcon,
@@ -259,6 +260,7 @@ type QueuedTurnDraft = {
   id: string;
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
+  scheduledSendAt?: number;
   reviewCommand?: {
     cwd?: string;
     displayText: string;
@@ -341,6 +343,18 @@ type ReviewWorkspaceOption = {
 };
 
 const DEFAULT_REASONING_EFFORT = "medium";
+const SCHEDULED_SEND_OPTIONS = [
+  { label: "Send in 15m", delayMs: 15 * 60_000 },
+  { label: "Send in 30m", delayMs: 30 * 60_000 },
+  { label: "Send in 1h", delayMs: 60 * 60_000 },
+  { label: "Send in 2h", delayMs: 2 * 60 * 60_000 },
+] as const;
+
+type ScheduledSendMenuOption = {
+  delayMs?: number;
+  label: string;
+  scheduledSendAt?: number;
+};
 
 let queuedTurnIdSequence = 0;
 
@@ -350,6 +364,86 @@ function createQueuedTurnId(): string {
 }
 
 const globalQueuedTurnReleaseScopeKeys = new Set<string>();
+
+function getFutureScheduledSendAt(
+  scheduledSendAt: number | undefined,
+  now = Date.now(),
+): number | undefined {
+  if (typeof scheduledSendAt !== "number" || !Number.isFinite(scheduledSendAt)) {
+    return undefined;
+  }
+  return scheduledSendAt > now ? scheduledSendAt : undefined;
+}
+
+function formatScheduledSendCountdown(
+  scheduledSendAt: number,
+  now = Date.now(),
+): string {
+  return formatRunningDurationMs(Math.max(0, scheduledSendAt - now));
+}
+
+function isFiveHourRateLimitName(value?: string): boolean {
+  return value?.toLowerCase().endsWith("5h limit") ?? false;
+}
+
+function rateLimitMatchesModel(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+  selectedModelOption?: ModelOption,
+): boolean {
+  const modelTerms = [
+    selectedModelOption?.id,
+    selectedModelOption?.label,
+  ]
+    .filter((term): term is string => Boolean(term))
+    .map((term) => term.toLowerCase());
+  if (modelTerms.length === 0) {
+    return false;
+  }
+
+  const searchable = [
+    rateLimit.limitId,
+    rateLimit.name,
+  ]
+    .filter((term): term is string => Boolean(term))
+    .map((term) => term.toLowerCase());
+  return modelTerms.some((term) =>
+    searchable.some((candidate) => candidate.includes(term))
+  );
+}
+
+function getFiveHourRateLimitResetAt(params: {
+  backend?: BackendSummary;
+  now: number;
+  selectedModelOption?: ModelOption;
+}): number | undefined {
+  const candidates = (params.backend?.rateLimits ?? []).filter((rateLimit) => {
+    const resetAt = rateLimit.resetAt;
+    return (
+      typeof resetAt === "number" &&
+      Number.isFinite(resetAt) &&
+      resetAt > params.now &&
+      (isFiveHourRateLimitName(rateLimit.name) ||
+        isFiveHourRateLimitName(rateLimit.limitId))
+    );
+  });
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const modelSpecific = candidates.filter((candidate) =>
+    rateLimitMatchesModel(candidate, params.selectedModelOption)
+  );
+  const generic = candidates.filter(
+    (candidate) => candidate.name.toLowerCase() === "5h limit",
+  );
+  const ordered =
+    modelSpecific.length > 0
+      ? modelSpecific
+      : generic.length > 0
+        ? generic
+        : candidates;
+  return Math.min(...ordered.map((candidate) => candidate.resetAt!));
+}
 
 const SLASH_COMMANDS: SlashCommandSuggestion[] = [
   {
@@ -2311,6 +2405,15 @@ export function Composer(props: ComposerProps) {
     workspaceMenuOpen,
     () => setWorkspaceMenuOpen(false),
   );
+  const [scheduleMenuOpen, setScheduleMenuOpen] = useState(false);
+  const scheduleMenuRef = useDismissableMenu<HTMLDivElement>(
+    scheduleMenuOpen,
+    () => setScheduleMenuOpen(false),
+  );
+  const [scheduleTick, setScheduleTick] = useState(() => Date.now());
+  const [scheduledDraftSendAt, setScheduledDraftSendAt] = useState<
+    number | undefined
+  >();
   const [handoffDialog, setHandoffDialog] = useState<
     HandoffThreadWorkspaceRequest["direction"] | undefined
   >();
@@ -2514,6 +2617,10 @@ export function Composer(props: ComposerProps) {
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
   const queuedTurn = queuedTurns[0];
+  const futureScheduledDraftSendAt = getFutureScheduledSendAt(
+    scheduledDraftSendAt,
+    scheduleTick,
+  );
   launchpadUpdateRef.current = props.onUpdateLaunchpad;
   latestDraftSnapshotRef.current = {
     scopeKey: composerScopeKey,
@@ -3016,6 +3123,29 @@ export function Composer(props: ComposerProps) {
       return nextPendingSteer;
     });
   };
+  useEffect(() => {
+    const hasFutureScheduledQueue = queuedTurns.some((entry) =>
+      Boolean(getFutureScheduledSendAt(entry.scheduledSendAt))
+    );
+    if (!futureScheduledDraftSendAt && !hasFutureScheduledQueue) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setScheduleTick(Date.now());
+    }, 1_000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [futureScheduledDraftSendAt, queuedTurns]);
+
+  useEffect(() => {
+    if (scheduledDraftSendAt && !futureScheduledDraftSendAt) {
+      setScheduledDraftSendAt(undefined);
+    }
+  }, [futureScheduledDraftSendAt, scheduledDraftSendAt]);
+
   const markComposerDraftSubmitted = (scopeKey: string): void => {
     if (!isDraftStoreScope(scopeKey)) {
       return;
@@ -3325,6 +3455,8 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
+    setScheduleMenuOpen(false);
+    setScheduledDraftSendAt(undefined);
     setServerQueuedTurnEntryIdState(
       serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)
     );
@@ -4028,6 +4160,7 @@ export function Composer(props: ComposerProps) {
 
   const exitReviewComposer = (): void => {
     setReviewConfig(undefined);
+    setScheduledDraftSendAt(undefined);
     clearComposerDraft();
     setSendError(undefined);
     requestAnimationFrame(() => inputRef.current?.focus());
@@ -4044,6 +4177,13 @@ export function Composer(props: ComposerProps) {
     if (!configuredReviewCommand) {
       return;
     }
+    if (futureScheduledDraftSendAt) {
+      queueReviewCommand(configuredReviewCommand, {
+        scheduledSendAt: futureScheduledDraftSendAt,
+      });
+      return;
+    }
+
     await submitReviewCommand(configuredReviewCommand);
   };
 
@@ -4314,7 +4454,8 @@ export function Composer(props: ComposerProps) {
       serverQueuedTurnEntryId ||
       sending ||
       props.launchpad ||
-      props.disabled
+      props.disabled ||
+      getFutureScheduledSendAt(queuedTurn.scheduledSendAt, scheduleTick)
     ) {
       return;
     }
@@ -4332,6 +4473,7 @@ export function Composer(props: ComposerProps) {
     activeTurnId,
     queuedTurn,
     serverQueuedTurnEntryId,
+    scheduleTick,
     sending,
     props.threadBusy,
     props.disabled,
@@ -4361,7 +4503,7 @@ export function Composer(props: ComposerProps) {
     setPendingSteer(undefined);
   }, [activeTurnId, pendingSteer, props.launchpad, queuedTurn]);
 
-  const queueCurrentDraft = (): void => {
+  const queueCurrentDraft = (options?: { scheduledSendAt?: number }): void => {
     if (!hasComposerContent && imageAttachments.length === 0) {
       return;
     }
@@ -4376,6 +4518,9 @@ export function Composer(props: ComposerProps) {
       input: payload.input,
       text: canonicalDraft,
       imageAttachments,
+      ...(options?.scheduledSendAt
+        ? { scheduledSendAt: options.scheduledSendAt }
+        : {}),
     });
     recordComposerDraftHistory(
       composerScopeKey,
@@ -4385,19 +4530,26 @@ export function Composer(props: ComposerProps) {
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
+    setScheduledDraftSendAt(undefined);
     setReviewConfig(undefined);
     setSendError(undefined);
   };
 
-  const queueReviewCommand = (reviewCommand: {
-    cwd?: string;
-    displayText: string;
-    target: AppServerReviewTarget;
-  }): void => {
+  const queueReviewCommand = (
+    reviewCommand: {
+      cwd?: string;
+      displayText: string;
+      target: AppServerReviewTarget;
+    },
+    options?: { scheduledSendAt?: number },
+  ): void => {
     enqueueQueuedTurn({
       id: createQueuedTurnId(),
       text: reviewCommandToDraftText(reviewCommand),
       imageAttachments: [],
+      ...(options?.scheduledSendAt
+        ? { scheduledSendAt: options.scheduledSendAt }
+        : {}),
       reviewCommand,
     });
     recordComposerDraftHistory(
@@ -4408,6 +4560,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
+    setScheduledDraftSendAt(undefined);
     setReviewConfig(undefined);
     setSendError(undefined);
   };
@@ -4418,6 +4571,48 @@ export function Composer(props: ComposerProps) {
       Boolean(activeTurnIdRef.current) ||
       Boolean(serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)) ||
       sendingRef.current);
+
+  const scheduleCurrentDraft = (scheduledSendAt: number): void => {
+    if (props.launchpad || props.disabled) {
+      return;
+    }
+
+    const reviewCommand = parsedReviewCommand;
+    if (reviewCommand) {
+      if (isBareReviewCommand) {
+        setScheduledDraftSendAt(scheduledSendAt);
+        setReviewConfig(
+          reviewConfig ??
+            createReviewConfig({
+              directory: props.directory,
+              thread: props.thread,
+            })
+        );
+        setSendError(undefined);
+        return;
+      }
+      if (imageAttachments.length > 0) {
+        setSendError("/review does not accept image attachments.");
+        return;
+      }
+      if (reviewWorkspaceSelectionRequired) {
+        setScheduledDraftSendAt(scheduledSendAt);
+        setReviewConfig(
+          createReviewConfig({
+            directory: props.directory,
+            reviewCommand,
+            thread: props.thread,
+          })
+        );
+        setSendError("Choose a project to review.");
+        return;
+      }
+      queueReviewCommand(reviewCommand, { scheduledSendAt });
+      return;
+    }
+
+    queueCurrentDraft({ scheduledSendAt });
+  };
 
   const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
     const turnId = activeTurnIdRef.current;
@@ -4587,9 +4782,18 @@ export function Composer(props: ComposerProps) {
           setSendError("Choose a project to review.");
           return;
         }
-        queueReviewCommand(reviewCommand);
+        queueReviewCommand(
+          reviewCommand,
+          futureScheduledDraftSendAt
+            ? { scheduledSendAt: futureScheduledDraftSendAt }
+            : undefined,
+        );
       } else {
-        queueCurrentDraft();
+        queueCurrentDraft(
+          futureScheduledDraftSendAt
+            ? { scheduledSendAt: futureScheduledDraftSendAt }
+            : undefined,
+        );
       }
       return;
     }
@@ -4607,7 +4811,19 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
+      if (futureScheduledDraftSendAt) {
+        queueReviewCommand(reviewCommand, {
+          scheduledSendAt: futureScheduledDraftSendAt,
+        });
+        return;
+      }
+
       await submitReviewCommand(reviewCommand);
+      return;
+    }
+
+    if (futureScheduledDraftSendAt) {
+      queueCurrentDraft({ scheduledSendAt: futureScheduledDraftSendAt });
       return;
     }
 
@@ -5278,6 +5494,52 @@ export function Composer(props: ComposerProps) {
     selectedModelOption?.supportsSteering !== false &&
     props.thread?.source !== "grok";
   const launchpadSubmitting = isLaunchpad && sending;
+  const fiveHourResetAt = getFiveHourRateLimitResetAt({
+    backend,
+    now: scheduleTick,
+    selectedModelOption,
+  });
+  const scheduledSendOptions: ScheduledSendMenuOption[] = [
+    ...SCHEDULED_SEND_OPTIONS.map((option) => ({
+      delayMs: option.delayMs,
+      label: option.label,
+    })),
+    ...(fiveHourResetAt
+      ? [
+          {
+            label: `Send in ${formatScheduledSendCountdown(
+              fiveHourResetAt,
+              scheduleTick,
+            )} (5h context reset)`,
+            scheduledSendAt: fiveHourResetAt,
+          },
+        ]
+      : []),
+  ];
+  const sendButtonDisabled =
+    props.disabled ||
+    steering ||
+    (!activeTurnId && sending) ||
+    (!hasComposerContent && imageAttachments.length === 0);
+  const scheduleButtonDisabled =
+    sendButtonDisabled ||
+    Boolean(props.launchpad) ||
+    !props.thread ||
+    isCompactCommand;
+  const submitButtonLabel = futureScheduledDraftSendAt
+    ? `Send in ${formatScheduledSendCountdown(
+        futureScheduledDraftSendAt,
+        scheduleTick,
+      )}`
+    : activeTurnId || serverQueuedTurnEntryId || props.threadBusy
+      ? "Queue"
+      : sending
+        ? props.launchpad
+          ? "Starting…"
+          : "Sending…"
+        : props.launchpad
+          ? "Start thread"
+          : "Send";
   const launchpadWorkspaceOptions = props.launchpad
     ? buildLaunchpadWorkspaceOptions(props.launchpad, props.directory)
     : [];
@@ -6087,6 +6349,7 @@ export function Composer(props: ComposerProps) {
         data-composer-implementation="tiptap-wysiwyg-markdown-chips"
         onSubmit={(event) => {
           event.preventDefault();
+          setScheduleMenuOpen(false);
           if (isReviewComposerOpen) {
             void submitConfiguredReviewComposer();
           } else {
@@ -6187,58 +6450,76 @@ export function Composer(props: ComposerProps) {
         </div>
       ) : null}
 
-      {queuedTurns.map((queued, index) => (
-        <div
-          className="composer__queued"
-          aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
-          key={`${index}:${queued.text}:${queued.imageAttachments.length}`}
-        >
-          <div className="composer__queued-copy">
-            <span className="composer__queued-label">
-              {index === 0 ? "Queued next" : `Queued #${index + 1}`}
-            </span>
-            <span className="composer__queued-text">
-              {formatDraftPreview(queued)}
-            </span>
-          </div>
-          <QueuedImageAttachments attachments={queued.imageAttachments} />
-          <div className="composer__queued-actions">
-            {supportsSteering && !queued.reviewCommand ? (
+      {queuedTurns.map((queued, index) => {
+        const scheduledSendAt = getFutureScheduledSendAt(
+          queued.scheduledSendAt,
+          scheduleTick,
+        );
+        const queuedLabel = scheduledSendAt
+          ? `Sends in ${formatScheduledSendCountdown(scheduledSendAt, scheduleTick)}`
+          : index === 0
+            ? "Queued next"
+            : `Queued #${index + 1}`;
+
+        return (
+          <div
+            className={[
+              "composer__queued",
+              scheduledSendAt ? "composer__queued--scheduled" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
+            key={`${index}:${queued.text}:${queued.imageAttachments.length}:${queued.scheduledSendAt ?? ""}`}
+          >
+            <div className="composer__queued-copy">
+              <span className="composer__queued-label">
+                {queuedLabel}
+              </span>
+              <span className="composer__queued-text">
+                {formatDraftPreview(queued)}
+              </span>
+            </div>
+            <QueuedImageAttachments attachments={queued.imageAttachments} />
+            <div className="composer__queued-actions">
+              {supportsSteering && !queued.reviewCommand ? (
+                <button
+                  className="composer__secondary-action"
+                  disabled={props.disabled || steering || !activeTurnId}
+                  type="button"
+                  onClick={() => {
+                    steerQueuedTurn(queued);
+                  }}
+                >
+                  {steering ? "Steering..." : "Steer"}
+                </button>
+              ) : null}
               <button
                 className="composer__secondary-action"
-                disabled={props.disabled || steering || !activeTurnId}
                 type="button"
                 onClick={() => {
-                  steerQueuedTurn(queued);
+                  setComposerDraftFromCanonical(queued.text);
+                  setImageAttachments(queued.imageAttachments);
+                  setScheduledDraftSendAt(scheduledSendAt);
+                  removeQueuedTurnAt(index);
+                  requestAnimationFrame(() => inputRef.current?.focus());
                 }}
               >
-                {steering ? "Steering..." : "Steer"}
+                Edit
               </button>
-            ) : null}
-            <button
-              className="composer__secondary-action"
-              type="button"
-              onClick={() => {
-                setComposerDraftFromCanonical(queued.text);
-                setImageAttachments(queued.imageAttachments);
-                removeQueuedTurnAt(index);
-                requestAnimationFrame(() => inputRef.current?.focus());
-              }}
-            >
-              Edit
-            </button>
-            <button
-              className="composer__secondary-action"
-              type="button"
-              onClick={() => {
-                removeQueuedTurnAt(index);
-              }}
-            >
-              Delete
-            </button>
+              <button
+                className="composer__secondary-action"
+                type="button"
+                onClick={() => {
+                  removeQueuedTurnAt(index);
+                }}
+              >
+                Delete
+              </button>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
 
       {imageAttachments.length > 0 ? (
         <div className="composer__attachments" aria-label="Pasted images">
@@ -6461,7 +6742,12 @@ export function Composer(props: ComposerProps) {
                   void submitConfiguredReviewComposer();
                 }}
               >
-                Start review
+                {futureScheduledDraftSendAt
+                  ? `Send in ${formatScheduledSendCountdown(
+                      futureScheduledDraftSendAt,
+                      scheduleTick,
+                    )}`
+                  : "Start review"}
               </button>
             </div>
           </fieldset>
@@ -7213,26 +7499,57 @@ export function Composer(props: ComposerProps) {
               Cancel
             </button>
           ) : null}
-          <button
-            className="button button--primary"
-            disabled={
-              props.disabled ||
-              steering ||
-              (!activeTurnId && sending) ||
-              (!hasComposerContent && imageAttachments.length === 0)
-            }
-            type="submit"
+          <div
+            className={[
+              "composer__send-split",
+              scheduleMenuOpen ? "composer__send-split--open" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            ref={scheduleMenuRef}
           >
-            {activeTurnId || serverQueuedTurnEntryId || props.threadBusy
-              ? "Queue"
-              : sending
-              ? props.launchpad
-                ? "Starting…"
-                : "Sending…"
-              : props.launchpad
-                ? "Start thread"
-                : "Send"}
-          </button>
+            <button
+              aria-expanded={scheduleMenuOpen}
+              aria-haspopup="menu"
+              aria-label="Schedule message"
+              className="button button--primary composer__send-schedule-button"
+              disabled={scheduleButtonDisabled}
+              type="button"
+              onClick={() => {
+                setScheduleTick(Date.now());
+                setScheduleMenuOpen((current) => !current);
+              }}
+            >
+              <ArrowUpIcon size={13} />
+            </button>
+            <button
+              className="button button--primary composer__send-submit-button"
+              disabled={sendButtonDisabled}
+              type="submit"
+            >
+              {submitButtonLabel}
+            </button>
+            {scheduleMenuOpen ? (
+              <div className="composer__schedule-menu" role="menu">
+                {scheduledSendOptions.map((option) => (
+                  <button
+                    className="composer__schedule-menu-item"
+                    key={option.label}
+                    role="menuitem"
+                    type="button"
+                    onClick={() => {
+                      setScheduleMenuOpen(false);
+                      scheduleCurrentDraft(
+                        option.scheduledSendAt ?? Date.now() + option.delayMs!,
+                      );
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
       </form>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1668,6 +1668,216 @@ describe("Composer", () => {
     });
   });
 
+  it("schedules the current draft from the send split menu", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-scheduled",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Schedule send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Check this in a bit" } });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 15m" }));
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("");
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Sends in 15m"
+    );
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Check this in a bit"
+    );
+  });
+
+  it("preserves a scheduled send time while editing a scheduled queued draft", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-scheduled",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Edit scheduled send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Original scheduled text" } });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 1h" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(textarea).toHaveValue("Original scheduled text");
+    expect(screen.getByRole("button", { name: "Send in 1h" })).toBeEnabled();
+
+    fireEvent.change(textarea, { target: { value: "Edited scheduled text" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send in 1h" }));
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(textarea).toHaveValue("");
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Sends in 1h"
+    );
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Edited scheduled text"
+    );
+  });
+
+  it("preserves schedule selection through bare review configuration", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Scheduled review",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 30m" }));
+
+    const reviewTarget = screen.getByRole("group", { name: "Review target" });
+    expect(reviewTarget).toBeInTheDocument();
+    expect(
+      within(reviewTarget).getByRole("button", { name: "Send in 30m" })
+    ).toBeEnabled();
+
+    fireEvent.click(
+      within(reviewTarget).getByRole("button", { name: "Send in 30m" })
+    );
+
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Sends in 30m"
+    );
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Review changes against main"
+    );
+  });
+
+  it("shows a 5h context reset schedule option when the backend exposes a reset", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-scheduled",
+    }));
+
+    render(
+      <Composer
+        backends={[
+          {
+            ...backendSummary("codex"),
+            rateLimits: [
+              {
+                name: "5h limit",
+                resetAt: Date.now() + 154 * 60_000,
+                usedPercent: 80,
+              },
+            ],
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Reset schedule",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "After the reset" } });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", {
+        name: "Send in 2h 34m (5h context reset)",
+      })
+    );
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "Sends in 2h 34m"
+    );
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "After the reset"
+    );
+  });
+
   it("queues slash review submits while a turn start is pending", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1878,6 +1878,36 @@ describe("Composer", () => {
     );
   });
 
+  it("hides the schedule caret on a launchpad where scheduling does not apply", () => {
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo/PwrAgent",
+          directoryKind: "directory",
+          directoryLabel: "PwrAgent",
+          directoryPath: "/repo/PwrAgent",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Kick off a new thread",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        skills={[]}
+      />
+    );
+
+    // The split collapses to a plain Send/Start pill: no caret, no divider.
+    expect(
+      screen.queryByRole("button", { name: "Schedule message" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Start thread" })
+    ).toBeInTheDocument();
+  });
+
   it("queues slash review submits while a turn start is pending", async () => {
     let agentEventHandler:
       | ((event: {
@@ -4253,6 +4283,69 @@ describe("Composer", () => {
       expect(screen.queryByText("Queued elsewhere")).not.toBeInTheDocument();
     });
     expect(startTurn).not.toHaveBeenCalled();
+  });
+
+  it("releases a due scheduled queued turn ahead of an earlier future scheduled turn", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const draftStore = createComposerDraftStore();
+    const scopeKey = "thread:codex:thread-1";
+    draftStore.setQueuedTurns(scopeKey, [
+      {
+        id: "queued-later",
+        text: "Later scheduled turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Later scheduled turn" }],
+        scheduledSendAt: Date.now() + 2 * 60 * 60_000,
+      },
+      {
+        id: "queued-sooner",
+        text: "Sooner scheduled turn",
+        imageAttachments: [],
+        input: [{ type: "text", text: "Sooner scheduled turn" }],
+        scheduledSendAt: Date.now() + 15 * 60_000,
+      },
+    ]);
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-sooner",
+    }));
+    const thread = {
+      id: "thread-1",
+      title: "Out of order schedule",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    vi.setSystemTime(new Date("2026-07-10T12:15:00Z"));
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "Sooner scheduled turn" }],
+      })
+    );
+    expect(draftStore.getQueuedTurns(scopeKey).map((entry) => entry.text)).toEqual([
+      "Later scheduled turn",
+    ]);
   });
 
   it("dispatches a queued turn even when selected-thread preflight would block a new send", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -62,6 +62,25 @@ export type ComposerDraftStore = {
   set(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
 };
 
+export function getQueuedTurnReleaseDelayMs(
+  queuedTurn: Pick<ComposerQueuedTurnSnapshot, "scheduledSendAt">,
+  now = Date.now(),
+): number {
+  const scheduledSendAt = queuedTurn.scheduledSendAt;
+  if (typeof scheduledSendAt !== "number" || !Number.isFinite(scheduledSendAt)) {
+    return 0;
+  }
+  return Math.max(0, scheduledSendAt - now);
+}
+
+export function getNextReleasableQueuedTurn<
+  T extends Pick<ComposerQueuedTurnSnapshot, "scheduledSendAt">,
+>(queuedTurns: readonly T[], now = Date.now()): T | undefined {
+  return queuedTurns.find((queuedTurn) =>
+    getQueuedTurnReleaseDelayMs(queuedTurn, now) === 0
+  );
+}
+
 export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
   const pendingSteerStoreRef = useRef(new Map<string, ComposerPendingSteerSnapshot>());

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -22,6 +22,7 @@ export type ComposerQueuedTurnSnapshot = {
   input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  scheduledSendAt?: number;
   reviewCommand?: {
     cwd?: string;
     displayText: string;

--- a/apps/desktop/src/renderer/src/icons/ChevronUpIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/ChevronUpIcon.tsx
@@ -1,0 +1,9 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function ChevronUpIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="m18 15-6-6-6 6" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -3,6 +3,7 @@ export { AutomationsIcon } from "./AutomationsIcon";
 export { BranchIcon } from "./BranchIcon";
 export { ChevronLeftIcon } from "./ChevronLeftIcon";
 export { ChevronRightIcon } from "./ChevronRightIcon";
+export { ChevronUpIcon } from "./ChevronUpIcon";
 export { CloseIcon } from "./CloseIcon";
 export { CopyIcon } from "./CopyIcon";
 export { DiscordIcon } from "./DiscordIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -440,6 +440,82 @@ describe("useQueuedTurnRelease", () => {
     );
   });
 
+  it("releases the due scheduled background turn ahead of an earlier future scheduled turn", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-sooner",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurns("thread:codex:thread-a", [
+      {
+        id: "queued-later",
+        text: "Later background reply",
+        imageAttachments: [],
+        scheduledSendAt: Date.now() + 2 * 60 * 60_000,
+        input: [{ type: "text", text: "Later background reply" }],
+      },
+      {
+        id: "queued-sooner",
+        text: "Sooner background reply",
+        imageAttachments: [],
+        scheduledSendAt: Date.now() + 15 * 60_000,
+        input: [{ type: "text", text: "Sooner background reply" }],
+      },
+    ]);
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    vi.setSystemTime(new Date("2026-07-10T12:15:00Z"));
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-a",
+              status: { type: "idle" },
+            },
+          },
+        });
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-a",
+        input: [{ type: "text", text: "Sooner background reply" }],
+      })
+    );
+    expect(
+      composerDraftStore.getQueuedTurns("thread:codex:thread-a").map((entry) => entry.text)
+    ).toEqual(["Later background reply"]);
+  });
+
   it("releases a queued review with review/start for a non-focused thread", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -359,6 +359,87 @@ describe("useQueuedTurnRelease", () => {
     expect(composerDraftStore.getQueuedTurn("thread:codex:thread-a")).toBeUndefined();
   });
 
+  it("waits until a scheduled queued message is due before background release", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-a",
+      turnId: "turn-next",
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      startTurn,
+    };
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-scheduled",
+      text: "Future background reply",
+      imageAttachments: [],
+      scheduledSendAt: Date.now() + 15 * 60_000,
+      input: [{ type: "text", text: "Future background reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi,
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      })
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-a",
+              status: { type: "idle" },
+            },
+          },
+        });
+      }
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+
+    vi.setSystemTime(new Date("2026-07-10T12:15:00Z"));
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/status/changed",
+            params: {
+              threadId: "thread-a",
+              status: { type: "idle" },
+            },
+          },
+        });
+      }
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-a",
+        input: [{ type: "text", text: "Future background reply" }],
+      })
+    );
+  });
+
   it("releases a queued review with review/start for a non-focused thread", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn();

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -23,6 +23,17 @@ const TERMINAL_TURN_METHODS = new Set([
 const BACKGROUND_QUEUE_RELEASE_INTERVAL_MS = 30_000;
 const globalInFlightScopeKeys = new Set<string>();
 
+function getQueuedTurnReleaseDelayMs(
+  queuedTurn: Pick<ComposerQueuedTurnSnapshot, "scheduledSendAt">,
+  now = Date.now(),
+): number {
+  const scheduledSendAt = queuedTurn.scheduledSendAt;
+  if (typeof scheduledSendAt !== "number" || !Number.isFinite(scheduledSendAt)) {
+    return 0;
+  }
+  return Math.max(0, scheduledSendAt - now);
+}
+
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
   return (
@@ -163,6 +174,9 @@ export function useQueuedTurnRelease(params: {
     if (!queuedTurn || isThreadSelected(current, thread)) {
       return;
     }
+    if (getQueuedTurnReleaseDelayMs(queuedTurn) > 0) {
+      return;
+    }
     const queuedTurnId = queuedTurn.id;
 
     const readReleaseCandidate = (candidateThread: NavigationThreadSummary) => {
@@ -174,6 +188,9 @@ export function useQueuedTurnRelease(params: {
       const releaseQueuedSnapshot =
         releaseState.composerDraftStore.getQueuedTurn(scopeKey);
       if (!releaseQueuedSnapshot || releaseQueuedSnapshot.id !== queuedTurnId) {
+        return undefined;
+      }
+      if (getQueuedTurnReleaseDelayMs(releaseQueuedSnapshot) > 0) {
         return undefined;
       }
 
@@ -449,4 +466,56 @@ export function useQueuedTurnRelease(params: {
       window.clearInterval(timer);
     };
   }, []);
+
+  useEffect(() => {
+    const current = paramsRef.current;
+    let nextReleaseAt: number | undefined;
+    for (const thread of current.threads) {
+      if (
+        current.selectedThread?.source === thread.source &&
+        current.selectedThread.id === thread.id
+      ) {
+        continue;
+      }
+
+      const queuedTurn = current.composerDraftStore.getQueuedTurn(
+        getThreadScopeKey(thread),
+      );
+      const scheduledSendAt = queuedTurn?.scheduledSendAt;
+      if (
+        typeof scheduledSendAt !== "number" ||
+        !Number.isFinite(scheduledSendAt) ||
+        scheduledSendAt <= Date.now()
+      ) {
+        continue;
+      }
+
+      nextReleaseAt =
+        nextReleaseAt === undefined
+          ? scheduledSendAt
+          : Math.min(nextReleaseAt, scheduledSendAt);
+    }
+
+    if (nextReleaseAt === undefined) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const releaseState = paramsRef.current;
+      for (const thread of releaseState.threads) {
+        if (
+          releaseState.selectedThread?.source === thread.source &&
+          releaseState.selectedThread.id === thread.id
+        ) {
+          continue;
+        }
+
+        void releaseQueuedTurnForThread(thread, { verifyIdle: true });
+      }
+    }, Math.max(0, nextReleaseAt - Date.now()));
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [params.threads, params.selectedThread, params.composerDraftStore]);
 }

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -5,9 +5,10 @@ import type {
   BackendSummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
-import type {
-  ComposerDraftStore,
-  ComposerQueuedTurnSnapshot,
+import {
+  getNextReleasableQueuedTurn,
+  type ComposerDraftStore,
+  type ComposerQueuedTurnSnapshot,
 } from "../features/composer/useComposerDraftStore";
 import type { DesktopApi } from "./desktop-api";
 
@@ -22,17 +23,6 @@ const TERMINAL_TURN_METHODS = new Set([
 ]);
 const BACKGROUND_QUEUE_RELEASE_INTERVAL_MS = 30_000;
 const globalInFlightScopeKeys = new Set<string>();
-
-function getQueuedTurnReleaseDelayMs(
-  queuedTurn: Pick<ComposerQueuedTurnSnapshot, "scheduledSendAt">,
-  now = Date.now(),
-): number {
-  const scheduledSendAt = queuedTurn.scheduledSendAt;
-  if (typeof scheduledSendAt !== "number" || !Number.isFinite(scheduledSendAt)) {
-    return 0;
-  }
-  return Math.max(0, scheduledSendAt - now);
-}
 
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
@@ -170,11 +160,10 @@ export function useQueuedTurnRelease(params: {
       return;
     }
 
-    const queuedTurn = current.composerDraftStore.getQueuedTurn(scopeKey);
+    const queuedTurn = getNextReleasableQueuedTurn(
+      current.composerDraftStore.getQueuedTurns(scopeKey),
+    );
     if (!queuedTurn || isThreadSelected(current, thread)) {
-      return;
-    }
-    if (getQueuedTurnReleaseDelayMs(queuedTurn) > 0) {
       return;
     }
     const queuedTurnId = queuedTurn.id;
@@ -185,12 +174,10 @@ export function useQueuedTurnRelease(params: {
         return undefined;
       }
 
-      const releaseQueuedSnapshot =
-        releaseState.composerDraftStore.getQueuedTurn(scopeKey);
+      const releaseQueuedSnapshot = getNextReleasableQueuedTurn(
+        releaseState.composerDraftStore.getQueuedTurns(scopeKey),
+      );
       if (!releaseQueuedSnapshot || releaseQueuedSnapshot.id !== queuedTurnId) {
-        return undefined;
-      }
-      if (getQueuedTurnReleaseDelayMs(releaseQueuedSnapshot) > 0) {
         return undefined;
       }
 
@@ -478,22 +465,23 @@ export function useQueuedTurnRelease(params: {
         continue;
       }
 
-      const queuedTurn = current.composerDraftStore.getQueuedTurn(
+      for (const queuedTurn of current.composerDraftStore.getQueuedTurns(
         getThreadScopeKey(thread),
-      );
-      const scheduledSendAt = queuedTurn?.scheduledSendAt;
-      if (
-        typeof scheduledSendAt !== "number" ||
-        !Number.isFinite(scheduledSendAt) ||
-        scheduledSendAt <= Date.now()
-      ) {
-        continue;
-      }
+      )) {
+        const scheduledSendAt = queuedTurn.scheduledSendAt;
+        if (
+          typeof scheduledSendAt !== "number" ||
+          !Number.isFinite(scheduledSendAt) ||
+          scheduledSendAt <= Date.now()
+        ) {
+          continue;
+        }
 
-      nextReleaseAt =
-        nextReleaseAt === undefined
-          ? scheduledSendAt
-          : Math.min(nextReleaseAt, scheduledSendAt);
+        nextReleaseAt =
+          nextReleaseAt === undefined
+            ? scheduledSendAt
+            : Math.min(nextReleaseAt, scheduledSendAt);
+      }
     }
 
     if (nextReleaseAt === undefined) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13627,6 +13627,15 @@ textarea,
   color: var(--status-warning);
 }
 
+.composer__queued--scheduled {
+  border-color: var(--accent-border);
+  background: color-mix(in srgb, var(--accent-soft) 36%, var(--bg-panel-elevated));
+}
+
+.composer__queued--scheduled .composer__queued-label {
+  color: var(--accent-bright);
+}
+
 .composer__queued-copy {
   display: flex;
   min-width: 0;
@@ -15773,6 +15782,64 @@ textarea,
   padding: 0 12px;
   border-radius: 999px;
   font-size: 13px;
+}
+
+.composer__send-split {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.composer__actions .composer__send-schedule-button {
+  width: 28px;
+  min-width: 28px;
+  justify-content: center;
+  padding: 0;
+  border-radius: 999px;
+}
+
+.composer__send-split--open .composer__send-schedule-button,
+.composer__send-schedule-button:hover:not(:disabled),
+.composer__send-schedule-button:focus-visible:not(:disabled) {
+  background: var(--accent);
+  color: var(--button-text);
+}
+
+.composer__schedule-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 32;
+  min-width: 168px;
+  padding: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+  box-shadow: var(--shadow-popover);
+}
+
+.composer__schedule-menu-item {
+  width: 100%;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.3;
+  text-align: left;
+}
+
+.composer__schedule-menu-item:hover,
+.composer__schedule-menu-item:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
 }
 
 .context-window-moon {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15784,26 +15784,100 @@ textarea,
   font-size: 13px;
 }
 
+/* Scheduled-send split button. One pill, two zones: a caret trigger that opens
+   the time menu and the primary Send action, joined by a hairline divider. The
+   pill owns the border, radius, and background; the inner zones are transparent
+   buttons clipped to the pill silhouette (overflow: hidden) so a hover fill
+   never bleeds past the rounded corners or hides the other zone's highlight.
+   When scheduling doesn't apply the caret isn't rendered and the pill collapses
+   to a plain Send button. */
 .composer__send-split {
   position: relative;
   display: inline-flex;
+}
+
+.composer__send-split-pill {
+  display: inline-flex;
   align-items: stretch;
-  gap: 4px;
-}
-
-.composer__actions .composer__send-schedule-button {
-  width: 28px;
-  min-width: 28px;
-  justify-content: center;
-  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--accent-border);
   border-radius: 999px;
+  background: var(--bg-row-active);
 }
 
-.composer__send-split--open .composer__send-schedule-button,
-.composer__send-schedule-button:hover:not(:disabled),
-.composer__send-schedule-button:focus-visible:not(:disabled) {
+/* Dim the whole pill as one control. When the caret is present it shares the
+   Send button's disabled state, so this is always the uniform both-off case. */
+.composer__send-split-pill.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+/* Inner zones shed their own chrome; the pill supplies border, radius, and bg. */
+.composer__actions .composer__send-split-pill .button {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent-bright);
+}
+
+/* The pill already dims via .is-disabled; keep zones opaque so it isn't dimmed
+   twice into near-invisibility. */
+.composer__send-split-pill .button[disabled] {
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.composer__actions .composer__send-split-pill .composer__send-schedule-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  min-width: 30px;
+  padding: 0;
+  border-right: 1px solid var(--accent-border);
+}
+
+/* The divider is a rest-only seam that hints the pill has two targets. Once a
+   zone fills — hover anywhere on the pill, or the menu is open — the fill's own
+   edge is the boundary, so the hairline would just read as a stray orange sliver
+   beside the filled caret. Fade it out (border-color transitions via .button). */
+.composer__send-split-pill:hover .composer__send-schedule-button,
+.composer__send-split--open .composer__send-split-pill .composer__send-schedule-button {
+  border-right-color: transparent;
+}
+
+.composer__send-schedule-button svg {
+  transition: transform 120ms ease;
+}
+
+.composer__send-split--open .composer__send-schedule-button svg {
+  transform: rotate(180deg);
+}
+
+/* Per-zone hover so it's always obvious which half a click will fire — the fix
+   for the old two-button version where one highlight hid under the other. */
+.composer__send-split-pill .button:not(:disabled):hover,
+.composer__send-split--open .composer__send-schedule-button:not(:disabled) {
   background: var(--accent);
   color: var(--button-text);
+}
+
+/* One focus ring around the whole pill. A per-zone outline would be cropped by
+   the pill's overflow clip; this reads as a single control regardless. */
+.composer__send-split-pill:has(:focus),
+.composer__send-split-pill:has(:focus-visible) {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* Kill the inner buttons' own focus outline on ANY :focus, not just
+   :focus-visible. A mouse click focuses the button without :focus-visible, so
+   the base `.button:focus` rule's 2px accent outline slipped through — and
+   because the pill clips with overflow:hidden, only the outline's interior edge
+   survived, showing as a thick orange bar at the seam that stuck until blur.
+   Focus is still shown by the pill ring above. */
+.composer__send-split-pill .button:focus {
+  outline: none;
 }
 
 .composer__schedule-menu {


### PR DESCRIPTION
## Summary

The composer can now hold a message until a chosen send time instead of only sending immediately or queueing behind an active turn. The send CTA is split so the chevron opens scheduling choices for 15m, 30m, 1h, 2h, and the current backend's future 5h limit reset when that reset time is available.

Scheduled messages stay in the existing queued-message area with a live countdown, can still be edited or deleted, and preserve their scheduled time while editing until that time passes. The focused composer and background queued-turn releaser both gate dispatch on the scheduled timestamp, so scheduled sends reuse the normal queued-turn send path once due.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` passed with the repo's existing warning baseline and no errors.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is local desktop renderer behavior; validation is covered by focused composer and queued-release tests. For post-release smoke validation, open a desktop thread, schedule a draft for a short interval, confirm the queued row countdown appears, then confirm the turn starts after the countdown expires.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
