### PR TITLE
fix(desktop): use readable ACP rollout paths

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -69,7 +69,7 @@ describe("AcpRolloutStore", () => {
     expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(false);
   });
 
-  it("merges legacy encoded backend rollout history with new records", () => {
+  it("migrates legacy encoded backend rollout history before writing", () => {
     const backendId = "acp:grok" as AcpBackendId;
     const legacyRolloutPath = path.join(
       tempDir,
@@ -104,13 +104,106 @@ describe("AcpRolloutStore", () => {
     });
     const replay = store.readReplay({ backendId, sessionId: "session-1" });
 
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(false);
     expect(
       fs.existsSync(path.join(tempDir, "acp_grok", "session-1", "rollout.jsonl")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tempDir, ".backend-path-layout-v2")),
     ).toBe(true);
     expect(replay.messages.map((message) => message.text)).toEqual([
       "from the old path",
       "from the new path",
     ]);
+  });
+
+  it("keeps colliding legacy backend names disjoint after migration", () => {
+    const sessionId = "shared-session";
+    const writeLegacyRollout = (
+      backendDirectory: string,
+      prompt: string,
+    ): void => {
+      const rolloutPath = path.join(
+        tempDir,
+        backendDirectory,
+        sessionId,
+        "rollout.jsonl",
+      );
+      fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+      fs.writeFileSync(
+        rolloutPath,
+        `${JSON.stringify({
+          type: "update",
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt,
+            turnId: "turn-1",
+          },
+        })}\n`,
+        "utf8",
+      );
+    };
+    writeLegacyRollout("acp_3Agrok", "grok history");
+    writeLegacyRollout("acp_3A3Agrok", "3Agrok history");
+
+    const store = new AcpRolloutStore(tempDir);
+
+    expect(
+      store
+        .readReplay({
+          backendId: "acp:grok" as AcpBackendId,
+          sessionId,
+        })
+        .messages.map((message) => message.text),
+    ).toEqual(["grok history"]);
+    expect(
+      store
+        .readReplay({
+          backendId: "acp:3Agrok" as AcpBackendId,
+          sessionId,
+        })
+        .messages.map((message) => message.text),
+    ).toEqual(["3Agrok history"]);
+    expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_3A3Agrok"))).toBe(false);
+  });
+
+  it("does not remigrate new backend directories on later startups", () => {
+    const backendId = "acp:3Agrok" as AcpBackendId;
+    const firstStore = new AcpRolloutStore(tempDir);
+    firstStore.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "belongs to 3Agrok",
+        turnId: "turn-1",
+      },
+    });
+
+    const secondStore = new AcpRolloutStore(tempDir);
+
+    expect(
+      secondStore
+        .readReplay({ backendId, sessionId: "session-1" })
+        .messages.map((message) => message.text),
+    ).toEqual(["belongs to 3Agrok"]);
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(false);
+  });
+
+  it("refuses to overwrite an existing migration destination", () => {
+    fs.mkdirSync(path.join(tempDir, "acp_3Agrok"), { recursive: true });
+    fs.mkdirSync(path.join(tempDir, "acp_grok"), { recursive: true });
+
+    expect(() => new AcpRolloutStore(tempDir)).toThrow(
+      /both paths exist/,
+    );
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(true);
   });
 
   it("hides Qwen thought chunks when restoring rollout replay", () => {

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -48,6 +48,71 @@ describe("AcpRolloutStore", () => {
     ]);
   });
 
+  it("stores ACP rollouts under readable backend directory names", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:grok" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "hello",
+        turnId: "turn-1",
+      },
+    });
+
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_grok", "session-1", "rollout.jsonl")),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(false);
+  });
+
+  it("merges legacy encoded backend rollout history with new records", () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const legacyRolloutPath = path.join(
+      tempDir,
+      "acp_3Agrok",
+      "session-1",
+      "rollout.jsonl",
+    );
+    fs.mkdirSync(path.dirname(legacyRolloutPath), { recursive: true });
+    fs.writeFileSync(
+      legacyRolloutPath,
+      `${JSON.stringify({
+        type: "update",
+        receivedAt: 1000,
+        update: {
+          kind: "pwragent_user_prompt",
+          prompt: "from the old path",
+          turnId: "turn-1",
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const store = new AcpRolloutStore(tempDir);
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "from the new path" },
+      },
+    });
+    const replay = store.readReplay({ backendId, sessionId: "session-1" });
+
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_grok", "session-1", "rollout.jsonl")),
+    ).toBe(true);
+    expect(replay.messages.map((message) => message.text)).toEqual([
+      "from the old path",
+      "from the new path",
+    ]);
+  });
+
   it("hides Qwen thought chunks when restoring rollout replay", () => {
     const store = new AcpRolloutStore(tempDir);
     const backendId = "acp:qwen" as AcpBackendId;

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -67,20 +67,9 @@ export class AcpRolloutStore {
     sessionId: string;
   }): AcpRolloutRecord[] {
     this.flushSession(params.backendId, params.sessionId);
-    const rolloutPath = this.rolloutPath(params.backendId, params.sessionId);
-    if (!fs.existsSync(rolloutPath)) {
-      return [];
-    }
-    return fs
-      .readFileSync(rolloutPath, "utf8")
-      .split(/\r?\n/)
-      .flatMap((line) => {
-        if (!line.trim()) {
-          return [];
-        }
-        const parsed = parseJson(line);
-        return isRolloutRecord(parsed) ? [parsed] : [];
-      });
+    return this.readRolloutPaths(params.backendId, params.sessionId)
+      .flatMap((rolloutPath) => readRolloutRecords(rolloutPath))
+      .sort((left, right) => left.receivedAt - right.receivedAt);
   }
 
   readReplay(params: {
@@ -177,10 +166,27 @@ export class AcpRolloutStore {
   private rolloutPath(backendId: AcpBackendId, sessionId: string): string {
     return path.join(
       this.rootDir,
-      encodePathSegment(backendId),
+      encodeBackendPathSegment(backendId),
       encodePathSegment(sessionId),
       "rollout.jsonl",
     );
+  }
+
+  private readRolloutPaths(
+    backendId: AcpBackendId,
+    sessionId: string,
+  ): string[] {
+    const sessionPathSegment = encodePathSegment(sessionId);
+    const legacyPath = path.join(
+      this.rootDir,
+      encodePathSegment(backendId),
+      sessionPathSegment,
+      "rollout.jsonl",
+    );
+    const currentPath = this.rolloutPath(backendId, sessionId);
+    return legacyPath === currentPath
+      ? [currentPath]
+      : [legacyPath, currentPath];
   }
 }
 
@@ -310,6 +316,26 @@ function hashString(value: string): string {
 
 function encodePathSegment(value: string): string {
   return encodeURIComponent(value).replaceAll("%", "_");
+}
+
+function encodeBackendPathSegment(value: AcpBackendId): string {
+  return value.replace(":", "_");
+}
+
+function readRolloutRecords(rolloutPath: string): AcpRolloutRecord[] {
+  if (!fs.existsSync(rolloutPath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(rolloutPath, "utf8")
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      if (!line.trim()) {
+        return [];
+      }
+      const parsed = parseJson(line);
+      return isRolloutRecord(parsed) ? [parsed] : [];
+    });
 }
 
 function parseJson(value: string): unknown {

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { AcpBackendId, AppServerThreadReplay } from "@pwragent/shared";
+import {
+  isAcpBackendId,
+  type AcpBackendId,
+  type AppServerThreadReplay,
+} from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
   isAcpUserBoilerplateMessage,
@@ -31,12 +35,17 @@ type ChunkBuffer = {
 };
 
 const CHUNK_FLUSH_TEXT_LENGTH = 2_048;
+const LEGACY_BACKEND_PATH_PREFIX = "acp_3A";
+const CURRENT_BACKEND_PATH_PREFIX = "acp_";
+const PATH_LAYOUT_MIGRATION_MARKER = ".backend-path-layout-v2";
 
 export class AcpRolloutStore {
   private readonly chunkBuffers = new Map<string, ChunkBuffer>();
   private readonly lastFingerprints = new Map<string, string>();
 
-  constructor(private readonly rootDir: string) {}
+  constructor(private readonly rootDir: string) {
+    migrateLegacyBackendDirectories(rootDir);
+  }
 
   appendUpdate(params: AcpRolloutStoreAppendParams): void {
     if (!shouldPersistUpdate(params.update)) {
@@ -67,9 +76,9 @@ export class AcpRolloutStore {
     sessionId: string;
   }): AcpRolloutRecord[] {
     this.flushSession(params.backendId, params.sessionId);
-    return this.readRolloutPaths(params.backendId, params.sessionId)
-      .flatMap((rolloutPath) => readRolloutRecords(rolloutPath))
-      .sort((left, right) => left.receivedAt - right.receivedAt);
+    return readRolloutRecords(
+      this.rolloutPath(params.backendId, params.sessionId),
+    );
   }
 
   readReplay(params: {
@@ -170,23 +179,6 @@ export class AcpRolloutStore {
       encodePathSegment(sessionId),
       "rollout.jsonl",
     );
-  }
-
-  private readRolloutPaths(
-    backendId: AcpBackendId,
-    sessionId: string,
-  ): string[] {
-    const sessionPathSegment = encodePathSegment(sessionId);
-    const legacyPath = path.join(
-      this.rootDir,
-      encodePathSegment(backendId),
-      sessionPathSegment,
-      "rollout.jsonl",
-    );
-    const currentPath = this.rolloutPath(backendId, sessionId);
-    return legacyPath === currentPath
-      ? [currentPath]
-      : [legacyPath, currentPath];
   }
 }
 
@@ -320,6 +312,72 @@ function encodePathSegment(value: string): string {
 
 function encodeBackendPathSegment(value: AcpBackendId): string {
   return value.replace(":", "_");
+}
+
+function migrateLegacyBackendDirectories(rootDir: string): void {
+  const markerPath = path.join(rootDir, PATH_LAYOUT_MIGRATION_MARKER);
+  if (fs.existsSync(markerPath)) {
+    return;
+  }
+
+  fs.mkdirSync(rootDir, { recursive: true });
+  const legacyDirectoryNames = fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name.startsWith(LEGACY_BACKEND_PATH_PREFIX) &&
+        isAcpBackendId(
+          `acp:${entry.name.slice(LEGACY_BACKEND_PATH_PREFIX.length)}`,
+        ),
+    )
+    .map((entry) => entry.name)
+    .sort(
+      (left, right) =>
+        left.length - right.length || left.localeCompare(right),
+    );
+
+  for (const legacyDirectoryName of legacyDirectoryNames) {
+    const registryId = legacyDirectoryName.slice(
+      LEGACY_BACKEND_PATH_PREFIX.length,
+    );
+    const currentDirectoryName = `${CURRENT_BACKEND_PATH_PREFIX}${registryId}`;
+    const legacyPath = path.join(rootDir, legacyDirectoryName);
+    const currentPath = path.join(rootDir, currentDirectoryName);
+    if (!fs.existsSync(legacyPath)) {
+      continue;
+    }
+    if (fs.existsSync(currentPath)) {
+      throw new Error(
+        `Cannot migrate ACP rollout directory because both paths exist: ${legacyPath} and ${currentPath}`,
+      );
+    }
+    try {
+      fs.renameSync(legacyPath, currentPath);
+    } catch (error) {
+      if (
+        isErrnoException(error) &&
+        error.code === "ENOENT" &&
+        !fs.existsSync(legacyPath) &&
+        fs.existsSync(currentPath)
+      ) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  try {
+    fs.writeFileSync(markerPath, "2\n", { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    if (!isErrnoException(error) || error.code !== "EEXIST") {
+      throw error;
+    }
+  }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function readRolloutRecords(rolloutPath: string): AcpRolloutRecord[] {


### PR DESCRIPTION
## Summary

- write ACP rollout history beneath readable backend directories such as `acp_grok`
- migrate legacy percent-derived directories such as `acp_3Agrok` during rollout-store startup
- record the completed path-layout migration so future valid backend IDs such as `acp:3Agrok` remain disjoint

## Why

The rollout path encoded `acp:grok` with `encodeURIComponent`, producing
`acp%3Agrok`, and then replaced `%` with `_`. That left the
implementation-detail directory name `acp_3Agrok` instead of the intended
readable `acp_grok` form.

The initial compatibility approach read both names, but that could alias the
legacy directory for `acp:grok` with the new directory for a valid backend such
as `acp:3Agrok`. Startup now renames legacy directories before the store is
used and then reads only the new layout.

No database rewrite is required because ACP rollout paths are derived from the
logical backend and session IDs rather than persisted in SQLite.

## Migration safety

- legacy directories are renamed shortest-name first so colliding legacy names remain separable
- a version marker prevents the migration from reinterpreting new directories on later startups
- an existing destination is never overwritten
- concurrent rename completion is handled idempotently

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-rollout-store.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts`
- `pnpm exec eslint apps/desktop/src/main/acp/acp-rollout-store.ts apps/desktop/src/main/__tests__/acp-rollout-store.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check`
