### PR TITLE
fix(messaging): attach Slack handoffs in source threads

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -152,6 +152,100 @@ describe("SlackAdapter", () => {
     expect(adapter.capabilityProfile.text.markdownDialect).toBe("slack-mrkdwn");
   });
 
+  it("creates a bindable Slack thread from the invoking root message", async () => {
+    const posted: unknown[] = [];
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({
+        conversations: { C012ABCDEF0: "signals-chat" },
+        posted,
+      }),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "app_mention",
+        channel: "C012ABCDEF0",
+        channel_type: "channel",
+        team: "T012ABCDEF0",
+        ts: "1712023030.000000",
+        user: "U012ABCDEF0",
+        text: "<@U0BOTUSERID> inspect my open PRs",
+      },
+    });
+
+    const source = events[0]!;
+    await expect(adapter.getManagedConversationRights({
+      actor: source.actor,
+      channel: source.channel,
+      routingState: source.routingState,
+    })).resolves.toMatchObject({
+      channel: "slack",
+      operations: [
+        {
+          operation: "create_child",
+          supported: true,
+        },
+      ],
+      outcome: "ok",
+    });
+
+    const created = await adapter.createManagedConversation({
+      actor: source.actor,
+      parent: source.channel,
+      routingState: source.routingState,
+      title: "GIPHY-services PR status",
+    });
+    expect(created).toMatchObject({
+      channel: "slack",
+      conversation: {
+        id: "C012ABCDEF0",
+        kind: "thread",
+        parentId: "1712023030.000000",
+        parentTitle: "signals-chat",
+        title: "GIPHY-services PR status",
+      },
+      outcome: "created",
+      routingState: {
+        opaque: {
+          channelId: "C012ABCDEF0",
+          teamId: "T012ABCDEF0",
+          threadTs: "1712023030.000000",
+        },
+      },
+    });
+
+    await adapter.deliver({
+      id: "thread-status",
+      kind: "status",
+      createdAt: 1,
+      status: "working",
+      text: "Working on recent PRs",
+      targetSurface: {
+        channel: "slack",
+        id: "slack-thread",
+        state: created.routingState!,
+      },
+    });
+
+    expect(posted).toEqual([
+      expect.objectContaining({
+        channel: "C012ABCDEF0",
+        text: "Working on recent PRs",
+        thread_ts: "1712023030.000000",
+      }),
+    ]);
+  });
+
   it("signals Slack Assistant thread status for active typing activity", async () => {
     const assistantStatuses: Array<{ channelId: string; status: string; threadTs: string }> = [];
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -25,6 +25,10 @@ import type {
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingManagedConversationCreateRequest,
+  MessagingManagedConversationCreateResult,
+  MessagingManagedConversationRightsRequest,
+  MessagingManagedConversationRightsResult,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingResponseMode,
@@ -188,6 +192,12 @@ export type SlackProviderAdapter = {
   downloadAttachment(
     request: MessagingAttachmentDownloadRequest,
   ): Promise<MessagingAttachmentDownloadResult>;
+  getManagedConversationRights(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult>;
+  createManagedConversation(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult>;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
@@ -658,6 +668,73 @@ export class SlackAdapter implements SlackProviderAdapter {
       conversation: request.channel.conversation,
       outcome: "unsupported",
       title: request.title,
+      updatedAt: this.now(),
+    };
+  }
+
+  async getManagedConversationRights(
+    request: MessagingManagedConversationRightsRequest,
+  ): Promise<MessagingManagedConversationRightsResult> {
+    const conversation = request.channel.conversation;
+    const target = slackManagedThreadTarget(request.channel, request.routingState);
+    const supported = target !== undefined;
+    return {
+      channel: this.channel,
+      conversation,
+      operations: [
+        {
+          operation: "create_child",
+          supported,
+          ...(!supported
+            ? {
+                reason: conversation.kind === "thread"
+                  ? "Slack does not support nested threads"
+                  : "the source message timestamp is unavailable",
+              }
+            : {}),
+        },
+      ],
+      outcome: supported ? "ok" : "unsupported",
+      updatedAt: this.now(),
+    };
+  }
+
+  async createManagedConversation(
+    request: MessagingManagedConversationCreateRequest,
+  ): Promise<MessagingManagedConversationCreateResult> {
+    const target = slackManagedThreadTarget(request.parent, request.routingState);
+    if (!target) {
+      return {
+        channel: this.channel,
+        errorMessage: request.parent.conversation.kind === "thread"
+          ? "Slack does not support nested threads."
+          : "Slack thread creation needs the source message timestamp.",
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+    // Slack has no separate create-thread API. A thread exists when the first
+    // reply is posted, so return routing for the source message and let the
+    // controller's initial status delivery materialize it through thread_ts.
+    return {
+      channel: this.channel,
+      conversation: {
+        id: target.channelId,
+        kind: "thread",
+        parentId: target.threadTs,
+        ...(request.parent.conversation.title
+          ? { parentTitle: request.parent.conversation.title }
+          : {}),
+        title: request.title,
+      },
+      outcome: "created",
+      routingState: {
+        opaque: {
+          channelId: target.channelId,
+          ...(target.teamId ? { teamId: target.teamId } : {}),
+          threadTs: target.threadTs,
+        },
+      },
       updatedAt: this.now(),
     };
   }
@@ -2168,15 +2245,53 @@ function normalizeSlackSlashCommand(
 function readSlackSurfaceState(
   surface: MessagingSurfaceRef | undefined,
 ): SlackSurfaceOpaqueState | undefined {
-  const opaque = surface?.state?.opaque;
+  return readSlackOpaqueState(surface?.state?.opaque);
+}
+
+function readSlackAdapterState(
+  state: MessagingAdapterState | undefined,
+): SlackSurfaceOpaqueState & { teamId?: string } | undefined {
+  return readSlackOpaqueState(state?.opaque);
+}
+
+function readSlackOpaqueState(
+  opaque: MessagingJsonValue | undefined,
+): SlackSurfaceOpaqueState & { teamId?: string } | undefined {
   if (!opaque || typeof opaque !== "object" || Array.isArray(opaque)) {
     return undefined;
   }
   const record = opaque as Record<string, MessagingJsonValue>;
   return {
     ...(typeof record.channelId === "string" ? { channelId: record.channelId } : {}),
+    ...(typeof record.teamId === "string" ? { teamId: record.teamId } : {}),
     ...(typeof record.threadTs === "string" ? { threadTs: record.threadTs } : {}),
     ...(typeof record.ts === "string" ? { ts: record.ts } : {}),
+  };
+}
+
+function slackManagedThreadTarget(
+  channel: MessagingChannelRef,
+  routingState: MessagingAdapterState | undefined,
+): { channelId: string; teamId?: string; threadTs: string } | undefined {
+  if (channel.conversation.kind === "thread") {
+    return undefined;
+  }
+  const state = readSlackAdapterState(routingState);
+  const channelId = channel.conversation.id;
+  const threadTs = state?.ts;
+  if (
+    !validateSlackChannelId(channelId).ok
+    || (state?.channelId !== undefined && state.channelId !== channelId)
+    || !validateSlackMessageTs(threadTs).ok
+  ) {
+    return undefined;
+  }
+  return {
+    channelId,
+    ...(state?.teamId && validateSlackTeamId(state.teamId).ok
+      ? { teamId: state.teamId }
+      : {}),
+    threadTs: threadTs!,
   };
 }
 


### PR DESCRIPTION
## Summary

- I fixed Slack Agent handoffs so a request from a channel message attaches to a native Slack thread under that source message instead of reporting that child conversations are unsupported.
- I reuse Slack's preserved source timestamp as `thread_ts`; the first status delivery materializes the thread, while nested threads and sources without a message timestamp remain unsupported.
- I added regression coverage from an inbound app mention through managed-conversation discovery, binding creation, and threaded delivery.

## Verification

- `pnpm test` — 4,743 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`

## Notes

- This uses the Slack adapter's existing `chat.postMessage` path and does not require an additional OAuth scope.
