### PR TITLE
fix(desktop): expose Grok 4.5 effort controls

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -51,6 +51,42 @@ describe("describeInstalledAcpBackend", () => {
     expect(backend.methods).toContain("session/load");
   });
 
+  it("advertises Grok 4.5 reasoning efforts in launchpad options", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:grok" as AcpBackendId,
+      registryId: "grok",
+      name: "Grok",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        models: {
+          currentModelId: "grok-4.5",
+          availableModels: [
+            {
+              id: "grok-4.5",
+              label: "Grok 4.5",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(backend.launchpadOptions).toEqual({
+      models: [
+        {
+          id: "grok-4.5",
+          label: "Grok 4.5",
+          current: true,
+          defaultReasoningEffort: "high",
+          reasoningEfforts: ["low", "medium", "high"],
+          supportsReasoning: true,
+        },
+      ],
+    });
+  });
+
   it("suppresses hardcoded execution modes for Kimi once it advertises runtime modes (#658)", () => {
     // Kimi exposes its own Default/Plan/Auto/Yolo runtime modes. Surfacing the
     // hardcoded Default/Full Access modes too produced a second, overlapping

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -770,19 +770,26 @@ describe("AcpAgentClient", () => {
       model_id: "grok-4.5",
       reasoning_effort: "low",
     });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "model_changed",
+      model_id: "gemini-3-pro-preview",
+    });
 
     expect(store.getSession("acp:gemini", session.sessionId)).toMatchObject({
       acpRuntime: {
         currentModeId: "yolo",
-        currentModelId: "grok-4.5",
-        reasoningEffort: "low",
+        currentModelId: "gemini-3-pro-preview",
         configValues: {
           "approval-mode": "yolo",
         },
       },
     });
+    expect(
+      store.getSession("acp:gemini", session.sessionId)?.acpRuntime
+        ?.reasoningEffort,
+    ).toBeUndefined();
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
-    expect(runtimeUpdates).toHaveLength(3);
+    expect(runtimeUpdates).toHaveLength(4);
   });
 
   it("keeps requested ACP mode when set_mode returns no fresh runtime state", async () => {
@@ -829,14 +836,24 @@ describe("AcpAgentClient", () => {
     });
   });
 
-  it("keeps requested ACP model when set_model returns no fresh runtime state", async () => {
+  it("keeps requested ACP model and clears stale effort without fresh runtime state", async () => {
     const transport = new FakeAcpAgentTransport({
       "session/new": {
         sessionId: "gemini-session",
         models: {
           currentModelId: "gemini-3-flash-preview",
           availableModels: [
-            { modelId: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
+            {
+              modelId: "gemini-3-flash-preview",
+              name: "Gemini 3 Flash Preview",
+              _meta: {
+                reasoningEffort: "high",
+                reasoningEfforts: [
+                  { value: "low" },
+                  { value: "high", default: true },
+                ],
+              },
+            },
             { modelId: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
           ],
         },
@@ -855,6 +872,7 @@ describe("AcpAgentClient", () => {
       cwd: "/repo",
       executionMode: "default",
     });
+    expect(session.acpRuntime?.reasoningEffort).toBe("high");
 
     await expect(
       client.setRuntimeOption({
@@ -878,6 +896,10 @@ describe("AcpAgentClient", () => {
         currentModelId: "gemini-3-pro-preview",
       },
     });
+    expect(
+      store.getSession("acp:gemini", session.sessionId)?.acpRuntime
+        ?.reasoningEffort,
+    ).toBeUndefined();
   });
 
   it("sends reasoning effort through ACP model metadata", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -736,7 +736,7 @@ describe("AcpAgentClient", () => {
     );
   });
 
-  it("updates ACP runtime state without rendering config notifications", async () => {
+  it("updates ACP runtime state without rendering runtime notifications", async () => {
     const runtimeUpdates: unknown[] = [];
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({
@@ -765,17 +765,24 @@ describe("AcpAgentClient", () => {
         currentValue: "yolo",
       },
     });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "model_changed",
+      model_id: "grok-4.5",
+      reasoning_effort: "low",
+    });
 
     expect(store.getSession("acp:gemini", session.sessionId)).toMatchObject({
       acpRuntime: {
         currentModeId: "yolo",
+        currentModelId: "grok-4.5",
+        reasoningEffort: "low",
         configValues: {
           "approval-mode": "yolo",
         },
       },
     });
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
-    expect(runtimeUpdates).toHaveLength(2);
+    expect(runtimeUpdates).toHaveLength(3);
   });
 
   it("keeps requested ACP mode when set_mode returns no fresh runtime state", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -873,6 +873,74 @@ describe("AcpAgentClient", () => {
     });
   });
 
+  it("sends reasoning effort through ACP model metadata", async () => {
+    const transport = new FakeAcpAgentTransport({
+      "session/new": {
+        sessionId: "grok-session",
+        models: {
+          currentModelId: "grok-4.5",
+          availableModels: [
+            {
+              modelId: "grok-4.5",
+              name: "Grok 4.5",
+              _meta: {
+                supportsReasoningEffort: true,
+                reasoningEffort: "high",
+                reasoningEfforts: [
+                  { value: "low" },
+                  { value: "medium" },
+                  { value: "high" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      "session/set_model": {},
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+
+    await expect(
+      client.setRuntimeOption({
+        sessionId: session.sessionId,
+        source: "model",
+        optionId: "model",
+        value: "grok-4.5",
+        reasoningEffort: "medium",
+      }),
+    ).resolves.toMatchObject({
+      currentModelId: "grok-4.5",
+      reasoningEffort: "medium",
+    });
+    expect(transport.requests.at(-1)).toEqual({
+      method: "session/set_model",
+      params: {
+        sessionId: "grok-session",
+        modelId: "grok-4.5",
+        _meta: {
+          reasoningEffort: "medium",
+        },
+      },
+    });
+    expect(store.getSession("acp:grok", session.sessionId)).toMatchObject({
+      acpRuntime: {
+        currentModelId: "grok-4.5",
+        reasoningEffort: "medium",
+      },
+    });
+  });
+
   it("keeps requested ACP config-option mode when response reports stale current mode", async () => {
     const transport = new FakeAcpAgentTransport({
       "session/new": {

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -78,6 +78,24 @@ describe("AcpRolloutStore", () => {
     ]);
   });
 
+  it("does not persist model change notifications", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:grok" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "model_changed",
+        model_id: "grok-4.5",
+        reasoning_effort: "low",
+      },
+    });
+
+    expect(store.readUpdates({ backendId, sessionId: "session-1" })).toEqual([]);
+  });
+
   it("coalesces unchanged tool updates before writing rollout records", () => {
     const store = new AcpRolloutStore(tempDir);
     const backendId = "acp:kimi" as AcpBackendId;

--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -163,4 +163,37 @@ describe("ACP runtime capabilities", () => {
       updatedAt: 1000,
     });
   });
+
+  it("marks missing effort as cleared when a session response selects a model", () => {
+    const state = acpSessionRuntimeStateFromResponse(
+      {
+        models: {
+          currentModelId: "gemini-3-pro-preview",
+          availableModels: [
+            {
+              modelId: "gemini-3-pro-preview",
+              name: "Gemini 3 Pro Preview",
+            },
+          ],
+        },
+      },
+      1000,
+    );
+
+    expect(state).toHaveProperty("currentModelId", "gemini-3-pro-preview");
+    expect(state).toHaveProperty("reasoningEffort", undefined);
+  });
+
+  it("marks missing effort as cleared in model change notifications", () => {
+    const state = acpSessionRuntimeStateFromUpdate(
+      {
+        sessionUpdate: "model_changed",
+        model_id: "gemini-3-pro-preview",
+      },
+      1000,
+    );
+
+    expect(state).toHaveProperty("currentModelId", "gemini-3-pro-preview");
+    expect(state).toHaveProperty("reasoningEffort", undefined);
+  });
 });

--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -3,6 +3,7 @@ import {
   acpRuntimeSupportsSessionHistoryReplay,
   acpSessionRuntimeStateFromCapabilities,
   acpSessionRuntimeStateFromResponse,
+  acpSessionRuntimeStateFromUpdate,
   normalizeAcpRuntimeCapabilities,
 } from "../acp/acp-runtime-capabilities";
 
@@ -143,6 +144,23 @@ describe("ACP runtime capabilities", () => {
       currentModelId: "grok-4.5",
       reasoningEffort: "medium",
       updatedAt: 1002,
+    });
+  });
+
+  it("reads Grok model change notifications as session runtime state", () => {
+    expect(
+      acpSessionRuntimeStateFromUpdate(
+        {
+          sessionUpdate: "model_changed",
+          model_id: "grok-4.5",
+          reasoning_effort: "low",
+        },
+        1000,
+      ),
+    ).toEqual({
+      currentModelId: "grok-4.5",
+      reasoningEffort: "low",
+      updatedAt: 1000,
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -91,4 +91,44 @@ describe("ACP runtime capabilities", () => {
 
     expect(capabilities?.agentCapabilities?.prompt?.image).toBe(true);
   });
+
+  it("normalizes model-specific reasoning effort metadata", () => {
+    const capabilities = normalizeAcpRuntimeCapabilities({
+      now: 1000,
+      source: "initialize",
+      value: {
+        models: {
+          currentModelId: "grok-4.5",
+          availableModels: [
+            {
+              modelId: "grok-4.5",
+              name: "Grok 4.5",
+              _meta: {
+                supportsReasoningEffort: true,
+                reasoningEffort: "high",
+                reasoningEfforts: [
+                  { value: "low", label: "Low" },
+                  { value: "medium", label: "Medium" },
+                  { value: "high", label: "High", default: true },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(capabilities?.models).toEqual({
+      currentModelId: "grok-4.5",
+      availableModels: [
+        {
+          id: "grok-4.5",
+          label: "Grok 4.5",
+          defaultReasoningEffort: "high",
+          reasoningEfforts: ["low", "medium", "high"],
+          supportsReasoning: true,
+        },
+      ],
+    });
+  });
 });

--- a/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-capabilities.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   acpRuntimeSupportsSessionHistoryReplay,
+  acpSessionRuntimeStateFromCapabilities,
+  acpSessionRuntimeStateFromResponse,
   normalizeAcpRuntimeCapabilities,
 } from "../acp/acp-runtime-capabilities";
 
@@ -93,29 +95,30 @@ describe("ACP runtime capabilities", () => {
   });
 
   it("normalizes model-specific reasoning effort metadata", () => {
+    const response = {
+      models: {
+        currentModelId: "grok-4.5",
+        availableModels: [
+          {
+            modelId: "grok-4.5",
+            name: "Grok 4.5",
+            _meta: {
+              supportsReasoningEffort: true,
+              reasoningEffort: "medium",
+              reasoningEfforts: [
+                { value: "low", label: "Low" },
+                { value: "medium", label: "Medium" },
+                { value: "high", label: "High", default: true },
+              ],
+            },
+          },
+        ],
+      },
+    };
     const capabilities = normalizeAcpRuntimeCapabilities({
       now: 1000,
       source: "initialize",
-      value: {
-        models: {
-          currentModelId: "grok-4.5",
-          availableModels: [
-            {
-              modelId: "grok-4.5",
-              name: "Grok 4.5",
-              _meta: {
-                supportsReasoningEffort: true,
-                reasoningEffort: "high",
-                reasoningEfforts: [
-                  { value: "low", label: "Low" },
-                  { value: "medium", label: "Medium" },
-                  { value: "high", label: "High", default: true },
-                ],
-              },
-            },
-          ],
-        },
-      },
+      value: response,
     });
 
     expect(capabilities?.models).toEqual({
@@ -129,6 +132,17 @@ describe("ACP runtime capabilities", () => {
           supportsReasoning: true,
         },
       ],
+    });
+    expect(acpSessionRuntimeStateFromCapabilities(capabilities, 1001)).toEqual({
+      currentModelId: "grok-4.5",
+      updatedAt: 1001,
+    });
+    expect(
+      acpSessionRuntimeStateFromResponse(response, 1002),
+    ).toEqual({
+      currentModelId: "grok-4.5",
+      reasoningEffort: "medium",
+      updatedAt: 1002,
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -958,6 +958,22 @@ describe("AcpSessionReplayNormalizer", () => {
     });
   });
 
+  it("omits model change notifications from transcript replay", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "model_changed",
+        model_id: "grok-4.5",
+        reasoning_effort: "low",
+      },
+    });
+
+    expect(replay.entries).toEqual([]);
+  });
+
   it("records PwrAgent turn failures as warning activity", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3327,7 +3327,7 @@ describe("DesktopBackendRegistry", () => {
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it("applies Grok ACP reasoning effort on launch and thread updates", async () => {
+  it("applies Grok ACP reasoning effort without racing turn startup", async () => {
     const sessions: AcpSessionMetadata[] = [];
     const acpBackendId = "acp:grok" as AcpBackendId;
     const setRuntimeOption = vi.fn(
@@ -3362,7 +3362,13 @@ describe("DesktopBackendRegistry", () => {
         sessions.push(metadata);
         return metadata;
       }),
-      startPrompt: vi.fn(),
+      startPrompt: vi.fn((params: {
+        sessionId: string;
+        turnId?: string;
+      }) => ({
+        sessionId: params.sessionId,
+        turnId: params.turnId ?? "grok-turn",
+      })),
       ensureSession: vi.fn(async () => undefined),
       loadSession: vi.fn(),
       refreshSession: vi.fn(async () => undefined),
@@ -3446,6 +3452,37 @@ describe("DesktopBackendRegistry", () => {
       value: "grok-4.5",
       reasoningEffort: "low",
     });
+
+    const turnStartupReachedEnsureSession = createDeferred<void>();
+    const releaseTurnStartup = createDeferred<void>();
+    acpClient.ensureSession.mockImplementationOnce(async () => {
+      turnStartupReachedEnsureSession.resolve();
+      await releaseTurnStartup.promise;
+    });
+    const turnPromise = registry.startTurn({
+      backend: acpBackendId,
+      threadId: "grok-session",
+      input: [{ type: "text", text: "start work" }],
+    });
+    await turnStartupReachedEnsureSession.promise;
+
+    const settingsPromise = registry.setThreadModelSettings({
+      backend: acpBackendId,
+      threadId: "grok-session",
+      reasoningEffort: "high",
+    });
+    await flushAsync();
+    expect(acpClient.startPrompt).not.toHaveBeenCalled();
+
+    releaseTurnStartup.resolve();
+    await turnPromise;
+    const runtimeUpdatesAfterPromptStarted = setRuntimeOption.mock.calls.length;
+    await settingsPromise;
+
+    expect(acpClient.startPrompt).toHaveBeenCalledTimes(1);
+    expect(setRuntimeOption).toHaveBeenCalledTimes(
+      runtimeUpdatesAfterPromptStarted,
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3327,6 +3327,129 @@ describe("DesktopBackendRegistry", () => {
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("applies Grok ACP reasoning effort on launch and thread updates", async () => {
+    const sessions: AcpSessionMetadata[] = [];
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const setRuntimeOption = vi.fn(
+      async (params: {
+        value: string;
+        reasoningEffort?: string;
+      }): Promise<BackendAcpSessionRuntimeState> => ({
+        currentModelId: params.value,
+        reasoningEffort: params.reasoningEffort,
+        updatedAt: 2000,
+      }),
+    );
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async (params: {
+        cwd?: string;
+        executionMode: ThreadExecutionMode;
+        acpRuntime?: BackendAcpSessionRuntimeState;
+      }) => {
+        const metadata: AcpSessionMetadata = {
+          backendId: acpBackendId,
+          sessionId: "grok-session",
+          title: "ACP session",
+          cwd: params.cwd,
+          createdAt: 1000,
+          updatedAt: 1000,
+          executionMode: params.executionMode,
+          acpRuntime: params.acpRuntime,
+          status: "idle",
+        };
+        sessions.push(metadata);
+        return metadata;
+      }),
+      startPrompt: vi.fn(),
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+      setRuntimeOption,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "grok",
+          name: "Grok",
+          distributionKind: "local",
+          distributionSource: "grok --acp",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-grok-cli",
+          installedAt: 1000,
+          updatedAt: 1000,
+          runtimeCapabilities: {
+            schemaVersion: 1,
+            status: "discovered",
+            checkedAt: 1000,
+            models: {
+              currentModelId: "grok-4.5",
+              availableModels: [
+                {
+                  id: "grok-4.5",
+                  label: "Grok 4.5",
+                  defaultReasoningEffort: "high",
+                  reasoningEfforts: ["low", "medium", "high"],
+                  supportsReasoning: true,
+                },
+              ],
+            },
+          },
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+    });
+
+    await registry.startThread({
+      backend: acpBackendId,
+      cwd: "/repo/project",
+      model: "grok-4.5",
+      reasoningEffort: "medium",
+    });
+
+    expect(setRuntimeOption).toHaveBeenLastCalledWith({
+      sessionId: "grok-session",
+      source: "model",
+      optionId: "model",
+      value: "grok-4.5",
+      reasoningEffort: "medium",
+    });
+
+    await registry.setThreadModelSettings({
+      backend: acpBackendId,
+      threadId: "grok-session",
+      reasoningEffort: "low",
+    });
+
+    expect(setRuntimeOption).toHaveBeenLastCalledWith({
+      sessionId: "grok-session",
+      source: "model",
+      optionId: "model",
+      value: "grok-4.5",
+      reasoningEffort: "low",
+    });
+
+    await registry.close();
+  });
+
   it("runs Kimi ACP execution mode changes through slash control prompts", async () => {
     const sessions: AcpSessionMetadata[] = [];
     const acpBackendId = "acp:kimi" as AcpBackendId;

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -20,7 +20,7 @@ import {
 import {
   acpRuntimeSupportsSessionHistoryReplay,
   acpRuntimeSupportsSessionLoad,
-  acpSessionRuntimeStateFromCapabilities,
+  acpSessionRuntimeStateFromResponse,
   acpSessionRuntimeStateFromUpdate,
   normalizeAcpRuntimeCapabilities,
 } from "./acp-runtime-capabilities.js";
@@ -277,10 +277,7 @@ export class AcpAgentClient {
       source: "session-new",
       result,
     });
-    const runtimeState = acpSessionRuntimeStateFromCapabilities(
-      runtimeCapabilities,
-      now,
-    );
+    const runtimeState = acpSessionRuntimeStateFromResponse(result, now);
     const combinedRuntimeState =
       params.acpRuntime || runtimeState
         ? mergeAcpRuntimeState(params.acpRuntime, runtimeState ?? {})
@@ -540,19 +537,11 @@ export class AcpAgentClient {
       reasoningEffort: params.reasoningEffort,
     });
     const now = this.now();
-    const responseRuntimeCapabilities = normalizeAcpRuntimeCapabilities({
-      value: result,
-      now,
-      source: "session-load",
-    });
     const runtimeCapabilities = this.captureRuntimeCapabilities({
       source: "session-load",
       result,
     });
-    const responseRuntimeState = acpSessionRuntimeStateFromCapabilities(
-      responseRuntimeCapabilities,
-      now,
-    );
+    const responseRuntimeState = acpSessionRuntimeStateFromResponse(result, now);
     const requestedRuntimeState: BackendAcpSessionRuntimeState =
       params.source === "configOption"
         ? {
@@ -971,10 +960,7 @@ export class AcpAgentClient {
       source: "session-load",
       result,
     });
-    const runtimeState = acpSessionRuntimeStateFromCapabilities(
-      runtimeCapabilities,
-      this.now(),
-    );
+    const runtimeState = acpSessionRuntimeStateFromResponse(result, this.now());
     if (runtimeState) {
       this.updateSessionRuntimeState(metadata.sessionId, runtimeState);
       void Promise.resolve(

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -529,6 +529,7 @@ export class AcpAgentClient {
     source: BackendAcpRuntimeOptionSource;
     optionId: string;
     value: string;
+    reasoningEffort?: string;
   }): Promise<BackendAcpSessionRuntimeState | undefined> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     const result = await this.setRuntimeOptionOnTransport({
@@ -536,6 +537,7 @@ export class AcpAgentClient {
       source: params.source,
       optionId: params.optionId,
       value: params.value,
+      reasoningEffort: params.reasoningEffort,
     });
     const now = this.now();
     const responseRuntimeCapabilities = normalizeAcpRuntimeCapabilities({
@@ -567,6 +569,9 @@ export class AcpAgentClient {
             }
           : {
               currentModelId: params.value,
+              ...(params.reasoningEffort
+                ? { reasoningEffort: params.reasoningEffort }
+                : {}),
               updatedAt: now,
             };
     const runtimeState = mergeAcpRuntimeState(
@@ -595,6 +600,7 @@ export class AcpAgentClient {
     source: BackendAcpRuntimeOptionSource;
     optionId: string;
     value: string;
+    reasoningEffort?: string;
   }): Promise<unknown> {
     if (params.source === "configOption") {
       return await this.options.transport.request("session/set_config_option", {
@@ -614,6 +620,9 @@ export class AcpAgentClient {
     return await this.options.transport.request("session/set_model", {
       sessionId: params.protocolSessionId,
       modelId: params.value,
+      ...(params.reasoningEffort
+        ? { _meta: { reasoningEffort: params.reasoningEffort } }
+        : {}),
     });
   }
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -558,9 +558,9 @@ export class AcpAgentClient {
             }
           : {
               currentModelId: params.value,
-              ...(params.reasoningEffort
-                ? { reasoningEffort: params.reasoningEffort }
-                : {}),
+              reasoningEffort:
+                responseRuntimeState?.reasoningEffort ??
+                params.reasoningEffort,
               updatedAt: now,
             };
     const runtimeState = mergeAcpRuntimeState(

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -189,7 +189,8 @@ function shouldPersistUpdate(update: Record<string, unknown>): boolean {
   if (
     kind === "available_commands_update" ||
     kind === "config_option_update" ||
-    kind === "current_mode_update"
+    kind === "current_mode_update" ||
+    kind === "model_changed"
   ) {
     return false;
   }

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -88,9 +88,6 @@ export function acpSessionRuntimeStateFromCapabilities(
           : [],
       ),
   );
-  const currentModel = capabilities.models?.availableModels.find(
-    (model) => model.id === capabilities.models?.currentModelId,
-  );
   const state: BackendAcpSessionRuntimeState = {
     updatedAt: now,
     ...(Object.keys(configValues).length > 0 ? { configValues } : {}),
@@ -100,11 +97,29 @@ export function acpSessionRuntimeStateFromCapabilities(
     ...(capabilities.models?.currentModelId
       ? { currentModelId: capabilities.models.currentModelId }
       : {}),
-    ...(currentModel?.defaultReasoningEffort
-      ? { reasoningEffort: currentModel.defaultReasoningEffort }
-      : {}),
   };
   return Object.keys(state).length > 1 ? state : undefined;
+}
+
+export function acpSessionRuntimeStateFromResponse(
+  value: unknown,
+  now: number,
+): BackendAcpSessionRuntimeState | undefined {
+  const responseCapabilities = normalizeAcpRuntimeCapabilities({
+    value,
+    now,
+    source: "session-load",
+  });
+  const state = acpSessionRuntimeStateFromCapabilities(responseCapabilities, now);
+  const reasoningEffort = readCurrentReasoningEffort(value);
+  if (!reasoningEffort) {
+    return state;
+  }
+  return {
+    ...state,
+    reasoningEffort,
+    updatedAt: now,
+  };
 }
 
 export function acpRuntimeSupportsSessionLoad(
@@ -273,33 +288,38 @@ function readModel(value: unknown): BackendAcpRuntimeModel[] {
     return [];
   }
   const meta = asRecord(record._meta ?? record.meta);
-  const reasoningEfforts = readReasoningEfforts(
+  const reasoningEffortOptions = readReasoningEfforts(
     meta?.reasoningEfforts ?? meta?.reasoning_efforts,
   );
-  const defaultReasoningEffort =
-    readString(meta, "reasoningEffort") ??
-    readString(meta, "reasoning_effort");
   const supportsReasoning =
     readBoolean(meta, "supportsReasoningEffort") ??
     readBoolean(meta, "supports_reasoning_effort") ??
-    (reasoningEfforts.length > 0 ? true : undefined);
+    (reasoningEffortOptions.values.length > 0 ? true : undefined);
   return [
     {
       id,
       label: readString(record, "name") ?? readString(record, "label"),
       description: readString(record, "description"),
-      ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
-      ...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+      ...(reasoningEffortOptions.defaultValue
+        ? { defaultReasoningEffort: reasoningEffortOptions.defaultValue }
+        : {}),
+      ...(reasoningEffortOptions.values.length > 0
+        ? { reasoningEfforts: reasoningEffortOptions.values }
+        : {}),
       ...(supportsReasoning !== undefined ? { supportsReasoning } : {}),
     },
   ];
 }
 
-function readReasoningEfforts(value: unknown): string[] {
+function readReasoningEfforts(value: unknown): {
+  defaultValue?: string;
+  values: string[];
+} {
   if (!Array.isArray(value)) {
-    return [];
+    return { values: [] };
   }
-  return [
+  let defaultValue: string | undefined;
+  const values = [
     ...new Set(
       value
         .flatMap((item) => {
@@ -307,15 +327,47 @@ function readReasoningEfforts(value: unknown): string[] {
             return [item.trim()];
           }
           const record = asRecord(item);
-          return [
+          const optionValue =
             readString(record, "value") ??
-              readString(record, "id") ??
-              "",
-          ];
+            readString(record, "id");
+          if (optionValue && readBoolean(record, "default") === true) {
+            defaultValue = optionValue;
+          }
+          return optionValue ? [optionValue] : [];
         })
         .filter(Boolean),
     ),
   ];
+  return {
+    ...(defaultValue ? { defaultValue } : {}),
+    values,
+  };
+}
+
+function readCurrentReasoningEffort(value: unknown): string | undefined {
+  const record = asRecord(value);
+  const models = asRecord(record?.models);
+  const availableModels = Array.isArray(models?.availableModels)
+    ? models.availableModels
+    : [];
+  const currentModelId =
+    readString(models, "currentModelId") ??
+    readString(models, "modelId");
+  const currentModel =
+    availableModels
+      .map(asRecord)
+      .find((model) =>
+        currentModelId
+          ? readString(model, "modelId") === currentModelId ||
+            readString(model, "id") === currentModelId
+          : readBoolean(model, "current") === true,
+      ) ??
+    (availableModels.length === 1 ? asRecord(availableModels[0]) : undefined);
+  const meta = asRecord(currentModel?._meta ?? currentModel?.meta);
+  return (
+    readString(meta, "reasoningEffort") ??
+    readString(meta, "reasoning_effort")
+  );
 }
 
 function readAgentCapabilities(

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -88,6 +88,9 @@ export function acpSessionRuntimeStateFromCapabilities(
           : [],
       ),
   );
+  const currentModel = capabilities.models?.availableModels.find(
+    (model) => model.id === capabilities.models?.currentModelId,
+  );
   const state: BackendAcpSessionRuntimeState = {
     updatedAt: now,
     ...(Object.keys(configValues).length > 0 ? { configValues } : {}),
@@ -96,6 +99,9 @@ export function acpSessionRuntimeStateFromCapabilities(
       : {}),
     ...(capabilities.models?.currentModelId
       ? { currentModelId: capabilities.models.currentModelId }
+      : {}),
+    ...(currentModel?.defaultReasoningEffort
+      ? { reasoningEffort: currentModel.defaultReasoningEffort }
       : {}),
   };
   return Object.keys(state).length > 1 ? state : undefined;
@@ -266,12 +272,49 @@ function readModel(value: unknown): BackendAcpRuntimeModel[] {
   if (!record || !id) {
     return [];
   }
+  const meta = asRecord(record._meta ?? record.meta);
+  const reasoningEfforts = readReasoningEfforts(
+    meta?.reasoningEfforts ?? meta?.reasoning_efforts,
+  );
+  const defaultReasoningEffort =
+    readString(meta, "reasoningEffort") ??
+    readString(meta, "reasoning_effort");
+  const supportsReasoning =
+    readBoolean(meta, "supportsReasoningEffort") ??
+    readBoolean(meta, "supports_reasoning_effort") ??
+    (reasoningEfforts.length > 0 ? true : undefined);
   return [
     {
       id,
       label: readString(record, "name") ?? readString(record, "label"),
       description: readString(record, "description"),
+      ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
+      ...(reasoningEfforts.length > 0 ? { reasoningEfforts } : {}),
+      ...(supportsReasoning !== undefined ? { supportsReasoning } : {}),
     },
+  ];
+}
+
+function readReasoningEfforts(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return [
+    ...new Set(
+      value
+        .flatMap((item) => {
+          if (typeof item === "string") {
+            return [item.trim()];
+          }
+          const record = asRecord(item);
+          return [
+            readString(record, "value") ??
+              readString(record, "id") ??
+              "",
+          ];
+        })
+        .filter(Boolean),
+    ),
   ];
 }
 

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -112,7 +112,7 @@ export function acpSessionRuntimeStateFromResponse(
   });
   const state = acpSessionRuntimeStateFromCapabilities(responseCapabilities, now);
   const reasoningEffort = readCurrentReasoningEffort(value);
-  if (!reasoningEffort) {
+  if (!state?.currentModelId && !reasoningEffort) {
     return state;
   }
   return {
@@ -165,7 +165,7 @@ export function acpSessionRuntimeStateFromUpdate(
     return currentModelId || reasoningEffort
       ? {
           ...(currentModelId ? { currentModelId } : {}),
-          ...(reasoningEffort ? { reasoningEffort } : {}),
+          reasoningEffort,
           updatedAt: now,
         }
       : undefined;

--- a/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-capabilities.ts
@@ -153,6 +153,23 @@ export function acpSessionRuntimeStateFromUpdate(
       readString(update, "id");
     return currentModeId ? { currentModeId, updatedAt: now } : undefined;
   }
+  if (kind === "model_changed") {
+    const currentModelId =
+      readString(update, "currentModelId") ??
+      readString(update, "current_model_id") ??
+      readString(update, "modelId") ??
+      readString(update, "model_id");
+    const reasoningEffort =
+      readString(update, "reasoningEffort") ??
+      readString(update, "reasoning_effort");
+    return currentModelId || reasoningEffort
+      ? {
+          ...(currentModelId ? { currentModelId } : {}),
+          ...(reasoningEffort ? { reasoningEffort } : {}),
+          updatedAt: now,
+        }
+      : undefined;
+  }
   if (kind === "config_option_update") {
     const configOption = asRecord(update.configOption ?? update.config_option) ?? update;
     const id =

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -158,7 +158,11 @@ export class AcpSessionReplayNormalizer {
       this.applyUserMessageChunk(update, createdAt);
     } else if (kind === "available_commands_update") {
       // Command metadata belongs in provider capabilities, not the transcript.
-    } else if (kind === "config_option_update" || kind === "current_mode_update") {
+    } else if (
+      kind === "config_option_update" ||
+      kind === "current_mode_update" ||
+      kind === "model_changed"
+    ) {
       // Runtime configuration changes belong in ACP session metadata.
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -296,7 +296,10 @@ export function describeInstalledAcpBackend(
     ],
     capabilities: buildAcpCapabilities(),
     executionModes: buildAcpExecutionModes(agent, available, unavailableReason),
-    launchpadOptions: buildAcpLaunchpadOptions(runtimeCapabilities),
+    launchpadOptions: buildAcpLaunchpadOptions(
+      runtimeCapabilities,
+      agent.registryId,
+    ),
     unavailableReason,
   };
 }
@@ -399,14 +402,25 @@ function buildAcpExecutionModes(
 
 export function buildAcpLaunchpadOptions(
   runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined,
+  registryId?: string,
 ): BackendLaunchpadOptions | undefined {
   const modelOptions =
     runtimeCapabilities?.models?.availableModels.map(
-      (model): BackendModelOption => ({
-        id: model.id,
-        label: model.label,
-        current: runtimeCapabilities.models?.currentModelId === model.id,
-      }),
+      (model): BackendModelOption => {
+        const isGrok45 = registryId === "grok" && model.id === "grok-4.5";
+        return {
+          id: model.id,
+          label: model.label,
+          current: runtimeCapabilities.models?.currentModelId === model.id,
+          defaultReasoningEffort:
+            model.defaultReasoningEffort ?? (isGrok45 ? "high" : undefined),
+          reasoningEfforts:
+            model.reasoningEfforts ??
+            (isGrok45 ? ["low", "medium", "high"] : undefined),
+          supportsReasoning:
+            model.supportsReasoning ?? (isGrok45 ? true : undefined),
+        };
+      },
     ) ?? [];
   const configModelOption =
     runtimeCapabilities?.configOptions
@@ -792,8 +806,10 @@ export class AcpBackendAdapter {
     if (!isAcpBackendId(backend)) {
       return undefined;
     }
+    const agent = this.acpAgentStore?.getInstalledAgent(backend);
     return buildAcpLaunchpadOptions(
-      this.acpAgentStore?.getInstalledAgent(backend)?.runtimeCapabilities,
+      agent?.runtimeCapabilities,
+      agent?.registryId,
     );
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10172,34 +10172,48 @@ export class DesktopBackendRegistry {
       },
       "settings-refresh",
     );
-    if (
-      isAcpBackendId(params.backend) &&
-      modelSettings.model &&
-      !this.threadHasActiveTurn(params.threadId, params.backend) &&
-      (
-        modelSettings.model !== current?.model ||
-        modelSettings.reasoningEffort !== current?.reasoningEffort
-      )
-    ) {
-      const session = this.acpBackend.getSession(params.backend, params.threadId);
-      if (!session) {
-        throw new Error(`ACP session not found: ${params.threadId}`);
-      }
-      const client = await this.acpBackend.getClient(params.backend);
-      await client.ensureSession?.(session);
-      await client.setRuntimeOption?.({
-        sessionId: params.threadId,
-        source: "model",
-        optionId: "model",
-        value: modelSettings.model,
-        reasoningEffort: modelSettings.reasoningEffort,
+    const acpBackend = isAcpBackendId(params.backend)
+      ? params.backend
+      : undefined;
+    const acpRuntimeModelChanged =
+      modelSettings.model !== current?.model ||
+      modelSettings.reasoningEffort !== current?.reasoningEffort;
+    const persistModelSettings = async (): Promise<void> => {
+      await this.overlayStore.setThreadModelSettings({
+        backend: params.backend,
+        threadId: params.threadId,
+        ...modelSettings,
       });
+    };
+    if (acpBackend && modelSettings.model && acpRuntimeModelChanged) {
+      const runtimeModel = modelSettings.model;
+      await this.acpSessionPromptLocks.run(
+        executionModeQueueKey(acpBackend, params.threadId),
+        async () => {
+          if (!this.threadHasActiveTurn(params.threadId, acpBackend)) {
+            const session = this.acpBackend.getSession(
+              acpBackend,
+              params.threadId,
+            );
+            if (!session) {
+              throw new Error(`ACP session not found: ${params.threadId}`);
+            }
+            const client = await this.acpBackend.getClient(acpBackend);
+            await client.ensureSession?.(session);
+            await client.setRuntimeOption?.({
+              sessionId: params.threadId,
+              source: "model",
+              optionId: "model",
+              value: runtimeModel,
+              reasoningEffort: modelSettings.reasoningEffort,
+            });
+          }
+          await persistModelSettings();
+        },
+      );
+    } else {
+      await persistModelSettings();
     }
-    await this.overlayStore.setThreadModelSettings({
-      backend: params.backend,
-      threadId: params.threadId,
-      ...modelSettings,
-    });
 
     await this.emit({
       backend: params.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6669,6 +6669,7 @@ export class DesktopBackendRegistry {
     cwd?: string;
     executionMode: ThreadExecutionMode;
     acpRuntime?: BackendAcpSessionRuntimeState;
+    reasoningEffort?: string;
   }): Promise<{ threadId: string }> {
     const client = await this.acpBackend.getClient(params.backend);
     const initialExecutionMode = this.usesSlashControlledAcpExecutionModes(
@@ -6691,7 +6692,12 @@ export class DesktopBackendRegistry {
         executionMode: params.executionMode,
       });
     }
-    await this.applyAcpRuntimeSelection(client, session.sessionId, params.acpRuntime);
+    await this.applyAcpRuntimeSelection(
+      client,
+      session.sessionId,
+      params.acpRuntime,
+      params.reasoningEffort,
+    );
     return { threadId: session.sessionId };
   }
 
@@ -6699,6 +6705,8 @@ export class DesktopBackendRegistry {
     backend: AcpBackendId;
     threadId: string;
     input: AppServerTurnInputItem[];
+    model?: string;
+    reasoningEffort?: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     return await this.acpSessionPromptLocks.run(
       executionModeQueueKey(params.backend, params.threadId),
@@ -6710,6 +6718,8 @@ export class DesktopBackendRegistry {
     backend: AcpBackendId;
     threadId: string;
     input: AppServerTurnInputItem[];
+    model?: string;
+    reasoningEffort?: string;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     const promptPayload = inputToAcpPrompt(params.input);
     if (!promptPayload) {
@@ -6738,6 +6748,21 @@ export class DesktopBackendRegistry {
         await this.assertAcpSessionCanRebindForWorkspace(params.backend, sessionForTurn);
         sessionForTurn = await this.rebindAcpSessionForWorkspace(client, sessionForTurn);
       }
+    }
+    if (
+      params.model &&
+      (
+        sessionForTurn.acpRuntime?.currentModelId !== params.model ||
+        sessionForTurn.acpRuntime?.reasoningEffort !== params.reasoningEffort
+      )
+    ) {
+      await client.setRuntimeOption?.({
+        sessionId: params.threadId,
+        source: "model",
+        optionId: "model",
+        value: params.model,
+        reasoningEffort: params.reasoningEffort,
+      });
     }
     const syntheticStartedTurnId = `pending:${params.threadId}:${Date.now()}`;
     await this.emit({
@@ -6797,6 +6822,7 @@ export class DesktopBackendRegistry {
     client: AcpRuntimeClient,
     sessionId: string,
     runtime: BackendAcpSessionRuntimeState | undefined,
+    reasoningEffort?: string,
   ): Promise<void> {
     for (const [optionId, value] of Object.entries(runtime?.configValues ?? {})) {
       await client.setRuntimeOption?.({
@@ -6820,6 +6846,7 @@ export class DesktopBackendRegistry {
         source: "model",
         optionId: "model",
         value: runtime.currentModelId,
+        reasoningEffort,
       });
     }
   }
@@ -8067,6 +8094,7 @@ export class DesktopBackendRegistry {
             cwd,
             executionMode: effectiveExecutionMode,
             acpRuntime,
+            reasoningEffort: modelSettings.reasoningEffort,
           })
         : await this.getClient(backend, effectiveExecutionMode).startThread({
             ...request,
@@ -8606,6 +8634,15 @@ export class DesktopBackendRegistry {
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     this.assertNotBootstrap("startTurn");
     if (isAcpBackendId(params.backend)) {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      const modelSettings = await this.resolveModelSettings(params.backend, {
+        model: params.model ?? overlay?.model,
+        reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+        reasoningEffortsByModel: overlay?.reasoningEffortsByModel,
+      });
       const reservationKey = buildTurnStartReservationKey(
         params.backend,
         params.threadId,
@@ -8629,6 +8666,8 @@ export class DesktopBackendRegistry {
           backend: params.backend,
           threadId: params.threadId,
           input: params.input,
+          model: modelSettings.model,
+          reasoningEffort: modelSettings.reasoningEffort,
         });
         this.scheduleThreadTitleGeneration({
           backend: params.backend,
@@ -10133,6 +10172,29 @@ export class DesktopBackendRegistry {
       },
       "settings-refresh",
     );
+    if (
+      isAcpBackendId(params.backend) &&
+      modelSettings.model &&
+      !this.threadHasActiveTurn(params.threadId, params.backend) &&
+      (
+        modelSettings.model !== current?.model ||
+        modelSettings.reasoningEffort !== current?.reasoningEffort
+      )
+    ) {
+      const session = this.acpBackend.getSession(params.backend, params.threadId);
+      if (!session) {
+        throw new Error(`ACP session not found: ${params.threadId}`);
+      }
+      const client = await this.acpBackend.getClient(params.backend);
+      await client.ensureSession?.(session);
+      await client.setRuntimeOption?.({
+        sessionId: params.threadId,
+        source: "model",
+        optionId: "model",
+        value: modelSettings.model,
+        reasoningEffort: modelSettings.reasoningEffort,
+      });
+    }
     await this.overlayStore.setThreadModelSettings({
       backend: params.backend,
       threadId: params.threadId,
@@ -15847,11 +15909,12 @@ export class DesktopBackendRegistry {
         ? session.acpRuntime.configValues.model
         : undefined);
     const reasoningEffort =
-      typeof session?.acpRuntime?.configValues?.reasoningEffort === "string"
+      session?.acpRuntime?.reasoningEffort ??
+      (typeof session?.acpRuntime?.configValues?.reasoningEffort === "string"
         ? session.acpRuntime.configValues.reasoningEffort
         : typeof session?.acpRuntime?.configValues?.reasoning_effort === "string"
           ? session.acpRuntime.configValues.reasoning_effort
-          : undefined;
+          : undefined);
     return {
       ...(model ? { model } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1584,6 +1584,45 @@ describe("Composer", () => {
     expect(screen.queryByRole("option", { name: "Default" })).not.toBeInTheDocument();
   });
 
+  it("shows Grok 4.5 ACP reasoning effort in the launchpad", () => {
+    render(
+      <Composer
+        backends={[
+          backendSummary("acp:grok", {
+            models: [
+              {
+                id: "grok-4.5",
+                label: "Grok 4.5",
+                current: true,
+                defaultReasoningEffort: "high",
+                reasoningEfforts: ["low", "medium", "high"],
+                supportsReasoning: true,
+              },
+            ],
+          }),
+        ]}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+          backend: "acp:grok",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("Model")).toHaveValue("grok-4.5");
+    expect(screen.getByLabelText("Reasoning")).toHaveValue("high");
+  });
+
   it("sends effective model defaults for threads without saved model settings", async () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -61,6 +61,9 @@ export type BackendAcpRuntimeModel = {
   label?: string;
   description?: string;
   current?: boolean;
+  defaultReasoningEffort?: string;
+  reasoningEfforts?: string[];
+  supportsReasoning?: boolean;
 };
 
 export type BackendAcpRuntimeModelState = {
@@ -110,6 +113,7 @@ export type BackendAcpSessionRuntimeState = {
   configValues?: Record<string, string>;
   currentModeId?: string;
   currentModelId?: string;
+  reasoningEffort?: string;
   updatedAt?: number;
 };
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -251,6 +251,7 @@ export type AppServerAcpSessionRuntimeState = {
   configValues?: Record<string, string>;
   currentModeId?: string;
   currentModelId?: string;
+  reasoningEffort?: string;
   updatedAt?: number;
 };
 


### PR DESCRIPTION
## Summary

- expose Grok 4.5 `low`, `medium`, and `high` reasoning effort choices in the launchpad and existing-thread composer
- normalize model-specific ACP reasoning metadata and retain the selected effort in ACP session runtime state
- send the effort through ACP `session/set_model` as `_meta.reasoningEffort`
- fall back to Grok 4.5's documented effort capabilities for older cached runtime records

## Why

Grok 4.5 supports configurable reasoning effort, but PwrAgent discarded the ACP model metadata that advertises those choices. The composer therefore had no capability signal to render its existing reasoning selector, and ACP model updates did not transmit an effort value.

## Impact

Grok 4.5 threads now default to high effort and allow low, medium, or high to be selected before launch or from an existing thread. Idle-thread changes apply immediately; changes made during an active turn are applied before the next turn.

## Validation

- focused Vitest coverage for ACP capability normalization, launchpad options, ACP transport metadata, registry application, and composer rendering
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors; baseline warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
