### PR TITLE
fix(desktop): keep launchpad directory labels human-readable

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8349,6 +8349,18 @@ script = "pnpm install"
       prompt: "Late composer update",
     });
 
+    const trailingWhitespace = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/tmp/repo ",
+      patch: { prompt: "Preserve the exact path" },
+    });
+
+    expect(trailingWhitespace.launchpad).toMatchObject({
+      directoryKind: "directory",
+      directoryLabel: "repo ",
+      directoryPath: "/tmp/repo ",
+      prompt: "Preserve the exact path",
+    });
+
     const workspace = await registry.updateDirectoryLaunchpad({
       directoryKey: "workspace:new-thread",
       patch: { prompt: "Late directory-less update" },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8326,6 +8326,44 @@ script = "pnpm install"
     await registry.close();
   });
 
+  it("derives launchpad identity when a late update recreates a missing row", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    const updated = await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/Users/huntharo/github/PwrAgnt",
+      patch: { prompt: "Late composer update" },
+    });
+
+    expect(updated.launchpad).toMatchObject({
+      directoryKind: "directory",
+      directoryLabel: "PwrAgnt",
+      directoryPath: "/Users/huntharo/github/PwrAgnt",
+      prompt: "Late composer update",
+    });
+
+    const workspace = await registry.updateDirectoryLaunchpad({
+      directoryKey: "workspace:new-thread",
+      patch: { prompt: "Late directory-less update" },
+    });
+
+    expect(workspace.launchpad).toMatchObject({
+      directoryKind: "workspace",
+      directoryLabel: "Workspaces",
+      directoryPath: undefined,
+      prompt: "Late directory-less update",
+    });
+
+    await registry.close();
+  });
+
   it("falls back to OpenAI launchpad state when sticky Grok defaults are unavailable", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4245,8 +4245,8 @@ function fallbackLaunchpadIdentity(
   "directoryKind" | "directoryLabel" | "directoryPath"
 > {
   if (directoryKey.startsWith("directory:")) {
-    const directoryPath = directoryKey.slice("directory:".length).trim();
-    if (directoryPath) {
+    const directoryPath = directoryKey.slice("directory:".length);
+    if (directoryPath.length > 0) {
       return {
         directoryKind: "directory",
         directoryLabel: path.basename(directoryPath) || directoryPath,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4238,6 +4238,31 @@ function defaultLaunchpadWorkMode(
     : "local";
 }
 
+function fallbackLaunchpadIdentity(
+  directoryKey: string,
+): Pick<
+  EnsureDirectoryLaunchpadRequest,
+  "directoryKind" | "directoryLabel" | "directoryPath"
+> {
+  if (directoryKey.startsWith("directory:")) {
+    const directoryPath = directoryKey.slice("directory:".length).trim();
+    if (directoryPath) {
+      return {
+        directoryKind: "directory",
+        directoryLabel: path.basename(directoryPath) || directoryPath,
+        directoryPath,
+      };
+    }
+  }
+
+  return {
+    directoryKind: directoryKey.startsWith("workspace:") ? "workspace" : "directory",
+    directoryLabel: directoryKey.startsWith("workspace:")
+      ? "Workspaces"
+      : directoryKey,
+  };
+}
+
 function resolveCodexEnvironmentSelection(
   launchpad: NavigationLaunchpadDraft,
   options: CodexEnvironmentOption[],
@@ -10871,8 +10896,7 @@ export class DesktopBackendRegistry {
       })) ??
       (await this.ensureDirectoryLaunchpad({
         directoryKey: request.directoryKey,
-        directoryKind: "directory",
-        directoryLabel: request.directoryKey,
+        ...fallbackLaunchpadIdentity(request.directoryKey),
       })).launchpad;
 
     const patch = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -43,6 +43,72 @@ describe("useThreadNavigation", () => {
     return { promise, resolve, reject };
   }
 
+  it("does not let a late launchpad update replace a directory label with its internal key", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgnt";
+    const defaults: NavigationLaunchpadDefaults = {
+      backend: "codex",
+      executionMode: "default",
+    };
+    const malformedLaunchpad: NavigationLaunchpadDraft = {
+      directoryKey,
+      directoryKind: "directory",
+      directoryLabel: directoryKey,
+      directoryPath: "/Users/huntharo/github/PwrAgnt",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "Late composer update",
+      workMode: "worktree",
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/github/PwrAgnt",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: malformedLaunchpad,
+      defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.label).toBe("PwrAgnt");
+    });
+
+    await act(async () => {
+      await result.current.updateDirectoryLaunchpad(directoryKey, {
+        prompt: "Late composer update",
+      });
+    });
+
+    expect(result.current.directories[0]).toMatchObject({
+      label: "PwrAgnt",
+      launchpad: {
+        directoryLabel: "PwrAgnt",
+      },
+    });
+  });
+
   it("clears a directory attention count after the selected thread is marked seen", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -34,6 +34,7 @@ import {
   sortSubthreadSummaries,
 } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
+import { fileLabelFromPath } from "./directory-references";
 import {
   buildSubthreadLaunchpadKey,
   getParentThreadIdFromSubthreadLaunchpadKey,
@@ -213,6 +214,44 @@ function sortNavigationDirectories(
   return [...directories].sort(compareNavigationDirectoriesByLabel);
 }
 
+function isInternalDirectoryLabel(value?: string): boolean {
+  return Boolean(value?.startsWith("directory:") || value?.startsWith("workspace:"));
+}
+
+function displayLaunchpadDirectoryLabel(
+  launchpad: NavigationLaunchpadDraft,
+  existing?: NavigationDirectorySummary,
+): string {
+  const launchpadLabel = launchpad.directoryLabel.trim();
+  if (launchpadLabel && !isInternalDirectoryLabel(launchpadLabel)) {
+    return launchpadLabel;
+  }
+
+  const existingLabel = existing?.label.trim();
+  if (existingLabel && !isInternalDirectoryLabel(existingLabel)) {
+    return existingLabel;
+  }
+
+  if (launchpad.directoryKind === "workspace") {
+    return ROOT_NEW_THREAD_WORKSPACE_LABEL;
+  }
+
+  const directoryPath =
+    launchpad.directoryPath?.trim()
+    ?? existing?.path?.trim()
+    ?? (
+      launchpad.directoryKey.startsWith("directory:")
+        ? launchpad.directoryKey.slice("directory:".length).trim()
+        : undefined
+    );
+  const normalizedPath = directoryPath?.replace(/[\\/]+$/, "");
+  return (
+    fileLabelFromPath(normalizedPath ?? "")
+    || launchpadLabel
+    || "Directory"
+  );
+}
+
 function findLaunchpadSourceDirectory(
   directories: NavigationSnapshot["directories"],
   launchpad: NavigationLaunchpadDraft,
@@ -251,9 +290,20 @@ function upsertLaunchpadDirectory(
   },
 ): NavigationSnapshot["directories"] {
   let foundDirectory = false;
+  const existingDirectory = directories.find(
+    (directory) => directory.key === launchpad.directoryKey,
+  );
+  const displayLabel = displayLaunchpadDirectoryLabel(
+    launchpad,
+    existingDirectory,
+  );
+  const normalizedLaunchpad =
+    displayLabel === launchpad.directoryLabel
+      ? launchpad
+      : { ...launchpad, directoryLabel: displayLabel };
   const sourceDirectory = findLaunchpadSourceDirectory(
     directories,
-    launchpad,
+    normalizedLaunchpad,
     options?.gitStatusSourcePath,
   );
   const hasGitStatusOverride =
@@ -262,17 +312,17 @@ function upsertLaunchpadDirectory(
     ? options.gitStatus ?? undefined
     : sourceDirectory?.gitStatus;
   const nextDirectories = directories.map((directory) => {
-    if (directory.key !== launchpad.directoryKey) {
+    if (directory.key !== normalizedLaunchpad.directoryKey) {
       return directory;
     }
 
     foundDirectory = true;
     const next: NavigationSnapshot["directories"][number] = {
       ...directory,
-      kind: launchpad.directoryKind,
-      label: launchpad.directoryLabel,
-      path: launchpad.directoryPath ?? directory.path,
-      launchpad,
+      kind: normalizedLaunchpad.directoryKind,
+      label: displayLabel,
+      path: normalizedLaunchpad.directoryPath ?? directory.path,
+      launchpad: normalizedLaunchpad,
     };
     if (hasGitStatusOverride) {
       if (inheritedGitStatus) {
@@ -292,16 +342,16 @@ function upsertLaunchpadDirectory(
       : [
           ...nextDirectories,
           {
-            key: launchpad.directoryKey,
-            kind: launchpad.directoryKind,
-            label: launchpad.directoryLabel,
-            path: launchpad.directoryPath,
+            key: normalizedLaunchpad.directoryKey,
+            kind: normalizedLaunchpad.directoryKind,
+            label: displayLabel,
+            path: normalizedLaunchpad.directoryPath,
             threadKeys: [],
             needsAttentionCount: 0,
             ...(inheritedGitStatus
               ? { gitStatus: inheritedGitStatus }
               : {}),
-            launchpad,
+            launchpad: normalizedLaunchpad,
           },
         ],
   );


### PR DESCRIPTION
## Summary

- I fixed a race that could expose an internal `directory:/Users/...` key as a directory name after starting a thread.
- I preserved the human-readable source-directory label across both late launchpad recreation and renderer updates, without changing the worktree selected for the thread.

## Verification

- I reproduced the failure from the default-profile log and state database: Grok launched in the correct managed worktree while the launchpad row stored its internal key as the display label.
- I added main-process and renderer regressions, observed both fail before the fix, and verified all 451 targeted tests pass afterward.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` with no errors.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The malformed value was display metadata; the thread's source-directory and managed-worktree association remained correct.
