### PR TITLE
feat(desktop): render live pull request link chips

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -54,7 +54,7 @@ import {
   useNavigationHistory,
   type NavigationHistoryLocation,
 } from "./lib/useNavigationHistory";
-import { ThreadLinkProvider } from "./lib/thread-links";
+import { TranscriptLinkProvider } from "./lib/transcript-links";
 import { useThreadNavigation } from "./lib/useThreadNavigation";
 import { usePwrAgentProfiles } from "./lib/usePwrAgentProfiles";
 import { usePullRequestRefresh } from "./features/pr-status/usePullRequestRefresh";
@@ -1216,7 +1216,7 @@ function DesktopAppShell(props: {
   };
 
   return (
-    <ThreadLinkProvider onShowThread={showThreadFromLink} threads={navigation.threads}>
+    <TranscriptLinkProvider onShowThread={showThreadFromLink} threads={navigation.threads}>
       <AppTitleBar
         desktopApi={desktopApi}
         onOpenMessagingActivity={openMessagingActivityWindow}
@@ -1581,7 +1581,7 @@ function DesktopAppShell(props: {
           <AppUpdateBanner desktopApi={desktopApi} />
         </div>
       </div>
-    </ThreadLinkProvider>
+    </TranscriptLinkProvider>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import { useEffect, type KeyboardEvent, type MouseEvent } from "react";
 import type { PrSummary } from "@pwragent/shared";
 import { CloseIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -29,6 +29,7 @@ export function PrChip(props: PrChipProps) {
   const tooltipController = useViewportTooltip({
     className: "viewport-tooltip",
   });
+  const updateTooltip = tooltipController.update;
   const label = props.showRepoPrefix
     ? `${pr.org}/${pr.repo}#${pr.number}`
     : `#${pr.number}`;
@@ -39,6 +40,9 @@ export function PrChip(props: PrChipProps) {
   const tooltip = title
     ? `${title}\n${identity} — ${status}`
     : `${identity} — ${status}`;
+  useEffect(() => {
+    updateTooltip(tooltip);
+  }, [tooltip, updateTooltip]);
 
   // Draft and merge-conflict ride ALONGSIDE the check-state dot color rather
   // than replacing it: an OPEN draft keeps its real status color and gains a
@@ -140,6 +144,16 @@ export function PrChip(props: PrChipProps) {
 }
 
 function prStatusLabel(pr: PrSummary): string {
+  if (
+    pr.state === "unknown"
+    && !pr.checkState
+    && !pr.lifecycleState
+    && !pr.reviewState
+    && !pr.mergeState
+  ) {
+    return "status unknown";
+  }
+
   const lifecycleState = resolveLifecycleState(pr);
   const parts: string[] = [];
   if (lifecycleState === "merged") {

--- a/apps/desktop/src/renderer/src/features/pr-status/PullRequestLinkChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PullRequestLinkChip.tsx
@@ -1,0 +1,22 @@
+import type { PrSummary } from "@pwragent/shared";
+import { useLivePullRequest } from "../../lib/pull-request-links";
+import { PrChip } from "./PrChip";
+
+export function PullRequestLinkChip(props: { pr: PrSummary }) {
+  const pr = useLivePullRequest(props.pr);
+
+  return (
+    <PrChip
+      pr={pr}
+      showRepoPrefix
+      onOpen={openPullRequest}
+    />
+  );
+}
+
+function openPullRequest(url: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -31,8 +31,13 @@ import {
   useThreadLinks,
   type ThreadLinkContextValue,
 } from "../../lib/thread-links";
+import {
+  resolvePullRequestHref,
+  usePullRequestLinks,
+} from "../../lib/pull-request-links";
 import { expandTildePath, tildifyPath } from "../../lib/tildify-path";
 import { SkillChip } from "../composer/SkillChip";
+import { PullRequestLinkChip } from "../pr-status/PullRequestLinkChip";
 import { ThreadChip } from "./ThreadChip";
 import { remarkTableProfile } from "./remark-table-profile";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
@@ -111,6 +116,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
   const [markdownViewerTarget, setMarkdownViewerTarget] =
     useState<MarkdownViewerTarget>();
   const threadLinks = useThreadLinks();
+  const pullRequestLinks = usePullRequestLinks();
   const editorApplication = useMemo(
     () =>
       props.applications?.editors.find(
@@ -210,6 +216,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           // the author's text rather than an anchor that goes nowhere — and
           // never let `pwragent:` reach the external-open path below.
           return <>{anchorProps.children}</>;
+        }
+
+        const pullRequest = resolvePullRequestHref(href, pullRequestLinks);
+        if (pullRequest) {
+          return <PullRequestLinkChip pr={pullRequest} />;
         }
 
         if (label.startsWith("@") && localTarget) {
@@ -440,6 +451,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       openLocalFileInEditor,
       openLocalFileLink,
       props.desktopApi,
+      pullRequestLinks,
       skillsByPath,
       threadLinks,
     ]

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -1,0 +1,181 @@
+import "@testing-library/jest-dom/vitest";
+import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseGitHubPullRequestUrl,
+  PullRequestLinkProvider,
+} from "../../../lib/pull-request-links";
+import { ThreadMarkdown } from "../ThreadMarkdown";
+
+const PR_URL = "https://github.com/Giphy/giphy-services/pull/13290";
+
+function prSummary(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    provider: "github.com",
+    number: 13290,
+    org: "Giphy",
+    repo: "giphy-services",
+    title: "Document JDK 17 for EMR jobs",
+    state: "pending",
+    checkState: "pending",
+    lifecycleState: "open",
+    reviewState: "draft",
+    mergeState: "mergeable",
+    url: PR_URL,
+    ...overrides,
+  };
+}
+
+function threadSummary(prs: PrSummary[]): NavigationThreadSummary {
+  return {
+    id: "thread-pr-link",
+    title: "EMR JDK 17 guidance",
+    titleSource: "derived",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: true, unread: false },
+    prs,
+  } as NavigationThreadSummary;
+}
+
+function renderWithPullRequests(
+  text: string,
+  prs: PrSummary[],
+) {
+  return render(
+    <PullRequestLinkProvider threads={[threadSummary(prs)]}>
+      <ThreadMarkdown text={text} />
+    </PullRequestLinkProvider>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pull request links in transcript markdown", () => {
+  it("renders a known GitHub PR link with the shared live status chip", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWithPullRequests(`Draft PR: [Giphy/giphy-services#13290](${PR_URL})`, [
+      prSummary(),
+    ]);
+
+    const chip = screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    });
+    expect(chip).toHaveClass("pr-chip", "pr-chip--pending", "pr-chip--draft");
+    expect(chip).toHaveTextContent("Giphy/giphy-services#13290");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    fireEvent.click(chip);
+    expect(open).toHaveBeenCalledWith(PR_URL, "_blank", "noopener,noreferrer");
+  });
+
+  it("updates chip modes and a visible tooltip from live PR status metadata", () => {
+    const text = `Draft PR: [Giphy/giphy-services#13290](${PR_URL})`;
+    const { rerender } = renderWithPullRequests(text, [prSummary()]);
+
+    const markdownNode = screen.getByText("Draft PR:").parentElement;
+    const pendingChip = screen.getByRole("button", {
+      name: /draft · checks pending/,
+    });
+    fireEvent.mouseEnter(pendingChip);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Document JDK 17 for EMR jobs",
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "draft · checks pending",
+    );
+
+    rerender(
+      <PullRequestLinkProvider
+        threads={[
+          threadSummary([
+            prSummary({
+              title: "Document JDK 17 for EMR and Spark jobs",
+              state: "merged",
+              checkState: "passing",
+              lifecycleState: "merged",
+              reviewState: "ready_for_review",
+            }),
+          ]),
+        ]}
+      >
+        <ThreadMarkdown text={text} />
+      </PullRequestLinkProvider>,
+    );
+
+    const mergedChip = screen.getByRole("button", { name: /\(merged\) in browser/ });
+    expect(mergedChip).toHaveClass("pr-chip--merged");
+    expect(mergedChip).not.toHaveClass("pr-chip--draft");
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Document JDK 17 for EMR and Spark jobs",
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Giphy/giphy-services#13290 — merged",
+    );
+    expect(screen.getByText("Draft PR:").parentElement).toBe(markdownNode);
+  });
+
+  it("renders an unhydrated bare GitHub PR URL as an unknown-status chip", () => {
+    renderWithPullRequests(`Draft PR: ${PR_URL}`, []);
+
+    const chip = screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(status unknown\) in browser/,
+    });
+    expect(chip).toHaveClass("pr-chip--unknown");
+    expect(chip).toHaveTextContent("Giphy/giphy-services#13290");
+  });
+
+  it("leaves non-PR GitHub links as normal transcript links", () => {
+    renderWithPullRequests(
+      "Issue: [Giphy/giphy-services#13290](https://github.com/Giphy/giphy-services/issues/13290)",
+      [],
+    );
+
+    expect(screen.queryByRole("button", { name: /Giphy\/giphy-services#13290/ }))
+      .not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Giphy/giphy-services#13290" }))
+      .toBeInTheDocument();
+  });
+
+  it("leaves PR links as normal links on surfaces without navigation metadata", () => {
+    render(<ThreadMarkdown text={`Draft PR: [#13290](${PR_URL})`} />);
+
+    expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "#13290" })).toBeInTheDocument();
+  });
+});
+
+describe("parseGitHubPullRequestUrl", () => {
+  it("accepts PR subpaths and query strings while preserving the target URL", () => {
+    const href = `${PR_URL}/files?diff=split#discussion_r1`;
+    expect(parseGitHubPullRequestUrl(href)).toMatchObject({
+      provider: "github.com",
+      org: "Giphy",
+      repo: "giphy-services",
+      number: 13290,
+      state: "unknown",
+      url: href,
+    });
+  });
+
+  it("rejects issues, invalid numbers, non-GitHub hosts, and insecure URLs", () => {
+    expect(parseGitHubPullRequestUrl(
+      "https://github.com/Giphy/giphy-services/issues/13290",
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      "https://github.com/Giphy/giphy-services/pull/not-a-number",
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      "https://gitlab.com/Giphy/giphy-services/pull/13290",
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      "http://github.com/Giphy/giphy-services/pull/13290",
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      "https://github.com/%E0%A4%A/giphy-services/pull/13290",
+    )).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -118,6 +118,57 @@ describe("pull request links in transcript markdown", () => {
     expect(screen.getByText("Draft PR:").parentElement).toBe(markdownNode);
   });
 
+  it("preserves an authored PR deep link while hydrating its live status", () => {
+    const deepLink = `${PR_URL}/files?diff=split#discussion_r1`;
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderWithPullRequests(`Review [the changed files](${deepLink})`, [
+      prSummary(),
+    ]);
+
+    const chip = screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    });
+    expect(chip).toHaveClass("pr-chip--pending", "pr-chip--draft");
+
+    fireEvent.click(chip);
+    expect(open).toHaveBeenCalledWith(
+      deepLink,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+
+  it("returns to unknown status when the last matching PR metadata disappears", () => {
+    const text = `Draft PR: [Giphy/giphy-services#13290](${PR_URL})`;
+    const { rerender } = renderWithPullRequests(text, [prSummary()]);
+
+    const hydratedChip = screen.getByRole("button", {
+      name: /draft · checks pending/,
+    });
+    fireEvent.mouseEnter(hydratedChip);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Document JDK 17 for EMR jobs",
+    );
+
+    rerender(
+      <PullRequestLinkProvider threads={[threadSummary([])]}>
+        <ThreadMarkdown text={text} />
+      </PullRequestLinkProvider>,
+    );
+
+    const fallbackChip = screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(status unknown\) in browser/,
+    });
+    expect(fallbackChip).toHaveClass("pr-chip--unknown");
+    expect(fallbackChip).not.toHaveClass("pr-chip--draft");
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Giphy/giphy-services#13290 — status unknown",
+    );
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent(
+      "Document JDK 17 for EMR jobs",
+    );
+  });
+
   it("renders an unhydrated bare GitHub PR URL as an unknown-status chip", () => {
     renderWithPullRequests(`Draft PR: ${PR_URL}`, []);
 

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -46,6 +46,7 @@ function samePullRequestChip(
  * are notified; ThreadMarkdown stays behind a stable context value.
  */
 class PullRequestLinkMetadataStore {
+  private hydratedSnapshots = new WeakMap<PrSummary, Map<string, PrSummary>>();
   private listeners = new Map<string, Set<() => void>>();
   private prs = new Map<string, PrSummary>();
 
@@ -54,7 +55,29 @@ class PullRequestLinkMetadataStore {
   }
 
   getSnapshot(fallback: PrSummary): PrSummary {
-    return this.prs.get(buildPullRequestStatusKey(fallback)) ?? fallback;
+    const live = this.prs.get(buildPullRequestStatusKey(fallback));
+    if (!live) {
+      return fallback;
+    }
+    if (live.url === fallback.url) {
+      return live;
+    }
+
+    // Status/title metadata belongs to the PR identity, but the URL belongs to
+    // this authored transcript link. Preserve deep links such as /files or a
+    // discussion fragment instead of replacing them with the cached root URL.
+    const snapshotsByUrl = this.hydratedSnapshots.get(live) ?? new Map();
+    const cached = snapshotsByUrl.get(fallback.url);
+    if (cached) {
+      return cached;
+    }
+    const hydrated = {
+      ...live,
+      url: fallback.url,
+    };
+    snapshotsByUrl.set(fallback.url, hydrated);
+    this.hydratedSnapshots.set(live, snapshotsByUrl);
+    return hydrated;
   }
 
   subscribe(pr: PrSummary, listener: () => void): () => void {
@@ -138,8 +161,10 @@ export function PullRequestLinkProvider(props: {
         return store.getSnapshot(fallback);
       },
       resolve(href) {
-        const fallback = parseGitHubPullRequestUrl(href);
-        return fallback ? store.getSnapshot(fallback) : undefined;
+        // Keep the parsed unknown summary as the chip's durable fallback. The
+        // live hook hydrates it synchronously from the store, and can return to
+        // it if the last matching navigation PR is later detached.
+        return parseGitHubPullRequestUrl(href);
       },
       subscribe(pr, listener) {
         return store.subscribe(pr, listener);

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -1,0 +1,230 @@
+import {
+  buildPullRequestStatusKey,
+  type NavigationThreadSummary,
+  type PrSummary,
+} from "@pwragent/shared";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+type PullRequestLinkContextValue = {
+  getSnapshot: (fallback: PrSummary) => PrSummary;
+  resolve: (href: string) => PrSummary | undefined;
+  subscribe: (pr: PrSummary, listener: () => void) => () => void;
+};
+
+function samePullRequestChip(
+  left: PrSummary | undefined,
+  right: PrSummary,
+): boolean {
+  return Boolean(
+    left
+    && left.provider === right.provider
+    && left.org === right.org
+    && left.repo === right.repo
+    && left.number === right.number
+    && left.title === right.title
+    && left.state === right.state
+    && left.checkState === right.checkState
+    && left.lifecycleState === right.lifecycleState
+    && left.reviewState === right.reviewState
+    && left.mergeState === right.mergeState
+    && left.url === right.url,
+  );
+}
+
+/**
+ * Live PR metadata keyed by the same provider/repo/number identity used by the
+ * pullRequest/status/updated navigation patcher. Only chips for a changed PR
+ * are notified; ThreadMarkdown stays behind a stable context value.
+ */
+class PullRequestLinkMetadataStore {
+  private listeners = new Map<string, Set<() => void>>();
+  private prs = new Map<string, PrSummary>();
+
+  constructor(threads: NavigationThreadSummary[]) {
+    this.prs = pullRequestsByKey(threads);
+  }
+
+  getSnapshot(fallback: PrSummary): PrSummary {
+    return this.prs.get(buildPullRequestStatusKey(fallback)) ?? fallback;
+  }
+
+  subscribe(pr: PrSummary, listener: () => void): () => void {
+    const key = buildPullRequestStatusKey(pr);
+    const listeners = this.listeners.get(key) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(key, listeners);
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.listeners.delete(key);
+      }
+    };
+  }
+
+  update(threads: NavigationThreadSummary[]): void {
+    const candidates = pullRequestsByKey(threads);
+    const nextPrs = new Map<string, PrSummary>();
+    const changedKeys = new Set<string>();
+
+    for (const [key, candidate] of candidates) {
+      const previous = this.prs.get(key);
+      const unchanged = samePullRequestChip(previous, candidate);
+      nextPrs.set(key, unchanged && previous ? previous : candidate);
+      if (!unchanged) {
+        changedKeys.add(key);
+      }
+    }
+
+    for (const key of this.prs.keys()) {
+      if (!nextPrs.has(key)) {
+        changedKeys.add(key);
+      }
+    }
+
+    this.prs = nextPrs;
+    for (const key of changedKeys) {
+      for (const listener of this.listeners.get(key) ?? []) {
+        listener();
+      }
+    }
+  }
+}
+
+function pullRequestsByKey(
+  threads: NavigationThreadSummary[],
+): Map<string, PrSummary> {
+  const prs = new Map<string, PrSummary>();
+  for (const thread of threads) {
+    for (const pr of thread.prs ?? []) {
+      const key = buildPullRequestStatusKey(pr);
+      if (!prs.has(key)) {
+        prs.set(key, pr);
+      }
+    }
+  }
+  return prs;
+}
+
+const PullRequestLinkContext =
+  createContext<PullRequestLinkContextValue | undefined>(undefined);
+
+export function PullRequestLinkProvider(props: {
+  children: ReactNode;
+  threads: NavigationThreadSummary[];
+}) {
+  const storeRef = useRef<PullRequestLinkMetadataStore | null>(null);
+  if (!storeRef.current) {
+    storeRef.current = new PullRequestLinkMetadataStore(props.threads);
+  }
+  const store = storeRef.current;
+
+  useLayoutEffect(() => {
+    store.update(props.threads);
+  }, [props.threads, store]);
+
+  const value = useMemo<PullRequestLinkContextValue>(
+    () => ({
+      getSnapshot(fallback) {
+        return store.getSnapshot(fallback);
+      },
+      resolve(href) {
+        const fallback = parseGitHubPullRequestUrl(href);
+        return fallback ? store.getSnapshot(fallback) : undefined;
+      },
+      subscribe(pr, listener) {
+        return store.subscribe(pr, listener);
+      },
+    }),
+    [store],
+  );
+
+  return (
+    <PullRequestLinkContext.Provider value={value}>
+      {props.children}
+    </PullRequestLinkContext.Provider>
+  );
+}
+
+export function usePullRequestLinks(): PullRequestLinkContextValue | undefined {
+  return useContext(PullRequestLinkContext);
+}
+
+export function useLivePullRequest(pr: PrSummary): PrSummary {
+  const links = usePullRequestLinks();
+  const subscribe = useCallback(
+    (listener: () => void) => links?.subscribe(pr, listener) ?? (() => {}),
+    [links, pr],
+  );
+  const getSnapshot = useCallback(
+    () => links?.getSnapshot(pr) ?? pr,
+    [links, pr],
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => pr,
+  );
+}
+
+export function resolvePullRequestHref(
+  href: string,
+  links: PullRequestLinkContextValue | undefined,
+): PrSummary | undefined {
+  return links?.resolve(href);
+}
+
+export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return undefined;
+  }
+
+  if (parsed.protocol !== "https:" || parsed.hostname.toLowerCase() !== "github.com") {
+    return undefined;
+  }
+
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length < 4 || segments[2] !== "pull") {
+    return undefined;
+  }
+  const numberText = segments[3] ?? "";
+  if (!/^[1-9]\d*$/.test(numberText)) {
+    return undefined;
+  }
+
+  const org = decodeUrlSegment(segments[0] ?? "");
+  const repo = decodeUrlSegment(segments[1] ?? "");
+  if (!org || !repo) {
+    return undefined;
+  }
+
+  return {
+    provider: "github.com",
+    org,
+    repo,
+    number: Number.parseInt(numberText, 10),
+    state: "unknown",
+    url: href,
+  };
+}
+
+function decodeUrlSegment(value: string): string | undefined {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/transcript-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/transcript-links.tsx
@@ -1,0 +1,27 @@
+import type {
+  AppServerBackendKind,
+  NavigationThreadSummary,
+} from "@pwragent/shared";
+import type { ReactNode } from "react";
+import { PullRequestLinkProvider } from "./pull-request-links";
+import { ThreadLinkProvider } from "./thread-links";
+
+export function TranscriptLinkProvider(props: {
+  children: ReactNode;
+  onShowThread: (request: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }) => void;
+  threads: NavigationThreadSummary[];
+}) {
+  return (
+    <ThreadLinkProvider
+      onShowThread={props.onShowThread}
+      threads={props.threads}
+    >
+      <PullRequestLinkProvider threads={props.threads}>
+        {props.children}
+      </PullRequestLinkProvider>
+    </ThreadLinkProvider>
+  );
+}


### PR DESCRIPTION
## Summary

- detect GitHub pull-request URLs in transcript markdown and render the shared PR chip
- hydrate matching links from the existing navigation PR snapshot and status notification flow
- update only chips for the affected provider/repository/number identity
- reuse existing check, draft, conflict, merged, closed, tooltip, and browser-open behavior
- update already-visible PR tooltips when live status metadata changes

## Status flow

The renderer does not introduce another GitHub poller or independent PR cache. Main’s existing `pullRequest/status/updated` notifications patch matching `thread.prs` entries in navigation. A keyed external store exposes those snapshots to transcript chips while keeping the markdown context stable, so status changes rerender only matching chips and do not reparse the transcript.

## Behavior

Known PRs render with their hydrated status and title. Valid GitHub PR URLs without current navigation metadata render in the shared neutral unknown-status mode and upgrade automatically if matching metadata appears. Non-PR links and ThreadMarkdown surfaces without navigation metadata remain ordinary links.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx`
- scoped ESLint on the new and changed PR-link implementation files
- `pnpm typecheck`
- `git diff --check`
