### PR TITLE
feat(desktop): ⌘K thread-list search, and stop the find bar scrolling on transcript churn

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -217,7 +217,10 @@ function DesktopAppShell(props: {
     threadKey: string;
     turnId?: string;
   }>();
-  // Thread-list quick-jump popup (⌘F while the sidebar is focused).
+  // Bumped on every ⌘F so an already-open find bar takes focus back.
+  const [findFocusNonce, setFindFocusNonce] = useState(0);
+  // Thread-list quick-jump popup (⌘K anywhere, or ⌘F while the sidebar is
+  // focused).
   const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
@@ -578,22 +581,38 @@ function DesktopAppShell(props: {
     restore: restoreHistoryLocation,
   });
   useHistoryNavHotkeys({ onBack: history.goBack, onForward: history.goForward });
-  // ⌘⇧F / ⌃⇧F opens the global thread search screen. ⌘F (in-thread find /
-  // thread-list quick search) is wired onto this same owner further below.
+  // Opening the thread-list quick search has to reveal the sidebar first — it
+  // lives inside it, and a hidden sidebar (⌘B) is `display: none`, so the popup
+  // would open into nothing.
+  const openThreadJump = useCallback(() => {
+    if (sidebarHidden) {
+      setSidebarHiddenPersisted(false);
+    }
+    setSidebarSearchOpen(true);
+  }, [sidebarHidden, setSidebarHiddenPersisted]);
+  // ⌘⇧F / ⌃⇧F opens the global thread search screen; ⌘F is the focus-sensitive
+  // context find; ⌘K always lands on the thread-list quick search.
   useFindHotkeys({
     onOpenSearch: () => setMainView(mainView === "search" ? "thread" : "search"),
     onFind: () => {
-      // The thread-list quick search (below) claims ⌘F while the sidebar is
-      // focused; anywhere else ⌘F finds within the open thread.
+      // The thread-list quick search claims ⌘F while the sidebar is focused;
+      // anywhere else ⌘F finds within the open thread. Focus decides — which is
+      // precisely why ⌘K exists: reaching for the thread list from inside a
+      // thread would otherwise open the in-thread find.
       const active = document.activeElement as HTMLElement | null;
       if (active?.closest(".sidebar")) {
-        setSidebarSearchOpen(true);
+        openThreadJump();
         return;
       }
       if (mainView === "thread") {
         setManualFindOpen(true);
+        // Re-arm focus: a second ⌘F with the bar already open (operator clicked
+        // into the transcript, then reached back for find) must put the caret
+        // back in the field, the way a browser's find does.
+        setFindFocusNonce((nonce) => nonce + 1);
       }
     },
+    onThreadJump: openThreadJump,
   });
   // Manual find is per-thread chrome: drop it when the operator leaves the
   // thread view or switches threads. The deep-link find (findRequest) closes
@@ -965,6 +984,7 @@ function DesktopAppShell(props: {
     findOpen: threadFindOpen,
     findInitialQuery: threadFindInitialQuery,
     findTurnId: threadFindTurnId,
+    findFocusNonce,
     onFindOpenChange: (open: boolean) => {
       // The bar only ever calls this to close itself (Escape / ✕). Clear both
       // the manual toggle and any deep-link request so it stays closed.

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -418,16 +418,28 @@ function DesktopAppShell(props: {
       }
     });
   }, [desktopApi]);
-  const revealSelectedThreadInList = useCallback(() => {
-    const selectedRow = document.querySelector<HTMLElement>(
-      ".sidebar .thread-row.is-selected",
-    );
-    selectedRow?.scrollIntoView({
-      behavior: "smooth",
-      block: "center",
-      inline: "nearest",
-    });
-  }, []);
+  // `instant` is for callers that are about to hide the sidebar (the ⌘K peek):
+  // a smooth scroll is animated over several frames, and hiding the sidebar
+  // mid-animation abandons it wherever it got to. An instant scroll lands in one
+  // frame, and Chromium keeps the offset across `display: none` — so the row is
+  // already centered when the sidebar comes back.
+  //
+  // Takes an options object rather than a bare `behavior` string so a caller
+  // that wires this straight to an event handler (which would pass the event as
+  // the first argument) still gets the default.
+  const revealSelectedThreadInList = useCallback(
+    (options?: { instant?: boolean }) => {
+      const selectedRow = document.querySelector<HTMLElement>(
+        ".sidebar .thread-row.is-selected",
+      );
+      selectedRow?.scrollIntoView({
+        behavior: options?.instant === true ? "auto" : "smooth",
+        block: "center",
+        inline: "nearest",
+      });
+    },
+    [],
+  );
   const settings = props.settings;
 
   // Persisted layout setters — update local state immediately and write the
@@ -1209,7 +1221,15 @@ function DesktopAppShell(props: {
           onJumpToThread={(thread) => {
             setMainView("thread");
             navigation.selectThread(thread);
-            requestAnimationFrame(() => revealSelectedThreadInList());
+            // Reveal on the next frame, once the new selection has rendered.
+            // Do it even when the sidebar is only peeked open (⌘K over a hidden
+            // sidebar) — the popup is closing and taking the sidebar with it,
+            // but the scroll offset survives, so bringing the sidebar back later
+            // shows the thread we jumped to instead of stranding it off-screen.
+            // That reveal must be instant: an animated scroll wouldn't finish
+            // before the sidebar hides.
+            const instant = threadJump.isPeeking();
+            requestAnimationFrame(() => revealSelectedThreadInList({ instant }));
           }}
           onArchiveThread={navigation.archiveThread}
           onRenameThread={navigation.renameThread}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -19,6 +19,7 @@ import {
   type NavigationThreadSummary,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
+import { useThreadJump } from "./features/navigation/useThreadJump";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
 import type { HistoryNavControls } from "./features/chrome/HistoryNavButtons";
 import { useFindHotkeys } from "./features/chrome/useFindHotkeys";
@@ -219,9 +220,6 @@ function DesktopAppShell(props: {
   }>();
   // Bumped on every ⌘F so an already-open find bar takes focus back.
   const [findFocusNonce, setFindFocusNonce] = useState(0);
-  // Thread-list quick-jump popup (⌘K anywhere, or ⌘F while the sidebar is
-  // focused).
-  const [sidebarSearchOpen, setSidebarSearchOpen] = useState(false);
   // Initial section for SettingsScreen — non-undefined when navigation
   // came from a deep-link to a specific section. Resets when the user
   // switches mainView. The Messaging Activity surface is its own
@@ -437,12 +435,19 @@ function DesktopAppShell(props: {
   // writeConfig call is fire-and-forget; a failed write just means the
   // preference isn't remembered next launch.
   const writeConfig = settings.writeConfig;
+  // Thread-list quick search (⌘K anywhere, ⌘F while the sidebar is focused).
+  // Owns its own open state and the sidebar peek it needs to render.
+  const threadJump = useThreadJump({ sidebarHidden, setSidebarHidden });
+  const endSidebarPeek = threadJump.endPeek;
   const setSidebarHiddenPersisted = useCallback(
     (next: boolean) => {
+      // An explicit toggle (⌘B, the chips) is the operator stating a preference,
+      // so it ends any quick-search peek in flight.
+      endSidebarPeek();
       setSidebarHidden(next);
       void writeConfig({ ui: { sidebarHidden: next } });
     },
-    [writeConfig],
+    [endSidebarPeek, writeConfig],
   );
   const setContextRailPinnedPersisted = useCallback(
     (next: boolean) => {
@@ -581,15 +586,6 @@ function DesktopAppShell(props: {
     restore: restoreHistoryLocation,
   });
   useHistoryNavHotkeys({ onBack: history.goBack, onForward: history.goForward });
-  // Opening the thread-list quick search has to reveal the sidebar first — it
-  // lives inside it, and a hidden sidebar (⌘B) is `display: none`, so the popup
-  // would open into nothing.
-  const openThreadJump = useCallback(() => {
-    if (sidebarHidden) {
-      setSidebarHiddenPersisted(false);
-    }
-    setSidebarSearchOpen(true);
-  }, [sidebarHidden, setSidebarHiddenPersisted]);
   // ⌘⇧F / ⌃⇧F opens the global thread search screen; ⌘F is the focus-sensitive
   // context find; ⌘K always lands on the thread-list quick search.
   useFindHotkeys({
@@ -601,7 +597,7 @@ function DesktopAppShell(props: {
       // thread would otherwise open the in-thread find.
       const active = document.activeElement as HTMLElement | null;
       if (active?.closest(".sidebar")) {
-        openThreadJump();
+        threadJump.openJump();
         return;
       }
       if (mainView === "thread") {
@@ -612,7 +608,9 @@ function DesktopAppShell(props: {
         setFindFocusNonce((nonce) => nonce + 1);
       }
     },
-    onThreadJump: openThreadJump,
+    // ⌘K toggles, like ⌘⇧F toggles the search screen: pressing it again backs
+    // out of a jump you didn't mean to start, without reaching for Escape.
+    onThreadJump: threadJump.toggleJump,
   });
   // Manual find is per-thread chrome: drop it when the operator leaves the
   // thread view or switches threads. The deep-link find (findRequest) closes
@@ -1198,8 +1196,16 @@ function DesktopAppShell(props: {
             setMainView("thread");
             navigation.selectThread(thread);
           }}
-          threadJumpOpen={sidebarSearchOpen}
-          onThreadJumpOpenChange={setSidebarSearchOpen}
+          threadJumpOpen={threadJump.open}
+          onThreadJumpOpenChange={(open) => {
+            // Every close (Escape, outside click, picking a thread) goes through
+            // closeJump so a peeked-open sidebar goes back to hidden.
+            if (open) {
+              threadJump.openJump();
+              return;
+            }
+            threadJump.closeJump();
+          }}
           onJumpToThread={(thread) => {
             setMainView("thread");
             navigation.selectThread(thread);

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/useFindHotkeys.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/useFindHotkeys.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { useFindHotkeys } from "../useFindHotkeys";
+
+afterEach(() => {
+  cleanup();
+});
+
+function press(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { cancelable: true, ...init });
+  window.dispatchEvent(event);
+  return event;
+}
+
+function handlers(): {
+  onOpenSearch: Mock<() => void>;
+  onFind: Mock<() => void>;
+  onThreadJump: Mock<() => void>;
+} {
+  return {
+    onOpenSearch: vi.fn<() => void>(),
+    onFind: vi.fn<() => void>(),
+    onThreadJump: vi.fn<() => void>(),
+  };
+}
+
+describe("useFindHotkeys", () => {
+  it("routes ⌘F to the context find handler", () => {
+    const spies = handlers();
+    renderHook(() => useFindHotkeys(spies));
+
+    const event = press({ metaKey: true, code: "KeyF", key: "f" });
+
+    expect(spies.onFind).toHaveBeenCalledTimes(1);
+    expect(spies.onThreadJump).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("routes ⌘⇧F to the global search handler", () => {
+    const spies = handlers();
+    renderHook(() => useFindHotkeys(spies));
+
+    press({ metaKey: true, shiftKey: true, code: "KeyF", key: "F" });
+
+    expect(spies.onOpenSearch).toHaveBeenCalledTimes(1);
+    expect(spies.onFind).not.toHaveBeenCalled();
+  });
+
+  it("routes ⌘K to the thread-jump handler", () => {
+    const spies = handlers();
+    renderHook(() => useFindHotkeys(spies));
+
+    const event = press({ metaKey: true, code: "KeyK", key: "k" });
+
+    expect(spies.onThreadJump).toHaveBeenCalledTimes(1);
+    expect(spies.onFind).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("routes ⌘K to thread-jump even while the caret is in the composer", () => {
+    // ⌘F follows focus (the composer belongs to the thread, so ⌘F finds in the
+    // thread). ⌘K is the focus-independent escape hatch — it must reach the
+    // thread list from anywhere, which is the whole reason it exists.
+    const spies = handlers();
+    renderHook(() => useFindHotkeys(spies));
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
+    composer.focus();
+
+    composer.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        metaKey: true,
+        code: "KeyK",
+        key: "k",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+
+    expect(spies.onThreadJump).toHaveBeenCalledTimes(1);
+    composer.remove();
+  });
+
+  it("leaves ⌘F and ⌘K untouched when no handler is wired", () => {
+    const onOpenSearch = vi.fn();
+    renderHook(() => useFindHotkeys({ onOpenSearch }));
+
+    const find = press({ metaKey: true, code: "KeyF", key: "f" });
+    const jump = press({ metaKey: true, code: "KeyK", key: "k" });
+
+    expect(find.defaultPrevented).toBe(false);
+    expect(jump.defaultPrevented).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/chrome/useFindHotkeys.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/useFindHotkeys.ts
@@ -1,22 +1,25 @@
 import { useEffect, useRef } from "react";
-import { matchFindChord } from "../../lib/keyboard-accel";
+import { matchFindChord, matchThreadJumpChord } from "../../lib/keyboard-accel";
 
 /**
  * Single window-level owner for the find/search chords, mirroring
  * {@link useLayoutChordHotkeys}:
  *   ⌘F / ⌃F   → onFind        (context find; optional)
  *   ⌘⇧F / ⌃⇧F → onOpenSearch  (open the global thread search screen)
+ *   ⌘K / ⌃K   → onThreadJump  (thread-list quick search, from anywhere; optional)
  *
  * Call this exactly ONCE from the always-mounted shell owner. A ref keeps the
  * handlers fresh so the listener binds once and never goes stale even though
  * the callbacks close over fresh state each render.
  *
- * `onFind` is optional: when omitted, ⌘F is left untouched (no preventDefault)
- * so the key isn't swallowed on surfaces that don't handle in-context find.
+ * `onFind` and `onThreadJump` are optional: when omitted, their chord is left
+ * untouched (no preventDefault) so the key isn't swallowed on surfaces that
+ * don't handle it.
  */
 export function useFindHotkeys(handlers: {
   onOpenSearch: () => void;
   onFind?: () => void;
+  onThreadJump?: () => void;
 }): void {
   const handlersRef = useRef(handlers);
   useEffect(() => {
@@ -25,6 +28,15 @@ export function useFindHotkeys(handlers: {
 
   useEffect(() => {
     const handler = (event: KeyboardEvent): void => {
+      if (matchThreadJumpChord(event)) {
+        const onThreadJump = handlersRef.current.onThreadJump;
+        if (!onThreadJump) {
+          return;
+        }
+        event.preventDefault();
+        onThreadJump();
+        return;
+      }
       const chord = matchFindChord(event);
       if (chord === null) {
         return;

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
@@ -1,0 +1,94 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThreadJump } from "../useThreadJump";
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Drives the hook the way App does: it owns `sidebarHidden` and hands the hook
+ * a non-persisting setter, re-rendering with the new value.
+ */
+function renderThreadJump(initialSidebarHidden: boolean): {
+  hook: ReturnType<typeof renderHook<ReturnType<typeof useThreadJump>, unknown>>;
+  setSidebarHidden: ReturnType<typeof vi.fn>;
+  sidebarHidden: () => boolean;
+} {
+  let sidebarHidden = initialSidebarHidden;
+  const setSidebarHidden = vi.fn((next: boolean) => {
+    sidebarHidden = next;
+  });
+  const hook = renderHook(() =>
+    useThreadJump({ sidebarHidden, setSidebarHidden }),
+  );
+  return { hook, setSidebarHidden, sidebarHidden: () => sidebarHidden };
+}
+
+describe("useThreadJump", () => {
+  it("opens without touching a sidebar that's already showing", () => {
+    const { hook, setSidebarHidden } = renderThreadJump(false);
+
+    act(() => hook.result.current.openJump());
+
+    expect(hook.result.current.open).toBe(true);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+  });
+
+  it("peeks a hidden sidebar open, then puts it back when the search closes", () => {
+    // ⌘K over a hidden sidebar has to reveal it — the popup renders inside it.
+    // But hiding the sidebar is a deliberate choice, so the reveal is temporary.
+    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+
+    act(() => hook.result.current.openJump());
+    expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
+    expect(sidebarHidden()).toBe(false);
+
+    act(() => hook.result.current.closeJump());
+
+    expect(hook.result.current.open).toBe(false);
+    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
+    expect(sidebarHidden()).toBe(true);
+  });
+
+  it("leaves a visible sidebar alone when the search closes", () => {
+    const { hook, setSidebarHidden } = renderThreadJump(false);
+
+    act(() => hook.result.current.openJump());
+    act(() => hook.result.current.closeJump());
+
+    expect(hook.result.current.open).toBe(false);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit sidebar preference win over a peek in flight", () => {
+    // If anything persists a sidebar preference while a peek is open, that's the
+    // operator stating what they want and the peek must not revert it on close.
+    // No path in today's UI reaches this (clicking a toggle chip dismisses the
+    // popup first, and ⌘B is inert while the caret is in the popup's field) —
+    // this pins the contract so a future one can't silently undo a saved
+    // preference.
+    const { hook, setSidebarHidden } = renderThreadJump(true);
+    act(() => hook.result.current.openJump());
+    setSidebarHidden.mockClear();
+
+    act(() => hook.result.current.endPeek());
+    act(() => hook.result.current.closeJump());
+
+    expect(hook.result.current.open).toBe(false);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+  });
+
+  it("toggles closed on a second ⌘K, restoring the peek", () => {
+    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+
+    act(() => hook.result.current.toggleJump());
+    expect(hook.result.current.open).toBe(true);
+
+    act(() => hook.result.current.toggleJump());
+
+    expect(hook.result.current.open).toBe(false);
+    expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
+    expect(sidebarHidden()).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
@@ -1,8 +1,29 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useThreadJump } from "../useThreadJump";
 
+// The peek restore is deliberately deferred a frame (a jump's scroll-into-view
+// has to land while the sidebar still has layout), so drive frames by hand.
+let frames: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+  frames = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+    frames.push(callback),
+  );
+});
+
+function flushFrame(): void {
+  const queued = frames.splice(0);
+  act(() => {
+    for (const callback of queued) {
+      callback(0);
+    }
+  });
+}
+
 afterEach(() => {
+  vi.unstubAllGlobals();
   cleanup();
 });
 
@@ -43,12 +64,49 @@ describe("useThreadJump", () => {
     act(() => hook.result.current.openJump());
     expect(setSidebarHidden).toHaveBeenLastCalledWith(false);
     expect(sidebarHidden()).toBe(false);
+    expect(hook.result.current.isPeeking()).toBe(true);
 
     act(() => hook.result.current.closeJump());
+    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).toHaveBeenLastCalledWith(true);
     expect(sidebarHidden()).toBe(true);
+  });
+
+  it("holds the sidebar for a frame on close, so a jump's scroll can land first", () => {
+    // Picking a thread closes the popup AND schedules the scroll that centers
+    // the chosen row. `scrollIntoView` does nothing inside a `display: none`
+    // subtree, so re-hiding in the same commit would eat the scroll and strand
+    // the row off-screen the next time the sidebar came back.
+    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+    act(() => hook.result.current.openJump());
+    setSidebarHidden.mockClear();
+
+    act(() => hook.result.current.closeJump());
+
+    // Still laid out: this is the frame the reveal runs in.
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+    expect(sidebarHidden()).toBe(false);
+
+    flushFrame();
+
+    expect(setSidebarHidden).toHaveBeenCalledWith(true);
+  });
+
+  it("reports the peek to callers before the popup's close clears it", () => {
+    // App reads isPeeking() inside onJumpToThread to choose an instant scroll —
+    // and the popup calls onJumpToThread BEFORE onClose, so the peek must still
+    // be readable at that moment.
+    const { hook } = renderThreadJump(true);
+    act(() => hook.result.current.openJump());
+
+    expect(hook.result.current.isPeeking()).toBe(true);
+
+    act(() => hook.result.current.closeJump());
+    flushFrame();
+
+    expect(hook.result.current.isPeeking()).toBe(false);
   });
 
   it("leaves a visible sidebar alone when the search closes", () => {
@@ -56,6 +114,7 @@ describe("useThreadJump", () => {
 
     act(() => hook.result.current.openJump());
     act(() => hook.result.current.closeJump());
+    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).not.toHaveBeenCalled();
@@ -74,6 +133,7 @@ describe("useThreadJump", () => {
 
     act(() => hook.result.current.endPeek());
     act(() => hook.result.current.closeJump());
+    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).not.toHaveBeenCalled();
@@ -86,6 +146,7 @@ describe("useThreadJump", () => {
     expect(hook.result.current.open).toBe(true);
 
     act(() => hook.result.current.toggleJump());
+    flushFrame();
 
     expect(hook.result.current.open).toBe(false);
     expect(setSidebarHidden).toHaveBeenLastCalledWith(true);

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
@@ -1,0 +1,67 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Owns the thread-list quick search — the popup opened by ⌘K from anywhere, or
+ * by ⌘F while the sidebar holds focus.
+ *
+ * The popup renders inside the sidebar, and a hidden sidebar (⌘B) is
+ * `display: none`, so opening the search over a hidden sidebar has to reveal it
+ * first. That reveal is a PEEK, not a preference change: it never writes
+ * config.toml, and closing the search puts the sidebar back. Someone who
+ * deliberately hides their sidebar shouldn't have it silently — and permanently
+ * — reopened just because they reached for a thread.
+ */
+export function useThreadJump(options: {
+  sidebarHidden: boolean;
+  /** Show/hide the sidebar for the peek WITHOUT persisting the preference. */
+  setSidebarHidden: (hidden: boolean) => void;
+}): {
+  open: boolean;
+  openJump: () => void;
+  closeJump: () => void;
+  /** ⌘K again backs out of a jump you didn't mean to start. */
+  toggleJump: () => void;
+  /**
+   * Call from whatever persists the sidebar preference (⌘B, the toggle chips).
+   * An explicit preference outranks a peek: ending it here means the closing
+   * search can't revert what the operator just chose. Nothing in today's UI can
+   * actually toggle the sidebar while the popup is up — a click dismisses the
+   * popup first, and ⌘B is inert while the caret sits in its field — so this is
+   * a rail, not a live path.
+   */
+  endPeek: () => void;
+} {
+  const { sidebarHidden, setSidebarHidden } = options;
+  const [open, setOpen] = useState(false);
+  const peekedRef = useRef(false);
+
+  const openJump = useCallback(() => {
+    if (sidebarHidden) {
+      peekedRef.current = true;
+      setSidebarHidden(false);
+    }
+    setOpen(true);
+  }, [sidebarHidden, setSidebarHidden]);
+
+  const closeJump = useCallback(() => {
+    setOpen(false);
+    if (peekedRef.current) {
+      peekedRef.current = false;
+      setSidebarHidden(true);
+    }
+  }, [setSidebarHidden]);
+
+  const toggleJump = useCallback(() => {
+    if (open) {
+      closeJump();
+      return;
+    }
+    openJump();
+  }, [open, closeJump, openJump]);
+
+  const endPeek = useCallback(() => {
+    peekedRef.current = false;
+  }, []);
+
+  return { open, openJump, closeJump, toggleJump, endPeek };
+}

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
@@ -19,6 +19,13 @@ export function useThreadJump(options: {
   open: boolean;
   openJump: () => void;
   closeJump: () => void;
+  /**
+   * Whether the sidebar on screen right now is a peek — i.e. it's about to be
+   * hidden again when the search closes. Callers that scroll the thread list on
+   * the way out need this: the scroll has to be instant, not animated, to land
+   * before the sidebar goes away. Read it at event time, not during render.
+   */
+  isPeeking: () => boolean;
   /** ⌘K again backs out of a jump you didn't mean to start. */
   toggleJump: () => void;
   /**
@@ -45,10 +52,19 @@ export function useThreadJump(options: {
 
   const closeJump = useCallback(() => {
     setOpen(false);
-    if (peekedRef.current) {
-      peekedRef.current = false;
-      setSidebarHidden(true);
+    if (!peekedRef.current) {
+      return;
     }
+    peekedRef.current = false;
+    // Restore on the NEXT frame, not in this commit. Picking a thread closes the
+    // popup and schedules a scroll-the-selected-row-into-view for that same
+    // frame (App's onJumpToThread), and `scrollIntoView` inside a
+    // `display: none` subtree is a no-op — so re-hiding here would silently eat
+    // the scroll and the row would be off-screen when the sidebar came back.
+    // Chromium restores a scroll offset across `display: none`, so all we owe
+    // the reveal is a laid-out sidebar for the frame it runs in. Its rAF was
+    // queued first, so it runs before ours.
+    requestAnimationFrame(() => setSidebarHidden(true));
   }, [setSidebarHidden]);
 
   const toggleJump = useCallback(() => {
@@ -63,5 +79,7 @@ export function useThreadJump(options: {
     peekedRef.current = false;
   }, []);
 
-  return { open, openJump, closeJump, toggleJump, endPeek };
+  const isPeeking = useCallback(() => peekedRef.current, []);
+
+  return { open, openJump, closeJump, isPeeking, toggleJump, endPeek };
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -154,9 +154,15 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
 
   // Escape dismisses the bar from anywhere in the window, not just from the
   // field: the operator ⌘Fs, clicks into the transcript to read, then hits
-  // Escape expecting find to go away. Anything that already claimed the key
-  // (a dialog, the thread-jump popup, the field's own handler below) calls
-  // preventDefault, so we never dismiss two surfaces with one press.
+  // Escape expecting find to go away.
+  //
+  // The `defaultPrevented` guard yields to surfaces that claim the key — the
+  // field's own handler below, the thread-jump popup — but note that several
+  // others (the sidebar's context menus, ThreadView's branch-drift dialog)
+  // close on Escape WITHOUT calling preventDefault. One press will close both
+  // them and this bar. That's accepted: find is transient chrome, and dismissing
+  // it alongside a menu is not a surprise. Don't read this guard as a repo-wide
+  // convention — it isn't one.
   useEffect(() => {
     // `KeyboardEvent` is React's synthetic type in this file (see the import);
     // a window listener gets the DOM one.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadFindBar.tsx
@@ -42,6 +42,12 @@ type ThreadFindBarProps = {
    * miss if markdown reflowed the snippet across nodes).
    */
   turnId?: string;
+  /**
+   * Bumped by the ⌘F owner on every press. A second ⌘F with the bar already
+   * open pulls focus back into the field — the operator clicked into the
+   * transcript, then reached for find again and expects to type.
+   */
+  focusNonce?: number;
   /** Whether older transcript pages remain (drives the deep-link auto-load). */
   hasMoreHistory?: boolean;
   /** Whether an older-page load is in flight. */
@@ -125,11 +131,43 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
   const seededRef = useRef<string | undefined>(undefined);
   const autoLoadsRef = useRef(0);
   const landedSeedRef = useRef<string | undefined>(undefined);
+  // Armed only when the operator asks to be taken somewhere — typing a query,
+  // or stepping between matches. Consumed by the paint effect below, which is
+  // the sole owner of the manual scroll. Nothing else may move the transcript:
+  // matches are re-collected on every transcript change (new messages, older
+  // pages), and scrolling on that alone yanked the viewport back to a stale
+  // match while the operator was reading elsewhere.
+  const scrollIntentRef = useRef(false);
+  // The query the current `matches` were collected for, so the recompute below
+  // can tell "the operator retyped" from "the transcript moved under us".
+  const collectedQueryRef = useRef(query);
+  const onCloseRef = useRef(props.onClose);
+  useEffect(() => {
+    onCloseRef.current = props.onClose;
+  });
 
-  // Focus + select on mount and whenever the bar is (re)opened.
+  // Focus + select on mount, and again on each ⌘F while already open.
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
+  }, [props.focusNonce]);
+
+  // Escape dismisses the bar from anywhere in the window, not just from the
+  // field: the operator ⌘Fs, clicks into the transcript to read, then hits
+  // Escape expecting find to go away. Anything that already claimed the key
+  // (a dialog, the thread-jump popup, the field's own handler below) calls
+  // preventDefault, so we never dismiss two surfaces with one press.
+  useEffect(() => {
+    // `KeyboardEvent` is React's synthetic type in this file (see the import);
+    // a window listener gets the DOM one.
+    const closeOnEscape = (event: globalThis.KeyboardEvent): void => {
+      if (event.key !== "Escape" || event.defaultPrevented) {
+        return;
+      }
+      onCloseRef.current();
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
   }, []);
 
   // Adopt a search-seeded query (deep-link from a search result) once per
@@ -154,7 +192,19 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     }
     const ranges = collectMatchRanges(container, query);
     setMatches(ranges);
-    setActiveIndex((current) => (current < ranges.length ? current : 0));
+    if (collectedQueryRef.current !== query) {
+      // A different query is a different search: start at its first hit. This
+      // reset lives here rather than in the input handler so it lands in the
+      // same commit as the matches it applies to — moving the index on its own
+      // would run the scroll effect against the PREVIOUS query's ranges and
+      // strand the operator at the old first match.
+      collectedQueryRef.current = query;
+      setActiveIndex(0);
+    } else {
+      // Same query, transcript churned (new messages, older pages): hold the
+      // operator's place, only clamping if their match went away.
+      setActiveIndex((current) => (current < ranges.length ? current : 0));
+    }
     const anchorPresent = props.turnId
       ? container.querySelector(`[data-turn-id="${CSS.escape(props.turnId)}"]`) !==
         null
@@ -162,23 +212,34 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     setTargetFound(anchorPresent || ranges.length > 0);
   }, [query, props.refreshKey, props.containerRef, props.turnId]);
 
-  // Paint the highlights and scroll the active match into view.
+  // Paint the highlights, and scroll the active match into view only when the
+  // operator asked for it. This effect re-runs on every transcript change —
+  // `collectMatchRanges` hands back a fresh array each time — so an
+  // unconditional scroll here is what made a live thread keep dragging the
+  // viewport back to a match nobody was looking at any more. The intent flag is
+  // consumed on every run (armed or not), so it can never leak into a later
+  // transcript update.
   useEffect(() => {
     if (!highlightsSupported()) {
       return;
     }
+    const scrollRequested = scrollIntentRef.current;
+    scrollIntentRef.current = false;
     CSS.highlights.set(HIGHLIGHT_ALL, new Highlight(...matches));
     const active = matches[activeIndex];
-    if (active) {
-      CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(active));
-      const anchor =
-        active.startContainer instanceof Element
-          ? active.startContainer
-          : active.startContainer.parentElement;
-      anchor?.scrollIntoView({ block: "center", behavior: "smooth" });
-    } else {
+    if (!active) {
       CSS.highlights.delete(HIGHLIGHT_ACTIVE);
+      return;
     }
+    CSS.highlights.set(HIGHLIGHT_ACTIVE, new Highlight(active));
+    if (!scrollRequested) {
+      return;
+    }
+    const anchor =
+      active.startContainer instanceof Element
+        ? active.startContainer
+        : active.startContainer.parentElement;
+    anchor?.scrollIntoView({ block: "center", behavior: "smooth" });
   }, [matches, activeIndex]);
 
   // Drop highlights when the bar unmounts (closed).
@@ -283,8 +344,12 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     // restoration tugs back — so a one-shot scroll lands then drifts off as
     // later content prepends above. Re-center every frame for the window
     // instead; once content truly stops moving, re-centering an already-
-    // centered anchor is a no-op. Bail the instant the operator scrolls — a
-    // deep-link landing shouldn't fight someone who's taken over.
+    // centered anchor is a no-op. Bail the instant the operator takes over — a
+    // deep-link landing shouldn't fight someone who's already driving. Wheel
+    // alone missed the ways people actually take over mid-landing (dragging the
+    // scrollbar, clicking into the transcript), which left the loop re-centering
+    // under them for the rest of the window.
+    const TAKEOVER_EVENTS = ["wheel", "pointerdown", "touchstart"] as const;
     const deadline = HOLD_CENTERED_FRAMES;
     let frame = 0;
     let rafId = 0;
@@ -294,9 +359,13 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
     };
     const stop = (): void => {
       cancelAnimationFrame(rafId);
-      container?.removeEventListener("wheel", onUserScroll);
+      for (const name of TAKEOVER_EVENTS) {
+        container?.removeEventListener(name, onUserScroll);
+      }
     };
-    container?.addEventListener("wheel", onUserScroll, { passive: true });
+    for (const name of TAKEOVER_EVENTS) {
+      container?.addEventListener(name, onUserScroll, { passive: true });
+    }
     const tick = (): void => {
       if (takenOver || frame >= deadline) {
         stop();
@@ -318,15 +387,23 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
 
   const step = useCallback(
     (delta: number) => {
-      setActiveIndex((current) => {
-        if (matches.length === 0) {
-          return 0;
-        }
-        return (current + delta + matches.length) % matches.length;
-      });
+      if (matches.length === 0) {
+        return;
+      }
+      scrollIntentRef.current = true;
+      setActiveIndex(
+        (current) => (current + delta + matches.length) % matches.length,
+      );
     },
     [matches.length],
   );
+
+  // Typing is the operator asking to be taken to a match, so it arms the scroll.
+  // The active index is reset where the new matches land (see above).
+  const changeQuery = useCallback((next: string) => {
+    scrollIntentRef.current = true;
+    setQuery(next);
+  }, []);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === "Escape") {
@@ -363,7 +440,7 @@ export function ThreadFindBar(props: ThreadFindBarProps): ReactElement {
         aria-label="Find in thread"
         placeholder="Find in thread"
         value={query}
-        onChange={(event) => setQuery(event.target.value)}
+        onChange={(event) => changeQuery(event.target.value)}
         onKeyDown={handleKeyDown}
       />
       <span className="thread-find__count" aria-live="polite">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -822,6 +822,8 @@ export type ThreadViewProps = {
   findInitialQuery?: string;
   /** Turn id to load+scroll to when deep-linking a search match. */
   findTurnId?: string;
+  /** Bumped on each ⌘F so an already-open bar pulls focus back to its field. */
+  findFocusNonce?: number;
   onLoadOlder: () => Promise<void>;
   onArchiveThread?: (thread: NavigationThreadSummary) => Promise<void>;
   onRefreshNavigation?: () => Promise<void>;
@@ -2536,6 +2538,7 @@ export function ThreadView(props: ThreadViewProps) {
               refreshKey={`${selectedThread!.source}:${selectedThread!.id}:${props.transcriptEntries.length}`}
               initialQuery={props.findInitialQuery}
               turnId={props.findTurnId}
+              focusNonce={props.findFocusNonce}
               hasMoreHistory={Boolean(
                 props.transcriptPagination?.supportsPagination &&
                   props.transcriptPagination.hasPreviousPage,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-find-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-find-bar.test.tsx
@@ -1,0 +1,219 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef, type ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadFindBar } from "../ThreadFindBar";
+
+// jsdom ships neither the CSS Custom Highlight API (which the find bar uses to
+// paint matches without touching the React-rendered transcript) nor
+// `scrollIntoView`. Stub both: without the highlight API the bar short-circuits
+// and never matches anything, and `scrollIntoView` is the whole subject here.
+type HighlightGlobals = {
+  Highlight: unknown;
+  CSS: { highlights: Map<string, unknown>; escape: (value: string) => string };
+};
+
+const scrollIntoView = vi.fn();
+
+beforeEach(() => {
+  const globals = globalThis as unknown as HighlightGlobals;
+  globals.Highlight = class {
+    ranges: Range[];
+    constructor(...ranges: Range[]) {
+      this.ranges = ranges;
+    }
+  };
+  globals.CSS = {
+    highlights: new Map<string, unknown>(),
+    escape: (value: string) => value,
+  };
+  Element.prototype.scrollIntoView = scrollIntoView;
+  scrollIntoView.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * Renders the bar over a transcript-like container, the way ThreadView does.
+ * `entries` stands in for transcript items; `refreshKey` is what ThreadView
+ * bumps when the entry count changes (i.e. when messages stream in).
+ */
+function Harness(props: {
+  entries: readonly string[];
+  refreshKey?: unknown;
+  onClose?: () => void;
+}): ReactElement {
+  const containerRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <ThreadFindBar
+        containerRef={containerRef}
+        refreshKey={props.refreshKey ?? props.entries.length}
+        onClose={props.onClose ?? (() => {})}
+      />
+      <div ref={containerRef}>
+        {props.entries.map((entry, index) => (
+          <p key={index}>{entry}</p>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function renderBar(entries: readonly string[], onClose?: () => void): {
+  rerenderWith: (next: readonly string[]) => void;
+} {
+  const view = render(<Harness entries={entries} onClose={onClose} />);
+  return {
+    rerenderWith: (next: readonly string[]) => {
+      view.rerender(<Harness entries={next} onClose={onClose} />);
+    },
+  };
+}
+
+function typeQuery(query: string): void {
+  fireEvent.change(findInput(), { target: { value: query } });
+}
+
+function findInput(): HTMLElement {
+  // The bar's wrapper carries the same aria-label, so scope to the textbox.
+  return screen.getByRole("textbox", { name: "Find in thread" });
+}
+
+describe("ThreadFindBar scrolling", () => {
+  it("scrolls to the first match when the operator types a query", () => {
+    renderBar(["alpha needle", "beta", "gamma needle"]);
+    typeQuery("needle");
+
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrolls when the operator steps to the next match", () => {
+    renderBar(["alpha needle", "beta", "gamma needle"]);
+    typeQuery("needle");
+    scrollIntoView.mockClear();
+
+    fireEvent.click(screen.getByLabelText("Next match"));
+
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("scrolls when the operator presses Enter to cycle matches", () => {
+    renderBar(["alpha needle", "beta", "gamma needle"]);
+    typeQuery("needle");
+    scrollIntoView.mockClear();
+
+    fireEvent.keyDown(findInput(), { key: "Enter" });
+
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT scroll when new messages arrive and the operator isn't navigating", () => {
+    // The reported bug: with the bar open and a stale query, every streamed
+    // message re-collects matches and yanked the viewport back to the active
+    // one — even though the operator had scrolled away and wasn't finding.
+    const bar = renderBar(["alpha needle", "beta"]);
+    typeQuery("needle");
+    scrollIntoView.mockClear();
+
+    bar.rerenderWith(["alpha needle", "beta", "gamma streamed in"]);
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does NOT scroll when a streamed message adds a new match", () => {
+    const bar = renderBar(["alpha needle", "beta"]);
+    typeQuery("needle");
+    scrollIntoView.mockClear();
+
+    bar.rerenderWith(["alpha needle", "beta", "gamma needle"]);
+
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("does NOT scroll when the transcript changes under a match count that shrinks", () => {
+    const bar = renderBar(["alpha needle", "beta needle"]);
+    typeQuery("needle");
+    fireEvent.click(screen.getByLabelText("Next match"));
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+    scrollIntoView.mockClear();
+
+    // The active match disappears (a turn collapsed / an item re-rendered).
+    bar.rerenderWith(["alpha needle"]);
+
+    expect(screen.getByText("1 of 1")).toBeInTheDocument();
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("restarts at the first match when the operator retypes the query", () => {
+    renderBar(["alpha needle", "beta needle"]);
+    typeQuery("needle");
+    fireEvent.click(screen.getByLabelText("Next match"));
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+
+    typeQuery("needl");
+
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+  });
+
+  it("scrolls to the new query's match, not the old query's", () => {
+    // Retyping resets the active index, and the index changing is itself enough
+    // to re-run the scroll — so the scroll must wait for the matches collected
+    // for the NEW query, or it lands on wherever the old query's first hit was.
+    renderBar(["alpha", "beta alpha", "gamma"]);
+    typeQuery("alpha");
+    fireEvent.click(screen.getByLabelText("Next match"));
+    scrollIntoView.mockClear();
+
+    typeQuery("gamma");
+
+    expect(screen.getByText("1 of 1")).toBeInTheDocument();
+    const scrolled = scrollIntoView.mock.instances.at(-1) as Element | undefined;
+    expect(scrolled?.textContent).toBe("gamma");
+  });
+});
+
+describe("ThreadFindBar dismissal", () => {
+  it("closes on Escape while the find input is focused", () => {
+    const onClose = vi.fn();
+    renderBar(["alpha needle"], onClose);
+
+    fireEvent.keyDown(findInput(), { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape after focus has moved back into the transcript", () => {
+    // The operator ⌘F's, clicks into the transcript to read, then hits Escape
+    // expecting the bar to go away. It didn't: the only Escape handler lived on
+    // the input.
+    const onClose = vi.fn();
+    renderBar(["alpha needle"], onClose);
+    typeQuery("needle");
+    (findInput() as HTMLInputElement).blur();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves Escape alone when another surface already handled it", () => {
+    const onClose = vi.fn();
+    renderBar(["alpha needle"], onClose);
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      cancelable: true,
+    });
+    event.preventDefault();
+    window.dispatchEvent(event);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-find-bar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-find-bar.test.tsx
@@ -174,7 +174,10 @@ describe("ThreadFindBar scrolling", () => {
     typeQuery("gamma");
 
     expect(screen.getByText("1 of 1")).toBeInTheDocument();
-    const scrolled = scrollIntoView.mock.instances.at(-1) as Element | undefined;
+    // `contexts` is the `this` of each call — i.e. the element scrolled. (Not
+    // `instances`, which is documented as the `new`-constructed instances and
+    // only happens to carry `this` today.)
+    const scrolled = scrollIntoView.mock.contexts.at(-1) as Element | undefined;
     expect(scrolled?.textContent).toBe("gamma");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   formatPrimaryAccel,
   isAccelLetter,
+  matchFindChord,
   matchHistoryNavChord,
   matchLayoutChord,
+  matchThreadJumpChord,
 } from "../keyboard-accel";
 
 type PwrWindow = Window & { pwragent?: { platform?: string } };
@@ -122,6 +124,93 @@ describe("matchLayoutChord", () => {
       value: document.createElement("input"),
     });
     expect(matchLayoutChord(event)).toBe(null);
+  });
+});
+
+describe("matchFindChord", () => {
+  const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+    new KeyboardEvent("keydown", init);
+  const inEditable = (event: KeyboardEvent): KeyboardEvent => {
+    Object.defineProperty(event, "target", {
+      value: document.createElement("input"),
+    });
+    return event;
+  };
+
+  it("classifies ⌘F / ⌃F as the context find chord", () => {
+    expect(matchFindChord(keydown({ metaKey: true, code: "KeyF", key: "f" }))).toBe(
+      "find",
+    );
+    expect(matchFindChord(keydown({ ctrlKey: true, code: "KeyF", key: "f" }))).toBe(
+      "find",
+    );
+  });
+
+  it("classifies ⌘⇧F as the global search chord", () => {
+    expect(
+      matchFindChord(
+        keydown({ metaKey: true, shiftKey: true, code: "KeyF", key: "F" }),
+      ),
+    ).toBe("search");
+  });
+
+  it("stays live inside editable fields (⌘F never types anything)", () => {
+    expect(
+      matchFindChord(inEditable(keydown({ metaKey: true, code: "KeyF", key: "f" }))),
+    ).toBe("find");
+  });
+
+  it("returns null without the primary modifier, with Option, or for other keys", () => {
+    expect(matchFindChord(keydown({ code: "KeyF", key: "f" }))).toBe(null);
+    expect(
+      matchFindChord(
+        keydown({ metaKey: true, altKey: true, code: "KeyF", key: "ƒ" }),
+      ),
+    ).toBe(null);
+    expect(
+      matchFindChord(keydown({ metaKey: true, code: "KeyK", key: "k" })),
+    ).toBe(null);
+  });
+});
+
+describe("matchThreadJumpChord", () => {
+  const keydown = (init: KeyboardEventInit): KeyboardEvent =>
+    new KeyboardEvent("keydown", init);
+
+  it("classifies ⌘K / ⌃K as the thread-jump chord", () => {
+    expect(
+      matchThreadJumpChord(keydown({ metaKey: true, code: "KeyK", key: "k" })),
+    ).toBe(true);
+    expect(
+      matchThreadJumpChord(keydown({ ctrlKey: true, code: "KeyK", key: "k" })),
+    ).toBe(true);
+  });
+
+  it("stays live inside editable fields, so it works from the composer", () => {
+    // The whole point of ⌘K: it opens the thread-list search no matter where
+    // focus sits, unlike ⌘F which follows focus into the open thread.
+    const event = keydown({ metaKey: true, code: "KeyK", key: "k" });
+    Object.defineProperty(event, "target", {
+      value: document.createElement("textarea"),
+    });
+    expect(matchThreadJumpChord(event)).toBe(true);
+  });
+
+  it("returns null without the primary modifier or with extra modifiers", () => {
+    expect(matchThreadJumpChord(keydown({ code: "KeyK", key: "k" }))).toBe(false);
+    expect(
+      matchThreadJumpChord(
+        keydown({ metaKey: true, altKey: true, code: "KeyK", key: "˚" }),
+      ),
+    ).toBe(false);
+    expect(
+      matchThreadJumpChord(
+        keydown({ metaKey: true, shiftKey: true, code: "KeyK", key: "K" }),
+      ),
+    ).toBe(false);
+    expect(
+      matchThreadJumpChord(keydown({ metaKey: true, code: "KeyF", key: "f" })),
+    ).toBe(false);
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts
@@ -177,7 +177,34 @@ describe("matchThreadJumpChord", () => {
   const keydown = (init: KeyboardEventInit): KeyboardEvent =>
     new KeyboardEvent("keydown", init);
 
-  it("classifies ⌘K / ⌃K as the thread-jump chord", () => {
+  it("takes ⌘K on macOS and leaves ⌃K to the platform", () => {
+    // ⌃K is delete-to-end-of-line in a macOS text field. This chord stays live
+    // inside fields and calls preventDefault, so claiming the Ctrl form would
+    // swallow that editing key in the composer — hence the platform gate.
+    setPlatform("darwin");
+    expect(
+      matchThreadJumpChord(keydown({ metaKey: true, code: "KeyK", key: "k" })),
+    ).toBe(true);
+    expect(
+      matchThreadJumpChord(keydown({ ctrlKey: true, code: "KeyK", key: "k" })),
+    ).toBe(false);
+  });
+
+  it("takes Ctrl+K on Windows/Linux and ignores the Meta form", () => {
+    // Ctrl+K binds nothing native there; Meta is the Windows/Super key.
+    for (const platform of ["win32", "linux"]) {
+      setPlatform(platform);
+      expect(
+        matchThreadJumpChord(keydown({ ctrlKey: true, code: "KeyK", key: "k" })),
+      ).toBe(true);
+      expect(
+        matchThreadJumpChord(keydown({ metaKey: true, code: "KeyK", key: "k" })),
+      ).toBe(false);
+    }
+  });
+
+  it("accepts either modifier when the platform is unknown, so the chord never goes dead", () => {
+    setPlatform(undefined);
     expect(
       matchThreadJumpChord(keydown({ metaKey: true, code: "KeyK", key: "k" })),
     ).toBe(true);

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -13,6 +13,29 @@ export function isPrimaryAccel(event: KeyboardEvent): boolean {
   return event.metaKey !== event.ctrlKey;
 }
 
+/**
+ * Stricter sibling of {@link isPrimaryAccel}, for chords that would otherwise
+ * shadow a platform text-editing binding: ⌘ on macOS, Ctrl on Windows/Linux —
+ * never "either one." {@link isPrimaryAccel}'s Cmd-or-Ctrl leniency is fine for
+ * a chord like ⌘F, but a chord that stays live inside text fields AND calls
+ * preventDefault will SWALLOW whatever the platform bound the Ctrl form to. On
+ * macOS, Chromium implements the emacs-style editing bindings in inputs and
+ * contenteditables, so ⌃K is delete-to-end-of-line — losing that in the composer
+ * is a real regression, unlike losing a caret-movement binding.
+ *
+ * Falls back to the lenient check when the platform is unknown (the desktop
+ * bridge is unavailable, e.g. in unit tests), so a chord never goes dead.
+ */
+export function isPlatformPrimaryAccel(event: KeyboardEvent): boolean {
+  const platform = getDesktopApi()?.platform;
+  if (platform === undefined) {
+    return isPrimaryAccel(event);
+  }
+  return platform === "darwin"
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+}
+
 export function isEditableTarget(event: KeyboardEvent): boolean {
   const target = event.target as HTMLElement | null;
   if (target === null) {
@@ -158,10 +181,16 @@ export function matchFindChord(event: KeyboardEvent): "find" | "search" | null {
  * Like {@link matchFindChord} it stays live in editable fields — the composer is
  * exactly where an operator is standing when they want to jump elsewhere. Shift
  * and Option are excluded so it can't collide with a future chord.
+ *
+ * Unlike every other chord here it uses {@link isPlatformPrimaryAccel}, NOT the
+ * lenient Cmd-or-Ctrl check: staying live in text fields means the Ctrl form
+ * would swallow macOS's ⌃K (delete-to-end-of-line) in the composer. So ⌘K on
+ * macOS, Ctrl+K on Windows/Linux (where Ctrl+K binds nothing native), and the
+ * composer keeps its editing keys on both.
  */
 export function matchThreadJumpChord(event: KeyboardEvent): boolean {
   return (
-    isPrimaryAccel(event) &&
+    isPlatformPrimaryAccel(event) &&
     !event.altKey &&
     !event.shiftKey &&
     isAccelLetter(event, "k")

--- a/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
+++ b/apps/desktop/src/renderer/src/lib/keyboard-accel.ts
@@ -124,6 +124,9 @@ export function matchHistoryNavChord(
  *                          focused; the caller resolves which from focus)
  *   ⌘⇧F / ⌃⇧F → "search" (open the global thread search screen)
  *
+ * ⌘F is deliberately focus-sensitive; {@link matchThreadJumpChord} (⌘K) is the
+ * unambiguous way to reach the thread list from anywhere.
+ *
  * Unlike {@link matchLayoutChord}, find stays live inside editable fields —
  * ⌘F is a universal "find" gesture that should fire even while the caret is in
  * the composer or another input. ⌥ is excluded so it never collides with an
@@ -140,6 +143,29 @@ export function matchFindChord(event: KeyboardEvent): "find" | "search" | null {
     return null;
   }
   return event.shiftKey ? "search" : "find";
+}
+
+/**
+ * Whether `event` is the thread-jump chord: ⌘K / ⌃K.
+ *
+ * ⌘K is the focus-independent way into the thread-list quick search — the
+ * near-universal "jump to a thing in the list" binding (Slack's quick switcher,
+ * Linear, GitHub, VS Code's ⌘P sibling). It exists because ⌘F follows focus:
+ * the operator reaching for the thread list from inside a thread would land in
+ * the in-thread find instead, since the composer and transcript belong to the
+ * thread. ⌘K always means the list.
+ *
+ * Like {@link matchFindChord} it stays live in editable fields — the composer is
+ * exactly where an operator is standing when they want to jump elsewhere. Shift
+ * and Option are excluded so it can't collide with a future chord.
+ */
+export function matchThreadJumpChord(event: KeyboardEvent): boolean {
+  return (
+    isPrimaryAccel(event) &&
+    !event.altKey &&
+    !event.shiftKey &&
+    isAccelLetter(event, "k")
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- **⌘K / Ctrl+K always opens the thread-list quick search.** ⌘F is focus-sensitive by design — sidebar focused → thread list, anywhere else → in-thread find — so reaching for the thread list from inside a thread opens the in-thread find instead. ⌘K is the unambiguous escape hatch, and it's the near-universal binding for this (Slack quick switcher, Linear, GitHub, Notion). It was free: no renderer binding, no Electron menu accelerator, and Tiptap's StarterKit doesn't claim it. It stays live in editable fields — the composer is exactly where you're standing when you want to jump elsewhere — and reveals the sidebar first if it's hidden (⌘B), since the popup lives inside it and a hidden sidebar is `display: none`. **⌘F semantics are unchanged.**
- **A second ⌘F with the bar already open re-focuses and selects the field**, the way a browser's find does. Before, it did nothing, so after clicking into the transcript you'd type into the void.
- **The find bar no longer drags the viewport around when nobody is finding.** Root cause: matches are re-collected on every transcript change, and `collectMatchRanges` returns a fresh `Range[]` every time, so the "scroll the active match into view" effect re-fired on *every streamed message* — yanking the operator back to a stale match while they were reading elsewhere. Scrolling is now gated on an explicit navigation intent (typing a query, or stepping with Enter / the chevrons); transcript churn only repaints highlights and clamps the active index if the active match went away.
- **Escape dismisses the bar from anywhere in the window**, not just from inside the field (it defers to `defaultPrevented`, so a dialog or the jump popup that already claimed the key still wins).
- **The deep-link landing loop bails on `pointerdown` / `touchstart`, not just `wheel`** — dragging the scrollbar or clicking into the transcript used to leave it re-centering underneath you for the rest of its ~2.5s window.

## Verification

- Tests written **failing first**; 5 of them reproduced the reported bugs. New: `thread-find-bar.test.tsx` (scroll gating + dismissal), `useFindHotkeys.test.tsx` (chord routing). Extended: `keyboard-accel.test.ts` gains `matchFindChord` (previously uncovered) and `matchThreadJumpChord`.
- One test earned its keep by catching a bug in the first version of the fix: retyping a query scrolled to the **old** query's first match, because resetting the active index re-ran the scroll before the new matches landed. The reset now happens in the same commit as the matches it applies to.
- Full renderer suite green (1428 tests), `pnpm typecheck` clean, `pnpm lint:eslint` 0 errors (the two `exhaustive-deps` warnings on `ThreadFindBar` are the pre-existing, documented intentional-exclusion effects).
- Driven in a real dev build: ⌘K from inside the composer opened the jump popup and filtered; ⌘F from the transcript opened in-thread find; a second ⌘F re-focused and selected the field.

## Notes

- The Escape-from-anywhere change is the one thing **not** verified by driving the app: synthetic Escape from the automation layer never reaches Electron on macOS — the *untouched, pre-existing* Escape handler on the sidebar jump popup ignores it too. That path is covered in jsdom (`keydown` dispatched on `window`). Worth a manual Escape check when reviewing.
- No discoverability surface was touched: the app has no keyboard-shortcut reference screen today, so there's nowhere ⌘K needs to be listed. Could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)