### PR TITLE
fix(desktop): improve warning toast contrast

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5842,6 +5842,7 @@ export function Composer(props: ComposerProps) {
     props.onShowNotice?.({
       id: `composer-notice-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       ...notice,
+      tone: notice.tone ?? "warning",
     });
   };
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -11984,6 +11984,7 @@ describe("Composer", () => {
       expect.objectContaining({
         title: "Images not supported",
         message: expect.stringContaining("GPT-5.3-Codex-Spark"),
+        tone: "warning",
       })
     );
     expect(

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -12,6 +12,7 @@ export type AppNoticeToastNotice = {
   message: string;
   detail?: string;
   copyText?: string;
+  tone?: "neutral" | "warning";
 };
 
 export function AppNoticeToast(props: {
@@ -67,6 +68,7 @@ export function AppNoticeToast(props: {
   return (
     <aside
       className="app-notice-toast"
+      data-tone={props.notice.tone ?? "neutral"}
       role="status"
       aria-live="polite"
       onMouseEnter={() => setPaused(true)}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -41,6 +41,17 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("marks warning notices for high-contrast styling", () => {
+    render(
+      <AppNoticeToast
+        notice={{ ...notice, tone: "warning" }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveAttribute("data-tone", "warning");
+  });
+
   it("copies an explicit handoff value without rendering it", () => {
     const copyText = vi.fn(async () => undefined);
     const handoff = [

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -265,6 +265,23 @@ describe("Tangerine Terminal theme contract", () => {
     expect(warningBannerRule).toContain("-webkit-app-region: no-drag;");
   });
 
+  it("keeps warning notices distinct from dark app surfaces", () => {
+    const warningNoticeRule = extractRuleBody(
+      css,
+      '.app-notice-toast[data-tone="warning"]',
+    );
+
+    expect(warningNoticeRule).toContain(
+      "border-color: color-mix(in srgb, var(--status-warning) 52%, var(--border-subtle));",
+    );
+    expect(warningNoticeRule).toContain(
+      "background: color-mix(in srgb, var(--bg-panel-elevated) 92%, var(--status-warning) 8%);",
+    );
+    expect(css).toMatch(
+      /\.app-notice-toast\[data-tone="warning"\] \.app-notice-toast__eyebrow\s*\{[\s\S]*?color:\s*var\(--status-warning\);[\s\S]*?\}/,
+    );
+  });
+
   it("lets transcript scroll restoration own scroll anchoring", () => {
     expect(css).toMatch(
       /\.transcript-list__items\s*\{[\s\S]*?overflow-anchor:\s*none;[\s\S]*?\}/

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4996,6 +4996,11 @@ textarea,
   background: color-mix(in srgb, var(--bg-panel-elevated) 96%, var(--text-muted) 4%);
 }
 
+.app-notice-toast[data-tone="warning"] {
+  border-color: color-mix(in srgb, var(--status-warning) 52%, var(--border-subtle));
+  background: color-mix(in srgb, var(--bg-panel-elevated) 92%, var(--status-warning) 8%);
+}
+
 .app-update-banner {
   border: 1px solid var(--accent-border);
   background: color-mix(in srgb, var(--bg-panel-elevated) 94%, var(--accent) 6%);
@@ -5019,6 +5024,10 @@ textarea,
 
 .app-notice-toast__eyebrow {
   color: var(--text-secondary);
+}
+
+.app-notice-toast[data-tone="warning"] .app-notice-toast__eyebrow {
+  color: var(--status-warning);
 }
 
 .app-update-banner__eyebrow {
@@ -5090,6 +5099,10 @@ textarea,
   background: color-mix(in srgb, var(--text-muted) 42%, transparent);
   transform-origin: left center;
   animation: app-notice-toast-countdown 9000ms linear forwards;
+}
+
+.app-notice-toast[data-tone="warning"] .app-notice-toast__timer {
+  background: color-mix(in srgb, var(--status-warning) 72%, transparent);
 }
 
 .app-notice-toast__timer[data-paused="true"] {


### PR DESCRIPTION
## Summary

- I added a semantic warning tone to app notice toasts, using the existing amber warning tokens for a more visible border, surface, heading, and countdown indicator.
- I applied the warning tone to composer attachment rejection and limit notices while leaving routine notices neutral.
- I added component and theme-contract coverage for the warning treatment.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` (245 tests passed).
- I ran `pnpm lint:colors`.
- I ran `pnpm lint:eslint` (0 errors; existing warning baseline only).
- I ran `pnpm typecheck`.
- I ran `git diff --check`.

## Notes

- Neutral app notices keep their existing appearance.
- The checkpoint commit is signed.
