### PR TITLE
feat(desktop): track tool output accounting

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -147,6 +147,7 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
         threadPricingSummary: true,
         threadPricingDisplayUsd: false,
         threadPricingDisplayCodexCredits: true,
+        threadToolAccounting: true,
       },
     });
 
@@ -164,6 +165,11 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
       {
         op: "set",
         path: ["experimental", "thread_pricing_display_codex_credits"],
+        value: true,
+      },
+      {
+        op: "set",
+        path: ["experimental", "thread_tool_accounting"],
         value: true,
       },
     ]);

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1784,12 +1784,17 @@ describe("DesktopSettingsService", () => {
       value: false,
       source: "default",
     });
+    expect(initial.experimental.threadToolAccounting).toEqual({
+      value: false,
+      source: "default",
+    });
 
     await service.writeConfigPatch({
       experimental: {
         threadPricingSummary: false,
         threadPricingDisplayUsd: false,
         threadPricingDisplayCodexCredits: true,
+        threadToolAccounting: true,
       },
     });
 
@@ -1806,6 +1811,10 @@ describe("DesktopSettingsService", () => {
       value: true,
       source: "config",
     });
+    expect(updated.experimental.threadToolAccounting).toEqual({
+      value: true,
+      source: "config",
+    });
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "thread_pricing_summary = false",
     );
@@ -1814,6 +1823,9 @@ describe("DesktopSettingsService", () => {
     );
     expect(fs.readFileSync(configPath, "utf8")).toContain(
       "thread_pricing_display_codex_credits = true",
+    );
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      "thread_tool_accounting = true",
     );
   });
 

--- a/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts
@@ -1,0 +1,200 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  ThreadToolInvocationAlert,
+  ThreadToolInvocationRecord,
+} from "@pwragent/shared";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-tool-accounting-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SqliteOverlayStore tool invocation accounting", () => {
+  it("round-trips invocation metrics, summaries, recent reads, and alerts", async () => {
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({
+        invocationId: "tool-1",
+        outputChars: 12_000,
+        warningLines: 4,
+      }),
+    });
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({
+        invocationId: "tool-2",
+        itemId: "tool-2",
+        outputChars: 8_000,
+        observedAt: 1_800_000_030_000,
+        warningLines: 2,
+      }),
+    });
+    await store.markThreadToolInvocationNoisy({
+      invocationId: "tool-2",
+      reason: "repeat-polling-output",
+    });
+    await store.upsertThreadToolInvocationAlert({
+      alert: buildAlert(),
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(accounting.invocations).toHaveLength(2);
+    expect(accounting.invocations[0]).toMatchObject({
+      invocationId: "tool-2",
+      noisy: true,
+      noisyReason: "repeat-polling-output",
+      outputChars: 8_000,
+    });
+    expect(accounting.summaries).toEqual([
+      expect.objectContaining({
+        category: "polling",
+        estimatedOutputTokens: 5_000,
+        invocationCount: 2,
+        noisyInvocationCount: 1,
+        outputChars: 20_000,
+        toolName: "write_stdin",
+        warningLines: 6,
+      }),
+    ]);
+    expect(accounting.alerts).toEqual([
+      expect.objectContaining({
+        alertId: "alert-1",
+        invocationCount: 2,
+        totalOutputChars: 20_000,
+      }),
+    ]);
+
+    const recent = store.readRecentThreadToolInvocations({
+      backend: "codex",
+      limit: 5,
+      sessionId: "40500",
+      since: 1_800_000_000_000,
+      threadId: "thread-1",
+      toolName: "write_stdin",
+    });
+    expect(recent.map((record) => record.invocationId)).toEqual([
+      "tool-2",
+      "tool-1",
+    ]);
+  });
+
+  it("accumulates in-progress output deltas before terminal completion", async () => {
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({
+        invocationId: "delta-tool",
+        itemId: "delta-tool",
+        outputChars: 100,
+        outputLines: 4,
+        status: "in_progress",
+        warningLines: 1,
+      }),
+    });
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({
+        invocationId: "delta-tool",
+        itemId: "delta-tool",
+        observedAt: 1_800_000_001_000,
+        outputChars: 150,
+        outputLines: 6,
+        status: "in_progress",
+        warningLines: 2,
+      }),
+    });
+    await store.upsertThreadToolInvocation({
+      invocation: buildInvocation({
+        completedAt: 1_800_000_002_000,
+        invocationId: "delta-tool",
+        itemId: "delta-tool",
+        observedAt: 1_800_000_002_000,
+        outputChars: 200,
+        outputLines: 8,
+        status: "completed",
+        warningLines: 2,
+      }),
+    });
+
+    const accounting = await store.readThreadToolAccounting({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(accounting.invocations[0]).toMatchObject({
+      completedAt: 1_800_000_002_000,
+      estimatedOutputTokens: 63,
+      outputChars: 250,
+      outputLines: 10,
+      status: "completed",
+      warningLines: 3,
+    });
+  });
+});
+
+function buildInvocation(
+  patch: Partial<ThreadToolInvocationRecord> = {},
+): ThreadToolInvocationRecord {
+  const outputChars = patch.outputChars ?? 12_000;
+  const observedAt = patch.observedAt ?? 1_800_000_000_000;
+  return {
+    backend: "codex",
+    category: "polling",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: Math.ceil(outputChars / 4),
+    infoLines: 0,
+    invocationId: "tool-1",
+    itemId: "tool-1",
+    noisy: false,
+    normalizedCommand: "poll session 40500",
+    observedAt,
+    outputChars,
+    outputLines: 200,
+    outputTruncated: false,
+    sessionId: "40500",
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "write_stdin",
+    turnId: "turn-1",
+    updatedAt: observedAt,
+    warningLines: 0,
+    ...patch,
+  };
+}
+
+function buildAlert(): ThreadToolInvocationAlert {
+  return {
+    alertId: "alert-1",
+    averageIntervalMs: 30_000,
+    backend: "codex",
+    createdAt: 1_800_000_030_000,
+    estimatedOutputTokens: 5_000,
+    firstObservedAt: 1_800_000_000_000,
+    invocationCount: 2,
+    kind: "noisy-polling",
+    lastObservedAt: 1_800_000_030_000,
+    message: "Repeated write_stdin polling on session 40500 produced 20,000 chars.",
+    sessionId: "40500",
+    severity: "warning",
+    suggestedPrompt: "Use create_monitor_delegation.",
+    threadId: "thread-1",
+    toolName: "write_stdin",
+    totalOutputChars: 20_000,
+    updatedAt: 1_800_000_030_000,
+  };
+}

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -86,6 +86,29 @@ describe("StateDb", () => {
     ]);
   });
 
+  it("creates thread tool accounting tables", () => {
+    const tables = stateDb.raw
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (?, ?) ORDER BY name`,
+      )
+      .all(
+        "thread_tool_invocation_alerts",
+        "thread_tool_invocations",
+      ) as Array<{ name: string }>;
+
+    expect(tables.map((table) => table.name)).toEqual([
+      "thread_tool_invocation_alerts",
+      "thread_tool_invocations",
+    ]);
+    expect(indexNames("thread_tool_invocations")).toEqual(
+      expect.arrayContaining([
+        "idx_thread_tool_invocations_read_thread",
+        "idx_thread_tool_invocations_polling",
+        "idx_thread_tool_invocations_turn",
+      ]),
+    );
+  });
+
   it("carries observed context-replay columns on both the turn and the line", () => {
     // The tally's source of truth is thread_usage_turns. The line columns are a
     // DEPRECATED dual-write (issue #947) kept so older locally-run builds — which
@@ -1054,7 +1077,9 @@ function columnNames(
   return rows.map((row) => row.name);
 }
 
-function indexNames(tableName: "thread_usage_lines"): string[] {
+function indexNames(
+  tableName: "thread_tool_invocations" | "thread_usage_lines",
+): string[] {
   return (
     stateDb.raw.prepare(`PRAGMA index_list(${tableName})`).all() as Array<{
       name: string;

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -44,6 +44,23 @@ describe("tool invocation accounting", () => {
     });
   });
 
+  it("redacts secret-like shell command fragments before persistence", () => {
+    const normalized = normalizeToolInvocationCommand({
+      command:
+        "/bin/zsh -lc 'XAI_API_KEY=sk-secret pnpm test --token abc123 --password hunter2'",
+      toolName: "exec_command",
+    });
+
+    expect(normalized).toEqual({
+      category: "build-test",
+      normalizedCommand:
+        "XAI_API_KEY=[redacted] pnpm test --token [redacted] --password [redacted]",
+    });
+    expect(normalized.normalizedCommand).not.toContain("sk-secret");
+    expect(normalized.normalizedCommand).not.toContain("abc123");
+    expect(normalized.normalizedCommand).not.toContain("hunter2");
+  });
+
   it("counts output volume and sbt-style warning/error/info/debug lines", () => {
     const metrics = buildToolOutputMetrics(
       [

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -1,0 +1,153 @@
+import type { ThreadToolInvocationRecord } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import {
+  buildToolOutputMetrics,
+  detectNoisyPolling,
+  normalizeToolInvocationCommand,
+  toolInvocationFromNotification,
+} from "../app-server/tool-invocation-accounting";
+
+describe("tool invocation accounting", () => {
+  it("normalizes shell commands into durable command categories", () => {
+    expect(
+      normalizeToolInvocationCommand({
+        command: "/bin/zsh -lc 'sbt test'",
+        toolName: "exec_command",
+      }),
+    ).toEqual({
+      category: "build-test",
+      normalizedCommand: "sbt test",
+    });
+    expect(
+      normalizeToolInvocationCommand({
+        command: "rg -n pricing apps/desktop",
+        toolName: "exec_command",
+      }).category,
+    ).toBe("search");
+    expect(
+      normalizeToolInvocationCommand({
+        args: { chars: "", session_id: 40500 },
+        toolName: "write_stdin",
+      }),
+    ).toEqual({
+      category: "polling",
+      normalizedCommand: "poll session 40500",
+    });
+  });
+
+  it("counts output volume and sbt-style warning/error/info/debug lines", () => {
+    const metrics = buildToolOutputMetrics(
+      [
+        "[info] compiling 12 Scala sources",
+        "[warn] deprecated API",
+        "[debug] classpath resolved",
+        "[error] failed test",
+        "Exception in worker",
+        "PwrAgent renderer boundary: truncated",
+      ].join("\n"),
+    );
+
+    expect(metrics).toMatchObject({
+      debugLines: 1,
+      errorLines: 2,
+      infoLines: 1,
+      outputLines: 6,
+      outputTruncated: true,
+      warningLines: 1,
+    });
+    expect(metrics.outputChars).toBeGreaterThan(80);
+    expect(metrics.estimatedOutputTokens).toBe(Math.ceil(metrics.outputChars / 4));
+  });
+
+  it("extracts invocation stats from normalized live tool notifications", () => {
+    const invocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "tool-1",
+            type: "commandExecution",
+            status: "completed",
+            name: "write_stdin",
+            arguments: { session_id: 40500, chars: "", yield_time_ms: 30000 },
+            data: {
+              output: "[info] still running\n".repeat(300),
+            },
+          },
+        },
+      },
+    });
+
+    expect(invocation).toMatchObject({
+      backend: "codex",
+      category: "polling",
+      itemId: "tool-1",
+      normalizedCommand: "poll session 40500",
+      outputLines: 300,
+      sessionId: "40500",
+      status: "completed",
+      threadId: "thread-1",
+      toolName: "write_stdin",
+      turnId: "turn-1",
+    });
+  });
+
+  it("detects repeated noisy write_stdin polling against one process session", () => {
+    const records = [
+      buildPollingInvocation("tool-1", 1_800_000_000_000, 9_000),
+      buildPollingInvocation("tool-2", 1_800_000_030_000, 8_000),
+      buildPollingInvocation("tool-3", 1_800_000_060_000, 7_000),
+    ];
+
+    const detection = detectNoisyPolling({
+      current: records[2]!,
+      now: records[2]!.observedAt,
+      recent: records.slice(0, 2),
+    });
+
+    expect(detection?.invocationIds).toEqual(["tool-1", "tool-2", "tool-3"]);
+    expect(detection?.alert).toMatchObject({
+      estimatedOutputTokens: 6_000,
+      invocationCount: 3,
+      kind: "noisy-polling",
+      sessionId: "40500",
+      totalOutputChars: 24_000,
+    });
+    expect(detection?.alert.suggestedPrompt).toContain(
+      "create_monitor_delegation",
+    );
+  });
+});
+
+function buildPollingInvocation(
+  invocationId: string,
+  observedAt: number,
+  outputChars: number,
+): ThreadToolInvocationRecord {
+  return {
+    backend: "codex",
+    category: "polling",
+    debugLines: 0,
+    errorLines: 0,
+    estimatedOutputTokens: Math.ceil(outputChars / 4),
+    infoLines: 0,
+    invocationId,
+    itemId: invocationId,
+    noisy: false,
+    normalizedCommand: "poll session 40500",
+    observedAt,
+    outputChars,
+    outputLines: 100,
+    outputTruncated: false,
+    sessionId: "40500",
+    status: "completed",
+    threadId: "thread-1",
+    toolName: "write_stdin",
+    updatedAt: observedAt,
+    warningLines: 0,
+  };
+}

--- a/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts
@@ -33,6 +33,15 @@ describe("tool invocation accounting", () => {
       category: "polling",
       normalizedCommand: "poll session 40500",
     });
+    expect(
+      normalizeToolInvocationCommand({
+        args: { chars: "q", session_id: 40500 },
+        toolName: "write_stdin",
+      }),
+    ).toEqual({
+      category: "shell",
+      normalizedCommand: "write stdin session 40500",
+    });
   });
 
   it("counts output volume and sbt-style warning/error/info/debug lines", () => {
@@ -96,6 +105,51 @@ describe("tool invocation accounting", () => {
     });
   });
 
+  it("marks completed command invocations failed from success false or exit code", () => {
+    const successFalseInvocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          item: {
+            id: "tool-1",
+            type: "commandExecution",
+            name: "exec_command",
+            success: false,
+          },
+        },
+      },
+    });
+    const exitCodeInvocation = toolInvocationFromNotification({
+      backend: "codex",
+      now: 1_800_000_030_000,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          item: {
+            id: "tool-2",
+            type: "commandExecution",
+            name: "exec_command",
+            data: {
+              exitCode: 1,
+            },
+          },
+        },
+      },
+    });
+
+    expect(successFalseInvocation).toMatchObject({
+      status: "failed",
+    });
+    expect(exitCodeInvocation).toMatchObject({
+      exitCode: 1,
+      status: "failed",
+    });
+  });
+
   it("detects repeated noisy write_stdin polling against one process session", () => {
     const records = [
       buildPollingInvocation("tool-1", 1_800_000_000_000, 9_000),
@@ -121,16 +175,33 @@ describe("tool invocation accounting", () => {
       "create_monitor_delegation",
     );
   });
+
+  it("does not flag non-empty stdin writes as polling", () => {
+    const records = [
+      buildPollingInvocation("tool-1", 1_800_000_000_000, 9_000),
+      buildPollingInvocation("tool-2", 1_800_000_030_000, 8_000),
+      buildPollingInvocation("tool-3", 1_800_000_060_000, 7_000, "shell"),
+    ];
+
+    const detection = detectNoisyPolling({
+      current: records[2]!,
+      now: records[2]!.observedAt,
+      recent: records.slice(0, 2),
+    });
+
+    expect(detection).toBeUndefined();
+  });
 });
 
 function buildPollingInvocation(
   invocationId: string,
   observedAt: number,
   outputChars: number,
+  category: ThreadToolInvocationRecord["category"] = "polling",
 ): ThreadToolInvocationRecord {
   return {
     backend: "codex",
-    category: "polling",
+    category,
     debugLines: 0,
     errorLines: 0,
     estimatedOutputTokens: Math.ceil(outputChars / 4),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -300,6 +300,11 @@ import {
   createProtocolLogObserverFromEnv,
 } from "./protocol-log-observer";
 import {
+  detectNoisyPolling,
+  toolAccountingLookbackSince,
+  toolInvocationFromNotification,
+} from "./tool-invocation-accounting";
+import {
   ThreadTitleGenerationService,
   GrokThreadTitleGenerator,
   type ThreadTitleGenerator,
@@ -2713,6 +2718,7 @@ function buildTaskMonitorFinalHandoffInput(params: {
       : "",
     "",
     "Process this final monitor result. Do not resume polling unless the result explicitly says monitoring is still required.",
+    "Continue anything that was dependent upon this result that the user was expecting to continue when completed.",
   ]
     .filter(Boolean)
     .join("\n");
@@ -2726,7 +2732,7 @@ function buildTaskMonitorRecoveryPrompt(params: {
   return [
     "PwrAgent monitor recovery instruction:",
     "",
-    `The previous monitor turn ended with status \"${params.terminalStatus}\" before it called pwragent.complete_monitoring.`,
+    `The previous monitor turn ended with status "${params.terminalStatus}" before it called pwragent.complete_monitoring.`,
     "You must now report the final monitor result. Use only the monitor task context you already have.",
     "",
     `Monitor id: ${params.monitorId}`,
@@ -7589,12 +7595,20 @@ export class DesktopBackendRegistry {
             threadId: request.threadId,
           })
         : { lines: [], summaries: [] };
+    const toolAccounting =
+      typeof this.overlayStore.readThreadToolAccounting === "function"
+        ? await this.overlayStore.readThreadToolAccounting({
+            backend,
+            threadId: request.threadId,
+          })
+        : undefined;
 
     return {
       backend,
       fetchedAt: Date.now(),
       threadId: request.threadId,
       pricing,
+      ...(toolAccounting ? { toolAccounting } : {}),
       ...(replayWithImmutableUsage.threadStatus
         ? { threadStatus: replayWithImmutableUsage.threadStatus }
         : {}),
@@ -7633,6 +7647,29 @@ export class DesktopBackendRegistry {
         params: {
           threadId: params.threadId,
           pricing,
+        },
+      },
+    });
+  }
+
+  private async emitThreadToolAccountingUpdated(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    if (typeof this.overlayStore.readThreadToolAccounting !== "function") {
+      return;
+    }
+    const toolAccounting = await this.overlayStore.readThreadToolAccounting({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/toolAccounting/updated",
+        params: {
+          threadId: params.threadId,
+          toolAccounting,
         },
       },
     });
@@ -14189,6 +14226,65 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async recordToolInvocationAccounting(event: AgentEvent): Promise<void> {
+    if (typeof this.overlayStore.upsertThreadToolInvocation !== "function") {
+      return;
+    }
+    const now = Date.now();
+    const invocation = toolInvocationFromNotification({
+      backend: event.backend,
+      notification: event.notification,
+      now,
+    });
+    if (!invocation) {
+      return;
+    }
+
+    const stored = await this.overlayStore.upsertThreadToolInvocation({
+      invocation,
+    });
+    let shouldNotify = event.notification.method === "item/completed";
+    if (
+      typeof this.overlayStore.readRecentThreadToolInvocations === "function" &&
+      typeof this.overlayStore.markThreadToolInvocationNoisy === "function" &&
+      typeof this.overlayStore.upsertThreadToolInvocationAlert === "function"
+    ) {
+      const recent = this.overlayStore.readRecentThreadToolInvocations({
+        backend: stored.backend,
+        limit: 12,
+        processId: stored.processId,
+        sessionId: stored.sessionId,
+        since: toolAccountingLookbackSince(now),
+        threadId: stored.threadId,
+        toolName: stored.toolName,
+      });
+      const detection = detectNoisyPolling({
+        current: stored,
+        now,
+        recent,
+      });
+      if (detection) {
+        for (const invocationId of detection.invocationIds) {
+          await this.overlayStore.markThreadToolInvocationNoisy({
+            invocationId,
+            reason: "repeat-polling-output",
+          });
+        }
+        await this.overlayStore.upsertThreadToolInvocationAlert({
+          alert: detection.alert,
+        });
+        shouldNotify = true;
+      }
+    }
+
+    if (shouldNotify) {
+      await this.emitThreadToolAccountingUpdated({
+        backend: stored.backend,
+        threadId: stored.threadId,
+      });
+    }
+  }
+
   private async describeSingleBackend(
     kind: AppServerBackendKind,
     client: BackendClient
@@ -20203,6 +20299,7 @@ export class DesktopBackendRegistry {
     }
 
     await this.recordLiveThreadUsage(event);
+    await this.recordToolInvocationAccounting(event);
     this.forgetCompletedTurnReplayObservations(event);
     await this.recordCodexNativeSubAgentActivity(event);
     await this.recordCodexNativeSubAgentNotifications(event);

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -127,10 +127,13 @@ export function toolInvocationFromNotification(params: {
     readString(args, "sessionId") ??
     readString(item, "sessionId") ??
     readString(item, "session_id");
-  const status = normalizeToolInvocationStatus(
-    readString(item, "status"),
-    params.notification.method,
-  );
+  const exitCode = readExitCode(item);
+  const status = normalizeToolInvocationStatus({
+    exitCode: exitCode.exitCode,
+    method: params.notification.method,
+    status: readString(item, "status"),
+    success: readToolSuccess(item),
+  });
 
   return {
     ...emptyInvocationMetrics(metrics),
@@ -161,7 +164,7 @@ export function toolInvocationFromNotification(params: {
       : {}),
     ...(sessionId ? { sessionId } : {}),
     ...(processId ? { processId } : {}),
-    ...readExitCode(item),
+    ...exitCode,
   };
 }
 
@@ -214,10 +217,11 @@ export function normalizeToolInvocationCommand(params: {
     const sessionId = readString(params.args, "session_id") ??
       readString(params.args, "sessionId");
     const chars = readString(params.args, "chars");
+    const isPollingRead = chars === undefined || chars.length === 0;
     return {
-      category: "polling",
+      category: isPollingRead ? "polling" : "shell",
       normalizedCommand:
-        chars === undefined || chars.length === 0
+        isPollingRead
           ? `poll session ${sessionId ?? "unknown"}`
           : `write stdin session ${sessionId ?? "unknown"}`,
     };
@@ -392,15 +396,23 @@ function buildToolInvocationId(params: {
   ].join(":");
 }
 
-function normalizeToolInvocationStatus(
-  status: string | undefined,
-  method: "item/started" | "item/completed",
-): ThreadToolInvocationStatus {
-  if (method === "item/started") {
+function normalizeToolInvocationStatus(params: {
+  exitCode?: number;
+  method: "item/started" | "item/completed";
+  status: string | undefined;
+  success?: boolean;
+}): ThreadToolInvocationStatus {
+  if (params.method === "item/started") {
     return "in_progress";
   }
-  if (status === "failed" || status === "cancelled" || status === "completed") {
-    return status;
+  if (params.status === "failed" || params.success === false) {
+    return "failed";
+  }
+  if (params.exitCode !== undefined && params.exitCode !== 0) {
+    return "failed";
+  }
+  if (params.status === "cancelled" || params.status === "completed") {
+    return params.status;
   }
   return "completed";
 }
@@ -520,6 +532,18 @@ function readExitCode(
     readNumber(data, "exitCode") ??
     readNumber(data, "exit_code");
   return value === undefined ? {} : { exitCode: value };
+}
+
+function readToolSuccess(
+  item: Record<string, unknown> | undefined,
+): boolean | undefined {
+  const data = readRecord(item?.data);
+  return (
+    readBoolean(item, "success") ??
+    readBoolean(item, "ok") ??
+    readBoolean(data, "success") ??
+    readBoolean(data, "ok")
+  );
 }
 
 function readRecord(value: unknown): Record<string, unknown> | undefined {

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -6,6 +6,7 @@ import type {
   ThreadToolInvocationRecord,
   ThreadToolInvocationStatus,
 } from "@pwragent/shared";
+import { redactCommandText } from "../util/redact-command-text";
 
 const OUTPUT_TOKEN_CHAR_RATIO = 4;
 const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
@@ -423,7 +424,7 @@ function normalizeShellCommand(command: string | undefined): string | undefined 
     return undefined;
   }
   const shellMatch = trimmed.match(/^\/?(?:bin\/)?(?:ba|z|)sh\s+-lc\s+['"](.+)['"]$/);
-  return shellMatch?.[1]?.trim() || trimmed;
+  return redactCommandText(shellMatch?.[1]?.trim() || trimmed);
 }
 
 function categoryForToolName(toolName: string): ThreadToolInvocationCategory {

--- a/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
+++ b/apps/desktop/src/main/app-server/tool-invocation-accounting.ts
@@ -1,0 +1,561 @@
+import type {
+  AppServerBackendKind,
+  AppServerNotification,
+  ThreadToolInvocationAlert,
+  ThreadToolInvocationCategory,
+  ThreadToolInvocationRecord,
+  ThreadToolInvocationStatus,
+} from "@pwragent/shared";
+
+const OUTPUT_TOKEN_CHAR_RATIO = 4;
+const NOISY_POLL_LOOKBACK_MS = 5 * 60 * 1000;
+const NOISY_POLL_MIN_INVOCATIONS = 3;
+const NOISY_POLL_MIN_OUTPUT_CHARS = 20_000;
+const NOISY_POLL_MIN_INTERVAL_MS = 15_000;
+const NOISY_POLL_MAX_INTERVAL_MS = 75_000;
+
+export type ToolInvocationOutputMetrics = {
+  debugLines: number;
+  errorLines: number;
+  estimatedOutputTokens: number;
+  infoLines: number;
+  outputChars: number;
+  outputLines: number;
+  outputTruncated: boolean;
+  warningLines: number;
+};
+
+export type NormalizedToolCommand = {
+  category: ThreadToolInvocationCategory;
+  normalizedCommand?: string;
+};
+
+export type NoisyPollingDetection = {
+  alert: ThreadToolInvocationAlert;
+  invocationIds: string[];
+  lookbackSince: number;
+};
+
+export function toolInvocationFromNotification(params: {
+  backend: AppServerBackendKind;
+  notification: AppServerNotification;
+  now?: number;
+}): ThreadToolInvocationRecord | undefined {
+  const now = params.now ?? Date.now();
+  if (
+    params.notification.method !== "item/started" &&
+    params.notification.method !== "item/completed" &&
+    params.notification.method !== "item/commandExecution/outputDelta"
+  ) {
+    return undefined;
+  }
+
+  if (params.notification.method === "item/commandExecution/outputDelta") {
+    const notificationParams = params.notification.params as {
+      delta: string;
+      itemId: string;
+      threadId: string;
+      turnId?: string;
+    };
+    const metrics = buildToolOutputMetrics(notificationParams.delta);
+    return {
+      ...emptyInvocationMetrics(metrics),
+      backend: params.backend,
+      category: "shell",
+      invocationId: buildToolInvocationId({
+        backend: params.backend,
+        itemId: notificationParams.itemId,
+        threadId: notificationParams.threadId,
+        turnId: notificationParams.turnId,
+      }),
+      itemId: notificationParams.itemId,
+      observedAt: now,
+      outputTruncated: metrics.outputTruncated,
+      status: "in_progress",
+      threadId: notificationParams.threadId,
+      toolName: "commandExecution",
+      ...(notificationParams.turnId
+        ? { turnId: notificationParams.turnId }
+        : {}),
+      updatedAt: now,
+    };
+  }
+
+  const notificationParams = params.notification.params as {
+    item: Record<string, unknown>;
+    threadId: string;
+    turnId?: string;
+  };
+  const item = readRecord(notificationParams.item);
+  if (!item) {
+    return undefined;
+  }
+  if (readString(item, "type") !== "commandExecution") {
+    return undefined;
+  }
+
+  const itemId = readString(item, "id") ?? `tool:${now}`;
+  const args = readToolArguments(item);
+  const toolName =
+    readString(item, "toolName") ??
+    readString(item, "tool_name") ??
+    readString(item, "name") ??
+    readString(item, "type") ??
+    "commandExecution";
+  const command =
+    readString(item, "command") ??
+    readString(args, "cmd") ??
+    readString(args, "command");
+  const output = readToolOutput(item);
+  const metrics = buildToolOutputMetrics(output.text, {
+    outputTruncated: output.truncated,
+  });
+  const normalized = normalizeToolInvocationCommand({
+    args,
+    command,
+    toolName,
+  });
+  const processId =
+    readString(item, "processId") ??
+    readString(item, "process_id") ??
+    readString(item, "pid") ??
+    readString(readRecord(item.data), "processId") ??
+    readString(readRecord(item.data), "process_id") ??
+    readString(readRecord(item.data), "pid");
+  const sessionId =
+    readString(args, "session_id") ??
+    readString(args, "sessionId") ??
+    readString(item, "sessionId") ??
+    readString(item, "session_id");
+  const status = normalizeToolInvocationStatus(
+    readString(item, "status"),
+    params.notification.method,
+  );
+
+  return {
+    ...emptyInvocationMetrics(metrics),
+    backend: params.backend,
+    category: normalized.category,
+    invocationId: buildToolInvocationId({
+      backend: params.backend,
+      itemId,
+      threadId: notificationParams.threadId,
+      turnId: notificationParams.turnId,
+    }),
+    itemId,
+    observedAt: now,
+    outputTruncated: metrics.outputTruncated,
+    status,
+    threadId: notificationParams.threadId,
+    toolName,
+    updatedAt: now,
+    ...(status === "in_progress" ? { startedAt: now } : {}),
+    ...(status === "completed" || status === "failed" || status === "cancelled"
+      ? { completedAt: now }
+      : {}),
+    ...(notificationParams.turnId
+      ? { turnId: notificationParams.turnId }
+      : {}),
+    ...(normalized.normalizedCommand
+      ? { normalizedCommand: normalized.normalizedCommand }
+      : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(processId ? { processId } : {}),
+    ...readExitCode(item),
+  };
+}
+
+export function buildToolOutputMetrics(
+  output: string | undefined,
+  options?: { outputTruncated?: boolean },
+): ToolInvocationOutputMetrics {
+  const text = output ?? "";
+  const lines = splitOutputLines(text);
+  let debugLines = 0;
+  let errorLines = 0;
+  let infoLines = 0;
+  let warningLines = 0;
+  for (const line of lines) {
+    if (/\[(?:warn|warning)\]|\bwarn(?:ing)?\b/i.test(line)) {
+      warningLines += 1;
+    }
+    if (/\[error\]|\berror\b|\bfailed\b|\bfailure\b|\bexception\b/i.test(line)) {
+      errorLines += 1;
+    }
+    if (/\[debug\]|\bdebug\b|\btrace\b/i.test(line)) {
+      debugLines += 1;
+    }
+    if (/\[info\]|\binfo\b|\bnotice\b/i.test(line)) {
+      infoLines += 1;
+    }
+  }
+
+  return {
+    debugLines,
+    errorLines,
+    estimatedOutputTokens: Math.ceil(text.length / OUTPUT_TOKEN_CHAR_RATIO),
+    infoLines,
+    outputChars: text.length,
+    outputLines: lines.length,
+    outputTruncated:
+      Boolean(options?.outputTruncated) ||
+      /\btruncated\b|additional lines omitted|output clipped/i.test(text),
+    warningLines,
+  };
+}
+
+export function normalizeToolInvocationCommand(params: {
+  args?: Record<string, unknown>;
+  command?: string;
+  toolName: string;
+}): NormalizedToolCommand {
+  const toolName = params.toolName.trim() || "unknown";
+  if (toolName === "write_stdin") {
+    const sessionId = readString(params.args, "session_id") ??
+      readString(params.args, "sessionId");
+    const chars = readString(params.args, "chars");
+    return {
+      category: "polling",
+      normalizedCommand:
+        chars === undefined || chars.length === 0
+          ? `poll session ${sessionId ?? "unknown"}`
+          : `write stdin session ${sessionId ?? "unknown"}`,
+    };
+  }
+
+  if (
+    toolName === "create_monitor_delegation" ||
+    toolName === "spawn_agent" ||
+    toolName === "handoff_task"
+  ) {
+    return {
+      category: "sub-agent",
+      normalizedCommand: toolName,
+    };
+  }
+
+  const command = normalizeShellCommand(params.command ?? readString(params.args, "cmd"));
+  if (!command) {
+    return {
+      category: categoryForToolName(toolName),
+      normalizedCommand: toolName,
+    };
+  }
+
+  return {
+    category: categoryForCommand(command),
+    normalizedCommand: command,
+  };
+}
+
+export function detectNoisyPolling(params: {
+  current: ThreadToolInvocationRecord;
+  recent: ThreadToolInvocationRecord[];
+  now?: number;
+}): NoisyPollingDetection | undefined {
+  const current = params.current;
+  if (
+    current.toolName !== "write_stdin" ||
+    current.category !== "polling" ||
+    (!current.sessionId && !current.processId)
+  ) {
+    return undefined;
+  }
+
+  const now = params.now ?? current.observedAt;
+  const lookbackSince = now - NOISY_POLL_LOOKBACK_MS;
+  const records = [
+    current,
+    ...params.recent.filter((record) => record.invocationId !== current.invocationId),
+  ]
+    .filter(
+      (record) =>
+        record.toolName === current.toolName &&
+        record.category === "polling" &&
+        record.observedAt >= lookbackSince &&
+        (!current.sessionId || record.sessionId === current.sessionId) &&
+        (!current.processId || record.processId === current.processId),
+    )
+    .sort((left, right) => left.observedAt - right.observedAt);
+
+  if (records.length < NOISY_POLL_MIN_INVOCATIONS) {
+    return undefined;
+  }
+
+  const intervals = records
+    .slice(1)
+    .map((record, index) => record.observedAt - records[index]!.observedAt);
+  const pollLikeIntervals = intervals.filter(
+    (interval) =>
+      interval >= NOISY_POLL_MIN_INTERVAL_MS &&
+      interval <= NOISY_POLL_MAX_INTERVAL_MS,
+  );
+  const totalOutputChars = records.reduce(
+    (sum, record) => sum + record.outputChars,
+    0,
+  );
+  if (
+    pollLikeIntervals.length < NOISY_POLL_MIN_INVOCATIONS - 1 ||
+    totalOutputChars < NOISY_POLL_MIN_OUTPUT_CHARS
+  ) {
+    return undefined;
+  }
+
+  const averageIntervalMs = Math.round(
+    intervals.reduce((sum, interval) => sum + interval, 0) / intervals.length,
+  );
+  const estimatedOutputTokens = Math.ceil(totalOutputChars / OUTPUT_TOKEN_CHAR_RATIO);
+  const sessionLabel = current.sessionId
+    ? `session ${current.sessionId}`
+    : `process ${current.processId}`;
+  const message =
+    `Repeated write_stdin polling on ${sessionLabel} produced ${totalOutputChars.toLocaleString()} chars (~${estimatedOutputTokens.toLocaleString()} output tokens) across ${records.length.toLocaleString()} checks.`;
+  const suggestedPrompt = [
+    "Stop polling this long-running process in the main thread.",
+    "Use PwrAgent's create_monitor_delegation tool with the durable command, cwd, log/status files, poll cadence, and terminal success/failure criteria.",
+    "Continue unrelated work here, and let the monitor report completion back to this thread.",
+  ].join(" ");
+
+  return {
+    alert: {
+      alertId: [
+        "noisy-polling",
+        current.backend,
+        current.threadId,
+        current.toolName,
+        current.sessionId ?? current.processId ?? "unknown",
+      ].join(":"),
+      averageIntervalMs,
+      backend: current.backend,
+      createdAt: now,
+      estimatedOutputTokens,
+      firstObservedAt: records[0]!.observedAt,
+      invocationCount: records.length,
+      kind: "noisy-polling",
+      lastObservedAt: records[records.length - 1]!.observedAt,
+      message,
+      ...(current.processId ? { processId: current.processId } : {}),
+      ...(current.sessionId ? { sessionId: current.sessionId } : {}),
+      severity: "warning",
+      suggestedPrompt,
+      threadId: current.threadId,
+      toolName: current.toolName,
+      totalOutputChars,
+      updatedAt: now,
+    },
+    invocationIds: records.map((record) => record.invocationId),
+    lookbackSince,
+  };
+}
+
+export function toolAccountingLookbackSince(now: number): number {
+  return now - NOISY_POLL_LOOKBACK_MS;
+}
+
+function emptyInvocationMetrics(
+  metrics: ToolInvocationOutputMetrics,
+): Pick<
+  ThreadToolInvocationRecord,
+  | "debugLines"
+  | "errorLines"
+  | "estimatedOutputTokens"
+  | "infoLines"
+  | "noisy"
+  | "outputChars"
+  | "outputLines"
+  | "warningLines"
+> {
+  return {
+    debugLines: metrics.debugLines,
+    errorLines: metrics.errorLines,
+    estimatedOutputTokens: metrics.estimatedOutputTokens,
+    infoLines: metrics.infoLines,
+    noisy: false,
+    outputChars: metrics.outputChars,
+    outputLines: metrics.outputLines,
+    warningLines: metrics.warningLines,
+  };
+}
+
+function buildToolInvocationId(params: {
+  backend: string;
+  threadId: string;
+  turnId?: string;
+  itemId: string;
+}): string {
+  return [
+    "tool",
+    params.backend,
+    params.threadId,
+    params.turnId ?? "no-turn",
+    params.itemId,
+  ].join(":");
+}
+
+function normalizeToolInvocationStatus(
+  status: string | undefined,
+  method: "item/started" | "item/completed",
+): ThreadToolInvocationStatus {
+  if (method === "item/started") {
+    return "in_progress";
+  }
+  if (status === "failed" || status === "cancelled" || status === "completed") {
+    return status;
+  }
+  return "completed";
+}
+
+function normalizeShellCommand(command: string | undefined): string | undefined {
+  const trimmed = command?.replace(/\s+/g, " ").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const shellMatch = trimmed.match(/^\/?(?:bin\/)?(?:ba|z|)sh\s+-lc\s+['"](.+)['"]$/);
+  return shellMatch?.[1]?.trim() || trimmed;
+}
+
+function categoryForToolName(toolName: string): ThreadToolInvocationCategory {
+  if (
+    toolName === "read_file" ||
+    toolName === "list_files" ||
+    toolName === "edit_file" ||
+    toolName === "write_file"
+  ) {
+    return "file-io";
+  }
+  if (toolName === "search_code" || toolName === "grep") {
+    return "search";
+  }
+  if (toolName === "exec_command" || toolName === "commandExecution") {
+    return "shell";
+  }
+  return "unknown";
+}
+
+function categoryForCommand(command: string): ThreadToolInvocationCategory {
+  const lower = command.toLowerCase();
+  const first = lower.split(/\s+/)[0] ?? "";
+  if (first === "git") {
+    return "git";
+  }
+  if (["rg", "grep", "find"].includes(first)) {
+    return "search";
+  }
+  if (["cat", "head", "tail", "sed", "awk", "ls", "wc"].includes(first)) {
+    return "file-io";
+  }
+  if (["npm", "pnpm", "yarn", "bun", "npx"].includes(first)) {
+    return "package-manager";
+  }
+  if (
+    first === "sbt" ||
+    first === "mvn" ||
+    first === "gradle" ||
+    lower.includes(" test") ||
+    lower.includes(" vitest") ||
+    lower.includes(" jest")
+  ) {
+    return "build-test";
+  }
+  return "shell";
+}
+
+function splitOutputLines(text: string): string[] {
+  if (!text) {
+    return [];
+  }
+  const lines = text.split(/\r\n|\r|\n/);
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines;
+}
+
+function readToolArguments(
+  item: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const args = item?.arguments;
+  if (!args) {
+    return undefined;
+  }
+  if (typeof args === "string") {
+    try {
+      const parsed = JSON.parse(args) as unknown;
+      return readRecord(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+  return readRecord(args);
+}
+
+function readToolOutput(
+  item: Record<string, unknown> | undefined,
+): { text?: string; truncated?: boolean } {
+  const data = readRecord(item?.data);
+  const text =
+    readString(data, "output") ??
+    readString(data, "text") ??
+    readString(data, "result") ??
+    readString(item, "output") ??
+    readString(item, "stdout") ??
+    readString(item, "stderr");
+  const truncated =
+    readBoolean(data, "outputTruncated") ??
+    readBoolean(data, "output_truncated") ??
+    readBoolean(data, "truncated") ??
+    readBoolean(item, "outputTruncated") ??
+    readBoolean(item, "output_truncated") ??
+    readBoolean(item, "truncated");
+  return { text, truncated };
+}
+
+function readExitCode(
+  item: Record<string, unknown> | undefined,
+): Pick<ThreadToolInvocationRecord, "exitCode"> {
+  const data = readRecord(item?.data);
+  const value =
+    readNumber(item, "exitCode") ??
+    readNumber(item, "exit_code") ??
+    readNumber(data, "exitCode") ??
+    readNumber(data, "exit_code");
+  return value === undefined ? {} : { exitCode: value };
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readNumber(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.floor(value)
+    : undefined;
+}
+
+function readBoolean(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}

--- a/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-tool-activity.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import type { AgentEvent } from "@pwragent/shared";
+import {
+  redactCommandText,
+  safeCommandTitle as safeRedactedCommandTitle,
+} from "../../util/redact-command-text";
 
 export type MessagingToolActivityStatus = "completed" | "failed" | "cancelled";
 
@@ -19,11 +23,6 @@ export type MessagingToolActivity = {
   status: MessagingToolActivityStatus;
   title: string;
 };
-
-const SECRET_FRAGMENT_PATTERN =
-  /((?:--?)?(?:api[-_]?key|token|secret|password|authorization)(?:=|\s+))("[^"]*"|'[^']*'|\S+)/gi;
-const ASSIGNMENT_SECRET_PATTERN =
-  /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|AUTHORIZATION)[A-Z0-9_]*=)("[^"]*"|'[^']*'|\S+)/g;
 
 export function summarizeToolActivityFromBackendEvent(
   event: AgentEvent,
@@ -227,7 +226,7 @@ function mcpToolTitle(item: Record<string, unknown>): string {
 function webSearchTitle(item: Record<string, unknown>): string {
   const query = readString(item, "query") ?? readToolArgument(item, "query");
   return query
-    ? truncateTitle(`Searched web: ${redactTitleText(query)}`)
+    ? truncateTitle(`Searched web: ${redactCommandText(query)}`)
     : "Searched web";
 }
 
@@ -308,7 +307,7 @@ function readDynamicPathBasename(
   }
 
   const basename = path.basename(value) || value;
-  return redactTitleText(basename);
+  return redactCommandText(basename);
 }
 
 function readSafeDynamicText(
@@ -316,7 +315,7 @@ function readSafeDynamicText(
   keys: string[],
 ): string | undefined {
   const value = readFirstString(args, keys);
-  return value ? redactTitleText(value) : undefined;
+  return value ? redactCommandText(value) : undefined;
 }
 
 function readFirstString(
@@ -355,23 +354,7 @@ function readToolArguments(
 }
 
 function safeCommandTitle(command: string | undefined): string {
-  if (!command) {
-    return "Ran command";
-  }
-
-  const stripped = command
-    .replace(/^\/bin\/[a-z]+ -lc /, "")
-    .replace(/^['"]|['"]$/g, "");
-  const collapsed = redactTitleText(stripped);
-  return collapsed ? truncateTitle(collapsed) : "Ran command";
-}
-
-function redactTitleText(value: string): string {
-  return value
-    .replace(SECRET_FRAGMENT_PATTERN, "$1[redacted]")
-    .replace(ASSIGNMENT_SECRET_PATTERN, "$1[redacted]")
-    .replace(/\s+/g, " ")
-    .trim();
+  return truncateTitle(safeRedactedCommandTitle(command));
 }
 
 function normalizeToolStatus(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -106,6 +106,7 @@ export type DesktopSettingsConfig = {
     threadPricingSummary?: boolean;
     threadPricingDisplayUsd?: boolean;
     threadPricingDisplayCodexCredits?: boolean;
+    threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
     diffCondensation?: {
       enabled?: boolean;
@@ -671,6 +672,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "thread_pricing_display_codex_credits"],
       patch.experimental.threadPricingDisplayCodexCredits,
+    );
+  }
+  if (patch.experimental?.threadToolAccounting !== undefined) {
+    set(
+      ["experimental", "thread_tool_accounting"],
+      patch.experimental.threadToolAccounting,
     );
   }
   if (patch.experimental?.codexDefaultModeRequestUserInput !== undefined) {
@@ -1323,6 +1330,7 @@ function normalizeDesktopConfig(
       threadPricingDisplayCodexCredits: readBoolean(
         experimental?.thread_pricing_display_codex_credits,
       ),
+      threadToolAccounting: readBoolean(experimental?.thread_tool_accounting),
       codexDefaultModeRequestUserInput: readBoolean(
         experimental?.codex_default_mode_request_user_input,
       ),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -603,6 +603,10 @@ export class DesktopSettingsService {
           config.experimental?.threadPricingDisplayCodexCredits,
           false,
         ),
+        threadToolAccounting: this.resolveConfigBoolean(
+          config.experimental?.threadToolAccounting,
+          false,
+        ),
         codexDefaultModeRequestUserInput: this.resolveConfigBoolean(
           config.experimental?.codexDefaultModeRequestUserInput,
           false,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -17,6 +17,11 @@ import type {
   ThreadGitWorkingState,
   ThreadMessagingBindingTransition,
   ThreadOverlayState,
+  ThreadToolAccounting,
+  ThreadToolInvocationAlert,
+  ThreadToolInvocationRecord,
+  ThreadToolInvocationStatus,
+  ThreadToolInvocationSummary,
   ThreadPermissionTransition,
   ThreadPricingSummary,
   ThreadSubAgentSummary,
@@ -966,6 +971,277 @@ export class SqliteOverlayStore {
       lines,
       summaries: summaryRows.map(threadPricingSummaryFromRow),
     };
+  }
+
+  async upsertThreadToolInvocation(params: {
+    invocation: ThreadToolInvocationRecord;
+  }): Promise<ThreadToolInvocationRecord> {
+    const invocation = normalizeThreadToolInvocation(params.invocation);
+    const existing = this.readThreadToolInvocationSync(invocation.invocationId);
+    const merged = existing
+      ? mergeThreadToolInvocationForUpsert(invocation, existing)
+      : invocation;
+
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO thread_tool_invocations (
+          invocation_id,
+          backend,
+          thread_id,
+          turn_id,
+          item_id,
+          tool_name,
+          normalized_command,
+          category,
+          status,
+          started_at,
+          completed_at,
+          observed_at,
+          updated_at,
+          session_id,
+          process_id,
+          exit_code,
+          output_chars,
+          output_lines,
+          estimated_output_tokens,
+          warning_lines,
+          error_lines,
+          info_lines,
+          debug_lines,
+          output_truncated,
+          noisy,
+          noisy_reason
+        ) VALUES (
+          @invocationId,
+          @backend,
+          @threadId,
+          @turnId,
+          @itemId,
+          @toolName,
+          @normalizedCommand,
+          @category,
+          @status,
+          @startedAt,
+          @completedAt,
+          @observedAt,
+          @updatedAt,
+          @sessionId,
+          @processId,
+          @exitCode,
+          @outputChars,
+          @outputLines,
+          @estimatedOutputTokens,
+          @warningLines,
+          @errorLines,
+          @infoLines,
+          @debugLines,
+          @outputTruncated,
+          @noisy,
+          @noisyReason
+        )
+        ON CONFLICT(invocation_id) DO UPDATE SET
+          backend = excluded.backend,
+          thread_id = excluded.thread_id,
+          turn_id = excluded.turn_id,
+          item_id = excluded.item_id,
+          tool_name = excluded.tool_name,
+          normalized_command = excluded.normalized_command,
+          category = excluded.category,
+          status = excluded.status,
+          started_at = CASE
+            WHEN thread_tool_invocations.started_at IS NULL THEN excluded.started_at
+            WHEN excluded.started_at IS NULL THEN thread_tool_invocations.started_at
+            ELSE MIN(thread_tool_invocations.started_at, excluded.started_at)
+          END,
+          completed_at = excluded.completed_at,
+          observed_at = MAX(thread_tool_invocations.observed_at, excluded.observed_at),
+          updated_at = excluded.updated_at,
+          session_id = COALESCE(excluded.session_id, thread_tool_invocations.session_id),
+          process_id = COALESCE(excluded.process_id, thread_tool_invocations.process_id),
+          exit_code = COALESCE(excluded.exit_code, thread_tool_invocations.exit_code),
+          output_chars = excluded.output_chars,
+          output_lines = excluded.output_lines,
+          estimated_output_tokens = excluded.estimated_output_tokens,
+          warning_lines = excluded.warning_lines,
+          error_lines = excluded.error_lines,
+          info_lines = excluded.info_lines,
+          debug_lines = excluded.debug_lines,
+          output_truncated = excluded.output_truncated,
+          noisy = excluded.noisy,
+          noisy_reason = excluded.noisy_reason`,
+      )
+      .run(toThreadToolInvocationRowParams(merged));
+
+    return merged;
+  }
+
+  async markThreadToolInvocationNoisy(params: {
+    invocationId: string;
+    reason: string;
+  }): Promise<void> {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE thread_tool_invocations
+         SET noisy = 1, noisy_reason = ?, updated_at = ?
+         WHERE invocation_id = ?`,
+      )
+      .run(params.reason, Date.now(), params.invocationId);
+  }
+
+  async upsertThreadToolInvocationAlert(params: {
+    alert: ThreadToolInvocationAlert;
+  }): Promise<ThreadToolInvocationAlert> {
+    const alert = normalizeThreadToolInvocationAlert(params.alert);
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO thread_tool_invocation_alerts (
+          alert_id,
+          backend,
+          thread_id,
+          kind,
+          severity,
+          tool_name,
+          session_id,
+          process_id,
+          first_observed_at,
+          last_observed_at,
+          invocation_count,
+          total_output_chars,
+          estimated_output_tokens,
+          average_interval_ms,
+          message,
+          suggested_prompt,
+          created_at,
+          updated_at
+        ) VALUES (
+          @alertId,
+          @backend,
+          @threadId,
+          @kind,
+          @severity,
+          @toolName,
+          @sessionId,
+          @processId,
+          @firstObservedAt,
+          @lastObservedAt,
+          @invocationCount,
+          @totalOutputChars,
+          @estimatedOutputTokens,
+          @averageIntervalMs,
+          @message,
+          @suggestedPrompt,
+          @createdAt,
+          @updatedAt
+        )
+        ON CONFLICT(alert_id) DO UPDATE SET
+          backend = excluded.backend,
+          thread_id = excluded.thread_id,
+          kind = excluded.kind,
+          severity = excluded.severity,
+          tool_name = excluded.tool_name,
+          session_id = COALESCE(excluded.session_id, thread_tool_invocation_alerts.session_id),
+          process_id = COALESCE(excluded.process_id, thread_tool_invocation_alerts.process_id),
+          first_observed_at = MIN(thread_tool_invocation_alerts.first_observed_at, excluded.first_observed_at),
+          last_observed_at = MAX(thread_tool_invocation_alerts.last_observed_at, excluded.last_observed_at),
+          invocation_count = excluded.invocation_count,
+          total_output_chars = excluded.total_output_chars,
+          estimated_output_tokens = excluded.estimated_output_tokens,
+          average_interval_ms = excluded.average_interval_ms,
+          message = excluded.message,
+          suggested_prompt = excluded.suggested_prompt,
+          updated_at = excluded.updated_at`,
+      )
+      .run(toThreadToolInvocationAlertRowParams(alert));
+    return alert;
+  }
+
+  async readThreadToolAccounting(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<ThreadToolAccounting> {
+    const invocationRows = this.stateDb.raw
+      .prepare(
+        `SELECT *
+         FROM thread_tool_invocations
+         WHERE backend = ?
+           AND thread_id = ?
+         ORDER BY observed_at DESC, invocation_id DESC
+         LIMIT 200`,
+      )
+      .all(params.backend, params.threadId) as ThreadToolInvocationRow[];
+    const summaryRows = this.stateDb.raw
+      .prepare(
+        `SELECT
+           category,
+           tool_name,
+           COUNT(*) AS invocation_count,
+           COALESCE(SUM(output_chars), 0) AS output_chars,
+           COALESCE(SUM(output_lines), 0) AS output_lines,
+           COALESCE(SUM(estimated_output_tokens), 0) AS estimated_output_tokens,
+           COALESCE(SUM(warning_lines), 0) AS warning_lines,
+           COALESCE(SUM(error_lines), 0) AS error_lines,
+           COALESCE(SUM(info_lines), 0) AS info_lines,
+           COALESCE(SUM(debug_lines), 0) AS debug_lines,
+           COALESCE(SUM(CASE WHEN noisy = 1 THEN 1 ELSE 0 END), 0) AS noisy_invocation_count,
+           MAX(observed_at) AS last_observed_at
+         FROM thread_tool_invocations
+         WHERE backend = ?
+           AND thread_id = ?
+         GROUP BY category, tool_name
+         ORDER BY estimated_output_tokens DESC, output_chars DESC
+         LIMIT 50`,
+      )
+      .all(params.backend, params.threadId) as ThreadToolInvocationSummaryRow[];
+    const alertRows = this.stateDb.raw
+      .prepare(
+        `SELECT *
+         FROM thread_tool_invocation_alerts
+         WHERE backend = ?
+           AND thread_id = ?
+         ORDER BY updated_at DESC, alert_id DESC
+         LIMIT 20`,
+      )
+      .all(params.backend, params.threadId) as ThreadToolInvocationAlertRow[];
+
+    return {
+      alerts: alertRows.map(threadToolInvocationAlertFromRow),
+      invocations: invocationRows.map(threadToolInvocationFromRow),
+      summaries: summaryRows.map(threadToolInvocationSummaryFromRow),
+    };
+  }
+
+  readRecentThreadToolInvocations(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    toolName: string;
+    since: number;
+    sessionId?: string;
+    processId?: string;
+    limit?: number;
+  }): ThreadToolInvocationRecord[] {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT *
+         FROM thread_tool_invocations
+         WHERE backend = @backend
+           AND thread_id = @threadId
+           AND tool_name = @toolName
+           AND observed_at >= @since
+           AND (@sessionId IS NULL OR session_id = @sessionId)
+           AND (@processId IS NULL OR process_id = @processId)
+         ORDER BY observed_at DESC, invocation_id DESC
+         LIMIT @limit`,
+      )
+      .all({
+        backend: params.backend,
+        limit: params.limit ?? 12,
+        processId: params.processId ?? null,
+        sessionId: params.sessionId ?? null,
+        since: params.since,
+        threadId: params.threadId,
+        toolName: params.toolName,
+      }) as ThreadToolInvocationRow[];
+    return rows.map(threadToolInvocationFromRow);
   }
 
   // Per-turn metadata lives on thread_usage_turns. The turn record is refreshed
@@ -2246,6 +2522,15 @@ export class SqliteOverlayStore {
     return row ? threadUsageLineFromRow(row) : undefined;
   }
 
+  private readThreadToolInvocationSync(
+    invocationId: string,
+  ): ThreadToolInvocationRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare("SELECT * FROM thread_tool_invocations WHERE invocation_id = ?")
+      .get(invocationId) as ThreadToolInvocationRow | undefined;
+    return row ? threadToolInvocationFromRow(row) : undefined;
+  }
+
   private recomputeThreadPricingSummarySync(params: {
     backend: string;
     currency: string;
@@ -2519,6 +2804,190 @@ type ThreadPricingAggregateRow = Omit<
   "backend" | "thread_id" | "currency" | "updated_at"
 >;
 
+type ThreadToolInvocationRow = {
+  invocation_id: string;
+  backend: ThreadToolInvocationRecord["backend"];
+  thread_id: string;
+  turn_id: string | null;
+  item_id: string;
+  tool_name: string;
+  normalized_command: string | null;
+  category: ThreadToolInvocationRecord["category"];
+  status: ThreadToolInvocationStatus;
+  started_at: number | null;
+  completed_at: number | null;
+  observed_at: number;
+  updated_at: number;
+  session_id: string | null;
+  process_id: string | null;
+  exit_code: number | null;
+  output_chars: number;
+  output_lines: number;
+  estimated_output_tokens: number;
+  warning_lines: number;
+  error_lines: number;
+  info_lines: number;
+  debug_lines: number;
+  output_truncated: number;
+  noisy: number;
+  noisy_reason: string | null;
+};
+
+type ThreadToolInvocationSummaryRow = {
+  category: ThreadToolInvocationSummary["category"];
+  tool_name: string;
+  invocation_count: number;
+  output_chars: number;
+  output_lines: number;
+  estimated_output_tokens: number;
+  warning_lines: number;
+  error_lines: number;
+  info_lines: number;
+  debug_lines: number;
+  noisy_invocation_count: number;
+  last_observed_at: number;
+};
+
+type ThreadToolInvocationAlertRow = {
+  alert_id: string;
+  backend: ThreadToolInvocationAlert["backend"];
+  thread_id: string;
+  kind: ThreadToolInvocationAlert["kind"];
+  severity: ThreadToolInvocationAlert["severity"];
+  tool_name: string;
+  session_id: string | null;
+  process_id: string | null;
+  first_observed_at: number;
+  last_observed_at: number;
+  invocation_count: number;
+  total_output_chars: number;
+  estimated_output_tokens: number;
+  average_interval_ms: number | null;
+  message: string;
+  suggested_prompt: string;
+  created_at: number;
+  updated_at: number;
+};
+
+function normalizeThreadToolInvocation(
+  invocation: ThreadToolInvocationRecord,
+): ThreadToolInvocationRecord {
+  const outputChars = clampTokenCount(invocation.outputChars);
+  const estimatedOutputTokens =
+    invocation.estimatedOutputTokens > 0
+      ? clampTokenCount(invocation.estimatedOutputTokens)
+      : Math.ceil(outputChars / 4);
+  return {
+    ...invocation,
+    estimatedOutputTokens,
+    itemId: invocation.itemId.trim() || invocation.invocationId,
+    outputChars,
+    outputLines: clampTokenCount(invocation.outputLines),
+    warningLines: clampTokenCount(invocation.warningLines),
+    errorLines: clampTokenCount(invocation.errorLines),
+    infoLines: clampTokenCount(invocation.infoLines),
+    debugLines: clampTokenCount(invocation.debugLines),
+    toolName: invocation.toolName.trim() || "unknown",
+  };
+}
+
+function mergeThreadToolInvocationForUpsert(
+  incoming: ThreadToolInvocationRecord,
+  existing: ThreadToolInvocationRecord,
+): ThreadToolInvocationRecord {
+  const shouldAccumulateOutput =
+    existing.status === "in_progress" &&
+    incoming.status === "in_progress" &&
+    incoming.outputChars > 0;
+  const outputChars = shouldAccumulateOutput
+    ? existing.outputChars + incoming.outputChars
+    : Math.max(existing.outputChars, incoming.outputChars);
+  return {
+    ...incoming,
+    ...(incoming.completedAt !== undefined
+      ? { completedAt: incoming.completedAt }
+      : existing.completedAt !== undefined
+        ? { completedAt: existing.completedAt }
+        : {}),
+    ...(incoming.exitCode !== undefined
+      ? { exitCode: incoming.exitCode }
+      : existing.exitCode !== undefined
+        ? { exitCode: existing.exitCode }
+        : {}),
+    ...(incoming.normalizedCommand
+      ? { normalizedCommand: incoming.normalizedCommand }
+      : existing.normalizedCommand
+        ? { normalizedCommand: existing.normalizedCommand }
+        : {}),
+    ...(incoming.processId
+      ? { processId: incoming.processId }
+      : existing.processId
+        ? { processId: existing.processId }
+        : {}),
+    ...(incoming.sessionId
+      ? { sessionId: incoming.sessionId }
+      : existing.sessionId
+        ? { sessionId: existing.sessionId }
+        : {}),
+    ...(incoming.startedAt !== undefined || existing.startedAt !== undefined
+      ? {
+          startedAt: Math.min(
+            incoming.startedAt ?? incoming.observedAt,
+            existing.startedAt ?? existing.observedAt,
+          ),
+        }
+      : {}),
+    debugLines: shouldAccumulateOutput
+      ? existing.debugLines + incoming.debugLines
+      : Math.max(existing.debugLines, incoming.debugLines),
+    estimatedOutputTokens: Math.ceil(outputChars / 4),
+    errorLines: shouldAccumulateOutput
+      ? existing.errorLines + incoming.errorLines
+      : Math.max(existing.errorLines, incoming.errorLines),
+    infoLines: shouldAccumulateOutput
+      ? existing.infoLines + incoming.infoLines
+      : Math.max(existing.infoLines, incoming.infoLines),
+    noisy: existing.noisy || incoming.noisy,
+    ...(incoming.noisyReason
+      ? { noisyReason: incoming.noisyReason }
+      : existing.noisyReason
+        ? { noisyReason: existing.noisyReason }
+        : {}),
+    observedAt: Math.max(existing.observedAt, incoming.observedAt),
+    outputChars,
+    outputLines: shouldAccumulateOutput
+      ? existing.outputLines + incoming.outputLines
+      : Math.max(existing.outputLines, incoming.outputLines),
+    outputTruncated: existing.outputTruncated || incoming.outputTruncated,
+    status: terminalToolInvocationStatus(existing.status)
+      ? existing.status
+      : incoming.status,
+    updatedAt: Math.max(existing.updatedAt, incoming.updatedAt),
+    warningLines: shouldAccumulateOutput
+      ? existing.warningLines + incoming.warningLines
+      : Math.max(existing.warningLines, incoming.warningLines),
+  };
+}
+
+function terminalToolInvocationStatus(status: ThreadToolInvocationStatus): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+function normalizeThreadToolInvocationAlert(
+  alert: ThreadToolInvocationAlert,
+): ThreadToolInvocationAlert {
+  const totalOutputChars = clampTokenCount(alert.totalOutputChars);
+  return {
+    ...alert,
+    estimatedOutputTokens:
+      alert.estimatedOutputTokens > 0
+        ? clampTokenCount(alert.estimatedOutputTokens)
+        : Math.ceil(totalOutputChars / 4),
+    invocationCount: clampTokenCount(alert.invocationCount),
+    totalOutputChars,
+  };
+}
+
 function normalizeThreadUsageLine(
   line: ThreadUsageLineRecord,
   updatedAt: number,
@@ -2784,6 +3253,64 @@ function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string,
   };
 }
 
+function toThreadToolInvocationRowParams(
+  invocation: ThreadToolInvocationRecord,
+): Record<string, unknown> {
+  return {
+    backend: invocation.backend,
+    category: invocation.category,
+    completedAt: invocation.completedAt ?? null,
+    debugLines: invocation.debugLines,
+    errorLines: invocation.errorLines,
+    estimatedOutputTokens: invocation.estimatedOutputTokens,
+    exitCode: invocation.exitCode ?? null,
+    infoLines: invocation.infoLines,
+    invocationId: invocation.invocationId,
+    itemId: invocation.itemId,
+    noisy: invocation.noisy ? 1 : 0,
+    noisyReason: invocation.noisyReason ?? null,
+    normalizedCommand: invocation.normalizedCommand ?? null,
+    observedAt: invocation.observedAt,
+    outputChars: invocation.outputChars,
+    outputLines: invocation.outputLines,
+    outputTruncated: invocation.outputTruncated ? 1 : 0,
+    processId: invocation.processId ?? null,
+    sessionId: invocation.sessionId ?? null,
+    startedAt: invocation.startedAt ?? null,
+    status: invocation.status,
+    threadId: invocation.threadId,
+    toolName: invocation.toolName,
+    turnId: invocation.turnId ?? null,
+    updatedAt: invocation.updatedAt,
+    warningLines: invocation.warningLines,
+  };
+}
+
+function toThreadToolInvocationAlertRowParams(
+  alert: ThreadToolInvocationAlert,
+): Record<string, unknown> {
+  return {
+    alertId: alert.alertId,
+    averageIntervalMs: alert.averageIntervalMs ?? null,
+    backend: alert.backend,
+    createdAt: alert.createdAt,
+    estimatedOutputTokens: alert.estimatedOutputTokens,
+    firstObservedAt: alert.firstObservedAt,
+    invocationCount: alert.invocationCount,
+    kind: alert.kind,
+    lastObservedAt: alert.lastObservedAt,
+    message: alert.message,
+    processId: alert.processId ?? null,
+    sessionId: alert.sessionId ?? null,
+    severity: alert.severity,
+    suggestedPrompt: alert.suggestedPrompt,
+    threadId: alert.threadId,
+    toolName: alert.toolName,
+    totalOutputChars: alert.totalOutputChars,
+    updatedAt: alert.updatedAt,
+  };
+}
+
 function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord {
   return {
     backend: row.backend,
@@ -2857,6 +3384,85 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
   };
 }
 
+function threadToolInvocationFromRow(
+  row: ThreadToolInvocationRow,
+): ThreadToolInvocationRecord {
+  return {
+    backend: row.backend,
+    category: row.category,
+    ...(row.completed_at !== null ? { completedAt: row.completed_at } : {}),
+    debugLines: row.debug_lines,
+    errorLines: row.error_lines,
+    estimatedOutputTokens: row.estimated_output_tokens,
+    ...(row.exit_code !== null ? { exitCode: row.exit_code } : {}),
+    infoLines: row.info_lines,
+    invocationId: row.invocation_id,
+    itemId: row.item_id,
+    noisy: Boolean(row.noisy),
+    ...(row.noisy_reason ? { noisyReason: row.noisy_reason } : {}),
+    ...(row.normalized_command ? { normalizedCommand: row.normalized_command } : {}),
+    observedAt: row.observed_at,
+    outputChars: row.output_chars,
+    outputLines: row.output_lines,
+    outputTruncated: Boolean(row.output_truncated),
+    ...(row.process_id ? { processId: row.process_id } : {}),
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    ...(row.started_at !== null ? { startedAt: row.started_at } : {}),
+    status: row.status,
+    threadId: row.thread_id,
+    toolName: row.tool_name,
+    ...(row.turn_id ? { turnId: row.turn_id } : {}),
+    updatedAt: row.updated_at,
+    warningLines: row.warning_lines,
+  };
+}
+
+function threadToolInvocationSummaryFromRow(
+  row: ThreadToolInvocationSummaryRow,
+): ThreadToolInvocationSummary {
+  return {
+    category: row.category,
+    debugLines: row.debug_lines,
+    errorLines: row.error_lines,
+    estimatedOutputTokens: row.estimated_output_tokens,
+    infoLines: row.info_lines,
+    invocationCount: row.invocation_count,
+    lastObservedAt: row.last_observed_at,
+    noisyInvocationCount: row.noisy_invocation_count,
+    outputChars: row.output_chars,
+    outputLines: row.output_lines,
+    toolName: row.tool_name,
+    warningLines: row.warning_lines,
+  };
+}
+
+function threadToolInvocationAlertFromRow(
+  row: ThreadToolInvocationAlertRow,
+): ThreadToolInvocationAlert {
+  return {
+    alertId: row.alert_id,
+    ...(row.average_interval_ms !== null
+      ? { averageIntervalMs: row.average_interval_ms }
+      : {}),
+    backend: row.backend,
+    createdAt: row.created_at,
+    estimatedOutputTokens: row.estimated_output_tokens,
+    firstObservedAt: row.first_observed_at,
+    invocationCount: row.invocation_count,
+    kind: row.kind,
+    lastObservedAt: row.last_observed_at,
+    message: row.message,
+    ...(row.process_id ? { processId: row.process_id } : {}),
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    severity: row.severity,
+    suggestedPrompt: row.suggested_prompt,
+    threadId: row.thread_id,
+    toolName: row.tool_name,
+    totalOutputChars: row.total_output_chars,
+    updatedAt: row.updated_at,
+  };
+}
+
 function threadPricingSummaryFromRow(row: ThreadPricingSummaryRow): ThreadPricingSummary {
   return {
     backend: row.backend,
@@ -2891,6 +3497,11 @@ export type OverlayStoreLike = Pick<
   | "persistThreadUsageActivity"
   | "upsertThreadUsageLine"
   | "readThreadPricing"
+  | "upsertThreadToolInvocation"
+  | "markThreadToolInvocationNoisy"
+  | "upsertThreadToolInvocationAlert"
+  | "readThreadToolAccounting"
+  | "readRecentThreadToolInvocations"
   | "upsertThreadSubAgent"
   | "setThreadReaction"
   | "setThreadPin"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 26;
+export const CURRENT_STATE_DB_USER_VERSION = 27;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -643,6 +643,66 @@ CREATE TABLE IF NOT EXISTS thread_pricing_summaries (
 );
 `;
 
+const THREAD_TOOL_ACCOUNTING_SCHEMA = `
+CREATE TABLE IF NOT EXISTS thread_tool_invocations (
+  invocation_id             TEXT PRIMARY KEY,
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  turn_id                   TEXT,
+  item_id                   TEXT NOT NULL,
+  tool_name                 TEXT NOT NULL,
+  normalized_command        TEXT,
+  category                  TEXT NOT NULL,
+  status                    TEXT NOT NULL,
+  started_at                INTEGER,
+  completed_at              INTEGER,
+  observed_at               INTEGER NOT NULL,
+  updated_at                INTEGER NOT NULL,
+  session_id                TEXT,
+  process_id                TEXT,
+  exit_code                 INTEGER,
+  output_chars              INTEGER NOT NULL,
+  output_lines              INTEGER NOT NULL,
+  estimated_output_tokens   INTEGER NOT NULL,
+  warning_lines             INTEGER NOT NULL,
+  error_lines               INTEGER NOT NULL,
+  info_lines                INTEGER NOT NULL,
+  debug_lines               INTEGER NOT NULL,
+  output_truncated          INTEGER NOT NULL,
+  noisy                     INTEGER NOT NULL,
+  noisy_reason              TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_thread_tool_invocations_read_thread
+  ON thread_tool_invocations(backend, thread_id, observed_at DESC, invocation_id DESC);
+CREATE INDEX IF NOT EXISTS idx_thread_tool_invocations_polling
+  ON thread_tool_invocations(backend, thread_id, tool_name, session_id, process_id, observed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_thread_tool_invocations_turn
+  ON thread_tool_invocations(backend, thread_id, turn_id, observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS thread_tool_invocation_alerts (
+  alert_id                  TEXT PRIMARY KEY,
+  backend                   TEXT NOT NULL,
+  thread_id                 TEXT NOT NULL,
+  kind                      TEXT NOT NULL,
+  severity                  TEXT NOT NULL,
+  tool_name                 TEXT NOT NULL,
+  session_id                TEXT,
+  process_id                TEXT,
+  first_observed_at         INTEGER NOT NULL,
+  last_observed_at          INTEGER NOT NULL,
+  invocation_count          INTEGER NOT NULL,
+  total_output_chars        INTEGER NOT NULL,
+  estimated_output_tokens   INTEGER NOT NULL,
+  average_interval_ms       INTEGER,
+  message                   TEXT NOT NULL,
+  suggested_prompt          TEXT NOT NULL,
+  created_at                INTEGER NOT NULL,
+  updated_at                INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_thread_tool_invocation_alerts_read_thread
+  ON thread_tool_invocation_alerts(backend, thread_id, updated_at DESC, alert_id DESC);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -861,6 +921,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 26) {
       db.transaction(() => {
         ensureThreadUsageAttributedColumn(db);
+        db.pragma("user_version = 26");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 27) {
+      db.transaction(() => {
+        db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1016,6 +1082,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
+    db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/util/redact-command-text.ts
+++ b/apps/desktop/src/main/util/redact-command-text.ts
@@ -1,0 +1,24 @@
+const SECRET_FRAGMENT_PATTERN =
+  /((?:--?)?(?:api[-_]?key|token|secret|password|authorization)(?:=|\s+))("[^"]*"|'[^']*'|\S+)/gi;
+const ASSIGNMENT_SECRET_PATTERN =
+  /\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|AUTHORIZATION)[A-Z0-9_]*=)("[^"]*"|'[^']*'|\S+)/g;
+
+export function redactCommandText(value: string): string {
+  return value
+    .replace(SECRET_FRAGMENT_PATTERN, "$1[redacted]")
+    .replace(ASSIGNMENT_SECRET_PATTERN, "$1[redacted]")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function safeCommandTitle(command: string | undefined): string {
+  if (!command) {
+    return "Ran command";
+  }
+
+  const stripped = command
+    .replace(/^\/bin\/[a-z]+ -lc /, "")
+    .replace(/^['"]|['"]$/g, "");
+  const collapsed = redactCommandText(stripped);
+  return collapsed || "Ran command";
+}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -865,6 +865,7 @@ function DesktopAppShell(props: {
     messageCount: session.messages.length,
     contextWindow: session.contextWindow,
     pricing: session.response?.pricing,
+    toolAccounting: session.response?.toolAccounting,
     threadPricingSummaryEnabled:
       settings.snapshot?.experimental.threadPricingSummary?.value ?? true,
     pricingDisplayOptions: {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -865,7 +865,10 @@ function DesktopAppShell(props: {
     messageCount: session.messages.length,
     contextWindow: session.contextWindow,
     pricing: session.response?.pricing,
-    toolAccounting: session.response?.toolAccounting,
+    toolAccounting:
+      settings.snapshot?.experimental.threadToolAccounting?.value === true
+        ? session.response?.toolAccounting
+        : undefined,
     threadPricingSummaryEnabled:
       settings.snapshot?.experimental.threadPricingSummary?.value ?? true,
     pricingDisplayOptions: {

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -62,6 +62,11 @@ const DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS = {
   source: "default" as const,
 };
 
+const DEFAULT_THREAD_TOOL_ACCOUNTING = {
+  value: false,
+  source: "default" as const,
+};
+
 export function ExperimentalSettings(props: {
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
@@ -72,6 +77,7 @@ export function ExperimentalSettings(props: {
   onThreadPricingSummaryChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayUsdChange: (enabled: boolean) => Promise<void>;
   onThreadPricingDisplayCodexCreditsChange: (enabled: boolean) => Promise<void>;
+  onThreadToolAccountingChange: (enabled: boolean) => Promise<void>;
   onCodexDefaultModeRequestUserInputChange: (
     enabled: boolean,
   ) => Promise<void>;
@@ -93,6 +99,9 @@ export function ExperimentalSettings(props: {
   const threadPricingDisplayCodexCredits =
     props.snapshot.experimental.threadPricingDisplayCodexCredits ??
     DEFAULT_THREAD_PRICING_DISPLAY_CODEX_CREDITS;
+  const threadToolAccounting =
+    props.snapshot.experimental.threadToolAccounting ??
+    DEFAULT_THREAD_TOOL_ACCOUNTING;
   const codexDefaultModeRequestUserInput =
     props.snapshot.experimental.codexDefaultModeRequestUserInput ??
     DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT;
@@ -166,6 +175,22 @@ export function ExperimentalSettings(props: {
                 label="Display Codex Credits"
                 onChange={(enabled) => {
                   void props.onThreadPricingDisplayCodexCreditsChange(enabled);
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Display tool output accounting"
+            sub="Show experimental tool-output volume and noisy-polling alerts."
+            help="Collection stays on either way; this only controls the operator-facing Pricing panel section."
+            source={sourceBadge(threadToolAccounting)}
+            control={
+              <SettingsSwitch
+                checked={threadToolAccounting.value}
+                disabled={props.saving || !threadPricingSummary.value}
+                label="Display tool output accounting"
+                onChange={(enabled) => {
+                  void props.onThreadToolAccountingChange(enabled);
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -429,6 +429,11 @@ function SettingsSectionBody(props: {
             experimental: { threadPricingDisplayCodexCredits: enabled },
           });
         }}
+        onThreadToolAccountingChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { threadToolAccounting: enabled },
+          });
+        }}
         onCodexDefaultModeRequestUserInputChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { codexDefaultModeRequestUserInput: enabled },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -157,6 +157,10 @@ function createSnapshot(
         value: false,
         source: "default",
       },
+      threadToolAccounting: {
+        value: false,
+        source: "default",
+      },
       codexDefaultModeRequestUserInput: {
         value: false,
         source: "default",
@@ -668,6 +672,9 @@ describe("SettingsScreen", () => {
     expect(
       screen.getByRole("switch", { name: "Display Codex Credits" }),
     ).not.toBeDisabled();
+    expect(
+      screen.getByRole("switch", { name: "Display tool output accounting" }),
+    ).not.toBeDisabled();
 
     fireEvent.click(
       screen.getByRole("switch", {
@@ -871,6 +878,7 @@ describe("SettingsScreen", () => {
           threadPricingSummary: { value: true, source: "config" },
           threadPricingDisplayUsd: { value: true, source: "default" },
           threadPricingDisplayCodexCredits: { value: false, source: "default" },
+          threadToolAccounting: { value: false, source: "default" },
         },
       }),
     );
@@ -883,8 +891,12 @@ describe("SettingsScreen", () => {
     const creditsSwitch = screen.getByRole("switch", {
       name: "Display Codex Credits",
     });
+    const toolAccountingSwitch = screen.getByRole("switch", {
+      name: "Display tool output accounting",
+    });
     expect(usdSwitch).not.toBeDisabled();
     expect(creditsSwitch).not.toBeDisabled();
+    expect(toolAccountingSwitch).not.toBeDisabled();
 
     fireEvent.click(usdSwitch);
     await waitFor(() => {
@@ -899,6 +911,13 @@ describe("SettingsScreen", () => {
         experimental: { threadPricingDisplayCodexCredits: true },
       });
     });
+
+    fireEvent.click(toolAccountingSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { threadToolAccounting: true },
+      });
+    });
   });
 
   it("disables thread pricing display unit toggles when summary is off", () => {
@@ -910,6 +929,7 @@ describe("SettingsScreen", () => {
           threadPricingSummary: { value: false, source: "config" },
           threadPricingDisplayUsd: { value: true, source: "default" },
           threadPricingDisplayCodexCredits: { value: false, source: "default" },
+          threadToolAccounting: { value: false, source: "default" },
         },
       }),
     );
@@ -921,6 +941,9 @@ describe("SettingsScreen", () => {
     expect(screen.getByRole("switch", { name: "Display USD" })).toBeDisabled();
     expect(
       screen.getByRole("switch", { name: "Display Codex Credits" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", { name: "Display tool output accounting" }),
     ).toBeDisabled();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -18,6 +18,7 @@ import type {
   NavigationThreadSummary,
   CodexEnvironmentActionRun,
   ThreadPricingSummary,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { WindowPointerSnapshot } from "../../../../shared/window-pointer";
@@ -103,6 +104,7 @@ type ThreadContextPanelProps = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
+  toolAccounting?: ThreadToolAccounting;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -668,6 +670,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <PricingPanel
             activeTurnId={props.activeTurnId}
             pricing={props.pricing}
+            toolAccounting={props.toolAccounting}
             displayOptions={props.pricingDisplayOptions}
             onScrollToTurn={props.onScrollToTurn}
             subAgents={props.thread.subAgents}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -38,6 +38,7 @@ import type {
   PendingRequestAction,
   ThreadExecutionMode,
   ThreadPricingSummary,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -728,6 +729,7 @@ export type ThreadViewProps = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
+  toolAccounting?: ThreadToolAccounting;
   pricingDisplayOptions?: {
     codexCredits: boolean;
     usd: boolean;
@@ -2749,6 +2751,7 @@ export function ThreadView(props: ThreadViewProps) {
           platform={props.platform}
           thread={selectedThread!}
           pricing={props.pricing}
+          toolAccounting={props.toolAccounting}
           pricingDisplayOptions={props.pricingDisplayOptions}
           threadPricingSummaryEnabled={threadPricingSummaryEnabled}
           worktreeArchiveError={props.worktreeArchiveError}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -14,6 +14,7 @@ import type {
   BackendSummary,
   NavigationThreadSummary,
   ThreadPricingSummary,
+  ThreadToolAccounting,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { ThreadContextPanel } from "../ThreadContextPanel";
@@ -151,6 +152,7 @@ type PanelOverrides = Partial<
     | "editedFilesDock"
     | "onEditedFilesDockChange"
     | "pricing"
+    | "toolAccounting"
     | "pricingDisplayOptions"
     | "threadPricingSummaryEnabled"
   >
@@ -613,6 +615,88 @@ describe("ThreadContextPanel", () => {
       screen.queryByRole("heading", { level: 3, name: "Pricing" }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Thread info" })).toBeInTheDocument();
+  });
+
+  it("renders tool output accounting and noisy polling alerts in Pricing", () => {
+    const toolAccounting: ThreadToolAccounting = {
+      alerts: [
+        {
+          alertId: "alert-1",
+          averageIntervalMs: 30_000,
+          backend: "codex",
+          createdAt: 1_800_000_060_000,
+          estimatedOutputTokens: 6_000,
+          firstObservedAt: 1_800_000_000_000,
+          invocationCount: 3,
+          kind: "noisy-polling",
+          lastObservedAt: 1_800_000_060_000,
+          message:
+            "Repeated write_stdin polling on session 40500 produced 24,000 chars (~6,000 output tokens) across 3 checks.",
+          sessionId: "40500",
+          severity: "warning",
+          suggestedPrompt: "Use create_monitor_delegation.",
+          threadId: "thread-1",
+          toolName: "write_stdin",
+          totalOutputChars: 24_000,
+          updatedAt: 1_800_000_060_000,
+        },
+      ],
+      invocations: [
+        {
+          backend: "codex",
+          category: "polling",
+          debugLines: 0,
+          errorLines: 1,
+          estimatedOutputTokens: 3_000,
+          infoLines: 120,
+          invocationId: "tool-1",
+          itemId: "tool-1",
+          noisy: true,
+          normalizedCommand: "poll session 40500",
+          observedAt: 1_800_000_060_000,
+          outputChars: 12_000,
+          outputLines: 120,
+          outputTruncated: false,
+          sessionId: "40500",
+          status: "completed",
+          threadId: "thread-1",
+          toolName: "write_stdin",
+          turnId: "turn-1",
+          updatedAt: 1_800_000_060_000,
+          warningLines: 2,
+        },
+      ],
+      summaries: [
+        {
+          category: "polling",
+          debugLines: 0,
+          errorLines: 1,
+          estimatedOutputTokens: 6_000,
+          infoLines: 240,
+          invocationCount: 3,
+          lastObservedAt: 1_800_000_060_000,
+          noisyInvocationCount: 3,
+          outputChars: 24_000,
+          outputLines: 240,
+          toolName: "write_stdin",
+          warningLines: 4,
+        },
+      ],
+    };
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      threadPricingSummaryEnabled: true,
+      toolAccounting,
+    });
+
+    expect(screen.getByRole("heading", { level: 4, name: "Tool output" })).toBeInTheDocument();
+    expect(screen.getByText("Noisy polling detected")).toBeInTheDocument();
+    expect(screen.getByText(/Repeated write_stdin polling/)).toBeInTheDocument();
+    expect(screen.getByText("write_stdin · polling")).toBeInTheDocument();
+    expect(screen.getByText("poll session 40500")).toBeInTheDocument();
+    expect(screen.getAllByText(/6,000/).length).toBeGreaterThan(0);
   });
 
   it("renders cached pricing totals and per-turn model settings", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -2,6 +2,9 @@ import type {
   ThreadPricingSummary,
   ThreadSubAgentStatus,
   ThreadSubAgentSummary,
+  ThreadToolAccounting,
+  ThreadToolInvocationRecord,
+  ThreadToolInvocationSummary,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -25,6 +28,7 @@ type PricingPanelProps = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
+  toolAccounting?: ThreadToolAccounting;
   /**
    * Durable sub-agent (task-monitor) summaries for this thread, joined to
    * monitor-scope usage rows by `monitorId` === the row's `sourceItemId`.
@@ -66,6 +70,7 @@ export function PricingPanel(props: PricingPanelProps) {
     aggregateSummaries(displaySummaries) ?? aggregateUsageLines(displayLines);
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   const pricingTotals = buildPricingRunningTotals(displayLines);
+  const toolTotals = aggregateToolAccounting(props.toolAccounting);
   const activeTurnId = props.activeTurnId;
   const subAgentsById = new Map(
     (props.subAgents ?? []).map((subAgent) => [subAgent.monitorId, subAgent]),
@@ -146,6 +151,117 @@ export function PricingPanel(props: PricingPanelProps) {
         </>
       ) : displayLines.length === 0 ? (
         <p className="context-empty">No usage pricing recorded yet.</p>
+      ) : null}
+
+      {toolTotals ? (
+        <div className="pricing-tool-output">
+          <h4>Tool output</h4>
+          <dl className="context-grid">
+            <dt>Estimated output tokens</dt>
+            <dd>{formatTokenCount(toolTotals.estimatedOutputTokens)}</dd>
+            <dt>Output volume</dt>
+            <dd>
+              {formatCharacterCount(toolTotals.outputChars)} ·{" "}
+              {toolTotals.outputLines.toLocaleString()} lines
+            </dd>
+            <dt>Invocations</dt>
+            <dd>
+              {toolTotals.invocationCount.toLocaleString()}
+              {toolTotals.noisyInvocationCount > 0 ? (
+                <span className="context-list__meta">
+                  {" "}
+                  ({toolTotals.noisyInvocationCount.toLocaleString()} noisy)
+                </span>
+              ) : null}
+            </dd>
+            <dt>Warnings / errors</dt>
+            <dd>
+              {toolTotals.warningLines.toLocaleString()} /{" "}
+              {toolTotals.errorLines.toLocaleString()}
+            </dd>
+          </dl>
+          {props.toolAccounting?.alerts.length ? (
+            <ul className="context-list context-list--cards pricing-tool-alert-list">
+              {props.toolAccounting.alerts.map((alert) => (
+                <li
+                  key={alert.alertId}
+                  className="rail-card pricing-tool-alert"
+                >
+                  <p className="rail-card__title">Noisy polling detected</p>
+                  <p className="rail-card__usage">{alert.message}</p>
+                  <p className="rail-card__usage">
+                    Suggested steering: {alert.suggestedPrompt}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {props.toolAccounting?.summaries.length ? (
+            <ul className="context-list context-list--cards pricing-tool-summary-list">
+              {props.toolAccounting.summaries.slice(0, 6).map((summary) => (
+                <li
+                  key={`${summary.category}:${summary.toolName}`}
+                  className="rail-card pricing-tool-summary-row"
+                >
+                  <p className="rail-card__title">
+                    {formatToolSummaryTitle(summary)}
+                  </p>
+                  <p className="rail-card__usage">
+                    {formatTokenCount(summary.estimatedOutputTokens)} est. output tokens ·{" "}
+                    {formatCharacterCount(summary.outputChars)}
+                  </p>
+                  <p className="rail-card__usage">
+                    {summary.invocationCount.toLocaleString()} invocation
+                    {summary.invocationCount === 1 ? "" : "s"} ·{" "}
+                    {summary.warningLines.toLocaleString()} warn ·{" "}
+                    {summary.errorLines.toLocaleString()} error ·{" "}
+                    {(summary.infoLines + summary.debugLines).toLocaleString()} info/debug
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {props.toolAccounting?.invocations.length ? (
+            <ul className="context-list context-list--cards pricing-tool-invocation-list">
+              {props.toolAccounting.invocations.slice(0, 8).map((invocation) => (
+                <li
+                  key={invocation.invocationId}
+                  className={`rail-card pricing-tool-invocation-row${
+                    invocation.noisy ? " pricing-tool-invocation-row--noisy" : ""
+                  }`}
+                >
+                  <p className="rail-card__title">
+                    {invocation.normalizedCommand ?? invocation.toolName}
+                  </p>
+                  <p className="rail-card__model">
+                    {invocation.toolName} · {invocation.category} ·{" "}
+                    {invocation.status}
+                    {invocation.exitCode !== undefined
+                      ? ` · exit ${invocation.exitCode}`
+                      : ""}
+                  </p>
+                  <p className="rail-card__usage">
+                    {formatTokenCount(invocation.estimatedOutputTokens)} est. output tokens ·{" "}
+                    {formatCharacterCount(invocation.outputChars)} ·{" "}
+                    {invocation.outputLines.toLocaleString()} lines
+                    {invocation.outputTruncated ? " · truncated" : ""}
+                    {invocation.noisy ? " · noisy" : ""}
+                  </p>
+                  <p className="rail-card__usage">
+                    {invocation.warningLines.toLocaleString()} warn ·{" "}
+                    {invocation.errorLines.toLocaleString()} error ·{" "}
+                    {invocation.infoLines.toLocaleString()} info ·{" "}
+                    {invocation.debugLines.toLocaleString()} debug
+                  </p>
+                  <ToolInvocationTimestamp
+                    invocation={invocation}
+                    onScrollToTurn={props.onScrollToTurn}
+                  />
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
       ) : null}
 
       {displayLines.length > 0 ? (
@@ -244,6 +360,99 @@ export function PricingPanel(props: PricingPanelProps) {
         </ul>
       ) : null}
     </section>
+  );
+}
+
+type ToolAccountingTotals = {
+  debugLines: number;
+  errorLines: number;
+  estimatedOutputTokens: number;
+  infoLines: number;
+  invocationCount: number;
+  noisyInvocationCount: number;
+  outputChars: number;
+  outputLines: number;
+  warningLines: number;
+};
+
+function aggregateToolAccounting(
+  toolAccounting: ThreadToolAccounting | undefined,
+): ToolAccountingTotals | undefined {
+  if (!toolAccounting || toolAccounting.summaries.length === 0) {
+    return undefined;
+  }
+  return toolAccounting.summaries.reduce<ToolAccountingTotals>(
+    (totals, summary) => ({
+      debugLines: totals.debugLines + summary.debugLines,
+      errorLines: totals.errorLines + summary.errorLines,
+      estimatedOutputTokens:
+        totals.estimatedOutputTokens + summary.estimatedOutputTokens,
+      infoLines: totals.infoLines + summary.infoLines,
+      invocationCount: totals.invocationCount + summary.invocationCount,
+      noisyInvocationCount:
+        totals.noisyInvocationCount + summary.noisyInvocationCount,
+      outputChars: totals.outputChars + summary.outputChars,
+      outputLines: totals.outputLines + summary.outputLines,
+      warningLines: totals.warningLines + summary.warningLines,
+    }),
+    {
+      debugLines: 0,
+      errorLines: 0,
+      estimatedOutputTokens: 0,
+      infoLines: 0,
+      invocationCount: 0,
+      noisyInvocationCount: 0,
+      outputChars: 0,
+      outputLines: 0,
+      warningLines: 0,
+    },
+  );
+}
+
+function formatToolSummaryTitle(summary: ThreadToolInvocationSummary): string {
+  return `${summary.toolName} · ${summary.category}`;
+}
+
+function formatCharacterCount(chars: number): string {
+  if (chars >= 1_000_000) {
+    return `${(chars / 1_000_000).toFixed(chars >= 10_000_000 ? 0 : 1)}M chars`;
+  }
+  if (chars >= 1_000) {
+    return `${(chars / 1_000).toFixed(chars >= 10_000 ? 0 : 1)}k chars`;
+  }
+  return `${chars.toLocaleString()} chars`;
+}
+
+function ToolInvocationTimestamp(props: {
+  invocation: ThreadToolInvocationRecord;
+  onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
+}) {
+  const timestamp = formatTimestamp(props.invocation.observedAt);
+  const canScrollToTurn = Boolean(props.invocation.turnId && props.onScrollToTurn);
+
+  return (
+    <p className="rail-card__times">
+      {canScrollToTurn ? (
+        <button
+          type="button"
+          className="rail-card__time-button"
+          title="Scroll the transcript to this turn"
+          aria-label={`Scroll the transcript to this turn (${timestamp})`}
+          onClick={() =>
+            props.invocation.turnId &&
+            props.onScrollToTurn?.(
+              props.invocation.turnId,
+              props.invocation.observedAt,
+            )
+          }
+        >
+          {timestamp}
+        </button>
+      ) : (
+        timestamp
+      )}
+      {props.invocation.turnId ? ` · ${props.invocation.turnId}` : ""}
+    </p>
   );
 }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4381,6 +4381,19 @@ export function useThreadSessionState(params: {
           };
         }
 
+        if (event.notification.method === "thread/toolAccounting/updated") {
+          return {
+            ...current,
+            lastTouchedAt: nextLastTouchedAt,
+            response: current.response
+              ? {
+                  ...current.response,
+                  toolAccounting: event.notification.params.toolAccounting,
+                }
+              : current.response,
+          };
+        }
+
         if (event.notification.method === "thread/tokenUsage/updated") {
           const contextWindow = normalizeThreadContextWindowState(
             event.notification.params.tokenUsage

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13000,6 +13000,32 @@ textarea,
   user-select: text;
 }
 
+.pricing-tool-output {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.pricing-tool-output h4 {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.pricing-tool-alert,
+.pricing-tool-invocation-row--noisy {
+  border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border-subtle));
+  box-shadow: inset 2px 0 0 0 var(--status-warning);
+}
+
+.pricing-tool-alert .rail-card__title {
+  color: var(--text-primary);
+}
+
 /* The in-progress turn: a calm accent left-stripe + slightly firmer border,
    reading as "live" without the background wash that would look like a
    hover/selection state. Pairs with the Live chip in the card header. */

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -95,6 +95,10 @@ describe("desktop settings contracts", () => {
           value: false,
           source: "default",
         },
+        threadToolAccounting: {
+          value: false,
+          source: "default",
+        },
         codexDefaultModeRequestUserInput: {
           value: false,
           source: "default",

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -671,7 +671,97 @@ export type AppServerReadThreadResponse = {
     lines: ThreadUsageLineRecord[];
     summaries: ThreadPricingSummary[];
   };
+  toolAccounting?: ThreadToolAccounting;
   threadStatus?: AppServerThreadStatus;
+};
+
+export type ThreadToolInvocationCategory =
+  | "build-test"
+  | "file-io"
+  | "git"
+  | "package-manager"
+  | "polling"
+  | "search"
+  | "shell"
+  | "sub-agent"
+  | "unknown";
+
+export type ThreadToolInvocationStatus =
+  | "pending"
+  | "in_progress"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export type ThreadToolInvocationRecord = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  turnId?: string;
+  itemId: string;
+  invocationId: string;
+  toolName: string;
+  normalizedCommand?: string;
+  category: ThreadToolInvocationCategory;
+  status: ThreadToolInvocationStatus;
+  startedAt?: number;
+  completedAt?: number;
+  observedAt: number;
+  updatedAt: number;
+  sessionId?: string;
+  processId?: string;
+  exitCode?: number;
+  outputChars: number;
+  outputLines: number;
+  estimatedOutputTokens: number;
+  warningLines: number;
+  errorLines: number;
+  infoLines: number;
+  debugLines: number;
+  outputTruncated: boolean;
+  noisy: boolean;
+  noisyReason?: string;
+};
+
+export type ThreadToolInvocationSummary = {
+  category: ThreadToolInvocationCategory;
+  toolName: string;
+  invocationCount: number;
+  outputChars: number;
+  outputLines: number;
+  estimatedOutputTokens: number;
+  warningLines: number;
+  errorLines: number;
+  infoLines: number;
+  debugLines: number;
+  noisyInvocationCount: number;
+  lastObservedAt: number;
+};
+
+export type ThreadToolInvocationAlert = {
+  alertId: string;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  kind: "noisy-polling";
+  severity: "warning";
+  toolName: string;
+  sessionId?: string;
+  processId?: string;
+  firstObservedAt: number;
+  lastObservedAt: number;
+  invocationCount: number;
+  totalOutputChars: number;
+  estimatedOutputTokens: number;
+  averageIntervalMs?: number;
+  message: string;
+  suggestedPrompt: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ThreadToolAccounting = {
+  alerts: ThreadToolInvocationAlert[];
+  invocations: ThreadToolInvocationRecord[];
+  summaries: ThreadToolInvocationSummary[];
 };
 
 export type PersistThreadUsageActivityRequest = {
@@ -958,6 +1048,13 @@ export type AppServerNotification =
           lines: ThreadUsageLineRecord[];
           summaries: ThreadPricingSummary[];
         };
+      };
+    }
+  | {
+      method: "thread/toolAccounting/updated";
+      params: {
+        threadId: string;
+        toolAccounting: ThreadToolAccounting;
       };
     }
   | {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -498,6 +498,12 @@ export type DesktopSettingsSnapshot = {
      */
     threadPricingDisplayCodexCredits?: DesktopSettingsValue<boolean>;
     /**
+     * Shows experimental tool-output accounting inside the thread Pricing tab.
+     * The desktop app may still collect tool metrics while this is disabled;
+     * this only gates the operator-facing panel and noisy-polling alerts.
+     */
+    threadToolAccounting?: DesktopSettingsValue<boolean>;
+    /**
      * Enables Codex's upstream default-mode request_user_input feature for
      * ordinary turns, allowing skills to pause and ask structured questions
      * outside Plan mode when the installed Codex build supports it.
@@ -739,6 +745,7 @@ export type DesktopSettingsConfigPatch = {
     threadPricingSummary?: boolean;
     threadPricingDisplayUsd?: boolean;
     threadPricingDisplayCodexCredits?: boolean;
+    threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
     diffCondensation?: {
       enabled?: boolean;


### PR DESCRIPTION
## Summary
PwrAgent now records structured tool-output accounting from live app-server events into its own sqlite state, without reading Codex rollout/session files.

Collection stays on so operators can dogfood against real thread history, but the visible Tool output section is gated behind Settings → Experimental → Display tool output accounting and defaults off. When enabled, the Pricing panel shows tool-output totals, noisy command categories, recent invocations, warning/error/info/debug line counts, truncation signals, and noisy polling alerts.

Repeated empty `write_stdin` polling against a long-running process now raises a durable warning with an opt-in steering prompt; non-empty stdin writes are kept out of polling alerts. Shell commands are redacted before their normalized command text is persisted or displayed. Monitor completion handoff text also more explicitly tells the parent thread to continue dependent work.

## Validation
- `pnpm test packages/shared/src/contracts/__tests__/settings.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx apps/desktop/src/main/__tests__/tool-invocation-accounting.test.ts apps/desktop/src/main/__tests__/messaging-tool-activity.test.ts apps/desktop/src/main/__tests__/overlay-store-tool-accounting.test.ts apps/desktop/src/main/__tests__/state-db.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` passed with the existing warning baseline only
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![gpt-5.5 high](https://img.shields.io/badge/gpt--5.5_%28high%29-000000)
