### PR TITLE
fix(release): keep debug uploads from gating publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,8 @@ jobs:
             --clobber
 
       - name: Upload release artifacts (debug retention)
+        # Diagnostic retention must not block Linux assets or release notes.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
@@ -288,6 +290,8 @@ jobs:
             --clobber
 
       - name: Upload Linux artifacts (debug retention)
+        # Diagnostic retention must not block release-note publication.
+        continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -141,6 +141,10 @@ release jobs:
    GitHub Release body, and fails the workflow if the body still reads back as
    empty.
 
+The macOS and Linux workflow-artifact uploads labeled `debug retention` are
+diagnostic only. They are intentionally non-blocking, so a transient artifact
+service failure cannot prevent publishing release assets or release notes.
+
 The no-secret prepare job:
 
 1. Verifies `THIRD_PARTY_LICENSES` matches a fresh deterministic generation.

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -61,6 +61,22 @@ function assertWorkflowJobRunner(workflow, workflowPath, jobName, expectedRunner
   }
 }
 
+function assertWorkflowStepIsNonBlocking(workflow, workflowPath, stepName) {
+  const stepHeader = `      - name: ${stepName}\n`;
+  const stepStart = workflow.indexOf(stepHeader);
+  if (stepStart === -1) {
+    fail(`${workflowPath} must contain a ${stepName} step`);
+    return;
+  }
+  const nextStepStart = workflow.indexOf("\n      - name: ", stepStart + stepHeader.length);
+  const stepBody = nextStepStart === -1
+    ? workflow.slice(stepStart)
+    : workflow.slice(stepStart, nextStepStart);
+  if (!/^[ ]{8}continue-on-error: true\s*$/m.test(stepBody)) {
+    fail(`${workflowPath} ${stepName} must use continue-on-error: true`);
+  }
+}
+
 const tag = parseTagArg(process.argv.slice(2));
 if (!tag) {
   usage();
@@ -187,6 +203,16 @@ assertWorkflowJobRunner(
   "windows-package",
   "windows-2022",
 );
+for (const stepName of [
+  "Upload release artifacts (debug retention)",
+  "Upload Linux artifacts (debug retention)",
+]) {
+  assertWorkflowStepIsNonBlocking(
+    releaseWorkflow,
+    ".github/workflows/release.yml",
+    stepName,
+  );
+}
 
 for (const expected of [
   "PwrAgent-linux-x64.deb",


### PR DESCRIPTION
## Summary

- I made the diagnostic debug-retention uploads non-blocking, so a transient GitHub artifact-service timeout cannot skip Linux DEB publication or changelog-backed release notes.
- I kept signed macOS asset publishing, Linux release asset publishing, prerelease creation, and the non-empty release-body check as required release gates.
- I added a release metadata assertion and runbook guidance that lock in this failure-isolation contract.

## Verification

- `RELEASE_TAG=v1.0.0-beta.49 pnpm release:check`
- `node --check scripts/check-desktop-release-metadata.mjs`
- `git diff --check`

## Notes

- I did not create or modify a release tag or GitHub Release.
