### PR TITLE
feat(desktop): directory & file references in the composer

### DIFF
--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -532,7 +532,9 @@ test("directory launchpad Tiptap WYSIWYG composer serializes markdown blocks", a
     await app.window.keyboard.press("Delete");
     await app.window.keyboard.type("Before ");
     await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
-    await app.window.keyboard.type(" after");
+    // The commit guarantees one space after the chip with the caret
+    // parked after it, so continue typing without a leading space.
+    await app.window.keyboard.type("after");
 
     await expect(
       tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
@@ -669,7 +671,8 @@ test("directory launchpad skill autocomplete honors markdown offsets after forma
         hasText: "$ce:brainstorm",
       }),
     ).toBeVisible();
-    await expect(tiptapInput).toHaveAttribute("data-value", "## heading\n\n");
+    // The trailing space is the guaranteed post-chip space.
+    await expect(tiptapInput).toHaveAttribute("data-value", "## heading\n\n ");
   } finally {
     await app.close();
     await fixture.cleanup();
@@ -703,9 +706,12 @@ test("directory launchpad Tiptap composer selects focused skills as undoable inl
       "data-tooltip",
       /\/Users\/huntharo\/\.codex\/skills\/frontend-design\/SKILL\.md$/,
     );
-    await expect(tiptapInput).toHaveAttribute("data-value", "");
+    // The commit leaves one guaranteed space after the chip.
+    await expect(tiptapInput).toHaveAttribute("data-value", " ");
 
     await textbox.focus();
+    // A whitespace-only draft holding a single chip gets the one-shot
+    // Backspace clear (chip + its guaranteed space together, undoable).
     await app.window.keyboard.press("Backspace");
     await expect(chip).toBeHidden();
     await expect(tiptapInput).toHaveAttribute("data-value", "");
@@ -715,7 +721,8 @@ test("directory launchpad Tiptap composer selects focused skills as undoable inl
       process.platform === "darwin" ? "Meta+Z" : "Control+Z",
     );
     await expect(chip).toBeVisible();
-    await expect(tiptapInput).toHaveAttribute("data-value", "");
+    // Undo restores the pre-delete draft, including the guaranteed space.
+    await expect(tiptapInput).toHaveAttribute("data-value", " ");
   } finally {
     await app.close();
     await fixture.cleanup();
@@ -734,9 +741,11 @@ test("directory launchpad Tiptap composer preserves multiple skill chips across 
     const textbox = app.window.getByRole("textbox", { name: "New thread" });
     await textbox.focus();
     await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
-    await app.window.keyboard.type(" i like cats n dogs - ");
+    // Each commit guarantees a post-chip space, so continue typing
+    // without a leading space — the final plain draft is unchanged.
+    await app.window.keyboard.type("i like cats n dogs - ");
     await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
-    await app.window.keyboard.type(" and more");
+    await app.window.keyboard.type("and more");
 
     const planChip = tiptapInput.locator(".composer-tiptap-input__mention", {
       hasText: "$ce:plan",
@@ -971,9 +980,12 @@ test("directory launchpad types at the clicked text caret between skill chips", 
     const { root: richInput, textbox } = getLaunchpadComposer(app);
     await textbox.focus();
     await typeSkillChip(app, "$ce:brainstorm", /\$ce:brainstorm/i);
-    await app.window.keyboard.type(" Cats like hats. ");
+    // The leading space is the first chip's guaranteed post-chip space;
+    // the trailing double space is the typed trigger separator plus the
+    // second chip's guaranteed space.
+    await app.window.keyboard.type("Cats like hats. ");
     await typeSkillChip(app, "$ce:plan", /\$ce:plan/i);
-    await expect(richInput).toHaveAttribute("data-value", " Cats like hats. ");
+    await expect(richInput).toHaveAttribute("data-value", " Cats like hats.  ");
 
     const clickPoint = await richInput.evaluate((element) => {
       const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
@@ -1009,7 +1021,7 @@ test("directory launchpad types at the clicked text caret between skill chips", 
 
     await app.window.mouse.click(clickPoint.x, clickPoint.y);
     await app.window.keyboard.type("I");
-    await expect(richInput).toHaveAttribute("data-value", " Cats like Ihats. ");
+    await expect(richInput).toHaveAttribute("data-value", " Cats like Ihats.  ");
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
+++ b/apps/desktop/e2e/skill-autocomplete-interactions.spec.ts
@@ -93,7 +93,12 @@ test("thread reply Tiptap skill autocomplete filters and commits the reported mu
     await expect(
       tiptapInput.locator(".composer-tiptap-input__mention", { hasText: "$ce:plan" }),
     ).toBeVisible();
-    await expect(tiptapInput).toHaveAttribute("data-value", seededDraft ?? "");
+    // The commit appends the guaranteed post-chip space; the outgoing
+    // text below is trimmed, so the startTurn expectation is unchanged.
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      `${seededDraft ?? ""} `,
+    );
     await expect(tiptapInput).not.toContainText("$ce:plan plan");
 
     await app.window.getByRole("button", { name: "Send" }).click();
@@ -208,7 +213,11 @@ test("thread reply Tiptap skill insertion preserves rich Markdown blocks", async
     ).toBeVisible();
     await expect(codeBlock).toBeVisible();
     await expect(codeBlock).not.toContainText("```");
-    await expect(tiptapInput).toHaveAttribute("data-value", seededDraft ?? "");
+    // The commit appends the guaranteed post-chip space.
+    await expect(tiptapInput).toHaveAttribute(
+      "data-value",
+      `${seededDraft ?? ""} `,
+    );
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/main/__tests__/recent-file-references-store.test.ts
+++ b/apps/desktop/src/main/__tests__/recent-file-references-store.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  listRecentFileReferencePaths,
+  recordRecentFileReferencePaths,
+} from "../state/recent-file-references-store";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-recent-file-refs-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"), {
+    profileName: "dev",
+  });
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("recent-file-references-store", () => {
+  it("returns an empty list before anything is recorded", () => {
+    expect(listRecentFileReferencePaths(stateDb)).toEqual([]);
+  });
+
+  it("prepends new records most-recent-first", () => {
+    recordRecentFileReferencePaths(stateDb, ["/a.md"]);
+    recordRecentFileReferencePaths(stateDb, ["/b.md", "/c.md"]);
+
+    expect(listRecentFileReferencePaths(stateDb)).toEqual([
+      "/b.md",
+      "/c.md",
+      "/a.md",
+    ]);
+  });
+
+  it("dedupes by path, bumping a re-recorded file to the front", () => {
+    recordRecentFileReferencePaths(stateDb, ["/a.md", "/b.md"]);
+    recordRecentFileReferencePaths(stateDb, ["/b.md"]);
+
+    expect(listRecentFileReferencePaths(stateDb)).toEqual(["/b.md", "/a.md"]);
+  });
+
+  it("caps the list at 20 entries", () => {
+    for (let index = 0; index < 25; index += 1) {
+      recordRecentFileReferencePaths(stateDb, [`/file-${index}.md`]);
+    }
+
+    const listed = listRecentFileReferencePaths(stateDb);
+    expect(listed).toHaveLength(20);
+    expect(listed[0]).toBe("/file-24.md");
+    expect(listed[19]).toBe("/file-5.md");
+  });
+
+  it("ignores empty batches and empty paths", () => {
+    recordRecentFileReferencePaths(stateDb, []);
+    recordRecentFileReferencePaths(stateDb, [""]);
+
+    expect(listRecentFileReferencePaths(stateDb)).toEqual([]);
+  });
+
+  it("self-heals from a corrupt persisted value", () => {
+    stateDb.setMeta("recentFileReferences", "{not json");
+
+    expect(listRecentFileReferencePaths(stateDb)).toEqual([]);
+    recordRecentFileReferencePaths(stateDb, ["/a.md"]);
+    expect(listRecentFileReferencePaths(stateDb)).toEqual(["/a.md"]);
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -47,6 +47,7 @@ import {
   type GhStatus,
   type LinkedDirectorySummary,
   type PickDirectoryFromDiskResponse,
+  type PickFileFromDiskResponse,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
   type RefreshDirectoryGitStatusesRequest,
@@ -162,6 +163,7 @@ import {
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
+  NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SET_BROWSE_MODE_CHANNEL,
@@ -3246,6 +3248,40 @@ class DesktopAppServerService {
     return { canceled: false, path: result.filePaths[0] };
   }
 
+  async pickFileFromDisk(
+    parentWindow?: BrowserWindow,
+  ): Promise<PickFileFromDiskResponse> {
+    const e2ePickPaths = process.env.PWRAGENT_REPLAY_FIXTURE_PATH
+      ? process.env.PWRAGENT_E2E_PICK_FILE_PATHS?.trim()
+      : undefined;
+    if (e2ePickPaths) {
+      return {
+        canceled: false,
+        paths: e2ePickPaths.split(":").filter(Boolean),
+      };
+    }
+
+    const window =
+      parentWindow ?? BrowserWindow.getFocusedWindow() ?? undefined;
+    const defaultPath = this.lastPickedDirectoryParent ?? os.homedir();
+    const options = {
+      title: "Add file",
+      buttonLabel: "Add file",
+      defaultPath,
+      properties: ["openFile", "multiSelections"] as Array<
+        "openFile" | "multiSelections"
+      >,
+    };
+    const result = window
+      ? await dialog.showOpenDialog(window, options)
+      : await dialog.showOpenDialog(options);
+    if (result.canceled || result.filePaths.length === 0) {
+      return { canceled: true };
+    }
+    this.lastPickedDirectoryParent = path.dirname(result.filePaths[0]);
+    return { canceled: false, paths: result.filePaths };
+  }
+
   async registerDirectoryFromDisk(
     request: RegisterDirectoryFromDiskRequest,
   ): Promise<RegisterDirectoryFromDiskResponse> {
@@ -4082,6 +4118,16 @@ export function registerAppServerIpcHandlers(): void {
       // the focused window inside `pickDirectoryFromDisk`.
       const senderWindow = BrowserWindow.fromWebContents(event.sender);
       return await appServerService.pickDirectoryFromDisk(
+        senderWindow ?? undefined,
+      );
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
+    async (event): Promise<PickFileFromDiskResponse> => {
+      const senderWindow = BrowserWindow.fromWebContents(event.sender);
+      return await appServerService.pickFileFromDisk(
         senderWindow ?? undefined,
       );
     },

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, dialog, ipcMain } from "electron";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -46,8 +47,11 @@ import {
   type GetGhStatusRequest,
   type GhStatus,
   type LinkedDirectorySummary,
+  type ListRecentFileReferencesResponse,
   type PickDirectoryFromDiskResponse,
   type PickFileFromDiskResponse,
+  type PickReferenceFromDiskResponse,
+  type RecordRecentFileReferencesRequest,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
   type RefreshDirectoryGitStatusesRequest,
@@ -126,6 +130,10 @@ import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-env
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { getAppStateDb } from "../state/app-state";
 import {
+  listRecentFileReferencePaths,
+  recordRecentFileReferencePaths,
+} from "../state/recent-file-references-store";
+import {
   APP_SERVER_LIST_SKILLS_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
   THREAD_SEARCH_CHANNEL,
@@ -162,8 +170,11 @@ import {
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+  NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
+  NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
+  NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SET_BROWSE_MODE_CHANNEL,
@@ -253,6 +264,30 @@ function rejectNonDirectoryPinKey(directoryKey: string): void {
       `Cannot pin synthetic directory entry: ${directoryKey} (only directory:* and workspace:* keys are pinnable)`,
     );
   }
+}
+
+/**
+ * Classify combined reference-picker paths as files or directories via
+ * `fs.stat`. Unreadable paths (and exotic kinds like sockets) are
+ * skipped — the renderer only knows how to route these two kinds.
+ */
+function classifyReferencePaths(
+  paths: string[],
+): { path: string; kind: "file" | "directory" }[] {
+  const entries: { path: string; kind: "file" | "directory" }[] = [];
+  for (const candidate of paths) {
+    try {
+      const stats = fs.statSync(candidate);
+      if (stats.isDirectory()) {
+        entries.push({ path: candidate, kind: "directory" });
+      } else if (stats.isFile()) {
+        entries.push({ path: candidate, kind: "file" });
+      }
+    } catch {
+      // Skip unreadable paths.
+    }
+  }
+  return entries;
 }
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -3282,6 +3317,62 @@ class DesktopAppServerService {
     return { canceled: false, paths: result.filePaths };
   }
 
+  /**
+   * Combined file-or-directory reference picker. Only macOS can combine
+   * `openFile` + `openDirectory` in one dialog (Electron limitation on
+   * Windows/Linux — which is why the composer's reference picker keeps
+   * separate "Add directory…" / "Add file…" actions off-macOS). Each
+   * pick is classified via `fs.stat`; unreadable paths are skipped.
+   */
+  async pickReferenceFromDisk(
+    parentWindow?: BrowserWindow,
+  ): Promise<PickReferenceFromDiskResponse> {
+    const e2ePickPaths = process.env.PWRAGENT_REPLAY_FIXTURE_PATH
+      ? process.env.PWRAGENT_E2E_PICK_REFERENCE_PATHS?.trim()
+      : undefined;
+    if (e2ePickPaths) {
+      return {
+        canceled: false,
+        entries: classifyReferencePaths(e2ePickPaths.split(":").filter(Boolean)),
+      };
+    }
+
+    const window =
+      parentWindow ?? BrowserWindow.getFocusedWindow() ?? undefined;
+    const defaultPath = this.lastPickedDirectoryParent ?? os.homedir();
+    const options = {
+      title: "Add reference",
+      buttonLabel: "Add reference",
+      defaultPath,
+      properties: (process.platform === "darwin"
+        ? ["openFile", "openDirectory", "multiSelections"]
+        : ["openFile", "multiSelections"]) as Array<
+        "openFile" | "openDirectory" | "multiSelections"
+      >,
+    };
+    const result = window
+      ? await dialog.showOpenDialog(window, options)
+      : await dialog.showOpenDialog(options);
+    if (result.canceled || result.filePaths.length === 0) {
+      return { canceled: true };
+    }
+    this.lastPickedDirectoryParent = path.dirname(result.filePaths[0]);
+    return { canceled: false, entries: classifyReferencePaths(result.filePaths) };
+  }
+
+  listRecentFileReferences(): ListRecentFileReferencesResponse {
+    return {
+      files: listRecentFileReferencePaths(getAppStateDb()).map((filePath) => ({
+        label: path.basename(filePath),
+        path: filePath,
+      })),
+    };
+  }
+
+  recordRecentFileReferences(request: RecordRecentFileReferencesRequest): void {
+    recordRecentFileReferencePaths(getAppStateDb(), request.paths ?? []);
+  }
+
   async registerDirectoryFromDisk(
     request: RegisterDirectoryFromDiskRequest,
   ): Promise<RegisterDirectoryFromDiskResponse> {
@@ -4130,6 +4221,33 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.pickFileFromDisk(
         senderWindow ?? undefined,
       );
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
+    async (event): Promise<PickReferenceFromDiskResponse> => {
+      const senderWindow = BrowserWindow.fromWebContents(event.sender);
+      return await appServerService.pickReferenceFromDisk(
+        senderWindow ?? undefined,
+      );
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
+    async (): Promise<ListRecentFileReferencesResponse> => {
+      return appServerService.listRecentFileReferences();
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
+    async (
+      _event,
+      request: RecordRecentFileReferencesRequest,
+    ): Promise<void> => {
+      appServerService.recordRecentFileReferences(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);

--- a/apps/desktop/src/main/state/composer-draft-recovery-store.ts
+++ b/apps/desktop/src/main/state/composer-draft-recovery-store.ts
@@ -290,6 +290,9 @@ function normalizeDraftRecord(
     imageAttachments: Array.isArray(draft.imageAttachments)
       ? draft.imageAttachments
       : [],
+    fileAttachments: Array.isArray(draft.fileAttachments)
+      ? draft.fileAttachments
+      : undefined,
     skillTokens: Array.isArray(draft.skillTokens) ? draft.skillTokens : [],
   };
 }

--- a/apps/desktop/src/main/state/recent-file-references-store.ts
+++ b/apps/desktop/src/main/state/recent-file-references-store.ts
@@ -1,0 +1,54 @@
+import type { StateDb } from "./state-db.js";
+
+/**
+ * Tiny persisted list of recently referenced file paths, backing the
+ * composer reference picker's Files tab. Lives as a JSON array under a
+ * single `meta` key — the meta table is a generic key/value store, so no
+ * schema migration is needed. Most-recent-first, deduped by path, capped.
+ */
+const RECENT_FILE_REFERENCES_META_KEY = "recentFileReferences";
+const RECENT_FILE_REFERENCES_CAP = 20;
+
+export function listRecentFileReferencePaths(stateDb: StateDb): string[] {
+  const raw = stateDb.getMeta(RECENT_FILE_REFERENCES_META_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(
+      (entry): entry is string => typeof entry === "string" && entry.length > 0,
+    );
+  } catch {
+    // A corrupt value self-heals on the next record.
+    return [];
+  }
+}
+
+export function recordRecentFileReferencePaths(
+  stateDb: StateDb,
+  paths: string[],
+): void {
+  const incoming = paths.filter(
+    (entry) => typeof entry === "string" && entry.length > 0,
+  );
+  if (incoming.length === 0) {
+    return;
+  }
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of [...incoming, ...listRecentFileReferencePaths(stateDb)]) {
+    if (seen.has(entry)) {
+      continue;
+    }
+    seen.add(entry);
+    merged.push(entry);
+    if (merged.length >= RECENT_FILE_REFERENCES_CAP) {
+      break;
+    }
+  }
+  stateDb.setMeta(RECENT_FILE_REFERENCES_META_KEY, JSON.stringify(merged));
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -123,6 +123,9 @@ import type {
   PickDirectoryFromDiskResponse,
   PickFileFromDiskResponse,
   PickGhCommandResponse,
+  PickReferenceFromDiskResponse,
+  ListRecentFileReferencesResponse,
+  RecordRecentFileReferencesRequest,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
@@ -379,8 +382,11 @@ import {
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
   NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
+  NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
+  NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
+  NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
@@ -1246,6 +1252,17 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL),
   pickFileFromDisk: async (): Promise<PickFileFromDiskResponse> =>
     await ipcRenderer.invoke(NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL),
+  pickReferenceFromDisk: async (): Promise<PickReferenceFromDiskResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL),
+  listRecentFileReferences: async (): Promise<ListRecentFileReferencesResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL),
+  recordRecentFileReferences: async (
+    request: RecordRecentFileReferencesRequest,
+  ): Promise<void> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
+      request,
+    ),
   /**
    * Resolve the on-disk path of a dropped/pasted File object. Electron
    * removed the legacy `File.path` augmentation; `webUtils.getPathForFile`

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { clipboard, contextBridge, ipcRenderer } from "electron";
+import { clipboard, contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
   AgentEvent,
   AutomationIdRequest,
@@ -121,6 +121,7 @@ import type {
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
+  PickFileFromDiskResponse,
   PickGhCommandResponse,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
@@ -379,6 +380,7 @@ import {
   NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
+  NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
@@ -1242,6 +1244,21 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(COMPOSER_DRAFT_LIST_LATEST_CHANNEL),
   pickDirectoryFromDisk: async (): Promise<PickDirectoryFromDiskResponse> =>
     await ipcRenderer.invoke(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL),
+  pickFileFromDisk: async (): Promise<PickFileFromDiskResponse> =>
+    await ipcRenderer.invoke(NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL),
+  /**
+   * Resolve the on-disk path of a dropped/pasted File object. Electron
+   * removed the legacy `File.path` augmentation; `webUtils.getPathForFile`
+   * is its sandbox-safe replacement. Returns "" for synthetic Files that
+   * have no backing path.
+   */
+  getPathForFile: (file: File): string => {
+    try {
+      return webUtils.getPathForFile(file);
+    } catch {
+      return "";
+    }
+  },
   registerDirectoryFromDisk: async (
     request: RegisterDirectoryFromDiskRequest,
   ): Promise<RegisterDirectoryFromDiskResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1007,6 +1007,7 @@ function DesktopAppShell(props: {
     onPickAndAttachDirectoryToThread: () => {
       void navigation.pickAndAttachDirectoryToSelectedThread();
     },
+    onPickDirectoryForReference: () => navigation.pickDirectoryForReference(),
     onAttachDirectoryReferences: (
       paths: string[],
       target: { backend: AppServerBackendKind; threadId: string }

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1006,6 +1006,9 @@ function DesktopAppShell(props: {
     onPickAndAttachDirectoryToThread: () => {
       void navigation.pickAndAttachDirectoryToSelectedThread();
     },
+    onAttachDirectoryReferences: (paths: string[]) => {
+      void navigation.attachDirectoryPathsToSelectedThread(paths);
+    },
     onClearPickDirectoryError: navigation.clearPickDirectoryError,
     setExecutionModeError: navigation.setThreadExecutionModeError,
     setThreadModelSettingsError: navigation.setThreadModelSettingsError,
@@ -1068,7 +1071,24 @@ function DesktopAppShell(props: {
     onLoadOlder: session.loadOlder,
     onLiveTranscriptEntry: session.upsertLiveTranscriptEntry,
     onCancelLaunchpad: navigation.discardLaunchpad,
-    onMaterializeLaunchpad: navigation.materializeDirectoryLaunchpad,
+    // The composer's 5th argument is `extraDirectoryPaths` (draft
+    // `@`-references); the hook's 5th is `parentThreadId` (resolved from
+    // the launchpad draft internally), so map positions explicitly.
+    onMaterializeLaunchpad: (
+      directoryKey,
+      input,
+      collaborationMode,
+      reviewTarget,
+      extraDirectoryPaths
+    ) =>
+      navigation.materializeDirectoryLaunchpad(
+        directoryKey,
+        input,
+        collaborationMode,
+        reviewTarget,
+        undefined,
+        extraDirectoryPaths
+      ),
     onPendingStatusChange: session.setPendingStatusText,
     onRefreshNavigation: navigation.refresh,
     onSetExecutionMode: navigation.selectedThread

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import {
   buildThreadIdentityKey,
   parseThreadIdentityKey,
+  type AppServerBackendKind,
   type DesktopBootInfo,
   type DesktopCodexProfileModel,
   type DesktopPwrAgentProfileSummary,
@@ -1006,8 +1007,11 @@ function DesktopAppShell(props: {
     onPickAndAttachDirectoryToThread: () => {
       void navigation.pickAndAttachDirectoryToSelectedThread();
     },
-    onAttachDirectoryReferences: (paths: string[]) => {
-      void navigation.attachDirectoryPathsToSelectedThread(paths);
+    onAttachDirectoryReferences: (
+      paths: string[],
+      target: { backend: AppServerBackendKind; threadId: string }
+    ) => {
+      void navigation.attachDirectoryPathsToThread(target, paths);
     },
     onClearPickDirectoryError: navigation.clearPickDirectoryError,
     setExecutionModeError: navigation.setThreadExecutionModeError,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5153,9 +5153,44 @@ export function Composer(props: ComposerProps) {
     const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
     const nextDraft = `${before}${command.insertText}${needsTrailingSpace ? " " : ""}${after}`;
     const nextSelection = before.length + command.insertText.length + (needsTrailingSpace ? 1 : 0);
+    const nextSkillTokens = adjustSkillTokenIndexesForTextChange({
+      currentDraft: draft,
+      nextDraft,
+      skillTokens,
+    });
 
-    updateVisibleDraft(nextDraft);
-    setActiveSlashIndex(0);
+    // Same protected-update dance as applySkill / applyDirectoryReference:
+    // the editability sync in ComposerTiptapInput re-emits the editor's
+    // (still pre-insert) content through onChange before the external-value
+    // sync applies the new draft. The pending-programmatic guard in
+    // handleComposerChange swallows that stale replay so the two sides
+    // can't ping-pong.
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    // The caret lives in a ref, so the commit below re-renders with the
+    // PRE-insert caret still inside the inserted "/command" text — that
+    // prefix is itself a valid slash trigger, which would keep the popover
+    // open until the next interaction. Dismiss that phantom trigger's key;
+    // the dismissal self-clears as soon as the trigger key changes.
+    const lingeringTrigger = findSlashCommandTrigger(
+      nextDraft,
+      Math.min(selectionStart, nextDraft.length),
+    );
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveSlashIndex(0);
+      setDismissedAutocompleteKey(
+        lingeringTrigger
+          ? `slash:${lingeringTrigger.start}:${lingeringTrigger.end}:/${lingeringTrigger.query}`
+          : undefined,
+      );
+    });
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(nextSelection, nextSelection);

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -198,12 +198,20 @@ type ComposerProps = {
   onPickAndRegisterDirectory?: () => void;
   onPickAndAttachDirectoryToThread?: () => void;
   /**
-   * Link draft-referenced directories to the existing thread after a turn
-   * is sent (the launchpad path rides on `onMaterializeLaunchpad`'s
-   * `extraDirectoryPaths` instead). Fire-and-forget; failures must not
-   * block the turn.
+   * Link draft-referenced directories to the thread the turn was sent to
+   * (the launchpad path rides on `onMaterializeLaunchpad`'s
+   * `extraDirectoryPaths` instead). The composer names the target thread
+   * explicitly so a selection change while the send was in flight — or a
+   * queued turn firing later — cannot attach to the wrong thread.
+   * Fire-and-forget; failures must not block the turn.
    */
-  onAttachDirectoryReferences?: (paths: string[]) => void;
+  onAttachDirectoryReferences?: (
+    paths: string[],
+    target: {
+      backend: NavigationThreadSummary["source"];
+      threadId: string;
+    },
+  ) => void;
   onClearPickDirectoryError?: () => void;
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
@@ -4492,7 +4500,10 @@ export function Composer(props: ComposerProps) {
         .map((directory) => directory.path)
         .filter((path): path is string => Boolean(path));
       if (sentReferencedDirectoryPaths.length > 0) {
-        props.onAttachDirectoryReferences?.(sentReferencedDirectoryPaths);
+        props.onAttachDirectoryReferences?.(sentReferencedDirectoryPaths, {
+          backend: props.thread.source,
+          threadId: props.thread.id,
+        });
       }
       if (queued) {
         if (!options?.queueClaimed) {
@@ -6259,6 +6270,7 @@ export function Composer(props: ComposerProps) {
   const handleComposerClick = (): void => {
     setActiveSkillIndex(0);
     setActiveSlashIndex(0);
+    setActiveDirectoryRefIndex(0);
   };
   const handlePlainComposerKeyDown = (
     event: ReactKeyboardEvent<HTMLElement>,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -64,6 +64,7 @@ import {
   buildDirectoryReferenceInsertText,
   buildDirectoryReferenceMarkdown,
   buildDirectoryReferenceTooltip,
+  decodeMarkdownDestination,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -1330,6 +1331,7 @@ function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): str
     skillTokens.map((token) => ({
       id: token.id,
       index: token.index,
+      kind: token.kind,
       name: token.name,
       path: token.path,
     })),
@@ -1395,13 +1397,14 @@ function hydrateComposerDraft(
     }
 
     if (part.type === "directory") {
-      // Serialized paths are tilde form; the token carries the absolute
-      // path so send-time attach can use it directly.
+      // Serialized paths are percent-encoded tilde form; the token
+      // carries the decoded absolute path so send-time attach can use
+      // it directly.
       skillTokens.push(
         createComposerDirectoryToken(
           {
             label: part.name,
-            path: expandTildePath(part.path),
+            path: expandTildePath(decodeMarkdownDestination(part.path)),
           },
           draft.length,
         ),

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -62,6 +62,7 @@ import {
 import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
 import {
   buildDirectoryReferenceInsertText,
+  buildDirectoryReferenceTooltip,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -1309,6 +1310,19 @@ function createComposerSkillToken(
   };
 }
 
+function createComposerDirectoryToken(
+  directory: Pick<NavigationDirectorySummary, "label" | "path">,
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "directory",
+    name: directory.label,
+    path: directory.path,
+    id: `${directory.path ?? directory.label}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
 function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
   return JSON.stringify(
     skillTokens.map((token) => ({
@@ -1344,7 +1358,13 @@ function serializeDraftWithSkillTokens(
   for (const token of sortedTokens) {
     const index = clampSkillTokenIndex(token.index, draft);
     output += draft.slice(cursor, index);
-    output += buildSkillMentionMarkdown(token);
+    // Directory-reference chips serialize to the tilde path — plain,
+    // agent-readable text; the send-time scan re-derives the reference
+    // from it if the chip itself is ever lost (e.g. a prompt-only
+    // restore). Skills keep their `[$name](path)` markdown.
+    output += token.kind === "directory"
+      ? buildDirectoryReferenceInsertText(token)
+      : buildSkillMentionMarkdown(token);
     cursor = index;
   }
 
@@ -5223,23 +5243,30 @@ export function Composer(props: ComposerProps) {
       inputRef.current.selectionEnd ?? selectionStart,
       draft.length,
     );
-    const refTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
-    const insertText = buildDirectoryReferenceInsertText(directory);
-    if (!refTrigger || !insertText) {
+    const refTrigger =
+      findDirectoryReferenceTrigger(draft, selectionStart)
+      ?? findDirectoryReferenceTrigger(draft, draft.length);
+    if (!refTrigger || !directory.path) {
       return;
     }
 
+    // Mint a durable mention token (the `@label` chip) instead of
+    // splicing path text — mirrors applySkill. The chip is zero-width in
+    // the plain draft; serializeDraftWithSkillTokens splices the tilde
+    // path back in for the outgoing text and launchpad prompt.
     const before = draft.slice(0, refTrigger.start);
     const after = draft.slice(Math.max(refTrigger.end, selectionEnd));
-    const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
-    const nextDraft = `${before}${insertText}${needsTrailingSpace ? " " : ""}${after}`;
-    const nextSelection =
-      before.length + insertText.length + (needsTrailingSpace ? 1 : 0);
-    const nextSkillTokens = adjustSkillTokenIndexesForTextChange({
-      currentDraft: draft,
-      nextDraft,
-      skillTokens,
-    });
+    const nextAfter = after.length > 0 && !/^\s/.test(after) ? ` ${after}` : after;
+    const nextDraft = `${before}${nextAfter}`;
+    const tokenIndex = before.length;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      createComposerDirectoryToken(directory, tokenIndex),
+    ];
 
     // Same protected-update dance as applySkill: the editability sync in
     // ComposerTiptapInput re-emits the editor's (still pre-insert) content
@@ -5258,10 +5285,7 @@ export function Composer(props: ComposerProps) {
       setDraft(nextDraft);
       setActiveDirectoryRefIndex(0);
     });
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
-    });
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
 
   const removeImageAttachment = (id: string): void => {
@@ -7395,7 +7419,7 @@ export function Composer(props: ComposerProps) {
             <span
               key={directory.key}
               className="composer__directory-reference tooltip-target"
-              data-tooltip={`${buildDirectoryReferenceInsertText(directory)} — linked to the thread when you send`}
+              data-tooltip={buildDirectoryReferenceTooltip(directory.path ?? "")}
             >
               <FolderIcon size={13} aria-hidden="true" />
               <span className="composer__directory-reference-label">

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -62,11 +62,13 @@ import {
 import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
 import {
   buildDirectoryReferenceInsertText,
+  buildDirectoryReferenceMarkdown,
   buildDirectoryReferenceTooltip,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
 } from "../../lib/directory-references";
+import { expandTildePath } from "../../lib/tildify-path";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import {
@@ -1358,12 +1360,16 @@ function serializeDraftWithSkillTokens(
   for (const token of sortedTokens) {
     const index = clampSkillTokenIndex(token.index, draft);
     output += draft.slice(cursor, index);
-    // Directory-reference chips serialize to the tilde path — plain,
-    // agent-readable text; the send-time scan re-derives the reference
-    // from it if the chip itself is ever lost (e.g. a prompt-only
-    // restore). Skills keep their `[$name](path)` markdown.
+    // Directory-reference chips serialize to `[@label](~/path)` markdown
+    // — the parens bound the path so adjacent text can't glue onto it,
+    // the transcript renders it back as a chip, and hydrateComposerDraft
+    // rebuilds the token from a prompt-only restore. Skills keep their
+    // `[$name](path)` markdown.
     output += token.kind === "directory"
-      ? buildDirectoryReferenceInsertText(token)
+      ? buildDirectoryReferenceMarkdown({
+          label: token.name,
+          path: token.path ?? "",
+        })
       : buildSkillMentionMarkdown(token);
     cursor = index;
   }
@@ -1385,6 +1391,21 @@ function hydrateComposerDraft(
   for (const part of parseSkillMentionParts(canonicalDraft)) {
     if (part.type === "text") {
       draft += part.text;
+      continue;
+    }
+
+    if (part.type === "directory") {
+      // Serialized paths are tilde form; the token carries the absolute
+      // path so send-time attach can use it directly.
+      skillTokens.push(
+        createComposerDirectoryToken(
+          {
+            label: part.name,
+            path: expandTildePath(part.path),
+          },
+          draft.length,
+        ),
+      );
       continue;
     }
 
@@ -3403,14 +3424,15 @@ export function Composer(props: ComposerProps) {
     autocompleteListboxId && autocompleteKind
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
-  // Directories the given text references by path (`@`-inserted, typed by
-  // hand, or pasted). The draft text is the source of truth — deleting a
-  // path from the draft drops the reference. Directories that are already
-  // linked (the launchpad's own directory; a thread's linked directories,
-  // including worktree checkouts) are excluded so send-time attach only
-  // sees new references.
+  // Directories the draft references: `@` chips (authoritative, from the
+  // token state) unioned with paths typed or pasted as plain text (from
+  // the serialized-draft scan). Deleting a chip or a typed path drops the
+  // reference. Directories that are already linked (the launchpad's own
+  // directory; a thread's linked directories, including worktree
+  // checkouts) are excluded so send-time attach only sees new references.
   const listDraftReferencedDirectories = (
     text: string,
+    tokens?: ComposerSkillToken[],
   ): NavigationDirectorySummary[] => {
     const excludePaths = [
       props.directory?.path,
@@ -3420,11 +3442,45 @@ export function Composer(props: ComposerProps) {
         linked.worktreePath,
       ]),
     ].filter((path): path is string => Boolean(path));
-    return listReferencedDirectories(text, props.directories ?? [], {
+    const excluded = new Set(excludePaths.map((path) => path.replace(/[/\\]+$/, "")));
+    const scanned = listReferencedDirectories(text, props.directories ?? [], {
       excludePaths,
     });
+    const seenPaths = new Set(
+      scanned
+        .map((directory) => directory.path?.replace(/[/\\]+$/, ""))
+        .filter((path): path is string => Boolean(path)),
+    );
+    const fromTokens: NavigationDirectorySummary[] = [];
+    for (const token of tokens ?? []) {
+      if (token.kind !== "directory" || !token.path) {
+        continue;
+      }
+      const path = token.path.replace(/[/\\]+$/, "");
+      if (!path || seenPaths.has(path) || excluded.has(path)) {
+        continue;
+      }
+      seenPaths.add(path);
+      const tracked = (props.directories ?? []).find(
+        (directory) => directory.path?.replace(/[/\\]+$/, "") === path,
+      );
+      fromTokens.push(
+        tracked ?? {
+          key: `directory-reference:${path}`,
+          kind: "directory",
+          label: token.name,
+          path: token.path,
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      );
+    }
+    return [...scanned, ...fromTokens];
   };
-  const referencedDirectories = listDraftReferencedDirectories(canonicalDraft);
+  const referencedDirectories = listDraftReferencedDirectories(
+    canonicalDraft,
+    skillTokens,
+  );
   const reviewDirectory = useMemo(
     () =>
       findReviewDirectoryForWorkspace({
@@ -4104,7 +4160,7 @@ export function Composer(props: ComposerProps) {
           undefined,
           undefined,
           reviewCommand.target,
-          listDraftReferencedDirectories(canonicalDraft)
+          listDraftReferencedDirectories(canonicalDraft, skillTokens)
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );
@@ -4514,8 +4570,12 @@ export function Composer(props: ComposerProps) {
         updateActiveTurnId(response.turnId);
         props.onActiveTurnIdChange?.(response.turnId);
       }
+      // Queued turns only carry their serialized text, but that text is
+      // self-describing (`[@label](~/path)` markdown), so the scan alone
+      // recovers chip references there.
       const sentReferencedDirectoryPaths = listDraftReferencedDirectories(
         queued ? queued.text : canonicalDraft,
+        queued ? undefined : skillTokens,
       )
         .map((directory) => directory.path)
         .filter((path): path is string => Boolean(path));
@@ -5032,7 +5092,7 @@ export function Composer(props: ComposerProps) {
           payload.input,
           collaborationMode,
           undefined,
-          listDraftReferencedDirectories(canonicalDraft)
+          listDraftReferencedDirectories(canonicalDraft, skillTokens)
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5184,9 +5184,13 @@ export function Composer(props: ComposerProps) {
 
     const before = draft.slice(0, trigger.start);
     const after = draft.slice(Math.max(trigger.end, selectionEnd));
-    const nextAfter = after.length > 0 && !/^\s/.test(after) ? ` ${after}` : after;
+    // Always leave one space after the chip — including at the end of the
+    // draft — and park the caret after it, so typing straight on never
+    // glues onto the chip's serialized form.
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
     const nextDraft = `${before}${nextAfter}`;
     const tokenIndex = before.length;
+    const nextSelection = tokenIndex + 1;
     const nextSkillTokens = [
       ...adjustSkillTokenIndexesForTextChange({
         currentDraft: draft,
@@ -5208,7 +5212,10 @@ export function Composer(props: ComposerProps) {
       setDraft(nextDraft);
       setActiveSkillIndex(0);
     });
-    requestAnimationFrame(() => inputRef.current?.focus());
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
   };
 
   const applySlashCommand = (command: SlashCommandSuggestion): void => {
@@ -5312,13 +5319,16 @@ export function Composer(props: ComposerProps) {
 
     // Mint a durable mention token (the `@label` chip) instead of
     // splicing path text — mirrors applySkill. The chip is zero-width in
-    // the plain draft; serializeDraftWithSkillTokens splices the tilde
-    // path back in for the outgoing text and launchpad prompt.
+    // the plain draft; serializeDraftWithSkillTokens splices the markdown
+    // link back in for the outgoing text and launchpad prompt. Like
+    // applySkill, always leave one space after the chip and park the
+    // caret after it.
     const before = draft.slice(0, refTrigger.start);
     const after = draft.slice(Math.max(refTrigger.end, selectionEnd));
-    const nextAfter = after.length > 0 && !/^\s/.test(after) ? ` ${after}` : after;
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
     const nextDraft = `${before}${nextAfter}`;
     const tokenIndex = before.length;
+    const nextSelection = tokenIndex + 1;
     const nextSkillTokens = [
       ...adjustSkillTokenIndexesForTextChange({
         currentDraft: draft,
@@ -5345,7 +5355,10 @@ export function Composer(props: ComposerProps) {
       setDraft(nextDraft);
       setActiveDirectoryRefIndex(0);
     });
-    requestAnimationFrame(() => inputRef.current?.focus());
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
   };
 
   const removeImageAttachment = (id: string): void => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -91,6 +91,7 @@ import {
 } from "./ComposerInputTypes";
 import { ComposerTiptapInput } from "./ComposerTiptapInput";
 import { ProjectPicker } from "./ProjectPicker";
+import { ReferencePicker, type ReferencePickerFile } from "./ReferencePicker";
 import { TranscriptCopyButton } from "../thread-detail/TranscriptCopyButton";
 import {
   EnvActionRunEntry,
@@ -2577,10 +2578,11 @@ export function Composer(props: ComposerProps) {
     () => setScheduleMenuOpen(false),
   );
   const [addReferenceMenuOpen, setAddReferenceMenuOpen] = useState(false);
-  const addReferenceMenuRef = useDismissableMenu<HTMLSpanElement>(
-    addReferenceMenuOpen,
-    () => setAddReferenceMenuOpen(false),
-  );
+  // Recently referenced files for the reference picker's Files tab —
+  // loaded lazily from the main process each time the picker opens.
+  const [recentFileReferences, setRecentFileReferences] = useState<
+    ReferencePickerFile[]
+  >([]);
   const [scheduleTick, setScheduleTick] = useState(() => Date.now());
   const [scheduledDraftSendAt, setScheduledDraftSendAt] = useState<
     number | undefined
@@ -5622,6 +5624,11 @@ export function Composer(props: ComposerProps) {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(nextSelection, nextSelection);
     });
+
+    // Feed the reference picker's Files tab — fire-and-forget.
+    void props.desktopApi
+      ?.recordRecentFileReferences?.({ paths })
+      ?.catch(() => undefined);
   };
 
   /** "@ → Add file…" action: OS file picker → file-reference chips. */
@@ -5631,6 +5638,133 @@ export function Composer(props: ComposerProps) {
       return;
     }
     applyFileReferences(result.paths);
+  };
+
+  /**
+   * Mint directory-reference chips for a batch of picked directories —
+   * the multi-token sibling of `applyDirectoryReference`, sharing
+   * `applyFileReferences`' token layout (n-1 separator spaces plus the
+   * guaranteed post-chip space). Needed because the single-directory
+   * helper can't be called twice in one tick: each call captures the
+   * pre-insert draft, so the second insert would clobber the first.
+   */
+  const applyDirectoryReferenceChips = (
+    directories: { label: string; path: string }[],
+  ): void => {
+    if (!inputRef.current || directories.length === 0) {
+      return;
+    }
+
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
+    const refTrigger =
+      findDirectoryReferenceTrigger(draft, selectionStart)
+      ?? findDirectoryReferenceTrigger(draft, draft.length)
+      ?? { start: selectionStart, end: selectionEnd };
+
+    const before = draft.slice(0, refTrigger.start);
+    const after = draft.slice(Math.max(refTrigger.end, selectionEnd));
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
+    const nextDraft = `${before}${" ".repeat(directories.length - 1)}${nextAfter}`;
+    const nextSelection = before.length + directories.length;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      ...directories.map((directory, index) =>
+        createComposerDirectoryToken(directory, before.length + index),
+      ),
+    ];
+
+    // Same protected-update dance as applySkill / applyDirectoryReference:
+    // the editability sync in ComposerTiptapInput re-emits the editor's
+    // (still pre-insert) content through onChange before the
+    // external-value sync applies the new draft. The pending-programmatic
+    // guard in handleComposerChange swallows that stale replay so the two
+    // sides can't ping-pong.
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveDirectoryRefIndex(0);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
+  /**
+   * Combined "+ Add file or directory…" picker (macOS only): one OS
+   * dialog returns a mix of files and directories. Files land in the
+   * attachment tray (the "+ flow attaches" rule); directories are
+   * registered as tracked directories (non-fatal — the send-time attach
+   * re-registers anyway) and minted as reference chips. The tray attach
+   * runs first because it snapshots the current draft, which the chip
+   * mint is about to rewrite.
+   */
+  const applyPickedReferencesFromDisk = async (): Promise<void> => {
+    const result = await props.desktopApi?.pickReferenceFromDisk?.();
+    if (!result || result.canceled || result.entries.length === 0) {
+      return;
+    }
+    const filePaths = result.entries
+      .filter((entry) => entry.kind === "file")
+      .map((entry) => entry.path);
+    const directoryPaths = result.entries
+      .filter((entry) => entry.kind === "directory")
+      .map((entry) => entry.path);
+    if (filePaths.length > 0) {
+      attachFilePaths(filePaths);
+    }
+    for (const directoryPath of directoryPaths) {
+      void props.desktopApi
+        ?.registerDirectoryFromDisk?.({ path: directoryPath })
+        ?.then((response) => {
+          if (response && !response.ok) {
+            console.warn(
+              `Could not register picked directory ${directoryPath}: ${response.message}`,
+            );
+          }
+        })
+        .catch(() => undefined);
+    }
+    if (directoryPaths.length > 0) {
+      applyDirectoryReferenceChips(
+        directoryPaths.map((directoryPath) => ({
+          label: fileLabelFromPath(directoryPath),
+          path: directoryPath,
+        })),
+      );
+    }
+  };
+
+  /**
+   * Load the reference picker's Files tab from the main process. Called
+   * on every picker open; failures keep the previous list — recents are
+   * a convenience surface, not load-bearing.
+   */
+  const refreshRecentFileReferences = async (): Promise<void> => {
+    try {
+      const response = await props.desktopApi?.listRecentFileReferences?.();
+      setRecentFileReferences(response?.files ?? []);
+    } catch {
+      // Keep whatever list we had.
+    }
   };
 
   const removeImageAttachment = (id: string): void => {
@@ -5769,6 +5903,13 @@ export function Composer(props: ComposerProps) {
       skillTokens,
     });
     persistLaunchpadImageAttachments(imageAttachments, nextAttachments);
+
+    // Feed the reference picker's Files tab — fire-and-forget.
+    void props.desktopApi
+      ?.recordRecentFileReferences?.({
+        paths: accepted.map((attachment) => attachment.path),
+      })
+      ?.catch(() => undefined);
   };
 
   /**
@@ -8211,56 +8352,72 @@ export function Composer(props: ComposerProps) {
 
           {props.onPickDirectoryForReference ||
           props.desktopApi?.pickFileFromDisk ? (
-            <span className="composer__add-reference" ref={addReferenceMenuRef}>
+            <ReferencePicker
+              open={addReferenceMenuOpen}
+              onClose={() => setAddReferenceMenuOpen(false)}
+              directories={props.directories ?? []}
+              recentFiles={recentFileReferences}
+              platform={props.desktopApi?.platform}
+              onSelectDirectory={(directory) => {
+                setAddReferenceMenuOpen(false);
+                applyDirectoryReference(directory);
+              }}
+              onSelectFile={(path) => {
+                setAddReferenceMenuOpen(false);
+                attachFilePaths([path]);
+              }}
+              onPickFromDisk={
+                props.desktopApi?.pickReferenceFromDisk
+                  ? () => {
+                      // Close before the OS dialog opens so the sheet
+                      // doesn't float over a stale popover.
+                      setAddReferenceMenuOpen(false);
+                      void applyPickedReferencesFromDisk();
+                    }
+                  : undefined
+              }
+              onPickDirectoryFromDisk={
+                props.onPickDirectoryForReference
+                  ? () => {
+                      setAddReferenceMenuOpen(false);
+                      void applyPickedDirectoryReference();
+                    }
+                  : undefined
+              }
+              onPickFileFromDisk={
+                props.desktopApi?.pickFileFromDisk
+                  ? () => {
+                      setAddReferenceMenuOpen(false);
+                      void attachPickedFilesToTray();
+                    }
+                  : undefined
+              }
+            >
               <button
                 type="button"
                 className="composer__toggle tooltip-target"
                 aria-label="Add reference"
-                aria-haspopup="menu"
+                aria-haspopup="dialog"
                 aria-expanded={addReferenceMenuOpen}
-                data-tooltip="Reference a directory or file"
+                // Omit the CSS tooltip while the popover is open — the
+                // pseudo-element otherwise lingers over the panel.
+                data-tooltip={
+                  addReferenceMenuOpen
+                    ? undefined
+                    : "Reference a directory or file"
+                }
                 disabled={launchpadSubmitting}
-                onClick={() => setAddReferenceMenuOpen((current) => !current)}
+                onClick={() => {
+                  const next = !addReferenceMenuOpen;
+                  setAddReferenceMenuOpen(next);
+                  if (next) {
+                    void refreshRecentFileReferences();
+                  }
+                }}
               >
                 <PlusIcon size={15} aria-hidden="true" />
               </button>
-              {addReferenceMenuOpen ? (
-                <div className="composer-dropdown__menu" role="menu">
-                  {props.onPickDirectoryForReference ? (
-                    <button
-                      className="composer-dropdown__option"
-                      role="menuitem"
-                      type="button"
-                      onClick={() => {
-                        setAddReferenceMenuOpen(false);
-                        void applyPickedDirectoryReference();
-                      }}
-                    >
-                      <FolderIcon size={14} aria-hidden="true" />
-                      <span className="composer-dropdown__option-label">
-                        Add directory…
-                      </span>
-                    </button>
-                  ) : null}
-                  {props.desktopApi?.pickFileFromDisk ? (
-                    <button
-                      className="composer-dropdown__option"
-                      role="menuitem"
-                      type="button"
-                      onClick={() => {
-                        setAddReferenceMenuOpen(false);
-                        void attachPickedFilesToTray();
-                      }}
-                    >
-                      <FileCodeIcon size={14} aria-hidden="true" />
-                      <span className="composer-dropdown__option-label">
-                        Add file…
-                      </span>
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-            </span>
+            </ReferencePicker>
           ) : null}
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -31,6 +31,7 @@ import type {
   NavigationDirectorySummary,
   NavigationGitCommitSummary,
   NavigationLaunchpadDraft,
+  NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
   ThreadWorkspaceHandoffStrategy,
@@ -47,6 +48,7 @@ import {
   LightningIcon,
   PlanIcon,
   PlayIcon,
+  PlusIcon,
   SearchIcon,
 } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
@@ -64,7 +66,9 @@ import {
   buildDirectoryReferenceInsertText,
   buildDirectoryReferenceMarkdown,
   buildDirectoryReferenceTooltip,
+  buildFileReferenceTooltip,
   decodeMarkdownDestination,
+  fileLabelFromPath,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -187,6 +191,7 @@ type ComposerProps = {
         | "directoryLabel"
         | "directoryPath"
         | "imageAttachments"
+        | "fileAttachments"
       >
     >,
     options?: { stickySettingsChanged?: boolean }
@@ -216,6 +221,16 @@ type ComposerProps = {
       threadId: string;
     },
   ) => void;
+  /**
+   * "@ → Add directory…" / "+"-menu picker: opens the OS directory dialog,
+   * registers the pick as a tracked directory WITHOUT navigating, and
+   * resolves with its label/path so the composer can mint a reference chip
+   * in place. Resolves undefined on cancel or failure (failures surface
+   * via `pickDirectoryError`).
+   */
+  onPickDirectoryForReference?: () => Promise<
+    { label: string; path: string } | undefined
+  >;
   onClearPickDirectoryError?: () => void;
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
@@ -254,12 +269,21 @@ type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy;
 
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
+type ComposerFileAttachment = NavigationLaunchpadFileAttachment;
+
 /**
  * Maximum number of image attachments allowed on a single message. No
  * provider currently advertises its own per-message image limit, so this is
  * the default cap; if a backend ever reports one, prefer the smaller value.
  */
 const MAX_COMPOSER_IMAGE_ATTACHMENTS = 5;
+
+/**
+ * Maximum number of path-only file references on a single message. Higher
+ * than the image cap because references are a few bytes of text each — the
+ * limit only guards against an accidental mass drop.
+ */
+const MAX_COMPOSER_FILE_ATTACHMENTS = 20;
 
 type ComposerDropdownOption = {
   disabled?: boolean;
@@ -292,6 +316,7 @@ type QueuedTurnDraft = {
   id: string;
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
+  fileAttachments: ComposerFileAttachment[];
   scheduledSendAt?: number;
   reviewCommand?: {
     cwd?: string;
@@ -1000,6 +1025,12 @@ function formatDraftPreview(draft: QueuedTurnDraft): string {
     return text;
   }
 
+  if (draft.imageAttachments.length === 0 && draft.fileAttachments.length > 0) {
+    return `${draft.fileAttachments.length} file${
+      draft.fileAttachments.length === 1 ? "" : "s"
+    }`;
+  }
+
   return `${draft.imageAttachments.length} image${
     draft.imageAttachments.length === 1 ? "" : "s"
   }`;
@@ -1326,6 +1357,44 @@ function createComposerDirectoryToken(
   };
 }
 
+// Exported for the `@`-popover / picker surfaces that mint file-reference
+// chips; the drop/paste tray uses the pill list instead of chips.
+export function createComposerFileToken(
+  file: { label: string; path: string },
+  index: number,
+): ComposerSkillToken {
+  return {
+    kind: "file",
+    name: file.label,
+    path: file.path,
+    id: `${file.path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
+/**
+ * Append path-only file references to outgoing text as one
+ * `[@label](~/path)` line per file, separated from the typed draft by a
+ * blank line. A files-only message is just the reference block.
+ */
+function appendFileReferenceMarkdown(
+  text: string,
+  fileRefs: ComposerFileAttachment[],
+): string {
+  if (fileRefs.length === 0) {
+    return text;
+  }
+  const referenceBlock = fileRefs
+    .map((fileRef) =>
+      buildDirectoryReferenceMarkdown({
+        label: fileRef.label,
+        path: fileRef.path,
+      }),
+    )
+    .join("\n");
+  return text ? `${text}\n\n${referenceBlock}` : referenceBlock;
+}
+
 function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
   return JSON.stringify(
     skillTokens.map((token) => ({
@@ -1362,12 +1431,12 @@ function serializeDraftWithSkillTokens(
   for (const token of sortedTokens) {
     const index = clampSkillTokenIndex(token.index, draft);
     output += draft.slice(cursor, index);
-    // Directory-reference chips serialize to `[@label](~/path)` markdown
-    // — the parens bound the path so adjacent text can't glue onto it,
-    // the transcript renders it back as a chip, and hydrateComposerDraft
-    // rebuilds the token from a prompt-only restore. Skills keep their
-    // `[$name](path)` markdown.
-    output += token.kind === "directory"
+    // Directory- and file-reference chips serialize to `[@label](~/path)`
+    // markdown — the parens bound the path so adjacent text can't glue
+    // onto it, the transcript renders it back as a chip, and
+    // hydrateComposerDraft rebuilds the token from a prompt-only restore.
+    // Skills keep their `[$name](path)` markdown.
+    output += token.kind === "directory" || token.kind === "file"
       ? buildDirectoryReferenceMarkdown({
           label: token.name,
           path: token.path ?? "",
@@ -1399,7 +1468,10 @@ function hydrateComposerDraft(
     if (part.type === "directory") {
       // Serialized paths are percent-encoded tilde form; the token
       // carries the decoded absolute path so send-time attach can use
-      // it directly.
+      // it directly. File-reference chips serialize to the same
+      // `[@label](~/path)` form, so a restored file chip degrades to a
+      // directory-kind chip here — acceptable: the outgoing text is
+      // identical either way.
       skillTokens.push(
         createComposerDirectoryToken(
           {
@@ -2479,6 +2551,10 @@ export function Composer(props: ComposerProps) {
         savedInitialDraft?.imageAttachments ??
         props.launchpad?.imageAttachments ??
         [],
+      fileAttachments:
+        savedInitialDraft?.fileAttachments ??
+        props.launchpad?.fileAttachments ??
+        [],
       skillTokens:
         savedInitialDraft?.skillTokens ?? hydratedInitialLaunchpad?.skillTokens ?? [],
     },
@@ -2499,6 +2575,11 @@ export function Composer(props: ComposerProps) {
   const scheduleMenuRef = useDismissableMenu<HTMLDivElement>(
     scheduleMenuOpen,
     () => setScheduleMenuOpen(false),
+  );
+  const [addReferenceMenuOpen, setAddReferenceMenuOpen] = useState(false);
+  const addReferenceMenuRef = useDismissableMenu<HTMLSpanElement>(
+    addReferenceMenuOpen,
+    () => setAddReferenceMenuOpen(false),
   );
   const [scheduleTick, setScheduleTick] = useState(() => Date.now());
   const [scheduledDraftSendAt, setScheduledDraftSendAt] = useState<
@@ -2565,6 +2646,9 @@ export function Composer(props: ComposerProps) {
   const threadEnvActionStartingTimeoutRef = useRef<number | undefined>(undefined);
   const [imageAttachments, setImageAttachments] = useState<ComposerImageAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.imageAttachments
+  );
+  const [fileAttachments, setFileAttachments] = useState<ComposerFileAttachment[]>(
+    latestDraftSnapshotRef.current.snapshot.fileAttachments ?? []
   );
   // Per-attachment content signature (`<size>:<hash>`) cache used to reject
   // exact-duplicate pastes. Computed lazily on first use and kept only in
@@ -2725,6 +2809,7 @@ export function Composer(props: ComposerProps) {
       draft,
       editorDocument,
       imageAttachments,
+      fileAttachments,
       skillTokens,
     },
   };
@@ -2745,6 +2830,7 @@ export function Composer(props: ComposerProps) {
     draft: "",
     editorDocument: undefined,
     imageAttachments: [],
+    fileAttachments: [],
     skillTokens: [],
   });
   const clearSubmittedComposerDraftForStart = (
@@ -2757,6 +2843,7 @@ export function Composer(props: ComposerProps) {
     };
     clearComposerDraft();
     setImageAttachments([]);
+    setFileAttachments([]);
   };
   const hasLiveComposerContent = (): boolean => {
     const latest = latestDraftSnapshotRef.current;
@@ -2764,7 +2851,8 @@ export function Composer(props: ComposerProps) {
       (inputRef.current?.value ?? latest.snapshot.draft).trim() ||
         (inputRef.current?.skillTokenCount ??
           latest.snapshot.skillTokens.length) > 0 ||
-        latest.snapshot.imageAttachments.length > 0,
+        latest.snapshot.imageAttachments.length > 0 ||
+        (latest.snapshot.fileAttachments?.length ?? 0) > 0,
     );
   };
   const updateVisibleDraft = (
@@ -2801,14 +2889,16 @@ export function Composer(props: ComposerProps) {
     if (
       !state.draft.trim() &&
       state.skillTokens.length === 0 &&
-      state.imageAttachments.length === 0
+      state.imageAttachments.length === 0 &&
+      (state.fileAttachments?.length ?? 0) === 0
     ) {
       const previous = latestDraftSnapshotRef.current;
       if (
         previous.scopeKey === scopeKey &&
         (previous.snapshot.draft.trim() ||
           previous.snapshot.skillTokens.length > 0 ||
-          previous.snapshot.imageAttachments.length > 0)
+          previous.snapshot.imageAttachments.length > 0 ||
+          (previous.snapshot.fileAttachments?.length ?? 0) > 0)
       ) {
         recordComposerDraftHistory(scopeKey, previous.snapshot, "abandoned");
       }
@@ -2846,6 +2936,10 @@ export function Composer(props: ComposerProps) {
         type: attachment.type,
         url: attachment.url,
       })),
+      fileAttachments: (snapshot.fileAttachments ?? []).map((attachment) => ({
+        label: attachment.label,
+        path: attachment.path,
+      })),
       skillTokens: snapshot.skillTokens.map((token) => ({
         index: token.index,
         name: token.name,
@@ -2874,6 +2968,7 @@ export function Composer(props: ComposerProps) {
       setDraft(snapshot.draft);
       setEditorDocument(snapshot.editorDocument);
       setImageAttachments(snapshot.imageAttachments);
+      setFileAttachments(snapshot.fileAttachments ?? []);
       setSkillTokens(snapshot.skillTokens);
       setComposerSelectionRequest({
         id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
@@ -2905,7 +3000,8 @@ export function Composer(props: ComposerProps) {
     const latestSnapshotIsCleared =
       !latestSnapshot.draft.trim() &&
       latestSnapshot.skillTokens.length === 0 &&
-      latestSnapshot.imageAttachments.length === 0;
+      latestSnapshot.imageAttachments.length === 0 &&
+      (latestSnapshot.fileAttachments?.length ?? 0) === 0;
 
     if (
       latestSnapshotIsCleared &&
@@ -2918,7 +3014,8 @@ export function Composer(props: ComposerProps) {
     return Boolean(
       liveDraft.trim() ||
         liveSkillTokenCount > 0 ||
-        latestSnapshot.imageAttachments.length > 0,
+        latestSnapshot.imageAttachments.length > 0 ||
+        (latestSnapshot.fileAttachments?.length ?? 0) > 0,
     );
   };
   const recoverSubmittedComposerDraft = (
@@ -2941,6 +3038,7 @@ export function Composer(props: ComposerProps) {
       setDraft("");
       setEditorDocument(undefined);
       setImageAttachments([]);
+      setFileAttachments([]);
       setSkillTokens([]);
       setComposerSelectionRequest({
         id: `recovery:${++composerSelectionRequestSequenceRef.current}`,
@@ -3011,13 +3109,15 @@ export function Composer(props: ComposerProps) {
           draft: candidate.text,
           editorDocument: candidate.editorDocument as JSONContent | undefined,
           imageAttachments: candidate.imageAttachments,
+          fileAttachments: candidate.fileAttachments,
           skillTokens: candidate.skillTokens as ComposerSkillToken[],
         }))
         .filter(
           (candidate) =>
             candidate.draft.trim() ||
             candidate.skillTokens.length > 0 ||
-            candidate.imageAttachments.length > 0,
+            candidate.imageAttachments.length > 0 ||
+            (candidate.fileAttachments?.length ?? 0) > 0,
         );
       const uniqueCandidates = dedupeComposerDraftSnapshots(candidates);
       if (uniqueCandidates.length === 0) {
@@ -3088,7 +3188,12 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    if (!state || (!state.text.trim() && state.imageAttachments.length === 0)) {
+    if (
+      !state ||
+      (!state.text.trim() &&
+        state.imageAttachments.length === 0 &&
+        state.fileAttachments.length === 0)
+    ) {
       draftStore.deletePendingSteer(scopeKey);
       return;
     }
@@ -3108,6 +3213,7 @@ export function Composer(props: ComposerProps) {
         entry.reviewCommand ||
         entry.text.trim() ||
         entry.imageAttachments.length > 0 ||
+        entry.fileAttachments.length > 0 ||
         entry.input?.length,
     );
 
@@ -3260,6 +3366,7 @@ export function Composer(props: ComposerProps) {
       draft: "",
       editorDocument: undefined,
       imageAttachments: [],
+      fileAttachments: [],
       skillTokens: [],
     };
 
@@ -3274,6 +3381,7 @@ export function Composer(props: ComposerProps) {
     };
     clearComposerDraft();
     setImageAttachments([]);
+    setFileAttachments([]);
   };
   const persistLaunchpadDraftSnapshot = (
     scopeKey: string,
@@ -3288,6 +3396,8 @@ export function Composer(props: ComposerProps) {
     void updateLaunchpad(directoryKey, {
       imageAttachments:
         snapshot.imageAttachments.length > 0 ? snapshot.imageAttachments : undefined,
+      fileAttachments:
+        snapshot.fileAttachments?.length ? snapshot.fileAttachments : undefined,
       prompt: serializeDraftWithSkillTokens(snapshot.draft, snapshot.skillTokens),
     });
   };
@@ -3456,6 +3566,9 @@ export function Composer(props: ComposerProps) {
     );
     const fromTokens: NavigationDirectorySummary[] = [];
     for (const token of tokens ?? []) {
+      // Only directory-kind tokens are attachable directories. File-kind
+      // tokens are excluded here — a file's containing repo still links
+      // via the text scan's deeper-path matching above.
       if (token.kind !== "directory" || !token.path) {
         continue;
       }
@@ -3599,6 +3712,7 @@ export function Composer(props: ComposerProps) {
       draft,
       editorDocument,
       imageAttachments,
+      fileAttachments,
       skillTokens,
     };
     flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
@@ -3621,6 +3735,7 @@ export function Composer(props: ComposerProps) {
       setDraft(saved?.draft ?? "");
       setEditorDocument(saved?.editorDocument);
       setImageAttachments(saved?.imageAttachments ?? []);
+      setFileAttachments(saved?.fileAttachments ?? []);
       setSkillTokens(saved?.skillTokens ?? []);
       setPendingSteerState(
         savedPendingSteer ? { ...savedPendingSteer, status: "pending" } : undefined
@@ -3642,7 +3757,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-  }, [composerScopeKey, draft, editorDocument, imageAttachments, skillTokens]);
+  }, [composerScopeKey, draft, editorDocument, imageAttachments, fileAttachments, skillTokens]);
 
   useEffect(() => {
     const saved = draftStore.get(composerScopeKey);
@@ -3656,7 +3771,8 @@ export function Composer(props: ComposerProps) {
     if (
       latest.snapshot.draft.trim() ||
       latest.snapshot.skillTokens.length > 0 ||
-      latest.snapshot.imageAttachments.length > 0
+      latest.snapshot.imageAttachments.length > 0 ||
+      (latest.snapshot.fileAttachments?.length ?? 0) > 0
     ) {
       return;
     }
@@ -3664,6 +3780,7 @@ export function Composer(props: ComposerProps) {
     setDraft(saved.draft);
     setEditorDocument(saved.editorDocument);
     setImageAttachments(saved.imageAttachments);
+    setFileAttachments(saved.fileAttachments ?? []);
     setSkillTokens(saved.skillTokens);
   }, [composerScopeKey, draftStore, draftStoreHydrationVersion]);
 
@@ -3774,6 +3891,7 @@ export function Composer(props: ComposerProps) {
       setDraft(saved.draft);
       setEditorDocument(saved.editorDocument);
       setImageAttachments(saved.imageAttachments);
+      setFileAttachments(saved.fileAttachments ?? []);
       setSkillTokens(saved.skillTokens);
     } else {
       setComposerDraftFromCanonical(props.launchpad?.prompt ?? "");
@@ -3781,6 +3899,7 @@ export function Composer(props: ComposerProps) {
         props.launchpad?.editorDocument as JSONContent | undefined,
       );
       setImageAttachments(props.launchpad?.imageAttachments ?? []);
+      setFileAttachments(props.launchpad?.fileAttachments ?? []);
     }
     updateSending(false);
     setInterrupting(false);
@@ -4004,11 +4123,13 @@ export function Composer(props: ComposerProps) {
           if (queuedTurn) {
             setComposerDraftFromCanonical(pendingSteer.text);
             setImageAttachments(pendingSteer.imageAttachments);
+            setFileAttachments(pendingSteer.fileAttachments);
           } else {
             setQueuedTurn({
               id: createQueuedTurnId(),
               text: pendingSteer.text,
               imageAttachments: pendingSteer.imageAttachments,
+              fileAttachments: pendingSteer.fileAttachments,
             });
           }
         }
@@ -4074,6 +4195,7 @@ export function Composer(props: ComposerProps) {
 
       void props.onUpdateLaunchpad?.(launchpad.directoryKey, {
         imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
+        fileAttachments: fileAttachments.length > 0 ? fileAttachments : undefined,
         prompt: canonicalDraft,
         editorDocument: editorDocument as Record<string, unknown> | undefined,
       });
@@ -4087,6 +4209,7 @@ export function Composer(props: ComposerProps) {
     composerScopeKey,
     editorDocument,
     imageAttachments,
+    fileAttachments,
     launchpad,
     props.onUpdateLaunchpad,
   ]);
@@ -4163,7 +4286,13 @@ export function Composer(props: ComposerProps) {
           undefined,
           undefined,
           reviewCommand.target,
-          listDraftReferencedDirectories(canonicalDraft, skillTokens)
+          // No turn payload is built for a review materialize, so append
+          // the file references by hand — a dropped file inside a tracked
+          // repo should still link that repo to the new thread.
+          listDraftReferencedDirectories(
+            appendFileReferenceMarkdown(canonicalDraft, fileAttachments),
+            skillTokens,
+          )
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );
@@ -4256,8 +4385,8 @@ export function Composer(props: ComposerProps) {
       setSendError("Selected backend does not support compaction.");
       return;
     }
-    if (imageAttachments.length > 0) {
-      setSendError("/compact does not accept image attachments.");
+    if (imageAttachments.length > 0 || fileAttachments.length > 0) {
+      setSendError("/compact does not accept attachments.");
       return;
     }
     if (shouldQueueThreadSubmit()) {
@@ -4278,6 +4407,7 @@ export function Composer(props: ComposerProps) {
       draft: "",
       editorDocument: undefined,
       imageAttachments: [],
+      fileAttachments: [],
       skillTokens: [],
     };
     clearComposerDraftSnapshot(submittedScopeKey);
@@ -4296,6 +4426,7 @@ export function Composer(props: ComposerProps) {
     flushSync(() => {
       clearComposerDraft();
       setImageAttachments([]);
+      setFileAttachments([]);
       setReviewConfig(undefined);
     });
 
@@ -4320,6 +4451,7 @@ export function Composer(props: ComposerProps) {
       setDraft(submittedSnapshot.draft);
       setEditorDocument(submittedSnapshot.editorDocument);
       setImageAttachments(submittedSnapshot.imageAttachments);
+      setFileAttachments(submittedSnapshot.fileAttachments ?? []);
       setSkillTokens(submittedSnapshot.skillTokens);
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
@@ -4472,13 +4604,21 @@ export function Composer(props: ComposerProps) {
   const buildTurnPayload = (
     textDraft: string,
     attachments: ComposerImageAttachment[],
+    fileRefs: ComposerFileAttachment[],
   ): {
     displayText: string;
     imageParts: AppServerThreadImagePart[];
     input: AppServerTurnInputItem[];
   } => {
     const turnSkills = listMentionedSkills(textDraft, props.skills);
-    const displayText = hydrateSkillLabelsWithMarkdown(textDraft.trim(), turnSkills);
+    // File-reference pills ride the outgoing text as `[@label](~/path)`
+    // markdown appended after the typed draft — part of BOTH the display
+    // text and the text input item, so the agent and the transcript see
+    // the same message.
+    const displayText = appendFileReferenceMarkdown(
+      hydrateSkillLabelsWithMarkdown(textDraft.trim(), turnSkills),
+      fileRefs,
+    );
     const imageParts = attachments.map((attachment, index) => ({
       type: "image" as const,
       url: attachment.url,
@@ -4509,8 +4649,12 @@ export function Composer(props: ComposerProps) {
     }
 
     const payload = queued
-      ? buildTurnPayload(queued.text, queued.imageAttachments)
-      : buildTurnPayload(canonicalDraft, imageAttachments);
+      ? buildTurnPayload(
+          queued.text,
+          queued.imageAttachments,
+          queued.fileAttachments ?? [],
+        )
+      : buildTurnPayload(canonicalDraft, imageAttachments, fileAttachments);
     if (payload.input.length === 0 || props.disabled) {
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
@@ -4575,9 +4719,11 @@ export function Composer(props: ComposerProps) {
       }
       // Queued turns only carry their serialized text, but that text is
       // self-describing (`[@label](~/path)` markdown), so the scan alone
-      // recovers chip references there.
+      // recovers chip references there. Scan the outgoing display text —
+      // it also carries the appended file references, so a dropped file
+      // inside a tracked repo links that repo.
       const sentReferencedDirectoryPaths = listDraftReferencedDirectories(
-        queued ? queued.text : canonicalDraft,
+        payload.displayText,
         queued ? undefined : skillTokens,
       )
         .map((directory) => directory.path)
@@ -4715,22 +4861,28 @@ export function Composer(props: ComposerProps) {
     if (queuedTurn) {
       setComposerDraftFromCanonical(pendingSteer.text);
       setImageAttachments(pendingSteer.imageAttachments);
+      setFileAttachments(pendingSteer.fileAttachments);
     } else {
       setQueuedTurn({
         id: createQueuedTurnId(),
         text: pendingSteer.text,
         imageAttachments: pendingSteer.imageAttachments,
+        fileAttachments: pendingSteer.fileAttachments,
       });
     }
     setPendingSteer(undefined);
   }, [activeTurnId, pendingSteer, props.launchpad, queuedTurn]);
 
   const queueCurrentDraft = (options?: { scheduledSendAt?: number }): void => {
-    if (!hasComposerContent && imageAttachments.length === 0) {
+    if (
+      !hasComposerContent &&
+      imageAttachments.length === 0 &&
+      fileAttachments.length === 0
+    ) {
       return;
     }
 
-    const payload = buildTurnPayload(canonicalDraft, imageAttachments);
+    const payload = buildTurnPayload(canonicalDraft, imageAttachments, fileAttachments);
     if (payload.input.length === 0) {
       return;
     }
@@ -4740,6 +4892,7 @@ export function Composer(props: ComposerProps) {
       input: payload.input,
       text: canonicalDraft,
       imageAttachments,
+      fileAttachments,
       ...(options?.scheduledSendAt
         ? { scheduledSendAt: options.scheduledSendAt }
         : {}),
@@ -4752,6 +4905,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
+    setFileAttachments([]);
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
     setReviewConfig(undefined);
@@ -4770,6 +4924,7 @@ export function Composer(props: ComposerProps) {
       id: createQueuedTurnId(),
       text: reviewCommandToDraftText(reviewCommand),
       imageAttachments: [],
+      fileAttachments: [],
       ...(options?.scheduledSendAt
         ? { scheduledSendAt: options.scheduledSendAt }
         : {}),
@@ -4783,6 +4938,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
+    setFileAttachments([]);
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
     setReviewConfig(undefined);
@@ -4851,7 +5007,11 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const payload = buildTurnPayload(pending.text, pending.imageAttachments);
+    const payload = buildTurnPayload(
+      pending.text,
+      pending.imageAttachments,
+      pending.fileAttachments,
+    );
     if (payload.input.length === 0 || props.disabled || steering) {
       return;
     }
@@ -4878,11 +5038,13 @@ export function Composer(props: ComposerProps) {
         if (queuedTurn) {
           setDraft(pending.text);
           setImageAttachments(pending.imageAttachments);
+          setFileAttachments(pending.fileAttachments);
         } else {
           setQueuedTurn({
             id: createQueuedTurnId(),
             text: pending.text,
             imageAttachments: pending.imageAttachments,
+            fileAttachments: pending.fileAttachments,
           });
         }
         setPendingSteer(undefined);
@@ -4913,7 +5075,11 @@ export function Composer(props: ComposerProps) {
       return false;
     }
 
-    const payload = buildTurnPayload(pending.text, pending.imageAttachments);
+    const payload = buildTurnPayload(
+      pending.text,
+      pending.imageAttachments,
+      pending.fileAttachments,
+    );
     if (payload.input.length === 0 || props.disabled || pendingSteer) {
       return false;
     }
@@ -4923,6 +5089,7 @@ export function Composer(props: ComposerProps) {
       id: pending.id,
       text: pending.text,
       imageAttachments: pending.imageAttachments,
+      fileAttachments: pending.fileAttachments,
       status: "pending",
     });
     recordComposerDraftHistory(
@@ -4933,6 +5100,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraftSnapshot(composerScopeKey);
     clearComposerDraft();
     setImageAttachments([]);
+    setFileAttachments([]);
     setReviewConfig(undefined);
     return true;
   };
@@ -4953,6 +5121,7 @@ export function Composer(props: ComposerProps) {
       id: createQueuedTurnId(),
       text: canonicalDraft,
       imageAttachments,
+      fileAttachments,
     });
   };
 
@@ -5061,7 +5230,7 @@ export function Composer(props: ComposerProps) {
     // pending time so the toggle doesn't reappear after the immediate send.
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
-    const payload = buildTurnPayload(canonicalDraft, imageAttachments);
+    const payload = buildTurnPayload(canonicalDraft, imageAttachments, fileAttachments);
     const collaborationMode = planModeEnabled && supportsPlanMode
       ? ({
           mode: "plan",
@@ -5095,7 +5264,9 @@ export function Composer(props: ComposerProps) {
           payload.input,
           collaborationMode,
           undefined,
-          listDraftReferencedDirectories(canonicalDraft, skillTokens)
+          // Scan the outgoing display text so the appended file
+          // references also link their containing tracked repos.
+          listDraftReferencedDirectories(payload.displayText, skillTokens)
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );
@@ -5299,7 +5470,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const applyDirectoryReference = (
-    directory: NavigationDirectorySummary,
+    directory: Pick<NavigationDirectorySummary, "label" | "path">,
   ): void => {
     if (!inputRef.current) {
       return;
@@ -5313,10 +5484,15 @@ export function Composer(props: ComposerProps) {
       inputRef.current.selectionEnd ?? selectionStart,
       draft.length,
     );
+    // Prefer replacing the `@` trigger the popover opened from; when the
+    // reference arrives without one (the "+"-menu picker, or the trigger
+    // vanished while an OS dialog was open) fall back to a zero-width
+    // "trigger" at the current caret so the chip still lands in place.
     const refTrigger =
       findDirectoryReferenceTrigger(draft, selectionStart)
-      ?? findDirectoryReferenceTrigger(draft, draft.length);
-    if (!refTrigger || !directory.path) {
+      ?? findDirectoryReferenceTrigger(draft, draft.length)
+      ?? { start: selectionStart, end: selectionEnd };
+    if (!directory.path) {
       return;
     }
 
@@ -5364,6 +5540,99 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  /**
+   * "@ → Add directory…" / "+"-menu action: run the OS picker (which also
+   * registers the pick as a tracked directory, without navigating) and
+   * mint the returned directory as a chip. The trigger is recomputed
+   * inside `applyDirectoryReference` AFTER the dialog resolves, with a
+   * caret fallback for the no-trigger paths.
+   */
+  const applyPickedDirectoryReference = async (): Promise<void> => {
+    const picked = await props.onPickDirectoryForReference?.();
+    if (!picked?.path) {
+      return;
+    }
+    applyDirectoryReference(picked);
+  };
+
+  /**
+   * Mint file-reference chips at the `@` trigger (or the caret when no
+   * trigger survives) — the multi-token sibling of
+   * `applyDirectoryReference`. The plain draft gets n-1 separator spaces
+   * plus the guaranteed post-chip space, placing the n zero-width tokens
+   * at consecutive indexes so the serialized draft reads
+   * `chip␠chip␠…chip␠after` with exactly one space after every chip.
+   */
+  const applyFileReferences = (paths: string[]): void => {
+    if (!inputRef.current || paths.length === 0) {
+      return;
+    }
+
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
+    const refTrigger =
+      findDirectoryReferenceTrigger(draft, selectionStart)
+      ?? findDirectoryReferenceTrigger(draft, draft.length)
+      ?? { start: selectionStart, end: selectionEnd };
+
+    const before = draft.slice(0, refTrigger.start);
+    const after = draft.slice(Math.max(refTrigger.end, selectionEnd));
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
+    const nextDraft = `${before}${" ".repeat(paths.length - 1)}${nextAfter}`;
+    const nextSelection = before.length + paths.length;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      ...paths.map((path, index) =>
+        createComposerFileToken(
+          { label: fileLabelFromPath(path), path },
+          before.length + index,
+        ),
+      ),
+    ];
+
+    // Same protected-update dance as applySkill / applyDirectoryReference:
+    // the editability sync in ComposerTiptapInput re-emits the editor's
+    // (still pre-insert) content through onChange before the
+    // external-value sync applies the new draft. The pending-programmatic
+    // guard in handleComposerChange swallows that stale replay so the two
+    // sides can't ping-pong.
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveDirectoryRefIndex(0);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
+  /** "@ → Add file…" action: OS file picker → file-reference chips. */
+  const applyPickedFileReferences = async (): Promise<void> => {
+    const result = await props.desktopApi?.pickFileFromDisk?.();
+    if (!result || result.canceled || result.paths.length === 0) {
+      return;
+    }
+    applyFileReferences(result.paths);
+  };
+
   const removeImageAttachment = (id: string): void => {
     setImageAttachments((current) => {
       const nextAttachments = current.filter((attachment) => attachment.id !== id);
@@ -5371,6 +5640,7 @@ export function Composer(props: ComposerProps) {
         draft,
         editorDocument,
         imageAttachments: nextAttachments,
+        fileAttachments,
         skillTokens,
       });
       persistLaunchpadImageAttachments(nextAttachments);
@@ -5378,8 +5648,24 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  const removeFileAttachment = (id: string): void => {
+    setFileAttachments((current) => {
+      const nextAttachments = current.filter((attachment) => attachment.id !== id);
+      saveComposerDraftSnapshot(composerScopeKey, {
+        draft,
+        editorDocument,
+        imageAttachments,
+        fileAttachments: nextAttachments,
+        skillTokens,
+      });
+      persistLaunchpadImageAttachments(imageAttachments, nextAttachments);
+      return nextAttachments;
+    });
+  };
+
   const persistLaunchpadImageAttachments = (
     attachments: ComposerImageAttachment[],
+    files: ComposerFileAttachment[] = fileAttachments,
   ): void => {
     if (!props.launchpad || !props.onUpdateLaunchpad) {
       return;
@@ -5387,6 +5673,7 @@ export function Composer(props: ComposerProps) {
 
     void props.onUpdateLaunchpad(props.launchpad.directoryKey, {
       imageAttachments: attachments.length > 0 ? attachments : undefined,
+      fileAttachments: files.length > 0 ? files : undefined,
       prompt: canonicalDraft,
     });
   };
@@ -5435,14 +5722,110 @@ export function Composer(props: ComposerProps) {
     return files;
   };
 
+  /**
+   * Add path-only file attachments to the tray. Shared by drop/paste
+   * (after `attachFiles` resolves each File's path) and the "+"-menu
+   * "Add file…" picker (which already has paths). Dedupes against the
+   * pills already in the tray, caps the total, and persists the snapshot.
+   * Toasts once per batch when the cap clamps it.
+   */
+  const attachFilePaths = (paths: string[]): void => {
+    const resolved: ComposerFileAttachment[] = [];
+    const seenPaths = new Set(fileAttachments.map((attachment) => attachment.path));
+    for (const path of paths) {
+      if (!path || seenPaths.has(path)) {
+        continue;
+      }
+      seenPaths.add(path);
+      resolved.push({
+        id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+        label: fileLabelFromPath(path),
+        path,
+      });
+    }
+    if (resolved.length === 0) {
+      return;
+    }
+
+    const remaining = MAX_COMPOSER_FILE_ATTACHMENTS - fileAttachments.length;
+    if (resolved.length > remaining) {
+      showComposerNotice({
+        title: "Attachment limit reached",
+        message: `You can attach up to ${MAX_COMPOSER_FILE_ATTACHMENTS} files per message.`,
+      });
+    }
+    const accepted = resolved.slice(0, Math.max(0, remaining));
+    if (accepted.length === 0) {
+      return;
+    }
+
+    const nextAttachments = [...fileAttachments, ...accepted];
+    setFileAttachments(nextAttachments);
+    saveComposerDraftSnapshot(composerScopeKey, {
+      draft,
+      editorDocument,
+      imageAttachments,
+      fileAttachments: nextAttachments,
+      skillTokens,
+    });
+    persistLaunchpadImageAttachments(imageAttachments, nextAttachments);
+  };
+
+  /**
+   * Turn dropped/pasted non-image Files into path-only file attachments.
+   * Resolves each path via Electron's webUtils bridge (contents are never
+   * read) and hands off to `attachFilePaths` for dedupe/cap/persist.
+   * Toasts once per batch for unresolvable paths.
+   */
+  const attachFiles = (files: File[]): void => {
+    let unresolvedCount = 0;
+    const paths: string[] = [];
+    for (const file of files) {
+      const path = props.desktopApi?.getPathForFile?.(file) ?? "";
+      if (!path) {
+        unresolvedCount += 1;
+        continue;
+      }
+      paths.push(path);
+    }
+
+    if (unresolvedCount > 0) {
+      showComposerNotice({
+        title: "File path unavailable",
+        message: "Could not resolve a path for the dropped file.",
+      });
+    }
+    attachFilePaths(paths);
+  };
+
+  /** "+"-menu "Add file…" action: OS file picker → tray pills. */
+  const attachPickedFilesToTray = async (): Promise<void> => {
+    const result = await props.desktopApi?.pickFileFromDisk?.();
+    if (!result || result.canceled || result.paths.length === 0) {
+      return;
+    }
+    attachFilePaths(result.paths);
+  };
+
   const handlePaste = (event: ClipboardEvent<HTMLElement>): void => {
     const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
-    if (pastedFiles.length === 0) {
+    // Non-image FILES only (kind === "file" items) — plain text paste
+    // must fall through to the editor untouched.
+    const pastedNonImageFiles = getNonImageFilesFromDataTransfer(
+      event.clipboardData,
+    );
+    if (pastedFiles.length === 0 && pastedNonImageFiles.length === 0) {
       return;
     }
 
     event.preventDefault();
     setSendError(undefined);
+    if (pastedNonImageFiles.length > 0) {
+      attachFiles(pastedNonImageFiles);
+    }
+    if (pastedFiles.length === 0) {
+      return;
+    }
     const accepted = gateImageFilesForAttachment(pastedFiles);
     if (!accepted || accepted.length === 0) {
       return;
@@ -5451,7 +5834,7 @@ export function Composer(props: ComposerProps) {
   };
 
   const handleDragOver = (event: DragEvent<HTMLElement>): void => {
-    if (!hasImageFiles(event.dataTransfer)) {
+    if (!hasAnyFiles(event.dataTransfer)) {
       return;
     }
 
@@ -5461,12 +5844,21 @@ export function Composer(props: ComposerProps) {
 
   const handleDrop = (event: DragEvent<HTMLElement>): void => {
     const droppedFiles = getImageFilesFromDataTransfer(event.dataTransfer);
-    if (droppedFiles.length === 0) {
+    const droppedNonImageFiles = getNonImageFilesFromDataTransfer(
+      event.dataTransfer,
+    );
+    if (droppedFiles.length === 0 && droppedNonImageFiles.length === 0) {
       return;
     }
 
     event.preventDefault();
     setSendError(undefined);
+    if (droppedNonImageFiles.length > 0) {
+      attachFiles(droppedNonImageFiles);
+    }
+    if (droppedFiles.length === 0) {
+      return;
+    }
     const accepted = gateImageFilesForAttachment(droppedFiles);
     if (!accepted || accepted.length === 0) {
       return;
@@ -5479,6 +5871,7 @@ export function Composer(props: ComposerProps) {
     const pasteDraft = draft;
     const pasteEditorDocument = editorDocument;
     const pasteImageAttachments = imageAttachments;
+    const pasteFileAttachments = fileAttachments;
 
     try {
       const nextAttachments = await Promise.all(
@@ -5537,6 +5930,7 @@ export function Composer(props: ComposerProps) {
           draft: pasteDraft,
           editorDocument: pasteEditorDocument,
           imageAttachments: pasteImageAttachments,
+          fileAttachments: pasteFileAttachments,
           skillTokens,
         };
         // Drop exact duplicates against the background scope's own attachments
@@ -5553,6 +5947,7 @@ export function Composer(props: ComposerProps) {
             0,
             MAX_COMPOSER_IMAGE_ATTACHMENTS,
           ),
+          fileAttachments: saved.fileAttachments,
           skillTokens: saved.skillTokens,
         };
         saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
@@ -5596,14 +5991,21 @@ export function Composer(props: ComposerProps) {
           0,
           MAX_COMPOSER_IMAGE_ATTACHMENTS,
         );
+        // Read file pills from the latest snapshot ref, not the paste-time
+        // closure — a mixed drop attaches files synchronously before this
+        // async image path lands, and the stale list would wipe them.
+        const latestFileAttachments =
+          latestDraftSnapshotRef.current.snapshot.fileAttachments ??
+          pasteFileAttachments;
         const nextSnapshot = {
           draft,
           editorDocument,
           imageAttachments: mergedAttachments,
+          fileAttachments: latestFileAttachments,
           skillTokens,
         };
         saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
-        persistLaunchpadImageAttachments(mergedAttachments);
+        persistLaunchpadImageAttachments(mergedAttachments, latestFileAttachments);
         return mergedAttachments;
       });
     } catch (error) {
@@ -5646,6 +6048,8 @@ export function Composer(props: ComposerProps) {
       {
         imageAttachments:
           imageAttachments.length > 0 ? imageAttachments : undefined,
+        fileAttachments:
+          fileAttachments.length > 0 ? fileAttachments : undefined,
         prompt: canonicalDraft,
         ...patch,
       },
@@ -5870,7 +6274,9 @@ export function Composer(props: ComposerProps) {
     props.disabled ||
     steering ||
     (!activeTurnId && sending) ||
-    (!hasComposerContent && imageAttachments.length === 0);
+    (!hasComposerContent &&
+      imageAttachments.length === 0 &&
+      fileAttachments.length === 0);
   const scheduleButtonDisabled =
     sendButtonDisabled ||
     Boolean(props.launchpad) ||
@@ -6347,6 +6753,7 @@ export function Composer(props: ComposerProps) {
             draft: nextDraft,
             editorDocument: metadata?.editorDocument,
             imageAttachments,
+            fileAttachments,
             skillTokens: storedSkillTokens,
           }),
       ) === true;
@@ -6357,6 +6764,7 @@ export function Composer(props: ComposerProps) {
       draft: nextDraft,
       editorDocument: metadata?.editorDocument,
       imageAttachments,
+      fileAttachments,
       skillTokens: storedSkillTokens,
     });
     if (deletedSkillTokenHistoryEntry) {
@@ -6385,7 +6793,9 @@ export function Composer(props: ComposerProps) {
           (inputRef.current?.skillTokenCount ?? skillTokens.length) > 0,
       );
       const liveHasAnyComposerContent =
-        liveHasComposerContent || imageAttachments.length > 0;
+        liveHasComposerContent ||
+        imageAttachments.length > 0 ||
+        fileAttachments.length > 0;
       const recoveryCycle = recoveryCycleRef.current;
       const liveSelectionAtStart =
         (inputRef.current?.selectionStart ?? 0) === 0 &&
@@ -6409,7 +6819,8 @@ export function Composer(props: ComposerProps) {
       if (
         event.key === "ArrowUp" &&
         (!liveHasComposerContent || canCycleActiveRecovery) &&
-        (imageAttachments.length === 0 || canCycleActiveRecovery)
+        (imageAttachments.length === 0 || canCycleActiveRecovery) &&
+        (fileAttachments.length === 0 || canCycleActiveRecovery)
       ) {
         event.preventDefault();
         void recoverPreviousComposerDraft();
@@ -6419,7 +6830,8 @@ export function Composer(props: ComposerProps) {
         event.key === "ArrowDown" &&
         liveHasAnyComposerContent &&
         canCycleActiveRecovery &&
-        (imageAttachments.length === 0 || canCycleActiveRecovery)
+        (imageAttachments.length === 0 || canCycleActiveRecovery) &&
+        (fileAttachments.length === 0 || canCycleActiveRecovery)
       ) {
         event.preventDefault();
         recoverNextComposerDraft();
@@ -6777,6 +7189,7 @@ export function Composer(props: ComposerProps) {
                   onClick={() => {
                     setComposerDraftFromCanonical(pendingSteer.text);
                     setImageAttachments(pendingSteer.imageAttachments);
+                    setFileAttachments(pendingSteer.fileAttachments);
                     setPendingSteer(undefined);
                     requestAnimationFrame(() => inputRef.current?.focus());
                   }}
@@ -6847,7 +7260,7 @@ export function Composer(props: ComposerProps) {
               .filter(Boolean)
               .join(" ")}
             aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
-            key={`${index}:${queued.text}:${queued.imageAttachments.length}:${queued.scheduledSendAt ?? ""}`}
+            key={`${index}:${queued.text}:${queued.imageAttachments.length}:${queued.fileAttachments.length}:${queued.scheduledSendAt ?? ""}`}
           >
             <div className="composer__queued-copy">
               <span className="composer__queued-label">
@@ -6890,6 +7303,7 @@ export function Composer(props: ComposerProps) {
                 onClick={() => {
                   setComposerDraftFromCanonical(queued.text);
                   setImageAttachments(queued.imageAttachments);
+                  setFileAttachments(queued.fileAttachments);
                   setScheduledDraftSendAt(scheduledSendAt);
                   setScheduleArmed(true);
                   removeQueuedTurnAt(index);
@@ -6912,8 +7326,11 @@ export function Composer(props: ComposerProps) {
         );
       })}
 
-      {imageAttachments.length > 0 ? (
-        <div className="composer__attachments" aria-label="Pasted images">
+      {imageAttachments.length > 0 || fileAttachments.length > 0 ? (
+        <div
+          className="composer__attachments"
+          aria-label={fileAttachments.length > 0 ? "Attachments" : "Pasted images"}
+        >
           {imageAttachments.map((attachment, index) => {
             const dimensions = formatImageDimensions(
               attachment.width,
@@ -6958,6 +7375,28 @@ export function Composer(props: ComposerProps) {
               </div>
             );
           })}
+          {fileAttachments.map((attachment) => (
+            <span
+              className="composer__file-attachment tooltip-target"
+              data-tooltip={buildFileReferenceTooltip(attachment.path)}
+              key={attachment.id}
+            >
+              <FileCodeIcon size={13} aria-hidden="true" />
+              <span className="composer__file-attachment-label">
+                {attachment.label}
+              </span>
+              <button
+                aria-label={`Remove ${attachment.label}`}
+                className="composer__file-attachment-remove"
+                type="button"
+                onClick={() => {
+                  removeFileAttachment(attachment.id);
+                }}
+              >
+                <CloseIcon size={12} aria-hidden="true" />
+              </button>
+            </span>
+          ))}
         </div>
       ) : null}
 
@@ -7305,6 +7744,45 @@ export function Composer(props: ComposerProps) {
                 </span>
               </button>
             ))}
+            {props.onPickDirectoryForReference ||
+            props.desktopApi?.pickFileFromDisk ? (
+              <div
+                className="composer__autocomplete-separator"
+                role="separator"
+              />
+            ) : null}
+            {props.onPickDirectoryForReference ? (
+              <button
+                className="composer__autocomplete-option composer__autocomplete-option--action"
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => {
+                  void applyPickedDirectoryReference();
+                }}
+              >
+                <span className="composer__autocomplete-title">
+                  + Add directory…
+                </span>
+              </button>
+            ) : null}
+            {props.desktopApi?.pickFileFromDisk ? (
+              <button
+                className="composer__autocomplete-option composer__autocomplete-option--action"
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                }}
+                onClick={() => {
+                  void applyPickedFileReferences();
+                }}
+              >
+                <span className="composer__autocomplete-title">
+                  + Add file…
+                </span>
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -7729,6 +8207,60 @@ export function Composer(props: ComposerProps) {
             >
               <PlanIcon size={15} aria-hidden="true" />
             </button>
+          ) : null}
+
+          {props.onPickDirectoryForReference ||
+          props.desktopApi?.pickFileFromDisk ? (
+            <span className="composer__add-reference" ref={addReferenceMenuRef}>
+              <button
+                type="button"
+                className="composer__toggle tooltip-target"
+                aria-label="Add reference"
+                aria-haspopup="menu"
+                aria-expanded={addReferenceMenuOpen}
+                data-tooltip="Reference a directory or file"
+                disabled={launchpadSubmitting}
+                onClick={() => setAddReferenceMenuOpen((current) => !current)}
+              >
+                <PlusIcon size={15} aria-hidden="true" />
+              </button>
+              {addReferenceMenuOpen ? (
+                <div className="composer-dropdown__menu" role="menu">
+                  {props.onPickDirectoryForReference ? (
+                    <button
+                      className="composer-dropdown__option"
+                      role="menuitem"
+                      type="button"
+                      onClick={() => {
+                        setAddReferenceMenuOpen(false);
+                        void applyPickedDirectoryReference();
+                      }}
+                    >
+                      <FolderIcon size={14} aria-hidden="true" />
+                      <span className="composer-dropdown__option-label">
+                        Add directory…
+                      </span>
+                    </button>
+                  ) : null}
+                  {props.desktopApi?.pickFileFromDisk ? (
+                    <button
+                      className="composer-dropdown__option"
+                      role="menuitem"
+                      type="button"
+                      onClick={() => {
+                        setAddReferenceMenuOpen(false);
+                        void attachPickedFilesToTray();
+                      }}
+                    >
+                      <FileCodeIcon size={14} aria-hidden="true" />
+                      <span className="composer-dropdown__option-label">
+                        Add file…
+                      </span>
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+            </span>
           ) : null}
         </div>
       ) : null}
@@ -8284,14 +8816,65 @@ function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImag
   return files;
 }
 
-function hasImageFiles(dataTransfer: DataTransfer): boolean {
+/**
+ * Sibling of getImageFilesFromDataTransfer for the path-only file tray:
+ * every dropped/pasted File that is NOT an image (those keep the existing
+ * attach-image path), deduped by content key.
+ */
+function getNonImageFilesFromDataTransfer(dataTransfer: DataTransfer): File[] {
+  const files: File[] = [];
+  const seenFiles = new Set<string>();
+  let foundFileItem = false;
+
   for (const item of Array.from(dataTransfer.items)) {
-    if (item.kind === "file" && (!item.type || isImageMimeType(item.type))) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (!file) {
+      continue;
+    }
+
+    foundFileItem = true;
+    if (isImageMimeType(item.type) || inferTransferImageType(file)) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push(file);
+      seenFiles.add(key);
+    }
+  }
+
+  if (foundFileItem) {
+    return files;
+  }
+
+  for (const file of Array.from(dataTransfer.files)) {
+    if (inferTransferImageType(file)) {
+      continue;
+    }
+
+    const key = buildFileKey(file);
+    if (!seenFiles.has(key)) {
+      files.push(file);
+      seenFiles.add(key);
+    }
+  }
+
+  return files;
+}
+
+function hasAnyFiles(dataTransfer: DataTransfer): boolean {
+  for (const item of Array.from(dataTransfer.items)) {
+    if (item.kind === "file") {
       return true;
     }
   }
 
-  return Array.from(dataTransfer.files).some((file) => Boolean(inferTransferImageType(file)));
+  return dataTransfer.files.length > 0;
 }
 
 function buildFileKey(file: File): string {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -60,6 +60,12 @@ import {
   getAcpRuntimeModeControl,
 } from "../../lib/execution-mode";
 import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
+import {
+  buildDirectoryReferenceInsertText,
+  filterDirectoryReferenceCandidates,
+  findDirectoryReferenceTrigger,
+  listReferencedDirectories,
+} from "../../lib/directory-references";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import {
@@ -134,7 +140,12 @@ type ComposerProps = {
     directoryKey: string,
     input?: AppServerTurnInputItem[],
     collaborationMode?: AppServerCollaborationModeRequest,
-    reviewTarget?: AppServerReviewTarget
+    reviewTarget?: AppServerReviewTarget,
+    /**
+     * Paths of tracked directories the draft references (`@`-inserted or
+     * typed by hand). Linked to the new thread right after it is created.
+     */
+    extraDirectoryPaths?: string[]
   ) => Promise<void>;
   /** Discard this launchpad draft (the "Cancel" button next to "Start thread"). */
   onCancelLaunchpad?: (directoryKey: string) => void;
@@ -186,6 +197,13 @@ type ComposerProps = {
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onPickAndAttachDirectoryToThread?: () => void;
+  /**
+   * Link draft-referenced directories to the existing thread after a turn
+   * is sent (the launchpad path rides on `onMaterializeLaunchpad`'s
+   * `extraDirectoryPaths` instead). Fire-and-forget; failures must not
+   * block the turn.
+   */
+  onAttachDirectoryReferences?: (paths: string[]) => void;
   onClearPickDirectoryError?: () => void;
   pickDirectoryError?: string;
   pickingDirectory?: boolean;
@@ -313,7 +331,7 @@ type SlashCommandSuggestion = {
   sourceLabel: string;
 };
 
-type AutocompleteKind = "skills" | "slash";
+type AutocompleteKind = "skills" | "slash" | "directories";
 type ReviewTargetChoice = AppServerReviewTarget["type"];
 
 const CONTEXT_MOON_PHASES = [
@@ -2359,6 +2377,7 @@ export function Composer(props: ComposerProps) {
   const reviewCustomTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const skillListboxId = useId();
   const slashListboxId = useId();
+  const directoryRefListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
   const pendingProgrammaticComposerChangeRef =
     useRef<PendingProgrammaticComposerChange | undefined>(undefined);
@@ -2524,6 +2543,7 @@ export function Composer(props: ComposerProps) {
   }>();
   const [activeSkillIndex, setActiveSkillIndex] = useState(0);
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
+  const [activeDirectoryRefIndex, setActiveDirectoryRefIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
 
   const setThreadEnvActionStarting = (
@@ -3248,6 +3268,7 @@ export function Composer(props: ComposerProps) {
   };
   const trigger = findSkillTrigger(draft, selectionStart);
   const slashTrigger = findSlashCommandTrigger(draft, selectionStart);
+  const directoryRefTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
   const filteredSkills = useMemo(() => {
     if (!trigger) {
       return [];
@@ -3297,17 +3318,31 @@ export function Composer(props: ComposerProps) {
       );
     });
   }, [slashCommandSuggestions, slashTrigger?.query]);
+  const filteredDirectoryRefs = useMemo(() => {
+    if (!directoryRefTrigger) {
+      return [];
+    }
+
+    return filterDirectoryReferenceCandidates(
+      props.directories ?? [],
+      directoryRefTrigger.query,
+    );
+  }, [props.directories, directoryRefTrigger]);
   const availableAutocompleteKind: AutocompleteKind | undefined = trigger && filteredSkills.length > 0
     ? "skills"
     : slashTrigger && filteredSlashCommands.length > 0
       ? "slash"
-      : undefined;
+      : directoryRefTrigger && filteredDirectoryRefs.length > 0
+        ? "directories"
+        : undefined;
   const autocompleteKey =
     availableAutocompleteKind === "skills" && trigger
       ? `skills:${trigger.start}:${trigger.end}:${trigger.query}`
       : availableAutocompleteKind === "slash" && slashTrigger
         ? `slash:${slashTrigger.start}:${slashTrigger.end}:/${slashTrigger.query}`
-        : undefined;
+        : availableAutocompleteKind === "directories" && directoryRefTrigger
+          ? `directories:${directoryRefTrigger.start}:${directoryRefTrigger.end}:@${directoryRefTrigger.query}`
+          : undefined;
   const displayedAutocompleteKind =
     autocompleteKey && autocompleteKey === dismissedAutocompleteKey
       ? undefined
@@ -3317,21 +3352,51 @@ export function Composer(props: ComposerProps) {
     : displayedAutocompleteKind;
   const hasAutocomplete = Boolean(autocompleteKind);
   const activeAutocompleteIndex =
-    autocompleteKind === "skills" ? activeSkillIndex : activeSlashIndex;
+    autocompleteKind === "skills"
+      ? activeSkillIndex
+      : autocompleteKind === "directories"
+        ? activeDirectoryRefIndex
+        : activeSlashIndex;
   const autocompleteLength =
     autocompleteKind === "skills"
       ? filteredSkills.length
-      : filteredSlashCommands.length;
+      : autocompleteKind === "directories"
+        ? filteredDirectoryRefs.length
+        : filteredSlashCommands.length;
   const autocompleteListboxId =
     autocompleteKind === "skills"
       ? skillListboxId
       : autocompleteKind === "slash"
         ? slashListboxId
-        : undefined;
+        : autocompleteKind === "directories"
+          ? directoryRefListboxId
+          : undefined;
   const activeAutocompleteOptionId =
     autocompleteListboxId && autocompleteKind
       ? `${autocompleteListboxId}-option-${activeAutocompleteIndex}`
       : undefined;
+  // Directories the given text references by path (`@`-inserted, typed by
+  // hand, or pasted). The draft text is the source of truth — deleting a
+  // path from the draft drops the reference. Directories that are already
+  // linked (the launchpad's own directory; a thread's linked directories,
+  // including worktree checkouts) are excluded so send-time attach only
+  // sees new references.
+  const listDraftReferencedDirectories = (
+    text: string,
+  ): NavigationDirectorySummary[] => {
+    const excludePaths = [
+      props.directory?.path,
+      props.launchpad?.directoryPath,
+      ...(props.thread?.linkedDirectories ?? []).flatMap((linked) => [
+        linked.path,
+        linked.worktreePath,
+      ]),
+    ].filter((path): path is string => Boolean(path));
+    return listReferencedDirectories(text, props.directories ?? [], {
+      excludePaths,
+    });
+  };
+  const referencedDirectories = listDraftReferencedDirectories(canonicalDraft);
   const reviewDirectory = useMemo(
     () =>
       findReviewDirectoryForWorkspace({
@@ -3522,6 +3587,10 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     setActiveSlashIndex(0);
   }, [slashTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
+
+  useEffect(() => {
+    setActiveDirectoryRefIndex(0);
+  }, [directoryRefTrigger?.query, props.launchpad?.directoryKey, props.thread?.id]);
 
   useEffect(() => {
     if (!dismissedAutocompleteKey) {
@@ -4006,7 +4075,10 @@ export function Composer(props: ComposerProps) {
           props.launchpad.directoryKey,
           undefined,
           undefined,
-          reviewCommand.target
+          reviewCommand.target,
+          listDraftReferencedDirectories(canonicalDraft)
+            .map((directory) => directory.path)
+            .filter((path): path is string => Boolean(path))
         );
         clearSubmittedComposerDraft(submittedScopeKey);
         setReviewConfig(undefined);
@@ -4413,6 +4485,14 @@ export function Composer(props: ComposerProps) {
       } else {
         updateActiveTurnId(response.turnId);
         props.onActiveTurnIdChange?.(response.turnId);
+      }
+      const sentReferencedDirectoryPaths = listDraftReferencedDirectories(
+        queued ? queued.text : canonicalDraft,
+      )
+        .map((directory) => directory.path)
+        .filter((path): path is string => Boolean(path));
+      if (sentReferencedDirectoryPaths.length > 0) {
+        props.onAttachDirectoryReferences?.(sentReferencedDirectoryPaths);
       }
       if (queued) {
         if (!options?.queueClaimed) {
@@ -4919,7 +4999,11 @@ export function Composer(props: ComposerProps) {
         await props.onMaterializeLaunchpad(
           props.launchpad.directoryKey,
           payload.input,
-          collaborationMode
+          collaborationMode,
+          undefined,
+          listDraftReferencedDirectories(canonicalDraft)
+            .map((directory) => directory.path)
+            .filter((path): path is string => Boolean(path))
         );
         clearSubmittedComposerDraft(submittedScopeKey);
         if (collaborationMode) {
@@ -5072,6 +5156,62 @@ export function Composer(props: ComposerProps) {
 
     updateVisibleDraft(nextDraft);
     setActiveSlashIndex(0);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
+  const applyDirectoryReference = (
+    directory: NavigationDirectorySummary,
+  ): void => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
+    const refTrigger = findDirectoryReferenceTrigger(draft, selectionStart);
+    const insertText = buildDirectoryReferenceInsertText(directory);
+    if (!refTrigger || !insertText) {
+      return;
+    }
+
+    const before = draft.slice(0, refTrigger.start);
+    const after = draft.slice(Math.max(refTrigger.end, selectionEnd));
+    const needsTrailingSpace = after.length === 0 || !/^\s/.test(after);
+    const nextDraft = `${before}${insertText}${needsTrailingSpace ? " " : ""}${after}`;
+    const nextSelection =
+      before.length + insertText.length + (needsTrailingSpace ? 1 : 0);
+    const nextSkillTokens = adjustSkillTokenIndexesForTextChange({
+      currentDraft: draft,
+      nextDraft,
+      skillTokens,
+    });
+
+    // Same protected-update dance as applySkill: the editability sync in
+    // ComposerTiptapInput re-emits the editor's (still pre-insert) content
+    // through onChange before the external-value sync applies the new
+    // draft. The pending-programmatic guard in handleComposerChange
+    // swallows that stale replay so the two sides can't ping-pong.
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+      setActiveDirectoryRefIndex(0);
+    });
     requestAnimationFrame(() => {
       inputRef.current?.focus();
       inputRef.current?.setSelectionRange(nextSelection, nextSelection);
@@ -5825,6 +5965,13 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    if (autocompleteKind === "directories") {
+      applyDirectoryReference(
+        filteredDirectoryRefs[activeDirectoryRefIndex] ?? filteredDirectoryRefs[0]!,
+      );
+      return;
+    }
+
     const currentSlashText = slashTrigger
       ? `/${slashTrigger.query}`.toLowerCase()
       : undefined;
@@ -5912,6 +6059,8 @@ export function Composer(props: ComposerProps) {
     ): void => {
       if (autocompleteKind === "skills") {
         setActiveSkillIndex(updater);
+      } else if (autocompleteKind === "directories") {
+        setActiveDirectoryRefIndex(updater);
       } else {
         setActiveSlashIndex(updater);
       }
@@ -5964,6 +6113,7 @@ export function Composer(props: ComposerProps) {
       }
       setActiveSkillIndex(0);
       setActiveSlashIndex(0);
+      setActiveDirectoryRefIndex(0);
       requestAnimationFrame(() => inputRef.current?.focus());
       return;
     }
@@ -6964,6 +7114,51 @@ export function Composer(props: ComposerProps) {
               </button>
             ))}
           </div>
+        ) : autocompleteKind === "directories" ? (
+          <div
+            className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            ref={autocompleteListRef}
+            role="listbox"
+            aria-label="Directories"
+            id={directoryRefListboxId}
+            style={{ maxHeight: autocompleteLayout.maxHeight }}
+          >
+            {filteredDirectoryRefs.map((directory, index) => (
+              <button
+                key={directory.key}
+                id={`${directoryRefListboxId}-option-${index}`}
+                ref={(node) => {
+                  autocompleteOptionRefs.current[index] = node;
+                }}
+                aria-selected={index === activeDirectoryRefIndex}
+                className={`composer__autocomplete-option${index === activeDirectoryRefIndex ? " is-active" : ""}`}
+                tabIndex={index === activeDirectoryRefIndex ? 0 : -1}
+                type="button"
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  applyDirectoryReference(directory);
+                }}
+                onClick={() => {
+                  applyDirectoryReference(directory);
+                }}
+                onFocus={() => {
+                  setActiveDirectoryRefIndex(index);
+                }}
+                onKeyDown={handleAutocompleteKeyDown}
+              >
+                <span className="composer__autocomplete-title">
+                  <FolderIcon size={13} aria-hidden="true" />
+                  <HighlightedAutocompleteLabel
+                    label={directory.label}
+                    query={directoryRefTrigger?.query ?? ""}
+                  />
+                </span>
+                <span className="composer__autocomplete-meta">
+                  {buildDirectoryReferenceInsertText(directory)}
+                </span>
+              </button>
+            ))}
+          </div>
         ) : null}
       </div>
 
@@ -7148,6 +7343,19 @@ export function Composer(props: ComposerProps) {
               ) : null}
             </>
           ) : null}
+
+          {referencedDirectories.map((directory) => (
+            <span
+              key={directory.key}
+              className="composer__directory-reference tooltip-target"
+              data-tooltip={`${buildDirectoryReferenceInsertText(directory)} — linked to the thread when you send`}
+            >
+              <FolderIcon size={13} aria-hidden="true" />
+              <span className="composer__directory-reference-label">
+                {directory.label}
+              </span>
+            </span>
+          ))}
 
           {props.launchpad ? (
             <ComposerDropdown

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -8,8 +8,8 @@ import type { AppServerSkillSummary } from "@pwragent/shared";
  *   - skills (default, `kind` absent): `name`/`path` describe a skill;
  *     serializes to `[$name](path)` markdown.
  *   - directory references (`kind: "directory"`): `name` is the tracked
- *     directory's label and `path` its absolute path; serializes to the
- *     tilde-shortened path in the outgoing text.
+ *     directory's label and `path` its absolute path; serializes to
+ *     `[@label](~/path)` markdown in the outgoing text.
  */
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -3,18 +3,21 @@ import type { AppServerSkillSummary } from "@pwragent/shared";
 
 /**
  * A zero-width mention token anchored at a plain-draft character offset.
- * Despite the name (which predates the second kind), the token array
- * carries BOTH mention kinds the composer supports:
+ * Despite the name (which predates the other kinds), the token array
+ * carries ALL mention kinds the composer supports:
  *   - skills (default, `kind` absent): `name`/`path` describe a skill;
  *     serializes to `[$name](path)` markdown.
  *   - directory references (`kind: "directory"`): `name` is the tracked
  *     directory's label and `path` its absolute path; serializes to
  *     `[@label](~/path)` markdown in the outgoing text.
+ *   - file references (`kind: "file"`): `name` is the file's basename and
+ *     `path` its absolute file path; serializes to the same
+ *     `[@label](~/path)` markdown as directory references.
  */
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
-  kind?: "directory";
+  kind?: "directory" | "file";
 };
 
 export type ComposerInputChangeMetadata = {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -1,9 +1,20 @@
 import type { JSONContent } from "@tiptap/react";
 import type { AppServerSkillSummary } from "@pwragent/shared";
 
+/**
+ * A zero-width mention token anchored at a plain-draft character offset.
+ * Despite the name (which predates the second kind), the token array
+ * carries BOTH mention kinds the composer supports:
+ *   - skills (default, `kind` absent): `name`/`path` describe a skill;
+ *     serializes to `[$name](path)` markdown.
+ *   - directory references (`kind: "directory"`): `name` is the tracked
+ *     directory's label and `path` its absolute path; serializes to the
+ *     tilde-shortened path in the outgoing text.
+ */
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
+  kind?: "directory";
 };
 
 export type ComposerInputChangeMetadata = {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -21,6 +21,11 @@ import {
   repairNestedLanguageFences,
 } from "../../lib/markdown-fences";
 import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
+import {
+  buildDirectoryReferenceTooltip,
+  findDirectoryReferenceTrigger,
+} from "../../lib/directory-references";
+import { tildifyPath } from "../../lib/tildify-path";
 import type {
   ComposerInputChangeMetadata,
   ComposerInputHandle,
@@ -107,6 +112,10 @@ const SkillMention = Mention.extend({
         parseHTML: (element) =>
           element.getAttribute("data-skill-short-description"),
       },
+      kind: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-mention-kind"),
+      },
     };
   },
 }).configure({
@@ -115,6 +124,29 @@ const SkillMention = Mention.extend({
     class: "chip skill-chip composer-tiptap-input__mention",
   },
   renderHTML: ({ node }) => {
+    if (node.attrs.kind === "directory") {
+      // Directory-reference chip: `name` is the tracked directory's
+      // label, `path` its absolute path. Reuses the data-skill-* attr
+      // names so the shared parseHTML fallbacks round-trip both kinds.
+      const label = String(node.attrs.name ?? "directory");
+      const path = typeof node.attrs.path === "string" ? node.attrs.path : "";
+      const tooltip = path ? buildDirectoryReferenceTooltip(path) : "";
+      return [
+        "span",
+        {
+          class: "chip directory-chip composer-tiptap-input__mention",
+          "data-type": "mention",
+          "data-mention-kind": "directory",
+          "data-composer-skill-token-id": String(node.attrs.id ?? ""),
+          "data-id": String(node.attrs.id ?? ""),
+          "data-label": label,
+          "data-skill-name": label,
+          ...(path ? { "data-skill-path": path } : {}),
+          ...(tooltip ? { "data-tooltip": tooltip } : {}),
+        },
+        `@${label}`,
+      ];
+    }
     const skill = getSkillSummary(node.attrs);
     const tooltip = buildSkillTooltip(skill);
     return [
@@ -138,7 +170,10 @@ const SkillMention = Mention.extend({
       `$${skill.name}`,
     ];
   },
-  renderText: ({ node }) => `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
+  renderText: ({ node }) =>
+    node.attrs.kind === "directory"
+      ? tildifyPath(String(node.attrs.path ?? node.attrs.name ?? ""))
+      : `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
   suggestion: {
     char: "\uFFFF",
     items: () => [],
@@ -629,6 +664,7 @@ function buildTiptapContent(
         path: skill.path ?? null,
         description: skill.description ?? null,
         shortDescription: skill.shortDescription ?? null,
+        kind: skill.kind ?? null,
       },
     });
     cursor = index;
@@ -800,6 +836,7 @@ function mentionAttrsToSkill(
       typeof attrs.shortDescription === "string"
         ? attrs.shortDescription
         : undefined,
+    ...(attrs.kind === "directory" ? { kind: "directory" as const } : {}),
   };
 }
 
@@ -1677,6 +1714,7 @@ function getSkillMentionAttrs(skill: ComposerSkillToken): Record<string, unknown
     path: skill.path ?? null,
     description: skill.description ?? null,
     shortDescription: skill.shortDescription ?? null,
+    kind: skill.kind ?? null,
   };
 }
 
@@ -1720,9 +1758,15 @@ function applyExternalSkillInsertion(params: {
     return false;
   }
 
+  // Re-locate the autocomplete trigger the token replaced — `@` for a
+  // directory-reference chip, `$` for a skill.
+  const findTrigger =
+    insertedSkill.kind === "directory"
+      ? findDirectoryReferenceTrigger
+      : findSkillTrigger;
   const trigger =
-    findSkillTrigger(params.current.value, params.selectionIndex) ??
-    findSkillTrigger(params.current.value, params.current.value.length);
+    findTrigger(params.current.value, params.selectionIndex) ??
+    findTrigger(params.current.value, params.current.value.length);
   if (!trigger || trigger.start !== insertedSkill.index) {
     return false;
   }
@@ -2395,6 +2439,16 @@ export const ComposerTiptapInput = forwardRef<
             attribute.value,
           ]),
         );
+        if (attrs["data-mention-kind"] === "directory") {
+          const path = attrs["data-skill-path"];
+          if (path) {
+            node.setAttribute(
+              "data-tooltip",
+              buildDirectoryReferenceTooltip(path),
+            );
+          }
+          return;
+        }
         const tooltip = buildSkillTooltip(
           getSkillSummary({
             name: node.textContent?.replace(/^\$/, ""),

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1773,7 +1773,10 @@ function applyExternalSkillInsertion(params: {
 
   const before = params.current.value.slice(0, trigger.start);
   const after = params.current.value.slice(trigger.end);
-  const insertedSpace = after.length > 0 && !/^\s/.test(after);
+  // Mirrors the applier rule in Composer: a committed chip always gets
+  // one following space (even at the end of the draft) so the caret can
+  // land after it and typing never runs flush against the chip.
+  const insertedSpace = !/^\s/.test(after);
   const expectedValue = `${before}${insertedSpace ? " " : ""}${after}`;
   if (params.nextValue !== expectedValue) {
     return false;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -23,6 +23,7 @@ import {
 import { buildSkillTooltip, findSkillTrigger } from "../../lib/skill-mentions";
 import {
   buildDirectoryReferenceTooltip,
+  buildFileReferenceTooltip,
   findDirectoryReferenceTrigger,
 } from "../../lib/directory-references";
 import { tildifyPath } from "../../lib/tildify-path";
@@ -124,19 +125,28 @@ const SkillMention = Mention.extend({
     class: "chip skill-chip composer-tiptap-input__mention",
   },
   renderHTML: ({ node }) => {
-    if (node.attrs.kind === "directory") {
+    if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
       // Directory-reference chip: `name` is the tracked directory's
-      // label, `path` its absolute path. Reuses the data-skill-* attr
-      // names so the shared parseHTML fallbacks round-trip both kinds.
-      const label = String(node.attrs.name ?? "directory");
+      // label, `path` its absolute path. File-reference chips are the
+      // same shape with `name` = basename and a path-only tooltip.
+      // Reuses the data-skill-* attr names so the shared parseHTML
+      // fallbacks round-trip every kind.
+      const isFile = node.attrs.kind === "file";
+      const label = String(node.attrs.name ?? (isFile ? "file" : "directory"));
       const path = typeof node.attrs.path === "string" ? node.attrs.path : "";
-      const tooltip = path ? buildDirectoryReferenceTooltip(path) : "";
+      const tooltip = path
+        ? isFile
+          ? buildFileReferenceTooltip(path)
+          : buildDirectoryReferenceTooltip(path)
+        : "";
       return [
         "span",
         {
-          class: "chip directory-chip composer-tiptap-input__mention",
+          class: isFile
+            ? "chip file-chip composer-tiptap-input__mention"
+            : "chip directory-chip composer-tiptap-input__mention",
           "data-type": "mention",
-          "data-mention-kind": "directory",
+          "data-mention-kind": isFile ? "file" : "directory",
           "data-composer-skill-token-id": String(node.attrs.id ?? ""),
           "data-id": String(node.attrs.id ?? ""),
           "data-label": label,
@@ -171,7 +181,7 @@ const SkillMention = Mention.extend({
     ];
   },
   renderText: ({ node }) =>
-    node.attrs.kind === "directory"
+    node.attrs.kind === "directory" || node.attrs.kind === "file"
       ? tildifyPath(String(node.attrs.path ?? node.attrs.name ?? ""))
       : `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
   suggestion: {
@@ -836,7 +846,11 @@ function mentionAttrsToSkill(
       typeof attrs.shortDescription === "string"
         ? attrs.shortDescription
         : undefined,
-    ...(attrs.kind === "directory" ? { kind: "directory" as const } : {}),
+    ...(attrs.kind === "directory"
+      ? { kind: "directory" as const }
+      : attrs.kind === "file"
+        ? { kind: "file" as const }
+        : {}),
   };
 }
 
@@ -2442,12 +2456,17 @@ export const ComposerTiptapInput = forwardRef<
             attribute.value,
           ]),
         );
-        if (attrs["data-mention-kind"] === "directory") {
+        if (
+          attrs["data-mention-kind"] === "directory" ||
+          attrs["data-mention-kind"] === "file"
+        ) {
           const path = attrs["data-skill-path"];
           if (path) {
             node.setAttribute(
               "data-tooltip",
-              buildDirectoryReferenceTooltip(path),
+              attrs["data-mention-kind"] === "file"
+                ? buildFileReferenceTooltip(path)
+                : buildDirectoryReferenceTooltip(path),
             );
           }
           return;

--- a/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
@@ -1,0 +1,340 @@
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+import { FileCodeIcon, FolderIcon, SearchIcon } from "../../icons";
+import { tildifyPath } from "../../lib/tildify-path";
+
+/**
+ * Combined reference picker for the composer's setup-row "+" button.
+ *
+ * Two tabs:
+ *   - "Projects": recent tracked directories (same filter/sort as the
+ *     ProjectPicker — `latestUpdatedAt` desc, capped, pickable kinds
+ *     only). Clicking a row mints a directory-reference chip.
+ *   - "Files": recently referenced files, persisted by the main process
+ *     and loaded lazily by the parent. Clicking a row attaches the file
+ *     to the composer tray.
+ *
+ * The bottom action row is platform-aware: macOS can combine files and
+ * directories in ONE OS dialog (`onPickFromDisk`), while Windows/Linux
+ * dialogs cannot, so those platforms keep separate "Add directory…" /
+ * "Add file…" actions.
+ *
+ * The picker is a controlled popover: the parent owns the open state
+ * (its trigger button renders as `children` inside the anchor span so
+ * the outside-click handler here treats trigger clicks as inside —
+ * otherwise a pointerdown-close followed by the trigger's click-toggle
+ * would immediately reopen it). Escape and outside clicks call
+ * `onClose`; the parent also closes before opening any OS dialog.
+ */
+export type ReferencePickerFile = {
+  label: string;
+  path: string;
+};
+
+export type ReferencePickerProps = {
+  /** Whether the popover is open. The trigger child always renders. */
+  open: boolean;
+  onClose: () => void;
+  /** The trigger button — rendered inside the anchor span. */
+  children?: ReactNode;
+  /** All tracked directories from the navigation snapshot. */
+  directories: NavigationDirectorySummary[];
+  /** Recently referenced files, most-recent-first (loaded by parent). */
+  recentFiles: ReferencePickerFile[];
+  /** `process.platform` from the desktop bridge ("darwin", "win32", …). */
+  platform?: string;
+  onSelectDirectory: (directory: { label: string; path: string }) => void;
+  onSelectFile: (path: string) => void;
+  /** macOS-only combined file-or-directory OS dialog. */
+  onPickFromDisk?: () => void;
+  /** Separate OS dialogs for platforms without a combined dialog. */
+  onPickDirectoryFromDisk?: () => void;
+  onPickFileFromDisk?: () => void;
+};
+
+const RECENTS_LIMIT = 10;
+
+type ReferencePickerTab = "projects" | "files";
+
+function formatDirectoryLabel(directory: NavigationDirectorySummary): string {
+  return (
+    directory.label
+    || (directory.path ? tildifyPath(directory.path) : directory.key)
+  );
+}
+
+function isPickableDirectory(directory: NavigationDirectorySummary): boolean {
+  // Mirror ProjectPicker: the "unlinked" pseudo-directory isn't a folder
+  // the user picked. A reference chip also needs a real path.
+  return directory.kind !== "unlinked" && Boolean(directory.path);
+}
+
+export function ReferencePicker(props: ReferencePickerProps): ReactElement {
+  const [tab, setTab] = useState<ReferencePickerTab>("projects");
+  const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const panelId = useId();
+
+  useEffect(() => {
+    if (!props.open) {
+      return;
+    }
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        props.onClose();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        props.onClose();
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [props.open, props.onClose]);
+
+  const trimmedQuery = query.trim().toLowerCase();
+
+  const sortedDirectories = useMemo(() => {
+    const pickable = props.directories.filter(isPickableDirectory);
+    const ordered = [...pickable].sort(
+      (left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0),
+    );
+    const top = ordered.slice(0, RECENTS_LIMIT);
+    if (!trimmedQuery) {
+      return top;
+    }
+    return top.filter((directory) => {
+      const label = formatDirectoryLabel(directory).toLowerCase();
+      const path = (directory.path ?? "").toLowerCase();
+      return label.includes(trimmedQuery) || path.includes(trimmedQuery);
+    });
+  }, [props.directories, trimmedQuery]);
+
+  const filteredFiles = useMemo(() => {
+    if (!trimmedQuery) {
+      return props.recentFiles;
+    }
+    return props.recentFiles.filter(
+      (file) =>
+        file.label.toLowerCase().includes(trimmedQuery)
+        || file.path.toLowerCase().includes(trimmedQuery),
+    );
+  }, [props.recentFiles, trimmedQuery]);
+
+  const useCombinedPicker =
+    props.platform === "darwin" && Boolean(props.onPickFromDisk);
+
+  return (
+    <span
+      ref={containerRef}
+      className="reference-picker"
+      data-state={props.open ? "open" : "closed"}
+    >
+      {props.children}
+
+      {props.open ? (
+        <div
+          className="reference-picker__pop"
+          role="dialog"
+          aria-label="Add reference"
+        >
+          <div
+            className="reference-picker__tabs"
+            role="tablist"
+            aria-label="Reference kinds"
+          >
+            <button
+              type="button"
+              role="tab"
+              id={`${panelId}-tab-projects`}
+              aria-selected={tab === "projects"}
+              aria-controls={`${panelId}-panel-projects`}
+              className={`reference-picker__tab${
+                tab === "projects" ? " is-active" : ""
+              }`}
+              onClick={() => setTab("projects")}
+            >
+              Projects
+            </button>
+            <button
+              type="button"
+              role="tab"
+              id={`${panelId}-tab-files`}
+              aria-selected={tab === "files"}
+              aria-controls={`${panelId}-panel-files`}
+              className={`reference-picker__tab${
+                tab === "files" ? " is-active" : ""
+              }`}
+              onClick={() => setTab("files")}
+            >
+              Files
+            </button>
+          </div>
+
+          <div className="reference-picker__search">
+            <span aria-hidden="true" className="reference-picker__search-icon">
+              <SearchIcon size={13} />
+            </span>
+            <input
+              type="text"
+              autoFocus
+              placeholder={
+                tab === "projects" ? "Find a directory" : "Find a file"
+              }
+              className="reference-picker__search-input"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+
+          {tab === "projects" ? (
+            <ul
+              className="reference-picker__list"
+              id={`${panelId}-panel-projects`}
+              role="listbox"
+              aria-labelledby={`${panelId}-tab-projects`}
+            >
+              {sortedDirectories.length === 0 ? (
+                <li className="reference-picker__empty">
+                  {trimmedQuery ? "No matches." : "No tracked directories yet."}
+                </li>
+              ) : (
+                sortedDirectories.map((directory) => (
+                  <li key={directory.key}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      className="reference-picker__row"
+                      onClick={() => {
+                        if (!directory.path) {
+                          return;
+                        }
+                        props.onSelectDirectory({
+                          label: formatDirectoryLabel(directory),
+                          path: directory.path,
+                        });
+                      }}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="reference-picker__row-icon"
+                      >
+                        <FolderIcon size={13} />
+                      </span>
+                      <span className="reference-picker__row-name">
+                        {formatDirectoryLabel(directory)}
+                      </span>
+                      <span className="reference-picker__row-path">
+                        {directory.path ? tildifyPath(directory.path) : "—"}
+                      </span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          ) : (
+            <ul
+              className="reference-picker__list"
+              id={`${panelId}-panel-files`}
+              role="listbox"
+              aria-labelledby={`${panelId}-tab-files`}
+            >
+              {filteredFiles.length === 0 ? (
+                <li className="reference-picker__empty">
+                  {trimmedQuery
+                    ? "No matches."
+                    : "No recent files. Drop files on the composer or add one below."}
+                </li>
+              ) : (
+                filteredFiles.map((file) => (
+                  <li key={file.path}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      className="reference-picker__row"
+                      onClick={() => props.onSelectFile(file.path)}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="reference-picker__row-icon"
+                      >
+                        <FileCodeIcon size={13} />
+                      </span>
+                      <span className="reference-picker__row-name">
+                        {file.label}
+                      </span>
+                      <span className="reference-picker__row-path">
+                        {tildifyPath(file.path)}
+                      </span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          )}
+
+          <div className="reference-picker__separator" />
+
+          {useCombinedPicker ? (
+            <button
+              type="button"
+              className="reference-picker__row reference-picker__row--action"
+              onClick={() => props.onPickFromDisk?.()}
+            >
+              <span aria-hidden="true" className="reference-picker__plus">
+                +
+              </span>
+              <span className="reference-picker__row-name">
+                Add file or directory…
+              </span>
+            </button>
+          ) : (
+            <>
+              {props.onPickDirectoryFromDisk ? (
+                <button
+                  type="button"
+                  className="reference-picker__row reference-picker__row--action"
+                  onClick={() => props.onPickDirectoryFromDisk?.()}
+                >
+                  <span aria-hidden="true" className="reference-picker__plus">
+                    +
+                  </span>
+                  <span className="reference-picker__row-name">
+                    Add directory…
+                  </span>
+                </button>
+              ) : null}
+              {props.onPickFileFromDisk ? (
+                <button
+                  type="button"
+                  className="reference-picker__row reference-picker__row--action"
+                  onClick={() => props.onPickFileFromDisk?.()}
+                >
+                  <span aria-hidden="true" className="reference-picker__plus">
+                    +
+                  </span>
+                  <span className="reference-picker__row-name">Add file…</span>
+                </button>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
@@ -1,0 +1,231 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ReferencePicker,
+  type ReferencePickerProps,
+} from "../ReferencePicker";
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as { __pwragentHomeDir?: unknown }).__pwragentHomeDir;
+});
+
+const dirA: NavigationDirectorySummary = {
+  key: "directory:/Users/me/code/PwrAgent",
+  kind: "directory",
+  label: "PwrAgent",
+  path: "/Users/me/code/PwrAgent",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 1_000,
+};
+
+const dirB: NavigationDirectorySummary = {
+  key: "directory:/Users/me/code/PwrSnap",
+  kind: "directory",
+  label: "PwrSnap",
+  path: "/Users/me/code/PwrSnap",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 2_000,
+};
+
+const unlinked: NavigationDirectorySummary = {
+  key: "unlinked",
+  kind: "unlinked",
+  label: "No linked directory",
+  threadKeys: [],
+  needsAttentionCount: 0,
+};
+
+const recentFiles = [
+  { label: "spec.md", path: "/Users/me/notes/spec.md" },
+  { label: "todo.txt", path: "/Users/me/notes/todo.txt" },
+];
+
+function renderPicker(
+  overrides: Partial<ReferencePickerProps> = {},
+): ReturnType<typeof render> {
+  const props: ReferencePickerProps = {
+    open: true,
+    onClose: () => undefined,
+    directories: [],
+    recentFiles: [],
+    onSelectDirectory: () => undefined,
+    onSelectFile: () => undefined,
+    ...overrides,
+  };
+  return render(<ReferencePicker {...props} />);
+}
+
+describe("ReferencePicker", () => {
+  it("opens on the Projects tab with recent directories sorted by latestUpdatedAt desc", () => {
+    renderPicker({ directories: [dirA, dirB, unlinked] });
+
+    expect(
+      screen.getByRole("dialog", { name: "Add reference" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Projects" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+
+    const rows = screen.getAllByRole("option");
+    // The "unlinked" pseudo-directory is filtered out.
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("PwrSnap");
+    expect(rows[1]).toHaveTextContent("PwrAgent");
+  });
+
+  it("switches to the Files tab and lists recent files with tilde paths", () => {
+    (window as unknown as { __pwragentHomeDir?: unknown }).__pwragentHomeDir =
+      "/Users/me";
+    renderPicker({ directories: [dirA], recentFiles });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+
+    expect(screen.getByRole("tab", { name: "Files" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    const rows = screen.getAllByRole("option");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("spec.md");
+    expect(rows[0]).toHaveTextContent("~/notes/spec.md");
+    expect(rows[1]).toHaveTextContent("todo.txt");
+    // The projects list is replaced, not stacked.
+    expect(screen.queryByText("PwrAgent")).not.toBeInTheDocument();
+  });
+
+  it("invokes onSelectDirectory with the row's label and path", () => {
+    const onSelectDirectory = vi.fn();
+    renderPicker({ directories: [dirA], onSelectDirectory });
+
+    fireEvent.click(screen.getByRole("option", { name: /pwragent/i }));
+
+    expect(onSelectDirectory).toHaveBeenCalledExactlyOnceWith({
+      label: "PwrAgent",
+      path: "/Users/me/code/PwrAgent",
+    });
+  });
+
+  it("invokes onSelectFile with the row's path", () => {
+    const onSelectFile = vi.fn();
+    renderPicker({ recentFiles, onSelectFile });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    fireEvent.click(screen.getByRole("option", { name: /spec\.md/i }));
+
+    expect(onSelectFile).toHaveBeenCalledExactlyOnceWith(
+      "/Users/me/notes/spec.md",
+    );
+  });
+
+  it("shows the empty Files state copy when there are no recent files", () => {
+    renderPicker({ recentFiles: [] });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+
+    expect(
+      screen.getByText(
+        "No recent files. Drop files on the composer or add one below.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("filters the active tab by the search query", () => {
+    renderPicker({ directories: [dirA, dirB], recentFiles });
+
+    fireEvent.change(screen.getByPlaceholderText("Find a directory"), {
+      target: { value: "snap" },
+    });
+    let rows = screen.getAllByRole("option");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("PwrSnap");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Files" }));
+    fireEvent.change(screen.getByPlaceholderText("Find a file"), {
+      target: { value: "todo" },
+    });
+    rows = screen.getAllByRole("option");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent("todo.txt");
+  });
+
+  it("renders ONE combined add row on darwin", () => {
+    const onPickFromDisk = vi.fn();
+    renderPicker({
+      platform: "darwin",
+      onPickFromDisk,
+      onPickDirectoryFromDisk: () => undefined,
+      onPickFileFromDisk: () => undefined,
+    });
+
+    const combined = screen.getByRole("button", {
+      name: "Add file or directory…",
+    });
+    expect(
+      screen.queryByRole("button", { name: "Add directory…" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add file…" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(combined);
+    expect(onPickFromDisk).toHaveBeenCalledOnce();
+  });
+
+  it("renders separate directory/file add rows off-macOS", () => {
+    const onPickDirectoryFromDisk = vi.fn();
+    const onPickFileFromDisk = vi.fn();
+    renderPicker({
+      platform: "linux",
+      onPickFromDisk: () => undefined,
+      onPickDirectoryFromDisk,
+      onPickFileFromDisk,
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Add file or directory…" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add directory…" }));
+    expect(onPickDirectoryFromDisk).toHaveBeenCalledOnce();
+    fireEvent.click(screen.getByRole("button", { name: "Add file…" }));
+    expect(onPickFileFromDisk).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing but the trigger child when closed", () => {
+    renderPicker({
+      open: false,
+      children: <button type="button">Add reference</button>,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Add reference" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Add reference" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9495,9 +9495,10 @@ describe("Composer", () => {
       await waitFor(() => {
         expect(startTurn).toHaveBeenCalled();
       });
-      expect(onAttachDirectoryReferences).toHaveBeenCalledWith([
-        "/Users/huntharo/GIPHY/search-product",
-      ]);
+      expect(onAttachDirectoryReferences).toHaveBeenCalledWith(
+        ["/Users/huntharo/GIPHY/search-product"],
+        { backend: "codex", threadId: "thread-1" },
+      );
     } finally {
       delete (window as unknown as { __pwragentHomeDir?: string })
         .__pwragentHomeDir;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9420,13 +9420,21 @@ describe("Composer", () => {
       );
 
       // The commit mints a zero-width chip: the plain draft keeps only
-      // the surrounding text, the editor shows an @label mention chip,
-      // and the serialized draft (asserted on materialize below) carries
-      // the tilde path.
+      // the surrounding text plus the guaranteed post-chip space, the
+      // editor shows an @label mention chip, and the serialized draft
+      // (asserted on materialize below) carries the markdown link.
       await waitFor(() => {
         expect(screen.getByLabelText("New thread")).toHaveValue(
-          "Read SEARCH-4803 in "
+          "Read SEARCH-4803 in  "
         );
+      });
+      // Caret parks after the guaranteed post-chip space (set in a
+      // requestAnimationFrame after the commit).
+      await waitFor(() => {
+        expect(
+          (screen.getByLabelText("New thread") as HTMLInputElement)
+            .selectionStart
+        ).toBe("Read SEARCH-4803 in  ".length);
       });
       const richInput = screen.getByTestId("composer-tiptap-input");
       const chip = within(richInput).getByText("@search-product");
@@ -10058,7 +10066,9 @@ describe("Composer", () => {
     expect(screen.getByRole("listbox", { name: "Skills" })).toBeInTheDocument();
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(textarea).toHaveValue("Use ");
+    // The commit always leaves one space after the chip (the second
+    // space here; the first is the one typed before the trigger).
+    expect(textarea).toHaveValue("Use  ");
     expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
 
     await clickButton("Send");
@@ -10187,7 +10197,7 @@ describe("Composer", () => {
 
     const richInput = screen.getByTestId("composer-tiptap-input");
     expect(within(richInput).getByText("$ce:plan")).toBeInTheDocument();
-    expect((input as HTMLInputElement).value).toMatch(/Let's use $/);
+    expect((input as HTMLInputElement).value).toMatch(/Let's use {2}$/);
     expect(richInput).toHaveTextContent("Let's use");
     expect(richInput).not.toHaveTextContent("Let's use $ce:plan plan");
 
@@ -10804,7 +10814,7 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     expect(within(screen.getByTestId("composer-tiptap-input")).getByText("$ce:plan")).toBeInTheDocument();
-    expect(textarea).toHaveValue("Use ");
+    expect(textarea).toHaveValue("Use  ");
 
     await clickButton("Send");
 
@@ -11627,7 +11637,7 @@ describe("Composer", () => {
     fireEvent.keyDown(option, { key: "Enter" });
 
     expect(within(screen.getByTestId("composer-tiptap-input")).getByText("$ce:plan")).toBeInTheDocument();
-    expect(screen.getByLabelText("Reply")).toHaveValue("");
+    expect(screen.getByLabelText("Reply")).toHaveValue(" ");
     expect(screen.queryByRole("listbox", { name: "Skills" })).not.toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9444,10 +9444,89 @@ describe("Composer", () => {
       await waitFor(() => {
         expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
           "directory:/repo",
-          [{ type: "text", text: "Read SEARCH-4803 in ~/GIPHY/search-product" }],
+          [
+            {
+              type: "text",
+              text: "Read SEARCH-4803 in [@search-product](~/GIPHY/search-product)",
+            },
+          ],
           undefined,
           undefined,
           ["/Users/huntharo/GIPHY/search-product"]
+        );
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("rebuilds a directory chip from a prompt-only launchpad restore", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        // Serialized canonical prompt only — no editorDocument, as after
+        // an app restart that dropped the rich document.
+        prompt: "check [@agent-kit](~/pwrdrvr/agent-kit) please",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={{
+            key: "directory:/repo",
+            kind: "directory",
+            label: "Repo",
+            path: "/repo",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          }}
+          directories={[]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={onMaterializeLaunchpad}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(within(richInput).getByText("@agent-kit")).toBeInTheDocument();
+      });
+      expect(within(richInput).getByText("@agent-kit")).toHaveAttribute(
+        "data-skill-path",
+        "/Users/huntharo/pwrdrvr/agent-kit"
+      );
+
+      await clickButton("Start thread");
+
+      // The token alone drives the attach — `directories` is empty, so
+      // the text scan cannot resolve this path against a tracked entry.
+      await waitFor(() => {
+        expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+          "directory:/repo",
+          [
+            {
+              type: "text",
+              text: "check [@agent-kit](~/pwrdrvr/agent-kit) please",
+            },
+          ],
+          undefined,
+          undefined,
+          ["/Users/huntharo/pwrdrvr/agent-kit"]
         );
       });
     } finally {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9419,11 +9419,22 @@ describe("Composer", () => {
         within(listbox).getByRole("button", { name: /search-product/ })
       );
 
+      // The commit mints a zero-width chip: the plain draft keeps only
+      // the surrounding text, the editor shows an @label mention chip,
+      // and the serialized draft (asserted on materialize below) carries
+      // the tilde path.
       await waitFor(() => {
         expect(screen.getByLabelText("New thread")).toHaveValue(
-          "Read SEARCH-4803 in ~/GIPHY/search-product "
+          "Read SEARCH-4803 in "
         );
       });
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      const chip = within(richInput).getByText("@search-product");
+      expect(chip).toHaveAttribute("data-mention-kind", "directory");
+      expect(chip).toHaveAttribute(
+        "data-skill-path",
+        "/Users/huntharo/GIPHY/search-product"
+      );
       expect(
         screen.queryByRole("listbox", { name: "Directories" })
       ).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9504,6 +9504,55 @@ describe("Composer", () => {
     }
   });
 
+  it("commits a provider slash command insert without looping the draft", async () => {
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(),
+        }}
+        disabled={false}
+        providerCommands={[
+          {
+            name: "deployaudit",
+            description: "Audit the most recent deploy.",
+            backend: "codex",
+            scope: "backend",
+            source: "provider",
+          },
+        ]}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Deploy audit",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const input = screen.getByLabelText("Reply");
+    fireEvent.change(input, { target: { value: "/deploy" } });
+    expect(
+      within(screen.getByRole("listbox", { name: "Commands" })).getByRole(
+        "button",
+        { name: /\/deployaudit/i },
+      ),
+    ).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(input).toHaveValue("/deployaudit ");
+    });
+    expect(
+      screen.queryByRole("listbox", { name: "Commands" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not restore a submitted launchpad draft when materialization unmounts before local clear", async () => {
     const draftStore = createComposerDraftStore();
     const launchpad: NavigationLaunchpadDraft = {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9360,6 +9360,150 @@ describe("Composer", () => {
     });
   });
 
+  it("inserts a tilde path from the @ directory autocomplete and links it on start", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const repoDirectory: NavigationDirectorySummary = {
+        key: "directory:/repo",
+        kind: "directory",
+        label: "Repo",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 20,
+      };
+      const searchProductDirectory: NavigationDirectorySummary = {
+        key: "directory:/Users/huntharo/GIPHY/search-product",
+        kind: "directory",
+        label: "search-product",
+        path: "/Users/huntharo/GIPHY/search-product",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 10,
+      };
+      const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={repoDirectory}
+          directories={[repoDirectory, searchProductDirectory]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={onMaterializeLaunchpad}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("New thread"), {
+        target: { value: "Read SEARCH-4803 in @search" },
+      });
+
+      const listbox = screen.getByRole("listbox", { name: "Directories" });
+      fireEvent.click(
+        within(listbox).getByRole("button", { name: /search-product/ })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("New thread")).toHaveValue(
+          "Read SEARCH-4803 in ~/GIPHY/search-product "
+        );
+      });
+      expect(
+        screen.queryByRole("listbox", { name: "Directories" })
+      ).not.toBeInTheDocument();
+
+      await clickButton("Start thread");
+
+      await waitFor(() => {
+        expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+          "directory:/repo",
+          [{ type: "text", text: "Read SEARCH-4803 in ~/GIPHY/search-product" }],
+          undefined,
+          undefined,
+          ["/Users/huntharo/GIPHY/search-product"]
+        );
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("links a hand-typed directory reference after sending a reply", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+      const onAttachDirectoryReferences = vi.fn();
+      const searchProductDirectory: NavigationDirectorySummary = {
+        key: "directory:/Users/huntharo/GIPHY/search-product",
+        kind: "directory",
+        label: "search-product",
+        path: "/Users/huntharo/GIPHY/search-product",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 10,
+      };
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            startTurn,
+          }}
+          directories={[searchProductDirectory]}
+          disabled={false}
+          skills={[]}
+          onAttachDirectoryReferences={onAttachDirectoryReferences}
+          thread={{
+            id: "thread-1",
+            title: "Search cleanup",
+            titleSource: "explicit",
+            source: "codex",
+            executionMode: "default",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("Reply"), {
+        target: { value: "It might be in ~/GIPHY/search-product." },
+      });
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalled();
+      });
+      expect(onAttachDirectoryReferences).toHaveBeenCalledWith([
+        "/Users/huntharo/GIPHY/search-product",
+      ]);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("does not restore a submitted launchpad draft when materialization unmounts before local clear", async () => {
     const draftStore = createComposerDraftStore();
     const launchpad: NavigationLaunchpadDraft = {
@@ -9409,7 +9553,9 @@ describe("Composer", () => {
       expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
         "directory:/repo",
         [{ type: "text", text: "Submitted launchpad should not come back" }],
-        undefined
+        undefined,
+        undefined,
+        []
       );
     });
 
@@ -9484,7 +9630,8 @@ describe("Composer", () => {
         "directory:/repo",
         undefined,
         undefined,
-        { type: "baseBranch", branch: "main" }
+        { type: "baseBranch", branch: "main" },
+        []
       );
     });
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2484,18 +2484,21 @@ describe("Composer", () => {
         id: "queued-1",
         text: "First duplicate-owned turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "First duplicate-owned turn" }],
       },
       {
         id: "queued-2",
         text: "Second duplicate-owned turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Second duplicate-owned turn" }],
       },
       {
         id: "queued-3",
         text: "Third duplicate-owned turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Third duplicate-owned turn" }],
       },
     ]);
@@ -2543,6 +2546,7 @@ describe("Composer", () => {
         id: "queued-review",
         text: "/review main",
         imageAttachments: [],
+        fileAttachments: [],
         reviewCommand: {
           displayText: "Review changes against main",
           target: { type: "baseBranch", branch: "main" },
@@ -2552,6 +2556,7 @@ describe("Composer", () => {
         id: "queued-turn",
         text: "Run after failed review",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Run after failed review" }],
       },
     ]);
@@ -4444,6 +4449,7 @@ describe("Composer", () => {
         id: "queued-later",
         text: "Later scheduled turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Later scheduled turn" }],
         scheduledSendAt: Date.now() + 2 * 60 * 60_000,
       },
@@ -4451,6 +4457,7 @@ describe("Composer", () => {
         id: "queued-sooner",
         text: "Sooner scheduled turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Sooner scheduled turn" }],
         scheduledSendAt: Date.now() + 15 * 60_000,
       },
@@ -9603,6 +9610,235 @@ describe("Composer", () => {
     }
   });
 
+  it("mints file chips from the @ popover's Add file… action", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const repoDirectory: NavigationDirectorySummary = {
+        key: "directory:/repo",
+        kind: "directory",
+        label: "Repo",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 20,
+      };
+      const pickFileFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        paths: ["/Users/huntharo/notes/spec.md"],
+      }));
+      const onMaterializeLaunchpad = vi.fn(
+        async (..._args: unknown[]) => undefined,
+      );
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            pickFileFromDisk,
+          }}
+          directory={repoDirectory}
+          directories={[repoDirectory]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={onMaterializeLaunchpad}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("New thread"), {
+        target: { value: "Check @" },
+      });
+
+      const listbox = screen.getByRole("listbox", { name: "Directories" });
+      // Only the file action renders — this composer has no
+      // onPickDirectoryForReference, so the directory action is hidden.
+      expect(
+        within(listbox).queryByRole("button", { name: "+ Add directory…" })
+      ).not.toBeInTheDocument();
+      expect(
+        within(listbox).getByRole("button", { name: "+ Add file…" })
+      ).toBeInTheDocument();
+      await clickButton("+ Add file…");
+
+      expect(pickFileFromDisk).toHaveBeenCalledOnce();
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(within(richInput).getByText("@spec.md")).toBeInTheDocument();
+      });
+      const chip = within(richInput).getByText("@spec.md");
+      expect(chip).toHaveAttribute("data-mention-kind", "file");
+      expect(chip).toHaveAttribute(
+        "data-skill-path",
+        "/Users/huntharo/notes/spec.md"
+      );
+      expect(
+        screen.queryByRole("listbox", { name: "Directories" })
+      ).not.toBeInTheDocument();
+
+      await clickButton("Start thread");
+
+      await waitFor(() => {
+        expect(onMaterializeLaunchpad).toHaveBeenCalled();
+      });
+      const materializedInput = onMaterializeLaunchpad.mock
+        .calls[0][1] as unknown as { type: string; text: string }[];
+      expect(materializedInput).toEqual([
+        {
+          type: "text",
+          text: "Check [@spec.md](~/notes/spec.md)",
+        },
+      ]);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("mints a directory chip from the @ popover's Add directory… action", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const repoDirectory: NavigationDirectorySummary = {
+        key: "directory:/repo",
+        kind: "directory",
+        label: "Repo",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 20,
+      };
+      const onPickDirectoryForReference = vi.fn(async () => ({
+        label: "agent-kit",
+        path: "/Users/huntharo/pwrdrvr/agent-kit",
+      }));
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={repoDirectory}
+          directories={[repoDirectory]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={async () => undefined}
+          onPickDirectoryForReference={onPickDirectoryForReference}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      fireEvent.change(screen.getByLabelText("New thread"), {
+        target: { value: "Look in @" },
+      });
+
+      screen.getByRole("listbox", { name: "Directories" });
+      await clickButton("+ Add directory…");
+
+      expect(onPickDirectoryForReference).toHaveBeenCalledOnce();
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(within(richInput).getByText("@agent-kit")).toBeInTheDocument();
+      });
+      const chip = within(richInput).getByText("@agent-kit");
+      expect(chip).toHaveAttribute("data-mention-kind", "directory");
+      expect(chip).toHaveAttribute(
+        "data-skill-path",
+        "/Users/huntharo/pwrdrvr/agent-kit"
+      );
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("attaches picked files to the tray from the + Add reference menu", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pickFileFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        paths: ["/Users/huntharo/notes/spec.md"],
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            pickFileFromDisk,
+          }}
+          disabled={false}
+          skills={[]}
+          onPickDirectoryForReference={async () => undefined}
+          thread={{
+            id: "thread-1",
+            title: "Build Codex client",
+            titleSource: "explicit",
+            source: "codex",
+            executionMode: "default",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      await clickButton("Add reference");
+
+      const menu = screen.getByRole("menu");
+      expect(
+        within(menu).getByRole("menuitem", { name: "Add directory…" })
+      ).toBeInTheDocument();
+      await act(async () => {
+        fireEvent.click(
+          within(menu).getByRole("menuitem", { name: "Add file…" })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(pickFileFromDisk).toHaveBeenCalledOnce();
+      // The pick lands in the attachment tray as a pill, not as an
+      // editor chip, and the menu closes.
+      expect(await screen.findByText("spec.md")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove spec.md" })
+      ).toBeInTheDocument();
+      expect(screen.queryByText("@spec.md")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("commits a provider slash command insert without looping the draft", async () => {
     render(
       <Composer
@@ -11556,6 +11792,183 @@ describe("Composer", () => {
     });
   });
 
+  it("attaches a dropped non-image file as a path-only reference and appends it to the sent text", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+      const notesFile = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            getPathForFile: (file: File) => `/Users/huntharo/notes/${file.name}`,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Build Codex client",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      const textarea = screen.getByLabelText("Reply");
+      fireEvent.change(textarea, { target: { value: "Look at this" } });
+      fireEvent.drop(textarea, {
+        dataTransfer: {
+          files: [],
+          items: [
+            { kind: "file", type: "text/plain", getAsFile: () => notesFile },
+          ],
+        },
+      });
+
+      expect(await screen.findByText("notes.txt")).toBeInTheDocument();
+      expect(normalizeImageFile).not.toHaveBeenCalled();
+
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              {
+                type: "text",
+                text: "Look at this\n\n[@notes.txt](~/notes/notes.txt)",
+              },
+            ],
+          })
+        );
+      });
+      // The submitted draft clears, and the file pill clears with it.
+      await waitFor(() =>
+        expect(screen.queryByText("notes.txt")).not.toBeInTheDocument()
+      );
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("sends a files-only draft as just the reference block", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+      const notesFile = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            getPathForFile: (file: File) => `/Users/huntharo/notes/${file.name}`,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Build Codex client",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      fireEvent.drop(screen.getByLabelText("Reply"), {
+        dataTransfer: {
+          files: [],
+          items: [
+            { kind: "file", type: "text/plain", getAsFile: () => notesFile },
+          ],
+        },
+      });
+
+      expect(await screen.findByText("notes.txt")).toBeInTheDocument();
+
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              { type: "text", text: "[@notes.txt](~/notes/notes.txt)" },
+            ],
+          })
+        );
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("removes a file attachment via its pill remove button", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const notesFile = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            getPathForFile: (file: File) => `/Users/huntharo/notes/${file.name}`,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Build Codex client",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      fireEvent.drop(screen.getByLabelText("Reply"), {
+        dataTransfer: {
+          files: [],
+          items: [
+            { kind: "file", type: "text/plain", getAsFile: () => notesFile },
+          ],
+        },
+      });
+
+      expect(await screen.findByText("notes.txt")).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Remove notes.txt" })
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByText("notes.txt")).not.toBeInTheDocument()
+      );
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("keeps Shift+Enter available for a newline", () => {
     const startTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -12073,12 +12486,14 @@ describe("Composer", () => {
         id: "queued-1",
         text: "First queued stale turn",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "First queued stale turn" }],
       },
       {
         id: "queued-2",
         text: "Second queued follow-up",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Second queued follow-up" }],
       },
     ]);

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9809,15 +9809,26 @@ describe("Composer", () => {
         />
       );
 
+      // While closed, the trigger carries the CSS tooltip.
+      expect(
+        screen.getByRole("button", { name: "Add reference" })
+      ).toHaveAttribute("data-tooltip", "Reference a directory or file");
+
       await clickButton("Add reference");
 
-      const menu = screen.getByRole("menu");
+      const dialog = screen.getByRole("dialog", { name: "Add reference" });
+      // The tooltip is omitted while the popover is open so the
+      // pseudo-element can't linger over the panel.
       expect(
-        within(menu).getByRole("menuitem", { name: "Add directory…" })
+        screen.getByRole("button", { name: "Add reference" })
+      ).not.toHaveAttribute("data-tooltip");
+      // No platform reported → separate add rows (non-macOS behavior).
+      expect(
+        within(dialog).getByRole("button", { name: "Add directory…" })
       ).toBeInTheDocument();
       await act(async () => {
         fireEvent.click(
-          within(menu).getByRole("menuitem", { name: "Add file…" })
+          within(dialog).getByRole("button", { name: "Add file…" })
         );
         await Promise.resolve();
         await Promise.resolve();
@@ -9826,13 +9837,246 @@ describe("Composer", () => {
 
       expect(pickFileFromDisk).toHaveBeenCalledOnce();
       // The pick lands in the attachment tray as a pill, not as an
-      // editor chip, and the menu closes.
+      // editor chip, and the picker closes.
       expect(await screen.findByText("spec.md")).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Remove spec.md" })
       ).toBeInTheDocument();
       expect(screen.queryByText("@spec.md")).not.toBeInTheDocument();
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("dialog", { name: "Add reference" })
+      ).not.toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("attaches a recent file to the tray from the reference picker's Files tab", async () => {
+    const listRecentFileReferences = vi.fn(async () => ({
+      files: [
+        { label: "notes.md", path: "/Users/huntharo/notes/notes.md" },
+        { label: "todo.txt", path: "/Users/huntharo/notes/todo.txt" },
+      ],
+    }));
+    const recordRecentFileReferences = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          listRecentFileReferences,
+          recordRecentFileReferences,
+          pickFileFromDisk: vi.fn(async () => ({ canceled: true as const })),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    await clickButton("Add reference");
+
+    expect(listRecentFileReferences).toHaveBeenCalledOnce();
+    const dialog = screen.getByRole("dialog", { name: "Add reference" });
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("tab", { name: "Files" }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(
+        within(dialog).getByRole("option", { name: /notes\.md/ })
+      );
+      await Promise.resolve();
+    });
+
+    // The recent file lands in the attachment tray as a pill and the
+    // picker closes; committing it re-records the reference.
+    expect(await screen.findByText("notes.md")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove notes.md" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Add reference" })
+    ).not.toBeInTheDocument();
+    expect(recordRecentFileReferences).toHaveBeenCalledWith({
+      paths: ["/Users/huntharo/notes/notes.md"],
+    });
+  });
+
+  it("mints a directory chip from the reference picker's Projects tab", async () => {
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const repoDirectory: NavigationDirectorySummary = {
+      key: "directory:/repo",
+      kind: "directory",
+      label: "Repo",
+      path: "/repo",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      latestUpdatedAt: 20,
+    };
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          pickFileFromDisk: vi.fn(async () => ({ canceled: true as const })),
+        }}
+        directory={repoDirectory}
+        directories={[repoDirectory]}
+        draftStore={createComposerDraftStore()}
+        launchpad={launchpad}
+        onMaterializeLaunchpad={async () => undefined}
+        onPickDirectoryForReference={async () => undefined}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    await clickButton("Add reference");
+
+    const dialog = screen.getByRole("dialog", { name: "Add reference" });
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("option", { name: /Repo/ }));
+      await Promise.resolve();
+    });
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    await waitFor(() => {
+      expect(within(richInput).getByText("@Repo")).toBeInTheDocument();
+    });
+    const chip = within(richInput).getByText("@Repo");
+    expect(chip).toHaveAttribute("data-mention-kind", "directory");
+    expect(chip).toHaveAttribute("data-skill-path", "/repo");
+    expect(
+      screen.queryByRole("dialog", { name: "Add reference" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("routes the combined macOS picker's entries to tray pills and directory chips", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const repoDirectory: NavigationDirectorySummary = {
+        key: "directory:/repo",
+        kind: "directory",
+        label: "Repo",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 20,
+      };
+      const pickReferenceFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        entries: [
+          {
+            path: "/Users/huntharo/notes/spec.md",
+            kind: "file" as const,
+          },
+          {
+            path: "/Users/huntharo/pwrdrvr/agent-kit",
+            kind: "directory" as const,
+          },
+        ],
+      }));
+      // Registration failures are non-fatal — the chip mints anyway and
+      // the send-time attach re-registers.
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: false as const,
+        reason: "not-a-git-repo" as const,
+        message: "That folder isn't a git repository.",
+      }));
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            platform: "darwin",
+            pickFileFromDisk: vi.fn(async () => ({ canceled: true as const })),
+            pickReferenceFromDisk,
+            registerDirectoryFromDisk,
+          }}
+          directory={repoDirectory}
+          directories={[repoDirectory]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={async () => undefined}
+          onPickDirectoryForReference={async () => undefined}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      await clickButton("Add reference");
+
+      const dialog = screen.getByRole("dialog", { name: "Add reference" });
+      // macOS gets the single combined action row.
+      expect(
+        within(dialog).queryByRole("button", { name: "Add directory…" })
+      ).not.toBeInTheDocument();
+      await act(async () => {
+        fireEvent.click(
+          within(dialog).getByRole("button", {
+            name: "Add file or directory…",
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(pickReferenceFromDisk).toHaveBeenCalledOnce();
+      expect(registerDirectoryFromDisk).toHaveBeenCalledWith({
+        path: "/Users/huntharo/pwrdrvr/agent-kit",
+      });
+      // File → tray pill; directory → editor chip.
+      expect(await screen.findByText("spec.md")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Remove spec.md" })
+      ).toBeInTheDocument();
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(within(richInput).getByText("@agent-kit")).toBeInTheDocument();
+      });
+      expect(within(richInput).getByText("@agent-kit")).toHaveAttribute(
+        "data-mention-kind",
+        "directory"
+      );
     } finally {
       delete (window as unknown as { __pwragentHomeDir?: string })
         .__pwragentHomeDir;

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -6,6 +6,7 @@ import type {
   ComposerDraftLifecycle,
   ComposerDraftRecoveryCandidate,
   ListComposerDraftRecoveryCandidatesRequest,
+  NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
 } from "@pwragent/shared";
 import type { ComposerSkillToken } from "./ComposerInputTypes";
@@ -14,6 +15,8 @@ export type ComposerDraftSnapshot = {
   draft: string;
   editorDocument?: JSONContent;
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  /** Path-only file references from drag-and-drop / the file picker. */
+  fileAttachments?: NavigationLaunchpadFileAttachment[];
   skillTokens: ComposerSkillToken[];
 };
 
@@ -22,6 +25,7 @@ export type ComposerQueuedTurnSnapshot = {
   input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  fileAttachments: NavigationLaunchpadFileAttachment[];
   scheduledSendAt?: number;
   reviewCommand?: {
     cwd?: string;
@@ -34,6 +38,7 @@ export type ComposerPendingSteerSnapshot = {
   id: string;
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  fileAttachments: NavigationLaunchpadFileAttachment[];
 };
 
 export type ComposerDraftStore = {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -228,6 +228,7 @@ export function snapshotFromDraftRecord(
     draft: record.text,
     editorDocument: record.editorDocument as JSONContent | undefined,
     imageAttachments: record.imageAttachments,
+    fileAttachments: record.fileAttachments,
     skillTokens: record.skillTokens,
   };
 }
@@ -254,6 +255,7 @@ function buildDraftRecord(
     editorDocument: snapshot.editorDocument as ComposerDraftJsonValue | undefined,
     skillTokens: snapshot.skillTokens,
     imageAttachments: snapshot.imageAttachments,
+    fileAttachments: snapshot.fileAttachments,
     status,
     createdAt,
     updatedAt: now,
@@ -299,11 +301,16 @@ function shouldRecordHistory(
   const hasRecoverableContent =
     snapshot.draft.trim().length > 0 ||
     snapshot.imageAttachments.length > 0 ||
+    (snapshot.fileAttachments?.length ?? 0) > 0 ||
     snapshot.skillTokens.length > 0;
   if (status === "sent") {
     return hasRecoverableContent;
   }
-  if (snapshot.imageAttachments.length > 0 || snapshot.skillTokens.length > 0) {
+  if (
+    snapshot.imageAttachments.length > 0 ||
+    (snapshot.fileAttachments?.length ?? 0) > 0 ||
+    snapshot.skillTokens.length > 0
+  ) {
     return true;
   }
   return snapshot.draft.trim().length >= HISTORY_TEXT_THRESHOLD;
@@ -428,6 +435,9 @@ function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
     })),
     imageAttachments: snapshot.imageAttachments.map((attachment) => ({
       url: attachment.url,
+    })),
+    fileAttachments: (snapshot.fileAttachments ?? []).map((attachment) => ({
+      path: attachment.path,
     })),
   });
   let hash = 5381;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -18,9 +18,10 @@ import ReactMarkdown, { type Components, type UrlTransform } from "react-markdow
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { AppIcon } from "../../components/AppIcon";
-import { CloseIcon, PopoutIcon } from "../../icons";
+import { CloseIcon, FolderIcon, PopoutIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { repairNestedLanguageFences } from "../../lib/markdown-fences";
+import { expandTildePath, tildifyPath } from "../../lib/tildify-path";
 import { SkillChip } from "../composer/SkillChip";
 import { remarkTableProfile } from "./remark-table-profile";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
@@ -137,6 +138,22 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
 
         if (isImplicitBareAutolink({ href, label, source })) {
           return <>{anchorProps.children}</>;
+        }
+
+        if (label.startsWith("@") && localTarget) {
+          // Composer directory-reference chip (`[@label](~/path)`) —
+          // render it back as a chip in the transcript, mirroring how
+          // `[$name](path)` skill links become SkillChips.
+          return (
+            <span
+              className="chip directory-chip tooltip-target"
+              data-tooltip={tildifyPath(localTarget.path)}
+              tabIndex={0}
+            >
+              <FolderIcon size={13} aria-hidden="true" />
+              <span className="skill-chip__label">{label}</span>
+            </span>
+          );
         }
 
         if (
@@ -650,6 +667,13 @@ const normalizeMarkdownUrl: UrlTransform = (url) => {
   const trimmed = url.trim();
   if (trimmed.startsWith("/")) {
     return `file://${trimmed}`;
+  }
+  if (trimmed.startsWith("~/")) {
+    // Composer directory-reference links (`[@label](~/path)`) and other
+    // tilde-form local paths — expand to the same file:// form as
+    // absolute paths so the local-file machinery (and the directory
+    // chip) can resolve them.
+    return `file://${expandTildePath(trimmed)}`;
   }
 
   return isSafeMarkdownUrl(trimmed) ? trimmed : "";

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -764,7 +764,13 @@ export type ThreadViewProps = {
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onPickAndAttachDirectoryToThread?: () => void;
-  onAttachDirectoryReferences?: (paths: string[]) => void;
+  onAttachDirectoryReferences?: (
+    paths: string[],
+    target: {
+      backend: NavigationThreadSummary["source"];
+      threadId: string;
+    },
+  ) => void;
   onClearPickDirectoryError?: () => void;
   setExecutionModeError?: string;
   setThreadModelSettingsError?: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -764,6 +764,7 @@ export type ThreadViewProps = {
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onPickAndAttachDirectoryToThread?: () => void;
+  onAttachDirectoryReferences?: (paths: string[]) => void;
   onClearPickDirectoryError?: () => void;
   setExecutionModeError?: string;
   setThreadModelSettingsError?: string;
@@ -834,7 +835,8 @@ export type ThreadViewProps = {
     directoryKey: string,
     input?: AppServerTurnInputItem[],
     collaborationMode?: AppServerCollaborationModeRequest,
-    reviewTarget?: AppServerReviewTarget
+    reviewTarget?: AppServerReviewTarget,
+    extraDirectoryPaths?: string[]
   ) => Promise<void>;
   onCancelLaunchpad?: (directoryKey: string) => void;
   onPendingStatusChange?: (status?: string) => void;
@@ -2226,7 +2228,13 @@ export function ThreadView(props: ThreadViewProps) {
     );
     const handleMaterializeLaunchpad: NonNullable<
       ThreadViewProps["onMaterializeLaunchpad"]
-    > = async (directoryKey, input, collaborationMode, reviewTarget) => {
+    > = async (
+      directoryKey,
+      input,
+      collaborationMode,
+      reviewTarget,
+      extraDirectoryPaths
+    ) => {
       if (!props.onMaterializeLaunchpad) {
         return;
       }
@@ -2238,7 +2246,8 @@ export function ThreadView(props: ThreadViewProps) {
           directoryKey,
           input,
           collaborationMode,
-          reviewTarget
+          reviewTarget,
+          extraDirectoryPaths
         );
       } catch (error) {
         setLaunchpadMaterializeError(
@@ -2637,6 +2646,7 @@ export function ThreadView(props: ThreadViewProps) {
             onSetAcpRuntimeOption={props.onSetAcpRuntimeOption}
             onCancelExecutionModeQueue={props.onCancelExecutionModeQueue}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
+            onAttachDirectoryReferences={props.onAttachDirectoryReferences}
             pendingRequestActive={Boolean(props.pendingRequest)}
             pendingUserInputActive={Boolean(
               props.pendingUserInput || props.pendingMcpInteraction

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -764,6 +764,14 @@ export type ThreadViewProps = {
   onSelectNoDirectoryFromPicker?: () => void;
   onPickAndRegisterDirectory?: () => void;
   onPickAndAttachDirectoryToThread?: () => void;
+  /**
+   * Composer reference picker ("@ → Add directory…", the "+" menu): OS
+   * dialog → register (no navigation) → resolve with label/path so the
+   * composer can mint a reference chip. Undefined on cancel/failure.
+   */
+  onPickDirectoryForReference?: () => Promise<
+    { label: string; path: string } | undefined
+  >;
   onAttachDirectoryReferences?: (
     paths: string[],
     target: {
@@ -2411,6 +2419,7 @@ export function ThreadView(props: ThreadViewProps) {
               onPickAndAttachDirectoryToThread={
                 props.onPickAndAttachDirectoryToThread
               }
+              onPickDirectoryForReference={props.onPickDirectoryForReference}
               onClearPickDirectoryError={props.onClearPickDirectoryError}
               pickDirectoryError={props.pickDirectoryError}
               pickingDirectory={props.pickingDirectory}
@@ -2653,6 +2662,7 @@ export function ThreadView(props: ThreadViewProps) {
             onCancelExecutionModeQueue={props.onCancelExecutionModeQueue}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
             onAttachDirectoryReferences={props.onAttachDirectoryReferences}
+            onPickDirectoryForReference={props.onPickDirectoryForReference}
             pendingRequestActive={Boolean(props.pendingRequest)}
             pendingUserInputActive={Boolean(
               props.pendingUserInput || props.pendingMcpInteraction

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -706,4 +706,21 @@ describe("ThreadMarkdown", () => {
         .__pwragentHomeDir;
     }
   });
+
+  it("decodes percent-encoded directory reference paths in the chip tooltip", () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const { container } = render(
+        <ThreadMarkdown text={"[@repo](~/Backup%20%2850%25%20old%29/repo) has it."} />
+      );
+
+      const chip = container.querySelector(".directory-chip");
+      expect(chip).toHaveTextContent("@repo");
+      expect(chip).toHaveAttribute("data-tooltip", "~/Backup (50% old)/repo");
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -679,4 +679,31 @@ describe("ThreadMarkdown", () => {
     expect(container.querySelector("img")).toBeNull();
     expect(container.textContent).toContain("<em>safe</em>");
   });
+
+  it("renders composer directory references as chips", () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const { container } = render(
+        <ThreadMarkdown
+          text={
+            "[@agent-kit](~/pwrdrvr/agent-kit) and "
+            + "[@PwrAgnt](/Users/huntharo/pwrdrvr/PwrAgnt) are projects."
+          }
+        />
+      );
+
+      const chips = container.querySelectorAll(".directory-chip");
+      expect(chips).toHaveLength(2);
+      expect(chips[0]).toHaveTextContent("@agent-kit");
+      expect(chips[0]).toHaveAttribute("data-tooltip", "~/pwrdrvr/agent-kit");
+      expect(chips[1]).toHaveTextContent("@PwrAgnt");
+      expect(
+        screen.queryByRole("link", { name: "@agent-kit" })
+      ).not.toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
 });

--- a/apps/desktop/src/renderer/src/icons/PlusIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/PlusIcon.tsx
@@ -1,0 +1,10 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function PlusIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -22,6 +22,7 @@ export { NewThreadIcon } from "./NewThreadIcon";
 export { PinIcon } from "./PinIcon";
 export { PlanIcon } from "./PlanIcon";
 export { PlayIcon } from "./PlayIcon";
+export { PlusIcon } from "./PlusIcon";
 export { PopoutIcon } from "./PopoutIcon";
 export { PricingIcon } from "./PricingIcon";
 export { ProjectsIcon } from "./ProjectsIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
@@ -3,7 +3,9 @@ import type { NavigationDirectorySummary } from "@pwragent/shared";
 import {
   buildDirectoryReferenceInsertText,
   buildDirectoryReferenceMarkdown,
+  buildFileReferenceTooltip,
   decodeMarkdownDestination,
+  fileLabelFromPath,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -120,6 +122,41 @@ describe("filterDirectoryReferenceCandidates", () => {
       }),
     );
     expect(filterDirectoryReferenceCandidates(many, "")).toHaveLength(10);
+  });
+});
+
+describe("fileLabelFromPath", () => {
+  it("returns the basename of a posix path", () => {
+    expect(fileLabelFromPath("/Users/huntharo/notes/notes.txt")).toBe(
+      "notes.txt",
+    );
+  });
+
+  it("returns the basename of a windows path", () => {
+    expect(fileLabelFromPath("C:\\Users\\huntharo\\notes\\report.pdf")).toBe(
+      "report.pdf",
+    );
+  });
+
+  it("ignores a trailing separator", () => {
+    expect(fileLabelFromPath("/Users/huntharo/notes/")).toBe("notes");
+  });
+
+  it("returns a bare name unchanged", () => {
+    expect(fileLabelFromPath("notes.txt")).toBe("notes.txt");
+  });
+
+  it("falls back to the input when no segment survives", () => {
+    expect(fileLabelFromPath("")).toBe("");
+    expect(fileLabelFromPath("///")).toBe("///");
+  });
+});
+
+describe("buildFileReferenceTooltip", () => {
+  it("returns just the tilde path with no linked suffix", () => {
+    expect(
+      buildFileReferenceTooltip(`${HOME}/notes/notes.txt`, HOME),
+    ).toBe("~/notes/notes.txt");
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+import {
+  buildDirectoryReferenceInsertText,
+  filterDirectoryReferenceCandidates,
+  findDirectoryReferenceTrigger,
+  listReferencedDirectories,
+} from "../directory-references";
+
+const HOME = "/Users/huntharo";
+
+function makeDirectory(
+  overrides: Partial<NavigationDirectorySummary> & { key: string },
+): NavigationDirectorySummary {
+  return {
+    kind: "directory",
+    label: overrides.key,
+    threadKeys: [],
+    needsAttentionCount: 0,
+    ...overrides,
+  };
+}
+
+const GIPHY = makeDirectory({
+  key: "dir:giphy-services",
+  label: "giphy-services",
+  path: `${HOME}/GIPHY/giphy-services`,
+  latestUpdatedAt: 300,
+});
+const SEARCH = makeDirectory({
+  key: "dir:search-product",
+  label: "search-product",
+  path: `${HOME}/GIPHY/search-product`,
+  latestUpdatedAt: 200,
+});
+const PWRAGNT = makeDirectory({
+  key: "dir:pwragnt",
+  label: "PwrAgnt",
+  path: `${HOME}/pwrdrvr/PwrAgnt`,
+  latestUpdatedAt: 100,
+});
+const UNLINKED = makeDirectory({
+  key: "dir:unlinked",
+  kind: "unlinked",
+  label: "Unlinked",
+  latestUpdatedAt: 400,
+});
+
+describe("findDirectoryReferenceTrigger", () => {
+  it("matches a bare @ at the start of the draft", () => {
+    expect(findDirectoryReferenceTrigger("@", 1)).toEqual({
+      start: 0,
+      end: 1,
+      query: "",
+    });
+  });
+
+  it("matches @ after whitespace and captures the query", () => {
+    const text = "check out @gip";
+    expect(findDirectoryReferenceTrigger(text, text.length)).toEqual({
+      start: 10,
+      end: text.length,
+      query: "gip",
+    });
+  });
+
+  it("allows path-ish query characters", () => {
+    const text = "see @~/GIPHY/search";
+    expect(findDirectoryReferenceTrigger(text, text.length)?.query).toBe(
+      "~/GIPHY/search",
+    );
+  });
+
+  it("does not trigger inside an email address", () => {
+    const text = "mail huntharo@gmail.com";
+    expect(findDirectoryReferenceTrigger(text, text.length)).toBeUndefined();
+  });
+
+  it("does not trigger when the caret is before the @", () => {
+    expect(findDirectoryReferenceTrigger("@gip", 0)).toBeUndefined();
+  });
+});
+
+describe("filterDirectoryReferenceCandidates", () => {
+  const directories = [PWRAGNT, SEARCH, GIPHY, UNLINKED];
+
+  it("returns referenceable directories most recently updated first", () => {
+    expect(
+      filterDirectoryReferenceCandidates(directories, "").map((d) => d.key),
+    ).toEqual([GIPHY.key, SEARCH.key, PWRAGNT.key]);
+  });
+
+  it("filters by label", () => {
+    expect(
+      filterDirectoryReferenceCandidates(directories, "search").map((d) => d.key),
+    ).toEqual([SEARCH.key]);
+  });
+
+  it("filters by path substring", () => {
+    expect(
+      filterDirectoryReferenceCandidates(directories, "GIPHY/").map((d) => d.key),
+    ).toEqual([GIPHY.key, SEARCH.key]);
+  });
+
+  it("excludes unlinked pseudo-directories and path-less entries", () => {
+    const pathless = makeDirectory({ key: "dir:pathless", latestUpdatedAt: 500 });
+    expect(
+      filterDirectoryReferenceCandidates([UNLINKED, pathless], ""),
+    ).toEqual([]);
+  });
+
+  it("caps the result at ten candidates", () => {
+    const many = Array.from({ length: 15 }, (_, index) =>
+      makeDirectory({
+        key: `dir:${index}`,
+        path: `${HOME}/repos/repo-${index}`,
+        latestUpdatedAt: index,
+      }),
+    );
+    expect(filterDirectoryReferenceCandidates(many, "")).toHaveLength(10);
+  });
+});
+
+describe("buildDirectoryReferenceInsertText", () => {
+  it("tildifies the directory path", () => {
+    expect(buildDirectoryReferenceInsertText(SEARCH, HOME)).toBe(
+      "~/GIPHY/search-product",
+    );
+  });
+
+  it("leaves paths outside home unchanged", () => {
+    expect(
+      buildDirectoryReferenceInsertText({ path: "/opt/work/app" }, HOME),
+    ).toBe("/opt/work/app");
+  });
+});
+
+describe("listReferencedDirectories", () => {
+  const directories = [GIPHY, SEARCH, PWRAGNT, UNLINKED];
+
+  it("finds a tilde-path reference", () => {
+    expect(
+      listReferencedDirectories(
+        "You might be able to see it in ~/GIPHY/search-product.",
+        directories,
+        { homeDir: HOME },
+      ).map((d) => d.key),
+    ).toEqual([SEARCH.key]);
+  });
+
+  it("finds an absolute-path reference", () => {
+    expect(
+      listReferencedDirectories(
+        `compare against ${HOME}/pwrdrvr/PwrAgnt please`,
+        directories,
+        { homeDir: HOME },
+      ).map((d) => d.key),
+    ).toEqual([PWRAGNT.key]);
+  });
+
+  it("resolves a deeper file path to its tracked repo", () => {
+    expect(
+      listReferencedDirectories(
+        "look at ~/GIPHY/giphy-services/build.sbt",
+        directories,
+        { homeDir: HOME },
+      ).map((d) => d.key),
+    ).toEqual([GIPHY.key]);
+  });
+
+  it("does not match a sibling directory whose name extends the path", () => {
+    expect(
+      listReferencedDirectories(
+        "see ~/GIPHY/search-product-v2 for details",
+        directories,
+        { homeDir: HOME },
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns each directory once for repeated mentions", () => {
+    expect(
+      listReferencedDirectories(
+        "~/GIPHY/search-product and again ~/GIPHY/search-product",
+        directories,
+        { homeDir: HOME },
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("honors excludePaths for already-linked directories", () => {
+    expect(
+      listReferencedDirectories(
+        "work in ~/GIPHY/giphy-services and read ~/GIPHY/search-product",
+        directories,
+        { homeDir: HOME, excludePaths: [`${HOME}/GIPHY/giphy-services`] },
+      ).map((d) => d.key),
+    ).toEqual([SEARCH.key]);
+  });
+
+  it("keeps only the deepest match for nested tracked repos", () => {
+    const parent = makeDirectory({
+      key: "dir:giphy-root",
+      label: "GIPHY",
+      path: `${HOME}/GIPHY`,
+    });
+    expect(
+      listReferencedDirectories(
+        "fetch ~/GIPHY/search-product",
+        [...directories, parent],
+        { homeDir: HOME },
+      ).map((d) => d.key),
+    ).toEqual([SEARCH.key]);
+  });
+
+  it("accepts punctuation boundaries after the path", () => {
+    for (const draft of [
+      "(~/GIPHY/search-product)",
+      "~/GIPHY/search-product, then more",
+      "~/GIPHY/search-product? yes",
+    ]) {
+      expect(
+        listReferencedDirectories(draft, directories, { homeDir: HOME }),
+      ).toHaveLength(1);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { NavigationDirectorySummary } from "@pwragent/shared";
 import {
   buildDirectoryReferenceInsertText,
+  buildDirectoryReferenceMarkdown,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -132,6 +133,29 @@ describe("buildDirectoryReferenceInsertText", () => {
     expect(
       buildDirectoryReferenceInsertText({ path: "/opt/work/app" }, HOME),
     ).toBe("/opt/work/app");
+  });
+});
+
+describe("buildDirectoryReferenceMarkdown", () => {
+  it("builds a bounded markdown link with the tilde path", () => {
+    expect(
+      buildDirectoryReferenceMarkdown(
+        { label: "search-product", path: `${HOME}/GIPHY/search-product` },
+        HOME,
+      ),
+    ).toBe("[@search-product](~/GIPHY/search-product)");
+  });
+
+  it("stays scannable when text glues onto the link", () => {
+    const markdown = buildDirectoryReferenceMarkdown(
+      { label: "search-product", path: `${HOME}/GIPHY/search-product` },
+      HOME,
+    );
+    expect(
+      listReferencedDirectories(`${markdown}are two of my fave projects`, [SEARCH], {
+        homeDir: HOME,
+      }).map((d) => d.key),
+    ).toEqual([SEARCH.key]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/directory-references.test.ts
@@ -3,6 +3,7 @@ import type { NavigationDirectorySummary } from "@pwragent/shared";
 import {
   buildDirectoryReferenceInsertText,
   buildDirectoryReferenceMarkdown,
+  decodeMarkdownDestination,
   filterDirectoryReferenceCandidates,
   findDirectoryReferenceTrigger,
   listReferencedDirectories,
@@ -156,6 +157,33 @@ describe("buildDirectoryReferenceMarkdown", () => {
         homeDir: HOME,
       }).map((d) => d.key),
     ).toEqual([SEARCH.key]);
+  });
+
+  it("percent-encodes parens, spaces, and percents in the destination", () => {
+    const markdown = buildDirectoryReferenceMarkdown(
+      { label: "repo", path: `${HOME}/Backup (50% old)/repo` },
+      HOME,
+    );
+    expect(markdown).toBe("[@repo](~/Backup%20%2850%25%20old%29/repo)");
+    expect(decodeMarkdownDestination("~/Backup%20%2850%25%20old%29/repo")).toBe(
+      "~/Backup (50% old)/repo",
+    );
+  });
+
+  it("leaves never-encoded destinations unchanged when decoding", () => {
+    expect(decodeMarkdownDestination("~/GIPHY/search-product")).toBe(
+      "~/GIPHY/search-product",
+    );
+    expect(decodeMarkdownDestination("~/100%-legit")).toBe("~/100%-legit");
+  });
+
+  it("falls back to the bare tilde path for a link-breaking label", () => {
+    expect(
+      buildDirectoryReferenceMarkdown(
+        { label: "weird]name", path: `${HOME}/weird]name` },
+        HOME,
+      ),
+    ).toBe("~/weird]name");
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { getHomeDir, tildifyPath } from "../tildify-path";
+import { expandTildePath, getHomeDir, tildifyPath } from "../tildify-path";
 
 describe("tildifyPath", () => {
   it("collapses a home-prefixed path to ~", () => {
@@ -33,6 +33,38 @@ describe("tildifyPath", () => {
   it("returns the path unchanged when the home directory is unknown", () => {
     expect(tildifyPath("/Users/huntharo/app", undefined)).toBe("/Users/huntharo/app");
     expect(tildifyPath("/Users/huntharo/app", "")).toBe("/Users/huntharo/app");
+  });
+});
+
+describe("expandTildePath", () => {
+  it("expands a leading ~/ to the home directory", () => {
+    expect(expandTildePath("~/pwrdrvr/PwrAgnt", "/Users/huntharo")).toBe(
+      "/Users/huntharo/pwrdrvr/PwrAgnt",
+    );
+  });
+
+  it("expands a bare ~ to the home directory", () => {
+    expect(expandTildePath("~", "/Users/huntharo")).toBe("/Users/huntharo");
+  });
+
+  it("leaves non-tilde paths unchanged", () => {
+    expect(expandTildePath("/opt/work/app", "/Users/huntharo")).toBe(
+      "/opt/work/app",
+    );
+  });
+
+  it("leaves a tilde-user path (~foo) unchanged", () => {
+    expect(expandTildePath("~foo/app", "/Users/huntharo")).toBe("~foo/app");
+  });
+
+  it("returns the path unchanged when home is unknown", () => {
+    expect(expandTildePath("~/app", undefined)).toBe("~/app");
+  });
+
+  it("round-trips with tildifyPath", () => {
+    const home = "/Users/huntharo";
+    const absolute = "/Users/huntharo/GIPHY/search-product";
+    expect(expandTildePath(tildifyPath(absolute, home), home)).toBe(absolute);
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -153,12 +153,14 @@ describe("useQueuedTurnRelease", () => {
         id: "queued-1",
         text: "First background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "First background reply" }],
       },
       {
         id: "queued-2",
         text: "Second background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Second background reply" }],
       },
     ]);
@@ -237,12 +239,14 @@ describe("useQueuedTurnRelease", () => {
         id: "queued-1",
         text: "First background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "First background reply" }],
       },
       {
         id: "queued-2",
         text: "Second background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Second background reply" }],
       },
     ]);
@@ -313,6 +317,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-idle",
       text: "Idle status reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Idle status reply" }],
     });
 
@@ -384,6 +389,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-scheduled",
       text: "Future background reply",
       imageAttachments: [],
+      fileAttachments: [],
       scheduledSendAt: Date.now() + 15 * 60_000,
       input: [{ type: "text", text: "Future background reply" }],
     });
@@ -466,6 +472,7 @@ describe("useQueuedTurnRelease", () => {
         id: "queued-later",
         text: "Later background reply",
         imageAttachments: [],
+        fileAttachments: [],
         scheduledSendAt: Date.now() + 2 * 60 * 60_000,
         input: [{ type: "text", text: "Later background reply" }],
       },
@@ -473,6 +480,7 @@ describe("useQueuedTurnRelease", () => {
         id: "queued-sooner",
         text: "Sooner background reply",
         imageAttachments: [],
+        fileAttachments: [],
         scheduledSendAt: Date.now() + 15 * 60_000,
         input: [{ type: "text", text: "Sooner background reply" }],
       },
@@ -542,6 +550,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/selected-worktree",
         displayText: "Review changes against main",
@@ -633,6 +642,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         displayText: "Review changes against main",
         target: {
@@ -714,12 +724,14 @@ describe("useQueuedTurnRelease", () => {
         id: "queued-1",
         text: "First background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "First background reply" }],
       },
       {
         id: "queued-2",
         text: "Second background reply",
         imageAttachments: [],
+        fileAttachments: [],
         input: [{ type: "text", text: "Second background reply" }],
       },
     ]);
@@ -801,6 +813,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-branch",
       text: "Guarded background reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Guarded background reply" }],
     });
 
@@ -874,6 +887,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/background-worktree",
         displayText: "Review changes against main",
@@ -958,6 +972,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
@@ -1038,6 +1053,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/retained-worktree",
         displayText: "Review changes against main",
@@ -1119,6 +1135,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/retained-worktree",
         displayText: "Review changes against main",
@@ -1209,6 +1226,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
@@ -1301,6 +1319,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-branch",
       text: "Release background reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Release background reply" }],
     });
 
@@ -1374,6 +1393,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-branch",
       text: "Release background reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Release background reply" }],
     });
 
@@ -1461,6 +1481,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-old",
       text: "Stale background reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Stale background reply" }],
     });
 
@@ -1505,6 +1526,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-new",
       text: "Current background reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Current background reply" }],
     });
     await act(async () => {
@@ -1541,6 +1563,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-1",
       text: "Focused reply",
       imageAttachments: [],
+      fileAttachments: [],
       input: [{ type: "text", text: "Focused reply" }],
     });
 
@@ -1613,6 +1636,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
@@ -1671,6 +1695,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",
@@ -1758,6 +1783,7 @@ describe("useQueuedTurnRelease", () => {
       id: "queued-review",
       text: "/review main",
       imageAttachments: [],
+      fileAttachments: [],
       reviewCommand: {
         cwd: "/repo/polled-worktree",
         displayText: "Review changes against main",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6960,5 +6960,77 @@ describe("useThreadNavigation", () => {
       });
       expect(result.current.pickDirectoryError).toBeUndefined();
     });
+
+    it("pickDirectoryForReference registers the pick without navigating and returns it", async () => {
+      const launchpad = buildPickedLaunchpad();
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/Users/me/repos/PwrAgent",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: true as const,
+        directoryPath: "/Users/me/repos/PwrAgent",
+        directoryKey: launchpad.directoryKey,
+        directoryLabel: "PwrAgent",
+        currentBranch: "main",
+        launchpad,
+        defaults: launchpadDefaults,
+      }));
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let picked: { label: string; path: string } | undefined;
+      await act(async () => {
+        picked = await result.current.pickDirectoryForReference();
+      });
+
+      expect(picked).toEqual({
+        label: "PwrAgent",
+        path: "/Users/me/repos/PwrAgent",
+      });
+      expect(registerDirectoryFromDisk).toHaveBeenCalledExactlyOnceWith({
+        path: "/Users/me/repos/PwrAgent",
+      });
+      // The tracked set learns the directory, but nothing navigates.
+      expect(
+        result.current.directories.map((directory) => directory.label),
+      ).toContain("PwrAgent");
+      expect(result.current.selectedItemKey).toBeUndefined();
+      expect(result.current.pickDirectoryError).toBeUndefined();
+      expect(result.current.pickingDirectory).toBe(false);
+    });
+
+    it("pickDirectoryForReference surfaces validation failures and resolves undefined", async () => {
+      const pickDirectoryFromDisk = vi.fn(async () => ({
+        canceled: false as const,
+        path: "/tmp/not-a-repo",
+      }));
+      const registerDirectoryFromDisk = vi.fn(async () => ({
+        ok: false as const,
+        reason: "not-a-git-repo" as const,
+        message: "/tmp/not-a-repo is not inside a git repository.",
+      }));
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      let picked: { label: string; path: string } | undefined;
+      await act(async () => {
+        picked = await result.current.pickDirectoryForReference();
+      });
+
+      expect(picked).toBeUndefined();
+      expect(result.current.pickDirectoryError).toContain("not inside a git");
+      expect(result.current.selectedItemKey).toBeUndefined();
+    });
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
@@ -28,6 +28,7 @@ function makeQueuedTurn(
     id: "queued-1",
     text: "hello",
     imageAttachments: [],
+    fileAttachments: [],
     ...overrides,
   };
 }

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -128,6 +128,7 @@ import type {
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
+  PickFileFromDiskResponse,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
@@ -687,6 +688,13 @@ export type DesktopApi = {
    * seed a launchpad in one round-trip.
    */
   pickDirectoryFromDisk?: () => Promise<PickDirectoryFromDiskResponse>;
+  /** Composer file-reference picker (multi-select; paths only, no register step). */
+  pickFileFromDisk?: () => Promise<PickFileFromDiskResponse>;
+  /**
+   * Resolve the on-disk path of a dropped/pasted File (Electron
+   * webUtils.getPathForFile). Returns "" when the File has no backing path.
+   */
+  getPathForFile?: (file: File) => string;
   registerDirectoryFromDisk?: (
     request: RegisterDirectoryFromDiskRequest,
   ) => Promise<RegisterDirectoryFromDiskResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -129,6 +129,9 @@ import type {
   SetMessagingEnabledResponse,
   PickDirectoryFromDiskResponse,
   PickFileFromDiskResponse,
+  PickReferenceFromDiskResponse,
+  ListRecentFileReferencesResponse,
+  RecordRecentFileReferencesRequest,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
@@ -690,6 +693,19 @@ export type DesktopApi = {
   pickDirectoryFromDisk?: () => Promise<PickDirectoryFromDiskResponse>;
   /** Composer file-reference picker (multi-select; paths only, no register step). */
   pickFileFromDisk?: () => Promise<PickFileFromDiskResponse>;
+  /**
+   * Combined file-or-directory reference picker (macOS only — the other
+   * platforms cannot combine both kinds in one OS dialog). Entries come
+   * back classified by `fs.stat` so the composer can route files to the
+   * tray and directories to reference chips.
+   */
+  pickReferenceFromDisk?: () => Promise<PickReferenceFromDiskResponse>;
+  /** Recently referenced files for the reference picker's Files tab. */
+  listRecentFileReferences?: () => Promise<ListRecentFileReferencesResponse>;
+  /** Fire-and-forget record of freshly committed file references. */
+  recordRecentFileReferences?: (
+    request: RecordRecentFileReferencesRequest,
+  ) => Promise<void>;
   /**
    * Resolve the on-disk path of a dropped/pasted File (Electron
    * webUtils.getPathForFile). Returns "" when the File has no backing path.

--- a/apps/desktop/src/renderer/src/lib/directory-references.ts
+++ b/apps/desktop/src/renderer/src/lib/directory-references.ts
@@ -91,6 +91,29 @@ export function buildDirectoryReferenceInsertText(
   return tildifyPath(directory.path ?? "", homeDir);
 }
 
+/**
+ * Display label for a composer file reference: the path's basename.
+ * Handles both separators (a Windows path pasted on macOS still labels
+ * sensibly) and trailing separators; falls back to the input when no
+ * segment survives.
+ */
+export function fileLabelFromPath(path: string): string {
+  const segments = path.split(/[/\\]/).filter((segment) => segment.length > 0);
+  return segments[segments.length - 1] ?? path;
+}
+
+/**
+ * Hover copy for a file-reference chip/pill: just the tilde path. Unlike
+ * directory references there is no "linked to the thread" suffix — the
+ * file rides along as a path in the outgoing text, nothing gets linked.
+ */
+export function buildFileReferenceTooltip(
+  path: string,
+  homeDir: string | undefined = getHomeDir(),
+): string {
+  return tildifyPath(path, homeDir);
+}
+
 /** Hover copy shared by the editor chip and the setup-row pill. */
 export function buildDirectoryReferenceTooltip(
   path: string,

--- a/apps/desktop/src/renderer/src/lib/directory-references.ts
+++ b/apps/desktop/src/renderer/src/lib/directory-references.ts
@@ -100,6 +100,20 @@ export function buildDirectoryReferenceTooltip(
 }
 
 /**
+ * Serialized form of a directory-reference chip in the canonical draft
+ * and outgoing text: `[@label](~/path)`. A markdown link keeps the path
+ * bounded — text typed flush against the chip cannot glue onto it the
+ * way a bare tilde path could — and gives the transcript renderer and
+ * `parseSkillMentionParts` a self-describing form to chip/hydrate from.
+ */
+export function buildDirectoryReferenceMarkdown(
+  reference: { label: string; path: string },
+  homeDir: string | undefined = getHomeDir(),
+): string {
+  return `[@${reference.label}](${tildifyPath(reference.path, homeDir)})`;
+}
+
+/**
  * Characters that may legally follow a referenced path in prose. A `/`
  * counts so a deeper reference (`~/dev/app/src/index.ts`) still resolves
  * to the tracked repo root it lives under.

--- a/apps/desktop/src/renderer/src/lib/directory-references.ts
+++ b/apps/desktop/src/renderer/src/lib/directory-references.ts
@@ -1,0 +1,178 @@
+import type { NavigationDirectorySummary } from "@pwragent/shared";
+import { getHomeDir, tildifyPath } from "./tildify-path";
+
+/**
+ * Composer `@`-directory references.
+ *
+ * Typing `@` in the composer opens an autocomplete over the tracked
+ * directories (the same population as the project picker). Committing a
+ * candidate inserts the directory's tilde-shortened path as plain text at
+ * the caret — the draft text itself is the source of truth. At send time
+ * `listReferencedDirectories` re-scans the draft for any tracked
+ * directory's path (inserted via `@`, typed by hand, or pasted) and the
+ * caller links those directories to the thread. Deleting the path from the
+ * draft removes the reference; no separate token state to keep in sync.
+ */
+
+export type DirectoryReferenceTrigger = {
+  end: number;
+  query: string;
+  start: number;
+};
+
+/**
+ * Match an in-progress `@` token immediately before the caret, mirroring
+ * `findSkillTrigger`'s shape for `$` skills. The `@` must start the text
+ * or follow whitespace, so email-like text (`user@example.com`) never
+ * triggers. Path-ish query characters are allowed for narrowing.
+ */
+export function findDirectoryReferenceTrigger(
+  text: string,
+  caret: number,
+): DirectoryReferenceTrigger | undefined {
+  const prefix = text.slice(0, caret);
+  const match = /(?:^|\s)@([A-Za-z0-9._~/-]*)$/.exec(prefix);
+  if (!match) {
+    return undefined;
+  }
+
+  const start = prefix.length - match[0].length + match[0].lastIndexOf("@");
+  return {
+    start,
+    end: caret,
+    query: match[1] ?? "",
+  };
+}
+
+const CANDIDATE_LIMIT = 10;
+
+function isReferenceable(directory: NavigationDirectorySummary): boolean {
+  // Same exclusion as the project picker's `isPickable`, plus a real
+  // filesystem path requirement — a reference is only useful when there
+  // is a path to insert into the draft.
+  return directory.kind !== "unlinked" && Boolean(directory.path);
+}
+
+/**
+ * Rank tracked directories for the `@` autocomplete: referenceable
+ * entries whose label or path contains the query, most recently updated
+ * first, capped at 10. Unlike the project picker (which filters within
+ * its top 10 recents), the query searches the full tracked set so an
+ * older project is still reachable by name.
+ */
+export function filterDirectoryReferenceCandidates(
+  directories: NavigationDirectorySummary[],
+  query: string,
+): NavigationDirectorySummary[] {
+  const trimmed = query.trim().toLowerCase();
+  return directories
+    .filter(isReferenceable)
+    .filter((directory) => {
+      if (!trimmed) {
+        return true;
+      }
+      const label = directory.label.toLowerCase();
+      const path = (directory.path ?? "").toLowerCase();
+      return (
+        label.includes(trimmed)
+        || path.includes(trimmed)
+        || tildifyPath(directory.path ?? "").toLowerCase().includes(trimmed)
+      );
+    })
+    .sort((left, right) => (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0))
+    .slice(0, CANDIDATE_LIMIT);
+}
+
+/** The text committed into the draft for a referenced directory. */
+export function buildDirectoryReferenceInsertText(
+  directory: Pick<NavigationDirectorySummary, "path">,
+  homeDir: string | undefined = getHomeDir(),
+): string {
+  return tildifyPath(directory.path ?? "", homeDir);
+}
+
+/**
+ * Characters that may legally follow a referenced path in prose. A `/`
+ * counts so a deeper reference (`~/dev/app/src/index.ts`) still resolves
+ * to the tracked repo root it lives under.
+ */
+const REFERENCE_BOUNDARY = /^[\s.,;:!?)\]}'"/]/;
+
+function draftContainsPath(draft: string, candidate: string): boolean {
+  if (!candidate) {
+    return false;
+  }
+  let searchFrom = 0;
+  while (searchFrom <= draft.length - candidate.length) {
+    const index = draft.indexOf(candidate, searchFrom);
+    if (index < 0) {
+      return false;
+    }
+    const after = draft.slice(index + candidate.length);
+    if (after.length === 0 || REFERENCE_BOUNDARY.test(after)) {
+      return true;
+    }
+    searchFrom = index + 1;
+  }
+  return false;
+}
+
+/**
+ * Scan a draft for tracked directories it references by path — the
+ * tilde-shortened form, the absolute form, or a deeper path under either.
+ * The result drives which directories get linked to the thread at send
+ * time. `excludePaths` drops directories that are already linked (the
+ * launchpad's own directory, a thread's existing linked directories).
+ */
+export function listReferencedDirectories(
+  draft: string,
+  directories: NavigationDirectorySummary[],
+  options?: {
+    excludePaths?: string[];
+    homeDir?: string;
+  },
+): NavigationDirectorySummary[] {
+  if (!draft) {
+    return [];
+  }
+  const homeDir = options?.homeDir ?? getHomeDir();
+  const excluded = new Set(
+    (options?.excludePaths ?? [])
+      .filter((path): path is string => Boolean(path))
+      .map((path) => path.replace(/[/\\]+$/, "")),
+  );
+  const seenPaths = new Set<string>();
+  const referenced: NavigationDirectorySummary[] = [];
+
+  for (const directory of directories) {
+    if (!isReferenceable(directory)) {
+      continue;
+    }
+    const path = directory.path!.replace(/[/\\]+$/, "");
+    if (!path || seenPaths.has(path) || excluded.has(path)) {
+      continue;
+    }
+    const tilde = tildifyPath(path, homeDir);
+    if (
+      draftContainsPath(draft, path)
+      || (tilde !== path && draftContainsPath(draft, tilde))
+    ) {
+      seenPaths.add(path);
+      referenced.push(directory);
+    }
+  }
+
+  // Nested tracked repos: `~/dev/app` in the draft also substring-matches
+  // a tracked `~/dev`. Keep only the deepest match so the reference
+  // resolves to the repo the path actually points into.
+  return referenced.filter((directory) => {
+    const path = directory.path!.replace(/[/\\]+$/, "");
+    return !referenced.some((other) => {
+      if (other === directory) {
+        return false;
+      }
+      const otherPath = other.path!.replace(/[/\\]+$/, "");
+      return otherPath.startsWith(`${path}/`);
+    });
+  });
+}

--- a/apps/desktop/src/renderer/src/lib/directory-references.ts
+++ b/apps/desktop/src/renderer/src/lib/directory-references.ts
@@ -91,6 +91,14 @@ export function buildDirectoryReferenceInsertText(
   return tildifyPath(directory.path ?? "", homeDir);
 }
 
+/** Hover copy shared by the editor chip and the setup-row pill. */
+export function buildDirectoryReferenceTooltip(
+  path: string,
+  homeDir: string | undefined = getHomeDir(),
+): string {
+  return `${tildifyPath(path, homeDir)} — linked to the thread when you send`;
+}
+
 /**
  * Characters that may legally follow a referenced path in prose. A `/`
  * counts so a deeper reference (`~/dev/app/src/index.ts`) still resolves

--- a/apps/desktop/src/renderer/src/lib/directory-references.ts
+++ b/apps/desktop/src/renderer/src/lib/directory-references.ts
@@ -100,17 +100,55 @@ export function buildDirectoryReferenceTooltip(
 }
 
 /**
+ * Characters that would break the `[@label](path)` form: `%` so decoding
+ * stays lossless, parens because they delimit the destination (both for
+ * `parseSkillMentionParts` and CommonMark), and whitespace because a
+ * CommonMark destination cannot contain an unescaped space.
+ */
+const MARKDOWN_DESTINATION_UNSAFE = /[%()\s]/g;
+
+function encodeMarkdownDestination(path: string): string {
+  return path.replace(MARKDOWN_DESTINATION_UNSAFE, (char) =>
+    encodeURIComponent(char) === char
+      ? `%${char.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`
+      : encodeURIComponent(char),
+  );
+}
+
+/**
+ * Inverse of encodeMarkdownDestination for hydration. Tolerates paths
+ * that were never encoded (hand-authored links, older drafts): a decode
+ * failure returns the input unchanged.
+ */
+export function decodeMarkdownDestination(path: string): string {
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
  * Serialized form of a directory-reference chip in the canonical draft
  * and outgoing text: `[@label](~/path)`. A markdown link keeps the path
  * bounded — text typed flush against the chip cannot glue onto it the
  * way a bare tilde path could — and gives the transcript renderer and
  * `parseSkillMentionParts` a self-describing form to chip/hydrate from.
+ * Unsafe destination characters (parens, spaces, `%`) are percent-encoded
+ * so paths like `~/Backup (old)/repo` survive the round trip. A label
+ * that would break the link syntax (brackets, newlines) falls back to
+ * the bare tilde path — still glue-resistant at send time because the
+ * token state drives the attach, just without a transcript chip.
  */
 export function buildDirectoryReferenceMarkdown(
   reference: { label: string; path: string },
   homeDir: string | undefined = getHomeDir(),
 ): string {
-  return `[@${reference.label}](${tildifyPath(reference.path, homeDir)})`;
+  const tilde = tildifyPath(reference.path, homeDir);
+  if (/[[\]\r\n]/.test(reference.label)) {
+    return tilde;
+  }
+  return `[@${reference.label}](${encodeMarkdownDestination(tilde)})`;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/lib/skill-mentions.ts
+++ b/apps/desktop/src/renderer/src/lib/skill-mentions.ts
@@ -10,9 +10,20 @@ export type SkillMentionPart =
       label: string;
       name: string;
       path: string;
+    }
+  | {
+      /**
+       * Composer directory-reference chip, serialized as
+       * `[@label](~/path)`. `name` is the label without the `@`; `path`
+       * is as-written (usually tilde form — callers expand it).
+       */
+      type: "directory";
+      label: string;
+      name: string;
+      path: string;
     };
 
-const SKILL_MENTION_PATTERN = /\[(\$[^\]\r\n]+)\]\(([^)\r\n]+)\)/g;
+const SKILL_MENTION_PATTERN = /\[([$@][^\]\r\n]+)\]\(([^)\r\n]+)\)/g;
 const SKILL_TOKEN_BOUNDARY = "(?=$|\\s|[.,!?;:])";
 
 function escapeRegExp(value: string): string {
@@ -57,7 +68,7 @@ export function parseSkillMentionParts(text: string): SkillMentionPart[] {
     }
 
     output.push({
-      type: "skill",
+      type: label.startsWith("@") ? "directory" : "skill",
       label,
       name: label.slice(1),
       path,

--- a/apps/desktop/src/renderer/src/lib/tildify-path.ts
+++ b/apps/desktop/src/renderer/src/lib/tildify-path.ts
@@ -45,3 +45,28 @@ export function tildifyPath(
   }
   return absolutePath;
 }
+
+/**
+ * Inverse of tildifyPath: expands a leading `~` to the home directory.
+ * Returns the path unchanged when it doesn't start with `~` or when the
+ * home directory is unknown.
+ */
+export function expandTildePath(
+  path: string,
+  homeDir: string | undefined = getHomeDir(),
+): string {
+  if (!path || !homeDir || !path.startsWith("~")) {
+    return path;
+  }
+  const home = homeDir.replace(/[/\\]+$/, "");
+  if (!home) {
+    return path;
+  }
+  if (path === "~") {
+    return home;
+  }
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return `${home}${path.slice(1)}`;
+  }
+  return path;
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2116,6 +2116,7 @@ export function useThreadNavigation(
     collaborationMode?: AppServerCollaborationModeRequest,
     reviewTarget?: AppServerReviewTarget,
     parentThreadId?: string,
+    extraDirectoryPaths?: string[],
   ) => Promise<void>;
   /** Directory the New Thread button resolves to by default, or undefined for the directory-less workspace. */
   newThreadDirectoryLabel?: string;
@@ -2133,6 +2134,12 @@ export function useThreadNavigation(
   ) => Promise<void>;
   /** Existing-thread picker: OS dialog -> validate -> attach as an extra linked directory. */
   pickAndAttachDirectoryToSelectedThread: () => Promise<void>;
+  /**
+   * Attach known directory paths (composer `@`-references) to the selected
+   * thread. Per-path failures are non-fatal — the turn already carries the
+   * path as text, so a failed link only loses the sidebar association.
+   */
+  attachDirectoryPathsToSelectedThread: (paths: string[]) => Promise<void>;
   pickDirectoryError?: string;
   pickingDirectory: boolean;
   clearPickDirectoryError: () => void;
@@ -4270,6 +4277,50 @@ export function useThreadNavigation(
     }
   }, [desktopApi, refresh, selectedThread]);
 
+  const attachDirectoryPathsToSelectedThread = useCallback(
+    async (paths: string[]): Promise<void> => {
+      // Composer `@`-reference links (no OS dialog — the paths are already
+      // known). Failures stay non-fatal: the sent turn carries the path as
+      // text either way, so a failed link only loses the association.
+      if (
+        !desktopApi?.attachDirectoryToThread ||
+        !selectedThread ||
+        paths.length === 0
+      ) {
+        return;
+      }
+
+      const thread = selectedThread;
+      let attachedAny = false;
+      for (const path of paths) {
+        try {
+          const result = await desktopApi.attachDirectoryToThread({
+            backend: thread.source,
+            threadId: thread.id,
+            path,
+            preferredBackend: thread.source,
+          });
+          if (result.ok) {
+            attachedAny = true;
+          } else {
+            console.warn(
+              `Could not link referenced directory ${path}: ${result.message}`,
+            );
+          }
+        } catch (error) {
+          console.warn(
+            `Could not link referenced directory ${path}:`,
+            error,
+          );
+        }
+      }
+      if (attachedAny) {
+        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+      }
+    },
+    [desktopApi, refresh, selectedThread],
+  );
+
   const clearPickDirectoryError = useCallback((): void => {
     setPickDirectoryError(undefined);
   }, []);
@@ -4456,6 +4507,7 @@ export function useThreadNavigation(
       collaborationMode?: AppServerCollaborationModeRequest,
       reviewTarget?: AppServerReviewTarget,
       parentThreadId?: string,
+      extraDirectoryPaths?: string[],
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -4559,6 +4611,29 @@ export function useThreadNavigation(
       }
       if (response.turnStartFailure) {
         setLaunchpadError(response.turnStartFailure.message);
+      }
+      // Link composer `@`-referenced directories to the just-created
+      // thread before the refresh below so the snapshot comes back with
+      // them. Non-fatal per path — the turn already carries the path as
+      // text, so a failed link only loses the sidebar association.
+      if (extraDirectoryPaths && extraDirectoryPaths.length > 0) {
+        for (const path of extraDirectoryPaths) {
+          try {
+            const attachResult = await desktopApi.attachDirectoryToThread?.({
+              backend: response.backend,
+              threadId: response.threadId,
+              path,
+              preferredBackend: response.backend,
+            });
+            if (attachResult && !attachResult.ok) {
+              console.warn(
+                `Could not link referenced directory ${path}: ${attachResult.message}`,
+              );
+            }
+          } catch (error) {
+            console.warn(`Could not link referenced directory ${path}:`, error);
+          }
+        }
       }
       setState((current) => ({
         ...current,
@@ -5464,6 +5539,7 @@ export function useThreadNavigation(
     openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
     pickAndAttachDirectoryToSelectedThread,
+    attachDirectoryPathsToSelectedThread,
     pickDirectoryError,
     pickingDirectory,
     clearPickDirectoryError,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2135,11 +2135,18 @@ export function useThreadNavigation(
   /** Existing-thread picker: OS dialog -> validate -> attach as an extra linked directory. */
   pickAndAttachDirectoryToSelectedThread: () => Promise<void>;
   /**
-   * Attach known directory paths (composer `@`-references) to the selected
-   * thread. Per-path failures are non-fatal — the turn already carries the
-   * path as text, so a failed link only loses the sidebar association.
+   * Attach known directory paths (composer `@`-references) to a specific
+   * thread. The target is explicit — the composer resolves it from the
+   * turn it just sent — so a selection change while the turn request was
+   * in flight (or a queued turn firing later) cannot link the directories
+   * to the wrong thread. Per-path failures are non-fatal — the turn
+   * already carries the path as text, so a failed link only loses the
+   * sidebar association.
    */
-  attachDirectoryPathsToSelectedThread: (paths: string[]) => Promise<void>;
+  attachDirectoryPathsToThread: (
+    target: { backend: AppServerBackendKind; threadId: string },
+    paths: string[],
+  ) => Promise<void>;
   pickDirectoryError?: string;
   pickingDirectory: boolean;
   clearPickDirectoryError: () => void;
@@ -4277,28 +4284,28 @@ export function useThreadNavigation(
     }
   }, [desktopApi, refresh, selectedThread]);
 
-  const attachDirectoryPathsToSelectedThread = useCallback(
-    async (paths: string[]): Promise<void> => {
+  const attachDirectoryPathsToThread = useCallback(
+    async (
+      target: { backend: AppServerBackendKind; threadId: string },
+      paths: string[],
+    ): Promise<void> => {
       // Composer `@`-reference links (no OS dialog — the paths are already
-      // known). Failures stay non-fatal: the sent turn carries the path as
-      // text either way, so a failed link only loses the association.
-      if (
-        !desktopApi?.attachDirectoryToThread ||
-        !selectedThread ||
-        paths.length === 0
-      ) {
+      // known). The caller names the thread explicitly so a selection
+      // change during the send cannot misdirect the attach. Failures stay
+      // non-fatal: the sent turn carries the path as text either way, so a
+      // failed link only loses the association.
+      if (!desktopApi?.attachDirectoryToThread || paths.length === 0) {
         return;
       }
 
-      const thread = selectedThread;
       let attachedAny = false;
       for (const path of paths) {
         try {
           const result = await desktopApi.attachDirectoryToThread({
-            backend: thread.source,
-            threadId: thread.id,
+            backend: target.backend,
+            threadId: target.threadId,
             path,
-            preferredBackend: thread.source,
+            preferredBackend: target.backend,
           });
           if (result.ok) {
             attachedAny = true;
@@ -4315,10 +4322,19 @@ export function useThreadNavigation(
         }
       }
       if (attachedAny) {
-        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+        try {
+          await refresh(
+            buildThreadIdentityKey(target.backend, target.threadId),
+          );
+        } catch (error) {
+          // The attach itself landed and the threadDirectories/updated
+          // event will still reach the snapshot; a failed refresh here is
+          // not worth surfacing (and the caller fire-and-forgets us).
+          console.warn("Could not refresh after linking directories:", error);
+        }
       }
     },
-    [desktopApi, refresh, selectedThread],
+    [desktopApi, refresh],
   );
 
   const clearPickDirectoryError = useCallback((): void => {
@@ -5539,7 +5555,7 @@ export function useThreadNavigation(
     openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
     pickAndAttachDirectoryToSelectedThread,
-    attachDirectoryPathsToSelectedThread,
+    attachDirectoryPathsToThread,
     pickDirectoryError,
     pickingDirectory,
     clearPickDirectoryError,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2135,6 +2135,18 @@ export function useThreadNavigation(
   /** Existing-thread picker: OS dialog -> validate -> attach as an extra linked directory. */
   pickAndAttachDirectoryToSelectedThread: () => Promise<void>;
   /**
+   * No-navigation variant of `pickAndRegisterDirectory` for the composer's
+   * reference pickers ("@ → Add directory…", the "+" menu): OS dialog →
+   * validate/register → fold the new launchpad into the snapshot so the
+   * tracked set knows it, then resolve with the picked directory's
+   * label/path for the caller to mint a chip. Never changes the selected
+   * item. Resolves undefined on cancel or failure (failures also surface
+   * via `pickDirectoryError`).
+   */
+  pickDirectoryForReference: () => Promise<
+    { label: string; path: string } | undefined
+  >;
+  /**
    * Attach known directory paths (composer `@`-references) to a specific
    * thread. The target is explicit — the composer resolves it from the
    * turn it just sent — so a selection change while the turn request was
@@ -4244,6 +4256,63 @@ export function useThreadNavigation(
     [desktopApi, refresh],
   );
 
+  const pickDirectoryForReference = useCallback(async (): Promise<
+    { label: string; path: string } | undefined
+  > => {
+    // No-navigation sibling of pickAndRegisterDirectory: the composer's
+    // reference pickers register the picked directory (so the tracked set
+    // and the `@` autocomplete know it) but keep the current selection —
+    // the caller mints a chip in place instead of moving to the new
+    // launchpad. Same cancel-vs-failure split as the sibling: cancel is
+    // silent, validation failure surfaces via `pickDirectoryError`.
+    if (
+      !desktopApi?.pickDirectoryFromDisk ||
+      !desktopApi?.registerDirectoryFromDisk
+    ) {
+      setPickDirectoryError("Desktop bridge is missing the directory picker.");
+      return undefined;
+    }
+
+    setPickDirectoryError(undefined);
+    setPickingDirectory(true);
+    try {
+      const pick = await desktopApi.pickDirectoryFromDisk();
+      if (pick.canceled) {
+        return undefined;
+      }
+      const result = await desktopApi.registerDirectoryFromDisk({
+        path: pick.path,
+      });
+      if (!result.ok) {
+        setPickDirectoryError(result.message);
+        return undefined;
+      }
+      setLocalLaunchpads((current) => ({
+        ...current,
+        [result.directoryKey]: result.launchpad,
+      }));
+      setState((current) => ({
+        ...current,
+        response: applyLaunchpadUpdate(
+          current.response,
+          result.launchpad,
+          result.defaults,
+        ),
+      }));
+      return {
+        label: result.launchpad.directoryLabel,
+        path: result.launchpad.directoryPath ?? pick.path,
+      };
+    } catch (error) {
+      setPickDirectoryError(
+        error instanceof Error ? error.message : String(error),
+      );
+      return undefined;
+    } finally {
+      setPickingDirectory(false);
+    }
+  }, [desktopApi]);
+
   const pickAndAttachDirectoryToSelectedThread = useCallback(async (): Promise<void> => {
     if (
       !desktopApi?.pickDirectoryFromDisk ||
@@ -5555,6 +5624,7 @@ export function useThreadNavigation(
     openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
     pickAndAttachDirectoryToSelectedThread,
+    pickDirectoryForReference,
     attachDirectoryPathsToThread,
     pickDirectoryError,
     pickingDirectory,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11452,6 +11452,17 @@ textarea,
   border: 1px solid var(--border-subtle);
 }
 
+/* Composer directory-reference mention chip (`@label`). Same silhouette
+   as the skill chip; neutral surface so the accent stays reserved for
+   skills, per the one-accent rule. */
+.directory-chip {
+  max-width: 100%;
+  vertical-align: middle;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-hover);
+  color: var(--text-secondary);
+}
+
 .skill-chip--removable {
   gap: 6px;
   padding-right: 4px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -14497,21 +14497,23 @@ textarea,
 /* ============================================================
    Composer pickers — shared popover language
 
-   The project picker and the branch picker share ONE popover
-   look: an elevated panel, a search header (search icon +
-   borderless input + bottom divider), an uppercase section
-   eyebrow, and rows (leading check column + icon + label) that
-   tint to the accent on hover / keyboard focus. Picker-specific
-   content — a directory's path, a branch's badges + timestamp —
+   The project picker, the branch picker, and the "+" reference
+   picker share ONE popover look: an elevated panel, a search
+   header (search icon + borderless input + bottom divider), an
+   uppercase section eyebrow, and rows (leading check column +
+   icon + label) that tint to the accent on hover / keyboard
+   focus. Picker-specific content — a directory's path, a
+   branch's badges + timestamp, the reference picker's tabs —
    layers on top of these primitives.
 
    Edit the shared look HERE. Keep only genuinely per-picker
    overrides (panel anchor/size, project path/error, branch
-   badges/timestamp) in the `.project-picker__*` /
-   `.branch-picker__*` blocks.
+   badges/timestamp, reference tabs) in the `.project-picker__*`
+   / `.branch-picker__*` / `.reference-picker__*` blocks.
    ============================================================ */
 .project-picker__pop,
-.branch-picker__menu {
+.branch-picker__menu,
+.reference-picker__pop {
   position: absolute;
   z-index: 30;
   bottom: calc(100% + 8px);
@@ -14525,7 +14527,8 @@ textarea,
 }
 
 .project-picker__search,
-.branch-picker__search {
+.branch-picker__search,
+.reference-picker__search {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -14536,7 +14539,8 @@ textarea,
 }
 
 .project-picker__search-icon,
-.branch-picker__search-icon {
+.branch-picker__search-icon,
+.reference-picker__search-icon {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
@@ -14544,7 +14548,8 @@ textarea,
 }
 
 .project-picker__search-input,
-.branch-picker__search-input {
+.branch-picker__search-input,
+.reference-picker__search-input {
   flex: 1 1 auto;
   min-width: 0;
   border: 0;
@@ -14556,7 +14561,8 @@ textarea,
 }
 
 .project-picker__search-input::placeholder,
-.branch-picker__search-input::placeholder {
+.branch-picker__search-input::placeholder,
+.reference-picker__search-input::placeholder {
   color: var(--text-muted);
 }
 
@@ -14572,14 +14578,16 @@ textarea,
 }
 
 .project-picker__list,
-.branch-picker__list {
+.branch-picker__list,
+.reference-picker__list {
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
 
 .project-picker__row,
-.branch-picker__option {
+.branch-picker__option,
+.reference-picker__row {
   display: flex;
   width: 100%;
   align-items: center;
@@ -14601,7 +14609,9 @@ textarea,
 .project-picker__row:focus-visible:not(:disabled),
 .branch-picker__option:hover,
 .branch-picker__option:focus-visible,
-.branch-picker__option.is-active {
+.branch-picker__option.is-active,
+.reference-picker__row:hover:not(:disabled),
+.reference-picker__row:focus-visible:not(:disabled) {
   background: var(--accent-soft);
   color: var(--accent-bright);
   outline: none;
@@ -14619,7 +14629,8 @@ textarea,
 
 /* Leading row glyph (folder / branch icon). */
 .project-picker__row-icon,
-.branch-picker__option-icon {
+.branch-picker__option-icon,
+.reference-picker__row-icon {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
@@ -15054,7 +15065,8 @@ textarea,
   cursor: default;
 }
 
-.project-picker__row-name {
+.project-picker__row-name,
+.reference-picker__row-name {
   flex: 0 0 auto;
   max-width: 160px;
   overflow: hidden;
@@ -15063,7 +15075,8 @@ textarea,
   font-weight: 500;
 }
 
-.project-picker__row-path {
+.project-picker__row-path,
+.reference-picker__row-path {
   flex: 1;
   font-family: var(--font-mono);
   font-size: 11px;
@@ -15074,14 +15087,16 @@ textarea,
   text-align: right;
 }
 
-.project-picker__row--action {
+.project-picker__row--action,
+.reference-picker__row--action {
   flex: 0 0 auto;
   color: var(--accent-bright);
 }
 
 /* The "+" sits in the leading icon column; it follows the action row's
    accent color (not the muted glyph color) so it reads as an affordance. */
-.project-picker__plus {
+.project-picker__plus,
+.reference-picker__plus {
   display: inline-flex;
   flex: 0 0 14px;
   width: 14px;
@@ -15089,14 +15104,16 @@ textarea,
   font-weight: 700;
 }
 
-.project-picker__separator {
+.project-picker__separator,
+.reference-picker__separator {
   flex: 0 0 auto;
   height: 1px;
   margin: 4px 2px;
   background: var(--border-subtle);
 }
 
-.project-picker__empty {
+.project-picker__empty,
+.reference-picker__empty {
   padding: 8px 12px;
   color: var(--text-muted);
   font-size: 12px;
@@ -15156,6 +15173,68 @@ textarea,
   transform: translateX(-50%) rotate(45deg);
   background: currentColor;
   border-radius: 1px;
+}
+
+/* ---- Reference picker specifics (the composer's setup-row "+") ----
+   Shares the popover language above; adds a Projects / Files tab
+   switch under the panel top. Like the project picker, the panel is a
+   FIXED-size flex column: tabs + search pin to the top, the add-…
+   action row(s) pin to the bottom, and only the list scrolls. */
+.reference-picker {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.reference-picker__pop {
+  left: 0;
+  width: 440px;
+  max-width: calc(100vw - 32px);
+  height: 420px;
+  max-height: calc(100dvh - 128px);
+  gap: 4px;
+  overflow: hidden;
+}
+
+.reference-picker__tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 2px;
+  padding: 0 4px 4px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.reference-picker__tab {
+  flex: 0 0 auto;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.reference-picker__tab:hover,
+.reference-picker__tab:focus-visible {
+  color: var(--text-primary);
+  outline: none;
+}
+
+.reference-picker__tab.is-active {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.reference-picker__list {
+  /* Only the list scrolls; it's the sole flex-grow child of the
+     fixed-height panel, so the action row(s) stay pinned. */
+  flex: 1 1 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .workspace-handoff-modal {
@@ -15571,14 +15650,6 @@ textarea,
 .composer__toggle:disabled {
   opacity: 0.45;
   cursor: default;
-}
-
-/* Setup-row "+" reference button: the wrapper anchors the reused
-   composer-dropdown__menu popover above the toggle. */
-.composer__add-reference {
-  display: inline-flex;
-  position: relative;
-  flex: 0 0 auto;
 }
 
 .composer__autocomplete {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11463,6 +11463,17 @@ textarea,
   color: var(--text-secondary);
 }
 
+/* Composer file-reference mention chip (`@basename`). Same neutral
+   silhouette as the directory chip — files are path references, not
+   skills, so the accent stays reserved. */
+.file-chip {
+  max-width: 100%;
+  vertical-align: middle;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel-hover);
+  color: var(--text-secondary);
+}
+
 .skill-chip--removable {
   gap: 6px;
   padding-right: 4px;
@@ -14800,6 +14811,49 @@ textarea,
   white-space: nowrap;
 }
 
+/* Dropped/picked file reference pill in the attachments tray. Same
+   28px silhouette as the directory-reference pill, but a solid border:
+   the file is an explicit attachment with its own remove control, not
+   an informational echo of the draft text. */
+.composer__file-attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 6px 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-hover);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.composer__file-attachment-label {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer__file-attachment-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.composer__file-attachment-remove:hover {
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+}
+
 .composer__inline-error {
   max-width: min(320px, 100%);
   color: var(--danger-text);
@@ -15519,6 +15573,14 @@ textarea,
   cursor: default;
 }
 
+/* Setup-row "+" reference button: the wrapper anchors the reused
+   composer-dropdown__menu popover above the toggle. */
+.composer__add-reference {
+  display: inline-flex;
+  position: relative;
+  flex: 0 0 auto;
+}
+
 .composer__autocomplete {
   position: absolute;
   right: 0;
@@ -15646,6 +15708,23 @@ textarea,
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.45;
+}
+
+/* Divider between the matched options and the "Add directory… / Add
+   file…" action rows at the bottom of the `@` popover. */
+.composer__autocomplete-separator {
+  flex: 0 0 auto;
+  margin: 4px 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.composer__autocomplete-option--action .composer__autocomplete-title {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.composer__autocomplete-option--action:hover .composer__autocomplete-title {
+  color: var(--text-primary);
 }
 
 .composer__review-config {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -14767,6 +14767,28 @@ textarea,
   gap: 6px;
 }
 
+/* Draft `@`-referenced directory (linked to the thread when the turn is
+   sent). Informational — the reference is removed by deleting the path
+   from the draft text, so the chip has no close affordance. */
+.composer__directory-reference {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.composer__directory-reference-label {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .composer__inline-error {
   max-width: min(320px, 100%);
   color: var(--danger-text);

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -224,6 +224,23 @@ export const NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL =
  */
 export const NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL =
   "navigation:pick-file-from-disk";
+/**
+ * Combined file-or-directory variant used by the composer's reference
+ * picker on macOS, where one OS dialog can offer both kinds. The main
+ * process classifies each pick via `fs.stat` so the renderer can route
+ * files to the attachment tray and directories to reference chips.
+ */
+export const NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL =
+  "navigation:pick-reference-from-disk";
+/**
+ * Recently referenced files for the reference picker's Files tab —
+ * `list` reads the persisted most-recent-first list; `record` is a
+ * fire-and-forget append whenever the composer commits file references.
+ */
+export const NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL =
+  "navigation:list-recent-file-references";
+export const NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL =
+  "navigation:record-recent-file-references";
 export const COMPOSER_DRAFT_SAVE_CHANNEL = "composer-draft:save";
 export const COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL =
   "composer-draft:record-history";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -217,6 +217,13 @@ export const NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL =
   "navigation:pick-directory-from-disk";
 export const NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL =
   "navigation:register-directory-from-disk";
+/**
+ * File variant of the picker above, used by the composer's file
+ * reference flows ("Add file…" in the @ popover / + menu). No register
+ * step — files are referenced by path, not tracked like directories.
+ */
+export const NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL =
+  "navigation:pick-file-from-disk";
 export const COMPOSER_DRAFT_SAVE_CHANNEL = "composer-draft:save";
 export const COMPOSER_DRAFT_RECORD_HISTORY_CHANNEL =
   "composer-draft:record-history";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -453,6 +453,7 @@ export type UpdateDirectoryLaunchpadRequest = {
     Pick<
       NavigationLaunchpadDraft,
       | "imageAttachments"
+      | "fileAttachments"
       | "prompt"
       | "editorDocument"
       | "backend"
@@ -601,6 +602,16 @@ export type SetCodexThreadEnvironmentResponse = {
 export type PickDirectoryFromDiskResponse =
   | { canceled: true }
   | { canceled: false; path: string };
+
+/**
+ * Result of the composer's "Add file…" reference picker. Multi-select is
+ * allowed — each picked path becomes one file-reference chip or tray
+ * attachment. Files are referenced by path only; contents are never read
+ * by the picker.
+ */
+export type PickFileFromDiskResponse =
+  | { canceled: true }
+  | { canceled: false; paths: string[] };
 
 export type RegisterDirectoryFromDiskRequest = {
   /** Absolute path the user picked from the system dialog. */

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -613,6 +613,34 @@ export type PickFileFromDiskResponse =
   | { canceled: true }
   | { canceled: false; paths: string[] };
 
+/**
+ * Result of the composer's combined "Add file or directory…" reference
+ * picker (macOS only — Electron can combine `openFile` + `openDirectory`
+ * there; Windows/Linux dialogs cannot, so those platforms keep separate
+ * file/directory pickers). Each entry is classified main-side via
+ * `fs.stat`; unreadable paths are skipped.
+ */
+export type PickReferenceFromDiskResponse =
+  | { canceled: true }
+  | {
+      canceled: false;
+      entries: { path: string; kind: "file" | "directory" }[];
+    };
+
+/**
+ * Recently referenced files for the composer's reference picker. The main
+ * process persists a small most-recent-first list of paths (capped,
+ * deduped by path) and computes each label from the path's basename.
+ */
+export type ListRecentFileReferencesResponse = {
+  files: { label: string; path: string }[];
+};
+
+/** Fire-and-forget record of freshly committed file references. */
+export type RecordRecentFileReferencesRequest = {
+  paths: string[];
+};
+
 export type RegisterDirectoryFromDiskRequest = {
   /** Absolute path the user picked from the system dialog. */
   path: string;

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -21,6 +21,12 @@ export type ComposerDraftSkillToken = {
   description?: string;
   shortDescription?: string;
   source?: string;
+  /**
+   * Absent for skill mentions (the original kind). "directory" marks a
+   * composer directory-reference chip: `name` is the tracked directory's
+   * label and `path` its absolute path.
+   */
+  kind?: "directory";
 };
 
 export type ComposerDraftSnapshotRecord = {

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -1,5 +1,8 @@
 import type { AppServerBackendKind, ThreadIdentifier } from "./normalized-app-server";
-import type { NavigationLaunchpadImageAttachment } from "./navigation";
+import type {
+  NavigationLaunchpadFileAttachment,
+  NavigationLaunchpadImageAttachment,
+} from "./navigation";
 
 export type ComposerDraftScopeKind = "thread" | "launchpad" | "empty";
 
@@ -24,9 +27,11 @@ export type ComposerDraftSkillToken = {
   /**
    * Absent for skill mentions (the original kind). "directory" marks a
    * composer directory-reference chip: `name` is the tracked directory's
-   * label and `path` its absolute path.
+   * label and `path` its absolute path. "file" marks a file-reference
+   * chip: `name` is the file's basename and `path` its absolute file
+   * path. Both serialize to the same `[@label](~/path)` markdown.
    */
-  kind?: "directory";
+  kind?: "directory" | "file";
 };
 
 export type ComposerDraftSnapshotRecord = {
@@ -40,6 +45,7 @@ export type ComposerDraftSnapshotRecord = {
   editorDocument?: ComposerDraftJsonValue;
   skillTokens: ComposerDraftSkillToken[];
   imageAttachments: NavigationLaunchpadImageAttachment[];
+  fileAttachments?: NavigationLaunchpadFileAttachment[];
   status: ComposerDraftLifecycle;
   createdAt: number;
   updatedAt: number;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -507,6 +507,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
    */
   editorDocument?: Record<string, unknown>;
   imageAttachments?: NavigationLaunchpadImageAttachment[];
+  fileAttachments?: NavigationLaunchpadFileAttachment[];
   prompt: string;
   registeredAt?: number;
   settingsTouchedAt?: number;
@@ -544,6 +545,20 @@ export type NavigationLaunchpadImageAttachment = {
   type: string;
   url: string;
   width?: number;
+};
+
+/**
+ * A file referenced by path from the composer's attachment tray
+ * (drag-and-drop or the "+ Add file…" picker). Path-only by design —
+ * contents are never captured; the outgoing text carries a
+ * `[@label](~/path)` reference the agent reads itself.
+ */
+export type NavigationLaunchpadFileAttachment = {
+  id: string;
+  /** Display label, normally the file's basename. */
+  label: string;
+  /** Absolute on-disk path. */
+  path: string;
 };
 
 /**


### PR DESCRIPTION
## What

Typing `@` in the composer (launchpad or reply) opens an autocomplete over tracked directories — the same population as the project picker, most recently used first, filtered by label or path as you keep typing. Committing a pick mints a **durable `@label` mention chip** in the editor (like the `$skill` chips): an atomic token you delete as a unit, which serializes to the directory's **tilde-shortened path** (`~/GIPHY/search-product`) in the outgoing text and launchpad prompt.

References get linked to the thread at send time:

- **New thread**: paths ride along with materialization (`onMaterializeLaunchpad` gains `extraDirectoryPaths`) and are attached via the existing `attachDirectoryToThread` IPC right after the thread is created — so they land in `extraLinkedDirectories`, the Linked Projects panel, and the agent-visible linked-directory set from the first turn.
- **Existing thread**: attached right after the turn starts (`onAttachDirectoryReferences` → `attachDirectoryPathsToThread` in `useThreadNavigation`, with the target thread pinned explicitly).

The chip rides the existing skill-token rails via a `kind: "directory"` discriminator on `ComposerSkillToken` / the mention-node attrs: zero-width token anchored at a draft offset, index re-anchoring on edits, atomic backspace delete + undo, `editorDocument` round-trip, and draft-store persistence all come for free. The send-time derivation scans the **serialized** draft, so chips and hand-typed/pasted paths flow through one code path — a hand-typed `~/repo` still links, and if a prompt-only restore ever loses a chip, the tilde path it serialized to still re-derives the reference. Dashed pills in the setup row preview what will be linked. Attach failures are non-fatal — the turn already carries the path as text.

Matching details for the text scan: a sibling name that extends the path (`~/GIPHY/search-product-v2`) does not match; a deeper path resolves to its tracked repo; with nested tracked repos the deepest match wins; already-linked directories (the launchpad's own directory, a thread's linked directories including worktree checkouts) are excluded.

### File references

The same system extends to **files**, referenced by path only — contents are never read; the outgoing text carries `[@basename](~/path)` markdown the agent reads itself, and a file inside a tracked repo links that repo via the deeper-path scan. Three entry points, one rule — *chips when you're typing, tray when you're attaching*:

- **Drag-and-drop / paste** of non-image files lands in the same attachment tray as images, as removable path pills (paths resolved via a new preload `webUtils.getPathForFile` bridge; deduped, capped at 20). At send, pill references append after the typed text. Tray files persist with drafts and ride queued/steer turns; a files-only draft is sendable.
- The **`@` autocomplete** gains "Add directory…" / "Add file…" action rows (parity with the new-thread project picker's bottom action): the directory action pick-and-registers **without navigating** (`pickDirectoryForReference`) and mints a chip at the trigger; the file action opens a new multi-select `pickFileFromDisk` dialog and mints `kind: "file"` chips.
- A small **`+` Add-reference toggle** joins the setup row (same chrome as the fast/plan toggles) with the same two actions: directory → chip at the caret, file → tray.

## Why

Referencing a second repo in a prompt meant typing the full `/Users/...` path by hand, and the thread never learned about the association — the Linked Projects panel and cross-repo tooling only saw directories attached manually afterwards. This makes a reference one `@` away (or one drag-and-drop), durable in the draft, and part of the thread's linked-directory set (introspectable by the agent) from the first turn. Previously, dropping a non-image file on the composer did nothing at all.

## Reviewer notes

- **The chip reuses the single `mention` node type** with a `kind` attr rather than a parallel extension — `buildTiptapContent`/`readTiptapContent`, the external-insertion fast path (trigger re-located by kind: `@` vs `$`), persistence, and undo all stay shared. `serializeDraftWithSkillTokens` branches per kind: `[$name](path)` for skills, tilde path for directories.
- **Protected-update pattern**: all programmatic draft inserts (skills, slash commands, directory chips) use `pendingProgrammaticComposerChangeRef` + `flushSync`. An unguarded insert ping-pongs with the editability layout effect — tiptap's `setEditable` emits an `update` event that replays the editor's pre-insert content through `onChange` — until React's max update depth. `applySlashCommand` had this latent (pre-existing) bug; the second commit fixes it, dismisses the phantom slash trigger the stale caret leaves behind, and adds a provider-command regression test.
- **Thread-pinned attach**: the post-turn attach names its target thread explicitly (from the same render snapshot as the sent turn), so a selection change mid-send or a queued turn firing later cannot link directories to the wrong thread.
- The composer's `onMaterializeLaunchpad` 5th arg is `extraDirectoryPaths`, while the hook's 5th is `parentThreadId` — `App.tsx` maps positions explicitly.
- **Metacharacter hardening**: serialized destinations percent-encode parens/whitespace/`%` (lossless decode on hydration, tolerant of never-encoded links); a link-breaking label falls back to the bare tilde path.
- **File chips vs directory chips**: `kind: "file"` rides the same mention rails; a prompt-only restore degrades a file chip to directory kind (documented — affects tooltip copy only; attach never targets file paths, the scan links the containing repo).
- New IPC surface: `navigation:pick-file-from-disk` (window-anchored `openFile`+`multiSelections` dialog, E2E override `PWRAGENT_E2E_PICK_FILE_PATHS`) and the preload `getPathForFile` bridge. No file contents cross any boundary.

## Testing

- Unit suite `lib/__tests__/directory-references.test.ts` (31 tests: trigger detection incl. email non-trigger, candidate filtering/capping, markdown build/encode/decode round trips, file labels/tooltips, draft scanning boundaries/dedup/nesting/exclusions).
- Composer tests drive the real tiptap editor: `@` autocomplete → chip minted → serialized markdown + `extraDirectoryPaths` on Start thread; prompt-only chip rehydration with token-driven attach; hand-typed tilde path → thread-pinned attach after a reply; provider slash-command commit regression; guaranteed post-chip space + caret; file drop → tray pill → appended reference on send; files-only send; picker action rows and the `+` menu (mocked dialogs).
- `useThreadNavigation` tests cover `pickDirectoryForReference` (no navigation; error path).
- Full renderer suite: 1442 tests across 89 files pass; shared package 158; `typecheck`, `lint:eslint`, `lint:colors`, and `lint:boundaries` clean. Desktop E2E verified green on CI for the chip-commit expectation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

