### PR TITLE
fix(desktop): pill queued-banner and review actions to match footer chips

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15975,12 +15975,16 @@ textarea,
   gap: 8px;
 }
 
+/* Same chip language as the footer's Stop/Send/Queue pills
+   (.composer__actions .button) so queued-row and review actions read as
+   one family instead of taller squared-off strays. */
 .composer__secondary-action,
 .composer__primary-action {
-  min-height: 34px;
+  min-height: 26px;
   padding: 0 12px;
   border: 1px solid var(--border-subtle);
-  border-radius: 6px;
+  border-radius: 999px;
+  font-size: 13px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## What changed

The queued-turn banner actions (**Steer / Edit / Delete / Send now**), the pending-steer and permissions-queued banner buttons, and the review composer's **Cancel / Start review** now render as the same compact pills as the footer's Stop/Send/Queue buttons: `min-height: 26px`, `border-radius: 999px`, `font-size: 13px`.

## Why

The footer buttons get pilled by the scoped `.composer__actions .button` override, but the queued-row and review actions use a separate `.composer__secondary-action` / `.composer__primary-action` rule that still carried the older 34px-tall, 6px-radius metrics. The result was chunky squared-off buttons sitting directly above the pill-styled footer chrome — two button languages in the same visual band.

## Notes for review

- Single shared rule in `app.css`; a comment now ties it to the footer chip override so the two don't drift apart again.
- The env-action icon controls (`.composer__queued-env-action-control`) are unaffected — they explicitly override their own 26px-square size and 6px radius.
- Verified visually by rendering the real banner/footer/review markup against the edited stylesheet: queued-row buttons now read identically to the footer pills, and Start review picks up the accent-pill look like Send.
- Known remaining squared-off buttons elsewhere (composer "Add directory", transcript approval cards, transcript utility buttons, app banners) are intentionally out of scope for this fix and can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)