### PR TITLE
fix(desktop): reveal history-selected threads

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -194,6 +194,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   >(undefined);
   const [directoriesPinnedDividerDropTarget, setDirectoriesPinnedDividerDropTarget] =
     useState(false);
+  const previousSelectedItemKeyRef = useRef<string | undefined>(undefined);
   /**
    * Suppress the directory summary button's expand/collapse click
    * when the click is the trailing edge of a drag gesture. Browsers
@@ -368,9 +369,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
   useEffect(() => {
     const selectedItemKey = props.selectedItemKey;
+    const previousSelectedItemKey = previousSelectedItemKeyRef.current;
+    previousSelectedItemKeyRef.current = selectedItemKey;
     if (!selectedItemKey) {
       return;
     }
+    const selectedItemKeyChanged = selectedItemKey !== previousSelectedItemKey;
 
     setExpandedByKey((current) => {
       for (const directory of props.directories) {
@@ -378,16 +382,18 @@ export function DirectoriesList(props: DirectoriesListProps) {
           selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
           directory.threadKeys.includes(selectedItemKey)
         ) {
-          // Respect explicit user state in either direction. If the
-          // user has touched this directory's expand state at all
-          // (true OR false), leave it alone — they're driving. We
-          // only auto-expand on the first reveal when the key is
-          // `undefined`. Previously this checked `if (current[key])`
-          // which treated `false` as "not yet expanded" and re-
-          // overrode the user's collapse every time `directories`
-          // changed reference (which happens on EVERY snapshot
-          // mutation, e.g. unpinning an unrelated sibling).
-          if (current[directory.key] !== undefined) {
+          // Preserve explicit user collapse across unrelated
+          // directory snapshot changes, but allow a newly selected
+          // item (for example Back/Forward navigation to a hidden
+          // thread) to reopen its containing directory for reveal.
+          // Previously this checked `if (current[key])`, which
+          // treated `false` as "not yet expanded" and re-overrode
+          // the user's collapse every time `directories` changed
+          // reference (for example unpinning an unrelated sibling).
+          if (
+            current[directory.key] !== undefined &&
+            !selectedItemKeyChanged
+          ) {
             return current;
           }
 

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -369,42 +369,42 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
   useEffect(() => {
     const selectedItemKey = props.selectedItemKey;
-    const previousSelectedItemKey = previousSelectedItemKeyRef.current;
-    previousSelectedItemKeyRef.current = selectedItemKey;
     if (!selectedItemKey) {
+      previousSelectedItemKeyRef.current = undefined;
       return;
     }
+    const matchingDirectory = props.directories.find(
+      (directory) =>
+        selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
+        directory.threadKeys.includes(selectedItemKey),
+    );
+    if (!matchingDirectory) {
+      return;
+    }
+
+    const previousSelectedItemKey = previousSelectedItemKeyRef.current;
     const selectedItemKeyChanged = selectedItemKey !== previousSelectedItemKey;
+    previousSelectedItemKeyRef.current = selectedItemKey;
 
     setExpandedByKey((current) => {
-      for (const directory of props.directories) {
-        if (
-          selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
-          directory.threadKeys.includes(selectedItemKey)
-        ) {
-          // Preserve explicit user collapse across unrelated
-          // directory snapshot changes, but allow a newly selected
-          // item (for example Back/Forward navigation to a hidden
-          // thread) to reopen its containing directory for reveal.
-          // Previously this checked `if (current[key])`, which
-          // treated `false` as "not yet expanded" and re-overrode
-          // the user's collapse every time `directories` changed
-          // reference (for example unpinning an unrelated sibling).
-          if (
-            current[directory.key] !== undefined &&
-            !selectedItemKeyChanged
-          ) {
-            return current;
-          }
-
-          return {
-            ...current,
-            [directory.key]: true,
-          };
-        }
+      // Preserve explicit user collapse across unrelated directory
+      // snapshot changes, but allow a newly selected item (for
+      // example Back/Forward navigation to a hidden thread) to
+      // reopen its containing directory for reveal. Only mark a
+      // selected key as consumed after a matching directory exists;
+      // showThread() can set selection before the refreshed
+      // directory snapshot includes the thread.
+      if (
+        current[matchingDirectory.key] !== undefined &&
+        !selectedItemKeyChanged
+      ) {
+        return current;
       }
 
-      return current;
+      return {
+        ...current,
+        [matchingDirectory.key]: true,
+      };
     });
   }, [props.directories, props.selectedItemKey]);
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -103,6 +103,7 @@ export function ThreadRow(props: ThreadRowProps) {
   const isComposerSource = threadKey === props.composerSourceThreadKey;
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const rowButtonRef = useRef<HTMLButtonElement>(null);
   const addReactionRef = useRef<HTMLSpanElement>(null);
   const reactions = props.thread.reactions ?? [];
   const canReact = Boolean(props.onSetReaction);
@@ -125,6 +126,19 @@ export function ThreadRow(props: ThreadRowProps) {
       hoverTimerRef.current = undefined;
     }
   }, []);
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+
+    if (typeof rowButtonRef.current?.scrollIntoView !== "function") {
+      return;
+    }
+
+    rowButtonRef.current.scrollIntoView({
+      block: "nearest",
+    });
+  }, [selected, threadKey]);
   const armHoverPrefetch = (): void => {
     if (!props.onPrefetchPullRequests) return;
     if (hoverTimerRef.current !== undefined) return;
@@ -190,6 +204,7 @@ export function ThreadRow(props: ThreadRowProps) {
         />
       ) : null}
       <button
+        ref={rowButtonRef}
         aria-label={props.thread.title}
         aria-pressed={selected}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -22,6 +22,36 @@ async function clickElement(element: HTMLElement): Promise<void> {
   });
 }
 
+function withMockScrollIntoView(): {
+  scrollIntoView: ReturnType<typeof vi.fn>;
+  restore: () => void;
+} {
+  const scrollIntoView = vi.fn();
+  const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollIntoView",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: scrollIntoView,
+  });
+
+  return {
+    scrollIntoView,
+    restore: () => {
+      if (originalScrollIntoView) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollIntoView",
+          originalScrollIntoView,
+        );
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+      }
+    },
+  };
+}
+
 const backends: BackendSummary[] = [
   {
     kind: "codex",
@@ -191,6 +221,152 @@ afterEach(() => {
 });
 
 describe("Sidebar", () => {
+  it("scrolls a newly selected thread row into view", () => {
+    const { scrollIntoView, restore } = withMockScrollIntoView();
+    const nextThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-next",
+      title: "Next thread from history",
+    };
+
+    try {
+      const { rerender } = render(
+        <Sidebar
+          backends={backends}
+          browseMode="recents"
+          createThreadError={undefined}
+          directories={directories}
+          inboxThreads={[sharedThread, nextThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-1"
+          threads={[sharedThread, nextThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+      scrollIntoView.mockClear();
+
+      rerender(
+        <Sidebar
+          backends={backends}
+          browseMode="recents"
+          createThreadError={undefined}
+          directories={directories}
+          inboxThreads={[sharedThread, nextThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-next"
+          threads={[sharedThread, nextThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("expands a user-collapsed directory and scrolls the selected thread into view", async () => {
+    const { scrollIntoView, restore } = withMockScrollIntoView();
+    const nextThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-in-projectb",
+      title: "History target inside ProjectB",
+      linkedDirectories: [
+        {
+          id: "dir-projectb",
+          label: "ProjectB",
+          path: "/Users/huntharo/pwrdrvr/ProjectB",
+          kind: "local" as const,
+        },
+      ],
+    };
+    const projectBDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/pwrdrvr/ProjectB",
+      kind: "directory",
+      label: "ProjectB",
+      path: "/Users/huntharo/pwrdrvr/ProjectB",
+      threadKeys: ["codex:thread-in-projectb"],
+      needsAttentionCount: 0,
+      latestUpdatedAt: nextThread.updatedAt,
+    };
+
+    try {
+      const { rerender } = render(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          directories={[directories[0]!, projectBDirectory]}
+          inboxThreads={[sharedThread, nextThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-1"
+          threads={[sharedThread, nextThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      const projectBSummary = screen
+        .getAllByRole("button", { name: /ProjectB/i })
+        .find((button) => button.hasAttribute("aria-expanded"));
+      expect(projectBSummary).toBeDefined();
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.click(projectBSummary!);
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "true");
+      fireEvent.click(projectBSummary!);
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "false");
+      scrollIntoView.mockClear();
+
+      rerender(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          directories={[directories[0]!, projectBDirectory]}
+          inboxThreads={[sharedThread, nextThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-in-projectb"
+          threads={[sharedThread, nextThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(projectBSummary).toHaveAttribute("aria-expanded", "true");
+      });
+      expect(
+        screen.getByRole("button", { name: "History target inside ProjectB" }),
+      ).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("renders Inbox as the first thread lens and keeps directory rows available", () => {
     const onOpenSettings = vi.fn();
     render(

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -367,6 +367,121 @@ describe("Sidebar", () => {
     }
   });
 
+  it("reveals a selected thread after its directory membership refreshes", async () => {
+    const { scrollIntoView, restore } = withMockScrollIntoView();
+    const refreshedThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-after-refresh",
+      title: "History target after refresh",
+      linkedDirectories: [
+        {
+          id: "dir-projectb",
+          label: "ProjectB",
+          path: "/Users/huntharo/pwrdrvr/ProjectB",
+          kind: "local" as const,
+        },
+      ],
+    };
+    const projectBWithoutThread: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/pwrdrvr/ProjectB",
+      kind: "directory",
+      label: "ProjectB",
+      path: "/Users/huntharo/pwrdrvr/ProjectB",
+      threadKeys: [],
+      needsAttentionCount: 0,
+      latestUpdatedAt: refreshedThread.updatedAt,
+    };
+    const projectBWithThread: NavigationDirectorySummary = {
+      ...projectBWithoutThread,
+      threadKeys: ["codex:thread-after-refresh"],
+    };
+
+    try {
+      const { rerender } = render(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          directories={[directories[0]!, projectBWithoutThread]}
+          inboxThreads={[sharedThread, refreshedThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-1"
+          threads={[sharedThread, refreshedThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      const projectBSummary = screen
+        .getAllByRole("button", { name: /ProjectB/i })
+        .find((button) => button.hasAttribute("aria-expanded"));
+      expect(projectBSummary).toBeDefined();
+      fireEvent.click(projectBSummary!);
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "true");
+      fireEvent.click(projectBSummary!);
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "false");
+      scrollIntoView.mockClear();
+
+      rerender(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          directories={[directories[0]!, projectBWithoutThread]}
+          inboxThreads={[sharedThread, refreshedThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-after-refresh"
+          threads={[sharedThread, refreshedThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+      expect(projectBSummary).toHaveAttribute("aria-expanded", "false");
+      expect(
+        screen.queryByRole("button", { name: "History target after refresh" }),
+      ).not.toBeInTheDocument();
+
+      rerender(
+        <Sidebar
+          backends={backends}
+          browseMode="directories"
+          createThreadError={undefined}
+          directories={[directories[0]!, projectBWithThread]}
+          inboxThreads={[sharedThread, refreshedThread]}
+          launchpadError={undefined}
+          loading={false}
+          creatingThread={undefined}
+          selectedItemKey="codex:thread-after-refresh"
+          threads={[sharedThread, refreshedThread]}
+          onBrowseModeChange={() => undefined}
+          onCreateThread={async () => undefined}
+          onOpenLaunchpad={async () => undefined}
+          onSelectThread={() => undefined}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(projectBSummary).toHaveAttribute("aria-expanded", "true");
+      });
+      expect(
+        screen.getByRole("button", { name: "History target after refresh" }),
+      ).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("renders Inbox as the first thread lens and keeps directory rows available", () => {
     const onOpenSettings = vi.fn();
     render(


### PR DESCRIPTION
## Summary
Thread history navigation now keeps the sidebar anchored on the thread you landed on. When Back or Forward selects a thread that is outside the visible portion of the list, the selected row is scrolled into view; when that thread lives inside a collapsed directory group, the directory is reopened first so the row can be revealed.

The directory reveal still preserves intentional user collapse across unrelated directory snapshot updates, so pinning or unpinning another directory does not reopen a group unless the selected item actually changes into it.

## Validation
- Confirmed the new regression tests failed before the fix: one for missing `scrollIntoView`, one for a selected thread hidden inside a user-collapsed directory.
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
