### PR TITLE
fix(desktop): preserve provider launchpad settings

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8066,6 +8066,10 @@ name = "Codex Environment"
 
 [setup]
 script = "pnpm install"
+
+[[actions]]
+name = "Codex action"
+command = "pnpm codex"
 `,
       "utf8",
     );
@@ -8074,6 +8078,10 @@ script = "pnpm install"
       `
 version = 1
 name = "Grok Environment"
+
+[[actions]]
+name = "Grok action"
+command = "pnpm grok"
 `,
       "utf8",
     );
@@ -8101,6 +8109,7 @@ name = "Grok Environment"
         patch: {
           codexEnvironmentId: "codex",
           codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "codex-action",
         },
         stickySettingsChanged: true,
       });
@@ -8108,6 +8117,7 @@ name = "Grok Environment"
         backend: "codex",
         codexEnvironmentId: "codex",
         codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentActionId: "codex-action",
       });
 
       const switchedToAcp = await registry.updateDirectoryLaunchpad({
@@ -8138,6 +8148,7 @@ name = "Grok Environment"
         patch: {
           codexEnvironmentId: "grok",
           codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "grok-action",
         },
         stickySettingsChanged: true,
       });
@@ -8145,6 +8156,7 @@ name = "Grok Environment"
         backend: "acp:kimi",
         codexEnvironmentId: "grok",
         codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentActionId: "grok-action",
       });
 
       const restoredCodex = await registry.updateDirectoryLaunchpad({
@@ -8158,6 +8170,7 @@ name = "Grok Environment"
         backend: "codex",
         codexEnvironmentId: "codex",
         codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentActionId: "codex-action",
       });
 
       const restoredAcp = await registry.updateDirectoryLaunchpad({
@@ -8171,6 +8184,7 @@ name = "Grok Environment"
         backend: "acp:kimi",
         codexEnvironmentId: "grok",
         codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentActionId: "grok-action",
       });
       expect(restoredAcp.launchpad.codexEnvironmentOptions).toMatchObject([
         {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8055,17 +8055,25 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("keeps environment options available after switching a launchpad to ACP", async () => {
+  it("keeps environment selections scoped across repeated Codex and ACP flips", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-acp-env-options-"));
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
     await writeFile(
-      path.join(root, ".codex", "environments", "environment.toml"),
+      path.join(root, ".codex", "environments", "codex.toml"),
       `
 version = 1
-name = "Repo Environment"
+name = "Codex Environment"
 
 [setup]
 script = "pnpm install"
+`,
+      "utf8",
+    );
+    await writeFile(
+      path.join(root, ".codex", "environments", "grok.toml"),
+      `
+version = 1
+name = "Grok Environment"
 `,
       "utf8",
     );
@@ -8088,22 +8096,91 @@ script = "pnpm install"
         directoryPath: root,
       });
 
-      const updated = await registry.updateDirectoryLaunchpad({
+      const codexSelected = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          codexEnvironmentId: "codex",
+          codexEnvironmentExecutionTarget: "local",
+        },
+        stickySettingsChanged: true,
+      });
+      expect(codexSelected.launchpad).toMatchObject({
+        backend: "codex",
+        codexEnvironmentId: "codex",
+        codexEnvironmentExecutionTarget: "local",
+      });
+
+      const switchedToAcp = await registry.updateDirectoryLaunchpad({
         directoryKey: `directory:${root}`,
         patch: {
           backend: "acp:kimi" as AcpBackendId,
-          codexEnvironmentId: undefined,
-          codexEnvironmentExecutionTarget: undefined,
-          codexEnvironmentActionId: undefined,
         },
+        stickySettingsChanged: true,
+      });
+      expect(switchedToAcp.launchpad).toMatchObject({
+        backend: "acp:kimi",
+        codexEnvironmentOptions: [
+          {
+            id: "codex",
+            name: "Codex Environment",
+            setupScript: "pnpm install",
+          },
+          {
+            id: "grok",
+            name: "Grok Environment",
+          },
+        ],
+      });
+      expect(switchedToAcp.launchpad.codexEnvironmentId).toBeUndefined();
+
+      const acpSelected = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          codexEnvironmentId: "grok",
+          codexEnvironmentExecutionTarget: "local",
+        },
+        stickySettingsChanged: true,
+      });
+      expect(acpSelected.launchpad).toMatchObject({
+        backend: "acp:kimi",
+        codexEnvironmentId: "grok",
+        codexEnvironmentExecutionTarget: "local",
       });
 
-      expect(updated.launchpad.backend).toBe("acp:kimi");
-      expect(updated.launchpad.codexEnvironmentOptions).toMatchObject([
+      const restoredCodex = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          backend: "codex",
+        },
+        stickySettingsChanged: true,
+      });
+      expect(restoredCodex.launchpad).toMatchObject({
+        backend: "codex",
+        codexEnvironmentId: "codex",
+        codexEnvironmentExecutionTarget: "local",
+      });
+
+      const restoredAcp = await registry.updateDirectoryLaunchpad({
+        directoryKey: `directory:${root}`,
+        patch: {
+          backend: "acp:kimi" as AcpBackendId,
+        },
+        stickySettingsChanged: true,
+      });
+      expect(restoredAcp.launchpad).toMatchObject({
+        backend: "acp:kimi",
+        codexEnvironmentId: "grok",
+        codexEnvironmentExecutionTarget: "local",
+      });
+      expect(restoredAcp.launchpad.codexEnvironmentOptions).toMatchObject([
         {
-          id: "environment",
-          name: "Repo Environment",
+          id: "codex",
+          name: "Codex Environment",
           setupScript: "pnpm install",
+        },
+        {
+          id: "grok",
+          name: "Grok Environment",
         },
       ]);
     } finally {

--- a/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-config.test.ts
@@ -127,6 +127,8 @@ command = "pnpm dev:alt"
       directoryPath: "/repo",
       backend: "acp:kimi",
       executionMode: "default",
+      codexEnvironmentId: "environment",
+      codexEnvironmentActionId: "start-dev",
       prompt: "",
       workMode: "local",
       createdAt: 1,
@@ -140,11 +142,19 @@ command = "pnpm dev:alt"
           name: "Repo Environment",
           sourcePath: "/repo/.codex/environments/environment.toml",
           setupScript: "pnpm install",
-          actions: [],
+          actions: [
+            {
+              id: "start-dev",
+              name: "Start dev",
+              command: "pnpm dev",
+            },
+          ],
         },
       ]),
     ).toMatchObject({
       backend: "acp:kimi",
+      codexEnvironmentActionId: "start-dev",
+      codexEnvironmentId: "environment",
       codexEnvironmentOptions: [
         {
           id: "environment",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5169,6 +5169,8 @@ describe("MessagingController", () => {
         codexEnvironmentId: "codex-environment",
         codexEnvironmentExecutionTarget: "local",
         codexEnvironmentActionId: "codex-action",
+        model: "shared-model",
+        reasoningEffort: "high",
         codexEnvironmentOptions: [
           {
             id: "codex-environment",
@@ -5188,11 +5190,15 @@ describe("MessagingController", () => {
             codexEnvironmentId: "codex-environment",
             codexEnvironmentExecutionTarget: "local",
             codexEnvironmentActionId: "codex-action",
+            model: "shared-model",
+            reasoningEffort: "high",
           },
           grok: {
             codexEnvironmentId: "grok-environment",
             codexEnvironmentExecutionTarget: "local",
             codexEnvironmentActionId: "grok-action",
+            model: "grok-4.20-reasoning",
+            reasoningEffort: "low",
           },
         },
       },
@@ -5215,7 +5221,10 @@ describe("MessagingController", () => {
             kind: "codex",
             label: "Codex",
             launchpadOptions: {
-              models: [{ id: "gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+              models: [
+                { id: "shared-model", label: "Shared Model" },
+                { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+              ],
               reasoningEfforts: ["low", "medium", "high"],
               supportsFastMode: true,
             },
@@ -5224,7 +5233,10 @@ describe("MessagingController", () => {
             kind: "grok",
             label: "Grok",
             launchpadOptions: {
-              models: [{ id: "grok-4.20-reasoning", label: "Grok 4.20 Reasoning" }],
+              models: [
+                { id: "shared-model", label: "Shared Model" },
+                { id: "grok-4.20-reasoning", label: "Grok 4.20 Reasoning" },
+              ],
               reasoningEfforts: ["low", "medium", "high"],
               supportsFastMode: false,
             },
@@ -5260,6 +5272,25 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-model",
+        value: { model: "shared-model" },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-reasoning",
+        value: { reasoningEffort: "high" },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-environment",
+        value: { environmentId: "codex-environment" },
+      }),
+    );
+
+    await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "browse:new:backend" }),
     );
     expect(harness.delivered.at(-1)).toMatchObject({
@@ -5291,7 +5322,7 @@ describe("MessagingController", () => {
       kind: "confirmation",
       title: "Ready to start",
       body: expect.stringContaining(
-        "Provider: Grok\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Grok Environment",
+        "Provider: Grok\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Grok Environment\nModel: grok-4.20-reasoning\nReasoning: low",
       ),
       actions: expect.arrayContaining([
         expect.objectContaining({
@@ -5313,6 +5344,40 @@ describe("MessagingController", () => {
       },
     });
 
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:backend" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-backend",
+        value: { backend: "codex" },
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining(
+        "Provider: Codex\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Codex Environment\nModel: shared-model\nReasoning: high",
+      ),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:backend" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:new:set-backend",
+        value: { backend: "grok" },
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining(
+        "Provider: Grok\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Grok Environment\nModel: grok-4.20-reasoning\nReasoning: low",
+      ),
+    });
+
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
 
     expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
@@ -5323,6 +5388,8 @@ describe("MessagingController", () => {
           codexEnvironmentActionId: "grok-action",
           codexEnvironmentExecutionTarget: "local",
           codexEnvironmentId: "grok-environment",
+          model: "grok-4.20-reasoning",
+          reasoningEffort: "low",
         }),
       }),
       expectMaterializeOptions(),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5160,7 +5160,54 @@ describe("MessagingController", () => {
   });
 
   it("lets a pending new-thread session switch providers before creation", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      launchpad: {
+        ...navigation.directories[0]!.launchpad!,
+        backend: "codex",
+        codexEnvironmentId: "codex-environment",
+        codexEnvironmentExecutionTarget: "local",
+        codexEnvironmentActionId: "codex-action",
+        codexEnvironmentOptions: [
+          {
+            id: "codex-environment",
+            name: "Codex Environment",
+            sourcePath: "/repo/pwragent/.codex/environments/codex.toml",
+            actions: [],
+          },
+          {
+            id: "grok-environment",
+            name: "Grok Environment",
+            sourcePath: "/repo/pwragent/.codex/environments/grok.toml",
+            actions: [],
+          },
+        ],
+        providerSettings: {
+          codex: {
+            codexEnvironmentId: "codex-environment",
+            codexEnvironmentExecutionTarget: "local",
+            codexEnvironmentActionId: "codex-action",
+          },
+          grok: {
+            codexEnvironmentId: "grok-environment",
+            codexEnvironmentExecutionTarget: "local",
+            codexEnvironmentActionId: "grok-action",
+          },
+        },
+      },
+    };
     const harness = await createHarness({
+      navigation,
+      // Exercise the controller's fallback projection when the sticky write
+      // fails and the next ensure still returns the outgoing provider.
+      ensureDirectoryLaunchpad: async () => ({
+        defaults: navigation.launchpadDefaults,
+        launchpad: navigation.directories[0]!.launchpad!,
+      }),
+      updateDirectoryLaunchpad: async () => {
+        throw new Error("sticky update unavailable");
+      },
       listBackends: async (): Promise<ListBackendsResponse> => ({
         fetchedAt: 1000,
         backends: [
@@ -5201,7 +5248,9 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Provider: Codex"),
+      body: expect.stringContaining(
+        "Provider: Codex\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Codex Environment",
+      ),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:backend",
@@ -5241,7 +5290,9 @@ describe("MessagingController", () => {
     expect(grokReadyIntent).toMatchObject({
       kind: "confirmation",
       title: "Ready to start",
-      body: expect.stringContaining("Provider: Grok"),
+      body: expect.stringContaining(
+        "Provider: Grok\nWorkspace: Local\nPermissions: Default Access\nEnvironment: Grok Environment",
+      ),
       actions: expect.arrayContaining([
         expect.objectContaining({
           id: "browse:new:backend",
@@ -5254,12 +5305,12 @@ describe("MessagingController", () => {
         expect.objectContaining({ id: "browse:new:fast" }),
       ]),
     });
-    expect(harness.updateDirectoryLaunchpad).toHaveBeenCalledWith({
+    expect(harness.updateDirectoryLaunchpad).toHaveBeenLastCalledWith({
       directoryKey: "directory:pwragent",
       stickySettingsChanged: true,
-      patch: expect.objectContaining({
+      patch: {
         backend: "grok",
-      }),
+      },
     });
 
     await harness.controller.handleInboundEvent(buildTextEvent("Fix bug with Grok"));
@@ -5267,20 +5318,27 @@ describe("MessagingController", () => {
     expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
         directoryKey: expect.stringMatching(/^messaging:browse:/),
+        launchpad: expect.objectContaining({
+          backend: "grok",
+          codexEnvironmentActionId: "grok-action",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentId: "grok-environment",
+        }),
+      }),
+      expectMaterializeOptions(),
+    );
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "grok",
+        threadId: "new-thread-1",
         input: [
           {
             type: "text",
             text: "Fix bug with Grok",
           },
         ],
-        launchpad: expect.objectContaining({
-          backend: "grok",
-          directoryKey: "directory:pwragent",
-        }),
       }),
-      expectMaterializeOptions(),
     );
-    expect(harness.startTurn).not.toHaveBeenCalled();
     await expect(
       harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
     ).resolves.toMatchObject({

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyNavigationLaunchpadProviderSettingsPatch,
+  type NavigationLaunchpadDraft,
+} from "@pwragent/shared";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { StateDb } from "../state/state-db";
 import {
@@ -124,6 +128,116 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
         },
       },
     });
+  });
+
+  it("persists provider-specific launchpad environments across a database reopen", async () => {
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-provider-launchpad-test-",
+    );
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+
+    const initialLaunchpad = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "full-access",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "ultra",
+      fastMode: true,
+      codexEnvironmentId: "codex-environment",
+      codexEnvironmentExecutionTarget: "local",
+      codexEnvironmentActionId: "codex-action",
+      providerSettings: {
+        codex: {
+          executionMode: "full-access",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "ultra",
+          fastMode: true,
+          codexEnvironmentId: "codex-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "codex-action",
+        },
+        "acp:grok": {
+          executionMode: "default",
+          model: "grok-4.5",
+          reasoningEffort: "high",
+          serviceTier: "standard",
+          acpRuntime: {
+            currentModeId: "default",
+          },
+          codexEnvironmentId: "grok-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "grok-action",
+        },
+      },
+      prompt: "Keep the draft",
+      workMode: "worktree",
+      branchName: "feature/provider-memory",
+      createdAt: 1,
+      updatedAt: 1,
+    } as unknown as NavigationLaunchpadDraft;
+
+    try {
+      await store.upsertDirectoryLaunchpad(
+        applyNavigationLaunchpadProviderSettingsPatch(initialLaunchpad, {
+          backend: "acp:grok",
+        }),
+      );
+      stateDb.close();
+
+      const reopenedDb = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopenedDb);
+      try {
+        const restoredGrok = await reopenedStore.getDirectoryLaunchpad({
+          directoryKey: "directory:/repo",
+        });
+        expect(restoredGrok).toMatchObject({
+          backend: "acp:grok",
+          executionMode: "default",
+          model: "grok-4.5",
+          reasoningEffort: "high",
+          serviceTier: "standard",
+          acpRuntime: {
+            currentModeId: "default",
+          },
+          codexEnvironmentId: "grok-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "grok-action",
+          prompt: "Keep the draft",
+          workMode: "worktree",
+          branchName: "feature/provider-memory",
+        });
+
+        const restoredCodex = applyNavigationLaunchpadProviderSettingsPatch(
+          restoredGrok!,
+          { backend: "codex" },
+        );
+        expect(restoredCodex).toMatchObject({
+          backend: "codex",
+          executionMode: "full-access",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "ultra",
+          fastMode: true,
+          codexEnvironmentId: "codex-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "codex-action",
+          prompt: "Keep the draft",
+          workMode: "worktree",
+          branchName: "feature/provider-memory",
+        });
+      } finally {
+        reopenedDb.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
   });
 
   it("removes stale launchpad default rows when a setting is cleared", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -138,7 +138,7 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
     stateDb = StateDb.open(dbPath);
     store = new SqliteOverlayStore(stateDb);
 
-    const initialLaunchpad = {
+    const initialLaunchpad: NavigationLaunchpadDraft = {
       directoryKey: "directory:/repo",
       directoryKind: "directory",
       directoryLabel: "Repo",
@@ -179,7 +179,7 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
       branchName: "feature/provider-memory",
       createdAt: 1,
       updatedAt: 1,
-    } as unknown as NavigationLaunchpadDraft;
+    };
 
     try {
       await store.upsertDirectoryLaunchpad(

--- a/apps/desktop/src/main/app-server/codex-environment-config.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-config.ts
@@ -103,12 +103,15 @@ export function withCodexEnvironmentOptions(
   const selectedEnvironment = options.find(
     (environment) => environment.id === launchpad.codexEnvironmentId,
   );
+  const selectedAction = selectedEnvironment?.actions.find(
+    (action) => action.id === launchpad.codexEnvironmentActionId,
+  );
   return {
     ...launchpadWithoutDeprecatedSetupFlag,
     codexEnvironmentId: selectedEnvironment?.id,
     codexEnvironmentExecutionTarget:
       launchpad.codexEnvironmentExecutionTarget ?? "local",
-    codexEnvironmentActionId: undefined,
+    codexEnvironmentActionId: selectedAction?.id,
     codexEnvironmentOptions: options,
   };
 }

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4453,10 +4453,6 @@ export class MessagingController {
       );
       await this.updateNewThreadStickySettings(normalizedSession, {
         backend: selectedBackend.kind,
-        fastMode: normalizedSession.preferences?.fastMode,
-        model: normalizedSession.preferences?.model,
-        reasoningEffort: normalizedSession.preferences?.reasoningEffort,
-        serviceTier: normalizedSession.preferences?.serviceTier,
       });
       await this.presentNewThreadPromptGate(
         normalizedSession,
@@ -5689,7 +5685,7 @@ export class MessagingController {
     const options = directory?.launchpad?.codexEnvironmentOptions ?? [];
     const currentEnvironmentId = resolveNewThreadCodexEnvironmentId(
       session,
-      directory,
+      directory?.launchpad,
     );
     if (options.length === 0 && !currentEnvironmentId) {
       await this.presentNewThreadPromptGate(session, event, navigation);
@@ -13268,7 +13264,10 @@ function newThreadOptionsForSession(
       ? "directory-launchpad"
       : "launchpad-defaults";
   const codexEnvironmentOptions = directoryLaunchpad?.codexEnvironmentOptions ?? [];
-  const codexEnvironmentId = resolveNewThreadCodexEnvironmentId(session, directory);
+  const codexEnvironmentId = resolveNewThreadCodexEnvironmentId(
+    session,
+    directoryLaunchpad,
+  );
   const selectedEnvironment = codexEnvironmentOptions.find(
     (environment) => environment.id === codexEnvironmentId,
   );
@@ -13376,14 +13375,14 @@ function newThreadPromptGateBody(
 
 function resolveNewThreadCodexEnvironmentId(
   session: MessagingBrowseSessionRecord,
-  directory: NavigationDirectorySummary | undefined,
+  launchpad: NavigationLaunchpadDraft | undefined,
 ): string | null | undefined {
   if (session.preferences?.codexEnvironmentId === null) {
     return null;
   }
   return (
     session.preferences?.codexEnvironmentId ??
-    directory?.launchpad?.codexEnvironmentId
+    launchpad?.codexEnvironmentId
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4443,13 +4443,25 @@ export class MessagingController {
       if (!selectedBackend) {
         return;
       }
+      const backendChanged =
+        selectedBackend.kind !==
+        (nextSession.backend ?? navigation.launchpadDefaults.backend);
+      const updatedAt = this.now();
       const normalizedSession = normalizeNewThreadSessionForBackend(
-        {
-          ...nextSession,
-          backend: selectedBackend.kind,
-        },
+        backendChanged
+          ? clearNewThreadProviderPreferences(
+              {
+                ...nextSession,
+                backend: selectedBackend.kind,
+              },
+              updatedAt,
+            )
+          : {
+              ...nextSession,
+              backend: selectedBackend.kind,
+            },
         selectedBackend,
-        this.now(),
+        updatedAt,
       );
       await this.updateNewThreadStickySettings(normalizedSession, {
         backend: selectedBackend.kind,
@@ -6163,7 +6175,7 @@ export class MessagingController {
         now: this.now(),
         model: options.supportsModel ? options.model : undefined,
         reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
-        serviceTier: preferences?.serviceTier,
+        serviceTier: options.serviceTier,
         fastMode: options.supportsFast ? options.fastMode : undefined,
         acpRuntime: options.acpRuntime,
         codexEnvironmentRuntime: started.codexEnvironmentRuntime,
@@ -6238,7 +6250,7 @@ export class MessagingController {
       fastMode: options.supportsFast ? options.fastMode : undefined,
       model: options.supportsModel ? options.model : undefined,
       reasoningEffort: options.supportsReasoning ? options.reasoningEffort : undefined,
-      serviceTier: preferences?.serviceTier,
+      serviceTier: options.serviceTier,
       acpRuntime: options.acpRuntime,
       agent: agentForNewThreadSession(session),
       ...(options.workMode === "worktree"
@@ -13134,6 +13146,39 @@ function normalizeNewThreadSessionForBackend(
   };
 }
 
+function clearNewThreadProviderPreferences(
+  session: MessagingBrowseSessionRecord,
+  updatedAt: number,
+): MessagingBrowseSessionRecord {
+  if (!session.preferences) {
+    return session;
+  }
+
+  const preferences = { ...session.preferences };
+  delete preferences.acpRuntime;
+  delete preferences.codexEnvironmentActionId;
+  delete preferences.codexEnvironmentExecutionTarget;
+  delete preferences.codexEnvironmentId;
+  delete preferences.codexEnvironmentSetupEnabled;
+  delete preferences.executionMode;
+  delete preferences.fastMode;
+  delete preferences.model;
+  delete preferences.permissionsMode;
+  delete preferences.reasoningEffort;
+  delete preferences.serviceTier;
+
+  const hasPreferences = Object.keys(preferences).some((key) => key !== "updatedAt");
+  return {
+    ...session,
+    preferences: hasPreferences
+      ? {
+          ...preferences,
+          updatedAt,
+        }
+      : undefined,
+  };
+}
+
 function defaultBackendModel(
   models: NonNullable<BackendSummary["launchpadOptions"]>["models"] = [],
 ) {
@@ -13201,6 +13246,7 @@ type NewThreadOptionsSummary = {
   fastMode: boolean;
   model: string;
   reasoningEffort?: string;
+  serviceTier?: string;
   supportsFast: boolean;
   supportsModel: boolean;
   supportsReasoning: boolean;
@@ -13236,14 +13282,22 @@ function newThreadOptionsForSession(
   const models = backend.launchpadOptions?.models ?? [];
   const modelOption =
     models.find((model) => model.id === session.preferences?.model) ??
+    models.find((model) => model.id === directoryLaunchpad?.model) ??
     models.find((model) => model.id === launchpadDefaults.model) ??
     models.find((model) => model.current) ??
     models[0];
   const reasoningEfforts = reasoningEffortsForModel(backend, modelOption);
   const reasoningEffort = resolveReasoningEffortForModel(backend, modelOption, [
     session.preferences?.reasoningEffort,
+    directoryLaunchpad?.reasoningEffort,
     launchpadDefaults.reasoningEffort,
   ]);
+  const serviceTiers = backend.launchpadOptions?.serviceTiers ?? [];
+  const serviceTier = [
+    session.preferences?.serviceTier,
+    directoryLaunchpad?.serviceTier,
+    launchpadDefaults.serviceTier,
+  ].find((candidate) => candidate ? serviceTiers.includes(candidate) : false);
   const supportsFast =
     Boolean(backend.launchpadOptions?.supportsFastMode) ||
     Boolean(modelOption?.supportsFast);
@@ -13291,10 +13345,14 @@ function newThreadOptionsForSession(
     executionModeSource,
     fastMode:
       supportsFast
-        ? session.preferences?.fastMode ?? launchpadDefaults.fastMode ?? false
+        ? session.preferences?.fastMode ??
+          directoryLaunchpad?.fastMode ??
+          launchpadDefaults.fastMode ??
+          false
         : false,
     model: session.preferences?.model ?? modelOption?.id ?? "default",
     reasoningEffort,
+    serviceTier,
     supportsFast,
     supportsModel: models.length > 0,
     supportsReasoning,
@@ -14849,7 +14907,7 @@ function launchpadForMessagingProject(params: {
     reasoningEffort: params.options.supportsReasoning
       ? params.options.reasoningEffort
       : undefined,
-    serviceTier: params.preferences?.serviceTier,
+    serviceTier: params.options.serviceTier,
     fastMode: params.options.supportsFast ? params.options.fastMode : undefined,
     prompt: "",
     workMode: params.workMode,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7971,32 +7971,12 @@ export function Composer(props: ComposerProps) {
                 value: candidate.kind,
               }))}
               onChange={(value) => {
-                const currentLaunchpad = props.launchpad;
-                if (!currentLaunchpad) {
+                if (!props.launchpad) {
                   return;
                 }
                 const nextBackend = value as NavigationLaunchpadDraft["backend"];
-                const nextBackendSummary = props.backends?.find(
-                  (candidate) => candidate.kind === nextBackend
-                );
-                const executionModeStillAvailable = nextBackendSummary?.executionModes.some(
-                  (mode) => mode.available && mode.mode === currentLaunchpad.executionMode
-                );
-                const nextModelOption = getDefaultModelOption(nextBackendSummary);
                 handleLaunchpadPatch({
                   backend: nextBackend,
-                  executionMode: executionModeStillAvailable
-                    ? currentLaunchpad.executionMode
-                    : "default",
-                  model: nextModelOption?.id,
-                  reasoningEffort: nextModelOption?.supportsReasoning
-                    ? getDefaultReasoningEffort(nextBackendSummary, nextModelOption)
-                    : undefined,
-                  serviceTier: undefined,
-                  fastMode: undefined,
-                  codexEnvironmentId: undefined,
-                  codexEnvironmentExecutionTarget: undefined,
-                  codexEnvironmentActionId: undefined,
                 });
               }}
             />

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1807,7 +1807,10 @@ describe("Composer", () => {
           onUpdateLaunchpad={async (_directoryKey, patch) => {
             providerPatches.push(patch);
             setLaunchpad((current) =>
-              applyNavigationLaunchpadProviderSettingsPatch(current, patch),
+              applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+                current,
+                patch,
+              ),
             );
           }}
           skills={[]}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1717,7 +1717,7 @@ describe("Composer", () => {
         },
       },
     } satisfies BackendSummary;
-    const initialLaunchpad = {
+    const initialLaunchpad: NavigationLaunchpadDraft = {
       directoryKey: "directory:/repo",
       directoryKind: "directory",
       directoryLabel: "Repo",
@@ -1779,13 +1779,11 @@ describe("Composer", () => {
       branchName: "feature/provider-memory",
       createdAt: 1,
       updatedAt: 1,
-    } as unknown as NavigationLaunchpadDraft;
+    };
     const providerPatches: Array<Partial<NavigationLaunchpadDraft>> = [];
-    let currentLaunchpad = initialLaunchpad;
 
     function ProviderSwitchHarness(): React.JSX.Element {
       const [launchpad, setLaunchpad] = useState(initialLaunchpad);
-      currentLaunchpad = launchpad;
       return (
         <Composer
           backends={[codexBackend, grokBackend]}
@@ -1848,13 +1846,10 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Reasoning")).toHaveValue("low");
     expect(screen.getByLabelText("Service tier")).toHaveValue("priority");
     expect(screen.getByLabelText("Environment")).toHaveTextContent("Grok Environment");
-    expect(currentLaunchpad).toMatchObject({
-      codexEnvironmentActionId: "grok-action",
-      codexEnvironmentExecutionTarget: "local",
-      workMode: "worktree",
-      branchName: "feature/provider-memory",
-      prompt: "",
-    });
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("worktree");
+    expect(screen.getByLabelText("Base branch")).toHaveValue(
+      "feature/provider-memory",
+    );
 
     chooseDropdownOption("Reasoning", "medium");
     chooseDropdownOption("Service tier", "standard");
@@ -1872,13 +1867,10 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Reasoning")).toHaveValue("ultra");
     expect(screen.getByLabelText("Fast mode")).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByLabelText("Environment")).toHaveTextContent("Codex Environment");
-    expect(currentLaunchpad).toMatchObject({
-      codexEnvironmentActionId: "codex-action",
-      codexEnvironmentExecutionTarget: "local",
-      workMode: "worktree",
-      branchName: "feature/provider-memory",
-      prompt: "",
-    });
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("worktree");
+    expect(screen.getByLabelText("Base branch")).toHaveValue(
+      "feature/provider-memory",
+    );
 
     chooseDropdownOption("Provider", "Grok");
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,16 +1,17 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { StrictMode } from "react";
-import type {
-  BackendSummary,
-  CompactThreadRequest,
-  ComposerDraftRecoveryCandidate,
-  NavigationDirectorySummary,
-  NavigationThreadSummary,
-  NavigationLaunchpadDraft,
-  StartReviewRequest,
-  StartTurnRequest,
-  StartTurnResponse,
+import { StrictMode, useState } from "react";
+import {
+  applyNavigationLaunchpadProviderSettingsPatch,
+  type BackendSummary,
+  type CompactThreadRequest,
+  type ComposerDraftRecoveryCandidate,
+  type NavigationDirectorySummary,
+  type NavigationThreadSummary,
+  type NavigationLaunchpadDraft,
+  type StartReviewRequest,
+  type StartTurnRequest,
+  type StartTurnResponse,
 } from "@pwragent/shared";
 import type { JSONContent } from "@tiptap/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
@@ -1621,6 +1622,272 @@ describe("Composer", () => {
 
     expect(screen.getByLabelText("Model")).toHaveValue("grok-4.5");
     expect(screen.getByLabelText("Reasoning")).toHaveValue("high");
+  });
+
+  it("restores provider-specific launchpad settings across repeated OpenAI and Grok flips", async () => {
+    const codexBackend = {
+      ...backendSummary("codex", {
+        models: [
+          {
+            id: "gpt-5.6-sol",
+            label: "GPT-5.6 Sol",
+            current: true,
+            reasoningEfforts: ["medium", "high", "ultra"],
+            supportsFast: true,
+            supportsReasoning: true,
+          },
+          {
+            id: "gpt-5.6-luna",
+            label: "GPT-5.6 Luna",
+            reasoningEfforts: ["medium", "high"],
+            supportsFast: true,
+            supportsReasoning: true,
+          },
+        ],
+        reasoningEfforts: ["medium", "high", "ultra"],
+        supportsFastMode: true,
+      }),
+      label: "OpenAI",
+      executionModes: [
+        {
+          mode: "default" as const,
+          label: "Default Access",
+          available: true,
+          isDefault: true,
+        },
+        {
+          mode: "full-access" as const,
+          label: "Full Access",
+          available: true,
+        },
+      ],
+    } satisfies BackendSummary;
+    const grokBackend = {
+      ...backendSummary("acp:grok", {
+        models: [
+          {
+            id: "grok-4.5",
+            label: "Grok 4.5",
+            current: true,
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "medium", "high"],
+            supportsReasoning: true,
+          },
+          {
+            id: "grok-4.5-pro",
+            label: "Grok 4.5 Pro",
+            defaultReasoningEffort: "medium",
+            reasoningEfforts: ["low", "medium", "high"],
+            supportsReasoning: true,
+          },
+        ],
+        reasoningEfforts: ["low", "medium", "high"],
+        serviceTiers: ["standard", "priority"],
+      }),
+      label: "Grok CLI",
+      executionModes: [
+        {
+          mode: "default" as const,
+          label: "Default Access",
+          available: true,
+          isDefault: true,
+        },
+        {
+          mode: "full-access" as const,
+          label: "Full Access",
+          available: true,
+        },
+      ],
+      acp: {
+        registryId: "grok",
+        distributionKinds: ["local"],
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        runtime: {
+          schemaVersion: 1,
+          status: "discovered",
+          modes: {
+            availableModes: [
+              { id: "default", label: "Default" },
+              { id: "yolo", label: "YOLO" },
+            ],
+            currentModeId: "default",
+          },
+        },
+      },
+    } satisfies BackendSummary;
+    const initialLaunchpad = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "full-access",
+      model: "gpt-5.6-luna",
+      reasoningEffort: "high",
+      fastMode: true,
+      codexEnvironmentId: "codex-environment",
+      codexEnvironmentExecutionTarget: "local",
+      codexEnvironmentActionId: "codex-action",
+      codexEnvironmentOptions: [
+        {
+          id: "codex-environment",
+          name: "Codex Environment",
+          sourcePath: "/repo/.codex/environments/codex-environment.toml",
+          actions: [],
+        },
+        {
+          id: "grok-environment",
+          name: "Grok Environment",
+          sourcePath: "/repo/.codex/environments/grok-environment.toml",
+          actions: [],
+        },
+      ],
+      providerSettings: {
+        codex: {
+          executionMode: "full-access",
+          model: "gpt-5.6-luna",
+          reasoningEffort: "high",
+          reasoningEffortsByModel: {
+            "gpt-5.6-luna": "high",
+            "gpt-5.6-sol": "ultra",
+          },
+          fastMode: true,
+          codexEnvironmentId: "codex-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "codex-action",
+        },
+        "acp:grok": {
+          executionMode: "full-access",
+          model: "grok-4.5-pro",
+          reasoningEffort: "low",
+          reasoningEffortsByModel: {
+            "grok-4.5-pro": "low",
+          },
+          serviceTier: "priority",
+          acpRuntime: {
+            currentModeId: "yolo",
+          },
+          codexEnvironmentId: "grok-environment",
+          codexEnvironmentExecutionTarget: "local",
+          codexEnvironmentActionId: "grok-action",
+        },
+      },
+      prompt: "",
+      workMode: "worktree",
+      branchName: "feature/provider-memory",
+      createdAt: 1,
+      updatedAt: 1,
+    } as unknown as NavigationLaunchpadDraft;
+    const providerPatches: Array<Partial<NavigationLaunchpadDraft>> = [];
+    let currentLaunchpad = initialLaunchpad;
+
+    function ProviderSwitchHarness(): React.JSX.Element {
+      const [launchpad, setLaunchpad] = useState(initialLaunchpad);
+      currentLaunchpad = launchpad;
+      return (
+        <Composer
+          backends={[codexBackend, grokBackend]}
+          directory={{
+            key: "directory:/repo",
+            kind: "directory",
+            label: "Repo",
+            path: "/repo",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            gitStatus: {
+              currentBranch: "feature/provider-memory",
+              branches: ["feature/provider-memory", "main"],
+              syncState: "in-sync",
+            },
+          }}
+          fullAccessRiskWarningDismissed
+          launchpad={launchpad}
+          onUpdateLaunchpad={async (_directoryKey, patch) => {
+            providerPatches.push(patch);
+            setLaunchpad((current) =>
+              applyNavigationLaunchpadProviderSettingsPatch(current, patch),
+            );
+          }}
+          skills={[]}
+        />
+      );
+    }
+
+    render(<ProviderSwitchHarness />);
+
+    expect(screen.getByLabelText("Access mode")).toHaveValue("full-access");
+    expect(screen.getByLabelText("Model")).toHaveValue("gpt-5.6-luna");
+    expect(screen.getByLabelText("Reasoning")).toHaveValue("high");
+    expect(screen.getByLabelText("Fast mode")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("Codex Environment");
+
+    chooseDropdownOption("Model", "GPT-5.6 Sol");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Model")).toHaveValue("gpt-5.6-sol");
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("ultra");
+    });
+
+    chooseDropdownOption("Provider", "Grok");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Provider")).toHaveValue("acp:grok");
+    });
+    expect(providerPatches.at(-1)).toEqual({
+      backend: "acp:grok",
+      fileAttachments: undefined,
+      imageAttachments: undefined,
+      prompt: "",
+    });
+    expect(screen.getByLabelText("Access mode")).toHaveValue("full-access");
+    expect(screen.getByLabelText("Agent mode")).toHaveValue("yolo");
+    expect(screen.getByLabelText("Model")).toHaveValue("grok-4.5-pro");
+    expect(screen.getByLabelText("Reasoning")).toHaveValue("low");
+    expect(screen.getByLabelText("Service tier")).toHaveValue("priority");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("Grok Environment");
+    expect(currentLaunchpad).toMatchObject({
+      codexEnvironmentActionId: "grok-action",
+      codexEnvironmentExecutionTarget: "local",
+      workMode: "worktree",
+      branchName: "feature/provider-memory",
+      prompt: "",
+    });
+
+    chooseDropdownOption("Reasoning", "medium");
+    chooseDropdownOption("Service tier", "standard");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("medium");
+      expect(screen.getByLabelText("Service tier")).toHaveValue("standard");
+    });
+
+    chooseDropdownOption("Provider", "OpenAI");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Provider")).toHaveValue("codex");
+    });
+    expect(screen.getByLabelText("Access mode")).toHaveValue("full-access");
+    expect(screen.getByLabelText("Model")).toHaveValue("gpt-5.6-sol");
+    expect(screen.getByLabelText("Reasoning")).toHaveValue("ultra");
+    expect(screen.getByLabelText("Fast mode")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("Environment")).toHaveTextContent("Codex Environment");
+    expect(currentLaunchpad).toMatchObject({
+      codexEnvironmentActionId: "codex-action",
+      codexEnvironmentExecutionTarget: "local",
+      workMode: "worktree",
+      branchName: "feature/provider-memory",
+      prompt: "",
+    });
+
+    chooseDropdownOption("Provider", "Grok");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Provider")).toHaveValue("acp:grok");
+      expect(screen.getByLabelText("Model")).toHaveValue("grok-4.5-pro");
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("medium");
+      expect(screen.getByLabelText("Service tier")).toHaveValue("standard");
+      expect(screen.getByLabelText("Agent mode")).toHaveValue("yolo");
+      expect(screen.getByLabelText("Environment")).toHaveTextContent(
+        "Grok Environment",
+      );
+    });
   });
 
   it("sends effective model defaults for threads without saved model settings", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3591,7 +3591,7 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
   });
 
-  it("restores server-confirmed reasoning when a launchpad model changes", async () => {
+  it("atomically restores remembered reasoning when a launchpad model changes", async () => {
     const defaults: NavigationLaunchpadDefaults = {
       backend: "codex",
       executionMode: "default",
@@ -3623,35 +3623,51 @@ describe("useThreadNavigation", () => {
       createdAt: 1,
       updatedAt: 1,
     };
+    const terraUpdate = createDeferred<{
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    }>();
+    const solUpdate = createDeferred<{
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    }>();
     const updateDirectoryLaunchpad = vi
       .fn()
-      .mockResolvedValueOnce({
-        defaults: {
-          ...defaults,
-          model: "gpt-5.6-terra",
-          reasoningEffort: "medium",
-        },
-        launchpad: {
-          ...launchpad,
-          model: "gpt-5.6-terra",
-          reasoningEffort: "medium",
-          providerSettings: {
-            codex: {
-              ...launchpad.providerSettings?.codex,
-              model: "gpt-5.6-terra",
-              reasoningEffort: "medium",
-            },
+      .mockReturnValueOnce(terraUpdate.promise)
+      .mockReturnValueOnce(solUpdate.promise);
+    const terraResponse = {
+      defaults: {
+        ...defaults,
+        model: "gpt-5.6-terra",
+        reasoningEffort: "medium",
+      },
+      launchpad: {
+        ...launchpad,
+        model: "gpt-5.6-terra",
+        reasoningEffort: "medium",
+        providerSettings: {
+          codex: {
+            ...launchpad.providerSettings?.codex,
+            model: "gpt-5.6-terra",
+            reasoningEffort: "medium",
           },
-          updatedAt: 2,
         },
-      })
-      .mockResolvedValueOnce({
-        defaults,
-        launchpad: {
-          ...launchpad,
-          updatedAt: 3,
-        },
-      });
+        updatedAt: 2,
+      },
+    } satisfies {
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    };
+    const solResponse = {
+      defaults,
+      launchpad: {
+        ...launchpad,
+        updatedAt: 3,
+      },
+    } satisfies {
+      defaults: NavigationLaunchpadDefaults;
+      launchpad: NavigationLaunchpadDraft;
+    };
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,
       fetchedAt: Date.now(),
@@ -3683,8 +3699,9 @@ describe("useThreadNavigation", () => {
       expect(result.current.selectedLaunchpad?.reasoningEffort).toBe("high");
     });
 
-    await act(async () => {
-      await result.current.updateDirectoryLaunchpad(
+    let firstUpdate: Promise<void> | undefined;
+    act(() => {
+      firstUpdate = result.current.updateDirectoryLaunchpad(
         launchpad.directoryKey,
         { model: "gpt-5.6-terra" },
         { stickySettingsChanged: true },
@@ -3697,7 +3714,13 @@ describe("useThreadNavigation", () => {
     });
 
     await act(async () => {
-      await result.current.updateDirectoryLaunchpad(
+      terraUpdate.resolve(terraResponse);
+      await firstUpdate;
+    });
+
+    let secondUpdate: Promise<void> | undefined;
+    act(() => {
+      secondUpdate = result.current.updateDirectoryLaunchpad(
         launchpad.directoryKey,
         { model: "gpt-5.6-sol" },
         { stickySettingsChanged: true },
@@ -3707,6 +3730,11 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad).toMatchObject({
       model: "gpt-5.6-sol",
       reasoningEffort: "high",
+    });
+
+    await act(async () => {
+      solUpdate.resolve(solResponse);
+      await secondUpdate;
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3591,6 +3591,125 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedLaunchpad?.prompt).toBe("newer prompt");
   });
 
+  it("restores server-confirmed reasoning when a launchpad model changes", async () => {
+    const defaults: NavigationLaunchpadDefaults = {
+      backend: "codex",
+      executionMode: "default",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    };
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/Users/huntharo/github/PwrAgent",
+      directoryKind: "directory",
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/github/PwrAgent",
+      backend: "codex",
+      executionMode: "default",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      providerSettings: {
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          reasoningEffortsByModel: {
+            "gpt-5.6-sol": "high",
+            "gpt-5.6-terra": "medium",
+          },
+        },
+      },
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const updateDirectoryLaunchpad = vi
+      .fn()
+      .mockResolvedValueOnce({
+        defaults: {
+          ...defaults,
+          model: "gpt-5.6-terra",
+          reasoningEffort: "medium",
+        },
+        launchpad: {
+          ...launchpad,
+          model: "gpt-5.6-terra",
+          reasoningEffort: "medium",
+          providerSettings: {
+            codex: {
+              ...launchpad.providerSettings?.codex,
+              model: "gpt-5.6-terra",
+              reasoningEffort: "medium",
+            },
+          },
+          updatedAt: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        defaults,
+        launchpad: {
+          ...launchpad,
+          updatedAt: 3,
+        },
+      });
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [
+        {
+          key: launchpad.directoryKey,
+          kind: "directory" as const,
+          label: launchpad.directoryLabel,
+          path: launchpad.directoryPath,
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad,
+        },
+      ],
+      launchpadDefaults: defaults,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedLaunchpad?.reasoningEffort).toBe("high");
+    });
+
+    await act(async () => {
+      await result.current.updateDirectoryLaunchpad(
+        launchpad.directoryKey,
+        { model: "gpt-5.6-terra" },
+        { stickySettingsChanged: true },
+      );
+    });
+
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      model: "gpt-5.6-terra",
+      reasoningEffort: "medium",
+    });
+
+    await act(async () => {
+      await result.current.updateDirectoryLaunchpad(
+        launchpad.directoryKey,
+        { model: "gpt-5.6-sol" },
+        { stickySettingsChanged: true },
+      );
+    });
+
+    expect(result.current.selectedLaunchpad).toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+  });
+
   it("keeps launchpad environment controls stable after prompt-only update responses", async () => {
     const defaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1792,7 +1792,13 @@ function mergeLaunchpadUpdateResponse(
   const preserveSetting = <Key extends keyof NavigationLaunchpadDraft>(
     key: Key,
   ): void => {
-    if (!backendChanged && !(key in patch)) {
+    const serverResolvesReasoningForModel =
+      key === "reasoningEffort" && "model" in patch;
+    if (
+      !backendChanged
+      && !(key in patch)
+      && !serverResolvesReasoningForModel
+    ) {
       merged[key] = current[key] as NavigationLaunchpadDraft[Key];
     }
   };

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -23,6 +23,7 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  applyNavigationLaunchpadProviderSettingsPatch,
   buildAppendPinRank,
   buildPinnedRanks,
   buildPullRequestStatusKey,
@@ -4498,8 +4499,10 @@ export function useThreadNavigation(
           response: applyLaunchpadUpdate(
             currentResponse,
             {
-              ...currentLaunchpad,
-              ...patch,
+              ...applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+                currentLaunchpad,
+                patch,
+              ),
               directoryKey,
               updatedAt: Date.now(),
             },
@@ -4515,8 +4518,10 @@ export function useThreadNavigation(
         return {
           ...current,
           [directoryKey]: {
-            ...currentLaunchpad,
-            ...patch,
+            ...applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+              currentLaunchpad,
+              patch,
+            ),
             directoryKey,
             updatedAt: Date.now(),
           },
@@ -4525,8 +4530,10 @@ export function useThreadNavigation(
       const pendingPickedLaunchpad = pendingPickedLaunchpadRef.current.get(directoryKey);
       if (pendingPickedLaunchpad) {
         pendingPickedLaunchpadRef.current.set(directoryKey, {
-          ...pendingPickedLaunchpad,
-          ...patch,
+          ...applyNavigationLaunchpadProviderSettingsPatch<NavigationLaunchpadDraft>(
+            pendingPickedLaunchpad,
+            patch,
+          ),
           directoryKey,
           updatedAt: Date.now(),
         });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -304,6 +304,9 @@ export type NavigationLaunchpadProviderSettings = {
   serviceTier?: string;
   fastMode?: boolean;
   acpRuntime?: BackendAcpSessionRuntimeState;
+  codexEnvironmentId?: string;
+  codexEnvironmentExecutionTarget?: CodexEnvironmentExecutionTarget;
+  codexEnvironmentActionId?: string;
 };
 
 const NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS = [
@@ -314,6 +317,9 @@ const NAVIGATION_LAUNCHPAD_PROVIDER_SETTING_KEYS = [
   "serviceTier",
   "fastMode",
   "acpRuntime",
+  "codexEnvironmentId",
+  "codexEnvironmentExecutionTarget",
+  "codexEnvironmentActionId",
 ] as const satisfies readonly (keyof NavigationLaunchpadProviderSettings)[];
 
 export function extractNavigationLaunchpadProviderSettings(
@@ -438,6 +444,9 @@ function clearNavigationLaunchpadProviderFields<T extends NavigationLaunchpadDef
     serviceTier: undefined,
     fastMode: undefined,
     acpRuntime: undefined,
+    codexEnvironmentId: undefined,
+    codexEnvironmentExecutionTarget: undefined,
+    codexEnvironmentActionId: undefined,
   };
 }
 
@@ -458,6 +467,9 @@ export function projectNavigationLaunchpadProviderSettings<
     serviceTier: settings.serviceTier,
     fastMode: settings.fastMode,
     acpRuntime: settings.acpRuntime,
+    codexEnvironmentId: settings.codexEnvironmentId,
+    codexEnvironmentExecutionTarget: settings.codexEnvironmentExecutionTarget,
+    codexEnvironmentActionId: settings.codexEnvironmentActionId,
   };
 }
 


### PR DESCRIPTION
## Summary

- I fixed provider switching so returning to OpenAI/Codex restores its previous access mode, model, per-model reasoning effort, Fast/service tier, ACP runtime, and Codex Environment selection instead of saving destination defaults over them.
- I made the Codex Environment ID, execution target, and valid selected action provider-scoped through persistence and hydration. Messaging provider switches now clear outgoing provider-only pending-session overrides so the destination projection wins, including the fallback path when a sticky write is unavailable.
- I fixed the renderer response merge so switching between models restores each model's remembered reasoning effort instead of retaining the previous model's visible value. The optimistic renderer projection now updates the model and its remembered effort atomically instead of showing them about a second apart while IPC completes.

## Verification

- I added regressions for the real Composer OpenAI/Codex -> ACP Grok -> OpenAI/Codex flow, repeated flips with independent provider choices, an unresolved-backend-response frame for atomic Sol/high -> Terra/medium -> Sol/high model changes, SQLite close/reopen, backend-registry hydration, and messaging session overrides.
- I ran `pnpm test`: 386 files passed, 1 skipped; 4,989 tests passed, 3 skipped.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:sql`, `pnpm lint:codex-storage`, `pnpm lint:colors`, and `pnpm licenses:check`.

## Notes

- I kept work mode, branch, prompt, and attachment semantics unchanged.
- I intentionally left explicit default model and reasoning controls for Settings -> AI Providers out of this bug fix.
- Related: #1025 (separate root cause; this PR is independently mergeable).
