### PR TITLE
fix(desktop): keep ACP permission modes consistent

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1957,13 +1957,22 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
   });
 
-  it("does not render Grok transient vendor interaction updates", async () => {
-    const transport = new FakeAcpAgentTransport();
+  it("preserves a Grok assistant stream across transient vendor updates", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const assistantMessageItemIds: Array<string | undefined> = [];
     const client = new AcpAgentClient({
       backendId: "acp:grok",
       store,
       transport,
       now: () => 1000,
+      onSessionUpdate: ({ assistantMessageItemId, update }) => {
+        if (update.sessionUpdate === "agent_message_chunk") {
+          assistantMessageItemIds.push(assistantMessageItemId);
+        }
+      },
     });
 
     await client.initialize();
@@ -1971,11 +1980,23 @@ describe("AcpAgentClient", () => {
       cwd: "/repo",
       executionMode: "default",
     });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "Before ",
+      },
+    });
     for (const sessionUpdate of [
       "tool_call_delta_chunk",
       "pending_interaction",
       "interaction_resolved",
-      "turn_completed",
     ]) {
       transport.emitVendorNotification({
         method: "_x.ai/session_notification",
@@ -1983,10 +2004,87 @@ describe("AcpAgentClient", () => {
         update: { sessionUpdate },
       });
     }
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: "after",
+      },
+    });
 
-    expect(client.readReplay(session.sessionId)).toMatchObject({
-      entries: [],
-      threadStatus: "idle",
+    expect(assistantMessageItemIds).toEqual([
+      "assistant:turn-1:0",
+      "assistant:turn-1:0",
+    ]);
+    expect(client.readReplay(session.sessionId).entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "user",
+        text: "Inspect this",
+      }),
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        text: "Before after",
+      }),
+    ]);
+
+    promptResponse.resolve({ turnId: "turn-1" });
+    await vi.waitFor(() => {
+      expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
+    });
+  });
+
+  it("keeps a tracked Grok turn active until session/prompt resolves", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const statuses: string[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ replay }) => {
+        statuses.push(replay.threadStatus ?? "unknown");
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+    transport.emitVendorNotification({
+      method: "_x.ai/session_notification",
+      sessionId: session.sessionId,
+      update: {
+        sessionUpdate: "turn_completed",
+        prompt_id: "turn-1",
+        stop_reason: "end_turn",
+      },
+    });
+
+    expect(client.readReplay(session.sessionId).threadStatus).toBe("active");
+    expect(statuses.at(-1)).toBe("active");
+    expect(() =>
+      client.startPrompt({
+        sessionId: session.sessionId,
+        prompt: "Second turn",
+        turnId: "turn-2",
+      }),
+    ).toThrow("A turn is already active for this ACP session.");
+
+    promptResponse.resolve({ turnId: "turn-1" });
+    await vi.waitFor(() => {
+      expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
     });
   });
 

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1957,6 +1957,39 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay(session.sessionId).entries).toEqual([]);
   });
 
+  it("does not render Grok transient vendor interaction updates", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    for (const sessionUpdate of [
+      "tool_call_delta_chunk",
+      "pending_interaction",
+      "interaction_resolved",
+      "turn_completed",
+    ]) {
+      transport.emitVendorNotification({
+        method: "_x.ai/session_notification",
+        sessionId: session.sessionId,
+        update: { sessionUpdate },
+      });
+    }
+
+    expect(client.readReplay(session.sessionId)).toMatchObject({
+      entries: [],
+      threadStatus: "idle",
+    });
+  });
+
   it("reports fire-and-forget prompt failures", async () => {
     const transport = new FakeAcpAgentTransport();
     const quotaError =

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -884,6 +884,64 @@ describe("AcpSessionReplayNormalizer", () => {
     ).toBeUndefined();
   });
 
+  it("ignores transient Grok interaction updates without splitting text", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: { sessionUpdate: "agent_message_chunk", content: "Before " },
+    });
+    for (const sessionUpdate of [
+      "tool_call_delta_chunk",
+      "pending_interaction",
+      "interaction_resolved",
+    ]) {
+      normalizer.apply({
+        sessionId: "session-1",
+        receivedAt: 1001,
+        update: { sessionUpdate },
+      });
+    }
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1002,
+      update: { sessionUpdate: "agent_message_chunk", content: "after" },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "message",
+        role: "assistant",
+        text: "Before after",
+      }),
+    ]);
+  });
+
+  it("treats Grok turn_completed as an idempotent turn finish", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    normalizer.recordUserPrompt({
+      sessionId: "session-1",
+      prompt: "Inspect this",
+      turnId: "turn-1",
+      receivedAt: 1000,
+      waitingForAgent: true,
+    });
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: { sessionUpdate: "turn_completed" },
+    });
+
+    expect(replay.threadStatus).toBe("idle");
+    expect(
+      replay.entries.some(
+        (entry) => entry.type === "activity" && entry.status === "in_progress",
+      ),
+    ).toBe(false);
+  });
+
   it("records thought chunks as assistant response messages", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -251,7 +251,7 @@ function createOverlayStoreMock(params?: {
       backend,
       threadId,
     }: {
-      backend: "codex" | "grok";
+      backend: ThreadOverlayState["backend"];
       threadId: string;
     }) => overlays.get(`${backend}:${threadId}`),
     getThreadOverlayStates: async ({ threadIds }: { threadIds: string[] }) =>
@@ -385,7 +385,7 @@ function createOverlayStoreMock(params?: {
       threadId,
       executionMode,
     }: {
-      backend: "codex" | "grok";
+      backend: ThreadOverlayState["backend"];
       threadId: string;
       executionMode: "default" | "full-access";
     }) => {
@@ -3382,10 +3382,11 @@ describe("DesktopBackendRegistry", () => {
         threadStatus: "idle",
       })),
     };
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       acpAgentStore: createAcpAgentStoreMock([
         {
           backendId: acpBackendId,
@@ -3439,6 +3440,14 @@ describe("DesktopBackendRegistry", () => {
       sessionId: "kimi-session-1",
       prompt: "/yolo",
     });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "full-access",
+    });
 
     sendControlPrompt.mockClear();
     await expect(
@@ -3457,6 +3466,14 @@ describe("DesktopBackendRegistry", () => {
       prompt: "/yolo",
     });
     expect(sessions[0]?.executionMode).toBe("default");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "default",
+    });
 
     await registry.close();
   });
@@ -3497,6 +3514,13 @@ describe("DesktopBackendRegistry", () => {
       })),
       refreshSession: vi.fn(async () => undefined),
       cancelSession: vi.fn(),
+      setRuntimeOption: vi.fn(
+        async (): Promise<BackendAcpSessionRuntimeState> => ({
+          configValues: { "approval-mode": "yolo" },
+          currentModeId: "yolo",
+          updatedAt: 2000,
+        }),
+      ),
       readReplay: vi.fn((): AppServerThreadReplay => ({
         entries: [],
         messages: [],
@@ -3504,10 +3528,11 @@ describe("DesktopBackendRegistry", () => {
         threadStatus: "idle",
       })),
     };
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       acpAgentStore: createAcpAgentStoreMock([
         {
           backendId: acpBackendId,
@@ -3573,7 +3598,28 @@ describe("DesktopBackendRegistry", () => {
       threadId: "kimi-session-1",
       executionMode: "default",
     });
+    await registry.setAcpSessionRuntimeOption({
+      backend: acpBackendId,
+      threadId: "kimi-session-1",
+      source: "configOption",
+      optionId: "approval-mode",
+      value: "yolo",
+    });
     expect(sendControlPrompt).not.toHaveBeenCalled();
+    expect(acpClient.setRuntimeOption).toHaveBeenCalledWith({
+      sessionId: "kimi-session-1",
+      source: "configOption",
+      optionId: "approval-mode",
+      value: "yolo",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "kimi-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "full-access",
+    });
 
     await registry.close();
   });
@@ -3632,10 +3678,11 @@ describe("DesktopBackendRegistry", () => {
         threadStatus: "idle",
       })),
     };
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       acpAgentStore: createAcpAgentStoreMock([
         {
           backendId: acpBackendId,
@@ -3689,6 +3736,14 @@ describe("DesktopBackendRegistry", () => {
       prompt: "/always-approve on",
     });
     expect(sessions[0]?.executionMode).toBe("full-access");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "grok-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "full-access",
+    });
 
     // This is the assertion the user-reported bug fails on: listThreads
     // must surface the just-applied "full-access" mode so the renderer
@@ -3700,6 +3755,33 @@ describe("DesktopBackendRegistry", () => {
     );
     expect(thread).toBeDefined();
     expect(thread?.executionMode).toBe("full-access");
+
+    const permissionEvents: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      permissionEvents.push(event);
+    });
+    const handlePermissionRequest = (
+      registry as unknown as {
+        handleServerRequest(
+          backend: AcpBackendId,
+          request: AppServerPendingRequestNotification,
+        ): Promise<unknown>;
+      }
+    ).handleServerRequest.bind(registry);
+    const permissionRequest: AppServerPendingRequestNotification = {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "grok-session-1",
+        turnId: "turn-1",
+        requestId: "approval-1",
+        acpMethod: "session/request_permission",
+        command: "pnpm build",
+      },
+    };
+    await expect(
+      handlePermissionRequest(acpBackendId, permissionRequest),
+    ).resolves.toEqual({ decision: "approve" });
+    expect(permissionEvents).toEqual([]);
 
     sendControlPrompt.mockClear();
     await expect(
@@ -3718,7 +3800,39 @@ describe("DesktopBackendRegistry", () => {
       prompt: "/always-approve off",
     });
     expect(sessions[0]?.executionMode).toBe("default");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "grok-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "default",
+    });
 
+    permissionEvents.length = 0;
+    const defaultResponse = handlePermissionRequest(
+      acpBackendId,
+      permissionRequest,
+    );
+    await waitForCondition(() =>
+      permissionEvents.some(
+        (event) =>
+          event.notification.method === "item/commandExecution/requestApproval",
+      ),
+    );
+    expect(permissionEvents).toContainEqual({
+      backend: acpBackendId,
+      notification: permissionRequest,
+    });
+    await registry.submitServerRequest({
+      backend: acpBackendId,
+      threadId: "grok-session-1",
+      requestId: "approval-1",
+      response: { decision: "approve" },
+    });
+    await expect(defaultResponse).resolves.toEqual({ decision: "approve" });
+
+    unsubscribe();
     await registry.close();
   });
 
@@ -4212,10 +4326,11 @@ describe("DesktopBackendRegistry", () => {
         }),
       ),
     };
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       acpAgentStore: createAcpAgentStoreMock([
         {
           backendId: acpBackendId,
@@ -4283,6 +4398,14 @@ describe("DesktopBackendRegistry", () => {
           executionMode: "default",
         },
       },
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: acpBackendId,
+        threadId: "qwen-session-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "default",
     });
 
     unsubscribe();

--- a/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { ThreadPermissionTransition } from "@pwragent/shared";
+import type {
+  AppServerThreadSummary,
+  ThreadPermissionTransition,
+} from "@pwragent/shared";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 import {
@@ -155,5 +158,38 @@ describe("SqliteOverlayStore — permission transition log", () => {
     expect(grok?.permissionTransitionLog?.map((entry) => entry.id)).toEqual([
       "grok-1",
     ]);
+  });
+
+  it("repairs a stale ACP overlay from authoritative session metadata", async () => {
+    await store.setThreadExecutionMode({
+      backend: "acp:grok",
+      threadId: "thread-1",
+      executionMode: "default",
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Grok thread",
+      titleSource: "explicit",
+      source: "acp:grok",
+      linkedDirectories: [],
+      updatedAt: 2000,
+      executionMode: "full-access",
+    };
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "acp:grok",
+      fetchedAt: 2000,
+      threads: [thread],
+    });
+
+    expect(snapshot.threads[0]?.executionMode).toBe("full-access");
+    await expect(
+      store.getThreadOverlayState({
+        backend: "acp:grok",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "full-access",
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-permission-transitions.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AppServerThreadSummary,
   ThreadPermissionTransition,
@@ -34,6 +34,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   stateDb.close();
 });
 
@@ -165,6 +166,7 @@ describe("SqliteOverlayStore — permission transition log", () => {
       backend: "acp:grok",
       threadId: "thread-1",
       executionMode: "default",
+      updatedAt: 1000,
     });
     const thread: AppServerThreadSummary = {
       id: "thread-1",
@@ -180,6 +182,41 @@ describe("SqliteOverlayStore — permission transition log", () => {
       backend: "acp:grok",
       fetchedAt: 2000,
       threads: [thread],
+    });
+
+    expect(snapshot.threads[0]?.executionMode).toBe("full-access");
+    await expect(
+      store.getThreadOverlayState({
+        backend: "acp:grok",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      executionMode: "full-access",
+    });
+  });
+
+  it("does not replace a newer ACP mode with an older navigation snapshot", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2000);
+    await store.setThreadExecutionMode({
+      backend: "acp:grok",
+      threadId: "thread-1",
+      executionMode: "full-access",
+    });
+    const staleThread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Grok thread",
+      titleSource: "explicit",
+      source: "acp:grok",
+      linkedDirectories: [],
+      updatedAt: 1000,
+      executionMode: "default",
+    };
+
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "acp:grok",
+      fetchedAt: 3000,
+      threads: [staleThread],
     });
 
     expect(snapshot.threads[0]?.executionMode).toBe("full-access");

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -12,6 +12,7 @@ import type {
 } from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
+  isGrokTransientUpdateKind,
   readAcpContentText,
   readAcpTopicTitle,
   shouldSurfaceAcpThoughtsAsMessages,
@@ -700,7 +701,11 @@ export class AcpAgentClient {
       if (updateKind === "agent_message_chunk") {
         activeTurn.assistantText += text;
       }
-    } else if (!isAssistantTextUpdate && activeTurn) {
+    } else if (
+      !isAssistantTextUpdate
+      && activeTurn
+      && !isGrokTransientUpdateKind(updateKind)
+    ) {
       activeTurn.activeAssistantMessageItemId = undefined;
       activeTurn.activeAssistantMessagePhase = undefined;
     }
@@ -708,6 +713,8 @@ export class AcpAgentClient {
       sessionId,
       update,
       receivedAt,
+      deferTurnCompletion:
+        updateKind === "turn_completed" && activeTurn !== undefined,
     } satisfies AcpSessionUpdate);
     void this.notifySessionUpdate({
       assistantMessageItemId,

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -160,6 +160,18 @@ export class AcpSessionReplayNormalizer {
       // Command metadata belongs in provider capabilities, not the transcript.
     } else if (kind === "config_option_update" || kind === "current_mode_update") {
       // Runtime configuration changes belong in ACP session metadata.
+    } else if (
+      kind === "tool_call_delta_chunk"
+      || kind === "pending_interaction"
+      || kind === "interaction_resolved"
+    ) {
+      // Grok emits these transient xAI extension updates in addition to the
+      // canonical ACP tool calls and permission requests. They are transport
+      // state, not transcript entries, and must not split assistant bubbles.
+    } else if (kind === "turn_completed") {
+      // Grok's xAI extension uses turn_completed before the canonical
+      // turn_finished update. Treat it as an idempotent early completion.
+      this.recordTurnFinished();
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
     } else {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -19,6 +19,11 @@ export type AcpSessionUpdate = {
   sessionId: string;
   update: Record<string, unknown>;
   receivedAt?: number;
+  /**
+   * Live clients defer Grok's durable replay terminal until session/prompt
+   * resolves, which is the point at which another turn may safely start.
+   */
+  deferTurnCompletion?: boolean;
 };
 
 export type AcpSessionReplayNormalizerOptions = {
@@ -27,6 +32,14 @@ export type AcpSessionReplayNormalizerOptions = {
 
 export function shouldSurfaceAcpThoughtsAsMessages(backendId: string): boolean {
   return backendId !== "acp:qwen";
+}
+
+export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
+  return (
+    kind === "tool_call_delta_chunk"
+    || kind === "pending_interaction"
+    || kind === "interaction_resolved"
+  );
 }
 
 export class AcpSessionReplayNormalizer {
@@ -160,18 +173,17 @@ export class AcpSessionReplayNormalizer {
       // Command metadata belongs in provider capabilities, not the transcript.
     } else if (kind === "config_option_update" || kind === "current_mode_update") {
       // Runtime configuration changes belong in ACP session metadata.
-    } else if (
-      kind === "tool_call_delta_chunk"
-      || kind === "pending_interaction"
-      || kind === "interaction_resolved"
-    ) {
+    } else if (isGrokTransientUpdateKind(kind)) {
       // Grok emits these transient xAI extension updates in addition to the
       // canonical ACP tool calls and permission requests. They are transport
       // state, not transcript entries, and must not split assistant bubbles.
     } else if (kind === "turn_completed") {
-      // Grok's xAI extension uses turn_completed before the canonical
-      // turn_finished update. Treat it as an idempotent early completion.
-      this.recordTurnFinished();
+      // Grok persists this as a durable replay terminal, but emits it before
+      // the live session/prompt request resolves. The client defers the live
+      // idle transition until prompt resolution so queued work cannot overlap.
+      if (!update.deferTurnCompletion) {
+        this.recordTurnFinished();
+      }
     } else if (readAcpTopicTitle(update.update)) {
       // Topic updates are thread metadata, not transcript entries.
     } else {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6952,6 +6952,13 @@ export class DesktopBackendRegistry {
       executionMode: nextExecutionMode,
       updatedAt: Math.max(session.updatedAt, runtimeState?.updatedAt ?? Date.now()),
     });
+    if (this.isAcpRuntimeExecutionModeOption(params)) {
+      await this.overlayStore.setThreadExecutionMode({
+        backend: params.backend,
+        threadId: params.threadId,
+        executionMode: nextExecutionMode ?? "default",
+      });
+    }
 
     const fromLabel =
       options?.fromLabel ??
@@ -9711,6 +9718,11 @@ export class DesktopBackendRegistry {
       ...session,
       executionMode: params.executionMode,
       updatedAt: Math.max(session.updatedAt, updatedAt),
+    });
+    await this.overlayStore.setThreadExecutionMode({
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: params.executionMode,
     });
 
     await this.appendPermissionTransition({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6946,17 +6946,22 @@ export class DesktopBackendRegistry {
         ? "full-access"
         : "default"
       : session.executionMode;
+    const updatedAt = Math.max(
+      session.updatedAt,
+      runtimeState?.updatedAt ?? Date.now(),
+    );
     this.acpBackend.upsertSession({
       ...session,
       acpRuntime: mergedRuntime,
       executionMode: nextExecutionMode,
-      updatedAt: Math.max(session.updatedAt, runtimeState?.updatedAt ?? Date.now()),
+      updatedAt,
     });
     if (this.isAcpRuntimeExecutionModeOption(params)) {
       await this.overlayStore.setThreadExecutionMode({
         backend: params.backend,
         threadId: params.threadId,
         executionMode: nextExecutionMode ?? "default",
+        updatedAt,
       });
     }
 
@@ -9723,6 +9728,7 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
       executionMode: params.executionMode,
+      updatedAt,
     });
 
     await this.appendPermissionTransition({

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -40,6 +40,7 @@ import {
   buildThreadIdentityKey,
   applyNavigationLaunchpadProviderSettingsPatch,
   estimateOpenAiTokenUsageCost,
+  isAcpBackendId,
   parseThreadIdentityKey,
   projectNavigationLaunchpadProviderSettings,
   resolveOpenAiPricingServiceTier,
@@ -331,7 +332,9 @@ export class SqliteOverlayStore {
           ...(current ?? {}),
           backend: thread.source,
           threadId: thread.id,
-          executionMode: current?.executionMode ?? thread.executionMode ?? "default",
+          executionMode: isAcpBackendId(thread.source)
+            ? thread.executionMode ?? current?.executionMode ?? "default"
+            : current?.executionMode ?? thread.executionMode ?? "default",
           model: current?.model ?? thread.model,
           reasoningEffort: current?.reasoningEffort ?? thread.reasoningEffort,
           serviceTier: current?.serviceTier ?? thread.serviceTier,
@@ -357,6 +360,20 @@ export class SqliteOverlayStore {
           messagingBindingTransitionLog:
             current?.messagingBindingTransitionLog,
           turnFailureLog: current?.turnFailureLog,
+        });
+      }
+    }
+
+    for (const thread of params.threads) {
+      if (!isAcpBackendId(thread.source) || !thread.executionMode) {
+        continue;
+      }
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const current = this.getThread(threadKey);
+      if (current && current.executionMode !== thread.executionMode) {
+        this.putThread(threadKey, {
+          ...current,
+          executionMode: thread.executionMode,
         });
       }
     }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -290,6 +290,23 @@ export function normalizeNavigationBrowseMode(
     : DEFAULT_NAVIGATION_BROWSE_MODE;
 }
 
+function shouldApplyAcpExecutionModeSnapshot(
+  current: ThreadOverlayState | undefined,
+  thread: AppServerThreadSummary,
+): boolean {
+  return (
+    isAcpBackendId(thread.source)
+    && thread.executionMode !== undefined
+    && (
+      current?.executionModeUpdatedAt === undefined
+      || (
+        thread.updatedAt !== undefined
+        && thread.updatedAt > current.executionModeUpdatedAt
+      )
+    )
+  );
+}
+
 export class SqliteOverlayStore {
   constructor(private readonly stateDb: StateDb) {}
 
@@ -328,13 +345,22 @@ export class SqliteOverlayStore {
       for (const thread of params.threads) {
         const threadKey = buildThreadIdentityKey(thread.source, thread.id);
         const current = this.getThread(threadKey);
+        const applyAcpExecutionModeSnapshot =
+          shouldApplyAcpExecutionModeSnapshot(current, thread);
         this.putThread(threadKey, {
           ...(current ?? {}),
           backend: thread.source,
           threadId: thread.id,
           executionMode: isAcpBackendId(thread.source)
-            ? thread.executionMode ?? current?.executionMode ?? "default"
+            ? applyAcpExecutionModeSnapshot
+              ? thread.executionMode ?? current?.executionMode ?? "default"
+              : current?.executionMode ?? thread.executionMode ?? "default"
             : current?.executionMode ?? thread.executionMode ?? "default",
+          executionModeUpdatedAt: isAcpBackendId(thread.source)
+            ? applyAcpExecutionModeSnapshot && thread.executionMode
+              ? thread.updatedAt
+              : current?.executionModeUpdatedAt
+            : current?.executionModeUpdatedAt,
           model: current?.model ?? thread.model,
           reasoningEffort: current?.reasoningEffort ?? thread.reasoningEffort,
           serviceTier: current?.serviceTier ?? thread.serviceTier,
@@ -370,10 +396,18 @@ export class SqliteOverlayStore {
       }
       const threadKey = buildThreadIdentityKey(thread.source, thread.id);
       const current = this.getThread(threadKey);
-      if (current && current.executionMode !== thread.executionMode) {
+      if (
+        current
+        && shouldApplyAcpExecutionModeSnapshot(current, thread)
+        && (
+          current.executionMode !== thread.executionMode
+          || current.executionModeUpdatedAt !== thread.updatedAt
+        )
+      ) {
         this.putThread(threadKey, {
           ...current,
           executionMode: thread.executionMode,
+          executionModeUpdatedAt: thread.updatedAt,
         });
       }
     }
@@ -1932,6 +1966,7 @@ export class SqliteOverlayStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     executionMode: ThreadExecutionMode;
+    updatedAt?: number;
   }): Promise<ThreadOverlayState> {
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
     const current = this.getThread(threadKey) ?? {
@@ -1942,6 +1977,7 @@ export class SqliteOverlayStore {
     const nextState: ThreadOverlayState = {
       ...current,
       executionMode: params.executionMode,
+      executionModeUpdatedAt: params.updatedAt ?? Date.now(),
     };
     this.putThread(threadKey, nextState);
     return nextState;

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -71,6 +71,49 @@ function buildAutomationSummary(
   };
 }
 
+describe("navigation execution mode authority", () => {
+  it("uses authoritative ACP session mode over a stale overlay", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "acp:grok:thread-1": {
+          backend: "acp:grok",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+      previousKnownThreadKeys: ["acp:grok:thread-1"],
+      threads: [
+        buildThread({
+          source: "acp:grok",
+          executionMode: "full-access",
+        }),
+      ],
+    });
+
+    expect(thread?.executionMode).toBe("full-access");
+  });
+
+  it("continues to use the overlay as Codex execution mode authority", () => {
+    const [thread] = materializeNavigationThreads({
+      firstSnapshot: false,
+      overlayByThreadKey: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-1"],
+      threads: [buildThread({ executionMode: "full-access" })],
+    });
+
+    expect(thread?.executionMode).toBe("default");
+  });
+});
+
 describe("navigation fork metadata", () => {
   it("materializes fork origin metadata from thread overlays", () => {
     const [thread] = materializeNavigationThreads({

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -13,7 +13,11 @@ import type {
   NavigationLaunchpadDefaults,
   ThreadOverlayState,
 } from "@pwragent/shared";
-import { buildThreadIdentityKey, isToolManagedWorktreePath } from "@pwragent/shared";
+import {
+  buildThreadIdentityKey,
+  isAcpBackendId,
+  isToolManagedWorktreePath,
+} from "@pwragent/shared";
 import { deriveInboxState, rankInboxThreadKeys } from "./inbox";
 import { buildDirectorySummaries } from "./directory-navigation";
 
@@ -120,6 +124,25 @@ function resolveNavigationObservedBranch(params: {
   return params.thread.observedGitBranch ?? params.overlay?.observedGitBranch;
 }
 
+function resolveNavigationExecutionMode(params: {
+  overlay?: ThreadOverlayState;
+  thread: AppServerThreadSummary;
+}): NavigationThreadSummary["executionMode"] {
+  if (isAcpBackendId(params.thread.source)) {
+    return (
+      params.thread.executionMode
+      ?? params.overlay?.executionMode
+      ?? "default"
+    );
+  }
+
+  return (
+    params.overlay?.executionMode
+    ?? params.thread.executionMode
+    ?? "default"
+  );
+}
+
 function resolveNavigationParentThreadId(params: {
   overlay?: ThreadOverlayState;
   overlayByThreadKey: Record<string, ThreadOverlayState | undefined>;
@@ -190,7 +213,7 @@ export function materializeNavigationThreads(params: {
       gitBranch,
       observedGitBranch,
       retainedBranchDriftPairs: overlay?.retainedBranchDriftPairs,
-      executionMode: overlay?.executionMode ?? thread.executionMode ?? "default",
+      executionMode: resolveNavigationExecutionMode({ overlay, thread }),
       queuedExecutionMode: overlay?.queuedExecutionMode,
       queuedExecutionModeAt: overlay?.queuedExecutionModeAt,
       permissionTransitionLog: overlay?.permissionTransitionLog,

--- a/packages/agent-core/src/domain/navigation-state.ts
+++ b/packages/agent-core/src/domain/navigation-state.ts
@@ -129,8 +129,15 @@ function resolveNavigationExecutionMode(params: {
   thread: AppServerThreadSummary;
 }): NavigationThreadSummary["executionMode"] {
   if (isAcpBackendId(params.thread.source)) {
+    const overlayIsAtLeastAsFresh =
+      params.overlay?.executionModeUpdatedAt !== undefined
+      && (
+        params.thread.updatedAt === undefined
+        || params.overlay.executionModeUpdatedAt >= params.thread.updatedAt
+      );
     return (
-      params.thread.executionMode
+      (overlayIsAtLeastAsFresh ? params.overlay?.executionMode : undefined)
+      ?? params.thread.executionMode
       ?? params.overlay?.executionMode
       ?? "default"
     );

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1187,6 +1187,11 @@ export type ThreadOverlayState = {
   threadId: ThreadIdentifier;
   agent?: ThreadAgentMetadata;
   executionMode?: ThreadExecutionMode;
+  /**
+   * Timestamp of the source that last established `executionMode`.
+   * ACP navigation reconciliation uses this to reject older list snapshots.
+   */
+  executionModeUpdatedAt?: number;
   model?: string;
   reasoningEffort?: string;
   reasoningEffortsByModel?: Record<string, string>;


### PR DESCRIPTION
## Summary

- synchronize applied ACP permission modes into the durable thread overlay
- treat ACP session metadata as authoritative during navigation materialization and repair stale persisted overlays on refresh
- normalize Grok xAI transient interaction notifications so they do not appear as unknown transcript entries
- add provider-specific regressions for Grok, legacy and modern Kimi, and Qwen

## Root cause

ACP mode changes updated the harness session and permission transition log, but did not update the durable thread overlay. Navigation materialization preferred that stale overlay over the authoritative ACP session, so a Grok session could actually be in Full Access while the composer dropdown displayed Default Access.

Grok also emits transient `_x.ai/session_notification` updates alongside canonical ACP tool calls and permission reverse requests. Those transport-level updates were falling through to the unknown-activity renderer.

## Impact

The access-level dropdown now reflects the mode actually applied to the ACP session, including after refresh or restart. Existing stale ACP overlays repair themselves from session metadata. Default-mode permission requests continue to surface for explicit approval, while Full Access requests are auto-approved as intended.

Provider-specific behavior remains intact: Grok uses `/always-approve on|off`, legacy Kimi uses `/yolo`, modern Kimi uses its advertised runtime mode API, and Qwen uses its advertised runtime mode API.

## Validation

- `PWRAGENT_HOME=/tmp/pwragent-permission-fix-tests-20260726-1817 pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 362 passed
- focused navigation, overlay, ACP client, and normalizer tests — 91 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — no errors; existing warnings only
- `pnpm lint:boundaries`
- `git diff --check`
