### PR TITLE
feat(desktop): structured usage card for the context-window moon tooltip

### DIFF
--- a/apps/desktop/e2e/turn-lifecycle.spec.ts
+++ b/apps/desktop/e2e/turn-lifecycle.spec.ts
@@ -443,11 +443,21 @@ test("renders the context window moon from token usage notifications", async () 
     await app.advance({ stepId: "turn-started-1" });
     await app.advance({ stepId: "token-usage-1" });
 
-    await expect(
-      app.window.getByRole("img", {
-        name: /Context window 0% full, 1\.2k\/258\.4k tokens, new/,
-      })
-    ).toBeVisible();
+    const moon = app.window.getByRole("img", {
+      name: /Context window 0% full, 1\.2k\/258\.4k tokens, new/,
+    });
+    await expect(moon).toBeVisible();
+
+    await moon.hover();
+    const card = app.window.getByRole("tooltip");
+    await expect(card).toBeVisible();
+    await expect(card).toContainText("Context window");
+    await expect(card).toContainText("0% full");
+    await expect(card).toContainText("257.2k left");
+    await expect(card).toContainText("1.2k of 258.4k tokens");
+    await expect(card).toContainText("Current request");
+    await expect(card).toContainText("Input");
+    await expect(card).toContainText("1.2k");
   } finally {
     await app.close();
   }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -8799,9 +8799,33 @@ function ContextWindowMoon({
 }: {
   contextWindow?: ThreadContextWindowState;
 }) {
-  const { show, hide, tooltipNode } = useViewportTooltip({
+  const { show, update, hide, visible, tooltipNode } = useViewportTooltip({
     className: "context-usage-card",
   });
+
+  // Token-usage notifications keep streaming while a turn runs; push the
+  // fresh numbers into an already-open card instead of freezing it at
+  // hover-time values. If the context state disappears (thread switch),
+  // drop the card so it can't reappear at stale coordinates.
+  useEffect(() => {
+    if (!contextWindow) {
+      hide();
+      return;
+    }
+    if (!visible) {
+      return;
+    }
+    const phase = Math.min(
+      CONTEXT_MOON_PHASES.length - 1,
+      Math.max(0, contextWindow.phase),
+    );
+    update(
+      <ContextWindowUsageCard
+        contextWindow={contextWindow}
+        phaseLabel={CONTEXT_MOON_PHASES[phase]}
+      />,
+    );
+  }, [contextWindow, hide, update, visible]);
 
   if (!contextWindow) {
     return null;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -76,6 +76,7 @@ import {
 import { expandTildePath } from "../../lib/tildify-path";
 import { normalizeImageFile } from "../../lib/image-normalization";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
   findSkillTrigger,
   hydrateSkillLabelsWithMarkdown,
@@ -8798,6 +8799,10 @@ function ContextWindowMoon({
 }: {
   contextWindow?: ThreadContextWindowState;
 }) {
+  const { show, hide, tooltipNode } = useViewportTooltip({
+    className: "context-usage-card",
+  });
+
   if (!contextWindow) {
     return null;
   }
@@ -8809,15 +8814,20 @@ function ContextWindowMoon({
     contextWindow.totalTokens
   )}/${formatCompactNumber(contextWindow.modelContextWindow)}`;
   const label = `Context window ${percentLabel} full, ${tokenLabel} tokens, ${phaseLabel}`;
-  const tooltip = buildContextWindowTooltip(contextWindow, phaseLabel);
+  const card = (
+    <ContextWindowUsageCard contextWindow={contextWindow} phaseLabel={phaseLabel} />
+  );
 
   return (
     <div
       aria-label={label}
-      className="context-window-moon tooltip-target"
-      data-tooltip={tooltip}
+      className="context-window-moon"
       role="img"
       tabIndex={0}
+      onBlur={hide}
+      onFocus={(event) => show(event.currentTarget, card)}
+      onMouseEnter={(event) => show(event.currentTarget, card)}
+      onMouseLeave={hide}
     >
       <span
         aria-hidden="true"
@@ -8826,117 +8836,151 @@ function ContextWindowMoon({
         <span className="context-window-moon__disc" />
       </span>
       <span className="context-window-moon__label">{percentLabel}</span>
+      {tooltipNode}
     </div>
   );
 }
 
-function buildContextWindowTooltip(
-  contextWindow: ThreadContextWindowState,
-  phaseLabel: string
-): string {
-  const lines = [
-    `Context window: ${Math.round(contextWindow.usedPercent)}% full (${phaseLabel})`,
-    `Current snapshot: ${formatCompactNumber(contextWindow.totalTokens)} / ${formatCompactNumber(
-      contextWindow.modelContextWindow
-    )} tokens`,
-  ];
+function ContextWindowUsageCard({
+  contextWindow,
+  phaseLabel,
+}: {
+  contextWindow: ThreadContextWindowState;
+  phaseLabel: string;
+}) {
+  const usedPercent = Math.max(0, Math.min(100, contextWindow.usedPercent));
+  const critical = contextWindow.phase >= CONTEXT_MOON_PHASES.length - 1;
+  const hasBreakdown =
+    typeof contextWindow.inputTokens === "number"
+    || typeof contextWindow.cachedInputTokens === "number"
+    || typeof contextWindow.outputTokens === "number"
+    || typeof contextWindow.reasoningOutputTokens === "number";
 
-  if (typeof contextWindow.remainingTokens === "number") {
-    const remainingPercent =
-      typeof contextWindow.remainingPercent === "number"
-        ? `, ${Math.round(contextWindow.remainingPercent)}% remaining`
-        : "";
-    lines.push(
-      `Remaining: ${formatCompactNumber(contextWindow.remainingTokens)} tokens${remainingPercent}`
-    );
-  }
-
-  const breakdown = [
-    formatOptionalTokenDetail("input", contextWindow.inputTokens),
-    formatCachedTokenDetail(contextWindow.cachedInputTokens, contextWindow.inputTokens),
-    formatOptionalTokenDetail("output", contextWindow.outputTokens),
-    formatOptionalTokenDetail("reasoning", contextWindow.reasoningOutputTokens),
-  ].filter((detail): detail is string => Boolean(detail));
-
-  if (breakdown.length > 0) {
-    lines.push(`Current breakdown: ${breakdown.join(", ")}`);
-  }
-
-  if (typeof contextWindow.cumulativeTotalTokens === "number") {
-    lines.push(
-      `Cumulative usage reported: ${formatCompactNumber(
-        contextWindow.cumulativeTotalTokens
-      )} tokens`
-    );
-    const cumulativeCachedInput = formatCachedInputSummary(
-      contextWindow.cumulativeCachedInputTokens,
-      contextWindow.cumulativeInputTokens
-    );
-    if (cumulativeCachedInput) {
-      lines.push(`Cumulative cached input: ${cumulativeCachedInput}`);
-    }
-    const cumulativeOutput = formatCumulativeOutputSummary(
-      contextWindow.cumulativeOutputTokens,
-      contextWindow.cumulativeReasoningOutputTokens
-    );
-    if (cumulativeOutput) {
-      lines.push(`Cumulative output: ${cumulativeOutput}`);
-    }
-  }
-
-  return lines.join("\n");
+  return (
+    <>
+      <div className="context-usage-card__header">
+        <span className="context-usage-card__eyebrow">Context window</span>
+        <span className="context-usage-card__phase">{phaseLabel}</span>
+      </div>
+      <div className="context-usage-card__headline">
+        <span className="context-usage-card__percent">
+          {Math.round(usedPercent)}% full
+        </span>
+        {typeof contextWindow.remainingTokens === "number" ? (
+          <span className="context-usage-card__remaining">
+            {formatCompactNumber(contextWindow.remainingTokens)} left
+          </span>
+        ) : null}
+      </div>
+      <div aria-hidden="true" className="context-usage-card__meter">
+        <span
+          className={
+            critical
+              ? "context-usage-card__meter-fill context-usage-card__meter-fill--critical"
+              : "context-usage-card__meter-fill"
+          }
+          style={{ width: `${usedPercent}%` }}
+        />
+      </div>
+      <div className="context-usage-card__caption">
+        {`${formatCompactNumber(contextWindow.totalTokens)} of ${formatCompactNumber(
+          contextWindow.modelContextWindow
+        )} tokens`}
+      </div>
+      {hasBreakdown ? (
+        <div className="context-usage-card__section">
+          <span className="context-usage-card__section-title">Current request</span>
+          {typeof contextWindow.inputTokens === "number" ? (
+            <ContextUsageRow
+              label="Input"
+              value={formatCompactNumber(contextWindow.inputTokens)}
+            />
+          ) : null}
+          {typeof contextWindow.cachedInputTokens === "number" ? (
+            <ContextUsageCacheMeter
+              cachedTokens={contextWindow.cachedInputTokens}
+              inputTokens={contextWindow.inputTokens}
+            />
+          ) : null}
+          {typeof contextWindow.outputTokens === "number" ? (
+            <ContextUsageRow
+              label="Output"
+              value={formatCompactNumber(contextWindow.outputTokens)}
+            />
+          ) : null}
+          {typeof contextWindow.reasoningOutputTokens === "number" ? (
+            <ContextUsageRow
+              label="Reasoning"
+              value={formatCompactNumber(contextWindow.reasoningOutputTokens)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      {typeof contextWindow.cumulativeTotalTokens === "number" ? (
+        <div className="context-usage-card__section">
+          <span className="context-usage-card__section-title">Session total</span>
+          <ContextUsageRow
+            label="Tokens"
+            value={formatCompactNumber(contextWindow.cumulativeTotalTokens)}
+          />
+          {typeof contextWindow.cumulativeCachedInputTokens === "number" ? (
+            <ContextUsageCacheMeter
+              cachedTokens={contextWindow.cumulativeCachedInputTokens}
+              inputTokens={contextWindow.cumulativeInputTokens}
+            />
+          ) : null}
+          {typeof contextWindow.cumulativeOutputTokens === "number" ? (
+            <ContextUsageRow
+              label="Output"
+              value={formatCompactNumber(contextWindow.cumulativeOutputTokens)}
+            />
+          ) : null}
+          {typeof contextWindow.cumulativeReasoningOutputTokens === "number" ? (
+            <ContextUsageRow
+              label="Reasoning"
+              value={formatCompactNumber(contextWindow.cumulativeReasoningOutputTokens)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
 }
 
-function formatOptionalTokenDetail(label: string, value: number | undefined): string | undefined {
-  return typeof value === "number" ? `${formatCompactNumber(value)} ${label}` : undefined;
+function ContextUsageRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="context-usage-card__row">
+      <span className="context-usage-card__row-label">{label}</span>
+      <span className="context-usage-card__row-value">{value}</span>
+    </div>
+  );
 }
 
-function formatCachedTokenDetail(
-  cachedInputTokens: number | undefined,
-  inputTokens: number | undefined
-): string | undefined {
-  if (typeof cachedInputTokens !== "number") {
-    return undefined;
-  }
-
-  const percent = formatCachedInputPercent(cachedInputTokens, inputTokens);
-  return `${formatCompactNumber(cachedInputTokens)} cached${percent ? ` (${percent})` : ""}`;
-}
-
-function formatCumulativeOutputSummary(
-  outputTokens: number | undefined,
-  reasoningOutputTokens: number | undefined
-): string | undefined {
-  const details = [
-    formatOptionalTokenDetail("output", outputTokens),
-    formatOptionalTokenDetail("reasoning", reasoningOutputTokens),
-  ].filter((detail): detail is string => Boolean(detail));
-
-  return details.length > 0 ? details.join(", ") : undefined;
-}
-
-function formatCachedInputSummary(
-  cachedInputTokens: number | undefined,
-  inputTokens: number | undefined
-): string | undefined {
-  if (typeof cachedInputTokens !== "number") {
-    return undefined;
-  }
-
-  const percent = formatCachedInputPercent(cachedInputTokens, inputTokens);
-  return `${formatCompactNumber(cachedInputTokens)}${percent ? ` (${percent})` : ""}`;
-}
-
-function formatCachedInputPercent(
-  cachedInputTokens: number,
-  inputTokens: number | undefined
-): string | undefined {
+function ContextUsageCacheMeter({
+  cachedTokens,
+  inputTokens,
+}: {
+  cachedTokens: number;
+  inputTokens: number | undefined;
+}) {
   if (typeof inputTokens !== "number" || inputTokens <= 0) {
-    return undefined;
+    return <ContextUsageRow label="Cached" value={formatCompactNumber(cachedTokens)} />;
   }
 
-  const percent = Math.max(0, Math.min(100, (cachedInputTokens / inputTokens) * 100));
-  return formatPercent(percent);
+  const percent = Math.max(0, Math.min(100, (cachedTokens / inputTokens) * 100));
+  return (
+    <div className="context-usage-card__cache">
+      <span aria-hidden="true" className="context-usage-card__cache-meter">
+        <span
+          className="context-usage-card__cache-fill"
+          style={{ width: `${percent}%` }}
+        />
+      </span>
+      <span className="context-usage-card__cache-label">
+        {formatCompactNumber(cachedTokens)} cached ({formatPercent(percent)})
+      </span>
+    </div>
+  );
 }
 
 function formatPercent(value: number): string {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1432,6 +1432,68 @@ describe("Composer", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
+  it("live-updates the open context usage card as token usage changes", () => {
+    const thread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Context usage",
+      titleSource: "explicit",
+      source: "codex",
+      executionMode: "default",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const composerFor = (
+      contextWindow:
+        | Parameters<typeof Composer>[0]["contextWindow"]
+        | undefined
+    ) => (
+      <Composer
+        backends={[backendSummary("codex")]}
+        contextWindow={contextWindow}
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />
+    );
+
+    const { rerender } = render(
+      composerFor({
+        modelContextWindow: 128_000,
+        phase: 4,
+        remainingPercent: 50,
+        remainingTokens: 64_000,
+        totalTokens: 64_000,
+        usedPercent: 50,
+      })
+    );
+
+    fireEvent.mouseEnter(screen.getByRole("img", { name: /Context window/ }));
+    expect(screen.getByRole("tooltip")).toHaveTextContent("50% full");
+
+    // A fresh token-usage notification while the card is open updates it
+    // in place — no re-hover required.
+    rerender(
+      composerFor({
+        modelContextWindow: 128_000,
+        phase: 6,
+        remainingPercent: 25,
+        remainingTokens: 32_000,
+        totalTokens: 96_000,
+        usedPercent: 75,
+      })
+    );
+
+    const card = screen.getByRole("tooltip");
+    expect(card).toHaveTextContent("75% full");
+    expect(card).toHaveTextContent("32k left");
+    expect(card).toHaveTextContent("96k of 128k tokens");
+    expect(card).not.toHaveTextContent("50% full");
+
+    // Losing the context state entirely (thread switch) drops the card.
+    rerender(composerFor(undefined));
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("shows OpenAI model and reasoning defaults without a Default option", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1397,25 +1397,39 @@ describe("Composer", () => {
       />
     );
 
-    expect(
-      screen.getByRole("img", {
-        name: "Context window 50% full, 64k/128k tokens, full moon",
-      })
-    ).toBeInTheDocument();
-    expect(screen.getByRole("img")).toHaveAttribute(
-      "data-tooltip",
-      [
-        "Context window: 50% full (full moon)",
-        "Current snapshot: 64k / 128k tokens",
-        "Remaining: 64k tokens, 50% remaining",
-        "Current breakdown: 63k input, 32k cached (50.8%), 1k output",
-        "Cumulative usage reported: 80k tokens",
-        "Cumulative cached input: 48k (66.7%)",
-        "Cumulative output: 8k output, 4k reasoning",
-      ].join("\n")
-    );
-    expect(screen.getByRole("img")).not.toHaveAttribute("title");
+    const moon = screen.getByRole("img", {
+      name: "Context window 50% full, 64k/128k tokens, full moon",
+    });
+    expect(moon).toBeInTheDocument();
+    expect(moon).not.toHaveAttribute("title");
+    expect(moon).not.toHaveAttribute("data-tooltip");
     expect(screen.getByText("50%")).toBeInTheDocument();
+
+    // Hovering the moon opens the structured usage card.
+    fireEvent.mouseEnter(moon);
+    const card = screen.getByRole("tooltip");
+    expect(within(card).getByText("Context window")).toBeInTheDocument();
+    expect(within(card).getByText("full moon")).toBeInTheDocument();
+    expect(within(card).getByText("50% full")).toBeInTheDocument();
+    expect(within(card).getByText("64k left")).toBeInTheDocument();
+    expect(within(card).getByText("64k of 128k tokens")).toBeInTheDocument();
+
+    expect(within(card).getByText("Current request")).toBeInTheDocument();
+    expect(within(card).getByText("Input")).toBeInTheDocument();
+    expect(within(card).getByText("63k")).toBeInTheDocument();
+    expect(within(card).getByText("32k cached (50.8%)")).toBeInTheDocument();
+    expect(within(card).getAllByText("Output")).toHaveLength(2);
+    expect(within(card).getByText("1k")).toBeInTheDocument();
+
+    expect(within(card).getByText("Session total")).toBeInTheDocument();
+    expect(within(card).getByText("80k")).toBeInTheDocument();
+    expect(within(card).getByText("48k cached (66.7%)")).toBeInTheDocument();
+    expect(within(card).getByText("8k")).toBeInTheDocument();
+    expect(within(card).getByText("Reasoning")).toBeInTheDocument();
+    expect(within(card).getByText("4k")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(moon);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
   it("shows OpenAI model and reasoning defaults without a Default option", () => {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -53,17 +53,28 @@ export function useViewportTooltip(options: {
   className: string;
 }): {
   show: (target: HTMLElement, content: ReactNode) => void;
+  /**
+   * Replace the content of an already-visible tooltip in place (no-op
+   * while hidden). Keeps the current position until the re-measure pass
+   * settles, so live data updates don't blink the tooltip.
+   */
+  update: (content: ReactNode) => void;
   hide: () => void;
+  /** Whether the tooltip is currently shown. */
+  visible: boolean;
   tooltipNode: ReactNode;
 } {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [state, setState] = useState<TooltipState | undefined>(undefined);
 
-  // After the tooltip first paints (with left/top undefined → visibility
-  // hidden), measure it and clamp position so it stays in the viewport
-  // and on the side of the target where it fits.
+  // Measure the rendered tooltip and clamp position so it stays in the
+  // viewport and on the side of the target where it fits. The first
+  // paint renders with left/top undefined (visibility hidden); content
+  // updates re-measure from the already-visible position and only
+  // reposition when the size actually changed, so the pass settles
+  // without flicker.
   useLayoutEffect(() => {
-    if (!state || state.left !== undefined) {
+    if (!state) {
       return;
     }
     const tooltipElement = tooltipRef.current;
@@ -80,7 +91,9 @@ export function useViewportTooltip(options: {
     const top = fitsAbove
       ? state.targetTop - rect.height - TOOLTIP_GAP
       : state.targetBottom + TOOLTIP_GAP;
-    setState({ ...state, left, top });
+    if (state.left !== left || state.top !== top) {
+      setState({ ...state, left, top });
+    }
   }, [state]);
 
   const show = useCallback((target: HTMLElement, content: ReactNode): void => {
@@ -91,6 +104,10 @@ export function useViewportTooltip(options: {
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
     });
+  }, []);
+
+  const update = useCallback((content: ReactNode): void => {
+    setState((current) => (current ? { ...current, content } : current));
   }, []);
 
   const hide = useCallback((): void => {
@@ -137,5 +154,5 @@ export function useViewportTooltip(options: {
         )
       : null;
 
-  return { show, hide, tooltipNode };
+  return { show, update, hide, visible, tooltipNode };
 }

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -13,7 +13,7 @@ const VIEWPORT_PADDING = 12;
 const TOOLTIP_GAP = 10;
 
 type TooltipState = {
-  text: string;
+  content: ReactNode;
   targetTop: number;
   targetBottom: number;
   targetCenter: number;
@@ -52,7 +52,7 @@ export function useViewportTooltip(options: {
   /** CSS class applied to the rendered tooltip element. */
   className: string;
 }): {
-  show: (target: HTMLElement, text: string) => void;
+  show: (target: HTMLElement, content: ReactNode) => void;
   hide: () => void;
   tooltipNode: ReactNode;
 } {
@@ -83,10 +83,10 @@ export function useViewportTooltip(options: {
     setState({ ...state, left, top });
   }, [state]);
 
-  const show = useCallback((target: HTMLElement, text: string): void => {
+  const show = useCallback((target: HTMLElement, content: ReactNode): void => {
     const rect = target.getBoundingClientRect();
     setState({
-      text,
+      content,
       targetTop: rect.top,
       targetBottom: rect.bottom,
       targetCenter: rect.left + rect.width / 2,
@@ -131,7 +131,7 @@ export function useViewportTooltip(options: {
               visibility: state.left === undefined ? "hidden" : undefined,
             }}
           >
-            {state.text}
+            {state.content}
           </div>,
           document.body,
         )

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16402,6 +16402,158 @@ textarea,
   white-space: nowrap;
 }
 
+/* Portal-rendered hover card for the context-window moon (rendered by
+   useViewportTooltip). A structured usage card — meter + stat rows —
+   instead of a text-blob tooltip. */
+.context-usage-card {
+  position: fixed;
+  z-index: 90;
+  width: 264px;
+  max-width: calc(100vw - 32px);
+  padding: 12px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--popover-bg);
+  box-shadow: 0 12px 28px var(--shadow-tint-soft);
+  color: var(--text-primary);
+  pointer-events: none;
+  text-align: left;
+}
+
+.context-usage-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.context-usage-card__eyebrow,
+.context-usage-card__section-title {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.context-usage-card__phase {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.context-usage-card__headline {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.context-usage-card__percent {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.context-usage-card__remaining {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.context-usage-card__meter {
+  display: block;
+  height: 6px;
+  margin-top: 7px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.context-usage-card__meter-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--accent);
+}
+
+.context-usage-card__meter-fill--critical {
+  background: var(--status-error);
+}
+
+.context-usage-card__caption {
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.context-usage-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.context-usage-card__section-title {
+  margin-bottom: 2px;
+}
+
+.context-usage-card__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.context-usage-card__row-label {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.context-usage-card__row-value {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.context-usage-card__cache {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.context-usage-card__cache-meter {
+  display: block;
+  flex: 1 1 auto;
+  height: 4px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--text-primary) 9%, transparent);
+  overflow: hidden;
+}
+
+.context-usage-card__cache-fill {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--text-secondary) 62%, transparent);
+}
+
+.context-usage-card__cache-label {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .composer__error {
   margin: 0 16px;
   color: var(--danger-text);


### PR DESCRIPTION
## Summary

- Replaces the context-window moon's plain-text `data-tooltip` (seven lines of monospace prose) with a portal-rendered hover card: a tangerine usage meter with a mono "% full" headline and remaining-tokens figure, followed by hairline-separated **Current request** and **Session total** sections with right-aligned stat rows and small neutral cache-hit meters.
- Widens `useViewportTooltip` to accept `ReactNode` content (existing string callers unchanged), so the card reuses its portal rendering, viewport clamping, and blur/scroll teardown.
- Design follows the Tangerine Terminal rules: only the headline meter wears the accent, cache meters are quiet neutral fills, values are mono `--text-primary`, and every color goes through theme tokens so the card follows the light theme. The meter fill flips to `--status-error` when the moon reaches its existing "critical" phase — reusing that signal rather than inventing a new threshold. Output/reasoning stay as text rows since at ~0.1% of the window they'd be invisible as bar segments.
- The moon keeps its aria-label, keyboard focusability, and focus/blur triggers.

## Verification

- `pnpm test apps/desktop/.../composer.test.tsx` — 194/194 pass; the moon test now opens the card and asserts headline, caption, breakdown rows, and cache-meter labels, plus dismissal on mouse leave.
- `pnpm --filter @pwragent/desktop exec playwright test e2e/turn-lifecycle.spec.ts` — 4/4 pass; the moon E2E now hovers and verifies the card renders from live `thread/tokenUsage/updated` notifications.
- `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:colors`, `pnpm lint:eslint` — all clean (0 errors).
- Visually verified in a replay-backed Electron run seeded with rich usage data (67% full, 97.3% cache hit, 444M cumulative): card anchors above the moon, clamps to the viewport, and reads correctly over the composer.

## Notes

- The cumulative "Session total" section only renders when the backend reports cumulative usage, mirroring the old tooltip's conditional "Cumulative" lines.
- A follow-up idea: the session cache ratio is effectively the cost story — a per-model token-price hook could add an estimated-spend line to that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)