### PR TITLE
fix(desktop): stop cancelled launchpads leaking drafts and phantom directories

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1297,6 +1297,9 @@ function DesktopAppShell(props: {
           onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
           onSetDirectoryPin={navigation.setDirectoryPin}
           onReorderDirectoryPins={navigation.reorderDirectoryPins}
+          onRemoveDirectory={(directory) => {
+            void navigation.removeDirectory(directory.key);
+          }}
           onPrefetchPullRequests={pullRequests.prefetch}
           onDetachPullRequest={async (thread, pr) => {
             if (!desktopApi?.detachThreadPullRequest) return;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2675,7 +2675,7 @@ export function Composer(props: ComposerProps) {
     imageAttachments: [],
     skillTokens: [],
   });
-  const clearSubmittedComposerDraftForStart = (
+  const resetComposerDraftAndState = (
     scopeKey: string,
   ): void => {
     clearComposerDraftSnapshot(scopeKey);
@@ -2760,6 +2760,31 @@ export function Composer(props: ComposerProps) {
       return;
     }
     draftStore.recordHistory?.(scopeKey, state, status);
+  };
+  /**
+   * Discard the draft for `scopeKey` without destroying it: park whatever the
+   * user composed in the recovery journal as "abandoned" (so ArrowUp can bring
+   * it straight back), then reset the store AND the live component state.
+   * Cancelling a launchpad should empty the composer, not lose the message.
+   *
+   * The record check mirrors the abandon path in `saveComposerDraftSnapshot` —
+   * the live snapshot is re-stamped on every render, so it is current at click
+   * time. It reuses the same `resetComposerDraftAndState` the submit path calls,
+   * so a cancelled draft can't linger in local React state and get re-persisted
+   * into the next scope if this Composer instance is ever reused rather than
+   * remounted.
+   */
+  const abandonComposerDraftSnapshot = (scopeKey: string): void => {
+    const latest = latestDraftSnapshotRef.current;
+    if (
+      latest.scopeKey === scopeKey
+      && (latest.snapshot.draft.trim()
+        || latest.snapshot.skillTokens.length > 0
+        || latest.snapshot.imageAttachments.length > 0)
+    ) {
+      recordComposerDraftHistory(scopeKey, latest.snapshot, "abandoned");
+    }
+    resetComposerDraftAndState(scopeKey);
   };
   const getComposerDraftSnapshotSignature = (
     snapshot: ComposerDraftSnapshot,
@@ -4037,7 +4062,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(optimisticReviewId);
     const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
     if (!options?.queued) {
-      clearSubmittedComposerDraftForStart(composerScopeKey);
+      resetComposerDraftAndState(composerScopeKey);
       setReviewConfig(undefined);
     }
     try {
@@ -4388,7 +4413,7 @@ export function Composer(props: ComposerProps) {
     setActiveOptimisticMessageId(optimisticMessageId);
     const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
     if (!queued) {
-      clearSubmittedComposerDraftForStart(composerScopeKey);
+      resetComposerDraftAndState(composerScopeKey);
       if (collaborationMode) {
         setPlanModeEnabled(false);
       }
@@ -7598,6 +7623,12 @@ export function Composer(props: ComposerProps) {
               disabled={sending}
               type="button"
               onClick={() => {
+                // Cancel empties the launchpad without losing what was typed:
+                // the message is parked in the ArrowUp recovery buffer and the
+                // active draft is cleared. Leaving the draft in place instead
+                // would rehydrate it into the next launchpad opened for this key
+                // and keep the row's orange "has-draft" marker lit.
+                abandonComposerDraftSnapshot(composerScopeKey);
                 props.onCancelLaunchpad?.(props.launchpad!.directoryKey);
               }}
             >

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -382,6 +382,73 @@ describe("Composer", () => {
     });
   });
 
+  it("parks the launchpad's message in the recovery buffer when cancelled", async () => {
+    // Cancel empties the composer without losing the message: it is recorded as
+    // "abandoned" (an ArrowUp-recoverable status) and the active draft is
+    // cleared. Leaving the draft in place would rehydrate it into the next
+    // launchpad opened for this key and keep the row's orange marker lit.
+    const deleteDraft = vi.fn();
+    const recordHistory = vi.fn();
+    const draftStore: ComposerDraftStore = {
+      delete: deleteDraft,
+      recordHistory,
+      get: () => undefined,
+      deletePendingSteer: vi.fn(),
+      deleteQueuedTurn: vi.fn(),
+      getPendingSteer: () => undefined,
+      getQueuedTurn: () => undefined,
+      getQueuedTurns: () => [],
+      getQueuedTurnVersion: () => 0,
+      subscribeQueuedTurns: () => () => undefined,
+      removeQueuedTurnAt: () => undefined,
+      removeQueuedTurnById: () => undefined,
+      shiftQueuedTurn: () => undefined,
+      setPendingSteer: vi.fn(),
+      setQueuedTurn: vi.fn(),
+      setQueuedTurns: vi.fn(),
+      set: vi.fn(),
+    };
+    const onCancelLaunchpad = vi.fn();
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        disabled={false}
+        draftStore={draftStore}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:local",
+          directoryKind: "directory",
+          directoryLabel: "media-service",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Make a PR to swap all the icons",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onCancelLaunchpad={onCancelLaunchpad}
+        skills={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Recoverable via ArrowUp ("abandoned" is a recovery status), then cleared.
+    expect(recordHistory).toHaveBeenCalledWith(
+      "launchpad:subthread:codex:thread-parent:local",
+      expect.objectContaining({ draft: "Make a PR to swap all the icons" }),
+      "abandoned",
+    );
+    expect(deleteDraft).toHaveBeenCalledWith(
+      "launchpad:subthread:codex:thread-parent:local",
+    );
+    expect(onCancelLaunchpad).toHaveBeenCalledWith(
+      "subthread:codex:thread-parent:local",
+    );
+  });
+
   it("renders unavailable reason when provided", async () => {
     const unavailableReason = "Codex profile not logged in. Please check your settings.";
     render(

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -19,6 +19,7 @@ import {
   comparePinnedThreads,
   isPinnedDirectory,
   isPinnedThread,
+  isSubthreadLaunchpadKey,
   moveDirectoryKey,
   moveThreadKey,
   parseThreadIdentityKey,
@@ -137,6 +138,16 @@ function isPinnableDirectoryKind(
   return directory.kind === "directory" || directory.kind === "workspace";
 }
 
+/**
+ * Drives the row's orange "has-draft" marker. This means "you have composed
+ * something here" — typed text or attached images — and nothing else.
+ *
+ * `settingsTouchedAt` is deliberately NOT part of it. That stamp records that
+ * the user picked a model / reasoning level / access mode for this project,
+ * which is a sticky preference we keep, not an unsent draft. Including it made
+ * every project the user had ever configured look permanently half-drafted, and
+ * the marker survived Cancel because the stamp is persisted.
+ */
 function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolean {
   const launchpad = directory.launchpad;
   if (!launchpad) {
@@ -145,8 +156,7 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
 
   return (
     launchpad.prompt.trim().length > 0 ||
-    (launchpad.imageAttachments?.length ?? 0) > 0 ||
-    launchpad.settingsTouchedAt !== undefined
+    (launchpad.imageAttachments?.length ?? 0) > 0
   );
 }
 
@@ -246,24 +256,41 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const directoryDragEnabled = Boolean(
     props.onSetDirectoryPin && props.onReorderDirectoryPins,
   );
+  /**
+   * Sub-thread launchpads (`subthread:<source>:<parent>:<mode>`) are transient,
+   * thread-scoped composers rendered inline under their parent thread — never a
+   * project directory. The main-process snapshot already omits them, but the
+   * renderer's launchpad merge synthesizes a `kind: "directory"` summary for the
+   * one that's currently open, so filter them here too. Otherwise the open
+   * composer shows up as a phantom row duplicating its parent's directory, and
+   * (having no threads) it would be offered the "Remove Directory" action — which
+   * would delete the overlay row of the sub-thread being composed.
+   */
+  const visibleDirectories = useMemo(
+    () =>
+      props.directories.filter(
+        (directory) => !isSubthreadLaunchpadKey(directory.key),
+      ),
+    [props.directories],
+  );
   const pinnedDirectories = useMemo(
     () =>
-      props.directories
+      visibleDirectories
         .filter(isPinnedDirectory)
         .sort(comparePinnedDirectories),
-    [props.directories],
+    [visibleDirectories],
   );
   const pinnedDirectoryKeys = useMemo(
     () => pinnedDirectories.map((directory) => directory.key),
     [pinnedDirectories],
   );
   const unpinnedDirectories = useMemo(
-    () => props.directories.filter((directory) => !isPinnedDirectory(directory)),
-    [props.directories],
+    () => visibleDirectories.filter((directory) => !isPinnedDirectory(directory)),
+    [visibleDirectories],
   );
   const directoryByKey = useMemo(
-    () => new Map(props.directories.map((directory) => [directory.key, directory])),
-    [props.directories],
+    () => new Map(visibleDirectories.map((directory) => [directory.key, directory])),
+    [visibleDirectories],
   );
 
   const reorderDirectoryPins = (nextKeys: string[]): void => {
@@ -377,7 +404,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       previousSelectedItemKeyRef.current = undefined;
       return;
     }
-    const matchingDirectory = props.directories.find(
+    const matchingDirectory = visibleDirectories.find(
       (directory) =>
         selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
         directory.threadKeys.includes(selectedItemKey),
@@ -410,9 +437,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
         [matchingDirectory.key]: true,
       };
     });
-  }, [props.directories, props.selectedItemKey]);
+  }, [visibleDirectories, props.selectedItemKey]);
 
-  if (props.directories.length === 0) {
+  if (visibleDirectories.length === 0) {
     return <p className="sidebar-empty">No directory-linked threads.</p>;
   }
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -161,6 +161,13 @@ type SidebarProps = {
   ) => Promise<void>;
   onReorderDirectoryPins?: (directoryKeys: string[]) => Promise<void>;
   /**
+   * Remove an empty directory (no linked threads) from the Directories list.
+   * Offered in the directory context menu only when the directory has no
+   * threads; deletes the registered launchpad overlay row that keeps the empty
+   * row visible.
+   */
+  onRemoveDirectory?: (directory: NavigationDirectorySummary) => void;
+  /**
    * Called by thread rows when the user hovers a non-merged PR chip
    * (or the row itself, depending on chip strategy). Used to prefetch
    * fresh PR status before they click in.
@@ -533,6 +540,13 @@ export function Sidebar(props: SidebarProps) {
   ): void => {
     setDirectoryContextMenu(undefined);
     void props.onSetDirectoryPin?.(directory, !directory.pinnedRank);
+  };
+
+  const removeDirectoryFromContextMenu = (
+    directory: NavigationDirectorySummary,
+  ): void => {
+    setDirectoryContextMenu(undefined);
+    props.onRemoveDirectory?.(directory);
   };
 
   /**
@@ -1374,6 +1388,24 @@ export function Sidebar(props: SidebarProps) {
               </>
             ) : null}
           </div>
+          {props.onRemoveDirectory
+            && directoryContextMenu.directory.kind === "directory"
+            && directoryContextMenu.directory.threadKeys.length === 0 ? (
+            <>
+              <div className="thread-context-menu__separator" role="separator" />
+              <div className="thread-context-menu__section">
+                <button
+                  role="menuitem"
+                  type="button"
+                  onClick={() =>
+                    removeDirectoryFromContextMenu(directoryContextMenu.directory)
+                  }
+                >
+                  Remove Directory
+                </button>
+              </div>
+            </>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3111,6 +3111,7 @@ describe("Sidebar directory pinning", () => {
         pinned: boolean,
       ) => Promise<void>;
       onReorderDirectoryPins?: (directoryKeys: string[]) => Promise<void>;
+      onRemoveDirectory?: (directory: NavigationDirectorySummary) => void;
     } = {},
   ): void {
     render(
@@ -3131,9 +3132,165 @@ describe("Sidebar directory pinning", () => {
         onSelectThread={() => undefined}
         onSetDirectoryPin={overrides.onSetDirectoryPin}
         onReorderDirectoryPins={overrides.onReorderDirectoryPins}
+        onRemoveDirectory={overrides.onRemoveDirectory}
       />,
     );
   }
+
+  /**
+   * A sub-thread launchpad as the renderer's launchpad merge synthesizes it:
+   * a `kind: "directory"` summary keyed `subthread:...` with no threads. It must
+   * never surface in the Directories lens.
+   */
+  const subthreadLaunchpadDirectory: NavigationDirectorySummary = {
+    key: "subthread:codex:thread-parent:same-worktree",
+    kind: "directory",
+    label: "media-service",
+    path: "/Users/huntharo/pwrdrvr/media-service",
+    threadKeys: [],
+    needsAttentionCount: 0,
+    latestUpdatedAt: 4000,
+  };
+
+  /** Base launchpad draft for the orange "has-draft" marker tests. */
+  const projectBLaunchpad = {
+    directoryKey: projectBDirectory.key,
+    directoryKind: "directory" as const,
+    directoryLabel: "ProjectB",
+    directoryPath: projectBDirectory.path,
+    workMode: "local" as const,
+    backend: "codex" as const,
+    executionMode: "default" as const,
+    prompt: "",
+    createdAt: 1,
+    updatedAt: 2,
+  };
+
+  function getLaunchpadButton(label: string): HTMLElement {
+    return screen.getByRole("button", {
+      name: `Open new thread launchpad for ${label}`,
+    });
+  }
+
+  it("marks a directory as having a draft when a message is composed", () => {
+    renderSidebar(
+      [
+        {
+          ...projectBDirectory,
+          launchpad: { ...projectBLaunchpad, prompt: "Half-written message" },
+        },
+      ],
+      { onSetDirectoryPin: async () => undefined },
+    );
+
+    expect(getLaunchpadButton("ProjectB")).toHaveClass("has-draft");
+  });
+
+  it("does not mark a directory as having a draft when only its settings were touched", () => {
+    renderSidebar(
+      [
+        {
+          ...projectBDirectory,
+          launchpad: {
+            ...projectBLaunchpad,
+            executionMode: "full-access" as const,
+            prompt: "",
+            settingsTouchedAt: 2_000,
+          },
+        },
+      ],
+      { onSetDirectoryPin: async () => undefined },
+    );
+
+    // Picking a model / reasoning level / access mode for a project is a sticky
+    // preference we keep, not an unsent draft. The orange marker means "you
+    // composed something here" — it must stay off.
+    expect(getLaunchpadButton("ProjectB")).not.toHaveClass("has-draft");
+  });
+
+  it("does not render a sub-thread launchpad as a directory row", () => {
+    renderSidebar([projectADirectory, subthreadLaunchpadDirectory], {
+      onSetDirectoryPin: async () => undefined,
+      onRemoveDirectory: () => undefined,
+    });
+
+    expect(getDirectorySummary(/ProjectA/i)).toBeInTheDocument();
+    // The open sub-thread composer's transient row must not appear as a project
+    // directory — it would duplicate its parent's real directory and, having no
+    // threads, would be offered "Remove Directory".
+    expect(
+      screen.queryByRole("button", { name: /media-service/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to the empty state when only sub-thread launchpads exist", () => {
+    renderSidebar([subthreadLaunchpadDirectory], {
+      onSetDirectoryPin: async () => undefined,
+      onRemoveDirectory: () => undefined,
+    });
+
+    expect(screen.getByText("No directory-linked threads.")).toBeInTheDocument();
+  });
+
+  it("offers Remove Directory on an empty directory row", async () => {
+    const onRemoveDirectory = vi.fn();
+
+    renderSidebar([projectBDirectory], {
+      onSetDirectoryPin: async () => undefined,
+      onRemoveDirectory,
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/ProjectB/i));
+
+    const removeItem = await screen.findByRole("menuitem", {
+      name: "Remove Directory",
+    });
+    await clickElement(removeItem);
+
+    expect(onRemoveDirectory).toHaveBeenCalledWith(projectBDirectory);
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove Directory" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not offer Remove Directory on a directory that still has threads", async () => {
+    const populated: NavigationDirectorySummary = {
+      ...projectBDirectory,
+      threadKeys: ["codex:thread-1"],
+    };
+
+    renderSidebar([populated], {
+      onSetDirectoryPin: async () => undefined,
+      onRemoveDirectory: vi.fn(),
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/ProjectB/i));
+
+    // The pin item proves the menu opened; Remove must be absent because
+    // removing the row would strand the threads that live in it.
+    expect(
+      await screen.findByRole("menuitem", { name: "Pin Directory" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove Directory" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not offer Remove Directory on a workspace row", async () => {
+    renderSidebar([workspaceDirectory], {
+      onSetDirectoryPin: async () => undefined,
+      onRemoveDirectory: vi.fn(),
+    });
+
+    fireEvent.contextMenu(getDirectorySummary(/Workspace/i));
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Pin Directory" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove Directory" }),
+    ).not.toBeInTheDocument();
+  });
 
   it("renders pinned directories above the divider and unpinned below", () => {
     const pinned: NavigationDirectorySummary = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4884,6 +4884,419 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("deletes the persisted overlay row when a sub-thread launchpad is cancelled", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Local parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local" as const,
+        },
+      ],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const launchpad = {
+      directoryKey: "subthread:codex:thread-parent:local",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({ launchpad, defaults }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: { ...launchpad, updatedAt: 2 },
+      defaults,
+    }));
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: "subthread:codex:thread-parent:local",
+      defaults,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      updateDirectoryLaunchpad,
+      resetDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "local");
+    });
+    expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+      "subthread:codex:thread-parent:local",
+    );
+
+    await act(async () => {
+      result.current.discardLaunchpad("subthread:codex:thread-parent:local");
+    });
+
+    // A sub-thread launchpad has no registeredAt, so cancel drops the whole
+    // overlay row instead of leaving a phantom directory behind.
+    expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:local",
+    });
+    expect(result.current.selectedLaunchpad).toBeUndefined();
+  });
+
+  it("returns to the source thread when a sub-thread launchpad is cancelled after a refresh", async () => {
+    const parentThread = {
+      id: "thread-parent",
+      title: "Local parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: "/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "local" as const,
+        },
+      ],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const launchpad = {
+      directoryKey: "subthread:codex:thread-parent:local",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({ launchpad, defaults }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: { ...launchpad, updatedAt: 2 },
+      defaults,
+    }));
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: "subthread:codex:thread-parent:local",
+      defaults,
+    }));
+    // The main-process snapshot deliberately omits sub-thread launchpads, so a
+    // refresh while the composer is open wipes the row from state.response —
+    // it survives only in localLaunchpads.
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-parent"],
+      threads: [parentThread],
+      directories: [],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      updateDirectoryLaunchpad,
+      resetDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "local");
+    });
+
+    // Authoritative refresh lands while the sub-thread composer is still open.
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.selectedLaunchpad?.directoryKey).toBe(
+      "subthread:codex:thread-parent:local",
+    );
+
+    await act(async () => {
+      result.current.discardLaunchpad("subthread:codex:thread-parent:local");
+    });
+
+    // Cancel must still resolve the launchpad (from localLaunchpads via the
+    // merged memo) so it deletes the overlay row AND returns the user to the
+    // card they composed from, rather than clearing selection entirely.
+    expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "subthread:codex:thread-parent:local",
+    });
+    expect(result.current.selectedItemKey).toBe("codex:thread-parent");
+  });
+
+  it("keeps a registered directory but clears its message when its launchpad is cancelled", async () => {
+    const registeredLaunchpad = {
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "leftover draft",
+      registeredAt: 1_500,
+      settingsTouchedAt: 1_600,
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: { ...registeredLaunchpad, prompt: "", updatedAt: 3 },
+      defaults,
+    }));
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: "directory:/repo/app",
+      defaults,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2,
+          launchpad: registeredLaunchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      updateDirectoryLaunchpad,
+      resetDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(
+        result.current.directories.some(
+          (directory) => directory.key === "directory:/repo/app",
+        ),
+      ).toBe(true);
+    });
+
+    await act(async () => {
+      result.current.discardLaunchpad("directory:/repo/app");
+    });
+
+    // Registered directory: keep the row, wipe only the composed message.
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:/repo/app",
+      patch: { prompt: "", imageAttachments: [], editorDocument: undefined },
+    });
+    expect(resetDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(
+      result.current.directories.some(
+        (directory) => directory.key === "directory:/repo/app",
+      ),
+    ).toBe(true);
+  });
+
+  it("removes an empty registered directory and deletes its overlay row", async () => {
+    const registeredLaunchpad = {
+      directoryKey: "directory:/repo/app",
+      directoryKind: "directory" as const,
+      directoryLabel: "app",
+      directoryPath: "/repo/app",
+      workMode: "local" as const,
+      backend: "codex" as const,
+      executionMode: "default" as const,
+      prompt: "",
+      registeredAt: 1_500,
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: "directory:/repo/app",
+      defaults,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2,
+          launchpad: registeredLaunchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      resetDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(
+        result.current.directories.some(
+          (directory) => directory.key === "directory:/repo/app",
+        ),
+      ).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.removeDirectory("directory:/repo/app");
+    });
+
+    // The empty row is pruned immediately and its overlay row is deleted so it
+    // can't reappear on the next snapshot.
+    expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:/repo/app",
+    });
+    expect(
+      result.current.directories.some(
+        (directory) => directory.key === "directory:/repo/app",
+      ),
+    ).toBe(false);
+  });
+
+  it("refuses to remove a directory that still has threads", async () => {
+    const thread = {
+      id: "thread-1",
+      title: "Live work",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        { id: "/repo/app", label: "app", path: "/repo/app", kind: "local" as const },
+      ],
+      inbox: { inInbox: false },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const defaults = {
+      backend: "codex" as const,
+      executionMode: "default" as const,
+    };
+    const resetDirectoryLaunchpad = vi.fn(async () => ({
+      directoryKey: "directory:/repo/app",
+      defaults,
+    }));
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [thread],
+      directories: [
+        {
+          key: "directory:/repo/app",
+          kind: "directory" as const,
+          label: "app",
+          path: "/repo/app",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+          latestUpdatedAt: 2,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      resetDirectoryLaunchpad,
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(
+        result.current.directories.some(
+          (directory) => directory.key === "directory:/repo/app",
+        ),
+      ).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.removeDirectory("directory:/repo/app");
+    });
+
+    // Deleting the overlay row would strip the directory's registration and
+    // sticky settings while its threads kept the row on screen.
+    expect(resetDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(
+      result.current.directories.some(
+        (directory) => directory.key === "directory:/repo/app",
+      ),
+    ).toBe(true);
+  });
+
   it("opens new-worktree sub-thread launchpads with stable worktree mode", async () => {
     const parentThread = {
       id: "thread-parent",

--- a/apps/desktop/src/renderer/src/lib/subthread-launchpads.ts
+++ b/apps/desktop/src/renderer/src/lib/subthread-launchpads.ts
@@ -1,4 +1,5 @@
 import type { NavigationThreadSummary } from "@pwragent/shared";
+import { SUBTHREAD_LAUNCHPAD_KEY_PREFIX } from "@pwragent/shared";
 
 export type ThreadWorkspaceMode = "local" | "same-worktree" | "new-worktree";
 
@@ -6,7 +7,7 @@ export function buildSubthreadLaunchpadKey(
   parent: Pick<NavigationThreadSummary, "id" | "source">,
   mode: ThreadWorkspaceMode,
 ): string {
-  return `subthread:${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
+  return `${SUBTHREAD_LAUNCHPAD_KEY_PREFIX}${encodeURIComponent(parent.source)}:${encodeURIComponent(parent.id)}:${mode}`;
 }
 
 export function getSubthreadLaunchpadMode(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -29,6 +29,7 @@ import {
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
   insertSubthreadIdAfter,
+  isSubthreadLaunchpadKey,
   shortenDerivedThreadTitle,
   sortSubthreadSummaries,
 } from "@pwragent/shared";
@@ -2137,6 +2138,7 @@ export function useThreadNavigation(
   pickingDirectory: boolean;
   clearPickDirectoryError: () => void;
   resetDirectoryLaunchpad: (directoryKey: string) => Promise<void>;
+  removeDirectory: (directoryKey: string) => Promise<void>;
   selectedDirectory?: NavigationDirectorySummary;
   selectedItemKey?: string;
   selectedLaunchpad?: NavigationLaunchpadDraft;
@@ -4449,6 +4451,83 @@ export function useThreadNavigation(
     [desktopApi, directories, optimisticThread, state.response, threads]
   );
 
+  /**
+   * Remove an empty directory (one with no linked threads) from the Directories
+   * list. Such a row is kept alive solely by its registered
+   * `directory_launchpads` overlay row, so deleting that row via
+   * `resetDirectoryLaunchpad` clears `registeredAt` and the directory drops out
+   * of the next snapshot. We optimistically prune the row (and any local
+   * launchpad draft) so the list updates instantly; a directory that still has
+   * threads is left in place, and a failed delete is reconciled by `refresh`.
+   */
+  const removeDirectory = useCallback(
+    async (directoryKey: string): Promise<void> => {
+      if (!desktopApi?.resetDirectoryLaunchpad) {
+        setLaunchpadError("Desktop bridge is missing resetDirectoryLaunchpad().");
+        return;
+      }
+
+      // Only an empty directory may be removed. One that still holds threads
+      // keeps its row from the thread side, so deleting its overlay row would
+      // silently drop its registration and sticky settings while the row stayed
+      // on screen. Sub-thread launchpads are transient composers, not
+      // directories, and must never be torn down through this path.
+      const directory = directories.find(
+        (candidate) => candidate.key === directoryKey,
+      );
+      if (
+        !directory
+        || directory.threadKeys.length > 0
+        || isSubthreadLaunchpadKey(directoryKey)
+      ) {
+        return;
+      }
+
+      setLaunchpadError(undefined);
+      setLocalLaunchpads((current) => {
+        if (!current[directoryKey]) {
+          return current;
+        }
+        const next = { ...current };
+        delete next[directoryKey];
+        return next;
+      });
+      setState((current) => {
+        if (!current.response) {
+          return current;
+        }
+        return {
+          ...current,
+          response: {
+            ...current.response,
+            directories: current.response.directories.filter(
+              (directory) =>
+                directory.key !== directoryKey
+                || directory.threadKeys.length > 0,
+            ),
+          },
+        };
+      });
+      setSelectedItemKey((current) =>
+        current === buildLaunchpadSelectionKey(directoryKey) ? undefined : current,
+      );
+
+      try {
+        await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+        // Drop the pin overlay too. It lives in a separate `directory_overlay`
+        // row that resetDirectoryLaunchpad does not touch, and a stale
+        // pinnedRank would silently re-pin the directory if it is ever re-added.
+        if (directory.pinnedRank) {
+          await desktopApi.setDirectoryPin?.({ directoryKey, pinnedRank: null });
+        }
+      } catch (error) {
+        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        await refresh();
+      }
+    },
+    [desktopApi, directories, refresh],
+  );
+
   const materializeDirectoryLaunchpad = useCallback(
     async (
       directoryKey: string,
@@ -4588,11 +4667,23 @@ export function useThreadNavigation(
    * selection to the source card the user invoked it from.
    */
   const discardLaunchpad = useCallback((directoryKey: string): void => {
-    const launchpad = stateRef.current.response?.directories.find(
+    // Read from the merged `directories` memo, not the raw snapshot: the
+    // main-process snapshot deliberately omits sub-thread launchpads, so after
+    // an authoritative refresh they exist only in `localLaunchpads`. Sourcing
+    // from the raw snapshot would lose `sourceThreadId` (which is never
+    // persisted anyway) and drop the user to no selection instead of returning
+    // them to the card they composed from. Mirrors materializeDirectoryLaunchpad.
+    const launchpad = directories.find(
       (candidate) => candidate.key === directoryKey,
     )?.launchpad;
     const sourceThreadId = launchpad?.sourceThreadId;
     const sourceBackend = launchpad?.backend;
+    // An explicitly-registered directory (user added it, or it already holds
+    // threads) must stay in the Directories list — Cancel only discards its
+    // un-submitted message. Everything else (sub-thread launchpads, transient
+    // launchpad-only rows) exists solely because of the draft, so drop the row
+    // entirely instead of leaving it behind as a phantom directory entry.
+    const isRegisteredDirectory = launchpad?.registeredAt !== undefined;
 
     setLocalLaunchpads((current) => {
       if (!current[directoryKey]) {
@@ -4618,7 +4709,28 @@ export function useThreadNavigation(
         ? buildThreadIdentityKey(sourceBackend, sourceThreadId)
         : undefined,
     );
-  }, []);
+
+    // Persist the discard so the overlay row can't rehydrate the cancelled
+    // draft on the next open (or after a refresh / restart / in another window).
+    // The in-memory reset above only affects this render.
+    const handleDiscardError = (error: unknown): void => {
+      setLaunchpadError(error instanceof Error ? error.message : String(error));
+    };
+    if (isRegisteredDirectory) {
+      // Keep the registered directory (and its remembered sticky settings);
+      // clear just the composed message.
+      void desktopApi
+        ?.updateDirectoryLaunchpad?.({
+          directoryKey,
+          patch: { prompt: "", imageAttachments: [], editorDocument: undefined },
+        })
+        .catch(handleDiscardError);
+    } else {
+      void desktopApi
+        ?.resetDirectoryLaunchpad?.({ directoryKey })
+        .catch(handleDiscardError);
+    }
+  }, [desktopApi, directories]);
 
   const archiveThread = useCallback(
     async (
@@ -5468,6 +5580,7 @@ export function useThreadNavigation(
     pickingDirectory,
     clearPickDirectoryError,
     resetDirectoryLaunchpad,
+    removeDirectory,
     selectedDirectory,
     selectedItemKey,
     selectedLaunchpad,

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -367,6 +367,37 @@ describe("buildDirectorySummaries", () => {
     ]);
   });
 
+  it("does not surface a sub-thread launchpad as a project-directory row", () => {
+    // Repro for the launchpad leak: opening "create sub-thread", typing a
+    // prompt, then cancelling used to leave the subthread:<source>:<parent>:<mode>
+    // overlay row behind. Because it carried a prompt, buildDirectorySummaries
+    // rendered it as a phantom top-level project directory (labelled with the
+    // parent workspace name), duplicating the real directory row. Sub-thread
+    // launchpads are thread-scoped and reached inline from the parent thread —
+    // they must never masquerade as a directory in the Directories lens.
+    const directories = buildDirectorySummaries({
+      threads: [],
+      launchpadsByKey: {
+        "subthread:codex:thread-parent:same-worktree": {
+          directoryKey: "subthread:codex:thread-parent:same-worktree",
+          directoryKind: "directory",
+          directoryLabel: "media-service",
+          directoryPath: "/Users/huntharo/pwrdrvr/media-service",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "Make a PR to swap all the icons",
+          workMode: "worktree",
+          parentThreadId: "thread-parent",
+          parentThreadTitle: "media-service",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+    });
+
+    expect(directories).toEqual([]);
+  });
+
   it("groups the scratch workspace root under Workspaces instead of a projects directory", () => {
     const directories = buildDirectorySummaries({
       threads: [

--- a/packages/agent-core/src/domain/directory-navigation.ts
+++ b/packages/agent-core/src/domain/directory-navigation.ts
@@ -9,6 +9,7 @@ import type {
 import {
   buildThreadIdentityKey,
   compareThreadsByCreatedAtDesc,
+  isSubthreadLaunchpadKey,
   isToolManagedWorktreePath,
 } from "@pwragent/shared";
 
@@ -578,6 +579,17 @@ export function buildDirectorySummaries(params: {
 
   for (const [directoryKey, launchpad] of Object.entries(params.launchpadsByKey ?? {})) {
     if (!launchpad || !hasPersistableLaunchpadState(launchpad)) {
+      continue;
+    }
+    // Sub-thread launchpads (`subthread:<source>:<parent>:<mode>`) are
+    // thread-scoped drafts composed inline under their parent thread — they are
+    // never a project directory. Synthesizing one into a Directories-lens row
+    // duplicated the parent's real directory as a phantom entry that survived
+    // cancelling ("create sub-thread" → type → cancel/navigate away). The live,
+    // open composer resolves its draft from the renderer's `localLaunchpads`
+    // merge, so skipping the persisted overlay row here only drops the leaked /
+    // abandoned copies and never hides an active composer.
+    if (isSubthreadLaunchpadKey(directoryKey)) {
       continue;
     }
     const launchpadPath = launchpad.directoryPath ?? pathFromDirectoryKey(directoryKey);

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -789,6 +789,19 @@ export function buildThreadIdentityKey(
   return `${encodeURIComponent(backend)}:${threadId}`;
 }
 
+/**
+ * Directory-key prefix for a sub-thread launchpad
+ * (`subthread:<source>:<parent>:<mode>`). Sub-thread launchpads are transient,
+ * thread-scoped composers — never a project directory — so several layers must
+ * recognize and exclude them. Centralized here so the key format has one source
+ * of truth and the exclusions can't drift apart.
+ */
+export const SUBTHREAD_LAUNCHPAD_KEY_PREFIX = "subthread:";
+
+export function isSubthreadLaunchpadKey(directoryKey: string): boolean {
+  return directoryKey.startsWith(SUBTHREAD_LAUNCHPAD_KEY_PREFIX);
+}
+
 export function parseThreadIdentityKey(
   threadKey: string,
 ): ThreadIdentityKeyParts | undefined {


### PR DESCRIPTION
## What & why

Cancelling a launchpad — the new-thread composer, or a "create sub-thread" composer — only cleared renderer in-memory state. The two persisted stores survived, so an un-submitted message and configuration came back on the next open, and phantom directory rows lingered in the sidebar. Reported on a machine with several checkouts of the same project appearing as duplicate/leftover rows.

## Behavior after this PR

**Cancel**
- **Parks the typed message in the ArrowUp recovery buffer** (recorded as `abandoned`), then resets the composer via the same store+state reset the submit path uses. The message is one ArrowUp away — not destroyed.
- **Clears the launchpad's persisted overlay draft.** A registered directory keeps its row *and its sticky settings* (model / reasoning level / access mode); a sub-thread or launchpad-only row is deleted outright.

**Orange "has-draft" marker**
- Now means exactly "you composed something here" — typed text or attached images. It no longer keys off `settingsTouchedAt`. Picking a model or access mode for a project is a sticky preference, not an unsent draft; counting it made every configured project look permanently half-drafted and kept the marker lit after Cancel.

**Sub-thread launchpads never render as project directories**
- A `subthread:<source>:<parent>:<mode>` launchpad is a transient, thread-scoped composer shown inline under its parent thread. It's now excluded from the Directories lens in both the main-process snapshot and the renderer's launchpad merge, so an open or abandoned one can't masquerade as a project row. (Being thread-less, such a phantom row would also have been offered "Remove Directory" — which would delete the overlay row of the sub-thread being composed.) The open composer is unaffected; it resolves its draft via `selectedLaunchpad`, not the directory list. The key check is centralized in `@pwragent/shared` (`isSubthreadLaunchpadKey`) so the three exclusion sites can't drift apart.

**New: Remove Directory**
- A "Remove Directory" item in the directory context menu (empty directories only, `kind: "directory"`) drops a registered-but-empty directory from the list. It deletes the launchpad overlay row and clears any stale pin. `removeDirectory` guards emptiness in the hook, not just the UI.

## Testing
- New tests, each mutation-verified (they fail when the logic is reverted): the orange marker ignores touched settings but lights on typed text; Cancel records the message as recoverable then clears; a sub-thread launchpad is excluded from the Directories lens and collapses to the empty state; Remove is offered only on empty `directory` rows (not threaded, not workspace); cancel-after-refresh still resolves the launchpad and returns to the source thread; `removeDirectory` refuses a threaded directory.
- Full workspace typecheck clean; ESLint 0 errors; dependency boundaries clean; agent-core + shared + desktop composer/navigation/hook suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
