### PR TITLE
feat(desktop): scheduled/queued thread chips + send-now and schedule toggle

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -62,6 +62,7 @@ import {
 import { setSidebarResizing } from "./lib/sidebar-resize-signal";
 import { useThreadSkills } from "./lib/useThreadSkills";
 import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
+import { useThreadQueuedMessageIndicators } from "./lib/useThreadQueuedMessageIndicators";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
@@ -655,6 +656,13 @@ function DesktopAppShell(props: {
     selectedThread: navigation.selectedThread,
     threads: navigation.threads,
   });
+  // Per-thread "Scheduled"/"Queued" chip state, derived from the same
+  // queued-turn store useQueuedTurnRelease drains. Keyed by thread identity
+  // key so it threads down beside approvalRequestThreadKeys.
+  const queuedMessageThreadKeys = useThreadQueuedMessageIndicators({
+    composerDraftStore,
+    threads: navigation.threads,
+  });
   // Fetch the boot info once at mount. Stable for the renderer's
   // lifetime — the main process records the decision before this
   // window opens, and graduating the bootstrap profile spawns a
@@ -1123,6 +1131,7 @@ function DesktopAppShell(props: {
           loading={navigation.loading}
           approvalRequestThreadKeys={session.approvalRequestThreadKeys}
           inputRequestThreadKeys={session.inputRequestThreadKeys}
+          queuedMessageThreadKeys={queuedMessageThreadKeys}
           composerSourceThreadKey={navigation.composerSourceThreadKey}
           selectedItemKey={navigation.selectedItemKey}
           thinkingThreadKeys={session.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -39,6 +39,7 @@ import type {
 import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
 import {
   BranchIcon,
+  CheckIcon,
   ChevronUpIcon,
   CloseIcon,
   FileCodeIcon,
@@ -2432,6 +2433,11 @@ export function Composer(props: ComposerProps) {
   const [scheduledDraftSendAt, setScheduledDraftSendAt] = useState<
     number | undefined
   >();
+  // Whether the pending draft schedule (when one exists, e.g. after editing a
+  // scheduled item) is "armed". Armed → Send keeps the schedule (send later);
+  // unarmed → Send sends now. Defaults armed so a freshly-loaded schedule is
+  // preserved unless the operator explicitly unchecks it.
+  const [scheduleArmed, setScheduleArmed] = useState(true);
   const [handoffDialog, setHandoffDialog] = useState<
     HandoffThreadWorkspaceRequest["direction"] | undefined
   >();
@@ -3162,6 +3168,7 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     if (scheduledDraftSendAt && !futureScheduledDraftSendAt) {
       setScheduledDraftSendAt(undefined);
+      setScheduleArmed(true);
     }
   }, [futureScheduledDraftSendAt, scheduledDraftSendAt]);
 
@@ -3476,6 +3483,7 @@ export function Composer(props: ComposerProps) {
     setSteering(false);
     setScheduleMenuOpen(false);
     setScheduledDraftSendAt(undefined);
+    setScheduleArmed(true);
     setServerQueuedTurnEntryIdState(
       serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)
     );
@@ -4180,6 +4188,7 @@ export function Composer(props: ComposerProps) {
   const exitReviewComposer = (): void => {
     setReviewConfig(undefined);
     setScheduledDraftSendAt(undefined);
+    setScheduleArmed(true);
     clearComposerDraft();
     setSendError(undefined);
     requestAnimationFrame(() => inputRef.current?.focus());
@@ -4460,6 +4469,27 @@ export function Composer(props: ComposerProps) {
     await sendThreadTurn(claimedQueuedTurn, { queueClaimed: true });
   };
 
+  // Operator-initiated "Send now" on a queued/scheduled entry. Bypasses the
+  // release schedule and fires the turn immediately. Mirrors the auto-release
+  // effect's coordination (global scope-key guard + sending flag) so the
+  // background releaser in useQueuedTurnRelease can't double-send the claimed
+  // turn.
+  const sendQueuedTurnNow = (queued: QueuedTurnDraft): void => {
+    if (
+      props.disabled ||
+      sending ||
+      activeTurnIdRef.current ||
+      globalQueuedTurnReleaseScopeKeys.has(composerScopeKey)
+    ) {
+      return;
+    }
+    globalQueuedTurnReleaseScopeKeys.add(composerScopeKey);
+    updateSending(true);
+    void sendQueuedTurn(queued).finally(() => {
+      updateSending(false);
+    });
+  };
+
   useEffect(() => {
     if (activeTurnId) {
       queuedAutoReleaseAttemptIdRef.current = undefined;
@@ -4549,6 +4579,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraft();
     setImageAttachments([]);
     setScheduledDraftSendAt(undefined);
+    setScheduleArmed(true);
     setReviewConfig(undefined);
     setSendError(undefined);
   };
@@ -4579,6 +4610,7 @@ export function Composer(props: ComposerProps) {
     clearComposerDraft();
     setImageAttachments([]);
     setScheduledDraftSendAt(undefined);
+    setScheduleArmed(true);
     setReviewConfig(undefined);
     setSendError(undefined);
   };
@@ -4599,6 +4631,7 @@ export function Composer(props: ComposerProps) {
     if (reviewCommand) {
       if (isBareReviewCommand) {
         setScheduledDraftSendAt(scheduledSendAt);
+        setScheduleArmed(true);
         setReviewConfig(
           reviewConfig ??
             createReviewConfig({
@@ -4615,6 +4648,7 @@ export function Composer(props: ComposerProps) {
       }
       if (reviewWorkspaceSelectionRequired) {
         setScheduledDraftSendAt(scheduledSendAt);
+        setScheduleArmed(true);
         setReviewConfig(
           createReviewConfig({
             directory: props.directory,
@@ -4802,14 +4836,14 @@ export function Composer(props: ComposerProps) {
         }
         queueReviewCommand(
           reviewCommand,
-          futureScheduledDraftSendAt
-            ? { scheduledSendAt: futureScheduledDraftSendAt }
+          effectiveScheduledSendAt
+            ? { scheduledSendAt: effectiveScheduledSendAt }
             : undefined,
         );
       } else {
         queueCurrentDraft(
-          futureScheduledDraftSendAt
-            ? { scheduledSendAt: futureScheduledDraftSendAt }
+          effectiveScheduledSendAt
+            ? { scheduledSendAt: effectiveScheduledSendAt }
             : undefined,
         );
       }
@@ -4829,22 +4863,30 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
-      if (futureScheduledDraftSendAt) {
+      if (effectiveScheduledSendAt) {
         queueReviewCommand(reviewCommand, {
-          scheduledSendAt: futureScheduledDraftSendAt,
+          scheduledSendAt: effectiveScheduledSendAt,
         });
         return;
       }
 
+      // Unarmed schedule ("send now" on an edited scheduled review) — drop the
+      // pending time before firing so it doesn't linger and re-arm the toggle.
+      setScheduledDraftSendAt(undefined);
+      setScheduleArmed(true);
       await submitReviewCommand(reviewCommand);
       return;
     }
 
-    if (futureScheduledDraftSendAt) {
-      queueCurrentDraft({ scheduledSendAt: futureScheduledDraftSendAt });
+    if (effectiveScheduledSendAt) {
+      queueCurrentDraft({ scheduledSendAt: effectiveScheduledSendAt });
       return;
     }
 
+    // Unarmed schedule ("send now" on an edited scheduled message) — clear the
+    // pending time so the toggle doesn't reappear after the immediate send.
+    setScheduledDraftSendAt(undefined);
+    setScheduleArmed(true);
     const payload = buildTurnPayload(canonicalDraft, imageAttachments);
     const collaborationMode = planModeEnabled && supportsPlanMode
       ? ({
@@ -5554,12 +5596,17 @@ export function Composer(props: ComposerProps) {
   // permanently-dimmed half-button next to it.
   const scheduleAffordanceVisible =
     Boolean(props.thread) && !props.launchpad && !isCompactCommand;
-  const submitButtonLabel = futureScheduledDraftSendAt
-    ? `Send in ${formatScheduledSendCountdown(
-        futureScheduledDraftSendAt,
-        scheduleTick,
-      )}`
-    : activeTurnId || serverQueuedTurnEntryId || props.threadBusy
+  // A pending draft schedule (e.g. after editing a scheduled item) surfaces as
+  // a checkable toggle between the caret and Send rather than hijacking the
+  // Send label into a countdown. Armed → Send keeps the schedule; unarmed →
+  // Send fires now. The toggle only shows where scheduling applies.
+  const scheduleToggleVisible =
+    scheduleAffordanceVisible && Boolean(futureScheduledDraftSendAt);
+  const effectiveScheduledSendAt = scheduleArmed
+    ? futureScheduledDraftSendAt
+    : undefined;
+  const submitButtonLabel =
+    activeTurnId || serverQueuedTurnEntryId || props.threadBusy
       ? "Queue"
       : sending
         ? props.launchpad
@@ -6510,18 +6557,31 @@ export function Composer(props: ComposerProps) {
             </div>
             <QueuedImageAttachments attachments={queued.imageAttachments} />
             <div className="composer__queued-actions">
-              {supportsSteering && !queued.reviewCommand ? (
+              {activeTurnId ? (
+                supportsSteering && !queued.reviewCommand ? (
+                  <button
+                    className="composer__secondary-action"
+                    disabled={props.disabled || steering}
+                    type="button"
+                    onClick={() => {
+                      steerQueuedTurn(queued);
+                    }}
+                  >
+                    {steering ? "Steering..." : "Steer"}
+                  </button>
+                ) : null
+              ) : (
                 <button
                   className="composer__secondary-action"
-                  disabled={props.disabled || steering || !activeTurnId}
+                  disabled={props.disabled || sending}
                   type="button"
                   onClick={() => {
-                    steerQueuedTurn(queued);
+                    sendQueuedTurnNow(queued);
                   }}
                 >
-                  {steering ? "Steering..." : "Steer"}
+                  Send now
                 </button>
-              ) : null}
+              )}
               <button
                 className="composer__secondary-action"
                 type="button"
@@ -6529,6 +6589,7 @@ export function Composer(props: ComposerProps) {
                   setComposerDraftFromCanonical(queued.text);
                   setImageAttachments(queued.imageAttachments);
                   setScheduledDraftSendAt(scheduledSendAt);
+                  setScheduleArmed(true);
                   removeQueuedTurnAt(index);
                   requestAnimationFrame(() => inputRef.current?.focus());
                 }}
@@ -7569,6 +7630,49 @@ export function Composer(props: ComposerProps) {
                   }}
                 >
                   <ChevronUpIcon size={14} />
+                </button>
+              ) : null}
+              {scheduleToggleVisible ? (
+                <button
+                  aria-checked={scheduleArmed}
+                  aria-label={
+                    scheduleArmed
+                      ? `Send later, in ${formatScheduledSendCountdown(
+                          futureScheduledDraftSendAt!,
+                          scheduleTick,
+                        )}. Uncheck to send now.`
+                      : `Send now. Check to send later, in ${formatScheduledSendCountdown(
+                          futureScheduledDraftSendAt!,
+                          scheduleTick,
+                        )}.`
+                  }
+                  className={[
+                    "composer__send-schedule-toggle",
+                    scheduleArmed ? "is-armed" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  disabled={props.disabled}
+                  role="switch"
+                  type="button"
+                  onClick={() => {
+                    setScheduleTick(Date.now());
+                    setScheduleArmed((current) => !current);
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="composer__send-schedule-toggle-box"
+                  >
+                    {scheduleArmed ? <CheckIcon size={12} /> : null}
+                  </span>
+                  <span className="composer__send-schedule-toggle-label">
+                    in{" "}
+                    {formatScheduledSendCountdown(
+                      futureScheduledDraftSendAt!,
+                      scheduleTick,
+                    )}
+                  </span>
                 </button>
               ) : null}
               <button

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5599,9 +5599,14 @@ export function Composer(props: ComposerProps) {
   // A pending draft schedule (e.g. after editing a scheduled item) surfaces as
   // a checkable toggle between the caret and Send rather than hijacking the
   // Send label into a countdown. Armed → Send keeps the schedule; unarmed →
-  // Send fires now. The toggle only shows where scheduling applies.
+  // Send fires now. The toggle only shows where scheduling applies — and never
+  // while the review-config panel is open, since that panel owns its own
+  // scheduled-send button and doesn't read `scheduleArmed`; showing the toggle
+  // there would let an operator "uncheck" a schedule the review submit ignores.
   const scheduleToggleVisible =
-    scheduleAffordanceVisible && Boolean(futureScheduledDraftSendAt);
+    scheduleAffordanceVisible
+    && Boolean(futureScheduledDraftSendAt)
+    && !isReviewComposerOpen;
   const effectiveScheduledSendAt = scheduleArmed
     ? futureScheduledDraftSendAt
     : undefined;
@@ -7652,7 +7657,7 @@ export function Composer(props: ComposerProps) {
                   ]
                     .filter(Boolean)
                     .join(" ")}
-                  disabled={props.disabled}
+                  disabled={sendButtonDisabled}
                   role="switch"
                   type="button"
                   onClick={() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1926,6 +1926,48 @@ describe("Composer", () => {
     );
   });
 
+  it("hides the schedule toggle while the review-config panel owns the schedule", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview: vi.fn(async (request: StartReviewRequest) => ({
+            backend: request.backend,
+            threadId: request.threadId,
+            reviewThreadId: request.threadId,
+            turnId: "turn-review-1",
+          })),
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Scheduled review",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 30m" }));
+
+    // The review panel owns the scheduled-send button; the main-composer
+    // schedule toggle must NOT appear (it doesn't gate the review submit, so
+    // it would be a dead control that pretends to unarm the schedule).
+    expect(screen.getByRole("group", { name: "Review target" })).toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
   it("shows a 5h context reset schedule option when the backend exposes a reset", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -131,6 +131,8 @@ function createComposerDraftStore(): ComposerDraftStore {
     getPendingSteer: (scopeKey) => pendingSteers.get(scopeKey),
     getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey)?.[0],
     getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
+    getQueuedTurnVersion: () => 0,
+    subscribeQueuedTurns: () => () => {},
     removeQueuedTurnAt: (scopeKey, index) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const next = [...current];
@@ -1748,10 +1750,16 @@ describe("Composer", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Edit" }));
     expect(textarea).toHaveValue("Original scheduled text");
-    expect(screen.getByRole("button", { name: "Send in 1h" })).toBeEnabled();
+    // The Send button is plain "Send"; the schedule surfaces as an armed
+    // toggle beside it rather than a countdown label on Send itself.
+    const scheduleToggle = screen.getByRole("switch");
+    expect(scheduleToggle).toBeChecked();
+    expect(scheduleToggle).toHaveTextContent("in 1h");
+    expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
 
     fireEvent.change(textarea, { target: { value: "Edited scheduled text" } });
-    fireEvent.click(screen.getByRole("button", { name: "Send in 1h" }));
+    // Toggle stays armed → Send keeps the schedule (re-queues at the same time).
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(startTurn).not.toHaveBeenCalled();
     expect(textarea).toHaveValue("");
@@ -1761,6 +1769,105 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Edited scheduled text"
     );
+  });
+
+  it("sends now when the schedule toggle is unchecked while editing a scheduled draft", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-scheduled",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Edit scheduled send",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Scheduled text" } });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 1h" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    // Uncheck the schedule so Send fires immediately instead of re-queuing.
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByRole("switch")).not.toBeChecked();
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn.mock.calls[0]![0].input).toEqual([
+      { type: "text", text: "Scheduled text" },
+    ]);
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    // The toggle is gone once the schedule is consumed.
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("sends a scheduled queued message now via Send now when no turn is active", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T12:00:00Z"));
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "turn-scheduled",
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Send scheduled now",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Scheduled for later" } });
+    fireEvent.click(screen.getByRole("button", { name: "Schedule message" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Send in 1h" }));
+
+    // No active turn → the queued entry offers "Send now", not a dead "Steer".
+    expect(screen.queryByRole("button", { name: "Steer" })).not.toBeInTheDocument();
+    const sendNow = screen.getByRole("button", { name: "Send now" });
+
+    await act(async () => {
+      fireEvent.click(sendNow);
+    });
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn.mock.calls[0]![0].input).toEqual([
+      { type: "text", text: "Scheduled for later" },
+    ]);
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
   });
 
   it("preserves schedule selection through bare review configuration", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -45,6 +45,14 @@ export type ComposerDraftStore = {
   getPendingSteer(scopeKey: string): ComposerPendingSteerSnapshot | undefined;
   getQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
   getQueuedTurns(scopeKey: string): ComposerQueuedTurnSnapshot[];
+  /**
+   * Monotonic counter bumped whenever the queued-turn map mutates. Pairs
+   * with `subscribeQueuedTurns` for `useSyncExternalStore` so surfaces
+   * outside the composer (e.g. the sidebar thread rows) can reactively
+   * reflect queued/scheduled state that otherwise lives only in a ref Map.
+   */
+  getQueuedTurnVersion(): number;
+  subscribeQueuedTurns(listener: () => void): () => void;
   removeQueuedTurnAt(scopeKey: string, index: number): ComposerQueuedTurnSnapshot | undefined;
   removeQueuedTurnById(scopeKey: string, id: string): ComposerQueuedTurnSnapshot | undefined;
   shiftQueuedTurn(scopeKey: string): ComposerQueuedTurnSnapshot | undefined;
@@ -85,9 +93,23 @@ export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
   const pendingSteerStoreRef = useRef(new Map<string, ComposerPendingSteerSnapshot>());
   const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot[]>());
+  // Reactivity bridge for the queued-turn Map. The Map itself is a ref
+  // (no React state) so composer writes stay cheap, but subscribers like
+  // the sidebar need to know when it changes. Every mutation path below
+  // funnels through `notifyQueuedTurnChange`, which bumps the version and
+  // fans out to listeners registered via `subscribeQueuedTurns`.
+  const queuedTurnVersionRef = useRef(0);
+  const queuedTurnListenersRef = useRef(new Set<() => void>());
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    const notifyQueuedTurnChange = (): void => {
+      queuedTurnVersionRef.current += 1;
+      for (const listener of queuedTurnListenersRef.current) {
+        listener();
+      }
+    };
+
+    return {
       delete: (scopeKey) => {
         storeRef.current.delete(scopeKey);
       },
@@ -96,11 +118,20 @@ export function useComposerDraftStore(): ComposerDraftStore {
         pendingSteerStoreRef.current.delete(scopeKey);
       },
       deleteQueuedTurn: (scopeKey) => {
-        queuedTurnStoreRef.current.delete(scopeKey);
+        if (queuedTurnStoreRef.current.delete(scopeKey)) {
+          notifyQueuedTurnChange();
+        }
       },
       getPendingSteer: (scopeKey) => pendingSteerStoreRef.current.get(scopeKey),
       getQueuedTurn: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey)?.[0],
       getQueuedTurns: (scopeKey) => queuedTurnStoreRef.current.get(scopeKey) ?? [],
+      getQueuedTurnVersion: () => queuedTurnVersionRef.current,
+      subscribeQueuedTurns: (listener) => {
+        queuedTurnListenersRef.current.add(listener);
+        return () => {
+          queuedTurnListenersRef.current.delete(listener);
+        };
+      },
       removeQueuedTurnAt: (scopeKey, index) => {
         const current = queuedTurnStoreRef.current.get(scopeKey) ?? [];
         if (index < 0 || index >= current.length) {
@@ -113,6 +144,7 @@ export function useComposerDraftStore(): ComposerDraftStore {
         } else {
           queuedTurnStoreRef.current.set(scopeKey, next);
         }
+        notifyQueuedTurnChange();
         return removed;
       },
       removeQueuedTurnById: (scopeKey, id) => {
@@ -128,6 +160,7 @@ export function useComposerDraftStore(): ComposerDraftStore {
         } else {
           queuedTurnStoreRef.current.set(scopeKey, next);
         }
+        notifyQueuedTurnChange();
         return removed;
       },
       shiftQueuedTurn: (scopeKey) => {
@@ -141,6 +174,7 @@ export function useComposerDraftStore(): ComposerDraftStore {
         } else {
           queuedTurnStoreRef.current.set(scopeKey, rest);
         }
+        notifyQueuedTurnChange();
         return first;
       },
       setPendingSteer: (scopeKey, snapshot) => {
@@ -148,6 +182,7 @@ export function useComposerDraftStore(): ComposerDraftStore {
       },
       setQueuedTurn: (scopeKey, snapshot) => {
         queuedTurnStoreRef.current.set(scopeKey, [snapshot]);
+        notifyQueuedTurnChange();
       },
       setQueuedTurns: (scopeKey, snapshots) => {
         if (snapshots.length === 0) {
@@ -155,11 +190,11 @@ export function useComposerDraftStore(): ComposerDraftStore {
         } else {
           queuedTurnStoreRef.current.set(scopeKey, [...snapshots]);
         }
+        notifyQueuedTurnChange();
       },
       set: (scopeKey, snapshot) => {
         storeRef.current.set(scopeKey, snapshot);
       },
-    }),
-    [],
-  );
+    };
+  }, []);
 }

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -35,11 +35,13 @@ import {
   getDropIndicatorPosition,
   type DropIndicatorState,
 } from "./drag-drop";
+import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { ThreadRow } from "./ThreadRow";
 
 type DirectoriesListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
+  queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   composerSourceThreadKey?: string;
   directories: NavigationDirectorySummary[];
   selectedItemKey?: string;
@@ -487,6 +489,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               key={`${directory.key}:${childKey}`}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
+              queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               compact
               draggable={reorderable}
@@ -615,6 +618,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             key={`${directory.key}:${threadKey}`}
             approvalRequestThreadKeys={props.approvalRequestThreadKeys}
             inputRequestThreadKeys={props.inputRequestThreadKeys}
+            queuedMessageThreadKeys={props.queuedMessageThreadKeys}
             composerSourceThreadKey={props.composerSourceThreadKey}
             compact
             draggable={Boolean(props.onReorderThreadPins)}
@@ -920,6 +924,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
 	                          key={`${directory.key}:${threadKey}`}
                           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                           inputRequestThreadKeys={props.inputRequestThreadKeys}
+                          queuedMessageThreadKeys={props.queuedMessageThreadKeys}
                           composerSourceThreadKey={props.composerSourceThreadKey}
                           compact
                           dropIndicator={

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -17,11 +17,13 @@ import {
   getDropIndicatorPosition,
   type DropIndicatorState,
 } from "./drag-drop";
+import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
+  queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   composerSourceThreadKey?: string;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
@@ -142,6 +144,7 @@ export function RecentsList(props: RecentsListProps) {
               key={childKey}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
+              queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               dropIndicator={
                 dropIndicator?.targetKey === rowDropKey
@@ -233,6 +236,7 @@ export function RecentsList(props: RecentsListProps) {
         <ThreadRow
           approvalRequestThreadKeys={props.approvalRequestThreadKeys}
           inputRequestThreadKeys={props.inputRequestThreadKeys}
+          queuedMessageThreadKeys={props.queuedMessageThreadKeys}
           composerSourceThreadKey={props.composerSourceThreadKey}
           dropIndicator={
             dropIndicator?.targetKey === key

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -39,6 +39,7 @@ import {
   runtimeGitRefCopyValue,
 } from "../../lib/runtime-identity";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { formatPrimaryAccel } from "../../lib/keyboard-accel";
 import {
   DetachPullRequestWarning,
@@ -82,6 +83,11 @@ type SidebarProps = {
   settingsActive?: boolean;
   approvalRequestThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
+  /**
+   * Identity key → pending outbound-message state, for the
+   * "Scheduled"/"Queued" thread-row chip. Absent key = no pending send.
+   */
+  queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   /** Identity key of the card to highlight as the open composer's source. */
   composerSourceThreadKey?: string;
   selectedItemKey?: string;
@@ -915,6 +921,7 @@ export function Sidebar(props: SidebarProps) {
             <DirectoriesList
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
               inputRequestThreadKeys={props.inputRequestThreadKeys}
+              queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               directories={props.directories}
               selectedItemKey={props.selectedItemKey}
@@ -944,6 +951,7 @@ export function Sidebar(props: SidebarProps) {
               <RecentsList
                 approvalRequestThreadKeys={props.approvalRequestThreadKeys}
                 inputRequestThreadKeys={props.inputRequestThreadKeys}
+                queuedMessageThreadKeys={props.queuedMessageThreadKeys}
                 composerSourceThreadKey={props.composerSourceThreadKey}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -5,10 +5,17 @@ import { BranchIcon, FolderIcon, PinIcon, WorktreeIcon } from "../../icons";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { copyText } from "../../lib/copy-text";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 
 type ThreadMetaChipsProps = {
   hasApprovalRequest?: boolean;
   hasInputRequest?: boolean;
+  /**
+   * When set, renders the "Scheduled" (future send time) or "Queued"
+   * (waiting on the active turn) chip. Resolved upstream so a thread with
+   * both pending states shows only the higher-priority "Scheduled".
+   */
+  queuedMessageState?: ThreadQueuedMessageState;
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   thread: NavigationThreadSummary;
@@ -17,6 +24,7 @@ type ThreadMetaChipsProps = {
 export function ThreadMetaChips({
   hasApprovalRequest = false,
   hasInputRequest = false,
+  queuedMessageState,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
   thread,
@@ -132,6 +140,24 @@ export function ThreadMetaChips({
       <span className="thread-row__chip thread-row__chip--backend">
         {formatBackendLabel(thread.source)}
       </span>
+
+      {queuedMessageState === "scheduled" ? (
+        <span
+          aria-label="A message is scheduled to send"
+          className="thread-row__chip thread-row__chip--scheduled"
+          title="A message is scheduled to send"
+        >
+          Scheduled
+        </span>
+      ) : queuedMessageState === "queued" ? (
+        <span
+          aria-label="A message is queued to send"
+          className="thread-row__chip thread-row__chip--queued"
+          title="A message is queued to send"
+        >
+          Queued
+        </span>
+      ) : null}
 
       {hasApprovalRequest ? (
         <span

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -18,6 +18,7 @@ import {
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import { PrChip } from "../pr-status/PrChip";
 import type { DropIndicatorPosition } from "./drag-drop";
 import { ReactionPicker } from "./ReactionPicker";
@@ -33,6 +34,11 @@ const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
 type ThreadRowProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
   inputRequestThreadKeys?: Record<string, boolean>;
+  /**
+   * Identity key → pending outbound-message state, surfaced as the
+   * "Scheduled"/"Queued" chip. Absent key = no pending send.
+   */
+  queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   /**
    * Identity key of the card the open composer was spawned from. When it
    * matches this row, the row renders as the orange "composing" source.
@@ -262,6 +268,7 @@ export function ThreadRow(props: ThreadRowProps) {
           <ThreadMetaChips
             hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
             hasInputRequest={props.inputRequestThreadKeys?.[threadKey] === true}
+            queuedMessageState={props.queuedMessageThreadKeys?.[threadKey]}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}
             thread={props.thread}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -686,6 +686,46 @@ describe("ThreadRow chip flow", () => {
     expect(dirtyChip).not.toHaveTextContent("-0");
   });
 
+  it("renders a solid-accent Scheduled chip when the thread has a scheduled message", () => {
+    const { container } = renderRow({
+      queuedMessageThreadKeys: { "codex:thread-chips": "scheduled" },
+    });
+    const chip = container.querySelector(".thread-row__chip--scheduled");
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("Scheduled");
+    expect(chip).toHaveAttribute(
+      "aria-label",
+      "A message is scheduled to send",
+    );
+    // The lower-priority variant must not also render.
+    expect(container.querySelector(".thread-row__chip--queued")).toBeNull();
+  });
+
+  it("renders a softer Queued chip when the thread has a queued (non-scheduled) message", () => {
+    const { container } = renderRow({
+      queuedMessageThreadKeys: { "codex:thread-chips": "queued" },
+    });
+    const chip = container.querySelector(".thread-row__chip--queued");
+    expect(chip).not.toBeNull();
+    expect(chip).toHaveTextContent("Queued");
+    expect(chip).toHaveAttribute("aria-label", "A message is queued to send");
+    expect(container.querySelector(".thread-row__chip--scheduled")).toBeNull();
+  });
+
+  it("renders no pending-send chip when the thread has no queued message", () => {
+    const { container } = renderRow({ queuedMessageThreadKeys: {} });
+    expect(container.querySelector(".thread-row__chip--scheduled")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--queued")).toBeNull();
+  });
+
+  it("only keys the pending-send chip to the matching thread identity key", () => {
+    const { container } = renderRow({
+      queuedMessageThreadKeys: { "codex:some-other-thread": "scheduled" },
+    });
+    expect(container.querySelector(".thread-row__chip--scheduled")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--queued")).toBeNull();
+  });
+
   it("renders no git working-state chips when the tree is clean and pushed", () => {
     const { container } = renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/icons/CheckIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/CheckIcon.tsx
@@ -1,0 +1,9 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function CheckIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <path d="m5 12 5 5L20 7" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -1,6 +1,7 @@
 export { ArrowUpIcon } from "./ArrowUpIcon";
 export { AutomationsIcon } from "./AutomationsIcon";
 export { BranchIcon } from "./BranchIcon";
+export { CheckIcon } from "./CheckIcon";
 export { ChevronLeftIcon } from "./ChevronLeftIcon";
 export { ChevronRightIcon } from "./ChevronRightIcon";
 export { ChevronUpIcon } from "./ChevronUpIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -28,6 +28,8 @@ function createComposerDraftStore(): ComposerDraftStore {
     getPendingSteer: vi.fn(),
     getQueuedTurn: (scopeKey) => queuedTurns.get(scopeKey)?.[0],
     getQueuedTurns: (scopeKey) => queuedTurns.get(scopeKey) ?? [],
+    getQueuedTurnVersion: () => 0,
+    subscribeQueuedTurns: () => () => {},
     removeQueuedTurnAt: (scopeKey, index) => {
       const current = queuedTurns.get(scopeKey) ?? [];
       const next = [...current];

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
@@ -1,0 +1,129 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import {
+  useComposerDraftStore,
+  type ComposerDraftStore,
+  type ComposerQueuedTurnSnapshot,
+} from "../../features/composer/useComposerDraftStore";
+import { useThreadQueuedMessageIndicators } from "../useThreadQueuedMessageIndicators";
+
+function makeThread(id: string): NavigationThreadSummary {
+  return {
+    id,
+    title: id,
+    titleSource: "explicit",
+    source: "codex",
+    executionMode: "default",
+    updatedAt: 0,
+    inbox: { inInbox: false },
+    linkedDirectories: [],
+  };
+}
+
+function makeQueuedTurn(
+  overrides: Partial<ComposerQueuedTurnSnapshot> = {},
+): ComposerQueuedTurnSnapshot {
+  return {
+    id: "queued-1",
+    text: "hello",
+    imageAttachments: [],
+    ...overrides,
+  };
+}
+
+function scopeKey(thread: NavigationThreadSummary): string {
+  return `thread:${thread.source}:${thread.id}`;
+}
+
+function renderIndicators(threads: NavigationThreadSummary[]) {
+  return renderHook(
+    ({ threads: currentThreads }) => {
+      const store = useComposerDraftStore();
+      const indicators = useThreadQueuedMessageIndicators({
+        composerDraftStore: store,
+        threads: currentThreads,
+      });
+      return { store, indicators };
+    },
+    { initialProps: { threads } },
+  );
+}
+
+function setQueued(
+  store: ComposerDraftStore,
+  thread: NavigationThreadSummary,
+  turns: ComposerQueuedTurnSnapshot[],
+): void {
+  act(() => {
+    store.setQueuedTurns(scopeKey(thread), turns);
+  });
+}
+
+describe("useThreadQueuedMessageIndicators", () => {
+  it("returns an empty map when no thread has queued turns", () => {
+    const { result } = renderIndicators([makeThread("a")]);
+    expect(result.current.indicators).toEqual({});
+  });
+
+  it("classifies a queued turn without a send time as 'queued'", () => {
+    const thread = makeThread("a");
+    const { result } = renderIndicators([thread]);
+    setQueued(result.current.store, thread, [makeQueuedTurn()]);
+    expect(result.current.indicators).toEqual({ "codex:a": "queued" });
+  });
+
+  it("classifies a future-dated turn as 'scheduled'", () => {
+    const thread = makeThread("a");
+    const { result } = renderIndicators([thread]);
+    setQueued(result.current.store, thread, [
+      makeQueuedTurn({ scheduledSendAt: Date.now() + 60_000 }),
+    ]);
+    expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
+  });
+
+  it("prefers 'scheduled' when a thread has both a scheduled and a plain queued turn", () => {
+    const thread = makeThread("a");
+    const { result } = renderIndicators([thread]);
+    setQueued(result.current.store, thread, [
+      makeQueuedTurn({ id: "plain" }),
+      makeQueuedTurn({ id: "future", scheduledSendAt: Date.now() + 60_000 }),
+    ]);
+    expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
+  });
+
+  it("treats an already-elapsed send time as 'queued', not 'scheduled'", () => {
+    const thread = makeThread("a");
+    const { result } = renderIndicators([thread]);
+    setQueued(result.current.store, thread, [
+      makeQueuedTurn({ scheduledSendAt: Date.now() - 60_000 }),
+    ]);
+    expect(result.current.indicators).toEqual({ "codex:a": "queued" });
+  });
+
+  it("keys indicators by thread identity key across multiple threads", () => {
+    const a = makeThread("a");
+    const b = makeThread("b");
+    const { result } = renderIndicators([a, b]);
+    setQueued(result.current.store, a, [makeQueuedTurn()]);
+    setQueued(result.current.store, b, [
+      makeQueuedTurn({ scheduledSendAt: Date.now() + 60_000 }),
+    ]);
+    expect(result.current.indicators).toEqual({
+      "codex:a": "queued",
+      "codex:b": "scheduled",
+    });
+  });
+
+  it("reactively clears the indicator when the queued turn is released", () => {
+    const thread = makeThread("a");
+    const { result } = renderIndicators([thread]);
+    setQueued(result.current.store, thread, [makeQueuedTurn()]);
+    expect(result.current.indicators).toEqual({ "codex:a": "queued" });
+
+    act(() => {
+      result.current.store.shiftQueuedTurn(scopeKey(thread));
+    });
+    expect(result.current.indicators).toEqual({});
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
@@ -1,0 +1,74 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import type { ComposerDraftStore } from "../features/composer/useComposerDraftStore";
+
+/**
+ * A thread's pending outbound-message state, in descending information
+ * priority. `"scheduled"` (a message with a future send time) outranks
+ * `"queued"` (a message waiting for the active turn to finish) so a thread
+ * that has both surfaces the scheduled signal.
+ */
+export type ThreadQueuedMessageState = "scheduled" | "queued";
+
+function getThreadScopeKey(
+  thread: Pick<NavigationThreadSummary, "id" | "source">,
+): string {
+  return `thread:${thread.source}:${thread.id}`;
+}
+
+/**
+ * Derives a per-thread map of pending outbound-message indicators from the
+ * composer draft store's queued-turn Map. Queued/scheduled turns are
+ * renderer-only, in-memory state keyed by `thread:<source>:<id>`; the store
+ * lives at app root and is otherwise invisible to the sidebar. This hook
+ * subscribes to the store's queued-turn version and recomputes a
+ * `Record<threadIdentityKey, ThreadQueuedMessageState>` keyed the same way
+ * ThreadRow reads `approvalRequestThreadKeys` — so a single map threads down
+ * to every row.
+ *
+ * The classification is evaluated at compute time against `Date.now()`; a
+ * scheduled turn whose send time has passed but hasn't been released yet
+ * still reads as `"scheduled"` until the release mutates the store and bumps
+ * the version. That's intentional — the chip clears the moment the turn
+ * actually leaves the queue, and no per-second tick is needed for a static
+ * label.
+ */
+export function useThreadQueuedMessageIndicators(params: {
+  composerDraftStore: ComposerDraftStore;
+  threads: NavigationThreadSummary[];
+}): Record<string, ThreadQueuedMessageState> {
+  const { composerDraftStore, threads } = params;
+  const version = useSyncExternalStore(
+    composerDraftStore.subscribeQueuedTurns,
+    composerDraftStore.getQueuedTurnVersion,
+  );
+
+  return useMemo(() => {
+    const indicators: Record<string, ThreadQueuedMessageState> = {};
+    const now = Date.now();
+    for (const thread of threads) {
+      const queuedTurns = composerDraftStore.getQueuedTurns(
+        getThreadScopeKey(thread),
+      );
+      if (queuedTurns.length === 0) {
+        continue;
+      }
+      const hasScheduled = queuedTurns.some(
+        (turn) =>
+          typeof turn.scheduledSendAt === "number"
+          && Number.isFinite(turn.scheduledSendAt)
+          && turn.scheduledSendAt > now,
+      );
+      indicators[buildThreadIdentityKey(thread.source, thread.id)] = hasScheduled
+        ? "scheduled"
+        : "queued";
+    }
+    return indicators;
+    // `version` is intentionally a dependency (not referenced in the body):
+    // it forces recomputation when the queued-turn Map mutates, since the
+    // Map itself is a ref whose identity never changes. exhaustive-deps
+    // can't see that and flags it as unnecessary.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [composerDraftStore, threads, version]);
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -353,13 +353,16 @@
 /* Suppress directory / PR / agent / binding chips in the list. Reaction
    and pin markers stay visible — reactions because they're user-curated
    signals, pin because the pin marker on its own is information-dense.
+   The "Scheduled"/"Queued" pending-send chips also stay visible: a pending
+   outbound message is a time-sensitive commitment the operator needs to
+   spot at a glance, so it survives the density strip like the pin marker.
 
    Scope the rule to `.thread-row__chips` so non-list surfaces that
    carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
    chip in the transcript) don't get collapsed when compact density is
    on. The skill chip in the composer and the standalone SkillChip use
    `.chip` directly and aren't affected by this rule. */
-:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin) {
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued) {
   display: none;
 }
 
@@ -3625,6 +3628,26 @@ textarea,
 .thread-row__chip--approval:hover,
 .thread-row__chip--input:hover {
   background: var(--accent-strong);
+}
+
+/* Pending outbound-message chips. "Scheduled" is the solid-accent CTA —
+   a future send time is the highest-priority signal, so it mirrors the
+   approval/input pill weight. "Queued" (waiting on the active turn) is
+   the softer accent-tinted variant so it reads as subordinate when the
+   two labels sit in the same list. Only one renders per row (priority is
+   resolved upstream), but they share the base pill sizing. */
+.thread-row__chip--scheduled {
+  border: 1px solid var(--accent-strong);
+  background: var(--accent);
+  color: var(--button-text);
+  font-weight: 700;
+}
+
+.thread-row__chip--queued {
+  border: 1px solid var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  font-weight: 600;
 }
 
 .path-copy-target {
@@ -15878,6 +15901,65 @@ textarea,
 
 .composer__send-split--open .composer__send-schedule-button svg {
   transform: rotate(180deg);
+}
+
+/* Middle zone of the split pill shown only while a draft schedule is pending
+   (e.g. editing a scheduled item). A checkbox + countdown that arms/disarms
+   the schedule: armed → Send keeps the schedule, unarmed → Send fires now.
+   Reuses the pill's seam convention (right-hairline between zones). */
+.composer__actions .composer__send-split-pill .composer__send-schedule-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border: 0;
+  border-right: 1px solid var(--accent-border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.composer__send-split-pill:hover .composer__send-schedule-toggle,
+.composer__send-split--open .composer__send-split-pill .composer__send-schedule-toggle {
+  border-right-color: transparent;
+}
+
+.composer__send-schedule-toggle-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  color: var(--button-text);
+}
+
+.composer__send-schedule-toggle.is-armed .composer__send-schedule-toggle-box {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.composer__send-schedule-toggle:not(.is-armed) .composer__send-schedule-toggle-label {
+  opacity: 0.6;
+}
+
+/* Hover fills this zone like the caret/Send zones so it's clear a click lands
+   here — but keep the armed check box readable by giving it a solid outline. */
+.composer__send-split-pill .composer__send-schedule-toggle:not(:disabled):hover {
+  background: var(--accent);
+  color: var(--button-text);
+}
+
+.composer__send-split-pill
+  .composer__send-schedule-toggle:not(:disabled):hover
+  .composer__send-schedule-toggle-box {
+  border-color: var(--button-text);
 }
 
 /* Per-zone hover so it's always obvious which half a click will fire — the fix


### PR DESCRIPTION
## What

Surfaces pending outbound messages in the sidebar and fixes the scheduled-message send controls in the composer.

### Sidebar — Scheduled / Queued row chips
Thread rows now show a chip when the thread has a pending outbound message, so you can tell from the list — previously this state only existed inside the open composer.

- **Scheduled** (solid-accent CTA) — a message with a future send time.
- **Queued** (softer accent tint) — a message waiting for the active turn to finish.
- Scheduled outranks Queued when a thread has both (higher info priority).
- Chips survive compact density like the pin marker.

The queued/scheduled turns live only in an in-memory ref `Map` in the composer draft store, invisible to the sidebar. This adds a lightweight `subscribeQueuedTurns` + `getQueuedTurnVersion` bridge on the store, and a `useThreadQueuedMessageIndicators` hook that derives a per-thread `Record<threadKey, "scheduled" | "queued">` (keyed like `approvalRequestThreadKeys`) threaded down `App → Sidebar → lists → ThreadRow → ThreadMetaChips`.

### Composer — Send now, and a schedule toggle instead of a countdown
- A queued/scheduled entry's first action is now context-driven: **Steer** only while a turn is active; **Send now** when idle — which actually fires the message immediately (via the existing `sendQueuedTurn` path), instead of leaving a dead, disabled Steer button. Coordinates with the background releaser so nothing double-sends.
- Editing a scheduled message no longer hijacks the Send button into a `Send in 14m 56s` countdown. **Send** just reads **Send**; the schedule surfaces as an armed check toggle between the `^` caret and Send. Checked → Send keeps the schedule (re-queues at the same time); unchecked → Send fires now.

## Why

Two operator pain points: (1) you couldn't tell from the thread list that a thread had a message scheduled/queued, and (2) once a message was scheduled there was no way to send it now — the Steer button did nothing when idle — and the edit flow's countdown Send button conflated "send" with "when."

## Notes for reviewers

- The `/review` config panel keeps its own separate inline `Send in Xm` confirm button ([Composer.tsx](apps/desktop/src/renderer/src/features/composer/Composer.tsx)); this PR intentionally does not touch that surface.
- Search-panel thread rows reuse `ThreadRow` but are not wired for the chip yet (sidebar lists only) — the prop is optional, so they simply don't render it.
- No live countdown on the sidebar chip (static label) to avoid a per-second re-render cascade across every thread row.

## Testing

- New/updated unit tests: `useThreadQueuedMessageIndicators` (classification, scheduled-wins priority, past-time handling, reactivity), thread-row chip rendering/aria/priority, and composer coverage for the edit toggle (armed keeps schedule, unchecked sends now) and Send now on a scheduled entry.
- Full desktop typecheck, ESLint (0 errors), and the composer / navigation / lib suites pass.
- Verified the chip and send-split states visually via faithful token-accurate mockups; not driven end-to-end in a live Electron session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)