### PR TITLE
fix(messaging): restore queued Steer button

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -7,6 +7,28 @@ import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("reads active turns from the registry", async () => {
+    const bridge = createBridge({
+      entries: [],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    });
+
+    await expect(
+      bridge.readActiveTurn({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-live",
+    });
+  });
+
   it("prefers newer transcript assistant entries over stale replay messages", async () => {
     const bridge = createBridge({
       entries: [
@@ -131,6 +153,11 @@ function createBridge(replay: AppServerThreadReplay): DesktopMessagingBackendBri
     replay,
   };
   const registry = {
+    getActiveTurnForThread: vi.fn(async () => ({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-live",
+    })),
     readThread: vi.fn(async () => response),
   } as unknown as DesktopBackendRegistry;
   return new DesktopMessagingBackendBridge(registry);

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -8169,6 +8169,59 @@ describe("MessagingController", () => {
     });
   });
 
+  it("offers Steer on queued input when the registry still knows the active turn", async () => {
+    const harness = await createHarness({
+      readActiveTurn: async () => ({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-live",
+      }),
+    });
+    await bindThread(harness);
+    harness.startTurn.mockRejectedValueOnce(
+      new Error("thread already has an active turn in progress"),
+    );
+
+    await harness.controller.handleInboundEvent(buildTextEvent("second turn"));
+
+    const queuedNotice = harness.delivered
+      .filter((intent) => intent.kind === "confirmation" && intent.title === "Message queued")
+      .at(-1);
+    if (!queuedNotice || !("actions" in queuedNotice)) {
+      throw new Error("Queued notice was not delivered");
+    }
+    const queuedActions = Array.isArray(queuedNotice.actions)
+      ? queuedNotice.actions
+      : [];
+    const steerAction = queuedActions.find((action) =>
+      action.id.startsWith("queued-turn:steer:"),
+    );
+    expect(queuedNotice).toEqual(
+      expect.objectContaining({
+        body: expect.stringContaining("click Steer"),
+      }),
+    );
+    expect(steerAction?.disabled).toBe(false);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: steerAction!.id,
+      }),
+    );
+
+    expect(harness.steerTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      expectedTurnId: "turn-live",
+      input: [
+        {
+          type: "text",
+          text: "second turn",
+        },
+      ],
+    });
+  });
+
   it("clears a staged skill when backend concurrent-start rejection queues the prefixed request", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -15059,6 +15112,7 @@ async function createHarness(options?: {
   readThreadLastAssistantReply?: NonNullable<
     MessagingBackendBridge["readThreadLastAssistantReply"]
   >;
+  readActiveTurn?: NonNullable<MessagingBackendBridge["readActiveTurn"]>;
   setAcpSessionRuntimeOption?: NonNullable<
     MessagingBackendBridge["setAcpSessionRuntimeOption"]
   >;
@@ -15081,6 +15135,7 @@ async function createHarness(options?: {
   onBindingChanged: ReturnType<typeof vi.fn>;
   readThreadLastAssistantMessage: ReturnType<typeof vi.fn>;
   readThreadLastAssistantReply: ReturnType<typeof vi.fn>;
+  readActiveTurn: ReturnType<typeof vi.fn>;
   readThreadStatus: ReturnType<typeof vi.fn>;
   recordMessagingBindingTransition: ReturnType<typeof vi.fn>;
   setAcpSessionRuntimeOption: ReturnType<typeof vi.fn>;
@@ -15409,6 +15464,9 @@ async function createHarness(options?: {
   const readThreadLastAssistantReply = vi.fn(
     options?.readThreadLastAssistantReply ?? (async () => undefined),
   );
+  const readActiveTurn = vi.fn(
+    options?.readActiveTurn ?? (async () => undefined),
+  );
   const readThreadStatus = vi.fn(async () => undefined);
   const recordMessagingBindingTransition = vi.fn(async () => undefined);
   const submitServerRequest = vi.fn(async (request: SubmitServerRequestRequest) => ({
@@ -15427,6 +15485,7 @@ async function createHarness(options?: {
     ...(listSkills ? { listSkills } : {}),
     listBackends,
     materializeDirectoryLaunchpad,
+    readActiveTurn,
     readThreadLastAssistantReply,
     readThreadLastAssistantMessage,
     readThreadStatus,
@@ -15489,6 +15548,7 @@ async function createHarness(options?: {
     listBackends,
     materializeDirectoryLaunchpad,
     onBindingChanged,
+    readActiveTurn,
     readThreadLastAssistantMessage,
     readThreadLastAssistantReply,
     readThreadStatus,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8488,6 +8488,40 @@ export class DesktopBackendRegistry {
     return this.threadTurnQueue.canStartImmediately(params);
   }
 
+  getActiveTurnForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): { backend: AppServerBackendKind; threadId: string; turnId: string } | undefined {
+    if (params.backend === "codex") {
+      for (const key of this.activeCodexTurnModes.keys()) {
+        const parsed = parseThreadTurnKeyBody(key);
+        if (
+          parsed?.threadId === params.threadId &&
+          !parsed.turnId.startsWith("pending:")
+        ) {
+          return {
+            backend: params.backend,
+            threadId: parsed.threadId,
+            turnId: parsed.turnId,
+          };
+        }
+      }
+      return undefined;
+    }
+
+    for (const key of this.activeTurnKeys) {
+      const parsed = parseActiveTurnKey(key);
+      if (
+        parsed?.backend === params.backend &&
+        parsed.threadId === params.threadId &&
+        !parsed.turnId.startsWith("pending:")
+      ) {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
   getInProgressThreadSnapshotForQuit(): {
     count: number;
     threadIds: string[];

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -85,6 +85,12 @@ export type MessagingLastAssistantReply = {
   text: string;
 };
 
+export type MessagingActiveBackendTurn = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  turnId: string;
+};
+
 export type MessagingAdapter = {
   capabilityProfile: MessagingCapabilityProfile;
   clientRateLimitStrategy?: MessagingClientRateLimitStrategy;
@@ -127,6 +133,10 @@ export type MessagingBackendBridge = {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<AppServerThreadStatus | undefined>;
+  readActiveTurn?(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<MessagingActiveBackendTurn | undefined>;
   readThreadLastAssistantMessage?(request: {
     backend: AppServerBackendKind;
     threadId: string;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -2289,7 +2289,11 @@ export class MessagingController {
   }
 
   private async deliverQueuedTurnNotice(entry: MessagingQueuedTurnEntry): Promise<void> {
-    const canSteer = this.canSteerQueuedTurn(entry);
+    const activeTurn = await this.resolveSteerableActiveTurn(
+      entry.binding,
+      "queued_turn_notice",
+    );
+    const canSteer = this.canSteerQueuedTurn(activeTurn);
     const intent = buildConfirmationIntent({
       id: this.newIntentId("queued-turn"),
       capabilityProfile: this.capabilityProfile,
@@ -2318,8 +2322,9 @@ export class MessagingController {
     }
   }
 
-  private canSteerQueuedTurn(entry: MessagingQueuedTurnEntry): boolean {
-    const activeTurn = this.getActiveTurn(entry.binding);
+  private canSteerQueuedTurn(
+    activeTurn: MessagingActiveTurnSummary | undefined,
+  ): boolean {
     return Boolean(
       this.options.backend.steerTurn &&
         activeTurn &&
@@ -2395,7 +2400,7 @@ export class MessagingController {
       return;
     }
 
-    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+    const activeTurn = await this.resolveSteerableActiveTurn(
       entry.binding,
       "queued_turn_steer",
     );
@@ -10573,6 +10578,45 @@ export class MessagingController {
       reason: `${reason}:thread_status_idle`,
     });
     return completedTurn;
+  }
+
+  private async resolveSteerableActiveTurn(
+    binding: MessagingBindingRecord,
+    reason: string,
+  ): Promise<MessagingActiveTurnSummary | undefined> {
+    const activeTurn = await this.reconcileActiveTurnFromBackendStatus(
+      binding,
+      reason,
+    );
+    if (activeTurn && ["working", "waiting"].includes(activeTurn.status)) {
+      return activeTurn;
+    }
+
+    const backendTurn = await this.options.backend.readActiveTurn?.({
+      backend: binding.backend,
+      threadId: binding.threadId,
+    });
+    if (!backendTurn?.turnId) {
+      return activeTurn;
+    }
+
+    const restoredTurn: MessagingActiveTurnSummary = {
+      turnId: backendTurn.turnId,
+      status: "working",
+      updatedAt: this.now(),
+    };
+    this.setActiveTurn(binding, restoredTurn);
+    this.logBindingTurnStateChange(
+      binding,
+      activeTurn,
+      restoredTurn,
+      `${reason}:active_turn_lookup`,
+    );
+    await this.signalTurnActivity(binding, restoredTurn, {
+      force: true,
+      reason: `${reason}:active_turn_lookup`,
+    });
+    return restoredTurn;
   }
 
   private async retireApprovalCallbackIfBackendIdle(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -105,6 +105,20 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     return response.threadStatus ?? response.replay.threadStatus;
   }
 
+  async readActiveTurn(request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<
+    | {
+        backend: AppServerBackendKind;
+        threadId: string;
+        turnId: string;
+      }
+    | undefined
+  > {
+    return this.registry.getActiveTurnForThread(request);
+  }
+
   async readThreadLastAssistantMessage(request: {
     backend: AppServerBackendKind;
     threadId: string;


### PR DESCRIPTION
## Summary
Queued Telegram follow-ups now offer Steer when PwrAgent still has an active turn in the registry, even if the messaging controller lost its local active-turn cache. Before this, the queued-message notice could render only Cancel because Steer eligibility depended solely on controller memory; Telegram then hid the disabled Steer action entirely.

The messaging bridge now exposes the registry's active turn id for this recovery path, and queued-turn callbacks use the restored id as `expectedTurnId` for `turn/steer`.

## Validation
- `npm exec --yes pnpm@10.33.0 -- test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts`
- `npm exec --yes pnpm@10.33.0 -- typecheck`
- `npm exec --yes pnpm@10.33.0 -- lint:eslint` (0 errors; existing warning baseline remains)
- `npm exec --yes pnpm@10.33.0 -- lint:boundaries`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5.5](https://img.shields.io/badge/GPT--5.5-000000)
