### PR TITLE
fix(desktop): ignore idle terminals when quitting

### DIFF
--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -15,6 +15,32 @@ async function openSmokeThread(page: Page) {
   ).toBeVisible();
 }
 
+async function setQuitConfirmation(page: Page, enabled: boolean) {
+  await page.evaluate(async (nextEnabled) => {
+    await (
+      window as unknown as {
+        pwragent: {
+          writeSettingsConfig: (request: unknown) => Promise<unknown>;
+        };
+      }
+    ).pwragent.writeSettingsConfig({
+      patch: { general: { confirmQuitWithInProgressThreads: nextEnabled } },
+    });
+  }, enabled);
+}
+
+async function openIntegratedTerminal(page: Page) {
+  await page
+    .getByRole("button", { name: "Open integrated terminal" })
+    .click();
+  await expect(
+    page.getByLabel("Integrated terminal", { exact: true }),
+  ).toBeVisible();
+  await expect(page.locator(".integrated-terminal__status")).not.toHaveText(
+    "Starting shell...",
+  );
+}
+
 /**
  * The quit dialog is a standalone `data:` HTML window with no preload: it talks
  * to main by navigating to a fake scheme that `will-navigate` intercepts. That
@@ -41,33 +67,19 @@ test("lists running terminals, cancels auto-quit, and stays open", async () => {
     // The shared harness seeds quit confirmation OFF so specs can close cleanly
     // (and it does so after `preLaunchHook`). This spec is about the
     // confirmation, so turn it back on through the app's own settings IPC.
-    await app.window.evaluate(async () => {
-      await (
-        window as unknown as {
-          pwragent: {
-            writeSettingsConfig: (request: unknown) => Promise<unknown>;
-          };
-        }
-      ).pwragent.writeSettingsConfig({
-        patch: { general: { confirmQuitWithInProgressThreads: true } },
-      });
-    });
+    await setQuitConfirmation(app.window, true);
 
     await openSmokeThread(app.window);
 
-    // A running shell is a quit blocker, which is what summons the dialog.
-    await app.window
-      .getByRole("button", { name: "Open integrated terminal" })
-      .click();
+    // An idle shell is not a quit blocker. Start a foreground command so this
+    // spec still exercises the dialog and its terminal-row navigation.
+    await openIntegratedTerminal(app.window);
+    await app.window.locator(".integrated-terminal__viewport").click();
+    await app.window.keyboard.type("echo PWRAGENT_QUIT_BLOCKER_READY; sleep 60");
+    await app.window.keyboard.press("Enter");
     await expect(
-      app.window.getByLabel("Integrated terminal", { exact: true }),
-    ).toBeVisible();
-    // The pane renders before `createOrAttach` resolves. Wait for the status to
-    // flip off "Starting shell..." — that is the renderer's proof that main has
-    // actually registered the session, and therefore has a quit blocker.
-    await expect(
-      app.window.locator(".integrated-terminal__status"),
-    ).not.toHaveText("Starting shell...");
+      app.window.locator(".integrated-terminal .xterm-rows"),
+    ).toContainText("PWRAGENT_QUIT_BLOCKER_READY");
 
     const dialogPromise = app.electronApp.waitForEvent("window");
     // Not awaited: the modal holds the main process, so this round trip does
@@ -136,19 +148,46 @@ test("lists running terminals, cancels auto-quit, and stays open", async () => {
     // Disarm the confirmation before teardown. The terminal is still running,
     // so `app.close()` would trip the quit path again and hang on a second
     // dialog that nobody is there to answer.
-    await app.window
-      .evaluate(async () => {
-        await (
-          window as unknown as {
-            pwragent: {
-              writeSettingsConfig: (request: unknown) => Promise<unknown>;
-            };
-          }
-        ).pwragent.writeSettingsConfig({
-          patch: { general: { confirmQuitWithInProgressThreads: false } },
-        });
+    await setQuitConfirmation(app.window, false).catch(() => undefined);
+    await app.close();
+  }
+});
+
+test("does not confirm quit for a terminal sitting at its prompt", async () => {
+  test.setTimeout(90_000);
+
+  const app = await launchElectronApp({
+    fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
+  });
+
+  try {
+    await setQuitConfirmation(app.window, true);
+    await openSmokeThread(app.window);
+    await openIntegratedTerminal(app.window);
+
+    const closedPromise = app.electronApp.waitForEvent("close").then(() => ({
+      kind: "closed" as const,
+    }));
+    const dialogPromise = app.electronApp
+      .waitForEvent("window")
+      .then((dialog) => ({
+        kind: "dialog" as const,
+        dialog,
+      }));
+    void app.electronApp
+      .evaluate(({ app: electronApp }) => {
+        electronApp.quit();
       })
       .catch(() => undefined);
-    await app.close();
+
+    const outcome = await Promise.race([closedPromise, dialogPromise]);
+    if (outcome.kind === "dialog") {
+      // Clean up a regressed run before surfacing the assertion failure.
+      await outcome.dialog.locator("#quit").dispatchEvent("click");
+      await closedPromise;
+    }
+    expect(outcome.kind).toBe("closed");
+  } finally {
+    await app.close().catch(() => undefined);
   }
 });

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -251,6 +251,92 @@ describe("resolveTerminalShell", () => {
     });
   });
 
+  it("reports a Linux foreground pipeline when node-pty falls back to the shell name", async () => {
+    const pty = fakePty({ pid: 321, process: "sh" });
+    const serviceOptions = {
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "linux" as const,
+      readLinuxProcessStat: () => "321 (sh) S 1 321 321 34816 654",
+    };
+    const service = new IntegratedTerminalService(serviceOptions);
+
+    const response = await service.createOrAttach(
+      {
+        threadKey: "codex:thread-linux-pipeline",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 1,
+      sessionIds: [response.sessionId],
+      threadKeys: ["codex:thread-linux-pipeline"],
+    });
+  });
+
+  it("does not report a Linux terminal whose shell owns the foreground process group", async () => {
+    const pty = fakePty({ pid: 321, process: "sh" });
+    const serviceOptions = {
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "linux" as const,
+      readLinuxProcessStat: () => "321 (sh) S 1 321 321 34816 321",
+    };
+    const service = new IntegratedTerminalService(serviceOptions);
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-linux-idle",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 0,
+      sessionIds: [],
+      threadKeys: [],
+    });
+  });
+
+  it("conservatively reports a Linux terminal when process-group lookup fails", async () => {
+    const pty = fakePty({ pid: 321, process: "sh" });
+    const serviceOptions = {
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "linux" as const,
+      readLinuxProcessStat: () => {
+        throw new Error("proc unavailable");
+      },
+    };
+    const service = new IntegratedTerminalService(serviceOptions);
+
+    const response = await service.createOrAttach(
+      {
+        threadKey: "codex:thread-linux-lookup-failed",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 1,
+      sessionIds: [response.sessionId],
+      threadKeys: ["codex:thread-linux-lookup-failed"],
+    });
+  });
+
   it("conservatively reports terminals when foreground detection is unsupported", async () => {
     const pty = fakePty({ process: "powershell.exe" });
     const service = new IntegratedTerminalService({

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -199,12 +199,13 @@ describe("resolveTerminalShell", () => {
     expect(webContents.once).toHaveBeenCalledTimes(1);
   });
 
-  it("reports running terminal sessions for quit confirmation", async () => {
-    const pty = fakePty();
+  it("reports terminal sessions with a foreground command for quit confirmation", async () => {
+    const pty = fakePty({ process: "sleep" });
     const service = new IntegratedTerminalService({
       loadNodePty: async () => ({
         spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
       }),
+      platform: "darwin",
     });
 
     const response = await service.createOrAttach(
@@ -221,6 +222,89 @@ describe("resolveTerminalShell", () => {
       count: 1,
       sessionIds: [response.sessionId],
       threadKeys: ["codex:thread-a"],
+    });
+  });
+
+  it("does not report a terminal sitting idle at its shell prompt", async () => {
+    const pty = fakePty({ process: "-sh" });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "darwin",
+    });
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-idle",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 0,
+      sessionIds: [],
+      threadKeys: [],
+    });
+  });
+
+  it("conservatively reports terminals when foreground detection is unsupported", async () => {
+    const pty = fakePty({ process: "powershell.exe" });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "win32",
+    });
+
+    const response = await service.createOrAttach(
+      {
+        threadKey: "codex:thread-windows",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 1,
+      sessionIds: [response.sessionId],
+      threadKeys: ["codex:thread-windows"],
+    });
+  });
+
+  it("conservatively reports terminals when foreground detection fails", async () => {
+    const pty = fakePty();
+    Object.defineProperty(pty, "process", {
+      get: () => {
+        throw new Error("foreground lookup failed");
+      },
+    });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: vi.fn(() => pty) as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "darwin",
+    });
+
+    const response = await service.createOrAttach(
+      {
+        threadKey: "codex:thread-lookup-failed",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(service.getQuitSnapshot()).toEqual({
+      count: 1,
+      sessionIds: [response.sessionId],
+      threadKeys: ["codex:thread-lookup-failed"],
     });
   });
 

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -115,7 +115,7 @@ export class IntegratedTerminalService {
       cwd = resolveTerminalCwd(request.cwd);
       shell = resolveTerminalShell({
         env,
-        platform: process.platform,
+        platform: this.platform,
         windowsShell: settings.resolveIntegratedTerminalWindowsShell(),
       });
       const nodePty = await this.loadNodePty();

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -56,6 +56,7 @@ type IntegratedTerminalServiceOptions = {
   now?: () => number;
   onSessionsChanged?: (sessions: IntegratedTerminalSessionSummary[]) => void;
   platform?: NodeJS.Platform;
+  readLinuxProcessStat?: (pid: number) => string;
 };
 
 export class IntegratedTerminalService {
@@ -68,6 +69,7 @@ export class IntegratedTerminalService {
     sessions: IntegratedTerminalSessionSummary[],
   ) => void;
   private readonly platform: NodeJS.Platform;
+  private readonly readLinuxProcessStat: (pid: number) => string;
   /** Threads whose PTY is mid-spawn — the window in which a close has nothing
    *  to act on yet. */
   private readonly spawningThreadKeys = new Set<string>();
@@ -83,6 +85,9 @@ export class IntegratedTerminalService {
     this.now = options.now ?? Date.now;
     this.onSessionsChanged = options.onSessionsChanged;
     this.platform = options.platform ?? process.platform;
+    this.readLinuxProcessStat =
+      options.readLinuxProcessStat
+      ?? ((pid) => readFileSync(`/proc/${pid}/stat`, "utf8"));
   }
 
   async createOrAttach(
@@ -262,11 +267,15 @@ export class IntegratedTerminalService {
   }
 
   private hasForegroundCommand(session: TerminalSession): boolean {
-    // node-pty exposes the terminal's foreground process on macOS and Linux.
-    // Other platforms return only the originally spawned process name, which
-    // cannot distinguish an idle prompt from a running command. Keep the
-    // existing conservative warning where the signal is unavailable.
-    if (this.platform !== "darwin" && this.platform !== "linux") {
+    if (this.platform === "linux") {
+      return this.hasLinuxForegroundCommand(session);
+    }
+
+    // node-pty exposes the terminal's foreground process on macOS. Other
+    // platforms return only the originally spawned process name, which cannot
+    // distinguish an idle prompt from a running command. Keep the existing
+    // conservative warning where the signal is unavailable.
+    if (this.platform !== "darwin") {
       return true;
     }
 
@@ -274,6 +283,34 @@ export class IntegratedTerminalService {
       const activeProcess = normalizeTerminalProcessName(session.pty.process);
       const shellProcess = normalizeTerminalProcessName(session.shell);
       return !activeProcess || !shellProcess || activeProcess !== shellProcess;
+    } catch (error) {
+      this.logger.warn("foreground-process-check-failed", {
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: session.sessionId,
+      });
+      return true;
+    }
+  }
+
+  private hasLinuxForegroundCommand(session: TerminalSession): boolean {
+    try {
+      const stat = this.readLinuxProcessStat(session.pty.pid);
+      const closingParen = stat.lastIndexOf(")");
+      const fields = stat.slice(closingParen + 1).trim().split(/\s+/);
+      // After pid and the parenthesized command name, Linux stat fields begin
+      // at state (field 3); pgrp and tpgid are offsets 2 and 5 from there.
+      const processGroupId = Number(fields[2]);
+      const foregroundProcessGroupId = Number(fields[5]);
+      if (
+        closingParen < 0
+        || !Number.isInteger(processGroupId)
+        || processGroupId <= 0
+        || !Number.isInteger(foregroundProcessGroupId)
+        || foregroundProcessGroupId <= 0
+      ) {
+        throw new Error("Malformed Linux process stat");
+      }
+      return processGroupId !== foregroundProcessGroupId;
     } catch (error) {
       this.logger.warn("foreground-process-check-failed", {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -55,6 +55,7 @@ type IntegratedTerminalServiceOptions = {
   loadNodePty?: () => Promise<Pick<NodePtyModule, "spawn">>;
   now?: () => number;
   onSessionsChanged?: (sessions: IntegratedTerminalSessionSummary[]) => void;
+  platform?: NodeJS.Platform;
 };
 
 export class IntegratedTerminalService {
@@ -66,6 +67,7 @@ export class IntegratedTerminalService {
   private readonly onSessionsChanged?: (
     sessions: IntegratedTerminalSessionSummary[],
   ) => void;
+  private readonly platform: NodeJS.Platform;
   /** Threads whose PTY is mid-spawn — the window in which a close has nothing
    *  to act on yet. */
   private readonly spawningThreadKeys = new Set<string>();
@@ -80,6 +82,7 @@ export class IntegratedTerminalService {
     this.loadNodePty = options.loadNodePty ?? loadNodePty;
     this.now = options.now ?? Date.now;
     this.onSessionsChanged = options.onSessionsChanged;
+    this.platform = options.platform ?? process.platform;
   }
 
   async createOrAttach(
@@ -248,12 +251,36 @@ export class IntegratedTerminalService {
   }
 
   getQuitSnapshot(): IntegratedTerminalQuitSnapshot {
-    const sessions = [...this.sessionsById.values()];
+    const sessions = [...this.sessionsById.values()].filter((session) =>
+      this.hasForegroundCommand(session),
+    );
     return {
       count: sessions.length,
       sessionIds: sessions.map((session) => session.sessionId).sort(),
       threadKeys: sessions.map((session) => session.threadKey).sort(),
     };
+  }
+
+  private hasForegroundCommand(session: TerminalSession): boolean {
+    // node-pty exposes the terminal's foreground process on macOS and Linux.
+    // Other platforms return only the originally spawned process name, which
+    // cannot distinguish an idle prompt from a running command. Keep the
+    // existing conservative warning where the signal is unavailable.
+    if (this.platform !== "darwin" && this.platform !== "linux") {
+      return true;
+    }
+
+    try {
+      const activeProcess = normalizeTerminalProcessName(session.pty.process);
+      const shellProcess = normalizeTerminalProcessName(session.shell);
+      return !activeProcess || !shellProcess || activeProcess !== shellProcess;
+    } catch (error) {
+      this.logger.warn("foreground-process-check-failed", {
+        error: error instanceof Error ? error.message : String(error),
+        sessionId: session.sessionId,
+      });
+      return true;
+    }
   }
 
   private toCreateResponse(
@@ -395,6 +422,10 @@ export class IntegratedTerminalService {
       webContents.send(channel, payload);
     }
   }
+}
+
+function normalizeTerminalProcessName(value: string): string {
+  return path.basename(value.trim().replace(/^-+/, ""));
 }
 
 async function loadNodePty(): Promise<Pick<NodePtyModule, "spawn">> {

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -499,7 +499,7 @@ export function GeneralSettings(props: {
         <div className="settings-fields">
           <SettingsField
             label="Confirm quit when threads or terminals are active"
-            sub="Warn before quitting while agent turns or integrated terminal sessions are running. The prompt auto-quits after a short countdown so shutdown can continue."
+            sub="Warn before quitting while agent turns, integrated terminal commands, or environment actions are running. On macOS and Linux, idle terminal prompts do not block quit. The prompt auto-quits after a short countdown so shutdown can continue."
             source={sourceBadge(confirmQuitWithInProgressThreads)}
             control={
               <SettingsSwitch


### PR DESCRIPTION
## Summary

- Integrated terminals sitting at their shell prompt no longer trigger quit confirmation or appear as clickable blockers on macOS and Linux.
- Foreground commands still block quit, while Windows and failed foreground-process lookups retain the conservative warning.
- The quit path now uses node-pty's foreground process title only for quit classification; live terminal session and UI behavior are unchanged.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts apps/desktop/src/main/__tests__/quit-manager.test.ts apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts apps/desktop/src/main/__tests__/quit-dialog-render.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (90 passed)
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/quit-confirmation-dialog.spec.ts` (2 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; 140 existing warnings)
- `pnpm lint:boundaries`

## Notes

- Exact detection of long-running shell builtins, background jobs, or a child invocation of the same shell would require shell integration. This change intentionally uses the foreground-process signal and fails closed where it is unavailable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with_Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
