### PR TITLE
fix(messaging): route Telegram status stop callbacks

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -14372,6 +14372,48 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not overwrite a terminal turn from a stale status Stop callback", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(buildTextEvent("start work"));
+    const stopAction = findAction(harness.delivered.at(-1), "status:stop");
+    expect(stopAction.value).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    harness.interruptTurn.mockClear();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:stop",
+        value: stopAction.value,
+      }),
+    );
+
+    expect(harness.interruptTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining("Turn: completed"),
+    });
+  });
+
   it("starts compaction through the backend bridge", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "@pwragent/messaging-interface";
 import type {
   AgentEvent,
+  InterruptTurnRequest,
   NavigationSnapshot,
   StartTurnRequest,
 } from "@pwragent/shared";
@@ -2111,6 +2112,119 @@ describe("TelegramAdapter", () => {
     ).resolves.toMatchObject({
       backend: "codex",
       threadId: "thread-1",
+    });
+  });
+
+  it("routes a persisted Telegram status Stop button after controller restart", async () => {
+    const harness = await createControllerHarness();
+
+    await harness.adapter.start((event) => harness.controller.handleInboundEvent(event));
+    await harness.adapter.handleUpdate({
+      update_id: 1,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        message_id: 100,
+        text: "/resume",
+      },
+    });
+    const bindCallbackData =
+      harness.api.sendMessage.mock.calls.at(-1)?.[0].reply_markup?.inline_keyboard[0]?.[0]
+        ?.callback_data ?? "";
+    await harness.adapter.handleUpdate({
+      callback_query: {
+        data: bindCallbackData,
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        id: "callback-bind",
+        message: {
+          chat: {
+            id: 777,
+            type: "private",
+          },
+          message_id: 101,
+        },
+      },
+      update_id: 2,
+    });
+
+    await harness.adapter.handleUpdate({
+      update_id: 3,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        message_id: 102,
+        text: "start work",
+      },
+    });
+
+    const stopCallbackData =
+      harness.api.editMessageText.mock.calls.at(-1)?.[0].reply_markup
+        ?.inline_keyboard.flat()
+        .find((button: { text?: string }) => button.text === "Stop")
+        ?.callback_data ?? "";
+    expect(stopCallbackData).toMatch(/^tg:/);
+
+    const restartedInterruptTurn = vi.fn(
+      async (request: InterruptTurnRequest) => request,
+    );
+    const restartedController = new MessagingController({
+      adapter: harness.adapter,
+      authorizedActorIds: ["42"],
+      backend: {
+        getNavigationSnapshot: async () => buildNavigationSnapshot(),
+        interruptTurn: restartedInterruptTurn,
+        startTurn: async (request: StartTurnRequest) => ({
+          backend: request.backend,
+          threadId: request.threadId,
+          turnId: "turn-1",
+        }),
+      },
+      inputDebounceMs: 0,
+      now: () => 1000,
+      store: harness.store,
+    });
+    await harness.adapter.start((event) =>
+      restartedController.handleInboundEvent(event),
+    );
+
+    await harness.adapter.handleUpdate({
+      callback_query: {
+        data: stopCallbackData,
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        id: "callback-stop-after-restart",
+        message: {
+          chat: {
+            id: 777,
+            type: "private",
+          },
+          message_id: 101,
+        },
+      },
+      update_id: 4,
+    });
+
+    expect(restartedInterruptTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
     });
   });
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -9509,25 +9509,36 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<void> {
+    const requestedTurn = readStatusStopTurnValue(
+      event.kind === "callback" ? event.value : undefined,
+      binding,
+    );
     const activeTurn = this.getActiveTurn(binding);
-    if (!activeTurn || !["working", "waiting"].includes(activeTurn.status)) {
+    const targetTurn =
+      requestedTurn ??
+      (activeTurn && ["working", "waiting"].includes(activeTurn.status)
+        ? activeTurn
+        : undefined);
+    if (!targetTurn) {
       await this.renderBindingStatus(binding, event);
       return;
     }
     await this.options.backend.interruptTurn?.({
       backend: binding.backend,
       threadId: binding.threadId,
-      turnId: activeTurn.turnId,
+      turnId: targetTurn.turnId,
     });
-    const interruptedTurn: MessagingActiveTurnSummary = {
-      ...activeTurn,
-      status: "interrupted",
-      updatedAt: this.now(),
-    };
-    this.setActiveTurn(binding, interruptedTurn);
-    await this.signalTurnActivity(binding, interruptedTurn, {
-      force: true,
-    });
+    if (!activeTurn || activeTurn.turnId === targetTurn.turnId) {
+      const interruptedTurn: MessagingActiveTurnSummary = {
+        ...targetTurn,
+        status: "interrupted",
+        updatedAt: this.now(),
+      };
+      this.setActiveTurn(binding, interruptedTurn);
+      await this.signalTurnActivity(binding, interruptedTurn, {
+        force: true,
+      });
+    }
     await this.renderBindingStatus(binding, event);
   }
 
@@ -14837,6 +14848,33 @@ function readBindingTargetFromValue(
   }
 
   return undefined;
+}
+
+function readStatusStopTurnValue(
+  value: MessagingJsonValue | undefined,
+  binding: MessagingBindingRecord,
+): { turnId: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const backend = value.backend;
+  const threadId = value.threadId;
+  const turnId = value.turnId;
+  if (
+    typeof backend !== "string" ||
+    !isAppServerBackendKind(backend) ||
+    backend !== binding.backend ||
+    typeof threadId !== "string" ||
+    threadId !== binding.threadId ||
+    typeof turnId !== "string"
+  ) {
+    return undefined;
+  }
+
+  return {
+    turnId,
+  };
 }
 
 function readStringValue(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -9514,11 +9514,17 @@ export class MessagingController {
       binding,
     );
     const activeTurn = this.getActiveTurn(binding);
-    const targetTurn =
-      requestedTurn ??
-      (activeTurn && ["working", "waiting"].includes(activeTurn.status)
+    const activeTurnIsInterruptible =
+      activeTurn && ["working", "waiting"].includes(activeTurn.status);
+    const targetTurn = requestedTurn
+      ? !activeTurn
+        ? requestedTurn
+        : activeTurnIsInterruptible && activeTurn.turnId === requestedTurn.turnId
+          ? activeTurn
+          : undefined
+      : activeTurnIsInterruptible
         ? activeTurn
-        : undefined);
+        : undefined;
     if (!targetTurn) {
       await this.renderBindingStatus(binding, event);
       return;
@@ -9528,7 +9534,10 @@ export class MessagingController {
       threadId: binding.threadId,
       turnId: targetTurn.turnId,
     });
-    if (!activeTurn || activeTurn.turnId === targetTurn.turnId) {
+    if (
+      !activeTurn ||
+      (activeTurnIsInterruptible && activeTurn.turnId === targetTurn.turnId)
+    ) {
       const interruptedTurn: MessagingActiveTurnSummary = {
         ...targetTurn,
         status: "interrupted",

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -209,6 +209,8 @@ export function buildBindingStatusIntent(params: {
       .filter((line): line is string => Boolean(line))
       .join("\n"),
     actions: buildStatusActions({
+      activeTurn,
+      binding: params.binding,
       capabilityProfile: params.capabilityProfile,
       allowFullAccessEscalation: params.allowFullAccessEscalation,
       fastMode,
@@ -444,7 +446,9 @@ function mentionRequiredLine(
 }
 
 function buildStatusActions(params: {
+  activeTurn?: MessagingResolvedThreadState["activeTurn"];
   allowFullAccessEscalation?: boolean;
+  binding: MessagingBindingRecord;
   capabilityProfile?: MessagingCapabilityProfile;
   fastMode: boolean | undefined;
   handoff?: MessagingWorkspaceHandoffContext;
@@ -578,6 +582,15 @@ function buildStatusActions(params: {
       fallbackText: "stop",
       priority: 1,
       layout: { rowBreakBefore: true },
+      ...(isInterruptibleActiveTurn(params.activeTurn)
+        ? {
+            value: {
+              backend: params.binding.backend,
+              threadId: params.binding.threadId,
+              turnId: params.activeTurn.turnId,
+            },
+          }
+        : {}),
     },
     {
       id: "status:refresh",
@@ -1499,6 +1512,12 @@ function handoffOverviewText(context: MessagingWorkspaceHandoffContext): string 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isInterruptibleActiveTurn(
+  activeTurn: MessagingResolvedThreadState["activeTurn"],
+): activeTurn is NonNullable<MessagingResolvedThreadState["activeTurn"]> {
+  return activeTurn?.status === "working" || activeTurn?.status === "waiting";
 }
 
 function unavailable(): string {


### PR DESCRIPTION
## Summary
Telegram status Stop buttons now continue to interrupt the turn they were rendered for even if the messaging controller restarts before the operator taps them. The status card stores the active `{backend, threadId, turnId}` in the persisted callback handle, and the callback handler validates that context against the current binding before calling `interruptTurn`.

This closes the path where Telegram could resolve an opaque callback back to `status:stop`, but the new controller instance no longer had enough in-memory state to know which turn to stop.

## Validation
- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm --filter @pwragent/desktop exec tsc --noEmit --pretty false`
- `pnpm lint:eslint apps/desktop/src/main/__tests__/telegram-adapter.test.ts apps/desktop/src/main/messaging/core/messaging-controller.ts apps/desktop/src/main/messaging/core/messaging-status-card.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
