### PR TITLE
feat(desktop): add transient ACP messages and work grouping

### DIFF
--- a/apps/desktop/e2e/acp-runtime-modes.spec.ts
+++ b/apps/desktop/e2e/acp-runtime-modes.spec.ts
@@ -709,8 +709,9 @@ test("shows ACP tool progress while a turn is still running", async () => {
     await app.window.getByRole("button", { name: "Send" }).click();
 
     await expect(app.window.getByRole("button", { name: "Stop" })).toBeVisible();
-    await expect(app.window.getByText(/Explored 1 item/i)).toBeVisible();
-    await app.window.getByRole("button", { name: /Explored 1 item/i }).click();
+    const readSummary = app.window.getByRole("button", { name: "Read README.md" });
+    await expect(readSummary).toBeVisible();
+    await readSummary.click();
     await expect(app.window.getByText(/README\.md/)).toBeVisible();
     await expect(
       app.window.getByText(/Read lines 1-80 of 200 from README\.md/),

--- a/apps/desktop/e2e/acp-runtime-modes.spec.ts
+++ b/apps/desktop/e2e/acp-runtime-modes.spec.ts
@@ -712,9 +712,12 @@ test("shows ACP tool progress while a turn is still running", async () => {
     const readSummary = app.window.getByRole("button", { name: "Read README.md" });
     await expect(readSummary).toBeVisible();
     await readSummary.click();
-    await expect(app.window.getByText(/README\.md/)).toBeVisible();
+    const readActivity = app.window.locator("aside", { has: readSummary });
+    await expect(readActivity.getByText("README.md", { exact: true })).toBeVisible();
     await expect(
-      app.window.getByText(/Read lines 1-80 of 200 from README\.md/),
+      readActivity.getByText("Read lines 1-80 of 200 from README.md", {
+        exact: true,
+      }),
     ).toBeVisible();
   } finally {
     await app.close();

--- a/apps/desktop/e2e/live-agent-messages.spec.ts
+++ b/apps/desktop/e2e/live-agent-messages.spec.ts
@@ -117,9 +117,10 @@ test("preserves live assistant commentary messages, exploration activity, and fi
     }).first();
     await expect(commandSummary).toBeVisible();
     await commandSummary.click();
-    await expect(transcript).toContainText(
-      'rg -n "Telegram|telegram|webhook" docs apps packages (1.1s)'
-    );
+    await expect(
+      transcript.getByText('$ rg -n "Telegram|telegram|webhook" docs apps packages')
+    ).toBeVisible();
+    await expect(transcript.getByText("Success · ran for 1.1s")).toBeVisible();
     await commandSummary.click();
 
     await app.advance({ stepId: "turn-completed-1" });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -717,7 +717,7 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
-  it("emits Grok thoughts as transient status instead of transcript text", async () => {
+  it("emits Grok thoughts as transient messages instead of replayable text", async () => {
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();
     const events: AgentEvent[] = [];
@@ -785,6 +785,10 @@ describe("AcpBackendAdapter", () => {
       content: { type: "text", text: "Tracing the image support flags." },
     });
     transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "```ts\nconst hidden = true;" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_message_chunk",
       content: { type: "text", text: "The image flag is disabled." },
     });
@@ -794,25 +798,42 @@ describe("AcpBackendAdapter", () => {
         events
           .filter(
             (event) =>
-              event.notification.method === "item/agentThought/updated" ||
+              event.notification.method === "item/transientMessage/updated" ||
               event.notification.method === "item/agentMessage/delta",
           )
           .map((event) => event.notification),
       ).toEqual([
         {
-          method: "item/agentThought/updated",
+          method: "item/transientMessage/updated",
           params: {
             threadId: session.sessionId,
             turnId: "turn-1",
-            text: "So the key logic is:\n```",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "So the key logic is:",
+            phase: "commentary",
           },
         },
         {
-          method: "item/agentThought/updated",
+          method: "item/transientMessage/updated",
           params: {
             threadId: session.sessionId,
             turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
             text: "Tracing the image support flags.",
+            phase: "commentary",
+          },
+        },
+        {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "",
+            phase: "commentary",
           },
         },
         {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -717,6 +717,130 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("emits Grok thoughts as transient status instead of transcript text", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok CLI",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: ["agent", "stdio"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "Inspect this",
+      turnId: "turn-1",
+    });
+
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "So the key logic is:\n```" },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_thought_chunk",
+      content: { type: "text", text: "Tracing the image support flags." },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      session_update: "agent_message_chunk",
+      content: { type: "text", text: "The image flag is disabled." },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        events
+          .filter(
+            (event) =>
+              event.notification.method === "item/agentThought/updated" ||
+              event.notification.method === "item/agentMessage/delta",
+          )
+          .map((event) => event.notification),
+      ).toEqual([
+        {
+          method: "item/agentThought/updated",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            text: "So the key logic is:\n```",
+          },
+        },
+        {
+          method: "item/agentThought/updated",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            text: "Tracing the image support flags.",
+          },
+        },
+        {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            itemId: "assistant:turn-1:0",
+            delta: "The image flag is disabled.",
+            phase: "final",
+          },
+        },
+      ]);
+    });
+    expect(client.readReplay(session.sessionId).messages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        text: "Inspect this",
+      }),
+      expect.objectContaining({
+        role: "assistant",
+        text: "The image flag is disabled.",
+      }),
+    ]);
+
+    await adapter.close();
+  });
+
   it("does not emit replayed ACP assistant text without a live turn", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -2199,13 +2199,27 @@ describe("AcpBackendAdapter", () => {
       entries: [
         {
           type: "message" as const,
+          id: "user:provider",
+          role: "user" as const,
+          text: "Timestamped provider prompt",
+          createdAt: 1001,
+        },
+        {
+          type: "message" as const,
           id: "assistant:provider",
           role: "assistant" as const,
+          phase: "final" as const,
           text: "Timestamped provider reply",
           createdAt: 1002,
         },
       ],
       messages: [
+        {
+          id: "user:provider",
+          role: "user" as const,
+          text: "Timestamped provider prompt",
+          createdAt: 1001,
+        },
         {
           id: "assistant:provider",
           role: "assistant" as const,
@@ -2213,6 +2227,7 @@ describe("AcpBackendAdapter", () => {
           createdAt: 1002,
         },
       ],
+      lastUserMessage: "Timestamped provider prompt",
       lastAssistantMessage: "Timestamped provider reply",
       pagination: {
         supportsPagination: false,
@@ -2259,9 +2274,26 @@ describe("AcpBackendAdapter", () => {
       handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
     });
 
-    await expect(adapter.readReplay(backendId, "session-1")).resolves.toMatchObject({
+    const replay = await adapter.readReplay(backendId, "session-1");
+    expect(replay).toMatchObject({
       lastAssistantMessage: "Timestamped provider reply",
     });
+    expect(replay.entries.map((entry) => entry.turn)).toEqual([
+      {
+        id: "inferred:user:provider",
+        status: "completed",
+        startedAt: 1001,
+        completedAt: 1002,
+        durationMs: 1,
+      },
+      {
+        id: "inferred:user:provider",
+        status: "completed",
+        startedAt: 1001,
+        completedAt: 1002,
+        durationMs: 1,
+      },
+    ]);
     expect(loadSession).toHaveBeenCalledOnce();
 
     await adapter.close();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -776,18 +776,33 @@ describe("AcpBackendAdapter", () => {
       turnId: "turn-1",
     });
 
+    for (const text of [
+      "The ",
+      "code ",
+      "seems ",
+      "to ",
+      "be ",
+      "over ",
+      "here",
+      ".",
+    ]) {
+      transport.emitSessionUpdate(session.sessionId, {
+        session_update: "agent_thought_chunk",
+        content: { type: "text", text },
+      });
+    }
     transport.emitSessionUpdate(session.sessionId, {
-      session_update: "agent_thought_chunk",
-      content: { type: "text", text: "So the key logic is:\n```" },
+      session_update: "tool_call",
+      tool_call_id: "tool-1",
+      title: "cat package.json",
+      status: "completed",
     });
-    transport.emitSessionUpdate(session.sessionId, {
-      session_update: "agent_thought_chunk",
-      content: { type: "text", text: "Tracing the image support flags." },
-    });
-    transport.emitSessionUpdate(session.sessionId, {
-      session_update: "agent_thought_chunk",
-      content: { type: "text", text: "```ts\nconst hidden = true;" },
-    });
+    for (const text of ["So ", "the ", "key ", "logic is:\n```"]) {
+      transport.emitSessionUpdate(session.sessionId, {
+        session_update: "agent_thought_chunk",
+        content: { type: "text", text },
+      });
+    }
     transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_message_chunk",
       content: { type: "text", text: "The image flag is disabled." },
@@ -810,7 +825,7 @@ describe("AcpBackendAdapter", () => {
             turnId: "turn-1",
             itemId: "transient-thought:turn-1",
             role: "assistant",
-            text: "So the key logic is:",
+            text: "The",
             phase: "commentary",
           },
         },
@@ -821,7 +836,7 @@ describe("AcpBackendAdapter", () => {
             turnId: "turn-1",
             itemId: "transient-thought:turn-1",
             role: "assistant",
-            text: "Tracing the image support flags.",
+            text: "The code",
             phase: "commentary",
           },
         },
@@ -832,10 +847,31 @@ describe("AcpBackendAdapter", () => {
             turnId: "turn-1",
             itemId: "transient-thought:turn-1",
             role: "assistant",
-            text: "",
+            text: "The code seems",
             phase: "commentary",
           },
         },
+        ...[
+          "The code seems to",
+          "The code seems to be",
+          "The code seems to be over",
+          "The code seems to be over here",
+          "The code seems to be over here.",
+          "So",
+          "So the",
+          "So the key",
+          "So the key logic is:",
+        ].map((text) => ({
+          method: "item/transientMessage/updated" as const,
+          params: {
+            threadId: session.sessionId,
+            turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant" as const,
+            text,
+            phase: "commentary" as const,
+          },
+        })),
         {
           method: "item/agentMessage/delta",
           params: {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -776,7 +776,7 @@ describe("AcpBackendAdapter", () => {
       turnId: "turn-1",
     });
 
-    for (const text of [
+    const firstThoughtChunks = [
       "The ",
       "code ",
       "seems ",
@@ -785,23 +785,44 @@ describe("AcpBackendAdapter", () => {
       "over ",
       "here",
       ".",
-    ]) {
+    ];
+    for (const [index, text] of firstThoughtChunks.entries()) {
       transport.emitSessionUpdate(session.sessionId, {
         session_update: "agent_thought_chunk",
         content: { type: "text", text },
       });
+      if (index === 0) {
+        transport.emitSessionUpdate(session.sessionId, {
+          session_update: "available_commands_update",
+          available_commands: [
+            {
+              name: "review",
+              description: "Review the current changes",
+            },
+          ],
+        });
+      }
     }
-    transport.emitSessionUpdate(session.sessionId, {
+    const completedToolUpdate = {
       session_update: "tool_call",
       tool_call_id: "tool-1",
       title: "cat package.json",
       status: "completed",
-    });
-    for (const text of ["So ", "the ", "key ", "logic is:\n```"]) {
+    };
+    transport.emitSessionUpdate(session.sessionId, completedToolUpdate);
+    for (const [index, text] of [
+      "So ",
+      "the ",
+      "key ",
+      "logic is:\n```",
+    ].entries()) {
       transport.emitSessionUpdate(session.sessionId, {
         session_update: "agent_thought_chunk",
         content: { type: "text", text },
       });
+      if (index === 0) {
+        transport.emitSessionUpdate(session.sessionId, completedToolUpdate);
+      }
     }
     transport.emitSessionUpdate(session.sessionId, {
       session_update: "agent_message_chunk",
@@ -884,6 +905,17 @@ describe("AcpBackendAdapter", () => {
         },
       ]);
     });
+    expect(
+      events.filter(
+        (event) =>
+          event.notification.method === "thread/availableCommands/updated",
+      ),
+    ).toHaveLength(1);
+    expect(
+      events.filter(
+        (event) => event.notification.method === "item/completed",
+      ),
+    ).toHaveLength(1);
     expect(client.readReplay(session.sessionId).messages).toEqual([
       expect.objectContaining({
         role: "user",

--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -227,6 +227,52 @@ describe("acpToolUpdateNotifications", () => {
     expect(item?.data).toBeUndefined();
   });
 
+  it("uses Grok command descriptions as live command labels", () => {
+    const command = "python3 - <<'PY'\nprint('Grok 4.5')\nPY";
+    const description = "Inspect Grok 4.5 model cache entry";
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "run-terminal-1",
+        kind: "execute",
+        title: `Execute \`${command}\``,
+        status: "completed",
+        rawInput: {
+          variant: "Bash",
+          command,
+          description,
+        },
+        content: {
+          type: "text",
+          text: "Grok 4.5",
+        },
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "run-terminal-1",
+            command,
+            commandActions: [
+              {
+                type: "unknown",
+                name: description,
+              },
+            ],
+            data: {
+              output: "Grok 4.5",
+            },
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("surfaces Grok search arguments as a structured tool invocation", () => {
     const notifications = acpToolUpdateNotifications({
       threadId: "session-1",

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -416,6 +416,53 @@ describe("AcpRolloutStore", () => {
     expect(store.readUpdates({ backendId, sessionId: "session-1" })).toEqual([]);
   });
 
+  it("keeps Grok thoughts in the rollout but omits them from replay", () => {
+    const store = new AcpRolloutStore(tempDir);
+    const backendId = "acp:grok" as AcpBackendId;
+
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "So the key logic is:\n```" },
+      },
+    });
+    store.appendUpdate({
+      backendId,
+      sessionId: "session-1",
+      receivedAt: 1001,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Tracing the image support flags." },
+      },
+    });
+
+    expect(store.readUpdates({ backendId, sessionId: "session-1" })).toEqual([
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "So the key logic is:\n```" },
+        }),
+      }),
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Tracing the image support flags." },
+        }),
+      }),
+    ]);
+    expect(
+      store.readReplay({ backendId, sessionId: "session-1" }).messages,
+    ).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        text: "Tracing the image support flags.",
+      }),
+    ]);
+  });
+
   it("coalesces unchanged tool updates before writing rollout records", () => {
     const store = new AcpRolloutStore(tempDir);
     const backendId = "acp:kimi" as AcpBackendId;

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -35,8 +35,23 @@ describe("AcpSessionReplayNormalizer", () => {
           id: "final-1",
           role: "assistant",
           phase: "final",
-          text: "First response",
+          text: "First response segment",
           createdAt: 1200,
+        },
+        {
+          type: "activity",
+          id: "tool-after-final-1",
+          summary: "Tool after assistant delivery",
+          details: [],
+          createdAt: 1300,
+        },
+        {
+          type: "message",
+          id: "final-1b",
+          role: "assistant",
+          phase: "final",
+          text: "Second response segment",
+          createdAt: 1400,
         },
         {
           type: "message",
@@ -80,25 +95,29 @@ describe("AcpSessionReplayNormalizer", () => {
       id: "inferred:user-1",
       status: "completed",
       startedAt: 1000,
-      completedAt: 1200,
-      durationMs: 200,
+      completedAt: 1400,
+      durationMs: 400,
     });
     expect(replay.entries[2]?.turn).toEqual(replay.entries[1]?.turn);
     expect(replay.entries[3]?.turn).toEqual(replay.entries[1]?.turn);
-    expect(replay.entries[4]?.turn).toEqual({
+    expect(replay.entries[4]?.turn).toEqual(replay.entries[1]?.turn);
+    expect(replay.entries[5]?.turn).toEqual(replay.entries[1]?.turn);
+    expect(replay.entries[6]?.turn).toEqual({
       id: "inferred:user-2",
       status: "interrupted",
       startedAt: 2000,
-      completedAt: 3000,
-      durationMs: 1000,
-    });
-    expect(replay.entries[5]?.turn).toEqual(replay.entries[4]?.turn);
-    expect(replay.entries[6]?.turn).toEqual({
-      id: "inferred:user-3",
-      status: "in_progress",
-      startedAt: 3000,
+      completedAt: 2100,
+      durationMs: 100,
     });
     expect(replay.entries[7]?.turn).toEqual(replay.entries[6]?.turn);
+    expect(replay.entries[8]?.turn).toEqual({
+      id: "inferred:user-3",
+      status: "interrupted",
+      startedAt: 3000,
+      completedAt: 3100,
+      durationMs: 100,
+    });
+    expect(replay.entries[9]?.turn).toEqual(replay.entries[8]?.turn);
   });
 
   it("streams assistant message chunks into one replay message", () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1276,6 +1276,54 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("uses Grok command descriptions while preserving the full command", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+    const command = "python3 - <<'PY'\nprint('Grok 4.5')\nPY";
+    const description = "Inspect Grok 4.5 model cache entry";
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "run-terminal-1",
+        kind: "execute",
+        title: `Execute \`${command}\``,
+        status: "completed",
+        rawInput: {
+          variant: "Bash",
+          command,
+          description,
+        },
+        content: {
+          type: "text",
+          text: "Grok 4.5",
+        },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "run-terminal-1",
+        summary: description,
+        status: "completed",
+        details: [
+          expect.objectContaining({
+            kind: "command",
+            label: description,
+            command: {
+              displayCommand: command,
+              rawCommand: command,
+              output: "Grok 4.5",
+              exitCode: undefined,
+            },
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("ignores available command updates in transcripts", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -844,7 +844,7 @@ describe("AcpSessionReplayNormalizer", () => {
       expect.objectContaining({
         type: "activity",
         id: "grep-1",
-        summary: "Searching code",
+        summary: "Searching code: grok",
         status: "in_progress",
         details: [
           expect.objectContaining({
@@ -877,7 +877,7 @@ describe("AcpSessionReplayNormalizer", () => {
       expect.objectContaining({
         type: "activity",
         id: "grep-1",
-        summary: "Searched code",
+        summary: "Searched code: grok",
         status: "completed",
         details: [
           expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -1,10 +1,106 @@
 import { describe, expect, it } from "vitest";
 import {
   AcpSessionReplayNormalizer,
+  inferAcpReplayTurns,
   readAcpTopicTitle,
 } from "../acp/acp-session-normalizer";
 
 describe("AcpSessionReplayNormalizer", () => {
+  it("keeps inferred provider work inside user-message boundaries", () => {
+    const replay = inferAcpReplayTurns({
+      entries: [
+        {
+          type: "activity",
+          id: "before-user",
+          summary: "Provider setup",
+          details: [],
+          createdAt: 900,
+        },
+        {
+          type: "message",
+          id: "user-1",
+          role: "user",
+          text: "First request",
+          createdAt: 1000,
+        },
+        {
+          type: "activity",
+          id: "tool-1",
+          summary: "First tool",
+          details: [],
+          createdAt: 1100,
+        },
+        {
+          type: "message",
+          id: "final-1",
+          role: "assistant",
+          phase: "final",
+          text: "First response",
+          createdAt: 1200,
+        },
+        {
+          type: "message",
+          id: "user-2",
+          role: "user",
+          text: "Second request",
+          createdAt: 2000,
+        },
+        {
+          type: "activity",
+          id: "tool-2",
+          summary: "Second tool",
+          details: [],
+          createdAt: 2100,
+        },
+        {
+          type: "message",
+          id: "user-3",
+          role: "user",
+          text: "Third request",
+          createdAt: 3000,
+        },
+        {
+          type: "activity",
+          id: "tool-3",
+          summary: "Third tool",
+          details: [],
+          createdAt: 3100,
+        },
+      ],
+      messages: [],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle",
+    });
+
+    expect(replay.entries[0]?.turn).toBeUndefined();
+    expect(replay.entries[1]?.turn).toEqual({
+      id: "inferred:user-1",
+      status: "completed",
+      startedAt: 1000,
+      completedAt: 1200,
+      durationMs: 200,
+    });
+    expect(replay.entries[2]?.turn).toEqual(replay.entries[1]?.turn);
+    expect(replay.entries[3]?.turn).toEqual(replay.entries[1]?.turn);
+    expect(replay.entries[4]?.turn).toEqual({
+      id: "inferred:user-2",
+      status: "interrupted",
+      startedAt: 2000,
+      completedAt: 3000,
+      durationMs: 1000,
+    });
+    expect(replay.entries[5]?.turn).toEqual(replay.entries[4]?.turn);
+    expect(replay.entries[6]?.turn).toEqual({
+      id: "inferred:user-3",
+      status: "in_progress",
+      startedAt: 3000,
+    });
+    expect(replay.entries[7]?.turn).toEqual(replay.entries[6]?.turn);
+  });
+
   it("streams assistant message chunks into one replay message", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
@@ -709,26 +805,36 @@ describe("AcpSessionReplayNormalizer", () => {
   it("preserves Grok search arguments across sparse completion updates", () => {
     const normalizer = new AcpSessionReplayNormalizer();
 
-    normalizer.apply({
+    const activeReplay = normalizer.apply({
       sessionId: "session-1",
       receivedAt: 1000,
       update: {
         sessionUpdate: "tool_call",
         toolCallId: "grep-1",
-        title: "grep",
+        title: "grok",
+        kind: "search",
         rawInput: {
+          variant: "Grep",
           pattern: "grok",
           glob: "*.{ts,tsx,md,json}",
           head_limit: 20,
         },
-        _meta: {
-          "x.ai/tool": {
-            name: "grep",
-            kind: "search",
-          },
-        },
       },
     });
+    expect(activeReplay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "grep-1",
+        summary: "Searching code",
+        status: "in_progress",
+        details: [
+          expect.objectContaining({
+            kind: "read",
+            label: "Searching code: grok",
+          }),
+        ],
+      }),
+    ]);
     const replay = normalizer.apply({
       sessionId: "session-1",
       receivedAt: 1001,
@@ -752,11 +858,11 @@ describe("AcpSessionReplayNormalizer", () => {
       expect.objectContaining({
         type: "activity",
         id: "grep-1",
-        summary: "grep",
+        summary: "Searched code",
         status: "completed",
         details: [
           expect.objectContaining({
-            label: "grep",
+            label: "Searched code: grok",
             command: {
               displayCommand:
                 'grep(pattern="grok", glob="*.{ts,tsx,md,json}", head_limit=20)',

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5590,6 +5590,43 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not expose transient transcript messages to messaging surfaces", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleBackendEvent({
+      backend: "grok",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "grok",
+      notification: {
+        method: "item/transientMessage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "transient-thought:turn-1",
+          role: "assistant",
+          text: "So the key logic is:",
+          phase: "commentary",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+  });
+
   it("posts a readable error notice when a turn fails", async () => {
     const harness = await createHarness();
     await bindThread(harness);

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -8,6 +8,20 @@ export function readAcpToolCommand(
   );
 }
 
+export function readAcpToolDescription(
+  record: Record<string, unknown>,
+): string | undefined {
+  const rawInput = asRecord(record.rawInput);
+  const rawOutput = asRecord(record.rawOutput);
+  const metadataInput = asRecord(readAcpToolMetadata(record)?.input);
+  return (
+    readString(rawInput ?? {}, "description") ??
+    readString(rawOutput ?? {}, "description") ??
+    readString(metadataInput ?? {}, "description") ??
+    readString(record, "description")
+  );
+}
+
 export function readAcpToolInvocation(
   record: Record<string, unknown>,
 ): string | undefined {

--- a/apps/desktop/src/main/acp/acp-command-extraction.ts
+++ b/apps/desktop/src/main/acp/acp-command-extraction.ts
@@ -22,6 +22,21 @@ export function readAcpToolInvocation(
     return `web_fetch(url=${formatInvocationValue(webFetchUrl)})`;
   }
 
+  return readAcpCodeSearch(record)?.invocation;
+}
+
+export type AcpCodeSearch = {
+  invocation: string;
+  query?: string;
+};
+
+export function readAcpCodeSearch(
+  record: Record<string, unknown>,
+): AcpCodeSearch | undefined {
+  if (readAcpWebSearch(record)) {
+    return undefined;
+  }
+
   const rawInput = asRecord(record.rawInput);
   if (!rawInput) {
     return undefined;
@@ -35,7 +50,14 @@ export function readAcpToolInvocation(
   const kind =
     readString(metadata ?? {}, "kind") ??
     readString(record, "kind");
-  if (!name || (kind !== "search" && name !== "grep" && variant !== "Grep")) {
+  if (
+    !name
+    || (
+      kind !== "search"
+      && name.toLowerCase() !== "grep"
+      && variant?.toLowerCase() !== "grep"
+    )
+  ) {
     return undefined;
   }
 
@@ -51,7 +73,13 @@ export function readAcpToolInvocation(
       return `${displayKey}=${formatInvocationValue(value)}`;
     })
     .join(", ");
-  return argumentsText ? `${name}(${argumentsText})` : name;
+  const query =
+    readString(rawInput, "pattern") ??
+    readString(rawInput, "query");
+  return {
+    invocation: argumentsText ? `${name}(${argumentsText})` : name,
+    ...(query ? { query } : {}),
+  };
 }
 
 export type AcpWebSearch = {

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -4,6 +4,7 @@ import {
   isGenericShellToolTitle,
   readAcpToolCommand,
   readAcpToolContentCommand,
+  readAcpToolDescription,
   readAcpToolInvocation,
   readAcpWebFetchUrl,
   readAcpWebSearch,
@@ -125,7 +126,12 @@ function liveItemForAcpToolUpdate(
     readString(update, "id") ??
     readString(update, "itemId") ??
     readString(update, "item_id");
+  const rawCommand = readAcpToolCommand(update);
+  const description = rawCommand
+    ? readAcpToolDescription(update)
+    : undefined;
   const title =
+    description ??
     readString(update, "title") ??
     readString(update, "command") ??
     readString(update, "name") ??
@@ -153,12 +159,12 @@ function liveItemForAcpToolUpdate(
   }
 
   const webFetchUrl = readAcpWebFetchUrl(update);
-  const rawCommand = readAcpToolCommand(update);
   const invocation = readAcpToolInvocation(update);
   const command = rawCommand ?? invocation ?? title;
   const commandActions = acpCommandActions({
     kind: webFetchUrl ? "read" : toolKind,
     path,
+    semanticTitle: description,
     title: webFetchUrl
       ? `Fetched ${webFetchUrl}`
       : isGenericShellToolTitle(title)
@@ -181,6 +187,7 @@ function liveItemForAcpToolUpdate(
 function acpCommandActions(params: {
   kind: string;
   path: string | undefined;
+  semanticTitle?: string;
   title: string;
 }): Record<string, unknown>[] {
   if (params.kind === "read") {
@@ -210,7 +217,14 @@ function acpCommandActions(params: {
       },
     ];
   }
-  return [];
+  return params.semanticTitle
+    ? [
+        {
+          type: "unknown",
+          name: params.semanticTitle,
+        },
+      ]
+    : [];
 }
 
 function normalizeAcpToolStatus(status: string | undefined): string {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -38,7 +38,7 @@ export function shouldSurfaceAcpThoughtsAsMessages(backendId: string): boolean {
   return backendId !== "acp:qwen" && backendId !== "acp:grok";
 }
 
-export function shouldSurfaceAcpThoughtsAsTransientStatus(
+export function shouldSurfaceAcpThoughtsAsTransientMessages(
   backendId: string,
 ): boolean {
   return backendId === "acp:grok";
@@ -50,6 +50,14 @@ export function isGrokTransientUpdateKind(kind: string | undefined): boolean {
     || kind === "pending_interaction"
     || kind === "interaction_resolved"
   );
+}
+
+export function formatAcpTransientThoughtMessage(
+  text: string,
+): string | undefined {
+  const beforeCodeFence = text.split("```", 1)[0] ?? "";
+  const compact = beforeCodeFence.replace(/\s+/gu, " ").trim();
+  return compact || undefined;
 }
 
 export class AcpSessionReplayNormalizer {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -35,7 +35,13 @@ export type AcpSessionReplayNormalizerOptions = {
 };
 
 export function shouldSurfaceAcpThoughtsAsMessages(backendId: string): boolean {
-  return backendId !== "acp:qwen";
+  return backendId !== "acp:qwen" && backendId !== "acp:grok";
+}
+
+export function shouldSurfaceAcpThoughtsAsTransientStatus(
+  backendId: string,
+): boolean {
+  return backendId === "acp:grok";
 }
 
 export function isGrokTransientUpdateKind(kind: string | undefined): boolean {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -11,6 +11,7 @@ import type {
 } from "@pwragent/shared";
 import {
   isGenericShellToolTitle,
+  readAcpCodeSearch,
   readAcpToolCommand,
   readAcpToolContentCommand,
   readAcpToolInvocation,
@@ -58,6 +59,109 @@ export function formatAcpTransientThoughtMessage(
   const beforeCodeFence = text.split("```", 1)[0] ?? "";
   const compact = beforeCodeFence.replace(/\s+/gu, " ").trim();
   return compact || undefined;
+}
+
+type InferredAcpTurn = {
+  id: string;
+  indexes: number[];
+  startedAt?: number;
+};
+
+/**
+ * ACP session/load history has ordered transcript phases but no turn IDs.
+ * Fill only missing metadata: a user message opens a window, a final assistant
+ * response completes it, and a later user message interrupts any open window.
+ */
+export function inferAcpReplayTurns(
+  replay: AppServerThreadReplay,
+): AppServerThreadReplay {
+  const entries: AppServerThreadEntry[] = replay.entries.map((entry) => ({
+    ...entry,
+  }));
+  let active: InferredAcpTurn | undefined;
+
+  const applyActiveTurn = (
+    status: "completed" | "interrupted" | "in_progress",
+    completedAt?: number,
+  ): void => {
+    if (!active) {
+      return;
+    }
+    for (const index of active.indexes) {
+      const entry = entries[index];
+      if (!entry || entry.turn) {
+        continue;
+      }
+      entries[index] = {
+        ...entry,
+        turn: {
+          id: active.id,
+          status,
+          ...(active.startedAt !== undefined
+            ? { startedAt: active.startedAt }
+            : {}),
+          ...(completedAt !== undefined ? { completedAt } : {}),
+          ...(active.startedAt !== undefined && completedAt !== undefined
+            ? { durationMs: Math.max(0, completedAt - active.startedAt) }
+            : {}),
+        },
+      };
+    }
+  };
+  const settleActive = (
+    status: "completed" | "interrupted",
+    completedAt?: number,
+  ): void => {
+    applyActiveTurn(status, completedAt);
+    active = undefined;
+  };
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (!entry) {
+      continue;
+    }
+    const isUserMessage = entry.type === "message" && entry.role === "user";
+    if (isUserMessage) {
+      const turnId = entry.turn?.id ?? `inferred:${entry.id}`;
+      if (active?.id === turnId) {
+        if (!entry.turn) {
+          active.indexes.push(index);
+        }
+        continue;
+      }
+      settleActive("interrupted", entry.createdAt);
+      active = {
+        id: turnId,
+        indexes: entry.turn ? [] : [index],
+        startedAt: entry.turn?.startedAt ?? entry.createdAt,
+      };
+      continue;
+    }
+    if (!active) {
+      continue;
+    }
+    if (entry.turn && entry.turn.id !== active.id) {
+      settleActive("interrupted", entry.createdAt);
+      continue;
+    }
+    if (!entry.turn) {
+      active.indexes.push(index);
+    }
+    if (
+      entry.type === "message"
+      && entry.role === "assistant"
+      && entry.phase === "final"
+    ) {
+      settleActive("completed", entry.createdAt);
+    }
+  }
+
+  applyActiveTurn("in_progress");
+  return {
+    ...replay,
+    entries,
+  };
 }
 
 export class AcpSessionReplayNormalizer {
@@ -941,6 +1045,39 @@ function toolActivity(
   }
 
   const webFetchUrl = readAcpWebFetchUrl(update.update);
+  const codeSearch = readAcpCodeSearch(update.update);
+  if (codeSearch) {
+    const status = normalizeToolActivityStatus(
+      readString(update.update, "status"),
+    );
+    const summary =
+      status === "in_progress" ? "Searching code" : "Searched code";
+    const detailLabel = codeSearch.query
+      ? `${summary}: ${codeSearch.query}`
+      : summary;
+    const output = readToolOutput(update.update);
+    const exitCode = readNumber(update.update, "exitCode");
+    return {
+      type: "activity",
+      id,
+      createdAt,
+      summary,
+      status,
+      details: [
+        {
+          id: `${id}:detail`,
+          kind: "read",
+          label: detailLabel,
+          command: {
+            displayCommand: codeSearch.invocation,
+            source: "tool",
+            output,
+            exitCode,
+          },
+        },
+      ],
+    };
+  }
   const rawCommand = readAcpToolCommand(update.update);
   const invocation = readAcpToolInvocation(update.update);
   const displayCommand = rawCommand ?? invocation;
@@ -1015,13 +1152,34 @@ function mergeActivity(
   existing: AppServerThreadActivityEntry,
   incoming: AppServerThreadActivityEntry,
 ): AppServerThreadActivityEntry {
+  const status = incoming.status ?? existing.status;
+  const details = mergeActivityEntryDetails(existing.details, incoming.details)
+    .map((detail) => ({
+      ...detail,
+      label: settledSearchLabel(detail.label, status),
+    }));
   return {
     ...existing,
     createdAt: existing.createdAt ?? incoming.createdAt,
-    summary: preferSpecificLabel(existing.summary, incoming.summary),
-    status: incoming.status ?? existing.status,
-    details: mergeActivityEntryDetails(existing.details, incoming.details),
+    summary: settledSearchLabel(
+      preferSpecificLabel(existing.summary, incoming.summary),
+      status,
+    ),
+    status,
+    details,
   };
+}
+
+function settledSearchLabel(
+  label: string,
+  status: AppServerThreadActivityEntry["status"],
+): string {
+  if (status === "in_progress" || status === undefined) {
+    return label;
+  }
+  return label
+    .replace(/^Searching code\b/u, "Searched code")
+    .replace(/^Searching Web\b/u, "Searched Web");
 }
 
 function mergeActivityEntryDetails(

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -1095,7 +1095,7 @@ function toolActivity(
       type: "activity",
       id,
       createdAt,
-      summary,
+      summary: detailLabel,
       status,
       details: [
         {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -7,6 +7,7 @@ import type {
   AppServerThreadPlanEntry,
   AppServerThreadReplay,
   AppServerThreadStatus,
+  AppServerThreadTurnStatus,
   AppServerTranscriptPhase,
 } from "@pwragent/shared";
 import {
@@ -64,13 +65,16 @@ export function formatAcpTransientThoughtMessage(
 type InferredAcpTurn = {
   id: string;
   indexes: number[];
+  lastEntryAt?: number;
+  sawFinalResponse: boolean;
   startedAt?: number;
 };
 
 /**
  * ACP session/load history has ordered transcript phases but no turn IDs.
- * Fill only missing metadata: a user message opens a window, a final assistant
- * response completes it, and a later user message interrupts any open window.
+ * Fill only missing metadata: a user message opens a window, while lifecycle
+ * metadata, a later user message, or an idle replay boundary closes it.
+ * Assistant delivery alone is not a lifecycle boundary.
  */
 export function inferAcpReplayTurns(
   replay: AppServerThreadReplay,
@@ -81,7 +85,7 @@ export function inferAcpReplayTurns(
   let active: InferredAcpTurn | undefined;
 
   const applyActiveTurn = (
-    status: "completed" | "interrupted" | "in_progress",
+    status: AppServerThreadTurnStatus,
     completedAt?: number,
   ): void => {
     if (!active) {
@@ -109,11 +113,20 @@ export function inferAcpReplayTurns(
     }
   };
   const settleActive = (
-    status: "completed" | "interrupted",
+    status: Exclude<AppServerThreadTurnStatus, "in_progress">,
     completedAt?: number,
   ): void => {
     applyActiveTurn(status, completedAt);
     active = undefined;
+  };
+  const settleAtBoundary = (): void => {
+    if (!active) {
+      return;
+    }
+    settleActive(
+      active.sawFinalResponse ? "completed" : "interrupted",
+      active.lastEntryAt,
+    );
   };
 
   for (let index = 0; index < entries.length; index += 1) {
@@ -128,12 +141,15 @@ export function inferAcpReplayTurns(
         if (!entry.turn) {
           active.indexes.push(index);
         }
+        active.lastEntryAt = entry.createdAt ?? active.lastEntryAt;
         continue;
       }
-      settleActive("interrupted", entry.createdAt);
+      settleAtBoundary();
       active = {
         id: turnId,
         indexes: entry.turn ? [] : [index],
+        lastEntryAt: entry.createdAt,
+        sawFinalResponse: false,
         startedAt: entry.turn?.startedAt ?? entry.createdAt,
       };
       continue;
@@ -142,26 +158,44 @@ export function inferAcpReplayTurns(
       continue;
     }
     if (entry.turn && entry.turn.id !== active.id) {
-      settleActive("interrupted", entry.createdAt);
+      settleAtBoundary();
       continue;
     }
     if (!entry.turn) {
       active.indexes.push(index);
+    }
+    active.lastEntryAt = entry.createdAt ?? active.lastEntryAt;
+    if (isSettledTurnStatus(entry.turn?.status)) {
+      settleActive(
+        entry.turn.status,
+        entry.turn.completedAt ?? entry.createdAt,
+      );
+      continue;
     }
     if (
       entry.type === "message"
       && entry.role === "assistant"
       && entry.phase === "final"
     ) {
-      settleActive("completed", entry.createdAt);
+      active.sawFinalResponse = true;
     }
   }
 
-  applyActiveTurn("in_progress");
+  if (replay.threadStatus === "idle") {
+    settleAtBoundary();
+  } else {
+    applyActiveTurn("in_progress");
+  }
   return {
     ...replay,
     entries,
   };
+}
+
+function isSettledTurnStatus(
+  status: AppServerThreadTurnStatus | undefined,
+): status is Exclude<AppServerThreadTurnStatus, "in_progress"> {
+  return Boolean(status && status !== "in_progress");
 }
 
 export class AcpSessionReplayNormalizer {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -481,7 +481,10 @@ export class AcpSessionReplayNormalizer {
       (message) => message.id === params.id,
     );
     if (existingMessage) {
-      existingMessage.text = appendTranscriptChunk(existingMessage.text, params.text);
+      existingMessage.text = appendAcpTranscriptChunk(
+        existingMessage.text,
+        params.text,
+      );
     } else {
       this.messages.push({
         id: params.id,
@@ -496,7 +499,10 @@ export class AcpSessionReplayNormalizer {
         entry.type === "message" && entry.id === params.id,
     );
     if (existingEntry) {
-      existingEntry.text = appendTranscriptChunk(existingEntry.text, params.text);
+      existingEntry.text = appendAcpTranscriptChunk(
+        existingEntry.text,
+        params.text,
+      );
     } else {
       this.entries.push(this.withCurrentTurn({
         type: "message",
@@ -553,7 +559,10 @@ export class AcpSessionReplayNormalizer {
   }
 }
 
-function appendTranscriptChunk(existing: string, next: string): string {
+export function appendAcpTranscriptChunk(
+  existing: string,
+  next: string,
+): string {
   if (!existing || !next) {
     return `${existing}${next}`;
   }

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -15,6 +15,7 @@ import {
   readAcpCodeSearch,
   readAcpToolCommand,
   readAcpToolContentCommand,
+  readAcpToolDescription,
   readAcpToolInvocation,
   readAcpWebFetchUrl,
   readAcpWebSearch,
@@ -1113,9 +1114,13 @@ function toolActivity(
     };
   }
   const rawCommand = readAcpToolCommand(update.update);
+  const description = rawCommand
+    ? readAcpToolDescription(update.update)
+    : undefined;
   const invocation = readAcpToolInvocation(update.update);
   const displayCommand = rawCommand ?? invocation;
   const labelCandidate =
+    description ??
     readString(update.update, "title") ??
     readString(update.update, "name") ??
     readString(update.update, "kind") ??

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -75,9 +75,10 @@ import {
 } from "../acp/acp-session-store";
 import {
   AcpSessionReplayNormalizer,
+  formatAcpTransientThoughtMessage,
   readAcpContentText,
   shouldSurfaceAcpThoughtsAsMessages,
-  shouldSurfaceAcpThoughtsAsTransientStatus,
+  shouldSurfaceAcpThoughtsAsTransientMessages,
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import { getMainLogger } from "../log";
@@ -1782,18 +1783,22 @@ export class AcpBackendAdapter {
         if (
           turnId &&
           updateKind === "agent_thought_chunk" &&
-          shouldSurfaceAcpThoughtsAsTransientStatus(agent.backendId)
+          shouldSurfaceAcpThoughtsAsTransientMessages(agent.backendId)
         ) {
-          const text = readAcpUpdateText(update);
-          if (text) {
+          const rawText = readAcpUpdateText(update);
+          if (rawText) {
+            const text = formatAcpTransientThoughtMessage(rawText) ?? "";
             await this.emit({
               backend: agent.backendId,
               notification: {
-                method: "item/agentThought/updated",
+                method: "item/transientMessage/updated",
                 params: {
                   threadId: sessionId,
                   turnId,
+                  itemId: `transient-thought:${turnId}`,
+                  role: "assistant",
                   text,
+                  phase: "commentary",
                 },
               },
             });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -77,6 +77,7 @@ import {
   AcpSessionReplayNormalizer,
   appendAcpTranscriptChunk,
   formatAcpTransientThoughtMessage,
+  inferAcpReplayTurns,
   readAcpContentText,
   shouldSurfaceAcpThoughtsAsMessages,
   shouldSurfaceAcpThoughtsAsTransientMessages,
@@ -1320,7 +1321,7 @@ export class AcpBackendAdapter {
     replay: AppServerThreadReplay,
   ): AppServerThreadReplay {
     if (!this.acpRolloutStore) {
-      return replay;
+      return inferAcpReplayTurns(replay);
     }
     const normalizer = new AcpSessionReplayNormalizer({
       surfaceThoughtsAsMessages: shouldSurfaceAcpThoughtsAsMessages(
@@ -1342,9 +1343,11 @@ export class AcpBackendAdapter {
         update: record.update,
       });
     }
-    return syntheticUpdateCount > 0
-      ? mergeAcpReplayWithSyntheticHistory(replay, normalizer.replay())
-      : replay;
+    return inferAcpReplayTurns(
+      syntheticUpdateCount > 0
+        ? mergeAcpReplayWithSyntheticHistory(replay, normalizer.replay())
+        : replay,
+    );
   }
 
   private providerReplayOrRolloutFallback(params: {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -77,6 +77,7 @@ import {
   AcpSessionReplayNormalizer,
   readAcpContentText,
   shouldSurfaceAcpThoughtsAsMessages,
+  shouldSurfaceAcpThoughtsAsTransientStatus,
 } from "../acp/acp-session-normalizer";
 import { AcpStdioJsonRpcTransport } from "../acp/acp-stdio-transport";
 import { getMainLogger } from "../log";
@@ -1779,6 +1780,25 @@ export class AcpBackendAdapter {
           }
         }
         if (
+          turnId &&
+          updateKind === "agent_thought_chunk" &&
+          shouldSurfaceAcpThoughtsAsTransientStatus(agent.backendId)
+        ) {
+          const text = readAcpUpdateText(update);
+          if (text) {
+            await this.emit({
+              backend: agent.backendId,
+              notification: {
+                method: "item/agentThought/updated",
+                params: {
+                  threadId: sessionId,
+                  turnId,
+                  text,
+                },
+              },
+            });
+          }
+        } else if (
           turnId &&
           (updateKind === "agent_message_chunk" ||
             (updateKind === "agent_thought_chunk" &&

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1732,10 +1732,28 @@ export class AcpBackendAdapter {
           turnId
             ? `${agent.backendId}:${sessionId}:${turnId}`
             : undefined;
-        if (
-          transientThoughtKey &&
-          updateKind !== "agent_thought_chunk"
-        ) {
+        const agentMessageDelta =
+          updateKind === "agent_message_chunk"
+            ? readAcpUpdateText(update)
+            : undefined;
+        const toolNotifications = fromSessionLoad
+          ? []
+          : acpToolUpdateNotifications({
+              threadId: sessionId,
+              turnId,
+              update,
+            }).filter((notification) =>
+              this.shouldEmitLiveToolNotification(agent.backendId, notification),
+            );
+        // Reset only when this callback will emit a notification that settles
+        // the renderer's active segment. Metadata and deduplicated tool updates
+        // must preserve both sides of the replacement-value contract.
+        const settlesTransientThought =
+          Boolean(agentMessageDelta)
+          || toolNotifications.length > 0
+          || (updateKind === "turn_finished" && Boolean(turnId))
+          || replay.threadStatus === "idle";
+        if (transientThoughtKey && settlesTransientThought) {
           this.transientThoughtText.delete(transientThoughtKey);
         }
         if (title) {
@@ -1831,7 +1849,7 @@ export class AcpBackendAdapter {
             (updateKind === "agent_thought_chunk" &&
               shouldSurfaceAcpThoughtsAsMessages(agent.backendId)))
         ) {
-          const delta = readAcpUpdateText(update);
+          const delta = agentMessageDelta ?? readAcpUpdateText(update);
           if (delta) {
             const phase =
               updateKind === "agent_thought_chunk" ? "commentary" : "final";
@@ -1851,15 +1869,6 @@ export class AcpBackendAdapter {
             });
           }
         }
-        const toolNotifications = fromSessionLoad
-          ? []
-          : acpToolUpdateNotifications({
-              threadId: sessionId,
-              turnId,
-              update,
-            }).filter((notification) =>
-              this.shouldEmitLiveToolNotification(agent.backendId, notification),
-            );
         for (const notification of toolNotifications) {
           await this.emit({
             backend: agent.backendId,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -75,6 +75,7 @@ import {
 } from "../acp/acp-session-store";
 import {
   AcpSessionReplayNormalizer,
+  appendAcpTranscriptChunk,
   formatAcpTransientThoughtMessage,
   readAcpContentText,
   shouldSurfaceAcpThoughtsAsMessages,
@@ -912,6 +913,7 @@ export class AcpBackendAdapter {
   private closePromise?: Promise<void>;
   private readonly closeTimeoutMs: number;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
+  private readonly transientThoughtText = new Map<string, string>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -1546,6 +1548,7 @@ export class AcpBackendAdapter {
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
     this.liveTurnUsage.clear();
+    this.transientThoughtText.clear();
     this.closePromise = this.closeResources(acpClients);
     return await this.closePromise;
   }
@@ -1725,6 +1728,16 @@ export class AcpBackendAdapter {
               turnId,
             })
           : undefined;
+        const transientThoughtKey =
+          turnId
+            ? `${agent.backendId}:${sessionId}:${turnId}`
+            : undefined;
+        if (
+          transientThoughtKey &&
+          updateKind !== "agent_thought_chunk"
+        ) {
+          this.transientThoughtText.delete(transientThoughtKey);
+        }
         if (title) {
           await this.emit({
             backend: agent.backendId,
@@ -1786,8 +1799,17 @@ export class AcpBackendAdapter {
           shouldSurfaceAcpThoughtsAsTransientMessages(agent.backendId)
         ) {
           const rawText = readAcpUpdateText(update);
-          if (rawText) {
-            const text = formatAcpTransientThoughtMessage(rawText) ?? "";
+          if (rawText && transientThoughtKey) {
+            const accumulatedText = appendAcpTranscriptChunk(
+              this.transientThoughtText.get(transientThoughtKey) ?? "",
+              rawText,
+            );
+            this.transientThoughtText.set(
+              transientThoughtKey,
+              accumulatedText,
+            );
+            const text =
+              formatAcpTransientThoughtMessage(accumulatedText) ?? "";
             await this.emit({
               backend: agent.backendId,
               notification: {
@@ -1893,6 +1915,9 @@ export class AcpBackendAdapter {
       onPromptError: async ({ sessionId, turnId, error }) => {
         this.liveTurnUsage.delete(
           [agent.backendId, sessionId, turnId].join(":"),
+        );
+        this.transientThoughtText.delete(
+          `${agent.backendId}:${sessionId}:${turnId}`,
         );
         await this.emit({
           backend: agent.backendId,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1147,6 +1147,13 @@ export class MessagingController {
     if (!threadId) {
       return;
     }
+    if (event.notification.method === "item/transientMessage/updated") {
+      // Transient transcript text is a local, replaceable desktop surface.
+      // It is intentionally not translated into a messaging intent: remote
+      // delivery would give it durable-message queueing, retry, and budget
+      // semantics that it must never inherit.
+      return;
+    }
     const scheduledAction = scheduledActionForBackendEvent(event);
     if (
       scheduledAction?.origin === "messaging"

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1139,6 +1139,7 @@ function DesktopAppShell(props: {
       usd: settings.snapshot?.experimental.threadPricingDisplayUsd?.value ?? true,
     },
     pendingAssistantMessage: session.pendingAssistantMessage,
+    transientMessage: session.transientMessage,
     pendingMcpInteraction: session.pendingMcpInteraction,
     pendingRequest: session.pendingRequest,
     pendingUserInput: session.pendingUserInput,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1140,6 +1140,7 @@ function DesktopAppShell(props: {
     },
     pendingAssistantMessage: session.pendingAssistantMessage,
     transientMessage: session.transientMessage,
+    transientMessages: session.transientMessages,
     pendingMcpInteraction: session.pendingMcpInteraction,
     pendingRequest: session.pendingRequest,
     pendingUserInput: session.pendingUserInput,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -21,6 +21,7 @@ import type {
   AppServerThreadPlanEntry,
   AppServerThreadPlanStep,
   AppServerThreadTurnMetadata,
+  AppServerTransientThreadMessageEntry,
   AppServerTurnInputItem,
   AppServerThreadReplayPagination,
   AppServerSkillSummary,
@@ -888,6 +889,7 @@ export type ThreadViewProps = {
   };
   threadPricingSummaryEnabled?: boolean;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  transientMessage?: AppServerTransientThreadMessageEntry;
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
@@ -3091,6 +3093,7 @@ export function ThreadView(props: ThreadViewProps) {
               // "Thinking" indicator.
               pendingActivityEntry={pendingTranscriptActivityEntry}
               pendingAssistantMessage={props.pendingAssistantMessage}
+              transientMessage={props.transientMessage}
               pendingPlanEntry={undefined}
               pendingMcpInteraction={props.pendingMcpInteraction}
               pendingRequest={props.pendingRequest}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -890,6 +890,7 @@ export type ThreadViewProps = {
   threadPricingSummaryEnabled?: boolean;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   transientMessage?: AppServerTransientThreadMessageEntry;
+  transientMessages?: AppServerTransientThreadMessageEntry[];
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
@@ -3094,6 +3095,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingActivityEntry={pendingTranscriptActivityEntry}
               pendingAssistantMessage={props.pendingAssistantMessage}
               transientMessage={props.transientMessage}
+              transientMessages={props.transientMessages}
               pendingPlanEntry={undefined}
               pendingMcpInteraction={props.pendingMcpInteraction}
               pendingRequest={props.pendingRequest}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -15,6 +15,7 @@ import type {
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
   AppServerThreadPlanEntry,
+  AppServerTransientThreadMessageEntry,
   AppServerThreadFileChangeKind,
   AppServerSkillSummary,
   AppServerThreadReplayPagination,
@@ -89,6 +90,7 @@ type TranscriptListProps = {
   pendingProtocolActivityEntry?: AppServerThreadActivityEntry;
   pendingUsageActivityEntry?: AppServerThreadActivityEntry;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
+  transientMessage?: AppServerTransientThreadMessageEntry;
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingRequestBusy?: boolean;
@@ -724,6 +726,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingProtocolActivityEntry ||
       props.pendingUsageActivityEntry ||
       props.pendingAssistantMessage ||
+      props.transientMessage ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
       props.pendingMcpInteraction ||
@@ -785,12 +788,20 @@ export function TranscriptList(props: TranscriptListProps) {
 
   const transcriptEntries = useMemo(() => {
     const entries = [...props.entries];
+    const transientMessageEntry: AppServerThreadMessageEntry | undefined =
+      props.transientMessage
+        ? {
+            ...props.transientMessage,
+            type: "message",
+          }
+        : undefined;
     for (const pendingEntry of pendingEntriesInEventOrder([
       props.pendingPlanEntry,
       props.pendingActivityEntry,
       props.pendingProtocolActivityEntry,
       props.pendingUsageActivityEntry,
       props.pendingAssistantMessage,
+      transientMessageEntry,
     ])) {
       insertPendingEntry(entries, pendingEntry);
     }
@@ -811,6 +822,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingProtocolActivityEntry,
     props.pendingUsageActivityEntry,
     props.pendingAssistantMessage,
+    props.transientMessage,
     props.pendingPlanEntry,
     props.messagingBindingTransitions,
     props.permissionTransitions,
@@ -832,13 +844,15 @@ export function TranscriptList(props: TranscriptListProps) {
         entries: transcriptEntries,
         activeTurnId: props.activeTurnId,
         activeTurnStartedAt: props.activeTurnStartedAt,
-        activeMessageId: props.pendingAssistantMessage?.id,
+        activeMessageId:
+          props.transientMessage?.id ?? props.pendingAssistantMessage?.id,
         now: renderNow,
       }),
     [
       props.activeTurnId,
       props.activeTurnStartedAt,
       props.pendingAssistantMessage?.id,
+      props.transientMessage?.id,
       renderNow,
       transcriptEntries,
     ]

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -59,6 +59,7 @@ import {
   ACTIVE_WORK_GROUP_THRESHOLD_MS,
   buildTranscriptRenderItems,
 } from "./transcript-render-items";
+import { readRendererSequence } from "./live-transcript-activity";
 
 type TranscriptViewport = {
   distanceFromBottom: number;
@@ -91,6 +92,7 @@ type TranscriptListProps = {
   pendingUsageActivityEntry?: AppServerThreadActivityEntry;
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   transientMessage?: AppServerTransientThreadMessageEntry;
+  transientMessages?: AppServerTransientThreadMessageEntry[];
   pendingPlanEntry?: AppServerThreadPlanEntry;
   pendingRequest?: AppServerPendingRequestNotification;
   pendingRequestBusy?: boolean;
@@ -183,6 +185,16 @@ function pendingEntriesInEventOrder(
       Boolean(item.entry)
     )
     .sort((left, right) => {
+      const leftSequence = readRendererSequence(left.entry);
+      const rightSequence = readRendererSequence(right.entry);
+      if (
+        typeof leftSequence === "number"
+        && typeof rightSequence === "number"
+        && leftSequence !== rightSequence
+      ) {
+        return leftSequence - rightSequence;
+      }
+
       const leftCreatedAt = entryCreatedAt(left.entry);
       const rightCreatedAt = entryCreatedAt(right.entry);
       if (
@@ -216,6 +228,22 @@ function insertPendingEntry(
   const existingIndex = entries.findIndex((entry) => entry.id === pendingEntry.id);
   if (existingIndex >= 0) {
     entries[existingIndex] = pendingEntry;
+    return;
+  }
+
+  const pendingSequence = readRendererSequence(pendingEntry);
+  const sequencedIndex =
+    typeof pendingSequence === "number"
+      ? entries.findIndex((entry) => {
+          const entrySequence = readRendererSequence(entry);
+          return (
+            typeof entrySequence === "number"
+            && entrySequence > pendingSequence
+          );
+        })
+      : -1;
+  if (sequencedIndex !== -1) {
+    entries.splice(sequencedIndex, 0, pendingEntry);
     return;
   }
 
@@ -727,6 +755,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.pendingUsageActivityEntry ||
       props.pendingAssistantMessage ||
       props.transientMessage ||
+      props.transientMessages?.length ||
       props.pendingPlanEntry ||
       props.pendingRequest ||
       props.pendingMcpInteraction ||
@@ -788,20 +817,20 @@ export function TranscriptList(props: TranscriptListProps) {
 
   const transcriptEntries = useMemo(() => {
     const entries = [...props.entries];
-    const transientMessageEntry: AppServerThreadMessageEntry | undefined =
-      props.transientMessage
-        ? {
-            ...props.transientMessage,
-            type: "message",
-          }
-        : undefined;
+    const transientMessageEntries: AppServerThreadMessageEntry[] =
+      (props.transientMessages ??
+        (props.transientMessage ? [props.transientMessage] : []))
+        .map((transientMessage) => ({
+          ...transientMessage,
+          type: "message",
+        }));
     for (const pendingEntry of pendingEntriesInEventOrder([
       props.pendingPlanEntry,
       props.pendingActivityEntry,
       props.pendingProtocolActivityEntry,
       props.pendingUsageActivityEntry,
       props.pendingAssistantMessage,
-      transientMessageEntry,
+      ...transientMessageEntries,
     ])) {
       insertPendingEntry(entries, pendingEntry);
     }
@@ -823,11 +852,21 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingUsageActivityEntry,
     props.pendingAssistantMessage,
     props.transientMessage,
+    props.transientMessages,
     props.pendingPlanEntry,
     props.messagingBindingTransitions,
     props.permissionTransitions,
     props.turnFailures,
   ]);
+  const alwaysVisibleTransientMessageIds = useMemo(
+    () =>
+      new Set(
+        (props.transientMessages ??
+          (props.transientMessage ? [props.transientMessage] : []))
+          .map((message) => message.id),
+      ),
+    [props.transientMessage, props.transientMessages],
+  );
   const pendingApprovalContext = useMemo(
     () =>
       props.pendingRequest
@@ -846,6 +885,7 @@ export function TranscriptList(props: TranscriptListProps) {
         activeTurnStartedAt: props.activeTurnStartedAt,
         activeMessageId:
           props.transientMessage?.id ?? props.pendingAssistantMessage?.id,
+        alwaysVisibleEntryIds: alwaysVisibleTransientMessageIds,
         now: renderNow,
       }),
     [
@@ -853,6 +893,7 @@ export function TranscriptList(props: TranscriptListProps) {
       props.activeTurnStartedAt,
       props.pendingAssistantMessage?.id,
       props.transientMessage?.id,
+      alwaysVisibleTransientMessageIds,
       renderNow,
       transcriptEntries,
     ]

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/chevron-placement.test.tsx
@@ -83,6 +83,43 @@ describe("transcript disclosure chevron placement", () => {
     expect(screen.getByText("found 20 matches")).toBeInTheDocument();
   });
 
+  it("renders a single code search as one disclosure", () => {
+    const { container } = render(
+      <TranscriptActivity
+        entry={{
+          type: "activity",
+          id: "grep-1",
+          summary: "Searched code: supportsImage|Grok|grok",
+          details: [
+            {
+              id: "grep-1:detail",
+              kind: "read",
+              label: "Searched code: supportsImage|Grok|grok",
+              command: {
+                displayCommand: 'grep(pattern="supportsImage|Grok|grok")',
+                source: "tool",
+                output: "found 9 matches",
+              },
+            },
+          ],
+        }}
+      />
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: "Searched code: supportsImage|Grok|grok",
+    });
+    expect(container.querySelectorAll(".transcript-activity__toggle")).toHaveLength(1);
+    expect(container.querySelectorAll(".transcript-activity__detail-toggle")).toHaveLength(0);
+
+    fireEvent.click(toggle);
+
+    expect(container.querySelectorAll(".transcript-activity__toggle")).toHaveLength(1);
+    expect(container.querySelectorAll(".transcript-activity__detail-toggle")).toHaveLength(0);
+    expect(screen.getByText('grep(pattern="supportsImage|Grok|grok")')).toBeInTheDocument();
+    expect(screen.getByText("found 9 matches")).toBeInTheDocument();
+  });
+
   it("opens a rendered tool image through the shared lightbox callback", () => {
     const onOpenImage = vi.fn();
     const image = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -439,6 +439,57 @@ describe("mergeCommandDetail", () => {
 });
 
 describe("mergeActivityDetails", () => {
+  it("keeps a read action label when an ACP completion omits its path", () => {
+    const started = buildLiveToolDetails({
+      id: "read-file-1",
+      type: "commandExecution",
+      toolName: "read",
+      status: "in_progress",
+      command: "README.md",
+      commandSource: "tool",
+      commandActions: [
+        {
+          type: "read",
+          path: "/repo/README.md",
+          name: "README.md",
+        },
+      ],
+    });
+    const completed = buildLiveToolDetails({
+      id: "read-file-1",
+      type: "commandExecution",
+      toolName: "read",
+      status: "completed",
+      command: "README.md",
+      commandSource: "tool",
+      commandActions: [
+        {
+          type: "read",
+          name: "README.md",
+        },
+      ],
+      data: {
+        output: "Read lines 1-80 of 200 from README.md",
+      },
+    });
+
+    const merged = mergeActivityDetails(started, completed);
+
+    expect(merged).toEqual([
+      expect.objectContaining({
+        id: "read-file-1",
+        kind: "read",
+        label: "Read README.md",
+        status: "completed",
+        command: expect.objectContaining({
+          displayCommand: "README.md",
+          output: "Read lines 1-80 of 200 from README.md",
+        }),
+      }),
+    ]);
+    expect(summarizeLiveActivity(merged)).toBe("Read README.md");
+  });
+
   it("keeps a web fetch label and read kind across a sparse completion", () => {
     expect(
       mergeActivityDetails(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -85,6 +85,42 @@ describe("buildLiveToolDetails", () => {
         }),
       },
     ]);
+    expect(summarizeLiveActivity(details)).toBe('Searched "grok"');
+  });
+
+  it("keeps a described command on one direct activity row", () => {
+    const description = "Inspect Grok 4.5 model cache entry";
+    const command = "python3 - <<'PY'\nprint('Grok 4.5')\nPY";
+    const details = buildLiveToolDetails({
+      type: "commandExecution",
+      id: "run-terminal-1",
+      status: "completed",
+      command,
+      commandActions: [
+        {
+          type: "unknown",
+          name: description,
+        },
+      ],
+      data: {
+        output: "Grok 4.5",
+      },
+    });
+
+    expect(details).toEqual([
+      {
+        id: "run-terminal-1",
+        kind: "command",
+        label: description,
+        status: "completed",
+        command: expect.objectContaining({
+          displayCommand: "python3 - <<'PY' print('Grok 4.5') PY",
+          rawCommand: command,
+          output: "Grok 4.5",
+        }),
+      },
+    ]);
+    expect(summarizeLiveActivity(details)).toBe(description);
   });
 
   it("keeps completion status on the web search rather than its result links", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1393,6 +1393,57 @@ describe("TranscriptList", () => {
     );
   });
 
+  it("replaces a transient assistant message in transcript order", () => {
+    const entries = [
+      {
+        type: "message" as const,
+        id: "message-1",
+        role: "user" as const,
+        text: "Inspect the image support logic",
+      },
+    ];
+    const { rerender } = render(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        transientMessage={{
+          type: "transientMessage",
+          id: "transient-thought:turn-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "So the key logic is:",
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByText("So the key logic is:").closest("article")).toHaveClass(
+      "transcript-message--assistant"
+    );
+
+    rerender(
+      <TranscriptList
+        entries={entries}
+        loading={false}
+        loadingMore={false}
+        transientMessage={{
+          type: "transientMessage",
+          id: "transient-thought:turn-1",
+          role: "assistant",
+          phase: "commentary",
+          text: "Tracing the image support flags.",
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.queryByText("So the key logic is:")).not.toBeInTheDocument();
+    expect(screen.getByText("Tracing the image support flags.")).toBeVisible();
+  });
+
   it("collapses completed assistant commentary before the final answer", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1444,6 +1444,85 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Tracing the image support flags.")).toBeVisible();
   });
 
+  it("keeps settled transient segments ordered between tool invocations", () => {
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "activity",
+            id: "tool-1",
+            summary: "Read Composer.tsx",
+            details: [],
+            createdAt: 20,
+            turn: { id: "turn-1", status: "in_progress" },
+          },
+          {
+            type: "activity",
+            id: "tool-2",
+            summary: "Searched image support",
+            details: [],
+            createdAt: 40,
+            turn: { id: "turn-1", status: "in_progress" },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        transientMessages={[
+          {
+            type: "transientMessage",
+            id: "transient-thought:turn-1:settled:1",
+            role: "assistant",
+            phase: "commentary",
+            text: "I will inspect the composer first.",
+            createdAt: 10,
+            turn: { id: "turn-1", status: "in_progress" },
+          },
+          {
+            type: "transientMessage",
+            id: "transient-thought:turn-1:settled:3",
+            role: "assistant",
+            phase: "commentary",
+            text: "The image check is in the next branch.",
+            createdAt: 30,
+            turn: { id: "turn-1", status: "in_progress" },
+          },
+        ]}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const firstThought = screen
+      .getByText("I will inspect the composer first.")
+      .closest("article");
+    const firstTool = screen
+      .getByText("Read Composer.tsx")
+      .closest(".transcript-activity");
+    const secondThought = screen
+      .getByText("The image check is in the next branch.")
+      .closest("article");
+    const secondTool = screen
+      .getByText("Searched image support")
+      .closest(".transcript-activity");
+
+    expect(firstThought).not.toBeNull();
+    expect(firstTool).not.toBeNull();
+    expect(secondThought).not.toBeNull();
+    expect(secondTool).not.toBeNull();
+    expect(
+      firstThought!.compareDocumentPosition(firstTool!)
+      & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      firstTool!.compareDocumentPosition(secondThought!)
+      & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      secondThought!.compareDocumentPosition(secondTool!)
+      & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("collapses completed assistant commentary before the final answer", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -1054,6 +1054,8 @@ export function buildLiveToolDetails(
           : itemType === "dynamictoolcall" && title
             ? buildLiveDynamicToolCommandDetail(item, toolName, elapsedMs)
         : undefined;
+  const commandUsesDedicatedRenderer =
+    itemType === "commandexecution" || isExecFunctionCall;
   const details: AppServerThreadActivityDetail[] = [
     {
       id: itemId,
@@ -1067,9 +1069,9 @@ export function buildLiveToolDetails(
             : "command",
       label: [
         buildLiveToolLabel(item, itemType, status, toolName),
-        elapsedMs ? ` (${formatElapsedMs(elapsedMs)})` : "",
+        elapsedMs && !commandUsesDedicatedRenderer ? ` (${formatElapsedMs(elapsedMs)})` : "",
         query ? `: ${query}` : "",
-        preview ? ` - ${preview}` : "",
+        preview && !commandUsesDedicatedRenderer ? ` - ${preview}` : "",
       ].join(""),
       ...(images.length > 0 ? { images } : {}),
       ...(commandDetail ? { command: commandDetail } : {}),
@@ -1140,6 +1142,13 @@ function commandSummaryName(label: string): string | undefined {
 
 export function summarizeLiveActivity(details: AppServerThreadActivityDetail[]): string {
   const primaryDetails = details.filter((detail) => !detail.id.includes("-source-"));
+  if (
+    details.length === 1
+    && primaryDetails.length === 1
+    && primaryDetails[0]?.command
+  ) {
+    return primaryDetails[0].label;
+  }
   const readCount = primaryDetails.filter((detail) => detail.kind === "read").length;
   const commandLabels = [
     ...new Set(

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -636,8 +636,15 @@ function readCommandActionLabel(item: Record<string, unknown>): string | undefin
     const actionPath = readString(record, "path");
     const actionQuery = readString(record, "query");
     const fallbackName = readString(record, "name");
-    if (actionType === "read" && actionPath) {
-      return `Read ${actionPath.split("/").filter(Boolean).pop() ?? actionPath}`;
+    if (actionType === "read") {
+      if (actionPath) {
+        return `Read ${actionPath.split("/").filter(Boolean).pop() ?? actionPath}`;
+      }
+      if (fallbackName) {
+        return /^(?:read|fetched)\b/i.test(fallbackName)
+          ? fallbackName
+          : `Read ${fallbackName}`;
+      }
     }
     if (actionType === "listFiles") {
       return "Listed files";

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -1142,12 +1142,17 @@ function commandSummaryName(label: string): string | undefined {
 
 export function summarizeLiveActivity(details: AppServerThreadActivityDetail[]): string {
   const primaryDetails = details.filter((detail) => !detail.id.includes("-source-"));
+  const directDetail = primaryDetails.length === 1 ? primaryDetails[0] : undefined;
   if (
     details.length === 1
-    && primaryDetails.length === 1
-    && primaryDetails[0]?.command
+    && directDetail?.command
+    && (
+      directDetail.kind === "read"
+      || directDetail.label.trim().toLowerCase()
+        !== formatCommandLabel(directDetail.command.displayCommand).toLowerCase()
+    )
   ) {
-    return primaryDetails[0].label;
+    return directDetail.label;
   }
   const readCount = primaryDetails.filter((detail) => detail.kind === "read").length;
   const commandLabels = [

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -27,6 +27,7 @@ export function buildTranscriptRenderItems(params: {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
   activeMessageId?: string;
+  alwaysVisibleEntryIds?: ReadonlySet<string>;
   now?: number;
 }): TranscriptRenderItem[] {
   const activeTurnId =
@@ -38,12 +39,17 @@ export function buildTranscriptRenderItems(params: {
   }
 
   if (activeTurnId) {
-    const groups = buildCompletedGroups(params.entries, activeTurnId);
+    const groups = buildCompletedGroups(
+      params.entries,
+      activeTurnId,
+      params.alwaysVisibleEntryIds,
+    );
     const activeGroups = buildActiveWorkGroups(
       params.entries,
       activeTurnId,
       params.now,
-      params.activeTurnStartedAt
+      params.activeTurnStartedAt,
+      params.alwaysVisibleEntryIds,
     );
     groups.push(...activeGroups);
     if (groups.length > 0) {
@@ -53,12 +59,19 @@ export function buildTranscriptRenderItems(params: {
     return params.entries.map((entry) => ({ type: "entry", entry }));
   }
 
-  const completedGroups = buildCompletedGroups(params.entries);
+  const completedGroups = buildCompletedGroups(
+    params.entries,
+    undefined,
+    params.alwaysVisibleEntryIds,
+  );
   if (completedGroups.length > 0) {
     return renderWithGroups(params.entries, completedGroups);
   }
 
-  const fallbackGroups = buildCommentaryOnlyGroups(params.entries);
+  const fallbackGroups = buildCommentaryOnlyGroups(
+    params.entries,
+    params.alwaysVisibleEntryIds,
+  );
   if (fallbackGroups.length === 0) {
     return params.entries.map((entry) => ({ type: "entry", entry }));
   }
@@ -78,7 +91,8 @@ function buildActiveWorkGroups(
   entries: AppServerThreadEntry[],
   activeTurnId: string,
   now = Date.now(),
-  activeTurnStartedAt?: number
+  activeTurnStartedAt?: number,
+  alwaysVisibleEntryIds?: ReadonlySet<string>,
 ): RenderGroup[] {
   const turn = entries.find((entry) => entry.turn?.id === activeTurnId)?.turn;
   const startedAtCandidates = [activeTurnStartedAt, turn?.startedAt].filter(
@@ -98,7 +112,11 @@ function buildActiveWorkGroups(
   const activeEntries: AppServerThreadEntry[] = [];
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (entry.turn?.id !== activeTurnId || !isConcreteWorkEntry(entry)) {
+    if (
+      alwaysVisibleEntryIds?.has(entry.id)
+      || entry.turn?.id !== activeTurnId
+      || !isConcreteWorkEntry(entry)
+    ) {
       break;
     }
     activeEntries.unshift(entry);
@@ -121,7 +139,8 @@ function buildActiveWorkGroups(
 
 function buildCompletedGroups(
   entries: AppServerThreadEntry[],
-  excludeTurnId?: string
+  excludeTurnId?: string,
+  alwaysVisibleEntryIds?: ReadonlySet<string>,
 ): RenderGroup[] {
   const groups: RenderGroup[] = [];
   const groupIds = new Set<string>();
@@ -169,9 +188,10 @@ function buildCompletedGroups(
   for (const entry of entries) {
     const turnId = entry.turn?.id;
     const canJoinGroup =
-      Boolean(turnId) &&
-      turnId !== excludeTurnId &&
-      isWorkPhaseEntry(entry);
+      !alwaysVisibleEntryIds?.has(entry.id)
+      && Boolean(turnId)
+      && turnId !== excludeTurnId
+      && isWorkPhaseEntry(entry);
 
     if (!canJoinGroup) {
       flushCurrent();
@@ -201,7 +221,10 @@ function buildCommentaryOnlyGroup(
   };
 }
 
-function buildCommentaryOnlyGroups(entries: AppServerThreadEntry[]): RenderGroup[] {
+function buildCommentaryOnlyGroups(
+  entries: AppServerThreadEntry[],
+  alwaysVisibleEntryIds?: ReadonlySet<string>,
+): RenderGroup[] {
   const groups: RenderGroup[] = [];
   let currentMessages: AppServerThreadMessageEntry[] = [];
 
@@ -222,8 +245,9 @@ function buildCommentaryOnlyGroups(entries: AppServerThreadEntry[]): RenderGroup
 
   for (const entry of entries) {
     if (
-      isAssistantCommentaryMessage(entry) &&
-      !isLiveInProgressTurn(entry.turn, completedTurnIds)
+      !alwaysVisibleEntryIds?.has(entry.id)
+      && isAssistantCommentaryMessage(entry)
+      && !isLiveInProgressTurn(entry.turn, completedTurnIds)
     ) {
       currentMessages.push(entry);
       continue;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2131,6 +2131,188 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage).toBeUndefined();
   });
 
+  it("replaces Grok thought status without persisting it in the transcript", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.response?.replay.entries).toEqual([]);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "in_progress",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentThought/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            text: "So the key logic is:\n```",
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingStatusText).toBe("So the key logic is:");
+    expect(result.current.pendingAssistantMessage).toBeUndefined();
+    expect(result.current.messages).toEqual([]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentThought/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            text: "Tracing the image\nsupport flags.",
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingStatusText).toBe(
+      "Tracing the image support flags."
+    );
+    expect(result.current.messages).toEqual([]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "read-1",
+              type: "commandExecution",
+              command: "sed -n '1,40p' src/one.ts",
+              commandActions: [{ type: "read", path: "src/one.ts" }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentThought/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            text: "Found the relevant branch.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "message-1",
+            delta: "The image flag is disabled.",
+            phase: "final",
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.pendingAssistantMessage?.text).toBe(
+      "The image flag is disabled."
+    );
+    expect(
+      result.current.messages.some((message) =>
+        message.text.includes("Found the relevant branch.")
+      )
+    ).toBe(false);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "The image flag is disabled." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(
+      result.current.messages.map((message) => message.text)
+    ).toEqual(["The image flag is disabled."]);
+  });
+
   it("retimestamps streamed final assistant messages when the turn completes", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2131,7 +2131,7 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage).toBeUndefined();
   });
 
-  it("replaces Grok thought status without persisting it in the transcript", async () => {
+  it("replaces a transient message without persisting it in the transcript", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex" | "grok";
@@ -2198,17 +2198,26 @@ describe("useThreadSessionState", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
-          method: "item/agentThought/updated",
+          method: "item/transientMessage/updated",
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
-            text: "So the key logic is:\n```",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "So the key logic is:",
+            phase: "commentary",
           },
         },
       });
     });
 
-    expect(result.current.pendingStatusText).toBe("So the key logic is:");
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.transientMessage).toMatchObject({
+      id: "transient-thought:turn-1",
+      role: "assistant",
+      text: "So the key logic is:",
+      type: "transientMessage",
+    });
     expect(result.current.pendingAssistantMessage).toBeUndefined();
     expect(result.current.messages).toEqual([]);
 
@@ -2216,20 +2225,57 @@ describe("useThreadSessionState", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
-          method: "item/agentThought/updated",
+          method: "item/transientMessage/updated",
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
-            text: "Tracing the image\nsupport flags.",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "Tracing the image support flags.",
+            phase: "commentary",
           },
         },
       });
     });
 
-    expect(result.current.pendingStatusText).toBe(
+    expect(result.current.transientMessage?.text).toBe(
       "Tracing the image support flags."
     );
     expect(result.current.messages).toEqual([]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "",
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
+            text: "Inspecting the relevant file.",
+          },
+        },
+      });
+    });
 
     act(() => {
       agentEventHandler?.({
@@ -2251,16 +2297,20 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.pendingStatusText).toBe("Thinking");
+    expect(result.current.transientMessage).toBeUndefined();
 
     act(() => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
-          method: "item/agentThought/updated",
+          method: "item/transientMessage/updated",
           params: {
             threadId: "thread-1",
             turnId: "turn-1",
+            itemId: "transient-thought:turn-1",
+            role: "assistant",
             text: "Found the relevant branch.",
+            phase: "commentary",
           },
         },
       });
@@ -2283,6 +2333,7 @@ describe("useThreadSessionState", () => {
     expect(result.current.pendingAssistantMessage?.text).toBe(
       "The image flag is disabled."
     );
+    expect(result.current.transientMessage).toBeUndefined();
     expect(
       result.current.messages.some((message) =>
         message.text.includes("Found the relevant branch.")
@@ -2308,9 +2359,243 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.transientMessage).toBeUndefined();
     expect(
       result.current.messages.map((message) => message.text)
     ).toEqual(["The image flag is disabled."]);
+  });
+
+  it("isolates transient messages by thread and turn", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async ({
+        backend,
+        threadId,
+      }: {
+        backend?: AppServerBackendKind;
+        threadId: string;
+      }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const thread1 = buildThread({ id: "thread-1", updatedAt: 1_000 });
+    const thread2 = buildThread({ id: "thread-2", updatedAt: 1_000 });
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: thread1,
+        },
+      }
+    );
+
+    await waitForThreadHydration(result, "thread-1");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "transient:turn-1",
+            role: "assistant",
+            text: "Thread one thought.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-2",
+            itemId: "transient:turn-2",
+            role: "assistant",
+            text: "Thread two thought.",
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage?.text).toBe("Thread one thought.");
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.messages).toEqual([]);
+
+    rerender({ currentThread: thread2 });
+    await waitForThreadHydration(result, "thread-2");
+
+    expect(result.current.transientMessage?.text).toBe("Thread two thought.");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-3",
+            turn: {
+              id: "turn-3",
+              status: "in_progress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-2",
+            itemId: "transient:turn-2",
+            role: "assistant",
+            text: "Late thought from the previous turn.",
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-3",
+            itemId: "transient:turn-3",
+            role: "assistant",
+            text: "Current turn thought.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-2",
+            turn: {
+              id: "turn-2",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage?.text).toBe("Current turn thought.");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/cancelled",
+          params: {
+            threadId: "thread-2",
+            turnId: "turn-3",
+            turn: {
+              id: "turn-3",
+              status: "cancelled",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+
+    rerender({ currentThread: thread1 });
+    await waitForThreadHydration(result, "thread-1");
+
+    expect(result.current.transientMessage?.text).toBe("Thread one thought.");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: { type: "idle" },
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/transientMessage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "transient:turn-1",
+            role: "assistant",
+            text: "Thought before approval.",
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/requestApproval",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            requestId: "approval-1",
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.pendingStatusText).toBe("Waiting for approval");
   });
 
   it("retimestamps streamed final assistant messages when the turn completes", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2218,6 +2218,7 @@ describe("useThreadSessionState", () => {
       text: "So the key logic is:",
       type: "transientMessage",
     });
+    expect(result.current.transientMessages).toHaveLength(1);
     expect(result.current.pendingAssistantMessage).toBeUndefined();
     expect(result.current.messages).toEqual([]);
 
@@ -2241,6 +2242,9 @@ describe("useThreadSessionState", () => {
     expect(result.current.transientMessage?.text).toBe(
       "Tracing the image support flags."
     );
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Tracing the image support flags.",
+    ]);
     expect(result.current.messages).toEqual([]);
 
     act(() => {
@@ -2260,6 +2264,7 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages).toEqual([]);
 
     act(() => {
       agentEventHandler?.({
@@ -2298,6 +2303,9 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.pendingStatusText).toBe("Thinking");
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Inspecting the relevant file.",
+    ]);
 
     act(() => {
       agentEventHandler?.({
@@ -2334,6 +2342,10 @@ describe("useThreadSessionState", () => {
       "The image flag is disabled."
     );
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Inspecting the relevant file.",
+      "Found the relevant branch.",
+    ]);
     expect(
       result.current.messages.some((message) =>
         message.text.includes("Found the relevant branch.")
@@ -2360,9 +2372,71 @@ describe("useThreadSessionState", () => {
 
     expect(result.current.pendingStatusText).toBeUndefined();
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Inspecting the relevant file.",
+      "Found the relevant branch.",
+    ]);
     expect(
       result.current.messages.map((message) => message.text)
     ).toEqual(["The image flag is disabled."]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/compacted",
+          params: {
+            threadId: "thread-1",
+          },
+        },
+      });
+    });
+
+    expect(result.current.transientMessages).toEqual([]);
+
+    act(() => {
+      for (let index = 1; index <= 51; index += 1) {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "item/transientMessage/updated",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-cap",
+              itemId: "transient-thought:turn-cap",
+              role: "assistant",
+              text: `Ephemeral segment ${index}.`,
+              phase: "commentary",
+            },
+          },
+        });
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "item/started",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-cap",
+              item: {
+                id: `read-${index}`,
+                type: "commandExecution",
+                command: `sed -n '${index}p' src/file.ts`,
+                commandActions: [{ type: "read", path: "src/file.ts" }],
+              },
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.transientMessages).toHaveLength(50);
+    expect(result.current.transientMessages[0]?.text).toBe(
+      "Ephemeral segment 2.",
+    );
+    expect(result.current.transientMessages[49]?.text).toBe(
+      "Ephemeral segment 51.",
+    );
+    expect(result.current.messages).toEqual([]);
   });
 
   it("isolates transient messages by thread and turn", async () => {
@@ -2476,6 +2550,9 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Thread two thought.",
+    ]);
 
     act(() => {
       agentEventHandler?.({
@@ -2494,6 +2571,9 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Thread two thought.",
+    ]);
 
     act(() => {
       agentEventHandler?.({
@@ -2546,6 +2626,10 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Thread two thought.",
+      "Current turn thought.",
+    ]);
 
     rerender({ currentThread: thread1 });
     await waitForThreadHydration(result, "thread-1");
@@ -2566,6 +2650,9 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Thread one thought.",
+    ]);
 
     act(() => {
       agentEventHandler?.({
@@ -2595,6 +2682,10 @@ describe("useThreadSessionState", () => {
     });
 
     expect(result.current.transientMessage).toBeUndefined();
+    expect(result.current.transientMessages.map((message) => message.text)).toEqual([
+      "Thread one thought.",
+      "Thought before approval.",
+    ]);
     expect(result.current.pendingStatusText).toBe("Waiting for approval");
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3392,9 +3392,9 @@ describe("useThreadSessionState", () => {
       )
     ).toEqual([
       "message:First commentary.",
-      "activity:Explored 1 item",
+      "activity:Read one.ts",
       "message:The first scan shows this is a deep brainstorm.",
-      "activity:Explored 1 item",
+      "activity:Searched src",
       "message:Final answer.",
     ]);
     expect(
@@ -3560,9 +3560,9 @@ describe("useThreadSessionState", () => {
       )
     ).toEqual([
       "message:First commentary.",
-      "activity:Explored 1 item",
+      "activity:Searched src",
       "message:Second commentary.",
-      "activity:Explored 1 item",
+      "activity:Searched src",
       "message:Third commentary.",
     ]);
   });
@@ -3690,9 +3690,9 @@ describe("useThreadSessionState", () => {
             : entry.type
       )
     ).toEqual([
-      "activity:Explored 1 item:1",
+      "activity:Read one.ts:1",
       "message:Starting to look through the project.",
-      "activity:Explored 1 item:1",
+      "activity:Searched src:1",
     ]);
   });
 
@@ -3923,9 +3923,9 @@ describe("useThreadSessionState", () => {
 
     expect(transcriptLabels(result.current.entries)).toEqual([
       "message:First commentary.",
-      "activity:Explored 1 item",
+      "activity:Read one.ts",
       "message:Second commentary.",
-      "activity:Explored 1 item",
+      "activity:Searched src",
       "message:Final answer.",
     ]);
 
@@ -3937,9 +3937,9 @@ describe("useThreadSessionState", () => {
     await waitFor(() => {
       expect(transcriptLabels(result.current.entries)).toEqual([
         "message:First commentary.",
-        "activity:Explored 1 item",
+        "activity:Read one.ts",
         "message:Second commentary.",
-        "activity:Explored 1 item",
+        "activity:Searched src",
         "message:Final answer.",
       ]);
     });

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -16,6 +16,7 @@ import type {
   AppServerThreadMessageOrigin,
   AppServerThreadMessagePart,
   AppServerThreadReviewEntry,
+  AppServerTransientThreadMessageEntry,
   AppServerThreadTurnMetadata,
   AppServerThreadImagePart,
   MessagingChannelKind,
@@ -157,7 +158,7 @@ type ThreadSessionEntry = {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
-  transientThoughtText?: string;
+  transientMessage?: AppServerTransientThreadMessageEntry;
   pendingTurnUsage?: TurnUsageAccumulator;
   response?: AppServerReadThreadResponse;
   // Lightweight reading state belongs beside the bounded transcript cache.
@@ -182,6 +183,7 @@ type ThinkingStateReason = {
     | "pendingMcpInteraction"
     | "pendingRequest"
     | "pendingStatus"
+    | "transientMessage"
     | "pendingUserInput";
   turnId?: string;
   turnStatus?: string;
@@ -1501,6 +1503,15 @@ function describeThinkingState(session: ThreadSessionEntry): ThinkingStateReason
     });
   }
 
+  if (session.transientMessage) {
+    reasons.push({
+      entryId: session.transientMessage.id,
+      kind: "transientMessage",
+      turnId: session.transientMessage.turn?.id,
+      turnStatus: session.transientMessage.turn?.status,
+    });
+  }
+
   if (session.pendingMcpInteraction) {
     reasons.push({ kind: "pendingMcpInteraction" });
   }
@@ -2437,18 +2448,12 @@ function isThreadLocalTranscriptNotification(
     notification.method === "item/started" ||
     notification.method === "item/completed" ||
     notification.method === "item/agentMessage/delta" ||
-    notification.method === "item/agentThought/updated" ||
+    notification.method === "item/transientMessage/updated" ||
     notification.method === "item/mcpToolCall/progress" ||
     notification.method === "item/commandExecution/outputDelta" ||
     notification.method === "item/fileChange/outputDelta" ||
     notification.method === "thread/tokenUsage/updated"
   );
-}
-
-function formatTransientThoughtStatus(text: string): string | undefined {
-  const beforeCodeFence = text.split("```", 1)[0] ?? "";
-  const compact = beforeCodeFence.replace(/\s+/gu, " ").trim();
-  return compact || undefined;
 }
 
 function liveActivityNotificationSignature(params: {
@@ -3424,6 +3429,67 @@ function isMcpElicitationNotification(
   );
 }
 
+const TRANSIENT_MESSAGE_BOUNDARY_METHODS = new Set([
+  "item/agentMessage/delta",
+  "item/commandExecution/outputDelta",
+  "item/completed",
+  "item/fileChange/outputDelta",
+  "item/mcpToolCall/progress",
+  "item/started",
+  "thread/compacted",
+  "turn/cancelled",
+  "turn/completed",
+  "turn/failed",
+  "turn/started",
+]);
+
+function clearTransientMessageAtBoundary(
+  current: ThreadSessionEntry,
+  notification: AppServerNotification
+): ThreadSessionEntry {
+  if (
+    !current.transientMessage ||
+    notification.method === "item/transientMessage/updated"
+  ) {
+    return current;
+  }
+
+  const statusType =
+    notification.method === "thread/status/changed" &&
+    typeof notification.params.status === "object" &&
+    notification.params.status !== null &&
+    "type" in notification.params.status
+      ? notification.params.status.type
+      : undefined;
+  const isBoundary =
+    TRANSIENT_MESSAGE_BOUNDARY_METHODS.has(notification.method) ||
+    isApprovalRequestNotification(notification) ||
+    isRequestUserInputNotification(notification) ||
+    isMcpElicitationNotification(notification) ||
+    statusType === "idle";
+  if (!isBoundary) {
+    return current;
+  }
+
+  const notificationTurnId = readNotificationTurnId(notification);
+  const transientTurnId = current.transientMessage.turn?.id;
+  if (
+    notification.method !== "turn/started" &&
+    notification.method !== "thread/compacted" &&
+    statusType !== "idle" &&
+    notificationTurnId &&
+    transientTurnId &&
+    notificationTurnId !== transientTurnId
+  ) {
+    return current;
+  }
+
+  return {
+    ...current,
+    transientMessage: undefined,
+  };
+}
+
 function readCompletedTurnText(
   notification: AppServerPendingRequestNotification | AppServerReadThreadResponse["backend"] | unknown
 ): string | undefined {
@@ -3489,6 +3555,7 @@ export function useThreadSessionState(params: {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  transientMessage?: AppServerTransientThreadMessageEntry;
   runningTurnUsageText?: string;
   approvalRequestThreadKeys: Record<string, boolean>;
   inputRequestThreadKeys: Record<string, boolean>;
@@ -3812,9 +3879,9 @@ export function useThreadSessionState(params: {
               ownUpdateStillSettling || reviewUpdateStillSettling
               ? ownUpdateSettlesAt
               : undefined,
-            transientThoughtText: shouldClearStaleThinking
+            transientMessage: shouldClearStaleThinking
               ? undefined
-              : current.transientThoughtText,
+              : current.transientMessage,
           };
         });
       } catch (error) {
@@ -4139,7 +4206,11 @@ export function useThreadSessionState(params: {
         }
       }
 
-      updateSession(targetThreadKey, (current) => {
+      updateSession(targetThreadKey, (session) => {
+        const current = clearTransientMessageAtBoundary(
+          session,
+          event.notification
+        );
         const nextLastTouchedAt = Date.now();
 
         if (isApprovalRequestNotification(event.notification)) {
@@ -4151,7 +4222,6 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingRequest: event.notification,
             pendingStatusText: "Waiting for approval",
-            transientThoughtText: undefined,
           };
         }
 
@@ -4169,7 +4239,6 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingStatusText: "Waiting for input",
             pendingUserInput,
-            transientThoughtText: undefined,
           };
         }
 
@@ -4187,7 +4256,6 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingMcpInteraction,
             pendingStatusText: "Waiting for MCP approval",
-            transientThoughtText: undefined,
           };
         }
 
@@ -4208,13 +4276,7 @@ export function useThreadSessionState(params: {
           const item = getNotificationItem(event.notification.params);
           const details = item ? buildLiveToolDetails(item) : [];
           if (details.length === 0) {
-            return current.transientThoughtText
-              ? {
-                  ...current,
-                  lastTouchedAt: nextLastTouchedAt,
-                  transientThoughtText: undefined,
-                }
-              : current;
+            return current;
           }
 
           const turn = buildTurnMetadata({
@@ -4225,25 +4287,59 @@ export function useThreadSessionState(params: {
             fallbackStartedAt: current.activeTurnStartedAt,
             fallbackStatus: "in_progress",
           });
-          return upsertLiveActivityEntry(
-            {
-              ...current,
-              transientThoughtText: undefined,
-            },
-            {
-              details,
-              now: nextLastTouchedAt,
-              suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
-              threadId: notificationThreadId,
-              turn,
-            }
-          );
+          return upsertLiveActivityEntry(current, {
+            details,
+            now: nextLastTouchedAt,
+            suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
+            threadId: notificationThreadId,
+            turn,
+          });
         }
 
-        if (event.notification.method === "item/agentThought/updated") {
-          const text = formatTransientThoughtStatus(
-            event.notification.params.text
-          );
+        if (event.notification.method === "item/transientMessage/updated") {
+          if (
+            current.activeTurnId &&
+            event.notification.params.turnId &&
+            current.activeTurnId !== event.notification.params.turnId
+          ) {
+            return current;
+          }
+          const text = event.notification.params.text.trim();
+          if (!text) {
+            return current.transientMessage
+              ? {
+                  ...current,
+                  lastTouchedAt: nextLastTouchedAt,
+                  transientMessage: undefined,
+                }
+              : current;
+          }
+          const isSameTransientMessage =
+            current.transientMessage?.id === event.notification.params.itemId;
+          const turn = buildTurnMetadata({
+            fallbackId:
+              event.notification.params.turnId ?? current.activeTurnId,
+            fallbackStartedAt: current.activeTurnStartedAt,
+            fallbackStatus: "in_progress",
+          });
+          const sequence = isSameTransientMessage
+            ? readRendererSequence(current.transientMessage)
+            : current.nextLiveEntrySequence;
+          const transientMessage: AppServerTransientThreadMessageEntry =
+            withRendererSequence(
+              {
+                type: "transientMessage",
+                id: event.notification.params.itemId,
+                role: event.notification.params.role,
+                phase: event.notification.params.phase,
+                createdAt: isSameTransientMessage
+                  ? current.transientMessage?.createdAt
+                  : nextLastTouchedAt,
+                ...(turn ? { turn } : {}),
+                text,
+              },
+              sequence ?? current.nextLiveEntrySequence
+            );
           return {
             ...current,
             activeTurnId:
@@ -4251,7 +4347,10 @@ export function useThreadSessionState(params: {
             expectOwnUpdate: true,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
-            transientThoughtText: text,
+            nextLiveEntrySequence: isSameTransientMessage
+              ? current.nextLiveEntrySequence
+              : current.nextLiveEntrySequence + 1,
+            transientMessage,
           };
         }
 
@@ -4317,7 +4416,6 @@ export function useThreadSessionState(params: {
               allocatedSequence
             ),
             response: flushedResponse,
-            transientThoughtText: undefined,
           };
         }
 
@@ -4417,7 +4515,15 @@ export function useThreadSessionState(params: {
           const startedAt =
             normalizeNotificationTimestamp(startedTurnRecord?.startedAt) ?? Date.now();
 
-          if (!shouldAdoptStartedTurn(current, turnId)) {
+          const transientTurnYieldedToStartedTurn = Boolean(
+            session.transientMessage?.turn?.id
+            && session.transientMessage.turn.id === session.activeTurnId
+            && turnId !== session.activeTurnId
+          );
+          if (
+            !shouldAdoptStartedTurn(current, turnId) &&
+            !transientTurnYieldedToStartedTurn
+          ) {
             return current;
           }
 
@@ -4430,7 +4536,6 @@ export function useThreadSessionState(params: {
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingTurnUsage: undefined,
-            transientThoughtText: undefined,
           };
         }
 
@@ -4706,9 +4811,9 @@ export function useThreadSessionState(params: {
               pendingStatusText: completedTurnMatchesActive
                 ? undefined
                 : current.pendingStatusText,
-              transientThoughtText: completedTurnMatchesActive
+              transientMessage: completedTurnMatchesActive
                 ? undefined
-                : current.transientThoughtText,
+                : current.transientMessage,
             };
           }
 
@@ -4904,9 +5009,9 @@ export function useThreadSessionState(params: {
               ? undefined
               : current.pendingStatusText,
             response: nextResponse,
-            transientThoughtText: completedTurnMatchesActive
+            transientMessage: completedTurnMatchesActive
               ? undefined
-              : current.transientThoughtText,
+              : current.transientMessage,
           };
         }
 
@@ -4948,7 +5053,6 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
-            transientThoughtText: undefined,
           };
         }
 
@@ -4984,7 +5088,6 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
-            transientThoughtText: undefined,
           };
         }
 
@@ -5021,7 +5124,6 @@ export function useThreadSessionState(params: {
               lastTouchedAt: nextLastTouchedAt,
               pendingAssistantMessage: undefined,
               pendingStatusText: undefined,
-              transientThoughtText: undefined,
             };
           }
         }
@@ -5039,7 +5141,6 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingStatusText: undefined,
             response: undefined,
-            transientThoughtText: undefined,
           };
         }
 
@@ -5675,11 +5776,12 @@ export function useThreadSessionState(params: {
     selectedSession?.pendingStatusText &&
     selectedSession.pendingStatusText !== "Thinking"
       ? selectedSession.pendingStatusText
-      : selectedSession?.transientThoughtText ??
-        selectedSession?.pendingStatusText ??
-        (selectedSession?.activeTurnId || selectedSession?.backendReportedActive
-          ? "Thinking"
-          : undefined);
+      : selectedSession?.transientMessage
+        ? undefined
+        : selectedSession?.pendingStatusText ??
+          (selectedSession?.activeTurnId || selectedSession?.backendReportedActive
+            ? "Thinking"
+            : undefined);
   const threadBusy = selectedSession ? hasThinkingState(selectedSession) : false;
 
   return {
@@ -5700,6 +5802,7 @@ export function useThreadSessionState(params: {
     pendingRequest: selectedSession?.pendingRequest,
     pendingUserInput: selectedSession?.pendingUserInput,
     pendingStatusText,
+    transientMessage: selectedSession?.transientMessage,
     runningTurnUsageText: runningTurnUsageTextFromEntry(
       selectedSession?.pendingUsageActivityEntry
     ),

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -156,6 +156,7 @@ type ThreadSessionEntry = {
   pendingUsageActivityEntry?: AppServerThreadActivityEntry;
   pendingMcpInteraction?: PendingMcpInteractionState;
   pendingRequest?: AppServerPendingRequestNotification;
+  settledTransientMessages: AppServerTransientThreadMessageEntry[];
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   transientMessage?: AppServerTransientThreadMessageEntry;
@@ -203,6 +204,7 @@ function createEmptyThreadSessionEntry(): ThreadSessionEntry {
     needsHydrationAfterCompletion: false,
     nextLiveEntrySequence: 1,
     optimisticEntries: [],
+    settledTransientMessages: [],
   };
 }
 
@@ -3429,7 +3431,7 @@ function isMcpElicitationNotification(
   );
 }
 
-const TRANSIENT_MESSAGE_BOUNDARY_METHODS = new Set([
+const TRANSIENT_MESSAGE_SETTLEMENT_METHODS = new Set([
   "item/agentMessage/delta",
   "item/commandExecution/outputDelta",
   "item/completed",
@@ -3443,10 +3445,49 @@ const TRANSIENT_MESSAGE_BOUNDARY_METHODS = new Set([
   "turn/started",
 ]);
 
-function clearTransientMessageAtBoundary(
+const MAX_SETTLED_TRANSIENT_MESSAGES = 50;
+
+function settleTransientMessage(
+  current: ThreadSessionEntry,
+): ThreadSessionEntry {
+  if (!current.transientMessage) {
+    return current;
+  }
+  const sequence =
+    readRendererSequence(current.transientMessage)
+    ?? current.nextLiveEntrySequence;
+  const settledTransientMessage = {
+    ...current.transientMessage,
+    id: `${current.transientMessage.id}:settled:${sequence}`,
+  };
+  return {
+    ...current,
+    settledTransientMessages: [
+      ...current.settledTransientMessages,
+      settledTransientMessage,
+    ].slice(-MAX_SETTLED_TRANSIENT_MESSAGES),
+    transientMessage: undefined,
+  };
+}
+
+function transitionTransientMessagesAtBoundary(
   current: ThreadSessionEntry,
   notification: AppServerNotification
 ): ThreadSessionEntry {
+  if (notification.method === "thread/compacted") {
+    if (
+      !current.transientMessage &&
+      current.settledTransientMessages.length === 0
+    ) {
+      return current;
+    }
+    return {
+      ...current,
+      settledTransientMessages: [],
+      transientMessage: undefined,
+    };
+  }
+
   if (
     !current.transientMessage ||
     notification.method === "item/transientMessage/updated"
@@ -3462,7 +3503,7 @@ function clearTransientMessageAtBoundary(
       ? notification.params.status.type
       : undefined;
   const isBoundary =
-    TRANSIENT_MESSAGE_BOUNDARY_METHODS.has(notification.method) ||
+    TRANSIENT_MESSAGE_SETTLEMENT_METHODS.has(notification.method) ||
     isApprovalRequestNotification(notification) ||
     isRequestUserInputNotification(notification) ||
     isMcpElicitationNotification(notification) ||
@@ -3484,10 +3525,7 @@ function clearTransientMessageAtBoundary(
     return current;
   }
 
-  return {
-    ...current,
-    transientMessage: undefined,
-  };
+  return settleTransientMessage(current);
 }
 
 function readCompletedTurnText(
@@ -3556,6 +3594,7 @@ export function useThreadSessionState(params: {
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
   transientMessage?: AppServerTransientThreadMessageEntry;
+  transientMessages: AppServerTransientThreadMessageEntry[];
   runningTurnUsageText?: string;
   approvalRequestThreadKeys: Record<string, boolean>;
   inputRequestThreadKeys: Record<string, boolean>;
@@ -3822,6 +3861,10 @@ export function useThreadSessionState(params: {
               targetThreadKey,
             });
           }
+          const currentAfterStaleThinking =
+            shouldClearStaleThinking
+              ? settleTransientMessage(current)
+              : current;
 
           // A window that opens a thread mid-turn (a fresh local window, or a
           // federation remote viewer) never saw turn/started, so the hydrated
@@ -3837,7 +3880,7 @@ export function useThreadSessionState(params: {
             && shouldAdoptStartedTurn(current, trailingInProgressTurn.id);
 
           return {
-            ...current,
+            ...currentAfterStaleThinking,
             activeTurnId: shouldClearStaleThinking
               ? undefined
               : shouldAdoptHydratedTurn
@@ -4207,7 +4250,7 @@ export function useThreadSessionState(params: {
       }
 
       updateSession(targetThreadKey, (session) => {
-        const current = clearTransientMessageAtBoundary(
+        const current = transitionTransientMessagesAtBoundary(
           session,
           event.notification
         );
@@ -5783,6 +5826,18 @@ export function useThreadSessionState(params: {
             ? "Thinking"
             : undefined);
   const threadBusy = selectedSession ? hasThinkingState(selectedSession) : false;
+  const transientMessages = useMemo(
+    () => [
+      ...(selectedSession?.settledTransientMessages ?? []),
+      ...(selectedSession?.transientMessage
+        ? [selectedSession.transientMessage]
+        : []),
+    ],
+    [
+      selectedSession?.settledTransientMessages,
+      selectedSession?.transientMessage,
+    ],
+  );
 
   return {
     activeTurnId: selectedSession?.activeTurnId,
@@ -5803,6 +5858,7 @@ export function useThreadSessionState(params: {
     pendingUserInput: selectedSession?.pendingUserInput,
     pendingStatusText,
     transientMessage: selectedSession?.transientMessage,
+    transientMessages,
     runningTurnUsageText: runningTurnUsageTextFromEntry(
       selectedSession?.pendingUsageActivityEntry
     ),

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -157,6 +157,7 @@ type ThreadSessionEntry = {
   pendingRequest?: AppServerPendingRequestNotification;
   pendingUserInput?: PendingQuestionnaireState;
   pendingStatusText?: string;
+  transientThoughtText?: string;
   pendingTurnUsage?: TurnUsageAccumulator;
   response?: AppServerReadThreadResponse;
   // Lightweight reading state belongs beside the bounded transcript cache.
@@ -2436,11 +2437,18 @@ function isThreadLocalTranscriptNotification(
     notification.method === "item/started" ||
     notification.method === "item/completed" ||
     notification.method === "item/agentMessage/delta" ||
+    notification.method === "item/agentThought/updated" ||
     notification.method === "item/mcpToolCall/progress" ||
     notification.method === "item/commandExecution/outputDelta" ||
     notification.method === "item/fileChange/outputDelta" ||
     notification.method === "thread/tokenUsage/updated"
   );
+}
+
+function formatTransientThoughtStatus(text: string): string | undefined {
+  const beforeCodeFence = text.split("```", 1)[0] ?? "";
+  const compact = beforeCodeFence.replace(/\s+/gu, " ").trim();
+  return compact || undefined;
 }
 
 function liveActivityNotificationSignature(params: {
@@ -3804,6 +3812,9 @@ export function useThreadSessionState(params: {
               ownUpdateStillSettling || reviewUpdateStillSettling
               ? ownUpdateSettlesAt
               : undefined,
+            transientThoughtText: shouldClearStaleThinking
+              ? undefined
+              : current.transientThoughtText,
           };
         });
       } catch (error) {
@@ -4140,6 +4151,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingRequest: event.notification,
             pendingStatusText: "Waiting for approval",
+            transientThoughtText: undefined,
           };
         }
 
@@ -4157,6 +4169,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingStatusText: "Waiting for input",
             pendingUserInput,
+            transientThoughtText: undefined,
           };
         }
 
@@ -4174,6 +4187,7 @@ export function useThreadSessionState(params: {
             lastTouchedAt: nextLastTouchedAt,
             pendingMcpInteraction,
             pendingStatusText: "Waiting for MCP approval",
+            transientThoughtText: undefined,
           };
         }
 
@@ -4194,7 +4208,13 @@ export function useThreadSessionState(params: {
           const item = getNotificationItem(event.notification.params);
           const details = item ? buildLiveToolDetails(item) : [];
           if (details.length === 0) {
-            return current;
+            return current.transientThoughtText
+              ? {
+                  ...current,
+                  lastTouchedAt: nextLastTouchedAt,
+                  transientThoughtText: undefined,
+                }
+              : current;
           }
 
           const turn = buildTurnMetadata({
@@ -4205,13 +4225,34 @@ export function useThreadSessionState(params: {
             fallbackStartedAt: current.activeTurnStartedAt,
             fallbackStatus: "in_progress",
           });
-          return upsertLiveActivityEntry(current, {
-            details,
-            now: nextLastTouchedAt,
-            suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
-            threadId: notificationThreadId,
-            turn,
-          });
+          return upsertLiveActivityEntry(
+            {
+              ...current,
+              transientThoughtText: undefined,
+            },
+            {
+              details,
+              now: nextLastTouchedAt,
+              suppressDuplicateLiveActivityUpdates: liveTranscriptEventFiltering,
+              threadId: notificationThreadId,
+              turn,
+            }
+          );
+        }
+
+        if (event.notification.method === "item/agentThought/updated") {
+          const text = formatTransientThoughtStatus(
+            event.notification.params.text
+          );
+          return {
+            ...current,
+            activeTurnId:
+              event.notification.params.turnId ?? current.activeTurnId,
+            expectOwnUpdate: true,
+            interacted: true,
+            lastTouchedAt: nextLastTouchedAt,
+            transientThoughtText: text,
+          };
         }
 
         if (
@@ -4276,6 +4317,7 @@ export function useThreadSessionState(params: {
               allocatedSequence
             ),
             response: flushedResponse,
+            transientThoughtText: undefined,
           };
         }
 
@@ -4388,6 +4430,7 @@ export function useThreadSessionState(params: {
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
             pendingTurnUsage: undefined,
+            transientThoughtText: undefined,
           };
         }
 
@@ -4663,6 +4706,9 @@ export function useThreadSessionState(params: {
               pendingStatusText: completedTurnMatchesActive
                 ? undefined
                 : current.pendingStatusText,
+              transientThoughtText: completedTurnMatchesActive
+                ? undefined
+                : current.transientThoughtText,
             };
           }
 
@@ -4858,6 +4904,9 @@ export function useThreadSessionState(params: {
               ? undefined
               : current.pendingStatusText,
             response: nextResponse,
+            transientThoughtText: completedTurnMatchesActive
+              ? undefined
+              : current.transientThoughtText,
           };
         }
 
@@ -4899,6 +4948,7 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
+            transientThoughtText: undefined,
           };
         }
 
@@ -4934,6 +4984,7 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
+            transientThoughtText: undefined,
           };
         }
 
@@ -4970,6 +5021,7 @@ export function useThreadSessionState(params: {
               lastTouchedAt: nextLastTouchedAt,
               pendingAssistantMessage: undefined,
               pendingStatusText: undefined,
+              transientThoughtText: undefined,
             };
           }
         }
@@ -4987,6 +5039,7 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: undefined,
             pendingStatusText: undefined,
             response: undefined,
+            transientThoughtText: undefined,
           };
         }
 
@@ -5619,10 +5672,14 @@ export function useThreadSessionState(params: {
     [sessions]
   );
   const pendingStatusText =
-    selectedSession?.pendingStatusText ??
-    (selectedSession?.activeTurnId || selectedSession?.backendReportedActive
-      ? "Thinking"
-      : undefined);
+    selectedSession?.pendingStatusText &&
+    selectedSession.pendingStatusText !== "Thinking"
+      ? selectedSession.pendingStatusText
+      : selectedSession?.transientThoughtText ??
+        selectedSession?.pendingStatusText ??
+        (selectedSession?.activeTurnId || selectedSession?.backendReportedActive
+          ? "Thinking"
+          : undefined);
   const threadBusy = selectedSession ? hasThinkingState(selectedSession) : false;
 
   return {

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -203,6 +203,23 @@ remains the authoritative final response. Partial stream text may contain
 unfinished markdown, code fences, or links, so adapters should use conservative
 formatting until the final update or final assistant message arrives.
 
+## Transient Transcript Messages
+
+Transient transcript messages are local, replaceable desktop UI state. They are
+not assistant response streams and are not part of the generic messaging
+surface contract. The messaging controller must discard transient transcript
+updates at the backend-event boundary without converting them into `message`,
+`stream_update`, status, progress, or typing intents.
+
+This keeps transient text out of provider queues, delivery retries, rate
+budgets, pending-intent persistence, conversation history, and outbound
+activity records. Final assistant messages remain authoritative.
+
+If a future product explicitly opts a messaging surface into transient content,
+extend the generic interface with a distinct replace-only intent. It must be
+memory-only, non-queueable, non-retryable, and lower priority than
+`stream_partial`; it must never fall back to a durable `message`.
+
 ## Rate-Limit and Reconnect Health
 
 Adapters may expose `resolveDeliveryScope(intent)`, `onRateLimit(listener)`,

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -205,11 +205,17 @@ formatting until the final update or final assistant message arrives.
 
 ## Transient Transcript Messages
 
-Transient transcript messages are local, replaceable desktop UI state. They are
-not assistant response streams and are not part of the generic messaging
-surface contract. The messaging controller must discard transient transcript
-updates at the backend-event boundary without converting them into `message`,
-`stream_update`, status, progress, or typing intents.
+Transient transcript messages are local, replaceable desktop UI state. A
+desktop renderer may freeze completed segments in transcript order so live
+commentary remains visible between tool invocations, but those segments remain
+bounded, in-memory, and separate from durable replay entries. They are evicted
+before durable transcript state and discarded on reload, compaction, or cache
+eviction.
+
+Transient messages are not assistant response streams and are not part of the
+generic messaging surface contract. The messaging controller must discard
+transient transcript updates at the backend-event boundary without converting
+them into `message`, `stream_update`, status, progress, or typing intents.
 
 This keeps transient text out of provider queues, delivery retries, rate
 budgets, pending-intent persistence, conversation history, and outbound

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -507,6 +507,17 @@ export type AppServerThreadMessageEntry = AppServerThreadMessage & {
   turn?: AppServerThreadTurnMetadata;
 };
 
+/**
+ * A live transcript message that must never be added to a thread replay.
+ * Consumers render it alongside replay entries, then replace or discard it
+ * when another transcript boundary is received.
+ */
+export type AppServerTransientThreadMessageEntry = AppServerThreadMessage & {
+  type: "transientMessage";
+  phase?: AppServerTranscriptPhase;
+  turn?: AppServerThreadTurnMetadata;
+};
+
 export type AppServerThreadActivityStatus =
   | "in_progress"
   | "completed"
@@ -1082,11 +1093,15 @@ export type AppServerNotification =
       };
     }
   | {
-      method: "item/agentThought/updated";
+      method: "item/transientMessage/updated";
       params: {
         threadId: string;
         turnId?: string;
+        itemId: string;
+        role: AppServerThreadMessage["role"];
+        /** An empty value explicitly clears the transient message. */
         text: string;
+        phase?: AppServerTranscriptPhase;
       };
     }
   | {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1082,6 +1082,14 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "item/agentThought/updated";
+      params: {
+        threadId: string;
+        turnId?: string;
+        text: string;
+      };
+    }
+  | {
       method: "turn/completed";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -509,8 +509,9 @@ export type AppServerThreadMessageEntry = AppServerThreadMessage & {
 
 /**
  * A live transcript message that must never be added to a thread replay.
- * Consumers render it alongside replay entries, then replace or discard it
- * when another transcript boundary is received.
+ * Consumers may replace its active value or retain bounded, in-memory settled
+ * segments alongside replay entries. They must discard those segments on
+ * reload, compaction, or cache eviction.
  */
 export type AppServerTransientThreadMessageEntry = AppServerThreadMessage & {
   type: "transientMessage";
@@ -1099,7 +1100,7 @@ export type AppServerNotification =
         turnId?: string;
         itemId: string;
         role: AppServerThreadMessage["role"];
-        /** An empty value explicitly clears the transient message. */
+        /** Full replacement text; an empty value clears the active segment. */
         text: string;
         phase?: AppServerTranscriptPhase;
       };


### PR DESCRIPTION
## Summary

- add a first-class `transientMessage` transcript entry and replace-only live event for Grok thought chunks
- retain bounded, renderer-only settled thought segments between tools without adding them to durable replay or messaging queues
- infer missing turn metadata in timestamped ACP provider replay so intermediate commentary and tool activity collapse as one work phase
- render Grok local grep operations as `Searching code` / `Searched code: <pattern>` while preserving the structured invocation and sparse completion output

## Root causes

Grok Build emits `agent_thought_chunk` as ephemeral delta text. PwrAgent previously treated those updates as durable commentary, so partial Markdown such as an opening code fence could become a permanent empty assistant block. Treating the content as a single status cursor avoided that leak but erased explanatory text between tool calls.

Separately, timestamped `session/load` replay has ordered user, commentary, tool, and assistant-response entries but no turn IDs. Once Grok stopped depending on PwrAgent rollout history, those entries no longer received the completed turn metadata used by the transcript renderer, leaving every tool expanded. Grok grep updates also expose the search pattern as a raw title, so the UI showed labels such as `4.5` without identifying them as searches.

## Behavior

- transient chunks replace the active segment; tool and answer boundaries settle it in an in-memory lane
- transient content is cleared on reload or compaction, capped at 50 settled segments, and never enters durable entries, message history, hydration, generic messaging delivery, provider queues, retries, or delivery budgets
- replay turn inference only fills missing metadata; explicit provider or live turn metadata wins
- a user message opens an inferred window
- assistant final-channel delivery does not terminate the window; later tools and assistant segments remain in the same turn
- the next user message, explicit terminal turn metadata, or an idle replay boundary settles the window
- content before the first user boundary is not assigned
- local code searches use semantic titles while retaining their exact `grep(...)` invocation, output, and completion state
- web-search and web-fetch rendering remain on their existing paths

## Compatibility

Rebased onto current `origin/main`. The merged Grok ACP notification and lifecycle normalization remains intact. Token usage, tool lifecycle, prompt failure, approval/input boundaries, and explicit turn metadata are preserved.

## Validation

- constructed provider replay harness covering pre-turn activity, completed turns, interrupted turns, idle replay termination, assistant delivery followed by more tool work, and multiple user boundaries
- Grok `variant: "Grep"` harness covering bare-pattern titles and sparse completion updates
- focused ACP replay, rollout, live-notification, and transcript-renderer suites: 205 tests passed
- `pnpm typecheck`
- changed-file ESLint
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
