### PR TITLE
fix(desktop): discover PRs through tracked remote branches

### DIFF
--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -94,6 +94,99 @@ describe("detectPullRequestsForThread", () => {
     expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
+  it("uses the tracked remote branch when the local branch was renamed", async () => {
+    const repo = await createRepoWithRenamedTrackedBranch({
+      localBranch: "pr-13268",
+      remoteBranch: "search/query-rewrites",
+    });
+    const expectedPr = {
+      number: 13268,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13268",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) =>
+        branch === "search/query-rewrites" ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "pr-13268",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch: "search/query-rewrites",
+    });
+  });
+
+  it("uses the local branch when its tracked remote is the default branch", async () => {
+    const repo = await createRepoWithRenamedTrackedBranch({
+      localBranch: "fix/local-feature",
+      remoteBranch: "main",
+    });
+    const expectedPr = {
+      number: 13269,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13269",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) =>
+        branch === "fix/local-feature" ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix/local-feature",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch: "fix/local-feature",
+    });
+  });
+
+  it("uses the local branch when it has no upstream", async () => {
+    const branch = "fix/untracked-pr";
+    const repo = await createRepoWithBranch(branch);
+    await git(repo, "checkout", branch);
+    const expectedPr = {
+      number: 13270,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13270",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => [expectedPr]),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch,
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch,
+    });
+  });
+
   it("lets named-branch lookups degrade through the fetcher for invalid directories", async () => {
     const staleDirectory = await createNonGitDirectory();
     const fetcher = {
@@ -202,6 +295,34 @@ async function createRepoWithDefaultBranch(branch: string): Promise<string> {
     `refs/remotes/origin/${branch}`,
   );
   await git(repo, "branch", "--set-upstream-to", `origin/${branch}`, branch);
+  return repo;
+}
+
+async function createRepoWithRenamedTrackedBranch(params: {
+  localBranch: string;
+  remoteBranch: string;
+}): Promise<string> {
+  const repo = await createRepoWithBranch(params.localBranch);
+  const remote = await mkdtemp(
+    path.join(tmpdir(), "pwragent-pr-detection-remote-"),
+  );
+  tempDirs.push(remote);
+  await git(remote, "init", "--bare");
+  await git(repo, "remote", "add", "origin", remote);
+  await git(
+    repo,
+    "update-ref",
+    `refs/remotes/origin/${params.remoteBranch}`,
+    "HEAD",
+  );
+  await git(
+    repo,
+    "branch",
+    "--set-upstream-to",
+    `origin/${params.remoteBranch}`,
+    params.localBranch,
+  );
+  await git(repo, "checkout", params.localBranch);
   return repo;
 }
 

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -126,6 +126,111 @@ describe("detectPullRequestsForThread", () => {
     });
   });
 
+  it("uses the local branch when the tracked remote default is unknown", async () => {
+    const repo = await createRepoWithRenamedTrackedBranch({
+      localBranch: "fix/local-feature",
+      remoteBranch: "main",
+    });
+    await git(repo, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD");
+    await git(repo, "branch", "-D", "main");
+    const expectedPr = {
+      number: 13269,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13269",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) =>
+        branch === "fix/local-feature" ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix/local-feature",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch: "fix/local-feature",
+    });
+  });
+
+  it("does not use a descendant ref when the requested local branch is absent", async () => {
+    const repo = await createRepoWithRenamedTrackedBranch({
+      localBranch: "fix/descendant",
+      remoteBranch: "remote-feature",
+    });
+    const expectedPr = {
+      number: 13271,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13271",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch }) =>
+        branch === "fix" ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix",
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch: "fix",
+    });
+  });
+
+  it("does not use another local branch configured as the upstream", async () => {
+    const branch = "fix/local-upstream";
+    const repo = await createRepoWithBranch(branch);
+    await git(repo, "branch", "feature/parent");
+    await git(repo, "config", `branch.${branch}.remote`, ".");
+    await git(
+      repo,
+      "config",
+      `branch.${branch}.merge`,
+      "refs/heads/feature/parent",
+    );
+    await git(repo, "checkout", branch);
+    const expectedPr = {
+      number: 13272,
+      org: "Giphy",
+      repo: "giphy-services",
+      state: "pending" as const,
+      url: "https://github.com/Giphy/giphy-services/pull/13272",
+    };
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async ({ branch: lookupBranch }) =>
+        lookupBranch === branch ? [expectedPr] : [],
+      ),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch,
+      directoryPaths: [repo],
+    });
+
+    expect(prs).toEqual([expectedPr]);
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledOnce();
+    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
+      cwd: repo,
+      branch,
+    });
+  });
+
   it("uses the local branch when its tracked remote is the default branch", async () => {
     const repo = await createRepoWithRenamedTrackedBranch({
       localBranch: "fix/local-feature",
@@ -314,6 +419,13 @@ async function createRepoWithRenamedTrackedBranch(params: {
     "update-ref",
     `refs/remotes/origin/${params.remoteBranch}`,
     "HEAD",
+  );
+  await git(repo, "update-ref", "refs/remotes/origin/main", "HEAD");
+  await git(
+    repo,
+    "symbolic-ref",
+    "refs/remotes/origin/HEAD",
+    "refs/remotes/origin/main",
   );
   await git(
     repo,

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -13,8 +13,14 @@ const FALLBACK_DEFAULT_BRANCHES = [
 ] as const;
 
 type DefaultBranchInfo = {
+  defaultsByRemote: Map<string, string>;
   names: Set<string>;
-  upstreams: Set<string>;
+  remotes: Set<string>;
+};
+
+type TrackedRemoteBranch = {
+  name: string;
+  remote: string;
 };
 
 /**
@@ -75,19 +81,24 @@ async function resolvePrLookupBranches(params: {
   const defaultBranchInfo = await readDefaultBranchInfo(params.cwd);
 
   if (params.branch !== "HEAD") {
-    const trackedRemoteBranch = await readTrackedRemoteBranchName(
-      params.cwd,
-      params.branch,
-    );
+    const trackedRemoteBranch = await readTrackedRemoteBranch({
+      cwd: params.cwd,
+      localBranch: params.branch,
+      remotes: defaultBranchInfo.remotes,
+    });
     if (defaultBranchInfo.names.has(params.branch)) {
       return [];
     }
     // A local feature branch may track the remote default branch for pulls.
-    // Never query that default name; keep the local feature name instead.
+    // Only substitute a tracked branch after verifying that remote's default.
+    const trackedRemoteDefault = trackedRemoteBranch
+      ? defaultBranchInfo.defaultsByRemote.get(trackedRemoteBranch.remote)
+      : undefined;
     return [
       trackedRemoteBranch
-      && !defaultBranchInfo.names.has(trackedRemoteBranch)
-        ? trackedRemoteBranch
+      && trackedRemoteDefault
+      && trackedRemoteBranch.name !== trackedRemoteDefault
+        ? trackedRemoteBranch.name
         : params.branch,
     ];
   }
@@ -95,26 +106,51 @@ async function resolvePrLookupBranches(params: {
   return [];
 }
 
-async function readTrackedRemoteBranchName(
-  cwd: string,
-  localBranch: string,
-): Promise<string | undefined> {
-  const remoteRef = await readGitLine(cwd, [
-    "for-each-ref",
-    "--format=%(upstream:remoteref)",
-    `refs/heads/${localBranch}`,
-  ]);
-  const prefix = "refs/heads/";
-  if (!remoteRef?.startsWith(prefix)) {
+async function readTrackedRemoteBranch(params: {
+  cwd: string;
+  localBranch: string;
+  remotes: Set<string>;
+}): Promise<TrackedRemoteBranch | undefined> {
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync(
+      "git",
+      [
+        "for-each-ref",
+        "--format=%(refname)%09%(upstream:remotename)%09%(upstream:remoteref)",
+        `refs/heads/${params.localBranch}`,
+      ],
+      {
+        cwd: params.cwd,
+        maxBuffer: 64 * 1024,
+        timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
+      },
+    ));
+  } catch {
     return undefined;
   }
-  return remoteRef.slice(prefix.length).trim() || undefined;
+
+  const expectedRef = `refs/heads/${params.localBranch}`;
+  const remoteRefPrefix = "refs/heads/";
+  for (const line of stdout.split(/\r?\n/)) {
+    const [refName = "", remote = "", remoteRef = ""] = line.split("\t");
+    if (
+      refName !== expectedRef
+      || !params.remotes.has(remote)
+      || !remoteRef.startsWith(remoteRefPrefix)
+    ) {
+      continue;
+    }
+    const name = remoteRef.slice(remoteRefPrefix.length).trim();
+    return name ? { name, remote } : undefined;
+  }
+  return undefined;
 }
 
 async function readDefaultBranchInfo(cwd: string): Promise<DefaultBranchInfo> {
   try {
-    const upstreams = await readRemoteDefaultUpstreams(cwd);
-    const names = remoteDefaultBranchNames(upstreams);
+    const { defaultsByRemote, remotes } = await readRemoteDefaultBranches(cwd);
+    const names = new Set(defaultsByRemote.values());
 
     if (names.size === 0) {
       const fallbackDefaultBranch = await readFallbackDefaultBranchName(cwd);
@@ -123,20 +159,27 @@ async function readDefaultBranchInfo(cwd: string): Promise<DefaultBranchInfo> {
       }
     }
 
-    return { names, upstreams };
+    return { defaultsByRemote, names, remotes };
   } catch {
-    return { names: new Set(), upstreams: new Set() };
+    return {
+      defaultsByRemote: new Map(),
+      names: new Set(),
+      remotes: new Set(),
+    };
   }
 }
 
-async function readRemoteDefaultUpstreams(cwd: string): Promise<Set<string>> {
+async function readRemoteDefaultBranches(cwd: string): Promise<{
+  defaultsByRemote: Map<string, string>;
+  remotes: Set<string>;
+}> {
   const { stdout } = await execFileAsync("git", ["remote"], {
     cwd,
     maxBuffer: 64 * 1024,
     timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
   });
   const remotes = uniqueNonEmpty(stdout.split(/\r?\n/));
-  const upstreams = await Promise.all(
+  const defaults = await Promise.all(
     remotes.map(async (remote) => {
       const remoteHead = await readGitLine(cwd, [
         "symbolic-ref",
@@ -144,16 +187,20 @@ async function readRemoteDefaultUpstreams(cwd: string): Promise<Set<string>> {
         "--short",
         `refs/remotes/${remote}/HEAD`,
       ]);
-      return remoteHead ?? "";
+      const prefix = `${remote}/`;
+      return remoteHead?.startsWith(prefix)
+        ? ([remote, remoteHead.slice(prefix.length)] as const)
+        : undefined;
     }),
   );
-  return new Set(uniqueNonEmpty(upstreams));
-}
-
-function remoteDefaultBranchNames(defaultUpstreams: Set<string>): Set<string> {
-  return new Set(
-    [...defaultUpstreams].map((upstream) => upstream.replace(/^[^/]+\//, "")),
-  );
+  return {
+    defaultsByRemote: new Map(
+      defaults.filter(
+        (entry): entry is readonly [string, string] => Boolean(entry?.[1]),
+      ),
+    ),
+    remotes: new Set(remotes),
+  };
 }
 
 async function readFallbackDefaultBranchName(

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -75,10 +75,40 @@ async function resolvePrLookupBranches(params: {
   const defaultBranchInfo = await readDefaultBranchInfo(params.cwd);
 
   if (params.branch !== "HEAD") {
-    return defaultBranchInfo.names.has(params.branch) ? [] : [params.branch];
+    const trackedRemoteBranch = await readTrackedRemoteBranchName(
+      params.cwd,
+      params.branch,
+    );
+    if (defaultBranchInfo.names.has(params.branch)) {
+      return [];
+    }
+    // A local feature branch may track the remote default branch for pulls.
+    // Never query that default name; keep the local feature name instead.
+    return [
+      trackedRemoteBranch
+      && !defaultBranchInfo.names.has(trackedRemoteBranch)
+        ? trackedRemoteBranch
+        : params.branch,
+    ];
   }
 
   return [];
+}
+
+async function readTrackedRemoteBranchName(
+  cwd: string,
+  localBranch: string,
+): Promise<string | undefined> {
+  const remoteRef = await readGitLine(cwd, [
+    "for-each-ref",
+    "--format=%(upstream:remoteref)",
+    `refs/heads/${localBranch}`,
+  ]);
+  const prefix = "refs/heads/";
+  if (!remoteRef?.startsWith(prefix)) {
+    return undefined;
+  }
+  return remoteRef.slice(prefix.length).trim() || undefined;
 }
 
 async function readDefaultBranchInfo(cwd: string): Promise<DefaultBranchInfo> {


### PR DESCRIPTION
## Summary

Threads in worktrees whose local branch was renamed now recover their linked GitHub pull requests through the configured remote branch name. Previously, PwrAgent asked GitHub for the local alias, so a branch such as `pr-13268` could not match a PR whose actual head remained `search/query-rewrites`.

Non-default tracked branches are preferred for lookup, while local names remain the fallback for untracked repositories, invalid Git metadata, and feature branches that track the remote default branch. That preserves the existing protection against default-branch false positives without breaking custom or triangular tracking workflows.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/pr-detection.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (106 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec eslint apps/desktop/src/main/pr-status/pr-detection.ts apps/desktop/src/main/__tests__/pr-detection.test.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
