### PR TITLE
Bundle downstream Grok ACP runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,14 @@ jobs:
       - name: Test (unit)
         run: pnpm test
 
+      - name: Stage pinned Grok ACP runtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/stage-grok-bundle.mjs --platform macos-universal
+
       - name: Prepare release stage
+        env:
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: node apps/desktop/scripts/release.mjs --prepare-only
 
       - name: Archive signing input
@@ -128,6 +135,7 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: T44CNHC4UH
 
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: node apps/desktop/scripts/release.mjs --sign-stage-only --no-publish
 
       - name: Prepare stable-name DMG alias
@@ -166,9 +174,11 @@ jobs:
         include:
           - deb_arch: amd64
             builder_arch: x64
+            grok_platform: linux-x86_64
             runner: ubuntu-24.04
           - deb_arch: arm64
             builder_arch: arm64
+            grok_platform: linux-aarch64
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
@@ -188,9 +198,15 @@ jobs:
           RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: pnpm release:check
 
+      - name: Stage pinned Grok ACP runtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/stage-grok-bundle.mjs --platform ${{ matrix.grok_platform }}
+
       - name: Package Linux DEB
         env:
           PWRAGENT_LINUX_ARCH: ${{ matrix.builder_arch }}
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: node apps/desktop/scripts/release.mjs --linux --no-publish
 
       - name: Upload Linux package artifact
@@ -227,7 +243,14 @@ jobs:
           working-directory: .
           cache-electron: "true"
 
+      - name: Stage pinned Grok ACP runtime
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/stage-grok-bundle.mjs --platform windows-x86_64
+
       - name: Prepare Windows release stage
+        env:
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: node apps/desktop/scripts/release.mjs --win --prepare-only
 
       - name: Archive Windows signing input
@@ -307,6 +330,7 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: >-
           node apps/desktop/scripts/release.mjs
           --win --sign-stage-only --no-publish --require-signing

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ apps/desktop/e2e/fixtures/**/raw.capture.jsonl
 apps/desktop/dist/
 # pnpm deploy stage (release.mjs materializes a flat node_modules tree here)
 apps/desktop/release-stage/
+apps/desktop/build/bundled-agents/grok/
 
 # Release-time secrets — must never land in the repo
 .envrc.release

--- a/apps/desktop/build/bundled-agents/README.md
+++ b/apps/desktop/build/bundled-agents/README.md
@@ -1,0 +1,2 @@
+Release packaging stages pinned third-party agent runtimes under this directory.
+The source checkout intentionally contains no executable.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -75,6 +75,8 @@ extraResources:
     to: pwragent-app-icon.png
   - from: src/renderer/src/assets/pwrsnap/pwrsnap-app-icon.png
     to: pwrsnap-app-icon.png
+  - from: build/bundled-agents
+    to: agents
 
 # Electron fuses — ASAR integrity is NOT on by default in electron-builder.
 # Enable it explicitly so the runtime aborts if the .asar is tampered with.

--- a/apps/desktop/grok-bundle.json
+++ b/apps/desktop/grok-bundle.json
@@ -1,10 +1,10 @@
 {
   "repository": "pwrdrvr/grok-build",
-  "tag": "pwragent-v0.2.112-pwragent.1",
+  "tag": "pwragent-v1.0.0-pwragent.1",
   "assets": {
-    "macos-universal": "pwragent-grok-0.2.112-pwragent.1-macos-universal.tar.gz",
-    "linux-x86_64": "pwragent-grok-0.2.112-pwragent.1-linux-x86_64.tar.gz",
-    "linux-aarch64": "pwragent-grok-0.2.112-pwragent.1-linux-aarch64.tar.gz",
-    "windows-x86_64": "pwragent-grok-0.2.112-pwragent.1-windows-x86_64.zip"
+    "macos-universal": "pwragent-grok-1.0.0-pwragent.1-macos-universal.tar.gz",
+    "linux-x86_64": "pwragent-grok-1.0.0-pwragent.1-linux-x86_64.tar.gz",
+    "linux-aarch64": "pwragent-grok-1.0.0-pwragent.1-linux-aarch64.tar.gz",
+    "windows-x86_64": "pwragent-grok-1.0.0-pwragent.1-windows-x86_64.zip"
   }
 }

--- a/apps/desktop/grok-bundle.json
+++ b/apps/desktop/grok-bundle.json
@@ -1,10 +1,10 @@
 {
   "repository": "pwrdrvr/grok-build",
-  "tag": "pwragent-v1.0.0-pwragent.1",
+  "tag": "pwragent-v1.0.0-pwragent.2",
   "assets": {
-    "macos-universal": "pwragent-grok-1.0.0-pwragent.1-macos-universal.tar.gz",
-    "linux-x86_64": "pwragent-grok-1.0.0-pwragent.1-linux-x86_64.tar.gz",
-    "linux-aarch64": "pwragent-grok-1.0.0-pwragent.1-linux-aarch64.tar.gz",
-    "windows-x86_64": "pwragent-grok-1.0.0-pwragent.1-windows-x86_64.zip"
+    "macos-universal": "pwragent-grok-1.0.0-pwragent.2-macos-universal.tar.gz",
+    "linux-x86_64": "pwragent-grok-1.0.0-pwragent.2-linux-x86_64.tar.gz",
+    "linux-aarch64": "pwragent-grok-1.0.0-pwragent.2-linux-aarch64.tar.gz",
+    "windows-x86_64": "pwragent-grok-1.0.0-pwragent.2-windows-x86_64.zip"
   }
 }

--- a/apps/desktop/grok-bundle.json
+++ b/apps/desktop/grok-bundle.json
@@ -1,0 +1,10 @@
+{
+  "repository": "pwrdrvr/grok-build",
+  "tag": "pwragent-v0.2.112-pwragent.1",
+  "assets": {
+    "macos-universal": "pwragent-grok-0.2.112-pwragent.1-macos-universal.tar.gz",
+    "linux-x86_64": "pwragent-grok-0.2.112-pwragent.1-linux-x86_64.tar.gz",
+    "linux-aarch64": "pwragent-grok-0.2.112-pwragent.1-linux-aarch64.tar.gz",
+    "windows-x86_64": "pwragent-grok-0.2.112-pwragent.1-windows-x86_64.zip"
+  }
+}

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -466,6 +466,25 @@ function verifyPackagedGrok(resourcesDirectory) {
     cwd: dirname(bundledExecutable),
     env: { GROK_INSTALLER: "pwragent", NO_COLOR: "1" },
   });
+  if (process.platform === "darwin") {
+    runChecked("codesign", [
+      "--verify",
+      "--strict",
+      "--verbose=2",
+      bundledExecutable,
+    ]);
+  } else if (process.platform === "win32" && requireSigning) {
+    runChecked(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE; if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }",
+      ],
+      { env: { PWRAGENT_VERIFY_EXECUTABLE: bundledExecutable } },
+    );
+  }
   return bundledExecutable;
 }
 

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -426,6 +426,49 @@ function configureStageGithubReleaseType() {
   console.log(`  configured GitHub releaseType=${releaseType} for ${version}`);
 }
 
+function assertRequiredGrokBundle() {
+  if (process.env.PWRAGENT_REQUIRE_GROK_BUNDLE !== "1") {
+    return;
+  }
+  const executable = process.platform === "win32" ? "grok.exe" : "grok";
+  const bundledExecutable = join(
+    stageDir,
+    "build",
+    "bundled-agents",
+    "grok",
+    executable,
+  );
+  if (!existsSync(bundledExecutable)) {
+    throw new Error(
+      `PWRAGENT_REQUIRE_GROK_BUNDLE=1 but the staged executable is missing at ${bundledExecutable}`,
+    );
+  }
+  console.log(`  verified bundled Grok runtime: ${bundledExecutable}`);
+}
+
+function verifyPackagedGrok(resourcesDirectory) {
+  const executable = process.platform === "win32" ? "grok.exe" : "grok";
+  const bundledExecutable = join(
+    resourcesDirectory,
+    "agents",
+    "grok",
+    executable,
+  );
+  if (!existsSync(bundledExecutable)) {
+    if (process.env.PWRAGENT_REQUIRE_GROK_BUNDLE === "1") {
+      throw new Error(
+        `Packaged Grok runtime is missing at ${bundledExecutable}`,
+      );
+    }
+    return undefined;
+  }
+  runChecked(bundledExecutable, ["--version"], {
+    cwd: dirname(bundledExecutable),
+    env: { GROK_INSTALLER: "pwragent", NO_COLOR: "1" },
+  });
+  return bundledExecutable;
+}
+
 // 1. Decode CI-provided Apple API key (if present) to a real .p8 file.
 function maybeDecodeAppleApiKey() {
   if (process.env.APPLE_API_KEY && existsSync(process.env.APPLE_API_KEY)) {
@@ -511,14 +554,18 @@ if (!signStageOnly) {
   for (const file of ["LICENSE", "THIRD_PARTY_LICENSES", "CHANGELOG.md"]) {
     copyFileSync(join(repoRoot, file), join(stageDir, file));
   }
+  assertRequiredGrokBundle();
 
   if (prepareOnly) {
     step("prepared release-stage");
     console.log(`  stage: ${stageDir}`);
     process.exit(0);
   }
-} else if (!existsSync(stageDir)) {
-  throw new Error(`release-stage is missing at ${stageDir}`);
+} else {
+  if (!existsSync(stageDir)) {
+    throw new Error(`release-stage is missing at ${stageDir}`);
+  }
+  assertRequiredGrokBundle();
 }
 
 // 5. electron-builder.
@@ -585,6 +632,9 @@ const dist = join(stageDir, "dist");
 if (win) {
   const builtApp = findWindowsUnpackedDir(dist);
 
+  step("verify packaged Grok runtime");
+  verifyPackagedGrok(join(builtApp, "resources"));
+
   step("verify packaged asar contents");
   runChecked(
     "node",
@@ -603,6 +653,9 @@ if (win) {
 
 if (linux) {
   const builtApp = findLinuxUnpackedDir(dist);
+
+  step("verify packaged Grok runtime");
+  verifyPackagedGrok(join(builtApp, "resources"));
 
   step("verify packaged asar contents");
   runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);
@@ -666,6 +719,18 @@ for (const { binding, lipoArch, packageName } of MAC_CANVAS_BINDINGS) {
     ),
     "-verify_arch",
     lipoArch,
+  ]);
+}
+
+const bundledGrokExecutable = verifyPackagedGrok(
+  join(builtApp, "Contents", "Resources"),
+);
+if (bundledGrokExecutable) {
+  runChecked("lipo", [
+    bundledGrokExecutable,
+    "-verify_arch",
+    "x86_64",
+    "arm64",
   ]);
 }
 

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -467,12 +467,19 @@ function verifyPackagedGrok(resourcesDirectory) {
     env: { GROK_INSTALLER: "pwragent", NO_COLOR: "1" },
   });
   if (process.platform === "darwin") {
-    runChecked("codesign", [
+    const codesignArgs = [
       "--verify",
       "--strict",
       "--verbose=2",
-      bundledExecutable,
-    ]);
+    ];
+    if (!dryrun) {
+      codesignArgs.push(
+        "--test-requirement",
+        '=anchor apple generic and certificate leaf[subject.OU] = "T44CNHC4UH"',
+      );
+    }
+    codesignArgs.push(bundledExecutable);
+    runChecked("codesign", codesignArgs);
   } else if (process.platform === "win32" && requireSigning) {
     runChecked(
       "powershell.exe",
@@ -480,7 +487,7 @@ function verifyPackagedGrok(resourcesDirectory) {
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE; if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }",
+        "$signature = Get-AuthenticodeSignature -LiteralPath $env:PWRAGENT_VERIFY_EXECUTABLE; if ($signature.Status -ne 'Valid') { throw \"Bundled Grok Authenticode signature is $($signature.Status): $($signature.StatusMessage)\" }; if ($signature.SignerCertificate.Subject -notmatch '(^|,\\s*)CN=PwrDrvr LLC(,|$)') { throw \"Bundled Grok signer is not PwrDrvr LLC: $($signature.SignerCertificate.Subject)\" }",
       ],
       { env: { PWRAGENT_VERIFY_EXECUTABLE: bundledExecutable } },
     );

--- a/apps/desktop/scripts/stage-grok-bundle.mjs
+++ b/apps/desktop/scripts/stage-grok-bundle.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const desktopRoot = resolve(dirname(scriptPath), "..");
+const manifestPath = join(desktopRoot, "grok-bundle.json");
+const outputRoot = join(desktopRoot, "build", "bundled-agents", "grok");
+
+function readArgument(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function readManifest() {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  if (
+    typeof manifest.repository !== "string"
+    || typeof manifest.tag !== "string"
+    || !manifest.assets
+    || typeof manifest.assets !== "object"
+  ) {
+    throw new Error(`Invalid Grok bundle manifest: ${manifestPath}`);
+  }
+  return manifest;
+}
+
+async function download(url, targetPath) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/octet-stream",
+      "User-Agent": "PwrAgent-release-packager",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    redirect: "follow",
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed (${response.status}) for ${url}`);
+  }
+  await pipeline(response.body, createWriteStream(targetPath));
+}
+
+function expectedChecksum(checksumText, assetName) {
+  for (const line of checksumText.split(/\r?\n/u)) {
+    const match = /^([0-9a-fA-F]{64})\s+\*?(.+)$/u.exec(line.trim());
+    if (match?.[2] === assetName) {
+      return match[1].toLowerCase();
+    }
+  }
+  throw new Error(`SHA256SUMS does not contain ${assetName}`);
+}
+
+async function sha256(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function extractArchive(archivePath, targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  const tar = process.platform === "win32" ? "tar.exe" : "tar";
+  const result = spawnSync(tar, ["-xf", archivePath, "-C", targetDir], {
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${tar} exited with status ${result.status}`);
+  }
+}
+
+function validateExtractedBundle(directory) {
+  const executable = process.platform === "win32" ? "grok.exe" : "grok";
+  const executablePath = join(directory, executable);
+  const requiredFiles = [
+    executablePath,
+    join(directory, "LICENSE"),
+    join(directory, "THIRD-PARTY-NOTICES"),
+    join(directory, "SOURCE_REV"),
+    join(directory, "PWRAGENT-BUILD.txt"),
+  ];
+  for (const requiredFile of requiredFiles) {
+    if (!existsSync(requiredFile)) {
+      throw new Error(`Grok bundle is missing ${requiredFile}`);
+    }
+  }
+  if (process.platform !== "win32") {
+    chmodSync(executablePath, 0o755);
+  }
+}
+
+async function main() {
+  const platform = readArgument("--platform");
+  if (!platform) {
+    throw new Error("Usage: stage-grok-bundle.mjs --platform <asset-platform>");
+  }
+
+  const manifest = readManifest();
+  const assetName = manifest.assets[platform];
+  if (typeof assetName !== "string" || !assetName) {
+    throw new Error(`No Grok bundle asset is configured for ${platform}`);
+  }
+
+  const releaseBase =
+    `https://github.com/${manifest.repository}/releases/download/${manifest.tag}`;
+  const tempRoot = mkdtempSync(join(tmpdir(), "pwragent-grok-bundle-"));
+  try {
+    const checksumPath = join(tempRoot, "SHA256SUMS");
+    const archivePath = join(tempRoot, assetName);
+    await Promise.all([
+      download(`${releaseBase}/SHA256SUMS`, checksumPath),
+      download(`${releaseBase}/${assetName}`, archivePath),
+    ]);
+
+    const expected = expectedChecksum(
+      readFileSync(checksumPath, "utf8"),
+      assetName,
+    );
+    const actual = await sha256(archivePath);
+    if (actual !== expected) {
+      throw new Error(
+        `Checksum mismatch for ${assetName}: expected ${expected}, got ${actual}`,
+      );
+    }
+
+    const extractedRoot = join(tempRoot, "extracted");
+    extractArchive(archivePath, extractedRoot);
+    validateExtractedBundle(extractedRoot);
+
+    rmSync(outputRoot, { recursive: true, force: true });
+    cpSync(extractedRoot, outputRoot, { recursive: true });
+    writeFileSync(
+      join(outputRoot, "PWRAGENT-BUNDLE.json"),
+      `${JSON.stringify(
+        {
+          repository: manifest.repository,
+          tag: manifest.tag,
+          asset: assetName,
+          sha256: actual,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`Staged ${assetName} at ${outputRoot}`);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -355,6 +355,150 @@ describe("isAcpSessionMissingForProjectError", () => {
 });
 
 describe("AcpBackendAdapter", () => {
+  it("replaces a stale stored launch descriptor with the actively discovered executable", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const stored: AcpInstalledAgentRecord[] = [
+      {
+        ...buildInstalledAgent(),
+        backendId,
+        registryId: "grok",
+        name: "Grok",
+        version: "0.2.112",
+        launchDescriptor: {
+          backendId,
+          registryId: "grok",
+          distributionKind: "local",
+          command: "/Users/test/.grok/bin/grok",
+          args: ["agent", "stdio"],
+          env: {},
+        },
+        runtimeCapabilities: {
+          schemaVersion: 1,
+          status: "discovered",
+          checkedAt: 1000,
+          agentCapabilities: {
+            prompt: {
+              image: false,
+            },
+          },
+        },
+      },
+    ];
+    const discovered: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "0.2.112-pwragent.dev.4",
+      updatedAt: 2000,
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "/tmp/pwragent-grok-arm64/grok",
+        args: ["agent", "stdio"],
+        env: {},
+      },
+    };
+    const createAcpClient = vi.fn((agent: AcpInstalledAgentRecord) => ({
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(async () => undefined),
+      agent,
+    }));
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored[0],
+        listInstalledAgents: () => stored,
+        upsertInstalledAgent: (record) => {
+          stored[0] = record;
+        },
+      },
+      acpSessionStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const [available] = await adapter.listAvailableAgents();
+    expect(available?.launchDescriptor?.command).toBe(
+      "/tmp/pwragent-grok-arm64/grok",
+    );
+    expect(available?.runtimeCapabilities).toBeUndefined();
+
+    await adapter.getClient(backendId);
+    expect(createAcpClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchDescriptor: expect.objectContaining({
+          command: "/tmp/pwragent-grok-arm64/grok",
+        }),
+      }),
+    );
+
+    await adapter.close();
+  });
+
+  it("keeps cached runtime capabilities for the same discovered executable version", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const runtimeCapabilities = {
+      schemaVersion: 1 as const,
+      status: "discovered" as const,
+      checkedAt: 1000,
+      agentCapabilities: {
+        prompt: {
+          image: true,
+        },
+      },
+    };
+    const stored: AcpInstalledAgentRecord[] = [
+      {
+        ...buildInstalledAgent(),
+        backendId,
+        registryId: "grok",
+        name: "Grok",
+        version: "0.2.112-pwragent.dev.4",
+        launchDescriptor: {
+          backendId,
+          registryId: "grok",
+          distributionKind: "local",
+          command: "/tmp/pwragent-grok-arm64/grok",
+          args: ["agent", "stdio"],
+          env: {},
+        },
+        runtimeCapabilities,
+        lastDiscoveredAt: 1000,
+      },
+    ];
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored[0],
+        listInstalledAgents: () => stored,
+        upsertInstalledAgent: (record) => {
+          stored[0] = record;
+        },
+      },
+      acpSessionStore: null,
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [
+        {
+          ...stored[0]!,
+          runtimeCapabilities: undefined,
+          lastDiscoveredAt: undefined,
+          updatedAt: 2000,
+        },
+      ],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const [available] = await adapter.listAvailableAgents();
+    expect(available?.runtimeCapabilities).toEqual(runtimeCapabilities);
+    expect(available?.lastDiscoveredAt).toBe(1000);
+
+    await adapter.close();
+  });
+
   it("passes the installed agent name to ACP approval prompts", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -382,6 +382,14 @@ describe("AcpBackendAdapter", () => {
             },
           },
         },
+        update: {
+          status: "available",
+          checkedAt: 1000,
+          currentVersion: "0.2.112",
+          latestVersion: "1.0.0",
+          dismissedAt: 1100,
+        },
+        updateCommand: "/Users/test/.grok/bin/grok",
       },
     ];
     const discovered: AcpInstalledAgentRecord = {
@@ -426,6 +434,8 @@ describe("AcpBackendAdapter", () => {
       "/tmp/pwragent-grok-arm64/grok",
     );
     expect(available?.runtimeCapabilities).toBeUndefined();
+    expect(available?.update).toBeUndefined();
+    expect(available?.updateCommand).toBeUndefined();
 
     await adapter.getClient(backendId);
     expect(createAcpClient).toHaveBeenCalledWith(
@@ -495,6 +505,64 @@ describe("AcpBackendAdapter", () => {
     const [available] = await adapter.listAvailableAgents();
     expect(available?.runtimeCapabilities).toEqual(runtimeCapabilities);
     expect(available?.lastDiscoveredAt).toBe(1000);
+
+    await adapter.close();
+  });
+
+  it("keeps Grok update state for the same discovered executable", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const update = {
+      status: "available" as const,
+      checkedAt: 1000,
+      currentVersion: "1.0.0-pwragent.1",
+      latestVersion: "1.0.1",
+      dismissedAt: 1100,
+      snoozedUntil: 2000,
+    };
+    let stored: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      version: "1.0.0-pwragent.1",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "/app/resources/agents/grok/grok",
+        args: ["agent", "stdio"],
+        env: {},
+      },
+      update,
+      updateCommand: "/app/resources/agents/grok/grok",
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => stored,
+        listInstalledAgents: () => [stored],
+        upsertInstalledAgent: (record) => {
+          stored = record;
+        },
+      },
+      acpSessionStore: null,
+      captureStores: [],
+      discoverLocalAcpAgents: async () => [{
+        ...stored,
+        update: undefined,
+        updateCommand: undefined,
+        updatedAt: 2000,
+      }],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const [available] = await adapter.listAvailableAgents();
+    expect(available?.update).toEqual(update);
+    expect(available?.updateCommand).toBe(
+      "/app/resources/agents/grok/grok",
+    );
+    expect(stored.update).toEqual(update);
+    expect(stored.updateCommand).toBe("/app/resources/agents/grok/grok");
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -415,13 +415,15 @@ describe("resolveBundledGrokCommand", () => {
     expect(exists).toHaveBeenCalledWith(command);
   });
 
-  it("uses the Windows executable suffix and omits absent bundles", () => {
+  it("uses Windows path semantics and the executable suffix", () => {
+    const exists = vi.fn(() => true);
     const command = resolveBundledGrokCommand({
       resourcesPath: "C:\\PwrAgent\\resources",
       platform: "win32",
-      exists: () => false,
+      exists,
     });
 
-    expect(command).toBeUndefined();
+    expect(command).toBe("C:\\PwrAgent\\resources\\agents\\grok\\grok.exe");
+    expect(exists).toHaveBeenCalledWith(command);
   });
 });

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -354,18 +354,23 @@ describe("discoverLocalAcpAgentRecords", () => {
   it("surfaces bundled Grok when no system installation exists", async () => {
     const discover = vi.fn(async () => []);
     const bundledGrokCommand = "/app/resources/agents/grok/grok";
+    const readVersionOutput = vi.fn(async () =>
+      "grok 1.0.0-pwragent.1 (297a0c4) [stable]"
+    );
 
     const [record, ...rest] = await discoverLocalAcpAgentRecords({
       discover,
       bundledGrokCommand,
       now: () => 4242,
       enabledRegistryIds: ["grok"],
+      readVersionOutput,
     });
 
     expect(rest).toHaveLength(0);
     expect(record).toMatchObject({
       backendId: "acp:grok",
       registryId: "grok",
+      version: "1.0.0-pwragent.1",
       activeCommand: bundledGrokCommand,
       launchDescriptor: {
         command: bundledGrokCommand,
@@ -379,9 +384,17 @@ describe("discoverLocalAcpAgentRecords", () => {
         {
           command: bundledGrokCommand,
           source: "fallback",
+          version: "1.0.0-pwragent.1",
         },
       ],
+      registryAgent: {
+        version: "1.0.0-pwragent.1",
+      },
     });
+    expect(readVersionOutput).toHaveBeenCalledWith(
+      bundledGrokCommand,
+      expect.any(Object),
+    );
   });
 
   it("allows an explicit Grok override to win over the bundle", async () => {

--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -7,6 +7,7 @@ import {
   discoverLocalAcpAgentRecords,
   isLegacyPythonKimiCli,
 } from "../acp/acp-instance-discovery";
+import { resolveBundledGrokCommand } from "../acp/acp-bundled-agent";
 
 function instance(
   command: string,
@@ -183,8 +184,37 @@ describe("discoverAcpAgentInstances", () => {
 
   it("omits agents with no installed instances", async () => {
     const discover = vi.fn(async () => [group("gemini", [])]);
-    const result = await discoverAcpAgentInstances({ discover });
+    const result = await discoverAcpAgentInstances({
+      discover,
+      bundledGrokCommand: null,
+    });
     expect(result.has("gemini")).toBe(false);
+  });
+
+  it("uses the bundled Grok executable as the last fallback", async () => {
+    const discover = vi.fn(async () => [
+      group("grok", [instance("/usr/local/bin/grok", "path", "0.2.112")]),
+    ]);
+
+    const result = await discoverAcpAgentInstances({
+      discover,
+      bundledGrokCommand: "/app/resources/agents/grok/grok",
+    });
+
+    expect(result.get("grok")).toEqual({
+      activeCommand: "/usr/local/bin/grok",
+      instances: [
+        {
+          command: "/usr/local/bin/grok",
+          source: "path",
+          version: "0.2.112",
+        },
+        {
+          command: "/app/resources/agents/grok/grok",
+          source: "fallback",
+        },
+      ],
+    });
   });
 });
 
@@ -305,7 +335,10 @@ describe("discoverLocalAcpAgentRecords", () => {
 
   it("omits agents with no installed instances", async () => {
     const discover = vi.fn(async () => [group("gemini", [])]);
-    const records = await discoverLocalAcpAgentRecords({ discover });
+    const records = await discoverLocalAcpAgentRecords({
+      discover,
+      bundledGrokCommand: null,
+    });
     expect(records).toEqual([]);
   });
 
@@ -316,5 +349,79 @@ describe("discoverLocalAcpAgentRecords", () => {
       enabledRegistryIds: [],
     });
     expect(discover).toHaveBeenCalledWith(expect.objectContaining({ strategies: [] }));
+  });
+
+  it("surfaces bundled Grok when no system installation exists", async () => {
+    const discover = vi.fn(async () => []);
+    const bundledGrokCommand = "/app/resources/agents/grok/grok";
+
+    const [record, ...rest] = await discoverLocalAcpAgentRecords({
+      discover,
+      bundledGrokCommand,
+      now: () => 4242,
+      enabledRegistryIds: ["grok"],
+    });
+
+    expect(rest).toHaveLength(0);
+    expect(record).toMatchObject({
+      backendId: "acp:grok",
+      registryId: "grok",
+      activeCommand: bundledGrokCommand,
+      launchDescriptor: {
+        command: bundledGrokCommand,
+        args: ["agent", "stdio"],
+        env: {
+          GROK_INSTALLER: "pwragent",
+          NO_COLOR: "1",
+        },
+      },
+      instances: [
+        {
+          command: bundledGrokCommand,
+          source: "fallback",
+        },
+      ],
+    });
+  });
+
+  it("allows an explicit Grok override to win over the bundle", async () => {
+    const discover = vi.fn(async () => [
+      group("grok", [instance("/custom/grok", "override", "0.3.0")]),
+    ]);
+
+    const [record] = await discoverLocalAcpAgentRecords({
+      discover,
+      bundledGrokCommand: "/app/resources/agents/grok/grok",
+      preferences: { grok: { overridePath: "/custom/grok" } },
+    });
+
+    expect(record?.activeCommand).toBe("/custom/grok");
+    expect(record?.launchDescriptor?.env).toEqual({ NO_COLOR: "1" });
+  });
+});
+
+describe("resolveBundledGrokCommand", () => {
+  it("resolves the packaged Unix executable", () => {
+    const exists = vi.fn(() => true);
+    const command = resolveBundledGrokCommand({
+      resourcesPath: "/Applications/PwrAgent.app/Contents/Resources",
+      platform: "darwin",
+      exists,
+    });
+
+    expect(command).toBe(
+      "/Applications/PwrAgent.app/Contents/Resources/agents/grok/grok",
+    );
+    expect(exists).toHaveBeenCalledWith(command);
+  });
+
+  it("uses the Windows executable suffix and omits absent bundles", () => {
+    const command = resolveBundledGrokCommand({
+      resourcesPath: "C:\\PwrAgent\\resources",
+      platform: "win32",
+      exists: () => false,
+    });
+
+    expect(command).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -389,7 +389,20 @@ describe("settings ipc", () => {
         },
       },
     );
-    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(1);
+    await handlers.get(SETTINGS_WRITE_CONFIG_CHANNEL)?.(
+      {},
+      {
+        patch: {
+          acpAgents: {
+            grok: {
+              cliPath: "/tmp/pwragent-grok-arm64/grok",
+            },
+          },
+        },
+      },
+    );
+
+    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
     expect(invalidateAcpBackendDiscoveryMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/acp/acp-bundled-agent.ts
+++ b/apps/desktop/src/main/acp/acp-bundled-agent.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const BUNDLED_GROK_RELATIVE_PATH = ["agents", "grok"] as const;
+
+export function resolveBundledGrokCommand(options?: {
+  resourcesPath?: string;
+  platform?: NodeJS.Platform;
+  exists?: (path: string) => boolean;
+}): string | undefined {
+  const resourcesPath = options?.resourcesPath ?? process.resourcesPath;
+  if (!resourcesPath) {
+    return undefined;
+  }
+  const executable = (options?.platform ?? process.platform) === "win32"
+    ? "grok.exe"
+    : "grok";
+  const command = resolve(
+    resourcesPath,
+    ...BUNDLED_GROK_RELATIVE_PATH,
+    executable,
+  );
+  return (options?.exists ?? existsSync)(command) ? command : undefined;
+}

--- a/apps/desktop/src/main/acp/acp-bundled-agent.ts
+++ b/apps/desktop/src/main/acp/acp-bundled-agent.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { posix, win32 } from "node:path";
 
 export const BUNDLED_GROK_RELATIVE_PATH = ["agents", "grok"] as const;
 
@@ -12,10 +12,10 @@ export function resolveBundledGrokCommand(options?: {
   if (!resourcesPath) {
     return undefined;
   }
-  const executable = (options?.platform ?? process.platform) === "win32"
-    ? "grok.exe"
-    : "grok";
-  const command = resolve(
+  const platform = options?.platform ?? process.platform;
+  const executable = platform === "win32" ? "grok.exe" : "grok";
+  const pathApi = platform === "win32" ? win32 : posix;
+  const command = pathApi.resolve(
     resourcesPath,
     ...BUNDLED_GROK_RELATIVE_PATH,
     executable,

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -25,6 +25,7 @@ import type {
 } from "@pwragent/shared";
 import { resolveActiveAcpInstance } from "./acp-instance-resolver.js";
 import { acpAgentCapabilitiesForRegistryId } from "./acp-agent-capabilities.js";
+import { resolveBundledGrokCommand } from "./acp-bundled-agent.js";
 import { normalizeAcpLaunchDescriptor } from "./acp-launch-descriptor.js";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 import type {
@@ -81,6 +82,11 @@ export type DiscoverAcpAgentInstancesOptions = {
     command: string,
     env: NodeJS.ProcessEnv,
   ) => Promise<string | undefined>;
+  /**
+   * Packaged PwrAgent Grok executable. `undefined` auto-detects it under
+   * Electron resources; `null` disables it (primarily for tests).
+   */
+  bundledGrokCommand?: string | null;
 };
 
 /**
@@ -105,12 +111,20 @@ export async function discoverAcpAgentInstances(
   }
 
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
-  const groups = await discover({
+  const discoveredGroups = await discover({
     ...(strategies !== undefined ? { strategies } : {}),
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
   });
+  const groups = withBundledGrok(
+    discoveredGroups,
+    strategies,
+    options?.bundledGrokCommand === undefined
+      ? resolveBundledGrokCommand()
+      : options.bundledGrokCommand,
+    options?.now?.() ?? Date.now(),
+  );
 
   const byRegistryId = new Map<string, AcpInstanceDiscovery>();
   for (const group of groups) {
@@ -159,13 +173,23 @@ export async function discoverLocalAcpAgentRecords(
   }
 
   const discover = options?.discover ?? discoverLocalAcpAgentInstances;
-  const groups = await discover({
+  const discoveredGroups = await discover({
     ...(strategies !== undefined ? { strategies } : {}),
     ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
   });
   const now = options?.now?.() ?? Date.now();
+  const bundledGrokCommand =
+    options?.bundledGrokCommand === undefined
+      ? resolveBundledGrokCommand()
+      : options.bundledGrokCommand;
+  const groups = withBundledGrok(
+    discoveredGroups,
+    strategies,
+    bundledGrokCommand,
+    now,
+  );
 
   const records: AcpInstalledAgentRecord[] = [];
   for (const group of groups) {
@@ -203,7 +227,13 @@ export async function discoverLocalAcpAgentRecords(
       distributionKind: "local",
       command: active.command,
       args: group.args,
-      env: group.env,
+      env: {
+        ...group.env,
+        ...(group.strategyId === "grok"
+          && active.command === bundledGrokCommand
+          ? { GROK_INSTALLER: "pwragent" }
+          : {}),
+      },
     });
     const registryAgent: AcpRegistryAgent = {
       id: group.strategyId,
@@ -377,4 +407,53 @@ function strategiesForEnabledRegistryIds(
   }
   const enabled = new Set(enabledRegistryIds);
   return ACP_DISCOVERY_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
+}
+
+function withBundledGrok(
+  discoveredGroups: readonly DiscoveredAcpAgentGroup[],
+  enabledStrategies: readonly AcpAgentStrategy[] | undefined,
+  bundledGrokCommand: string | null | undefined,
+  discoveredAt: number,
+): DiscoveredAcpAgentGroup[] {
+  const groups = discoveredGroups.map((group) => ({
+    ...group,
+    instances: [...group.instances],
+  }));
+  if (!bundledGrokCommand) {
+    return groups;
+  }
+
+  const grokStrategy = (enabledStrategies ?? BUILT_IN_ACP_STRATEGIES).find(
+    (strategy) => strategy.id === "grok",
+  );
+  if (!grokStrategy) {
+    return groups;
+  }
+
+  const bundledInstance = {
+    command: bundledGrokCommand,
+    source: "fallback" as const,
+  };
+  const grokGroup = groups.find((group) => group.strategyId === "grok");
+  if (grokGroup) {
+    if (
+      !grokGroup.instances.some(
+        (instance) => instance.command === bundledGrokCommand,
+      )
+    ) {
+      grokGroup.instances.push(bundledInstance);
+    }
+    return groups;
+  }
+
+  groups.push({
+    strategyId: grokStrategy.id,
+    backendId: grokStrategy.backendId,
+    name: grokStrategy.displayName,
+    args: [...grokStrategy.spawn.args],
+    env: { ...grokStrategy.spawn.env },
+    instances: [bundledInstance],
+    discoveredAt,
+  });
+  return groups;
 }

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -76,8 +76,9 @@ export type DiscoverAcpAgentInstancesOptions = {
   discover?: (
     options?: LocalAcpDiscoveryOptions,
   ) => Promise<DiscoveredAcpAgentGroup[]>;
-  /** Injectable raw version-output probe used to distinguish products that
-   *  share one command name (currently legacy Python kimi-cli vs Kimi Code). */
+  /** Injectable raw version-output probe used for synthesized bundled instances
+   *  and to distinguish products that share one command name (currently legacy
+   *  Python kimi-cli vs Kimi Code). */
   readVersionOutput?: (
     command: string,
     env: NodeJS.ProcessEnv,
@@ -117,13 +118,14 @@ export async function discoverAcpAgentInstances(
     ...(options?.env ? { env: options.env } : {}),
     ...(options?.now ? { now: options.now } : {}),
   });
-  const groups = withBundledGrok(
+  const groups = await withBundledGrok(
     discoveredGroups,
     strategies,
     options?.bundledGrokCommand === undefined
       ? resolveBundledGrokCommand()
       : options.bundledGrokCommand,
     options?.now?.() ?? Date.now(),
+    options,
   );
 
   const byRegistryId = new Map<string, AcpInstanceDiscovery>();
@@ -184,11 +186,12 @@ export async function discoverLocalAcpAgentRecords(
     options?.bundledGrokCommand === undefined
       ? resolveBundledGrokCommand()
       : options.bundledGrokCommand;
-  const groups = withBundledGrok(
+  const groups = await withBundledGrok(
     discoveredGroups,
     strategies,
     bundledGrokCommand,
     now,
+    options,
   );
 
   const records: AcpInstalledAgentRecord[] = [];
@@ -409,12 +412,13 @@ function strategiesForEnabledRegistryIds(
   return ACP_DISCOVERY_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
 }
 
-function withBundledGrok(
+async function withBundledGrok(
   discoveredGroups: readonly DiscoveredAcpAgentGroup[],
   enabledStrategies: readonly AcpAgentStrategy[] | undefined,
   bundledGrokCommand: string | null | undefined,
   discoveredAt: number,
-): DiscoveredAcpAgentGroup[] {
+  options: DiscoverAcpAgentInstancesOptions | undefined,
+): Promise<DiscoveredAcpAgentGroup[]> {
   const groups = discoveredGroups.map((group) => ({
     ...group,
     instances: [...group.instances],
@@ -430,19 +434,21 @@ function withBundledGrok(
     return groups;
   }
 
-  const bundledInstance = {
-    command: bundledGrokCommand,
-    source: "fallback" as const,
-  };
   const grokGroup = groups.find((group) => group.strategyId === "grok");
   if (grokGroup) {
-    if (
-      !grokGroup.instances.some(
-        (instance) => instance.command === bundledGrokCommand,
-      )
-    ) {
-      grokGroup.instances.push(bundledInstance);
+    if (grokGroup.instances.some(
+      (instance) => instance.command === bundledGrokCommand,
+    )) {
+      return groups;
     }
+  }
+
+  const bundledInstance = await probeBundledGrokInstance(
+    bundledGrokCommand,
+    options,
+  );
+  if (grokGroup) {
+    grokGroup.instances.push(bundledInstance);
     return groups;
   }
 
@@ -456,4 +462,33 @@ function withBundledGrok(
     discoveredAt,
   });
   return groups;
+}
+
+async function probeBundledGrokInstance(
+  command: string,
+  options: DiscoverAcpAgentInstancesOptions | undefined,
+): Promise<AcpAgentInstance> {
+  const env = buildPwrAgentChildProcessEnv(options?.env ?? process.env);
+  const readVersionOutput = options?.readVersionOutput ?? defaultReadVersionOutput;
+  let version: string | undefined;
+  try {
+    version = parseCliVersion(await readVersionOutput(command, env));
+  } catch {
+    // The bundle path is a trusted packaged fallback. If an install/update race
+    // makes the version probe fail, retain the instance so launch can surface
+    // the concrete error instead of silently hiding Grok from discovery.
+  }
+  return {
+    command,
+    source: "fallback",
+    ...(version !== undefined ? { version } : {}),
+  };
+}
+
+function parseCliVersion(output: string | undefined): string | undefined {
+  const trimmed = output?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.match(/\d+\.\d+\.\d+(?:[-+][\w.-]+)?/)?.[0] ?? trimmed;
 }

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -424,7 +424,6 @@ function acpAgentLaunchIdentity(agent: AcpInstalledAgentRecord): string {
       : undefined,
   });
 }
-
 function effectiveAcpAgentCapabilities(
   agent: AcpInstalledAgentRecord,
 ): AcpAgentCapabilities {

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -126,8 +126,12 @@ async function refreshModelBackendsIfNeeded(params: {
   patch?: WriteDesktopSettingsConfigRequest["patch"];
   secret?: ReplaceDesktopSettingsSecretRequest["secret"];
 }): Promise<void> {
+  const acpCliPathChanged = Object.values(
+    params.patch?.acpAgents ?? {},
+  ).some((agent) => agent?.cliPath !== undefined);
   if (
     params.patch?.models?.codex?.path !== undefined
+    || acpCliPathChanged
   ) {
     await disposeDesktopBackendRegistry();
     return;

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -80,6 +80,30 @@ function acpSnapshot(
 }
 
 describe("AcpAgentsSettings", () => {
+  it("refreshes backend summaries after capability discovery completes", async () => {
+    const onBackendSummariesRefresh = vi.fn();
+    window.addEventListener(
+      BACKEND_SUMMARIES_REFRESH_EVENT,
+      onBackendSummariesRefresh,
+    );
+    const listAcpAgents = vi.fn(
+      async (_request?: { refresh?: boolean; force?: boolean }) => ({
+        fetchedAt: 1000,
+        entries: [geminiEntry()],
+      }),
+    );
+
+    render(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
+
+    await waitFor(() => {
+      expect(onBackendSummariesRefresh).toHaveBeenCalledTimes(1);
+    });
+    window.removeEventListener(
+      BACKEND_SUMMARIES_REFRESH_EVENT,
+      onBackendSummariesRefresh,
+    );
+  });
+
   it("keeps cached ACP agents visible while background discovery refreshes", async () => {
     const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     let resolveRefresh:

--- a/docs/acp-registry-backends.md
+++ b/docs/acp-registry-backends.md
@@ -14,7 +14,7 @@ Core behind ACP.
   rule, verification state, auth state, and launch descriptor.
 - ACP session metadata in the same navigation/thread model used by built-in
   backends.
-- Client-owned mediation for ACP filesystem, terminal, and cancellation flows.
+- Client-owned mediation for ACP permission requests and prompt cancellation.
 
 ## Allowlist Policy
 
@@ -42,11 +42,14 @@ permits that exact unverified source, and Settings surfaces that state.
 
 ## Trust Boundary
 
-Default Access and Full Access map to ACP requests that PwrAgent owns, such as
-filesystem writes and terminal creation requests sent through the ACP client
-API. PwrAgent cannot sandbox internal behavior an external ACP process performs
-outside those protocol requests. Treat installed ACP agents as third-party local
-executables with their own credential, network, and subprocess behavior.
+PwrAgent currently advertises ACP client filesystem and terminal capabilities
+as unsupported and handles only `session/request_permission` on the reverse
+request path. Default Access and Full Access affect that permission flow, but
+they do not turn an external ACP process into a PwrAgent-sandboxed process.
+PwrAgent cannot mediate filesystem, terminal, network, or subprocess behavior
+that an external agent performs internally. Treat installed ACP agents as
+third-party local executables with their own credential and operating-system
+access.
 
 ## Runtime State
 
@@ -65,5 +68,5 @@ than sqlite; see [thread-history-persistence.md](thread-history-persistence.md).
 
 Ship with a narrow allowlist. Add new agents only after agent-specific smoke
 testing covers install, launch, session creation, prompt turn, cancellation,
-filesystem/terminal requests, auth/setup status, and registry-unavailable
-startup.
+permission requests, rejection of unsupported reverse requests, auth/setup
+status, and registry-unavailable startup.

--- a/docs/bundled-grok-acp.md
+++ b/docs/bundled-grok-acp.md
@@ -1,0 +1,40 @@
+# Bundled Grok ACP runtime
+
+PwrAgent desktop releases embed a downstream build from
+[`pwrdrvr/grok-build`](https://github.com/pwrdrvr/grok-build). This is not an
+official xAI binary.
+
+## Release contract
+
+`apps/desktop/grok-bundle.json` pins one immutable downstream tag and its four
+release asset names:
+
+- macOS universal (Intel and Apple Silicon)
+- Linux x86_64
+- Linux aarch64
+- Windows x86_64
+
+The desktop release workflow downloads the matching asset and `SHA256SUMS`,
+verifies the archive, and stages it before Electron packaging and macOS
+signing. Packaging fails closed when the expected executable is absent. The
+archive's Apache license, third-party notices, upstream `SOURCE_REV`, and
+downstream provenance remain alongside the executable under
+`Resources/agents/grok/`.
+
+At runtime, the bundled executable is a final fallback. A valid explicit path
+or system installation remains preferred. Only the bundled launch descriptor
+sets `GROK_INSTALLER=pwragent`, preventing an xAI updater from replacing an
+embedded, signed resource.
+
+## Updating the pin
+
+1. Sync and test the `pwragent` branch of the downstream Grok fork.
+2. Publish a new signed `pwragent-v<upstream>-pwragent.<revision>` tag.
+3. Wait for all four assets and `SHA256SUMS` to be published.
+4. Update `apps/desktop/grok-bundle.json` to the new immutable tag and exact
+   asset names.
+5. Run ACP discovery tests and a PwrAgent package dry run before cutting the
+   desktop release.
+
+Do not reuse or replace an existing Grok release tag. The fork workflow rejects
+attempts to overwrite an existing downstream release.


### PR DESCRIPTION
## What changed

- Pin the downstream `pwrdrvr/grok-build` release contract for macOS universal,
  Linux x64/arm64, and Windows x64.
- Download and verify the matching Grok archive during desktop release
  packaging, then embed it before signing.
- Discover packaged Grok as a final fallback while preserving explicit and
  system-installed overrides.
- Disable Grok self-update only for the packaged launch descriptor and verify
  the native executable during packaging.
- Correct ACP trust-boundary documentation: PwrAgent currently handles
  permission reverse requests but does not advertise client filesystem or
  terminal capabilities.

## Why

Grok Build already accepts ACP image content but did not advertise image input.
The downstream fork fixes that capability negotiation and produces
PwrAgent-owned, checksummed binaries. This PR completes the consumer side so
PwrAgent can ship the corrected runtime consistently across its current desktop
targets.

## Release dependency

This stays draft until `pwragent-v0.2.112-pwragent.1` and its four assets plus
`SHA256SUMS` exist in `pwrdrvr/grok-build`. The desktop release workflow
intentionally fails closed before that dependency is published.

## Validation

- `pnpm install --frozen-lockfile`
- Desktop and shared TypeScript typechecks
- Targeted ACP discovery tests: 18 passed
- ESLint on changed source and release scripts
- Node syntax checks for both release scripts
- `zizmor .github/workflows/release.yml`: no findings
