### PR TITLE
fix(desktop): hide disabled AI providers from picker

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2566,6 +2566,32 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("invalidates ACP discovery without closing shared backend clients", async () => {
+    const codexClient = new MockBackendClient({});
+    const closeSpy = vi.spyOn(codexClient, "close");
+    const discoverLocalAcpAgents = vi.fn(async () => []);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      discoverLocalAcpAgents,
+    });
+
+    await registry.listBackends({ includeUnavailable: true });
+    await registry.listBackends({ includeUnavailable: true });
+    expect(discoverLocalAcpAgents).toHaveBeenCalledTimes(1);
+
+    registry.invalidateAcpBackendDiscovery();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    await registry.listBackends({ includeUnavailable: true });
+    expect(discoverLocalAcpAgents).toHaveBeenCalledTimes(2);
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("filters disabled ACP agents before default backend discovery", async () => {
     const tempRoot = await mkdtemp(
       path.join(os.tmpdir(), "pwragent-backend-registry-"),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2418,6 +2418,7 @@ describe("DesktopBackendRegistry", () => {
       codexClient: new MockBackendClient({}),
       grokClient: new MockBackendClient({}),
       overlayStore: createOverlayStoreMock(),
+      isAcpAgentEnabled: () => true,
       acpAgentStore: createAcpAgentStoreMock([
         {
           backendId: "acp:gemini",
@@ -2516,6 +2517,7 @@ describe("DesktopBackendRegistry", () => {
       grokClient: new MockBackendClient({}),
       overlayStore: createOverlayStoreMock(),
       acpAgentStore: createAcpAgentStoreMock([]),
+      isAcpAgentEnabled: () => true,
       discoverLocalAcpAgents: async () => [
         {
           backendId: "acp:gemini",
@@ -2609,6 +2611,83 @@ describe("DesktopBackendRegistry", () => {
       await registry.close();
       localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockReset();
       localAcpDiscoveryMock.discoverLocalAcpAgentRecords.mockResolvedValue([]);
+      if (previousHome === undefined) {
+        delete process.env.PWRAGENT_HOME;
+      } else {
+        process.env.PWRAGENT_HOME = previousHome;
+      }
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("omits disabled persisted ACP agents from backend pickers", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-backend-registry-"),
+    );
+    const previousHome = process.env.PWRAGENT_HOME;
+    const profileDir = path.join(tempRoot, "profiles", "default");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(
+      path.join(profileDir, "config.toml"),
+      [
+        "[acp_agents.gemini]",
+        "enabled = false",
+        "",
+      ].join("\n"),
+    );
+    process.env.PWRAGENT_HOME = tempRoot;
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      grokClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: "acp:gemini",
+          registryId: "gemini",
+          name: "Gemini CLI",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1000,
+          updatedAt: 1000,
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock([
+        {
+          backendId: "acp:gemini",
+          sessionId: "persisted-session",
+          title: "Existing Gemini thread",
+          cwd: "/repo/project",
+          createdAt: 1000,
+          updatedAt: 2000,
+          executionMode: "default",
+          status: "idle",
+        },
+      ]),
+      discoverLocalAcpAgents: async () => [],
+    });
+
+    try {
+      const response = await registry.listBackends({
+        includeUnavailable: true,
+      });
+
+      expect(
+        response.backends.some((backend) => backend.kind === "acp:gemini"),
+      ).toBe(false);
+      await expect(
+        registry.listThreads({ backend: "acp:gemini" }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          id: "persisted-session",
+          source: "acp:gemini",
+        }),
+      ]);
+    } finally {
+      await registry.close();
       if (previousHome === undefined) {
         delete process.env.PWRAGENT_HOME;
       } else {

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -373,6 +373,18 @@ describe("settings ipc", () => {
         },
       },
     );
+    await handlers.get(SETTINGS_WRITE_CONFIG_CHANNEL)?.(
+      {},
+      {
+        patch: {
+          acpAgents: {
+            gemini: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    );
     await handlers.get(SETTINGS_CLEAR_SECRET_CHANNEL)?.(
       {},
       {
@@ -380,7 +392,7 @@ describe("settings ipc", () => {
       },
     );
 
-    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
+    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(3);
   });
 
   it("does not run the saved Codex path when discovery rejected it", async () => {

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -10,7 +10,9 @@ const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const tempRoots: string[] = [];
 const disposeDesktopBackendRegistryMock = vi.fn(async () => undefined);
 const listThreadsMock = vi.fn(async () => [] as unknown[]);
+const invalidateAcpBackendDiscoveryMock = vi.fn();
 const getDesktopBackendRegistryMock = vi.fn(() => ({
+  invalidateAcpBackendDiscovery: invalidateAcpBackendDiscoveryMock,
   listThreads: listThreadsMock,
 }));
 const childProcessMocks = vi.hoisted(() => ({
@@ -183,6 +185,7 @@ describe("settings ipc", () => {
   beforeEach(() => {
     handlers.clear();
     disposeDesktopBackendRegistryMock.mockClear();
+    invalidateAcpBackendDiscoveryMock.mockClear();
     listThreadsMock.mockClear();
     listThreadsMock.mockResolvedValue([]);
     getDesktopBackendRegistryMock.mockClear();
@@ -392,7 +395,8 @@ describe("settings ipc", () => {
       },
     );
 
-    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(3);
+    expect(disposeDesktopBackendRegistryMock).toHaveBeenCalledTimes(2);
+    expect(invalidateAcpBackendDiscoveryMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not run the saved Codex path when discovery rejected it", async () => {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -781,6 +781,10 @@ export class AcpBackendAdapter {
       .map((agent) => describeInstalledAcpBackend(agent));
   }
 
+  invalidateLocalAgentDiscovery(): void {
+    this.localAcpAgentsPromise = undefined;
+  }
+
   listSessions(
     backendId: AcpBackendId,
     options?: { archived?: boolean },

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -128,6 +128,7 @@ export type AcpBackendAdapterOptions = {
   createAcpClient?: AcpClientFactory;
   createAcpTransport?: AcpTransportFactory;
   discoverLocalAcpAgents?: LocalAcpDiscovery;
+  isAcpAgentEnabled?: (registryId: string) => boolean;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
     backend: AcpBackendId,
@@ -700,6 +701,7 @@ export class AcpBackendAdapter {
   private readonly createAcpClient: AcpClientFactory;
   private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
+  private readonly isAcpAgentEnabled?: (registryId: string) => boolean;
   private readonly emit: (event: AgentEvent) => Promise<void>;
   private readonly handleServerRequest: (
     backend: AcpBackendId,
@@ -761,15 +763,22 @@ export class AcpBackendAdapter {
         });
         return records;
       });
+    this.isAcpAgentEnabled = options.isAcpAgentEnabled;
     this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =
       options.createAcpClient ?? ((agent) => this.createDefaultClient(agent));
   }
 
-  describeInstalledBackends(): Promise<BackendSummary[]> {
-    return this.listAvailableAgents().then((installedAgents) =>
-      installedAgents.map((agent) => describeInstalledAcpBackend(agent)),
-    );
+  async describeInstalledBackends(): Promise<BackendSummary[]> {
+    const config = readDesktopSettingsConfigSafe();
+    const installedAgents = await this.listAvailableAgents();
+    return installedAgents
+      .filter((agent) =>
+        this.isAcpAgentEnabled
+          ? this.isAcpAgentEnabled(agent.registryId)
+          : acpAgentEnabledFor(config, agent.registryId),
+      )
+      .map((agent) => describeInstalledAcpBackend(agent));
   }
 
   listSessions(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6204,6 +6204,10 @@ export class DesktopBackendRegistry {
     };
   }
 
+  invalidateAcpBackendDiscovery(): void {
+    this.acpBackend.invalidateLocalAgentDiscovery();
+  }
+
   /**
    * Throw if any method that reads or writes Codex thread data is
    * reached in bootstrap mode. Companion to the silent empty-return

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5514,6 +5514,7 @@ export class DesktopBackendRegistry {
     acpAgentStore?: AcpBackendAdapterOptions["acpAgentStore"];
     acpSessionStore?: AcpSessionStoreLike | null;
     discoverLocalAcpAgents?: LocalAcpDiscovery;
+    isAcpAgentEnabled?: (registryId: string) => boolean;
     createAcpClient?: AcpClientFactory;
     messagingStore?: MessagingArchiveCleanupStore | null;
     messagingArchiveCleaner?: MessagingArchiveCleaner | null;
@@ -5667,6 +5668,7 @@ export class DesktopBackendRegistry {
       captureStores: this.captureStores,
       createAcpClient: options?.createAcpClient,
       discoverLocalAcpAgents: options?.discoverLocalAcpAgents,
+      isAcpAgentEnabled: options?.isAcpAgentEnabled,
       emit: async (event) => await this.emit(event),
       handleServerRequest: async (backend, request) =>
         await this.handleServerRequest(backend, request),

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -119,10 +119,13 @@ async function refreshModelBackendsIfNeeded(params: {
 }): Promise<void> {
   if (
     params.patch?.models?.codex?.path !== undefined
-    || params.patch?.acpAgents !== undefined
     || params.secret === "grokApiKey"
   ) {
     await disposeDesktopBackendRegistry();
+    return;
+  }
+  if (params.patch?.acpAgents !== undefined) {
+    getDesktopBackendRegistry().invalidateAcpBackendDiscovery();
   }
 }
 

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -119,6 +119,7 @@ async function refreshModelBackendsIfNeeded(params: {
 }): Promise<void> {
   if (
     params.patch?.models?.codex?.path !== undefined
+    || params.patch?.acpAgents !== undefined
     || params.secret === "grokApiKey"
   ) {
     await disposeDesktopBackendRegistry();

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopSettingsSnapshot } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
+import { useDesktopSettings } from "../useDesktopSettings";
+
+describe("useDesktopSettings", () => {
+  it("refreshes backend summaries after ACP provider settings change", async () => {
+    const onRefresh = vi.fn();
+    const writeSettingsConfig = vi
+      .fn<NonNullable<DesktopApi["writeSettingsConfig"]>>()
+      .mockResolvedValue({
+        snapshot: {} as DesktopSettingsSnapshot,
+      });
+    const desktopApi: DesktopApi = {
+      writeSettingsConfig,
+    };
+    window.addEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, onRefresh);
+
+    try {
+      const { result } = renderHook(() => useDesktopSettings(desktopApi));
+
+      await act(async () => {
+        await expect(
+          result.current.writeConfig({
+            acpAgents: {
+              gemini: {
+                enabled: false,
+              },
+            },
+          }),
+        ).resolves.toBe(true);
+      });
+
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, onRefresh);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -67,7 +67,10 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         const request: WriteDesktopSettingsConfigRequest = { patch };
         const response = await desktopApi.writeSettingsConfig(request);
         setSnapshot(response.snapshot);
-        if (patch.models?.codex?.path !== undefined) {
+        if (
+          patch.models?.codex?.path !== undefined
+          || patch.acpAgents !== undefined
+        ) {
           window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
         }
         return true;


### PR DESCRIPTION
## What changed

- Filter persisted ACP provider records against the current AI Providers enablement settings before returning backend picker summaries.
- Rebuild the desktop backend registry when ACP provider settings change.
- Refresh renderer backend summaries immediately after an ACP toggle or path update.
- Preserve existing threads for disabled providers while preventing those providers from appearing as new-thread choices.
- Add regression coverage for persisted disabled providers, registry disposal, and renderer refresh behavior.

## Why

Turning Gemini off in Settings → AI Providers still left Gemini in the new-thread provider picker.

The backend registry merged durable ACP installation records into its provider summaries without reapplying the current enabled flag. The renderer also did not request a fresh backend summary after ACP settings writes, so stale entries could remain visible.

## Impact

Disabled ACP providers now disappear from the new-thread picker immediately. Re-enabling a provider also rebuilds discovery state, while historical threads remain accessible.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx` — 384 tests passed
- `pnpm typecheck` — passed
- Targeted ESLint — no errors
- `git diff --check` — passed
