### PR TITLE
fix(desktop): price Grok 4.5 ACP usage

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3363,6 +3363,70 @@ describe("DesktopBackendRegistry", () => {
     expect(acpClient.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("includes persisted pricing when reading ACP threads", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const threadId = "grok-session-pricing";
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertThreadUsageLine({
+      line: {
+        backend: acpBackendId,
+        usageLineId: `${acpBackendId}:${threadId}:turn-1:live-token-usage`,
+        threadId,
+        turnId: "turn-1",
+        scope: "turn",
+        source: "live",
+        status: "finalized",
+        model: "grok-4.5-build",
+        currency: "USD",
+        inputTokens: 18_881,
+        cachedInputTokens: 11_136,
+        uncachedInputTokens: 7_745,
+        outputTokens: 68,
+        reasoningOutputTokens: 35,
+        totalTokens: 18_949,
+        priceStatus: "priced",
+        provider: "xai",
+        cachedInputCostMicros: 3_341,
+        uncachedInputCostMicros: 15_490,
+        outputCostMicros: 408,
+        totalCostMicros: 19_239,
+        createdAt: 1_000,
+      },
+    });
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      overlayStore,
+      sessionId: threadId,
+      sessions: [
+        {
+          backendId: acpBackendId,
+          sessionId: threadId,
+          title: "Grok pricing",
+          createdAt: 1_000,
+          updatedAt: 2_000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ],
+    });
+
+    const response = await registry.readThread({
+      backend: acpBackendId,
+      threadId,
+    });
+
+    expect(response.pricing?.lines).toEqual([
+      expect.objectContaining({
+        backend: acpBackendId,
+        provider: "xai",
+        threadId,
+        totalCostMicros: 19_239,
+      }),
+    ]);
+
+    await registry.close();
+  });
+
   it("applies Grok ACP reasoning effort without racing turn startup", async () => {
     const sessions: AcpSessionMetadata[] = [];
     const acpBackendId = "acp:grok" as AcpBackendId;

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -798,6 +798,51 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("reprices persisted Grok ACP usage under the xAI provider", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        backend: "acp:grok",
+        cachedInputTokens: 11_136,
+        completedAt: Date.UTC(2026, 6, 26),
+        createdAt: Date.UTC(2026, 6, 26),
+        inputTokens: 21_208,
+        model: "grok-4.5-build",
+        outputTokens: 45,
+        priceStatus: "unpriced",
+        priceUnavailableReason: "missing-rate",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        reasoningOutputTokens: 28,
+        totalCostMicros: 0,
+        totalTokens: 21_253,
+        uncachedInputTokens: 10_072,
+        usageLineId: "line-grok-4-5-build",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:grok",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "priced",
+      pricingCatalogId: "xai-api",
+      pricingCatalogVersion: "2026-07-17",
+      pricingRateId: "xai:2026-07-17:grok-4.5:standard",
+      provider: "xai",
+      totalCostMicros: 23_755,
+    });
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      pricedUsageLineCount: 1,
+      provider: "xai",
+      totalCostMicros: 23_755,
+      unpricedUsageLineCount: 0,
+    });
+  });
+
   it("records one provider-scoped usage turn for multiple usage lines from the same turn", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -713,6 +713,125 @@ describe("StateDb", () => {
     });
   });
 
+  it("migrates legacy Grok usage from the OpenAI fallback to xAI pricing", () => {
+    stateDb.close();
+
+    const dbPath = path.join(tempDir, "grok-pricing-provider-repair-state.db");
+    stateDb = StateDb.open(dbPath);
+    stateDb.raw
+      .prepare(
+        `INSERT INTO thread_usage_lines (
+          usage_line_id,
+          usage_turn_id,
+          provider,
+          backend,
+          thread_id,
+          turn_id,
+          source,
+          source_item_id,
+          scope,
+          status,
+          created_at,
+          completed_at,
+          model,
+          service_tier,
+          fast_mode,
+          input_tokens,
+          cached_input_tokens,
+          uncached_input_tokens,
+          output_tokens,
+          reasoning_output_tokens,
+          total_tokens,
+          price_status,
+          price_unavailable_reason,
+          currency,
+          uncached_input_cost_micros,
+          cached_input_cost_micros,
+          output_cost_micros,
+          total_cost_micros,
+          updated_at
+        ) VALUES (
+          'live-line-grok-4-5',
+          'openai:acp-grok:thread-1:turn-1',
+          'openai',
+          'acp:grok',
+          'thread-1',
+          'turn-1',
+          'live',
+          'thread-token-usage',
+          'turn',
+          'pending',
+          ?,
+          ?,
+          'grok-4.5-build',
+          NULL,
+          0,
+          21208,
+          11136,
+          10072,
+          45,
+          28,
+          21253,
+          'unpriced',
+          'missing-rate',
+          'USD',
+          0,
+          0,
+          0,
+          0,
+          ?
+        )`,
+      )
+      .run(
+        Date.UTC(2026, 6, 26),
+        Date.UTC(2026, 6, 26),
+        Date.UTC(2026, 6, 26),
+      );
+    stateDb.raw.pragma("user_version = 28");
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    const line = stateDb.raw
+      .prepare(
+        `SELECT
+           provider,
+           price_status,
+           price_unavailable_reason,
+           pricing_catalog_id,
+           pricing_catalog_version,
+           pricing_rate_id,
+           total_cost_micros
+         FROM thread_usage_lines
+         WHERE usage_line_id = 'live-line-grok-4-5'`,
+      )
+      .get();
+    const summary = stateDb.raw
+      .prepare(
+        `SELECT provider, priced_usage_line_count, total_cost_micros
+         FROM thread_pricing_summaries
+         WHERE backend = 'acp:grok'
+           AND thread_id = 'thread-1'
+           AND currency = 'USD'`,
+      )
+      .get();
+
+    expect(line).toEqual({
+      provider: "xai",
+      price_status: "priced",
+      price_unavailable_reason: null,
+      pricing_catalog_id: "xai-api",
+      pricing_catalog_version: "2026-07-17",
+      pricing_rate_id: "xai:2026-07-17:grok-4.5:standard",
+      total_cost_micros: 23_755,
+    });
+    expect(summary).toEqual({
+      provider: "xai",
+      priced_usage_line_count: 1,
+      total_cost_micros: 23_755,
+    });
+  });
+
   it("reprices existing GPT-5.6 usage rows when the pricing catalog updates", () => {
     stateDb.close();
 

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -713,7 +713,7 @@ describe("StateDb", () => {
     });
   });
 
-  it("migrates legacy Grok usage from the OpenAI fallback to xAI pricing", () => {
+  it("migrates legacy Grok pricing without billing fork baselines", () => {
     stateDb.close();
 
     const dbPath = path.join(tempDir, "grok-pricing-provider-repair-state.db");
@@ -787,6 +787,59 @@ describe("StateDb", () => {
         Date.UTC(2026, 6, 26),
         Date.UTC(2026, 6, 26),
       );
+    stateDb.raw
+      .prepare(
+        `INSERT INTO thread_usage_lines (
+          usage_line_id,
+          provider,
+          backend,
+          thread_id,
+          parent_thread_id,
+          source,
+          scope,
+          status,
+          created_at,
+          model,
+          input_tokens,
+          cached_input_tokens,
+          uncached_input_tokens,
+          output_tokens,
+          reasoning_output_tokens,
+          total_tokens,
+          price_status,
+          currency,
+          uncached_input_cost_micros,
+          cached_input_cost_micros,
+          output_cost_micros,
+          total_cost_micros,
+          updated_at
+        ) VALUES (
+          'fork-baseline-grok-4-5',
+          'openai',
+          'acp:grok',
+          'thread-fork',
+          'thread-parent',
+          'hydration',
+          'fork-baseline',
+          'finalized',
+          ?,
+          'grok-4.5-build',
+          21208,
+          11136,
+          10072,
+          45,
+          28,
+          21253,
+          'priced',
+          'USD',
+          0,
+          0,
+          0,
+          0,
+          ?
+        )`,
+      )
+      .run(Date.UTC(2026, 6, 26), Date.UTC(2026, 6, 26));
     stateDb.raw.pragma("user_version = 28");
     stateDb.close();
 
@@ -806,12 +859,37 @@ describe("StateDb", () => {
          WHERE usage_line_id = 'live-line-grok-4-5'`,
       )
       .get();
+    const forkBaseline = stateDb.raw
+      .prepare(
+        `SELECT
+           provider,
+           price_status,
+           pricing_catalog_id,
+           pricing_catalog_version,
+           pricing_rate_id,
+           uncached_input_cost_micros,
+           cached_input_cost_micros,
+           output_cost_micros,
+           total_cost_micros
+         FROM thread_usage_lines
+         WHERE usage_line_id = 'fork-baseline-grok-4-5'`,
+      )
+      .get();
     const summary = stateDb.raw
       .prepare(
         `SELECT provider, priced_usage_line_count, total_cost_micros
          FROM thread_pricing_summaries
          WHERE backend = 'acp:grok'
            AND thread_id = 'thread-1'
+           AND currency = 'USD'`,
+      )
+      .get();
+    const forkSummary = stateDb.raw
+      .prepare(
+        `SELECT provider, priced_usage_line_count, total_cost_micros
+         FROM thread_pricing_summaries
+         WHERE backend = 'acp:grok'
+           AND thread_id = 'thread-parent'
            AND currency = 'USD'`,
       )
       .get();
@@ -824,6 +902,22 @@ describe("StateDb", () => {
       pricing_catalog_version: "2026-07-17",
       pricing_rate_id: "xai:2026-07-17:grok-4.5:standard",
       total_cost_micros: 23_755,
+    });
+    expect(forkBaseline).toEqual({
+      provider: "openai",
+      price_status: "priced",
+      pricing_catalog_id: null,
+      pricing_catalog_version: null,
+      pricing_rate_id: null,
+      uncached_input_cost_micros: 0,
+      cached_input_cost_micros: 0,
+      output_cost_micros: 0,
+      total_cost_micros: 0,
+    });
+    expect(forkSummary).toEqual({
+      provider: "openai",
+      priced_usage_line_count: 1,
+      total_cost_micros: 0,
     });
     expect(summary).toEqual({
       provider: "xai",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6683,9 +6683,17 @@ export class DesktopBackendRegistry {
       await this.acpBackend.readReplay(backend, request.threadId),
       request,
     );
+    const pricing =
+      typeof this.overlayStore.readThreadPricing === "function"
+        ? await this.overlayStore.readThreadPricing({
+            backend,
+            threadId: request.threadId,
+          })
+        : { lines: [], summaries: [] };
     return {
       backend,
       fetchedAt: Date.now(),
+      pricing,
       threadId: request.threadId,
       ...(replay.threadStatus ? { threadStatus: replay.threadStatus } : {}),
       replay,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -21,7 +21,7 @@ import {
   type AcpBackendId,
   buildThreadMarkdownLink,
   buildThreadUrl,
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   formatTokenUsageUsd,
   isToolManagedWorktreePath,
   resolveOpenAiPricingServiceTier,
@@ -3264,7 +3264,7 @@ function estimateTaskMonitorUsageCost(params: {
   serviceTier?: string;
   uncachedInputTokens: number;
 }): { model: string; totalUsd: number } | undefined {
-  const cost = estimateOpenAiTokenUsageCost(params);
+  const cost = estimateTokenUsageCost(params);
   return cost ? { model: cost.model, totalUsd: cost.totalUsd } : undefined;
 }
 
@@ -3320,7 +3320,7 @@ function buildTaskMonitorUsageLine(params: {
     tokenUsage.totalTokens ?? inputTokens + outputTokens + reasoningOutputTokens,
   );
   const model = params.model ?? params.usage.model ?? params.usage.cost?.model;
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     cachedInputTokens,
     fastMode: params.fastMode,
     model,
@@ -3539,7 +3539,7 @@ function buildLiveThreadUsageLine(params: {
   const cumulativeTokens = params.cumulativeTokenUsage
     ? normalizeTaskMonitorPricingTokens(params.cumulativeTokenUsage)
     : undefined;
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2,7 +2,7 @@ import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   formatSearchCommandActionLabel,
   formatTokenUsagePriceFactor,
   formatTokenUsageStandardRateSuffix,
@@ -2902,7 +2902,7 @@ function summarizeTokenUsageActivity(
     readTokenUsagePricingContext(record),
     pricingContext
   );
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     cachedInputTokens,
     at: createdAt,
     fastMode: resolvedPricingContext.fastMode,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -39,7 +39,7 @@ import {
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
   applyNavigationLaunchpadProviderSettingsPatch,
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   isAcpBackendId,
   parseThreadIdentityKey,
   projectNavigationLaunchpadProviderSettings,
@@ -676,7 +676,7 @@ export class SqliteOverlayStore {
     line: ThreadUsageLineRecord;
   }): Promise<{ line: ThreadUsageLineRecord; summary: ThreadPricingSummary }> {
     const now = Date.now();
-    let line = repriceOpenAiUsageLine(normalizeThreadUsageLine(params.line, now));
+    let line = repriceTokenUsageLine(normalizeThreadUsageLine(params.line, now));
     const upsert = this.stateDb.raw.transaction(() => {
       const existing = this.readThreadUsageLineSync(line.usageLineId);
       if (existing) {
@@ -3165,7 +3165,7 @@ function mergeThreadUsageLineForUpsert(
     ),
   };
 
-  return repriceOpenAiUsageLine(merged);
+  return repriceTokenUsageLine(merged);
 }
 
 function mergeUsageSettingValue<T extends string>(
@@ -3178,7 +3178,7 @@ function mergeUsageSettingValue<T extends string>(
   return next;
 }
 
-function repriceOpenAiUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRecord {
+function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRecord {
   if (line.provider !== "openai") {
     return line;
   }
@@ -3205,7 +3205,7 @@ function repriceOpenAiUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRec
     };
   }
 
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     at: line.createdAt,
     cachedInputTokens: line.cachedInputTokens,
     fastMode: line.fastMode,
@@ -3241,6 +3241,7 @@ function repriceOpenAiUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRec
     currency: cost?.currency ?? line.currency,
     outputCostMicros: cost?.outputCostMicros ?? 0,
     priceStatus: cost ? "priced" : "unpriced",
+    provider: cost?.provider ?? line.provider,
     ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1621,7 +1621,8 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          service_tier,
          uncached_input_tokens
        FROM thread_usage_lines
-       WHERE provider = 'openai'`,
+       WHERE provider = 'openai'
+         AND scope != 'fork-baseline'`,
     )
     .all() as Array<{
       cached_input_tokens: number;

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -3,13 +3,13 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import {
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   resolveOpenAiPricingServiceTier,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 28;
+export const CURRENT_STATE_DB_USER_VERSION = 29;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -882,7 +882,7 @@ export class StateDb {
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 22) {
       db.transaction(() => {
-        repairOpenAiThreadUsagePricing(db);
+        repairTokenUsagePricing(db);
         db.pragma("user_version = 22");
       })();
     }
@@ -932,7 +932,13 @@ export class StateDb {
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 28) {
       db.transaction(() => {
-        repairOpenAiThreadUsagePricing(db);
+        repairTokenUsagePricing(db);
+        db.pragma("user_version = 28");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 29) {
+      db.transaction(() => {
+        repairTokenUsagePricing(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1590,7 +1596,7 @@ CREATE INDEX IF NOT EXISTS idx_thread_usage_lines_summary_parent
 `);
 }
 
-function repairOpenAiThreadUsagePricing(db: BetterSqlite3.Database): void {
+function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   if (
     !tableExists(db, "thread_usage_lines") ||
     !tableExists(db, "thread_pricing_summaries")
@@ -1610,6 +1616,7 @@ function repairOpenAiThreadUsagePricing(db: BetterSqlite3.Database): void {
          model,
          output_tokens,
          price_status,
+         provider,
          reasoning_output_tokens,
          service_tier,
          uncached_input_tokens
@@ -1624,6 +1631,7 @@ function repairOpenAiThreadUsagePricing(db: BetterSqlite3.Database): void {
       model: string | null;
       output_tokens: number;
       price_status: string;
+      provider: string;
       reasoning_output_tokens: number;
       service_tier: string | null;
       uncached_input_tokens: number;
@@ -1641,13 +1649,14 @@ function repairOpenAiThreadUsagePricing(db: BetterSqlite3.Database): void {
        uncached_input_cost_micros = @uncachedInputCostMicros,
        cached_input_cost_micros = @cachedInputCostMicros,
        output_cost_micros = @outputCostMicros,
+       provider = @provider,
        total_cost_micros = @totalCostMicros,
        updated_at = @updatedAt
      WHERE usage_line_id = @usageLineId`,
   );
 
   for (const row of rows) {
-    const cost = estimateOpenAiTokenUsageCost({
+    const cost = estimateTokenUsageCost({
       at: row.created_at,
       cachedInputTokens: row.cached_input_tokens,
       fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
@@ -1679,6 +1688,7 @@ function repairOpenAiThreadUsagePricing(db: BetterSqlite3.Database): void {
       currency: cost?.currency ?? row.currency,
       outputCostMicros: cost?.outputCostMicros ?? 0,
       priceStatus: cost ? "priced" : "unpriced",
+      provider: cost?.provider ?? row.provider,
       priceUnavailableReason,
       pricingCatalogId: cost?.catalogId ?? null,
       pricingCatalogVersion: cost?.catalogVersion ?? null,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -333,6 +333,35 @@ describe("buildTokenUsageActivityEntry", () => {
     ]);
   });
 
+  it("prices the Grok ACP build model alias without double-billing reasoning", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "usage-grok-45",
+      model: "grok-4.5-build",
+      tokenUsage: {
+        last_token_usage: {
+          input_tokens: 21_208,
+          cached_input_tokens: 11_136,
+          output_tokens: 45,
+          reasoning_output_tokens: 28,
+          total_tokens: 21_253,
+        },
+      },
+    });
+
+    expect(entry?.summary).toContain("10,072 uncached in");
+    expect(entry?.summary).toContain("11,136 cached");
+    expect(entry?.summary).toContain("45 out (28 reasoning)");
+    expect(entry?.summary).toContain("$0.024 list price");
+    expect(entry?.details.map((detail) => detail.label)).toEqual([
+      "Input: 21,208 tokens (10,072 uncached, 11,136 cached)",
+      "Output: 45 tokens, including 28 reasoning",
+      "Uncached input cost: 10,072 tokens at $2.00/M = $0.021",
+      "Cached input cost: 11,136 tokens at $0.30/M (0.15x uncached) = $0.004",
+      "Output cost: 45 tokens at $6.00/M = <$0.001",
+      "Cost: $0.024 list price for Grok 4.5 Standard",
+    ]);
+  });
+
   it("uses Fast priority rates and labels the model variant", () => {
     const entry = buildTokenUsageActivityEntry({
       fastMode: true,

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@pwragent/shared";
 import {
   estimateOpenAiCodexCreditUsage,
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
 import { useEffect, useState } from "react";
@@ -765,7 +765,7 @@ function buildEstimatedHistoricalGapLine(params: {
   anchorLine: ThreadUsageLineRecord;
   gapTokens: PricingTokenBreakdown;
 }): PricingUsageLine | undefined {
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     at: params.anchorLine.createdAt,
     cachedInputTokens: params.gapTokens.cachedInputTokens,
     fastMode: false,

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -1,5 +1,5 @@
 import {
-  estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   formatSearchCommandActionLabel,
   formatTokenUsagePriceFactor,
   formatTokenUsageStandardRateSuffix,
@@ -278,8 +278,7 @@ export function buildTokenUsageActivityEntry(params: {
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
-  const billedOutputTokens = outputTokens + reasoningOutputTokens;
-  const cost = estimateOpenAiTokenUsageCost({
+  const cost = estimateTokenUsageCost({
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -288,6 +287,9 @@ export function buildTokenUsageActivityEntry(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
+  const billedOutputTokens = cost?.outputTokensIncludeReasoning
+    ? outputTokens
+    : outputTokens + reasoningOutputTokens;
   const summaryParts = [
     `${formatTokenCount(uncachedInputTokens)} uncached in`,
     `${formatTokenCount(cachedInputTokens)} cached`,

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   estimateOpenAiCodexCreditUsage,
   estimateOpenAiTokenUsageCost,
+  estimateTokenUsageCost,
   listOpenAiTokenUsagePricingRates,
+  listTokenUsagePricingRates,
   resolveOpenAiPricingServiceTier,
 } from "../token-usage-pricing";
 
@@ -202,6 +204,36 @@ describe("token usage pricing", () => {
     ).toBeUndefined();
   });
 
+  it("prices the Grok ACP build model alias with the Grok 4.5 rate", () => {
+    const cost = estimateTokenUsageCost({
+      at: Date.UTC(2026, 6, 26),
+      cachedInputTokens: 11_136,
+      model: "grok-4.5-build",
+      outputTokens: 45,
+      reasoningOutputTokens: 28,
+      uncachedInputTokens: 10_072,
+    });
+
+    expect(cost).toMatchObject({
+      cachedInputCostMicros: 3_341,
+      catalogId: "xai-api",
+      catalogVersion: "2026-07-17",
+      displayName: "Grok 4.5 Standard",
+      inputUsdPerMillion: 2,
+      cachedInputUsdPerMillion: 0.3,
+      model: "grok-4.5-build",
+      outputCostMicros: 270,
+      outputTokensIncludeReasoning: true,
+      outputUsdPerMillion: 6,
+      provider: "xai",
+      rateId: "xai:2026-07-17:grok-4.5:standard",
+      serviceTier: "standard",
+      totalCostMicros: 23_755,
+      totalUsd: 0.023755,
+      uncachedInputCostMicros: 20_144,
+    });
+  });
+
   it("returns undefined for unsupported models or service tiers", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -241,6 +273,19 @@ describe("token usage pricing", () => {
         provider: "openai",
         rateId: "openai:2026-07-09:gpt-5.6-luna:priority",
         serviceTier: "priority",
+      }),
+    );
+    expect(listTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        cachedInputUsdPerMillion: 0.3,
+        catalogId: "xai-api",
+        catalogVersion: "2026-07-17",
+        displayName: "Grok 4.5 Standard",
+        inputUsdPerMillion: 2,
+        model: "grok-4.5",
+        outputUsdPerMillion: 6,
+        provider: "xai",
+        rateId: "xai:2026-07-17:grok-4.5:standard",
       }),
     );
   });

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -1,5 +1,7 @@
 export type TokenUsagePricingServiceTier = "standard" | "priority";
 
+export type TokenUsagePricingProvider = "openai" | "xai";
+
 export type TokenUsagePriceStatus = "priced" | "unpriced";
 
 export type TokenUsagePriceUnavailableReason =
@@ -139,7 +141,7 @@ export type TokenUsagePricingCatalogRate = {
   model: string;
   outputMicrosPerMillion: number;
   outputUsdPerMillion: number;
-  provider: "openai";
+  provider: TokenUsagePricingProvider;
   rateId: string;
   serviceTier: TokenUsagePricingServiceTier;
 };
@@ -156,10 +158,11 @@ export type TokenUsageCostEstimate = {
   effectiveTo?: number;
   inputUsdPerMillion: number;
   model: string;
+  outputTokensIncludeReasoning: boolean;
   outputCostMicros: number;
   outputUsd: number;
   outputUsdPerMillion: number;
-  provider: "openai";
+  provider: TokenUsagePricingProvider;
   rateId: string;
   serviceTier: TokenUsagePricingServiceTier;
   standardCachedInputRateMultiplier?: number;
@@ -196,6 +199,7 @@ export type TokenUsageCreditEstimate = {
 };
 
 type PricingCatalogEntry = {
+  aliases?: readonly string[];
   cachedInputUsdPerMillion: number;
   catalogId: string;
   catalogVersion: string;
@@ -206,7 +210,8 @@ type PricingCatalogEntry = {
   inputUsdPerMillion: number;
   model: string;
   outputUsdPerMillion: number;
-  provider: "openai";
+  outputTokensIncludeReasoning?: boolean;
+  provider: TokenUsagePricingProvider;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -234,6 +239,9 @@ const OPENAI_GPT56_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 9);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-09";
+const XAI_PRICING_CATALOG_ID = "xai-api";
+const XAI_PRICING_CATALOG_VERSION = "2026-07-17";
+const XAI_GROK45_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 8);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
@@ -394,6 +402,33 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   },
 ];
 
+const XAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  {
+    aliases: [
+      "grok-4.5-build",
+      "grok-4.5-latest",
+      "grok-build-latest",
+    ],
+    catalogId: XAI_PRICING_CATALOG_ID,
+    catalogVersion: XAI_PRICING_CATALOG_VERSION,
+    model: "grok-4.5",
+    displayModel: "Grok 4.5",
+    displayTier: "Standard",
+    effectiveFrom: XAI_GROK45_PRICING_EFFECTIVE_FROM,
+    outputTokensIncludeReasoning: true,
+    provider: "xai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 2,
+    cachedInputUsdPerMillion: 0.3,
+    outputUsdPerMillion: 6,
+  },
+];
+
+const TOKEN_USAGE_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  ...OPENAI_PRICING_CATALOG,
+  ...XAI_PRICING_CATALOG,
+];
+
 const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
   {
     catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
@@ -549,6 +584,10 @@ export function listOpenAiTokenUsagePricingRates(): TokenUsagePricingCatalogRate
   return OPENAI_PRICING_CATALOG.map(toPublicRate);
 }
 
+export function listTokenUsagePricingRates(): TokenUsagePricingCatalogRate[] {
+  return TOKEN_USAGE_PRICING_CATALOG.map(toPublicRate);
+}
+
 export function estimateOpenAiTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
@@ -560,30 +599,69 @@ export function estimateOpenAiTokenUsageCost(params: {
   serviceTier?: string;
   uncachedInputTokens: number;
 }): TokenUsageCostEstimate | undefined {
+  return estimateTokenUsageCostFromCatalog(params, OPENAI_PRICING_CATALOG);
+}
+
+export function estimateTokenUsageCost(params: {
+  cachedInputTokens: number;
+  at?: number;
+  fastMode?: boolean;
+  outputTokensIncludeReasoning?: boolean;
+  model?: string;
+  outputTokens: number;
+  reasoningOutputTokens?: number;
+  serviceTier?: string;
+  uncachedInputTokens: number;
+}): TokenUsageCostEstimate | undefined {
+  return estimateTokenUsageCostFromCatalog(params, TOKEN_USAGE_PRICING_CATALOG);
+}
+
+function estimateTokenUsageCostFromCatalog(
+  params: {
+    cachedInputTokens: number;
+    at?: number;
+    fastMode?: boolean;
+    outputTokensIncludeReasoning?: boolean;
+    model?: string;
+    outputTokens: number;
+    reasoningOutputTokens?: number;
+    serviceTier?: string;
+    uncachedInputTokens: number;
+  },
+  catalog: readonly PricingCatalogEntry[],
+): TokenUsageCostEstimate | undefined {
   const model = params.model?.trim();
   if (!model) {
     return undefined;
   }
 
-  const serviceTier = resolveOpenAiPricingServiceTier({
-    fastMode: params.fastMode,
-    serviceTier: params.serviceTier,
-  });
-  const entry = OPENAI_PRICING_CATALOG.find(
+  const matchingEntries = catalog.filter(
     (candidate) =>
-      candidate.model === model &&
-      candidate.serviceTier === serviceTier &&
-      pricingEntryAppliesAt(candidate, params.at),
+      pricingEntryMatchesModel(candidate, model)
+      && pricingEntryAppliesAt(candidate, params.at),
+  );
+  const provider = matchingEntries[0]?.provider;
+  const serviceTier =
+    provider === "xai"
+      ? resolveXaiPricingServiceTier(params.serviceTier)
+      : resolveOpenAiPricingServiceTier({
+          fastMode: params.fastMode,
+          serviceTier: params.serviceTier,
+        });
+  const entry = matchingEntries.find(
+    (candidate) =>
+      candidate.serviceTier === serviceTier,
   );
   if (!entry) {
     return undefined;
   }
 
-  const standardEntry = OPENAI_PRICING_CATALOG.find(
+  const standardEntry = catalog.find(
     (candidate) =>
-      candidate.model === model &&
-      candidate.serviceTier === "standard" &&
-      pricingEntryAppliesAt(candidate, params.at),
+      candidate.model === entry.model
+      && candidate.provider === entry.provider
+      && candidate.serviceTier === "standard"
+      && pricingEntryAppliesAt(candidate, params.at),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
     params.uncachedInputTokens,
@@ -593,7 +671,11 @@ export function estimateOpenAiTokenUsageCost(params: {
     params.cachedInputTokens,
     entry.cachedInputUsdPerMillion,
   );
-  const billedOutputTokens = params.outputTokensIncludeReasoning
+  const outputTokensIncludeReasoning =
+    params.outputTokensIncludeReasoning
+    ?? entry.outputTokensIncludeReasoning
+    ?? false;
+  const billedOutputTokens = outputTokensIncludeReasoning
     ? params.outputTokens
     : params.outputTokens + Math.max(0, params.reasoningOutputTokens ?? 0);
   const outputCostMicros = calculateTokenCostMicros(
@@ -618,6 +700,7 @@ export function estimateOpenAiTokenUsageCost(params: {
     ...(entry.effectiveTo ? { effectiveTo: entry.effectiveTo } : {}),
     inputUsdPerMillion: entry.inputUsdPerMillion,
     model,
+    outputTokensIncludeReasoning,
     outputCostMicros,
     outputUsd,
     outputUsdPerMillion: entry.outputUsdPerMillion,
@@ -734,6 +817,15 @@ export function resolveOpenAiPricingServiceTier(params: {
   return undefined;
 }
 
+function resolveXaiPricingServiceTier(
+  serviceTier: string | undefined,
+): TokenUsagePricingServiceTier | undefined {
+  const normalized = serviceTier?.trim().toLowerCase();
+  return !normalized || normalized === "default" || normalized === "standard"
+    ? "standard"
+    : undefined;
+}
+
 export function formatTokenUsageUsd(value: number): string {
   if (value > 0 && value < 0.001) {
     return "<$0.001";
@@ -833,6 +925,13 @@ function pricingEntryAppliesAt(
     return entry.effectiveTo === undefined;
   }
   return entry.effectiveFrom <= at && (entry.effectiveTo === undefined || entry.effectiveTo > at);
+}
+
+function pricingEntryMatchesModel(
+  entry: PricingCatalogEntry,
+  model: string,
+): boolean {
+  return entry.model === model || entry.aliases?.includes(model) === true;
 }
 
 function buildPricingRateId(entry: PricingCatalogEntry): string {


### PR DESCRIPTION
## Summary

- add a provider-aware xAI pricing catalog for Grok 4.5
- canonicalize ACP/runtime model aliases including `grok-4.5-build`
- avoid double-billing Grok reasoning tokens because its reported output total already includes reasoning
- migrate previously unpriced Grok rows from the legacy OpenAI fallback to xAI pricing and summaries
- use the provider-aware estimator across live activity, persisted pricing, historical gaps, and monitor usage

## Root cause

PwrAgent's local list-price catalog only contained OpenAI models and required an exact model ID match. Grok ACP reported `grok-4.5-build`, while the public billable model is `grok-4.5`, so live and persisted usage remained unpriced. The old fallback also persisted those rows under provider `openai`.

Grok's usage contract reports reasoning as a subset of output tokens. The xAI catalog records that semantic so the displayed output cost does not add reasoning a second time.

## User impact

The captured request with 10,072 uncached input tokens, 11,136 cached tokens, and 45 output tokens now shows a `$0.024 list price` estimate instead of `Cost unavailable`. Existing affected rows are repaired by state database migration 29 and regrouped under provider `xai`.

## Grok ACP follow-up findings

Grok can also return exact server cost through `costUsdTicks`; PwrAgent currently uses the local comparable list-price estimate instead. Grok exposes aggregate subscription usage, weekly/monthly period, reset time, prepaid balance, on-demand limits, and subscription tier through `x.ai/billing`, but does not expose request-rate-limit remaining/reset values over ACP. Wiring that billing surface into backend status is intentionally outside this pricing fix.

## Validation

- `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts apps/desktop/src/main/__tests__/state-db.test.ts` — 85 passed
- `pnpm test` — 4,982/4,983 passed; one unrelated Git worktree-handoff test exceeded its 5-second timeout under full-suite load
- isolated rerun of that timed-out test — passed
- `pnpm lint:eslint` — 0 errors
- `pnpm lint:sql` — passed
- `pnpm lint:boundaries` — passed
- `pnpm --filter @pwragent/shared typecheck` — passed
- workspace/desktop typecheck remains blocked by the existing Agent Core AI SDK error at `packages/agent-core/src/providers/xai-ai-sdk-object-client.ts:56` (`instructions` is not accepted by the installed call type)
