### PR TITLE
fix(desktop): route HEAD worktree PR refreshes

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4090,6 +4090,125 @@ describe("app server ipc", () => {
     });
   });
 
+  it("routes post-turn retained PR refreshes back to HEAD worktree threads", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const stalePr = githubPr({
+      number: 981,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Restore queued steer",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/981",
+    });
+    const passingPr = githubPr({
+      number: stalePr.number,
+      org: stalePr.org,
+      repo: stalePr.repo,
+      title: stalePr.title,
+      state: "passing",
+      url: stalePr.url,
+    });
+    const requestKey = buildThreadPrRequestKey({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "HEAD",
+      directoryPaths: ["/worktrees/PwrAgnt"],
+    });
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/scratch/project",
+        linkedDirectories: [
+          {
+            id: "/repo/PwrAgnt",
+            label: "PwrAgnt",
+            path: "/repo/PwrAgnt",
+            kind: "worktree",
+            worktreePath: "/worktrees/PwrAgnt",
+            gitBranch: "HEAD",
+          },
+          {
+            id: "/scratch/project",
+            label: "project",
+            path: "/scratch/project",
+            kind: "local",
+          },
+        ],
+        prs: [stalePr],
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prs: [stalePr],
+      prsFetchedAt: Date.now() - 120_000,
+      prsRefreshKey: requestKey,
+    });
+    fetchPullRequestByUrl.mockResolvedValueOnce(passingPr);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    detectPullRequestsForThread.mockClear();
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "HEAD",
+        directoryPaths: ["/worktrees/PwrAgnt"],
+      });
+    });
+    await vi.waitFor(() => {
+      expect(fetchPullRequestByUrl).toHaveBeenCalledWith({
+        cwd: "/worktrees/PwrAgnt",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/981",
+      });
+    });
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [passingPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: requestKey,
+      });
+    });
+    await vi.waitFor(() => {
+      expect(publishLocalEvent).toHaveBeenCalledWith({
+        backend: "codex",
+        notification: {
+          method: "thread/pullRequests/updated",
+          params: {
+            threadId: "thread-1",
+            prs: [passingPr],
+          },
+        },
+      });
+    });
+  });
+
   it("ignores a completed non-git command for working-state refresh", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3518,16 +3518,25 @@ function isFreshWorktreeWorkingStateCacheEntry(
 
 function resolveThreadPullRequestContexts(
   thread: Pick<
-    AppServerThreadSummary,
-    "gitBranch" | "id" | "linkedDirectories" | "observedGitBranch" | "source"
+    NavigationSnapshot["threads"][number],
+    | "gitBranch"
+    | "id"
+    | "linkedDirectories"
+    | "observedGitBranch"
+    | "prs"
+    | "source"
   >,
 ): ThreadPrRefreshContext[] {
   const contexts: ThreadPrRefreshContext[] = [];
   const threadBranch =
     thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || "";
+  const hasRetainedPrs = (thread.prs?.length ?? 0) > 0;
   const unscopedDirectoryPaths = resolveThreadPullRequestDirectoryPaths({
     linkedDirectories: (thread.linkedDirectories ?? []).filter(
-      (directory) => !directory.gitBranch?.trim(),
+      (directory) => {
+        const branch = directory.gitBranch?.trim();
+        return !branch || branch === "HEAD";
+      },
     ),
   });
   if (threadBranch && unscopedDirectoryPaths.length > 0) {
@@ -3536,6 +3545,20 @@ function resolveThreadPullRequestContexts(
       threadId: thread.id,
       branch: threadBranch,
       directoryPaths: unscopedDirectoryPaths,
+      branchScoped: false,
+    });
+  }
+  const headDirectoryPaths = resolveThreadPullRequestDirectoryPaths({
+    linkedDirectories: (thread.linkedDirectories ?? []).filter(
+      (directory) => directory.gitBranch?.trim() === "HEAD",
+    ),
+  });
+  if (!threadBranch && hasRetainedPrs && headDirectoryPaths.length > 0) {
+    contexts.push({
+      backend: thread.source,
+      threadId: thread.id,
+      branch: "HEAD",
+      directoryPaths: headDirectoryPaths,
       branchScoped: false,
     });
   }

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -262,4 +262,42 @@ describe("usePullRequestRefresh", () => {
       });
     });
   });
+
+  it("prefetches retained PR chips from HEAD worktree links", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({ prs: [] }));
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { result } = renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+      }),
+    );
+
+    result.current.prefetch(buildThread({
+      gitBranch: undefined,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          kind: "worktree",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/.worktrees/app",
+          gitBranch: "HEAD",
+        },
+      ],
+      prs: buildResponse().prs,
+    }));
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "HEAD",
+        directoryPaths: ["/repo/.worktrees/app"],
+      });
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -300,4 +300,50 @@ describe("usePullRequestRefresh", () => {
       });
     });
   });
+
+  it("scopes directory-derived branch refreshes to matching linked directories", async () => {
+    const refreshThreadPullRequests = vi.fn(async () => buildResponse({ prs: [] }));
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    const { result } = renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+      }),
+    );
+
+    result.current.prefetch(buildThread({
+      gitBranch: undefined,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          kind: "worktree",
+          label: "app",
+          path: "/repo/app",
+          worktreePath: "/repo/.worktrees/app",
+          gitBranch: "feat/app",
+        },
+        {
+          id: "/repo/docs",
+          kind: "worktree",
+          label: "docs",
+          path: "/repo/docs",
+          worktreePath: "/repo/.worktrees/docs",
+          gitBranch: "feat/docs",
+        },
+      ],
+      prs: [],
+    }));
+
+    await waitFor(() => {
+      expect(refreshThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        trigger: "user",
+        branch: "feat/app",
+        directoryPaths: ["/repo/.worktrees/app"],
+      });
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -6,6 +6,11 @@ import type { DesktopApi } from "../../lib/desktop-api";
 
 const SELECTED_REFRESH_INTERVAL_MS = 60_000;
 
+type PullRequestLookupTarget = {
+  branch: string;
+  directoryPaths: string[];
+};
+
 /**
  * Drives focused-trigger PR refreshes:
  *
@@ -40,17 +45,15 @@ export function usePullRequestRefresh(params: {
       trigger: "scheduled" | "user" = "scheduled",
     ): void => {
       if (!desktopApi?.refreshThreadPullRequests) return;
-      const branch = resolvePullRequestLookupBranch(thread);
-      if (!branch) return;
-      const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
-      if (directoryPaths.length === 0) return;
+      const target = resolvePullRequestLookupTarget(thread);
+      if (!target) return;
       void desktopApi
         .refreshThreadPullRequests({
           backend: thread.source,
           threadId: thread.id,
           trigger,
-          branch,
-          directoryPaths,
+          branch: target.branch,
+          directoryPaths: target.directoryPaths,
         })
         .then((response) => {
           if (prSummariesEqual(thread.prs, response.prs)) {
@@ -127,38 +130,50 @@ export function usePullRequestRefresh(params: {
 }
 
 function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undefined {
-  const branch = resolvePullRequestLookupBranch(thread);
-  if (!branch) return undefined;
-
-  const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
-  if (directoryPaths.length === 0) return undefined;
+  const target = resolvePullRequestLookupTarget(thread);
+  if (!target) return undefined;
 
   return JSON.stringify({
     threadKey: buildThreadIdentityKey(thread.source, thread.id),
-    branch,
-    directoryPaths,
+    target,
   });
 }
 
-function resolvePullRequestLookupBranch(
+function resolvePullRequestLookupTarget(
   thread: NavigationThreadSummary,
-): string | undefined {
+): PullRequestLookupTarget | undefined {
   const threadBranch = thread.observedGitBranch?.trim()
     || thread.gitBranch?.trim()
     || undefined;
   if (threadBranch) {
-    return threadBranch;
+    const directoryPaths = resolveFetchableDirectoryPaths(thread.linkedDirectories);
+    return directoryPaths.length > 0
+      ? { branch: threadBranch, directoryPaths }
+      : undefined;
   }
 
-  const directoryBranches = thread.linkedDirectories
-    .map((directory) => directory.gitBranch?.trim())
-    .filter((branch): branch is string => Boolean(branch));
-  const nonHeadBranch = directoryBranches.find((branch) => branch !== "HEAD");
-  if (nonHeadBranch) {
-    return nonHeadBranch;
+  const headDirectoryPaths = resolveFetchableDirectoryPaths(
+    thread.linkedDirectories.filter(
+      (directory) => directory.gitBranch?.trim() === "HEAD",
+    ),
+  );
+  if ((thread.prs?.length ?? 0) > 0 && headDirectoryPaths.length > 0) {
+    return { branch: "HEAD", directoryPaths: headDirectoryPaths };
   }
-  if ((thread.prs?.length ?? 0) > 0 && directoryBranches.includes("HEAD")) {
-    return "HEAD";
+
+  for (const directory of thread.linkedDirectories) {
+    const branch = directory.gitBranch?.trim();
+    if (!branch || branch === "HEAD") {
+      continue;
+    }
+    const directoryPaths = resolveFetchableDirectoryPaths(
+      thread.linkedDirectories.filter(
+        (candidate) => candidate.gitBranch?.trim() === branch,
+      ),
+    );
+    if (directoryPaths.length > 0) {
+      return { branch, directoryPaths };
+    }
   }
   return undefined;
 }

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -143,7 +143,24 @@ function buildRefreshRequestKey(thread: NavigationThreadSummary): string | undef
 function resolvePullRequestLookupBranch(
   thread: NavigationThreadSummary,
 ): string | undefined {
-  return thread.observedGitBranch?.trim() || thread.gitBranch?.trim() || undefined;
+  const threadBranch = thread.observedGitBranch?.trim()
+    || thread.gitBranch?.trim()
+    || undefined;
+  if (threadBranch) {
+    return threadBranch;
+  }
+
+  const directoryBranches = thread.linkedDirectories
+    .map((directory) => directory.gitBranch?.trim())
+    .filter((branch): branch is string => Boolean(branch));
+  const nonHeadBranch = directoryBranches.find((branch) => branch !== "HEAD");
+  if (nonHeadBranch) {
+    return nonHeadBranch;
+  }
+  if ((thread.prs?.length ?? 0) > 0 && directoryBranches.includes("HEAD")) {
+    return "HEAD";
+  }
+  return undefined;
 }
 
 function prSummariesEqual(


### PR DESCRIPTION
## Summary
Retained PR chips on detached `HEAD` worktree threads now have a valid refresh route instead of staying stale when the thread has no top-level branch. Hover prefetch treats retained PRs plus a `HEAD` worktree link as a concrete lookup target, and post-turn refresh registration now subscribes the same thread to `HEAD` worktree PR updates.

The fallback is intentionally limited to threads that already retain PRs, so unrelated scratch or parent directories do not start broad PR discovery just because a linked worktree is detached.

## Validation
- `pnpm test apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx apps/desktop/src/main/__tests__/app-server-ipc.test.ts -- --runInBand`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `git diff --check`

Related: pwrdrvr/PwrAgent#981

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
