### PR TITLE
fix(desktop): support Codex protocol 0.144

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,14 @@ updates:
         update-types:
           - "version-update:semver-major"
     groups:
+      agent-kit:
+        patterns:
+          - "@pwrdrvr/agent-*"
+          - "@pwrdrvr/codex-*"
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       vite-toolchain:
         patterns:
           - "vite"
@@ -95,6 +103,8 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
+          - "@pwrdrvr/agent-*"
+          - "@pwrdrvr/codex-*"
           - "@tiptap/*"
           - "prosemirror-*"
           - "better-sqlite3"

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -63,7 +63,7 @@ MIT
 - @pwrdrvr/agent-core@0.2.0 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/agent-transport@0.1.6 | https://github.com/pwrdrvr/agent-kit
 - @pwrdrvr/codex-app-server-protocol@0.133.0 | https://github.com/pwrdrvr/codex-app-server-protocol
-- @pwrdrvr/codex-app-server-protocol@0.135.0 | https://github.com/pwrdrvr/codex-app-server-protocol
+- @pwrdrvr/codex-app-server-protocol@0.144.0 | https://github.com/pwrdrvr/codex-app-server-protocol
 - @pwrdrvr/codex-discovery@0.1.4 | https://github.com/pwrdrvr/agent-kit
 - @shutterstock/p-map-iterable@1.1.2 | https://github.com/shutterstock/p-map-iterable
 - @tiptap/core@3.27.1 | https://github.com/ueberdosis/tiptap
@@ -327,7 +327,7 @@ Applies to:
 - @pwrdrvr/agent-core@0.2.0 (MIT)
 - @pwrdrvr/agent-transport@0.1.6 (MIT)
 - @pwrdrvr/codex-app-server-protocol@0.133.0 (MIT)
-- @pwrdrvr/codex-app-server-protocol@0.135.0 (MIT)
+- @pwrdrvr/codex-app-server-protocol@0.144.0 (MIT)
 - @pwrdrvr/codex-discovery@0.1.4 (MIT)
 
 Representative file: @pwrdrvr/agent-acp@0.12.2/LICENSE

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -60,7 +60,7 @@
     "@pwrdrvr/agent-client": "^0.6.1",
     "@pwrdrvr/agent-core": "^0.2.0",
     "@pwrdrvr/agent-transport": "^0.1.6",
-    "@pwrdrvr/codex-app-server-protocol": "0.135.0",
+    "@pwrdrvr/codex-app-server-protocol": "0.144.0",
     "@pwrdrvr/codex-discovery": "^0.1.4",
     "@shutterstock/p-map-iterable": "^1.1.2",
     "@tiptap/extension-mention": "^3.22.5",

--- a/apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-inspection-codex-tools.test.ts
@@ -8,20 +8,26 @@ import {
 describe("automation inspection Codex dynamic tools", () => {
   it("projects automation inspection tools into dynamic tool specs", () => {
     expect(buildAutomationInspectionDynamicToolSpecs()).toEqual(
-      expect.arrayContaining([
+      [
         expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-          inputSchema: expect.objectContaining({ type: "object" }),
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent",
+          tools: expect.arrayContaining([
+            expect.objectContaining({
+              type: "function",
+              name: "list_automations",
+              inputSchema: expect.objectContaining({ type: "object" }),
+              deferLoading: false,
+            }),
+            expect.objectContaining({
+              type: "function",
+              name: "get_automation_run_artifact",
+              inputSchema: expect.objectContaining({ type: "object" }),
+              deferLoading: false,
+            }),
+          ]),
         }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_automation_run_artifact",
-          inputSchema: expect.objectContaining({ type: "object" }),
-          deferLoading: false,
-        }),
-      ]),
+      ],
     );
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15220,7 +15220,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("handles automation inspection dynamic tool calls without surfacing pending requests", async () => {
+  it("handles namespace-less legacy automation calls without surfacing pending requests", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
     });
@@ -15277,7 +15277,7 @@ command = "pnpm dev"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_automations",
+        namespace: null,
         tool: "list_automations",
         arguments: {
           limit: 2,
@@ -22412,7 +22412,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("creates task monitor delegations for active Codex turns", async () => {
+  it("creates task monitor delegations from namespace-less legacy calls", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
       models: TEST_TASK_MONITOR_MODELS,
@@ -22444,7 +22444,7 @@ script = "printf setup"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_task_monitors",
+        namespace: null,
         tool: "create_monitor_delegation",
         arguments: {
           task: "Watch PR #123 checks until they finish.",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -99,6 +99,42 @@ vi.mock("../window-show-thread", () => ({
   requestShowThread: requestShowThreadMock,
 }));
 
+type DynamicToolTestSpec = {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    required?: string[];
+  };
+};
+
+function pwragentDynamicTools(dynamicTools: unknown): DynamicToolTestSpec[] {
+  if (!Array.isArray(dynamicTools)) {
+    return [];
+  }
+  const namespace = dynamicTools.find(
+    (tool): tool is { type: "namespace"; name: string; tools: unknown[] } =>
+      Boolean(tool)
+      && typeof tool === "object"
+      && (tool as { type?: unknown }).type === "namespace"
+      && (tool as { name?: unknown }).name === "pwragent"
+      && Array.isArray((tool as { tools?: unknown }).tools),
+  );
+  return namespace?.tools as DynamicToolTestSpec[] ?? [];
+}
+
+function expectPwragentDynamicTools(dynamicTools: unknown, names: string[]): void {
+  expect(pwragentDynamicTools(dynamicTools)).toEqual(
+    expect.arrayContaining(
+      names.map((name) =>
+        expect.objectContaining({
+          type: "function",
+          name,
+        }),
+      ),
+    ),
+  );
+}
+
 // These tests pre-date the agent-core Grok experimental flag and exercise
 // the direct xAI HTTP provider's behavior (model warm-up, availability
 // reporting, etc.). The flag now defaults to off; enable it for this file
@@ -5849,48 +5885,16 @@ script = "echo setup"
 
     await registry.startThread({ backend: "codex" });
 
-    const dynamicTools = codexClient.lastStartThreadParams?.dynamicTools as
-      | Array<{ namespace: string; name: string }>
-      | undefined;
-    expect(dynamicTools).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "manage_pwragent",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "search_threads",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "read_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_current_messaging_surface",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "handoff_task",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "send_message_to_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "create_monitor_delegation",
-        }),
-      ]),
-    );
-    expect(new Set(dynamicTools?.map((tool) => tool.namespace))).toEqual(
-      new Set(["pwragent"]),
-    );
+    expectPwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools, [
+      "list_automations",
+      "manage_pwragent",
+      "search_threads",
+      "read_thread",
+      "get_current_messaging_surface",
+      "handoff_task",
+      "send_message_to_thread",
+      "create_monitor_delegation",
+    ]);
 
     await registry.close();
   });
@@ -5920,113 +5924,35 @@ script = "echo setup"
       },
     });
 
-    expect(codexClient.lastStartThreadParams?.dynamicTools).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_automation_run_artifact",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "create_monitor_delegation",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "manage_pwragent",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "search_threads",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "read_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_thread_status",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "mutate_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_current_messaging_surface",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "attach_thread_here",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "handoff_task",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "send_message_to_thread",
-        }),
-      ]),
-    );
-    expect(
-      new Set(
-        (codexClient.lastStartThreadParams?.dynamicTools as Array<{
-          namespace: string;
-        }>).map((tool) => tool.namespace),
-      ),
-    ).toEqual(
-      new Set(["pwragent"]),
-    );
-    expect(
-      (codexClient.lastStartThreadParams?.dynamicTools as Array<{
-        namespace: string;
-        name: string;
-      }> | undefined)
-        ?.filter((tool) => tool.name === "create_monitor_delegation")
-        .map((tool) => tool.name),
-    ).toEqual(["create_monitor_delegation"]);
-    const getThreadStatusTool = (
-      codexClient.lastStartThreadParams?.dynamicTools as Array<{
-        description?: string;
-        inputSchema?: {
-          required?: string[];
-        };
-        name: string;
-        namespace: string;
-      }> | undefined
-    )?.find((tool) => tool.name === "get_thread_status");
+    const dynamicTools = codexClient.lastStartThreadParams?.dynamicTools;
+    expectPwragentDynamicTools(dynamicTools, [
+      "list_automations",
+      "get_automation_run_artifact",
+      "create_monitor_delegation",
+      "manage_pwragent",
+      "search_threads",
+      "read_thread",
+      "get_thread_status",
+      "mutate_thread",
+      "get_current_messaging_surface",
+      "attach_thread_here",
+      "handoff_task",
+      "send_message_to_thread",
+    ]);
+    const getThreadStatusTool = pwragentDynamicTools(dynamicTools)
+      .find((tool) => tool.name === "get_thread_status");
     expect(getThreadStatusTool?.description).toContain(
       "Omit backend and threadId to inspect the current thread",
     );
     expect(getThreadStatusTool?.inputSchema?.required ?? []).toEqual([]);
-    const attachPullRequestTool = (
-      codexClient.lastStartThreadParams?.dynamicTools as Array<{
-        description?: string;
-        inputSchema?: {
-          required?: string[];
-        };
-        name: string;
-        namespace: string;
-      }> | undefined
-    )?.find((tool) => tool.name === "attach_thread_pull_request");
+    const attachPullRequestTool = pwragentDynamicTools(dynamicTools)
+      .find((tool) => tool.name === "attach_thread_pull_request");
     expect(attachPullRequestTool?.description).toContain(
       "Omit backend and threadId to attach to the current thread",
     );
     expect(attachPullRequestTool?.inputSchema?.required ?? []).toEqual([]);
-    const checkPullRequestStatusTool = (
-      codexClient.lastStartThreadParams?.dynamicTools as Array<{
-        description?: string;
-        inputSchema?: {
-          required?: string[];
-        };
-        name: string;
-        namespace: string;
-      }> | undefined
-    )?.find((tool) => tool.name === "check_thread_pull_request_status");
+    const checkPullRequestStatusTool = pwragentDynamicTools(dynamicTools)
+      .find((tool) => tool.name === "check_thread_pull_request_status");
     expect(checkPullRequestStatusTool?.description).toContain(
       "Omit backend and threadId to check the current thread",
     );
@@ -6067,50 +5993,16 @@ script = "echo setup"
       input: [{ type: "text", text: "continue" }],
     });
 
-    expect(codexClient.lastStartTurnParams?.dynamicTools).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "manage_pwragent",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "search_threads",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "read_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_current_messaging_surface",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "handoff_task",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "send_message_to_thread",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "create_monitor_delegation",
-        }),
-      ]),
-    );
-    expect(
-      (codexClient.lastStartTurnParams?.dynamicTools as Array<{
-        namespace: string;
-        name: string;
-      }> | undefined)
-        ?.filter((tool) => tool.name === "create_monitor_delegation")
-        .map((tool) => tool.name),
-    ).toEqual(["create_monitor_delegation"]);
+    expectPwragentDynamicTools(codexClient.lastStartTurnParams?.dynamicTools, [
+      "list_automations",
+      "manage_pwragent",
+      "search_threads",
+      "read_thread",
+      "get_current_messaging_surface",
+      "handoff_task",
+      "send_message_to_thread",
+      "create_monitor_delegation",
+    ]);
 
     await registry.close();
   });
@@ -6153,34 +6045,14 @@ script = "echo setup"
       input: [{ type: "text", text: "continue" }],
     });
 
-    expect(codexClient.lastStartTurnParams?.dynamicTools).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "search_threads",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "manage_pwragent",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "attach_thread_here",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "handoff_task",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "create_monitor_delegation",
-        }),
-      ]),
-    );
+    expectPwragentDynamicTools(codexClient.lastStartTurnParams?.dynamicTools, [
+      "list_automations",
+      "search_threads",
+      "manage_pwragent",
+      "attach_thread_here",
+      "handoff_task",
+      "create_monitor_delegation",
+    ]);
 
     await registry.close();
   });
@@ -8275,34 +8147,14 @@ script = "pnpm install"
       },
     });
 
-    expect(codexClient.lastStartThreadParams?.dynamicTools).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "list_automations",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "search_threads",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "manage_pwragent",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "get_current_messaging_surface",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "attach_thread_here",
-        }),
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "handoff_task",
-        }),
-      ]),
-    );
+    expectPwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools, [
+      "list_automations",
+      "search_threads",
+      "manage_pwragent",
+      "get_current_messaging_surface",
+      "attach_thread_here",
+      "handoff_task",
+    ]);
 
     await registry.close();
   });
@@ -8412,13 +8264,10 @@ script = "pnpm install"
       fastMode: undefined,
       approvalPolicy: "on-request",
       sandbox: "workspace-write",
-      dynamicTools: expect.arrayContaining([
-        expect.objectContaining({
-          namespace: "pwragent",
-          name: "create_monitor_delegation",
-        }),
-      ]),
     });
+    expectPwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools, [
+      "create_monitor_delegation",
+    ]);
 
     await registry.close();
   });
@@ -22656,10 +22505,8 @@ script = "printf setup"
       sandbox: "workspace-write",
     });
     expect(codexClient.lastStartThreadParams?.threadSource).toBeUndefined();
-    expect(
-      (codexClient.lastStartThreadParams?.dynamicTools as Array<{ name: string }> | undefined)
-        ?.map((tool) => tool.name),
-    ).toEqual(["inject_progress", "complete_monitoring"]);
+    expect(pwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools)
+      .map((tool) => tool.name)).toEqual(["inject_progress", "complete_monitoring"]);
     expect(codexClient.startTurnCallCount).toBe(1);
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "monitor-thread",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -5971,7 +5971,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("advertises PwrAgent dynamic tools when continuing existing Codex threads", async () => {
+  it("does not attempt to refresh dynamic tools on existing Codex threads", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
@@ -5993,21 +5993,12 @@ script = "echo setup"
       input: [{ type: "text", text: "continue" }],
     });
 
-    expectPwragentDynamicTools(codexClient.lastStartTurnParams?.dynamicTools, [
-      "list_automations",
-      "manage_pwragent",
-      "search_threads",
-      "read_thread",
-      "get_current_messaging_surface",
-      "handoff_task",
-      "send_message_to_thread",
-      "create_monitor_delegation",
-    ]);
+    expect(codexClient.lastStartTurnParams?.dynamicTools).toBeUndefined();
 
     await registry.close();
   });
 
-  it("preserves Agent dynamic tools when continuing existing Agent Codex threads", async () => {
+  it("relies on persisted dynamic tools when continuing Agent Codex threads", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {
         serverInfo: { name: "Codex App Server", version: "1.0.0" },
@@ -6045,14 +6036,7 @@ script = "echo setup"
       input: [{ type: "text", text: "continue" }],
     });
 
-    expectPwragentDynamicTools(codexClient.lastStartTurnParams?.dynamicTools, [
-      "list_automations",
-      "search_threads",
-      "manage_pwragent",
-      "attach_thread_here",
-      "handoff_task",
-      "create_monitor_delegation",
-    ]);
+    expect(codexClient.lastStartTurnParams?.dynamicTools).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5573,7 +5573,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("uses the 0.144 App Server wire contracts for all dynamic-tool request sites", async () => {
+  it("uses the 0.144 App Server wire contracts and advertises tools only at thread start", async () => {
     MockTransport.serverVersion = "0.144.0";
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const dynamicTools: DynamicToolSpec[] = [
@@ -5612,7 +5612,6 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-existing",
       input: [{ type: "text", text: "Continue" }],
       approvalPolicy: "on-failure",
-      dynamicTools,
     });
 
     const requests = MockTransport.instances.at(-1)!.sentMessages.map(
@@ -5640,9 +5639,9 @@ describe("CodexAppServerClient", () => {
       expect(payload).toMatchObject({ approvalPolicy: "on-request" });
     }
     expect(turnStart).toMatchObject({ approvalPolicy: "on-request" });
-    for (const payload of [threadStart, threadResume, turnStart]) {
-      expect(payload?.dynamicTools).toEqual(dynamicTools);
-    }
+    expect(threadStart?.dynamicTools).toEqual(dynamicTools);
+    expect(threadResume).not.toHaveProperty("dynamicTools");
+    expect(turnStart).not.toHaveProperty("dynamicTools");
 
     await client.close();
   });
@@ -5698,7 +5697,6 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-existing",
       input: [{ type: "text", text: "Continue" }],
       approvalPolicy: "on-failure",
-      dynamicTools,
     });
 
     const requests = MockTransport.instances.at(-1)!.sentMessages.map(
@@ -5728,9 +5726,9 @@ describe("CodexAppServerClient", () => {
       });
     }
     expect(turnStart).toMatchObject({ approvalPolicy: "on-failure" });
-    for (const payload of [threadStart, threadResume, turnStart]) {
-      expect(payload?.dynamicTools).toEqual(legacyDynamicTools);
-    }
+    expect(threadStart?.dynamicTools).toEqual(legacyDynamicTools);
+    expect(threadResume).not.toHaveProperty("dynamicTools");
+    expect(turnStart).not.toHaveProperty("dynamicTools");
 
     await client.close();
   });
@@ -6689,7 +6687,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("passes dynamic tool specs when resuming and starting a turn on an existing thread", async () => {
+  it("does not resend dynamic tools when resuming or starting a turn", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 
     const client = new CodexAppServerClient({
@@ -6700,25 +6698,6 @@ describe("CodexAppServerClient", () => {
     await client.startTurn({
       threadId: "thread-2",
       input: [{ type: "text", text: "Reply to the existing thread" }],
-      dynamicTools: [
-        {
-          type: "namespace",
-          name: "pwragent_task_monitors",
-          description: "PwrAgent task-monitoring tools.",
-          tools: [
-            {
-              type: "function",
-              name: "create_monitor_delegation",
-              description: "Delegate monitoring work.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-              },
-              deferLoading: false,
-            },
-          ],
-        },
-      ],
     });
 
     const transport = MockTransport.instances.at(-1);
@@ -6730,50 +6709,10 @@ describe("CodexAppServerClient", () => {
       .map((message) => JSON.parse(message) as { method?: string; params?: unknown })
       .find((payload) => payload.method === "turn/start");
 
-    expect(resumePayload?.params).toMatchObject({
-      threadId: "thread-2",
-      dynamicTools: [
-        {
-          type: "namespace",
-          name: "pwragent_task_monitors",
-          description: "PwrAgent task-monitoring tools.",
-          tools: [
-            {
-              type: "function",
-              name: "create_monitor_delegation",
-              description: "Delegate monitoring work.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-              },
-              deferLoading: false,
-            },
-          ],
-        },
-      ],
-    });
-    expect(turnStartPayload?.params).toMatchObject({
-      threadId: "thread-2",
-      dynamicTools: [
-        {
-          type: "namespace",
-          name: "pwragent_task_monitors",
-          description: "PwrAgent task-monitoring tools.",
-          tools: [
-            {
-              type: "function",
-              name: "create_monitor_delegation",
-              description: "Delegate monitoring work.",
-              inputSchema: {
-                type: "object",
-                additionalProperties: false,
-              },
-              deferLoading: false,
-            },
-          ],
-        },
-      ],
-    });
+    expect(resumePayload?.params).toEqual({ threadId: "thread-2" });
+    expect(turnStartPayload?.params).toMatchObject({ threadId: "thread-2" });
+    expect(resumePayload?.params).not.toHaveProperty("dynamicTools");
+    expect(turnStartPayload?.params).not.toHaveProperty("dynamicTools");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
+import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
 
 const codexClientLogError = vi.hoisted(() => vi.fn());
 const codexClientLogDebug = vi.hoisted(() => vi.fn());
@@ -21,6 +22,7 @@ vi.mock("../log", () => ({
 
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
+  static serverVersion = "1.0.0";
   static readThreadErrorByThreadId = new Map<string, { code: number; message: string }>();
   static readThreadResultByThreadId = new Map<string, unknown>();
   static threadStartResult: unknown = {
@@ -134,7 +136,7 @@ class MockTransport implements JsonRpcTransport {
           result: {
             serverInfo: {
               name: "Codex App Server",
-              version: "1.0.0"
+              version: MockTransport.serverVersion,
             }
           }
         })
@@ -969,6 +971,7 @@ describe("CodexAppServerClient", () => {
     codexClientLogInfo.mockClear();
     codexClientLogWarn.mockClear();
     MockTransport.instances.length = 0;
+    MockTransport.serverVersion = "1.0.0";
     MockTransport.readThreadErrorByThreadId.clear();
     MockTransport.readThreadResultByThreadId.clear();
     MockTransport.threadStartResult = {
@@ -5468,7 +5471,6 @@ describe("CodexAppServerClient", () => {
         "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
       },
       excludeTurns: true,
-      persistExtendedHistory: false,
       threadSource: "user",
     });
 
@@ -5501,7 +5503,6 @@ describe("CodexAppServerClient", () => {
       path: "/Users/example/.codex/sessions/source-thread.jsonl",
       cwd: "/Users/example/project",
       excludeTurns: true,
-      persistExtendedHistory: false,
       threadSource: "user",
     });
 
@@ -5520,14 +5521,21 @@ describe("CodexAppServerClient", () => {
       cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
       dynamicTools: [
         {
-          namespace: "pwragent_automations",
-          name: "list_automations",
-          description: "List attached automations.",
-          inputSchema: {
-            type: "object",
-            additionalProperties: false,
-          },
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent_automations",
+          description: "PwrAgent automation tools.",
+          tools: [
+            {
+              type: "function",
+              name: "list_automations",
+              description: "List attached automations.",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+              },
+              deferLoading: false,
+            },
+          ],
         },
       ],
     });
@@ -5542,17 +5550,186 @@ describe("CodexAppServerClient", () => {
       cwd: "/Users/huntharo/.pwragent/projects/2026-04-16-ab12cd",
       dynamicTools: [
         {
-          namespace: "pwragent_automations",
-          name: "list_automations",
-          description: "List attached automations.",
-          inputSchema: {
-            type: "object",
-            additionalProperties: false,
-          },
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent_automations",
+          description: "PwrAgent automation tools.",
+          tools: [
+            {
+              type: "function",
+              name: "list_automations",
+              description: "List attached automations.",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+              },
+              deferLoading: false,
+            },
+          ],
         },
       ],
     });
+
+    await client.close();
+  });
+
+  it("uses the 0.144 App Server wire contracts for all dynamic-tool request sites", async () => {
+    MockTransport.serverVersion = "codex-cli 0.144.0";
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const dynamicTools: DynamicToolSpec[] = [
+      {
+        type: "namespace",
+        name: "pwragent",
+        description: "PwrAgent tools.",
+        tools: [
+          {
+            type: "function",
+            name: "search_threads",
+            description: "Search PwrAgent threads.",
+            inputSchema: {
+              type: "object",
+              additionalProperties: false,
+            },
+            deferLoading: false,
+          },
+        ],
+      },
+    ];
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      approvalPolicy: "on-failure",
+      dynamicTools,
+    });
+    await client.forkThread({
+      threadId: "thread-to-fork",
+      approvalPolicy: "on-failure",
+    });
+    await client.startTurn({
+      threadId: "thread-existing",
+      input: [{ type: "text", text: "Continue" }],
+      approvalPolicy: "on-failure",
+      dynamicTools,
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) =>
+        JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+    );
+    const threadStart = requests.find(
+      (request) => request.method === "thread/start",
+    )?.params;
+    const threadFork = requests.find(
+      (request) => request.method === "thread/fork",
+    )?.params;
+    const threadResume = requests.find(
+      (request) => request.method === "thread/resume",
+    )?.params;
+    const turnStart = requests.find(
+      (request) => request.method === "turn/start",
+    )?.params;
+
+    for (const payload of [threadStart, threadFork, threadResume]) {
+      expect(payload).not.toHaveProperty("persistExtendedHistory");
+      expect(payload).toMatchObject({ approvalPolicy: "on-request" });
+    }
+    expect(turnStart).toMatchObject({ approvalPolicy: "on-request" });
+    for (const payload of [threadStart, threadResume, turnStart]) {
+      expect(payload?.dynamicTools).toEqual(dynamicTools);
+    }
+
+    await client.close();
+  });
+
+  it("preserves the 0.135 App Server wire contracts for local old servers", async () => {
+    MockTransport.serverVersion = "codex-cli 0.135.0";
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const dynamicTools: DynamicToolSpec[] = [
+      {
+        type: "namespace",
+        name: "pwragent",
+        description: "PwrAgent tools.",
+        tools: [
+          {
+            type: "function",
+            name: "search_threads",
+            description: "Search PwrAgent threads.",
+            inputSchema: {
+              type: "object",
+              additionalProperties: false,
+            },
+            deferLoading: false,
+          },
+        ],
+      },
+    ];
+    const legacyDynamicTools = [
+      {
+        namespace: "pwragent",
+        name: "search_threads",
+        description: "Search PwrAgent threads.",
+        inputSchema: {
+          type: "object",
+          additionalProperties: false,
+        },
+        deferLoading: false,
+      },
+    ];
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await client.startThread({
+      approvalPolicy: "on-failure",
+      dynamicTools,
+    });
+    await client.forkThread({
+      threadId: "thread-to-fork",
+      approvalPolicy: "on-failure",
+    });
+    await client.startTurn({
+      threadId: "thread-existing",
+      input: [{ type: "text", text: "Continue" }],
+      approvalPolicy: "on-failure",
+      dynamicTools,
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) =>
+        JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+    );
+    const threadStart = requests.find(
+      (request) => request.method === "thread/start",
+    )?.params;
+    const threadFork = requests.find(
+      (request) => request.method === "thread/fork",
+    )?.params;
+    const threadResume = requests.find(
+      (request) => request.method === "thread/resume",
+    )?.params;
+    const turnStart = requests.find(
+      (request) => request.method === "turn/start",
+    )?.params;
+
+    for (const payload of [threadStart, threadFork, threadResume]) {
+      expect(payload).toMatchObject({
+        approvalPolicy: "on-failure",
+        persistExtendedHistory: false,
+      });
+    }
+    expect(turnStart).toMatchObject({ approvalPolicy: "on-failure" });
+    for (const payload of [threadStart, threadResume, turnStart]) {
+      expect(payload?.dynamicTools).toEqual(legacyDynamicTools);
+    }
 
     await client.close();
   });
@@ -6524,14 +6701,21 @@ describe("CodexAppServerClient", () => {
       input: [{ type: "text", text: "Reply to the existing thread" }],
       dynamicTools: [
         {
-          namespace: "pwragent_task_monitors",
-          name: "create_monitor_delegation",
-          description: "Delegate monitoring work.",
-          inputSchema: {
-            type: "object",
-            additionalProperties: false,
-          },
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent_task_monitors",
+          description: "PwrAgent task-monitoring tools.",
+          tools: [
+            {
+              type: "function",
+              name: "create_monitor_delegation",
+              description: "Delegate monitoring work.",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+              },
+              deferLoading: false,
+            },
+          ],
         },
       ],
     });
@@ -6549,14 +6733,21 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       dynamicTools: [
         {
-          namespace: "pwragent_task_monitors",
-          name: "create_monitor_delegation",
-          description: "Delegate monitoring work.",
-          inputSchema: {
-            type: "object",
-            additionalProperties: false,
-          },
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent_task_monitors",
+          description: "PwrAgent task-monitoring tools.",
+          tools: [
+            {
+              type: "function",
+              name: "create_monitor_delegation",
+              description: "Delegate monitoring work.",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+              },
+              deferLoading: false,
+            },
+          ],
         },
       ],
     });
@@ -6564,14 +6755,21 @@ describe("CodexAppServerClient", () => {
       threadId: "thread-2",
       dynamicTools: [
         {
-          namespace: "pwragent_task_monitors",
-          name: "create_monitor_delegation",
-          description: "Delegate monitoring work.",
-          inputSchema: {
-            type: "object",
-            additionalProperties: false,
-          },
-          deferLoading: false,
+          type: "namespace",
+          name: "pwragent_task_monitors",
+          description: "PwrAgent task-monitoring tools.",
+          tools: [
+            {
+              type: "function",
+              name: "create_monitor_delegation",
+              description: "Delegate monitoring work.",
+              inputSchema: {
+                type: "object",
+                additionalProperties: false,
+              },
+              deferLoading: false,
+            },
+          ],
         },
       ],
     });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -134,10 +134,11 @@ class MockTransport implements JsonRpcTransport {
           jsonrpc: "2.0",
           id: payload.id,
           result: {
-            serverInfo: {
-              name: "Codex App Server",
-              version: MockTransport.serverVersion,
-            }
+            userAgent:
+              `codex_cli_rs/${MockTransport.serverVersion} (Mac OS 26.0; arm64)`,
+            codexHome: "/Users/huntharo/.codex",
+            platformFamily: "unix",
+            platformOs: "macos",
           }
         })
       );
@@ -5573,7 +5574,7 @@ describe("CodexAppServerClient", () => {
   });
 
   it("uses the 0.144 App Server wire contracts for all dynamic-tool request sites", async () => {
-    MockTransport.serverVersion = "codex-cli 0.144.0";
+    MockTransport.serverVersion = "0.144.0";
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const dynamicTools: DynamicToolSpec[] = [
       {
@@ -5647,7 +5648,7 @@ describe("CodexAppServerClient", () => {
   });
 
   it("preserves the 0.135 App Server wire contracts for local old servers", async () => {
-    MockTransport.serverVersion = "codex-cli 0.135.0";
+    MockTransport.serverVersion = "0.135.0";
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const dynamicTools: DynamicToolSpec[] = [
       {

--- a/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveCodexProtocolCompatibility,
+} from "../codex-app-server/protocol-compatibility";
+
+describe("Codex App Server protocol compatibility", () => {
+  it.each([
+    {
+      version: undefined,
+      expected: {
+        dynamicToolFormat: "flat",
+        includePersistExtendedHistory: true,
+        supportsOnFailureApprovalPolicy: true,
+      },
+    },
+    {
+      version: "codex-cli 0.136.0",
+      expected: {
+        dynamicToolFormat: "flat",
+        includePersistExtendedHistory: true,
+        supportsOnFailureApprovalPolicy: true,
+      },
+    },
+    {
+      version: "codex-cli 0.137.0",
+      expected: {
+        dynamicToolFormat: "flat",
+        includePersistExtendedHistory: false,
+        supportsOnFailureApprovalPolicy: true,
+      },
+    },
+    {
+      version: "codex-cli 0.141.0",
+      expected: {
+        dynamicToolFormat: "namespaced",
+        includePersistExtendedHistory: false,
+        supportsOnFailureApprovalPolicy: true,
+      },
+    },
+    {
+      version: "codex-cli 0.143.0",
+      expected: {
+        dynamicToolFormat: "namespaced",
+        includePersistExtendedHistory: false,
+        supportsOnFailureApprovalPolicy: false,
+      },
+    },
+  ])("negotiates the wire features for $version", ({ version, expected }) => {
+    expect(resolveCodexProtocolCompatibility(version)).toEqual(expected);
+  });
+});

--- a/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-app-agent-tools.test.ts
@@ -32,8 +32,14 @@ describe("PwrAgent app agent tools", () => {
 
     expect(router.buildDynamicToolSpecs()).toEqual([
       expect.objectContaining({
-        namespace: "pwragent",
-        name: "manage_pwragent",
+        type: "namespace",
+        name: "pwragent",
+        tools: [
+          expect.objectContaining({
+            type: "function",
+            name: "manage_pwragent",
+          }),
+        ],
       }),
     ]);
 

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -35,7 +35,24 @@ describe("PwrAgent messaging agent tools", () => {
     const router = buildPwrAgentMessagingToolRouter(handler);
 
     const specs = router.buildDynamicToolSpecs();
-    expect(specs.map((tool) => tool.name)).toEqual([
+    expect(specs).toEqual([
+      expect.objectContaining({
+        type: "namespace",
+        name: "pwragent",
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            type: "function",
+            name: "get_current_messaging_surface",
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "attach_thread_here",
+          }),
+        ]),
+      }),
+    ]);
+    expect(specs[0]?.type === "namespace" ? specs[0].tools.map((tool) => tool.name) : [])
+      .toEqual([
       "get_current_messaging_surface",
       "attach_thread_here",
     ]);

--- a/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-thread-agent-tools.test.ts
@@ -15,26 +15,30 @@ describe("PwrAgent thread agent tools", () => {
     }));
     const router = buildPwrAgentThreadToolRouter(handler);
 
-    expect(router.buildDynamicToolSpecs()).toEqual(
-      expect.arrayContaining([
+    expect(router.buildDynamicToolSpecs()).toEqual([
+      expect.objectContaining({
+        type: "namespace",
+        name: "pwragent",
+        tools: expect.arrayContaining([
         expect.objectContaining({
-          namespace: "pwragent",
+          type: "function",
           name: "search_threads",
         }),
         expect.objectContaining({
-          namespace: "pwragent",
+          type: "function",
           name: "read_thread",
         }),
         expect.objectContaining({
-          namespace: "pwragent",
+          type: "function",
           name: "get_thread_status",
         }),
         expect.objectContaining({
-          namespace: "pwragent",
+          type: "function",
           name: "mutate_thread",
         }),
-      ]),
-    );
+        ]),
+      }),
+    ]);
 
     await expect(
       router.handleDynamicToolCall({

--- a/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
@@ -17,11 +17,18 @@ describe("AgentToolRouter", () => {
 
     expect(router.buildDynamicToolSpecs()).toEqual([
       {
-        namespace: "pwragent_test",
-        name: "inspect",
-        description: "Inspect test state.",
-        inputSchema: { type: "object", additionalProperties: false },
-        deferLoading: false,
+        type: "namespace",
+        name: "pwragent_test",
+        description: "PwrAgent tools.",
+        tools: [
+          {
+            type: "function",
+            name: "inspect",
+            description: "Inspect test state.",
+            inputSchema: { type: "object", additionalProperties: false },
+            deferLoading: false,
+          },
+        ],
       },
     ]);
   });

--- a/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/agent-tool-router.test.ts
@@ -285,6 +285,27 @@ describe("AgentToolRouter", () => {
 
     expect(
       readAgentDynamicToolCall({
+        method: "item/tool/call",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-1",
+          namespace: null,
+          tool: "inspect",
+          arguments: {},
+        },
+      }),
+    ).toEqual({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: "pwragent",
+      tool: "inspect",
+      arguments: {},
+    });
+
+    expect(
+      readAgentDynamicToolCall({
         method: "thread/update",
         params: {},
       }),

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -11,93 +11,99 @@ describe("pwragent thread orchestration agent tools", () => {
 
     expect(router.buildDynamicToolSpecs()).toEqual([
       expect.objectContaining({
-        namespace: "pwragent",
-        name: "attach_thread_directory",
-        description: expect.stringContaining("secondary worktree"),
-        deferLoading: false,
-        inputSchema: expect.objectContaining({
-          required: ["path"],
-          properties: expect.objectContaining({
-            workspaceMode: expect.objectContaining({
-              enum: ["local", "new_worktree"],
-            }),
-            worktreeBranchMode: expect.objectContaining({
-              enum: ["attached", "detached"],
-            }),
-          }),
-        }),
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "detach_thread_directory",
-        description: expect.stringContaining("primary provider/runtime cwd"),
-        deferLoading: false,
-        inputSchema: expect.objectContaining({
-          additionalProperties: false,
-          properties: expect.objectContaining({
-            directoryId: expect.objectContaining({
-              description: expect.stringContaining("linked-directory id"),
-            }),
-            worktreePath: expect.objectContaining({
-              description: expect.stringContaining("worktree path"),
+        type: "namespace",
+        name: "pwragent",
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            type: "function",
+            name: "attach_thread_directory",
+            description: expect.stringContaining("secondary worktree"),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["path"],
+              properties: expect.objectContaining({
+                workspaceMode: expect.objectContaining({
+                  enum: ["local", "new_worktree"],
+                }),
+                worktreeBranchMode: expect.objectContaining({
+                  enum: ["attached", "detached"],
+                }),
+              }),
             }),
           }),
-        }),
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "handoff_task",
-        description: expect.stringContaining("cross-project handoffs are created ungrouped"),
-        deferLoading: false,
-        inputSchema: expect.objectContaining({
-          required: ["task"],
-          properties: expect.objectContaining({
-            seedMode: expect.objectContaining({
-              enum: ["clean", "fork"],
-            }),
-            groupingMode: expect.objectContaining({
-              enum: ["none", "subthread"],
-              description: expect.stringContaining("same-project sub-thread"),
-            }),
-            workspaceMode: expect.objectContaining({
-              enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
-            }),
-            cwd: expect.objectContaining({
-              description: expect.stringContaining("another project"),
-            }),
-            branchName: expect.objectContaining({
-              description: expect.stringContaining("existing base branch/ref"),
+          expect.objectContaining({
+            type: "function",
+            name: "detach_thread_directory",
+            description: expect.stringContaining("primary provider/runtime cwd"),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              additionalProperties: false,
+              properties: expect.objectContaining({
+                directoryId: expect.objectContaining({
+                  description: expect.stringContaining("linked-directory id"),
+                }),
+                worktreePath: expect.objectContaining({
+                  description: expect.stringContaining("worktree path"),
+                }),
+              }),
             }),
           }),
-        }),
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "move_thread_workspace",
-        description: expect.stringContaining("same-thread continuation"),
-        deferLoading: false,
-        inputSchema: expect.objectContaining({
-          additionalProperties: false,
-          properties: expect.objectContaining({
-            direction: expect.objectContaining({
-              enum: ["local-to-worktree", "worktree-to-local"],
-            }),
-            strategy: expect.objectContaining({
-              enum: ["move-branch", "detached-changes", "new-branch"],
-            }),
-            sourcePath: expect.objectContaining({
-              description: expect.stringContaining("multiple linked directories"),
+          expect.objectContaining({
+            type: "function",
+            name: "handoff_task",
+            description: expect.stringContaining("cross-project handoffs are created ungrouped"),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["task"],
+              properties: expect.objectContaining({
+                seedMode: expect.objectContaining({
+                  enum: ["clean", "fork"],
+                }),
+                groupingMode: expect.objectContaining({
+                  enum: ["none", "subthread"],
+                  description: expect.stringContaining("same-project sub-thread"),
+                }),
+                workspaceMode: expect.objectContaining({
+                  enum: ["same", "same_workspace", "project_local", "new_worktree", "none"],
+                }),
+                cwd: expect.objectContaining({
+                  description: expect.stringContaining("another project"),
+                }),
+                branchName: expect.objectContaining({
+                  description: expect.stringContaining("existing base branch/ref"),
+                }),
+              }),
             }),
           }),
-        }),
-      }),
-      expect.objectContaining({
-        namespace: "pwragent",
-        name: "send_message_to_thread",
-        deferLoading: false,
-        inputSchema: expect.objectContaining({
-          required: ["backend", "threadId", "prompt"],
-        }),
+          expect.objectContaining({
+            type: "function",
+            name: "move_thread_workspace",
+            description: expect.stringContaining("same-thread continuation"),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              additionalProperties: false,
+              properties: expect.objectContaining({
+                direction: expect.objectContaining({
+                  enum: ["local-to-worktree", "worktree-to-local"],
+                }),
+                strategy: expect.objectContaining({
+                  enum: ["move-branch", "detached-changes", "new-branch"],
+                }),
+                sourcePath: expect.objectContaining({
+                  description: expect.stringContaining("multiple linked directories"),
+                }),
+              }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "function",
+            name: "send_message_to_thread",
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["backend", "threadId", "prompt"],
+            }),
+          }),
+        ]),
       }),
     ]);
   });

--- a/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-catalog-registry.ts
@@ -61,7 +61,7 @@ export function resolveAgentToolCatalogs(params: {
         id: "automation_inspection",
         namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
-        toolCount: automationDynamicTools.length,
+        toolCount: countDynamicTools(automationDynamicTools),
         fingerprint: buildCatalogFingerprint({
           id: "automation_inspection",
           namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -76,7 +76,7 @@ export function resolveAgentToolCatalogs(params: {
         id: "app_management",
         namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
-        toolCount: appDynamicTools.length,
+        toolCount: countDynamicTools(appDynamicTools),
         fingerprint: buildCatalogFingerprint({
           id: "app_management",
           namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -91,7 +91,7 @@ export function resolveAgentToolCatalogs(params: {
         id: "thread_inspection",
         namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
-        toolCount: threadDynamicTools.length,
+        toolCount: countDynamicTools(threadDynamicTools),
         fingerprint: buildCatalogFingerprint({
           id: "thread_inspection",
           namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -106,7 +106,7 @@ export function resolveAgentToolCatalogs(params: {
         id: "messaging_context",
         namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
-        toolCount: messagingDynamicTools.length,
+        toolCount: countDynamicTools(messagingDynamicTools),
         fingerprint: buildCatalogFingerprint({
           id: "messaging_context",
           namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -121,7 +121,7 @@ export function resolveAgentToolCatalogs(params: {
         id: "thread_orchestration",
         namespace: PWRAGENT_TOOL_NAMESPACE,
         enabled: true,
-        toolCount: threadOrchestrationDynamicTools.length,
+        toolCount: countDynamicTools(threadOrchestrationDynamicTools),
         fingerprint: buildCatalogFingerprint({
           id: "thread_orchestration",
           namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -140,6 +140,20 @@ function buildCatalogFingerprint(params: {
   return [
     params.id,
     params.namespace,
-    ...params.tools.map((tool) => tool.name).sort(),
+    ...params.tools
+      .flatMap((tool) =>
+        tool.type === "namespace"
+          ? tool.tools.map((nestedTool) => `${tool.name}/${nestedTool.name}`)
+          : [tool.name],
+      )
+      .sort(),
   ].join(":");
+}
+
+function countDynamicTools(tools: DynamicToolSpec[]): number {
+  return tools.reduce(
+    (count, tool) =>
+      count + (tool.type === "namespace" ? tool.tools.length : 1),
+    0,
+  );
 }

--- a/apps/desktop/src/main/agent-tools/agent-tool-router.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-router.ts
@@ -2,6 +2,7 @@ import type { AppServerBackendKind } from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
   DynamicToolCallResponse,
+  DynamicToolNamespaceTool,
   DynamicToolSpec,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import type {
@@ -50,15 +51,28 @@ export class AgentToolRouter {
   }
 
   buildDynamicToolSpecs(): DynamicToolSpec[] {
-    return this.definitions
-      .filter((definition) => definition.advertise !== false)
-      .map((definition) => ({
-        namespace: definition.namespace,
+    const toolsByNamespace = new Map<string, DynamicToolNamespaceTool[]>();
+    for (const definition of this.definitions) {
+      if (definition.advertise === false) {
+        continue;
+      }
+      const tools = toolsByNamespace.get(definition.namespace) ?? [];
+      tools.push({
+        type: "function",
         name: definition.name,
         description: definition.description,
-        inputSchema: definition.inputSchema as DynamicToolSpec["inputSchema"],
+        inputSchema: definition.inputSchema as DynamicToolNamespaceTool["inputSchema"],
         deferLoading: definition.deferLoading ?? false,
-      }));
+      });
+      toolsByNamespace.set(definition.namespace, tools);
+    }
+
+    return Array.from(toolsByNamespace, ([name, tools]) => ({
+      type: "namespace" as const,
+      name,
+      description: "PwrAgent tools.",
+      tools,
+    }));
   }
 
   buildMcpTools(): AgentMcpTool[] {

--- a/apps/desktop/src/main/agent-tools/agent-tool-router.ts
+++ b/apps/desktop/src/main/agent-tools/agent-tool-router.ts
@@ -1,4 +1,7 @@
-import type { AppServerBackendKind } from "@pwragent/shared";
+import {
+  PWRAGENT_TOOL_NAMESPACE,
+  type AppServerBackendKind,
+} from "@pwragent/shared";
 import type {
   DynamicToolCallParams,
   DynamicToolCallResponse,
@@ -178,9 +181,11 @@ export function readAgentDynamicToolCall(
   const callId = readString(call.callId) ?? readString(call.requestId);
   const tool = readString(call.tool);
   const namespace =
-    typeof call.namespace === "string" || call.namespace === null
+    typeof call.namespace === "string"
       ? call.namespace
-      : undefined;
+      : call.namespace === null
+        ? PWRAGENT_TOOL_NAMESPACE
+        : undefined;
   if (!threadId || !callId || !tool || namespace === undefined) {
     return undefined;
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8750,13 +8750,6 @@ export class DesktopBackendRegistry {
           ? await this.withCodexThreadClient(params.threadId, async (client, mode) => {
               const effectiveMode = params.executionMode ?? mode;
               const modeSettings = EXECUTION_MODE_SUMMARIES[effectiveMode];
-              const agentToolCatalogs = resolveAgentToolCatalogs({
-                appManagementHandler: this.appManagementHandler,
-                automationInspectionHandler: this.automationInspectionHandler,
-                messagingHandler: this.messagingHandler,
-                threadInspectionHandler: this.threadInspectionHandler,
-                threadOrchestrationHandler: this.threadOrchestrationHandler,
-              });
               const started = await client.startTurn({
                 threadId: params.threadId,
                 input,
@@ -8770,7 +8763,6 @@ export class DesktopBackendRegistry {
                   : {}),
                 defaultModeRequestUserInput:
                   this.resolveCodexDefaultModeRequestUserInputFn(),
-                dynamicTools: buildCodexParentDynamicToolSpecs(agentToolCatalogs),
               });
               activeTurnMode = effectiveMode;
               return started;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5000,10 +5000,38 @@ function resolveGrokApiKeyForLiveClient(): string | undefined {
 function buildCodexParentDynamicToolSpecs(
   agentToolCatalogs: Array<{ dynamicTools: CodexDynamicToolSpec[] }> = [],
 ): CodexDynamicToolSpec[] {
-  return [
+  return mergeCodexDynamicToolSpecs([
     ...agentToolCatalogs.flatMap((catalog) => catalog.dynamicTools),
     ...buildTaskMonitorDynamicToolSpecs("parent"),
-  ];
+  ]);
+}
+
+function mergeCodexDynamicToolSpecs(
+  specs: CodexDynamicToolSpec[],
+): CodexDynamicToolSpec[] {
+  const namespaces = new Map<
+    string,
+    Extract<CodexDynamicToolSpec, { type: "namespace" }>
+  >();
+  const functions: CodexDynamicToolSpec[] = [];
+
+  for (const spec of specs) {
+    if (spec.type !== "namespace") {
+      functions.push(spec);
+      continue;
+    }
+    const existing = namespaces.get(spec.name);
+    if (existing) {
+      existing.tools.push(...spec.tools);
+      continue;
+    }
+    namespaces.set(spec.name, {
+      ...spec,
+      tools: [...spec.tools],
+    });
+  }
+
+  return [...functions, ...namespaces.values()];
 }
 
 function pageNormalizedReplay(

--- a/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
+++ b/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
@@ -20,6 +20,7 @@ import {
 import type {
   DynamicToolCallParams,
   DynamicToolCallResponse,
+  DynamicToolNamespaceTool,
   DynamicToolSpec,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 
@@ -30,8 +31,8 @@ export type TaskMonitorHandler = (
 export function buildTaskMonitorDynamicToolSpecs(
   role: "parent" | "monitor" | "all" = "all",
 ): DynamicToolSpec[] {
-  const createTool: DynamicToolSpec = {
-    namespace: PWRAGENT_TOOL_NAMESPACE,
+  const createTool: DynamicToolNamespaceTool = {
+    type: "function",
     name: "create_monitor_delegation",
     description:
       "Create and start a lightweight PwrAgent-managed monitor thread for long-running asynchronous work or repeatable status checks. Use this instead of polling from the parent agent when the task may take more than one short status check, especially when you are about to sleep/wait/poll every few seconds for a command, job, service, or external operation to finish. If you have checked something for progress for about 30 seconds and the check is repeatable, hand it to this monitor with enough context to run that check for you. The task and monitorContext must include the exact monitoring procedure the parent was about to run itself: cwd or target location, command/status command or wait API, poll cadence, terminal success/failure conditions, and relevant log collection steps. Do not pass parent-local Codex/tool session ids such as exec_command/write_stdin session_id values; monitor threads cannot access those sessions, stdout/stderr streams, stdin, or exit status. For a local build/test/script, delegate before starting it and provide cwd plus the exact command so the monitor starts it and captures output itself. Prefer separate stdout/stderr capture files plus a combined output file when practical, and include those file paths in the final handoff. If the command is already running, provide durable process/log/status files that the monitor can read. Use pollIntervalSeconds as the combined poll and heartbeat cadence; default to 30 seconds unless the delegated procedure clearly needs a different cadence. PwrAgent starts the monitor with the returned preferred model/reasoning settings and the monitor callback tools attached; do not call generic spawnAgent for this flow.",
@@ -51,9 +52,9 @@ export function buildTaskMonitorDynamicToolSpecs(
     },
     deferLoading: false,
   };
-  const monitorTools: DynamicToolSpec[] = [
+  const monitorTools: DynamicToolNamespaceTool[] = [
     {
-      namespace: PWRAGENT_TOOL_NAMESPACE,
+      type: "function",
       name: "inject_progress",
       description:
         "Inject a concise progress update from a monitor subagent into the parent PwrAgent thread without starting or waking a parent turn.",
@@ -73,7 +74,7 @@ export function buildTaskMonitorDynamicToolSpecs(
       deferLoading: false,
     },
     {
-      namespace: PWRAGENT_TOOL_NAMESPACE,
+      type: "function",
       name: "complete_monitoring",
       description:
         "Finish a monitor delegation, inject the final result, and by default trigger exactly one parent turn with the final context.",
@@ -95,13 +96,20 @@ export function buildTaskMonitorDynamicToolSpecs(
       deferLoading: false,
     },
   ];
-  if (role === "parent") {
-    return [createTool];
-  }
-  if (role === "monitor") {
-    return monitorTools;
-  }
-  return [createTool, ...monitorTools];
+  const tools =
+    role === "parent"
+      ? [createTool]
+      : role === "monitor"
+        ? monitorTools
+        : [createTool, ...monitorTools];
+  return [
+    {
+      type: "namespace",
+      name: PWRAGENT_TOOL_NAMESPACE,
+      description: "PwrAgent task monitoring tools.",
+      tools,
+    },
+  ];
 }
 
 export function readTaskMonitorDynamicToolCall(request: {

--- a/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
+++ b/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
@@ -125,9 +125,11 @@ export function readTaskMonitorDynamicToolCall(request: {
   const callId = readString(call.callId) ?? readString(call.requestId);
   const tool = readString(call.tool);
   const namespace =
-    typeof call.namespace === "string" || call.namespace === null
+    typeof call.namespace === "string"
       ? call.namespace
-      : undefined;
+      : call.namespace === null
+        ? PWRAGENT_TOOL_NAMESPACE
+        : undefined;
   if (!threadId || !callId || !tool || namespace === undefined) {
     return undefined;
   }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -51,6 +51,7 @@ import { getMainLogger } from "../log";
 import type {
   ClientRequest as CodexClientRequest,
   InitializeParams as CodexInitializeParams,
+  InitializeResponse as CodexInitializeResponse,
   ReasoningEffort as CodexReasoningEffort,
   ServerRequest as CodexServerRequest,
 } from "@pwrdrvr/codex-app-server-protocol";
@@ -193,7 +194,7 @@ export class CodexBootstrapDeferredError extends Error {
   }
 }
 
-type InitializeResult = {
+type InitializeResult = Partial<CodexInitializeResponse> & {
   serverInfo?: {
     name?: string;
     version?: string;
@@ -5603,7 +5604,8 @@ export class CodexAppServerClient {
 
   private getProtocolCompatibility(): CodexProtocolCompatibility {
     return resolveCodexProtocolCompatibility(
-      this.initializeResult?.serverInfo?.version,
+      this.initializeResult?.userAgent
+        ?? this.initializeResult?.serverInfo?.version,
     );
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -55,7 +55,6 @@ import type {
   ServerRequest as CodexServerRequest,
 } from "@pwrdrvr/codex-app-server-protocol";
 import type {
-  AskForApproval as CodexAskForApproval,
   ConfigValueWriteParams as CodexConfigValueWriteParams,
   ModelListParams as CodexModelListParams,
   SandboxMode as CodexSandboxMode,
@@ -92,6 +91,14 @@ import type {
   ThreadTitleAdapterParams,
   ThreadTitleAdapterResult,
 } from "../app-server/thread-title-generation-service";
+import {
+  normalizeCompatibleApprovalPolicy,
+  resolveCodexProtocolCompatibility,
+  serializeCompatibleDynamicTools,
+  type CodexProtocolCompatibility,
+  type CompatibleApprovalPolicy,
+  type CompatibleDynamicToolSpec,
+} from "./protocol-compatibility";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
 const ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS = 60_000;
@@ -213,12 +220,38 @@ type RawCodexThreadListPage = {
   threads: RawCodexThreadSummary[];
 };
 
-type CodexThreadResumePayload = CodexThreadResumeParams & {
-  dynamicTools?: CodexDynamicToolSpec[] | null;
+type CodexThreadStartPayload = Omit<
+  CodexThreadStartParams,
+  "approvalPolicy" | "dynamicTools"
+> & {
+  approvalPolicy?: CompatibleApprovalPolicy;
+  dynamicTools?: CompatibleDynamicToolSpec[] | null;
+  persistExtendedHistory?: boolean;
 };
 
-type CodexTurnStartPayload = CodexTurnStartParams & {
-  dynamicTools?: CodexDynamicToolSpec[] | null;
+type CodexThreadResumePayload = Omit<
+  CodexThreadResumeParams,
+  "approvalPolicy"
+> & {
+  approvalPolicy?: CompatibleApprovalPolicy;
+  dynamicTools?: CompatibleDynamicToolSpec[] | null;
+  persistExtendedHistory?: boolean;
+};
+
+type CodexThreadForkPayload = Omit<
+  CodexThreadForkParams,
+  "approvalPolicy"
+> & {
+  approvalPolicy?: CompatibleApprovalPolicy;
+  persistExtendedHistory?: boolean;
+};
+
+type CodexTurnStartPayload = Omit<
+  CodexTurnStartParams,
+  "approvalPolicy"
+> & {
+  approvalPolicy?: CompatibleApprovalPolicy;
+  dynamicTools?: CompatibleDynamicToolSpec[] | null;
 };
 
 type SkillCatalogEntry = {
@@ -4671,21 +4704,6 @@ function hydrateMissingLinkedDirectoriesFromSiblingRepos(
   });
 }
 
-function normalizeCodexApprovalPolicy(
-  value?: string
-): CodexAskForApproval | undefined {
-  const normalized = value?.trim();
-  if (
-    normalized === "untrusted" ||
-    normalized === "on-failure" ||
-    normalized === "on-request" ||
-    normalized === "never"
-  ) {
-    return normalized;
-  }
-  return undefined;
-}
-
 function normalizeCodexSandboxMode(
   value?: string
 ): CodexSandboxMode | undefined {
@@ -4788,11 +4806,13 @@ function buildThreadStartPayload(params: {
   defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
   threadSource?: CodexThreadStartParams["threadSource"];
-}): CodexThreadStartParams {
-  const base: CodexThreadStartParams = {
+}, compatibility: CodexProtocolCompatibility): CodexThreadStartPayload {
+  const base: CodexThreadStartPayload = {
     experimentalRawEvents: false,
-    persistExtendedHistory: false,
   };
+  if (compatibility.includePersistExtendedHistory) {
+    base.persistExtendedHistory = false;
+  }
 
   if (params.cwd?.trim()) {
     base.cwd = params.cwd.trim();
@@ -4804,7 +4824,10 @@ function buildThreadStartPayload(params: {
     base.model = params.model.trim();
   }
 
-  const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
+  const approvalPolicy = normalizeCompatibleApprovalPolicy(
+    params.approvalPolicy,
+    compatibility,
+  );
   if (approvalPolicy) {
     base.approvalPolicy = approvalPolicy;
   }
@@ -4835,7 +4858,10 @@ function buildThreadStartPayload(params: {
     base.config = config;
   }
   if (params.dynamicTools) {
-    base.dynamicTools = params.dynamicTools;
+    base.dynamicTools = serializeCompatibleDynamicTools(
+      params.dynamicTools,
+      compatibility,
+    );
   }
   if (
     params.codexEnvironmentRuntime?.executionTarget === "remote" &&
@@ -4915,13 +4941,15 @@ function buildThreadForkPayload(params: {
   serviceTier?: string;
   fastMode?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
-}): CodexThreadForkParams {
-  const base: CodexThreadForkParams = {
+}, compatibility: CodexProtocolCompatibility): CodexThreadForkPayload {
+  const base: CodexThreadForkPayload = {
     threadId: params.threadId,
     excludeTurns: true,
-    persistExtendedHistory: false,
     threadSource: "user",
   };
+  if (compatibility.includePersistExtendedHistory) {
+    base.persistExtendedHistory = false;
+  }
 
   if (params.path?.trim()) {
     base.path = params.path.trim();
@@ -4933,7 +4961,10 @@ function buildThreadForkPayload(params: {
     base.model = params.model.trim();
   }
 
-  const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
+  const approvalPolicy = normalizeCompatibleApprovalPolicy(
+    params.approvalPolicy,
+    compatibility,
+  );
   if (approvalPolicy) {
     base.approvalPolicy = approvalPolicy;
   }
@@ -4976,11 +5007,13 @@ function buildThreadResumePayloads(params: {
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   defaultModeRequestUserInput?: boolean;
   dynamicTools?: CodexDynamicToolSpec[];
-}): CodexThreadResumePayload[] {
+}, compatibility: CodexProtocolCompatibility): CodexThreadResumePayload[] {
   const base: CodexThreadResumePayload = {
     threadId: params.threadId,
-    persistExtendedHistory: false,
   };
+  if (compatibility.includePersistExtendedHistory) {
+    base.persistExtendedHistory = false;
+  }
 
   if (params.cwd?.trim()) {
     base.cwd = params.cwd.trim();
@@ -4989,7 +5022,10 @@ function buildThreadResumePayloads(params: {
     base.model = params.model.trim();
   }
 
-  const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
+  const approvalPolicy = normalizeCompatibleApprovalPolicy(
+    params.approvalPolicy,
+    compatibility,
+  );
   if (approvalPolicy) {
     base.approvalPolicy = approvalPolicy;
   }
@@ -5024,7 +5060,10 @@ function buildThreadResumePayloads(params: {
     return [
       {
         ...base,
-        dynamicTools: params.dynamicTools,
+        dynamicTools: serializeCompatibleDynamicTools(
+          params.dynamicTools,
+          compatibility,
+        ),
       },
       base,
     ];
@@ -5110,7 +5149,7 @@ function buildTurnStartPayload(params: {
   collaborationFallbackModel?: string;
   collaborationFallbackReasoningEffort?: string;
   dynamicTools?: CodexDynamicToolSpec[];
-}): CodexTurnStartPayload {
+}, compatibility: CodexProtocolCompatibility): CodexTurnStartPayload {
   const base: CodexTurnStartPayload = {
     threadId: params.threadId,
     input: params.input.map(toCodexUserInput),
@@ -5131,7 +5170,10 @@ function buildTurnStartPayload(params: {
   if (serviceTier !== undefined) {
     base.serviceTier = serviceTier;
   }
-  const approvalPolicy = normalizeCodexApprovalPolicy(params.approvalPolicy);
+  const approvalPolicy = normalizeCompatibleApprovalPolicy(
+    params.approvalPolicy,
+    compatibility,
+  );
   if (approvalPolicy) {
     base.approvalPolicy = approvalPolicy;
   }
@@ -5143,7 +5185,10 @@ function buildTurnStartPayload(params: {
     base.outputSchema = params.outputSchema;
   }
   if (params.dynamicTools?.length) {
-    base.dynamicTools = params.dynamicTools;
+    base.dynamicTools = serializeCompatibleDynamicTools(
+      params.dynamicTools,
+      compatibility,
+    );
   }
 
   const collaborationOverrides = buildCollaborationModeOverrides({
@@ -5554,6 +5599,12 @@ export class CodexAppServerClient {
   async getInitializeResult(): Promise<InitializeResult> {
     await this.ensureInitialized();
     return this.initializeResult ?? {};
+  }
+
+  private getProtocolCompatibility(): CodexProtocolCompatibility {
+    return resolveCodexProtocolCompatibility(
+      this.initializeResult?.serverInfo?.version,
+    );
   }
 
   async trustProject(params: {
@@ -6162,7 +6213,9 @@ export class CodexAppServerClient {
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/start"],
-      payloads: [buildThreadStartPayload(params)],
+      payloads: [
+        buildThreadStartPayload(params, this.getProtocolCompatibility()),
+      ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 
@@ -6195,7 +6248,9 @@ export class CodexAppServerClient {
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/fork"],
-      payloads: [buildThreadForkPayload(params)],
+      payloads: [
+        buildThreadForkPayload(params, this.getProtocolCompatibility()),
+      ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 
@@ -6242,19 +6297,22 @@ export class CodexAppServerClient {
       (await requestWithFallbacks({
         client: this.connection,
         methods: ["thread/resume"],
-        payloads: buildThreadResumePayloads({
-          threadId: params.threadId,
-          cwd: params.cwd,
-          approvalPolicy: params.approvalPolicy,
-          sandbox: params.sandbox,
-          model: params.model,
-          serviceTier: params.serviceTier,
-          reasoningEffort: params.reasoningEffort,
-          fastMode: params.fastMode,
-          codexEnvironmentRuntime: params.codexEnvironmentRuntime,
-          defaultModeRequestUserInput: params.defaultModeRequestUserInput,
-          dynamicTools: params.dynamicTools,
-        }),
+        payloads: buildThreadResumePayloads(
+          {
+            threadId: params.threadId,
+            cwd: params.cwd,
+            approvalPolicy: params.approvalPolicy,
+            sandbox: params.sandbox,
+            model: params.model,
+            serviceTier: params.serviceTier,
+            reasoningEffort: params.reasoningEffort,
+            fastMode: params.fastMode,
+            codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+            defaultModeRequestUserInput: params.defaultModeRequestUserInput,
+            dynamicTools: params.dynamicTools,
+          },
+          this.getProtocolCompatibility(),
+        ),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
       }).catch((error: unknown) => {
         codexClientLog.warn("thread/resume failed before turn/start", {
@@ -6270,26 +6328,29 @@ export class CodexAppServerClient {
       client: this.connection,
       methods: ["turn/start"],
       payloads: [
-        buildTurnStartPayload({
-          threadId: params.threadId,
-          input: params.input,
-          cwd: params.cwd,
-          model: params.model,
-          reasoningEffort: params.reasoningEffort,
-          serviceTier: params.serviceTier,
-          fastMode: params.fastMode,
-          approvalPolicy: params.approvalPolicy,
-          sandbox: params.sandbox,
-          collaborationMode: params.collaborationMode,
-          collaborationFallbackModel:
-            params.model?.trim() || extractStringProperty(resumeResult, "model"),
-          collaborationFallbackReasoningEffort: extractStringProperty(
-            resumeResult,
-            "reasoningEffort",
-            "reasoning_effort"
-          ),
-          dynamicTools: params.dynamicTools,
-        }),
+        buildTurnStartPayload(
+          {
+            threadId: params.threadId,
+            input: params.input,
+            cwd: params.cwd,
+            model: params.model,
+            reasoningEffort: params.reasoningEffort,
+            serviceTier: params.serviceTier,
+            fastMode: params.fastMode,
+            approvalPolicy: params.approvalPolicy,
+            sandbox: params.sandbox,
+            collaborationMode: params.collaborationMode,
+            collaborationFallbackModel:
+              params.model?.trim() || extractStringProperty(resumeResult, "model"),
+            collaborationFallbackReasoningEffort: extractStringProperty(
+              resumeResult,
+              "reasoningEffort",
+              "reasoning_effort"
+            ),
+            dynamicTools: params.dynamicTools,
+          },
+          this.getProtocolCompatibility(),
+        ),
       ],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
@@ -6344,22 +6405,28 @@ export class CodexAppServerClient {
         client: this.connection,
         methods: ["thread/start"],
         payloads: [
-          buildThreadStartPayload({
-            cwd: helperWorkspaceDir,
-            runtimeWorkspaceRoots: [helperWorkspaceDir],
-            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
-            serviceTier: null,
-            ephemeral: true,
-            config: CODEX_THREAD_TITLE_CONFIG,
-          }),
-          buildThreadStartPayload({
-            cwd: helperWorkspaceDir,
-            runtimeWorkspaceRoots: [helperWorkspaceDir],
-            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
-            serviceTier: null,
-            ephemeral: true,
-            config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
-          }),
+          buildThreadStartPayload(
+            {
+              cwd: helperWorkspaceDir,
+              runtimeWorkspaceRoots: [helperWorkspaceDir],
+              model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+              serviceTier: null,
+              ephemeral: true,
+              config: CODEX_THREAD_TITLE_CONFIG,
+            },
+            this.getProtocolCompatibility(),
+          ),
+          buildThreadStartPayload(
+            {
+              cwd: helperWorkspaceDir,
+              runtimeWorkspaceRoots: [helperWorkspaceDir],
+              model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+              serviceTier: null,
+              ephemeral: true,
+              config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
+            },
+            this.getProtocolCompatibility(),
+          ),
         ],
         timeoutMs,
       });
@@ -6377,14 +6444,17 @@ export class CodexAppServerClient {
         client: this.connection,
         methods: ["turn/start"],
         payloads: [
-          buildTurnStartPayload({
-            threadId: helperThreadId,
-            input: [{ type: "text", text: params.prompt }],
-            model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
-            serviceTier: null,
-            reasoningEffort: "low",
-            outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
-          }),
+          buildTurnStartPayload(
+            {
+              threadId: helperThreadId,
+              input: [{ type: "text", text: params.prompt }],
+              model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
+              serviceTier: null,
+              reasoningEffort: "low",
+              outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
+            },
+            this.getProtocolCompatibility(),
+          ),
         ],
         timeoutMs,
       });
@@ -6456,15 +6526,18 @@ export class CodexAppServerClient {
       await requestWithFallbacks({
         client: this.connection,
         methods: ["thread/resume"],
-        payloads: buildThreadResumePayloads({
-          threadId: params.threadId,
-          cwd: params.cwd,
-          model: params.model,
-          serviceTier: params.serviceTier,
-          reasoningEffort: params.reasoningEffort,
-          fastMode: params.fastMode,
-          codexEnvironmentRuntime: params.codexEnvironmentRuntime,
-        }),
+        payloads: buildThreadResumePayloads(
+          {
+            threadId: params.threadId,
+            cwd: params.cwd,
+            model: params.model,
+            serviceTier: params.serviceTier,
+            reasoningEffort: params.reasoningEffort,
+            fastMode: params.fastMode,
+            codexEnvironmentRuntime: params.codexEnvironmentRuntime,
+          },
+          this.getProtocolCompatibility(),
+        ),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       }).catch(() => undefined);
     }
@@ -6518,7 +6591,10 @@ export class CodexAppServerClient {
     const result = await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/resume"],
-      payloads: buildThreadResumePayloads(params),
+      payloads: buildThreadResumePayloads(
+        params,
+        this.getProtocolCompatibility(),
+      ),
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     });
 
@@ -6608,9 +6684,12 @@ export class CodexAppServerClient {
     await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/resume"],
-      payloads: buildThreadResumePayloads({
-        threadId: params.threadId,
-      }),
+      payloads: buildThreadResumePayloads(
+        {
+          threadId: params.threadId,
+        },
+        this.getProtocolCompatibility(),
+      ),
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     }).catch(() => undefined);
 
@@ -6658,9 +6737,12 @@ export class CodexAppServerClient {
     await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/resume"],
-      payloads: buildThreadResumePayloads({
-        threadId: params.threadId,
-      }),
+      payloads: buildThreadResumePayloads(
+        {
+          threadId: params.threadId,
+        },
+        this.getProtocolCompatibility(),
+      ),
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     }).catch(() => undefined);
 
@@ -6694,9 +6776,12 @@ export class CodexAppServerClient {
     await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/resume"],
-      payloads: buildThreadResumePayloads({
-        threadId: params.threadId,
-      }),
+      payloads: buildThreadResumePayloads(
+        {
+          threadId: params.threadId,
+        },
+        this.getProtocolCompatibility(),
+      ),
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     }).catch(() => undefined);
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -235,7 +235,6 @@ type CodexThreadResumePayload = Omit<
   "approvalPolicy"
 > & {
   approvalPolicy?: CompatibleApprovalPolicy;
-  dynamicTools?: CompatibleDynamicToolSpec[] | null;
   persistExtendedHistory?: boolean;
 };
 
@@ -252,7 +251,6 @@ type CodexTurnStartPayload = Omit<
   "approvalPolicy"
 > & {
   approvalPolicy?: CompatibleApprovalPolicy;
-  dynamicTools?: CompatibleDynamicToolSpec[] | null;
 };
 
 type SkillCatalogEntry = {
@@ -5007,7 +5005,6 @@ function buildThreadResumePayloads(params: {
   fastMode?: boolean;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   defaultModeRequestUserInput?: boolean;
-  dynamicTools?: CodexDynamicToolSpec[];
 }, compatibility: CodexProtocolCompatibility): CodexThreadResumePayload[] {
   const base: CodexThreadResumePayload = {
     threadId: params.threadId,
@@ -5055,19 +5052,6 @@ function buildThreadResumePayloads(params: {
   );
   if (config) {
     base.config = config;
-  }
-
-  if (params.dynamicTools?.length) {
-    return [
-      {
-        ...base,
-        dynamicTools: serializeCompatibleDynamicTools(
-          params.dynamicTools,
-          compatibility,
-        ),
-      },
-      base,
-    ];
   }
 
   return [base];
@@ -5149,7 +5133,6 @@ function buildTurnStartPayload(params: {
   collaborationMode?: AppServerCollaborationModeRequest;
   collaborationFallbackModel?: string;
   collaborationFallbackReasoningEffort?: string;
-  dynamicTools?: CodexDynamicToolSpec[];
 }, compatibility: CodexProtocolCompatibility): CodexTurnStartPayload {
   const base: CodexTurnStartPayload = {
     threadId: params.threadId,
@@ -5185,13 +5168,6 @@ function buildTurnStartPayload(params: {
   if (params.outputSchema) {
     base.outputSchema = params.outputSchema;
   }
-  if (params.dynamicTools?.length) {
-    base.dynamicTools = serializeCompatibleDynamicTools(
-      params.dynamicTools,
-      compatibility,
-    );
-  }
-
   const collaborationOverrides = buildCollaborationModeOverrides({
     collaborationMode: params.collaborationMode,
     fallbackModel: params.collaborationFallbackModel ?? params.model,
@@ -6282,7 +6258,6 @@ export class CodexAppServerClient {
     fastMode?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     defaultModeRequestUserInput?: boolean;
-    dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{
     threadId: string;
     turnId: string;
@@ -6294,6 +6269,8 @@ export class CodexAppServerClient {
     // before later turn/start calls. A just-created thread has no rollout
     // yet, so resume is guaranteed to be too early; turn/start already
     // carries the permission/model overrides needed for the first turn.
+    // Dynamic tools are intentionally absent here: Codex accepts them only
+    // on thread/start and restores that persisted catalog on thread/resume.
     const resumeResult =
       pendingFirstTurnResult ??
       (await requestWithFallbacks({
@@ -6311,7 +6288,6 @@ export class CodexAppServerClient {
             fastMode: params.fastMode,
             codexEnvironmentRuntime: params.codexEnvironmentRuntime,
             defaultModeRequestUserInput: params.defaultModeRequestUserInput,
-            dynamicTools: params.dynamicTools,
           },
           this.getProtocolCompatibility(),
         ),
@@ -6349,7 +6325,6 @@ export class CodexAppServerClient {
               "reasoningEffort",
               "reasoning_effort"
             ),
-            dynamicTools: params.dynamicTools,
           },
           this.getProtocolCompatibility(),
         ),

--- a/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
+++ b/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
@@ -1,0 +1,132 @@
+import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
+
+const PERSIST_EXTENDED_HISTORY_REMOVED_VERSION = [0, 137, 0] as const;
+const NAMESPACED_DYNAMIC_TOOLS_MIN_VERSION = [0, 141, 0] as const;
+const ON_FAILURE_APPROVAL_REMOVED_VERSION = [0, 143, 0] as const;
+
+export type CodexProtocolCompatibility = {
+  dynamicToolFormat: "flat" | "namespaced";
+  includePersistExtendedHistory: boolean;
+  supportsOnFailureApprovalPolicy: boolean;
+};
+
+type ModernDynamicToolFunction = Extract<
+  DynamicToolSpec,
+  { type: "function" }
+>;
+
+export type LegacyDynamicToolSpec = Omit<
+  ModernDynamicToolFunction,
+  "type"
+> & {
+  namespace?: string;
+};
+
+export type CompatibleDynamicToolSpec =
+  | DynamicToolSpec
+  | LegacyDynamicToolSpec;
+
+export type CompatibleApprovalPolicy =
+  | "untrusted"
+  | "on-failure"
+  | "on-request"
+  | "never";
+
+/**
+ * These experimental App Server contracts changed independently between the
+ * package's 0.135.0 and 0.144.0 snapshots:
+ * - 0.137.0 removed the deprecated `persistExtendedHistory` thread parameter.
+ * - 0.141.0 changed dynamic tools to function/namespace discriminated specs.
+ * - 0.143.0 removed the `on-failure` approval policy.
+ *
+ * Missing or unparseable versions stay on the legacy shape. That preserves
+ * the contract PwrAgent used before this migration instead of assuming that
+ * an unidentified local App Server understands newer experimental fields.
+ */
+export function resolveCodexProtocolCompatibility(
+  serverVersion?: string,
+): CodexProtocolCompatibility {
+  const version = parseSemanticVersion(serverVersion);
+  const isAtLeast = (minimum: readonly [number, number, number]): boolean =>
+    version !== undefined && compareSemanticVersions(version, minimum) >= 0;
+
+  return {
+    dynamicToolFormat: isAtLeast(NAMESPACED_DYNAMIC_TOOLS_MIN_VERSION)
+      ? "namespaced"
+      : "flat",
+    includePersistExtendedHistory:
+      !isAtLeast(PERSIST_EXTENDED_HISTORY_REMOVED_VERSION),
+    supportsOnFailureApprovalPolicy:
+      !isAtLeast(ON_FAILURE_APPROVAL_REMOVED_VERSION),
+  };
+}
+
+export function serializeCompatibleDynamicTools(
+  tools: DynamicToolSpec[],
+  compatibility: CodexProtocolCompatibility,
+): CompatibleDynamicToolSpec[] {
+  if (compatibility.dynamicToolFormat === "namespaced") {
+    return tools;
+  }
+
+  return tools.flatMap((spec): LegacyDynamicToolSpec[] => {
+    if (spec.type === "namespace") {
+      return spec.tools.map(({ type: _type, ...tool }) => ({
+        namespace: spec.name,
+        ...tool,
+      }));
+    }
+
+    const { type: _type, ...tool } = spec;
+    return [tool];
+  });
+}
+
+export function normalizeCompatibleApprovalPolicy(
+  value: string | undefined,
+  compatibility: CodexProtocolCompatibility,
+): CompatibleApprovalPolicy | undefined {
+  const normalized = value?.trim();
+  if (normalized === "on-failure") {
+    // New App Servers no longer accept on-failure. Preserve the old value for
+    // old servers and choose the safer interactive policy for modern servers.
+    return compatibility.supportsOnFailureApprovalPolicy
+      ? normalized
+      : "on-request";
+  }
+  if (
+    normalized === "untrusted" ||
+    normalized === "on-request" ||
+    normalized === "never"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function parseSemanticVersion(
+  value?: string,
+): readonly [number, number, number] | undefined {
+  const match = value?.match(/(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?:[^\d]|$)/);
+  if (!match) {
+    return undefined;
+  }
+  return [
+    Number.parseInt(match[1], 10),
+    Number.parseInt(match[2], 10),
+    Number.parseInt(match[3], 10),
+  ];
+}
+
+function compareSemanticVersions(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+): number {
+  for (let index = 0; index < left.length; index += 1) {
+    const difference = left[index] - right[index];
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6
       '@pwrdrvr/codex-app-server-protocol':
-        specifier: 0.135.0
-        version: 0.135.0
+        specifier: 0.144.0
+        version: 0.144.0
       '@pwrdrvr/codex-discovery':
         specifier: ^0.1.4
         version: 0.1.4
@@ -954,8 +954,8 @@ packages:
     resolution: {integrity: sha512-mt+geA0RZEz5A3kEK8poDE3wYDrteWGb2syfXS4/kzzgWEe26DUbQlbdQyFYoa7Zs/Z6L64gNGIfFHgemfzj8g==}
     engines: {node: '>=20'}
 
-  '@pwrdrvr/codex-app-server-protocol@0.135.0':
-    resolution: {integrity: sha512-lmebPpbmaE7yfe0EDqcT2MPRtKurUc1o9NinHAVdA3lBdF3c8ZK3okiHIw6r6GEQLqOTd+7dpEuPsk4a1dEpkw==}
+  '@pwrdrvr/codex-app-server-protocol@0.144.0':
+    resolution: {integrity: sha512-WmURXzmmNEY8lmnNZunNQj/Bnn3yjzS6Rc0gzlDU7sBHMd0kvtskXE9BCMcR+E7sVJ53V/gwjfksRUli0xUgdA==}
     engines: {node: '>=20'}
 
   '@pwrdrvr/codex-discovery@0.1.4':
@@ -4917,7 +4917,7 @@ snapshots:
 
   '@pwrdrvr/codex-app-server-protocol@0.133.0': {}
 
-  '@pwrdrvr/codex-app-server-protocol@0.135.0': {}
+  '@pwrdrvr/codex-app-server-protocol@0.144.0': {}
 
   '@pwrdrvr/codex-discovery@0.1.4':
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade `@pwrdrvr/codex-app-server-protocol` from 0.135.0 to 0.144.0 independently of routine production dependency bumps
- migrate PwrAgent dynamic-tool catalogs to the namespace/function protocol while serializing the old flat shape for older local Codex App Servers
- negotiate the three actual Codex CLI compatibility boundaries from the real initialize `userAgent` (with `serverInfo.version` retained as a compatibility fallback): removed `persistExtendedHistory` at 0.137.0, namespaced dynamic tools at 0.141.0, and removed `on-failure` approval at 0.143.0
- map obsolete `on-failure` requests to safer `on-request` on new servers, while preserving `on-failure` for old servers
- advertise dynamic tools only on `thread/start`; Codex persists the catalog in session metadata and restores it on resume
- normalize legacy namespace-less (`namespace: null`) tool calls into the unified `pwragent` namespace before routing
- isolate `@pwrdrvr/agent-*` and `@pwrdrvr/codex-*` updates into an `agent-kit` Dependabot group

## Why

The grouped production dependency PR exposed generated type failures, but a compile-only migration would also have broken operators running older local Codex App Servers. The upgraded client now selects the wire contract supported by the initialized server instead of assuming that the installed TypeScript package and local server are the same version.

Dynamic tools are a thread-creation contract in Codex. Codex 0.141+ explicitly normalizes the old flat catalog stored by earlier servers, so existing threads retain their persisted tools after the upgrade. `thread/resume` and `turn/start` do not accept catalog updates; newly added tools therefore become available only on newly created threads. Calls restored from older top-level tools can carry `namespace: null`; PwrAgent routes those by treating them as members of its unified namespace.

## Validation

- focused compatibility, client, router, and backend registry tests: 487 tests passed
- earlier affected-file suite: 502 tests passed
- realistic `userAgent`-only initialize responses cover both Codex 0.135 and 0.144 behavior
- end-to-end registry coverage for namespace-less ordinary and task-monitor tool calls
- `pnpm --filter @pwragent/desktop typecheck`
- touched-file ESLint (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm licenses:check`
- parsed `.github/dependabot.yml` with Ruby YAML
- `git diff --check origin/main`
