### PR TITLE
fix(desktop): sanitize ACP command output

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-live-notifications.test.ts
@@ -89,6 +89,43 @@ describe("acpToolUpdateNotifications", () => {
     ]);
   });
 
+  it("strips terminal control sequences from live ACP tool output", () => {
+    const notifications = acpToolUpdateNotifications({
+      threadId: "session-1",
+      turnId: "turn-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "gh-pr-list-1",
+        kind: "execute",
+        title: "Shell",
+        status: "completed",
+        content: [
+          {
+            type: "content",
+            content: {
+              type: "text",
+              text: "\u001b[1;37m{\u001b[0m\u001b[1;34m\"number\"\u001b[0m: 1014}",
+            },
+          },
+        ],
+      },
+    });
+
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        method: "item/completed",
+        params: expect.objectContaining({
+          item: expect.objectContaining({
+            id: "gh-pr-list-1",
+            data: {
+              output: "{\"number\": 1014}",
+            },
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("keeps non-shell ACP content with command fields as live output", () => {
     const output = "{\"command\":\"npm view pnpm\",\"result\":\"found text\"}";
     const notifications = acpToolUpdateNotifications({

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -774,6 +774,40 @@ describe("AcpSessionReplayNormalizer", () => {
     ]);
   });
 
+  it("strips terminal control sequences from replayed ACP tool output", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1000,
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "gh-pr-list-1",
+        kind: "execute",
+        title: "Shell",
+        status: "completed",
+        content: {
+          type: "text",
+          text: "\u001b[1;37m{\u001b[0m\u001b[1;34m\"number\"\u001b[0m: 1014}",
+        },
+      },
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "gh-pr-list-1",
+        details: [
+          expect.objectContaining({
+            command: expect.objectContaining({
+              output: "{\"number\": 1014}",
+            }),
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("keeps non-shell ACP content with command fields as transcript output", () => {
     const normalizer = new AcpSessionReplayNormalizer();
     const output = "{\"command\":\"npm view pnpm\",\"result\":\"found text\"}";

--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -124,6 +124,40 @@ describe("AcpStdioJsonRpcTransport", () => {
     await expect(request).resolves.toEqual({ ok: true });
   });
 
+  it("disables color when launching Grok ACP", async () => {
+    const child = new MockAcpChildProcess();
+    const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];
+    const spawn: AcpStdioSpawn = (command, args, options) => {
+      spawnCalls.push([command, args, options]);
+      return child;
+    };
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor({
+        backendId: "acp:grok" as AcpBackendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: ["agent", "stdio"],
+      }),
+      spawn,
+    });
+
+    const request = transport.request("initialize");
+    await vi.waitFor(() => expect(child.writes).toHaveLength(1));
+
+    expect(spawnCalls[0]?.[0]).toBe("grok");
+    expect(spawnCalls[0]?.[1]).toEqual(["agent", "stdio"]);
+    expect(spawnCalls[0]?.[2].env).toEqual(
+      expect.objectContaining({ NO_COLOR: "1" }),
+    );
+
+    const envelope = JSON.parse(child.writes[0]) as { id: string };
+    child.stdout.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: envelope.id, result: { ok: true } })}\n`,
+    );
+    await expect(request).resolves.toEqual({ ok: true });
+  });
+
   it("fans out ACP notifications until listeners unsubscribe", async () => {
     const child = new MockAcpChildProcess();
     const transport = new AcpStdioJsonRpcTransport({

--- a/apps/desktop/src/main/acp/acp-launch-descriptor.ts
+++ b/apps/desktop/src/main/acp/acp-launch-descriptor.ts
@@ -14,18 +14,32 @@ export type AcpLaunchDescriptor = {
 export function normalizeAcpLaunchDescriptor(
   descriptor: AcpLaunchDescriptor,
 ): AcpLaunchDescriptor {
-  if (descriptor.registryId !== "gemini" || !descriptor.args.includes("--acp")) {
-    return descriptor;
+  const normalizedDescriptor =
+    descriptor.registryId === "grok"
+      ? {
+          ...descriptor,
+          env: {
+            ...descriptor.env,
+            NO_COLOR: "1",
+          },
+        }
+      : descriptor;
+
+  if (
+    normalizedDescriptor.registryId !== "gemini"
+    || !normalizedDescriptor.args.includes("--acp")
+  ) {
+    return normalizedDescriptor;
   }
 
-  const args = descriptor.args.includes("--skip-trust")
-    ? descriptor.args
-    : [...descriptor.args, "--skip-trust"];
+  const args = normalizedDescriptor.args.includes("--skip-trust")
+    ? normalizedDescriptor.args
+    : [...normalizedDescriptor.args, "--skip-trust"];
   return {
-    ...descriptor,
+    ...normalizedDescriptor,
     args,
     env: {
-      ...descriptor.env,
+      ...normalizedDescriptor.env,
       GEMINI_CLI_TRUST_WORKSPACE: "true",
     },
   };

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -6,6 +6,7 @@ import {
   readAcpToolContentCommand,
   readAcpToolInvocation,
 } from "./acp-command-extraction.js";
+import { sanitizeAcpToolOutput } from "./acp-tool-output.js";
 
 export function acpToolUpdateNotifications(params: {
   threadId: string;
@@ -181,12 +182,12 @@ function isTerminalToolStatus(status: unknown): boolean {
 
 function readAcpToolOutput(record: Record<string, unknown>): string | undefined {
   const contentText = readAcpContentText(record.content);
-  return (
-    readString(record, "output") ??
-    readString(record, "stdout") ??
-    readString(record, "stderr") ??
-    readString(record, "result") ??
-    (readAcpToolContentCommand(record) ? undefined : contentText)
+  return sanitizeAcpToolOutput(
+    readString(record, "output")
+      ?? readString(record, "stdout")
+      ?? readString(record, "stderr")
+      ?? readString(record, "result")
+      ?? (readAcpToolContentCommand(record) ? undefined : contentText),
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -15,6 +15,7 @@ import {
   readAcpToolContentCommand,
   readAcpToolInvocation,
 } from "./acp-command-extraction.js";
+import { sanitizeAcpToolOutput } from "./acp-tool-output.js";
 
 export type AcpSessionUpdate = {
   sessionId: string;
@@ -707,12 +708,12 @@ function normalizeUserPrompt(
 
 function readToolOutput(record: Record<string, unknown>): string | undefined {
   const contentText = readContentText(record, "content");
-  return (
-    readString(record, "output") ??
-    readString(record, "stdout") ??
-    readString(record, "stderr") ??
-    readString(record, "result") ??
-    (readAcpToolContentCommand(record) ? undefined : contentText)
+  return sanitizeAcpToolOutput(
+    readString(record, "output")
+      ?? readString(record, "stdout")
+      ?? readString(record, "stderr")
+      ?? readString(record, "result")
+      ?? (readAcpToolContentCommand(record) ? undefined : contentText),
   );
 }
 

--- a/apps/desktop/src/main/acp/acp-tool-output.ts
+++ b/apps/desktop/src/main/acp/acp-tool-output.ts
@@ -1,0 +1,7 @@
+import { stripVTControlCharacters } from "node:util";
+
+export function sanitizeAcpToolOutput(
+  value: string | undefined,
+): string | undefined {
+  return value === undefined ? undefined : stripVTControlCharacters(value);
+}


### PR DESCRIPTION
## What changed

- launch Grok ACP with `NO_COLOR=1` so terminal tools such as `gh` suppress ANSI color when they honor the standard environment variable
- strip VT/ANSI control sequences from normalized ACP tool output for both live notifications and replayed transcripts
- add regression coverage using the colored GitHub CLI JSON pattern observed in the affected Grok thread

## Root cause

Grok's terminal tool returned raw terminal-formatted `content.text` containing ANSI SGR sequences. PwrAgent normalized that public ACP content directly into command output, and the renderer replaced only the ESC control byte, leaving suffixes such as `[1;37m` visible.

The environment override reduces colored output at the source, while normalization remains the provider-neutral safety boundary for tools that ignore `NO_COLOR` or emit other VT sequences.

## Impact

Grok command output should render as plain readable text in both live and restored transcripts. Existing ACP providers retain their current launch behavior, and PwrAgent no longer depends on Grok-specific `rawOutput.output_for_prompt` metadata.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-live-notifications.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts` — 47 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — passed with existing warnings only
- `pnpm lint:boundaries`
