### PR TITLE
fix(desktop): keep composer reference picker inside the viewport

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ReferencePicker.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -80,7 +81,10 @@ function isPickableDirectory(directory: NavigationDirectorySummary): boolean {
 export function ReferencePicker(props: ReferencePickerProps): ReactElement {
   const [tab, setTab] = useState<ReferencePickerTab>("projects");
   const [query, setQuery] = useState("");
+  const [menuShift, setMenuShift] = useState(0);
   const containerRef = useRef<HTMLSpanElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const panelId = useId();
 
   useEffect(() => {
@@ -104,6 +108,58 @@ export function ReferencePicker(props: ReferencePickerProps): ReactElement {
       document.removeEventListener("keydown", onKeyDown);
     };
   }, [props.open, props.onClose]);
+
+  // The popover is anchored to the trigger, which sits near the right edge of
+  // the composer toolbar — keep it inside the viewport by nudging it back in
+  // when it would overflow either gutter (same clamp as the BranchPicker).
+  // Runs before paint so there's no visible jump, and re-clamps on resize
+  // while open. Keeping the panel in-viewport is what lets it FLOAT over the
+  // transcript: an off-viewport panel would make the focused search input
+  // scroll overflow-hidden ancestors sideways to chase it, shoving the whole
+  // chat surface under the sidebar.
+  useLayoutEffect(() => {
+    if (!props.open) {
+      setMenuShift(0);
+      return;
+    }
+    const clamp = (): void => {
+      const menu = menuRef.current;
+      if (!menu) {
+        return;
+      }
+      const gutter = 12;
+      const rect = menu.getBoundingClientRect();
+      const overflowRight = rect.right - (window.innerWidth - gutter);
+      const overflowLeft = gutter - rect.left;
+      setMenuShift((current) => {
+        if (overflowRight > 0) {
+          return current - overflowRight;
+        }
+        if (overflowLeft > 0) {
+          return current + overflowLeft;
+        }
+        return current;
+      });
+    };
+    clamp();
+    window.addEventListener("resize", clamp);
+    return () => window.removeEventListener("resize", clamp);
+  }, [props.open]);
+
+  // Focus the search input AFTER the clamp above has positioned the panel
+  // (not via `autoFocus`, which fires during commit, before layout effects).
+  // `preventScroll` is belt-and-braces: focus must never scroll ancestor
+  // containers to reveal the input — that's the layout shove this popover
+  // is specifically built to avoid.
+  useEffect(() => {
+    if (!props.open) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() =>
+      inputRef.current?.focus({ preventScroll: true }),
+    );
+    return () => window.cancelAnimationFrame(frame);
+  }, [props.open]);
 
   const trimmedQuery = query.trim().toLowerCase();
 
@@ -148,8 +204,12 @@ export function ReferencePicker(props: ReferencePickerProps): ReactElement {
       {props.open ? (
         <div
           className="reference-picker__pop"
+          ref={menuRef}
           role="dialog"
           aria-label="Add reference"
+          style={
+            menuShift ? { transform: `translateX(${menuShift}px)` } : undefined
+          }
         >
           <div
             className="reference-picker__tabs"
@@ -190,7 +250,7 @@ export function ReferencePicker(props: ReferencePickerProps): ReactElement {
             </span>
             <input
               type="text"
-              autoFocus
+              ref={inputRef}
               placeholder={
                 tab === "projects" ? "Find a directory" : "Find a file"
               }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx
@@ -15,8 +15,25 @@ import {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   delete (window as unknown as { __pwragentHomeDir?: unknown }).__pwragentHomeDir;
 });
+
+/** Stub the panel's measured rect so the viewport clamp sees real geometry
+ *  (jsdom rects are all zeros otherwise). */
+function mockPanelRect(left: number, right: number): void {
+  vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+    left,
+    right,
+    top: 0,
+    bottom: 420,
+    width: right - left,
+    height: 420,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
 
 const dirA: NavigationDirectorySummary = {
   key: "directory:/Users/me/code/PwrAgent",
@@ -213,6 +230,34 @@ describe("ReferencePicker", () => {
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("nudges the panel left when it would overflow the right viewport gutter", () => {
+    // jsdom viewport is 1024 wide; gutter is 12 → right limit 1012.
+    mockPanelRect(800, 1240);
+    renderPicker({ directories: [dirA] });
+
+    expect(screen.getByRole("dialog", { name: "Add reference" })).toHaveStyle({
+      transform: "translateX(-228px)",
+    });
+  });
+
+  it("nudges the panel right when it would overflow the left viewport gutter", () => {
+    mockPanelRect(-50, 390);
+    renderPicker({ directories: [dirA] });
+
+    expect(screen.getByRole("dialog", { name: "Add reference" })).toHaveStyle({
+      transform: "translateX(62px)",
+    });
+  });
+
+  it("leaves the panel unshifted when it already fits the viewport", () => {
+    mockPanelRect(100, 540);
+    renderPicker({ directories: [dirA] });
+
+    expect(
+      screen.getByRole("dialog", { name: "Add reference" }),
+    ).not.toHaveAttribute("style");
   });
 
   it("renders nothing but the trigger child when closed", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15220,7 +15220,15 @@ textarea,
 }
 
 .reference-picker__pop {
-  left: 0;
+  /* Anchor to the trigger's right edge so the panel opens leftward, floating
+     over the composer/transcript — the "+" trigger is the LAST control in
+     the setup row, so a left-edge anchor would push the panel past the
+     viewport's right gutter on almost every window width (and the focused
+     search input would then drag overflow-hidden ancestors sideways). A
+     viewport clamp in ReferencePicker nudges it back in on narrow windows,
+     mirroring the branch picker. */
+  right: 0;
+  left: auto;
   width: 440px;
   max-width: calc(100vw - 32px);
   height: 420px;


### PR DESCRIPTION
## Summary

- The composer's "+" reference picker anchored its 440px popover to the trigger's **left** edge, but the trigger is the last control in the setup row — so the panel overflowed the viewport's right edge on almost every window width. The search input's `autoFocus` (which fires during React commit) then made the browser scroll `overflow: hidden` ancestors sideways to reveal the off-screen input, shoving the chat transcript left under the sidebar while the dialog stayed "pinned" to the right edge.
- Fix mirrors the BranchPicker, which already solved this exact geometry (its trigger also sits near the toolbar's right edge):
  - `.reference-picker__pop` now anchors `right: 0` so the panel opens leftward, floating over the composer/transcript; its right edge sits at the always-in-viewport "+" button.
  - `ReferencePicker` gains the same pre-paint viewport clamp (`translateX` nudge when the panel would cross either 12px gutter, re-clamped on window resize).
  - `autoFocus` replaced with a post-clamp `requestAnimationFrame` focus using `preventScroll: true`, so focusing the search input can never scroll ancestor containers again, even in geometry the clamp doesn't anticipate.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ReferencePicker.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 206 tests pass, including three new clamp tests (right-overflow nudge, left-overflow nudge, no-op when the panel fits).
- `pnpm --filter @pwragent/desktop typecheck` — clean.
- ESLint on touched files — no errors; the two remaining warnings (`within` unused import, `props` in the outside-click effect deps) predate this change.

## Notes

- In extremely narrow windows where the main pane is under ~465px, the clamped panel can extend over the sidebar area and may be clipped at the pane boundary rather than float above it — a far corner case, and strictly better than the previous layout shove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)