### PR TITLE
fix(desktop): hide threads with missing Codex rollouts

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25702,11 +25702,22 @@ script = "printf setup"
       ),
     });
     const overlayStore = createOverlayStoreMock();
+    const setThreadArchiveTombstone = vi.spyOn(
+      overlayStore,
+      "setThreadArchiveTombstone",
+    );
+    const requestBindingRevokeAllForThread = vi.fn(async () => ({
+      notifiedCount: 0,
+      revokedCount: 0,
+    }));
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      messagingArchiveCleaner: {
+        requestBindingRevokeAllForThread,
+      },
       overlayStore,
     });
 
@@ -25729,6 +25740,10 @@ script = "printf setup"
     ).resolves.toMatchObject({
       archiveTombstonedAt: response.archivedAt,
     });
+    expect(requestBindingRevokeAllForThread).toHaveBeenCalledTimes(1);
+    expect(
+      requestBindingRevokeAllForThread.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(setThreadArchiveTombstone.mock.invocationCallOrder[0]!);
     await expect(
       registry.listThreads({
         backend: "codex",
@@ -25750,6 +25765,110 @@ script = "printf setup"
         id: "thread-missing-rollout",
       }),
     ]);
+
+    await registry.close();
+  });
+
+  it("finishes best-effort cleanup before leaving a missing-rollout thread retryable", async () => {
+    const parentThread: AppServerThreadSummary = {
+      id: "thread-missing-rollout",
+      title: "Stale thread",
+      titleSource: "explicit",
+      linkedDirectories: [
+        {
+          id: "directory:/repo/app",
+          label: "app",
+          path: "/repo/app",
+          kind: "worktree",
+          worktreePath: "/repo/.worktrees/stale-thread",
+        },
+      ],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const childThread: AppServerThreadSummary = {
+      id: "thread-child",
+      title: "Child thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 1,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [parentThread, childThread],
+      archiveThreadError: new Error(
+        "json-rpc error (-32600): no rollout found for thread id thread-missing-rollout",
+      ),
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-child": {
+          backend: "codex",
+          threadId: "thread-child",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          parentThreadId: "thread-missing-rollout",
+        },
+      },
+    });
+    const setThreadParent = vi
+      .spyOn(overlayStore, "setThreadParent")
+      .mockRejectedValue(new Error("ungroup unavailable"));
+    const requestBindingRevokeAllForThread = vi.fn(async () => {
+      throw new Error("messaging unavailable");
+    });
+    const archiveWorktree = vi.fn(async () => {
+      throw new Error("worktree unavailable");
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      messagingArchiveCleaner: {
+        requestBindingRevokeAllForThread,
+      },
+      overlayStore,
+      worktreeArchiveService: {
+        archive: archiveWorktree,
+      } as unknown as WorktreeArchiveService,
+    });
+
+    await expect(
+      registry.archiveThread({
+        backend: "codex",
+        threadId: "thread-missing-rollout",
+      }),
+    ).rejects.toThrow(
+      /messaging cleanup failed: messaging unavailable; child ungrouping failed: ungroup unavailable; worktree cleanup failed.*worktree unavailable/,
+    );
+
+    expect(requestBindingRevokeAllForThread).toHaveBeenCalledTimes(1);
+    expect(setThreadParent).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-child",
+      parentThreadId: undefined,
+    });
+    expect(archiveWorktree).toHaveBeenCalledTimes(1);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-missing-rollout",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        forceRefresh: true,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "thread-missing-rollout",
+        }),
+      ]),
+    );
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -436,6 +436,29 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadArchiveTombstone: async ({
+      backend,
+      threadId,
+      archivedAt,
+    }: {
+      backend: ThreadOverlayState["backend"];
+      threadId: string;
+      archivedAt?: number;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        archiveTombstonedAt: archivedAt,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     setThreadModelSettings: async (settings: {
       backend: "codex" | "grok";
       threadId: string;
@@ -1158,6 +1181,7 @@ class MockBackendClient {
       listThreadsError?: Error;
       listThreadsDelay?: Promise<unknown>;
       archivedThreads?: AppServerThreadSummary[];
+      archiveThreadError?: Error;
       startThreadResult?: { threadId: string };
       startTurnDelay?: Promise<unknown>;
       startTurnError?: Error;
@@ -1214,6 +1238,9 @@ class MockBackendClient {
 
   async archiveThread(params: { threadId: string }): Promise<{ threadId: string }> {
     this.lastArchiveThreadParams = params;
+    if (this.options.archiveThreadError) {
+      throw this.options.archiveThreadError;
+    }
     return { threadId: params.threadId };
   }
 
@@ -25654,6 +25681,114 @@ script = "printf setup"
         },
       ],
     });
+
+    await registry.close();
+  });
+
+  it("tombstones a Codex thread when its rollout is already missing", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-missing-rollout",
+      title: "Stale thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+      archiveThreadError: new Error(
+        "json-rpc error (-32600): no rollout found for thread id thread-missing-rollout",
+      ),
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const response = await registry.archiveThread({
+      backend: "codex",
+      threadId: "thread-missing-rollout",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-missing-rollout",
+      archivedAt: expect.any(Number),
+      cleanup: [],
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-missing-rollout",
+      }),
+    ).resolves.toMatchObject({
+      archiveTombstonedAt: response.archivedAt,
+    });
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        forceRefresh: true,
+      }),
+    ).resolves.toEqual([]);
+
+    await registry.restoreThread({
+      backend: "codex",
+      threadId: "thread-missing-rollout",
+    });
+    await expect(
+      registry.listThreads({
+        backend: "codex",
+        forceRefresh: true,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-missing-rollout",
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("preserves non-rollout Codex archive failures", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-archive-error",
+      title: "Archive error",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      updatedAt: 2,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: [thread],
+      archiveThreadError: new Error("archive transport unavailable"),
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await expect(
+      registry.archiveThread({
+        backend: "codex",
+        threadId: "thread-archive-error",
+      }),
+    ).rejects.toThrow("archive transport unavailable");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-archive-error",
+      }),
+    ).resolves.toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4187,6 +4187,22 @@ function shouldEnrichThreadDirectories(
   }
 }
 
+function isCodexMissingRolloutArchiveError(
+  error: unknown,
+  threadId: string,
+): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  const normalizedThreadId = threadId.trim().toLowerCase();
+  if (!normalizedThreadId || !message.includes(normalizedThreadId)) {
+    return false;
+  }
+
+  return (
+    message.includes("no rollout found for thread id")
+    || message.includes("failed to locate rollout for thread")
+  );
+}
+
 function shouldBackfillCodexDirectoryRelationships(
   callerReason?: ThreadListCallerReason,
 ): boolean {
@@ -7400,12 +7416,37 @@ export class DesktopBackendRegistry {
       });
     }
 
-    const result =
-      backend === "codex"
-        ? await this.withCodexThreadClient(request.threadId, async (client) =>
-            await this.archiveWithClient(client, request.threadId),
-          )
-        : await this.archiveWithClient(this.grokClient, request.threadId);
+    let result: { threadId: string };
+    let archivedAt: number;
+    try {
+      result =
+        backend === "codex"
+          ? await this.withCodexThreadClient(request.threadId, async (client) =>
+              await this.archiveWithClient(client, request.threadId),
+            )
+          : await this.archiveWithClient(this.grokClient, request.threadId);
+      archivedAt = Date.now();
+    } catch (error) {
+      if (
+        backend !== "codex"
+        || !isCodexMissingRolloutArchiveError(error, request.threadId)
+      ) {
+        throw error;
+      }
+
+      archivedAt = Date.now();
+      await this.overlayStore.setThreadArchiveTombstone({
+        backend,
+        threadId: request.threadId,
+        archivedAt,
+      });
+      backendRegistryLog.warn("codex archive tombstoned missing rollout", {
+        backend,
+        threadId: request.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      result = { threadId: request.threadId };
+    }
     this.invalidateThreadListCache(backend);
     await this.cleanupMessagingForArchivedThread({
       backend,
@@ -7433,7 +7474,7 @@ export class DesktopBackendRegistry {
     return {
       backend,
       threadId: result.threadId,
-      archivedAt: Date.now(),
+      archivedAt,
       cleanup,
     };
   }
@@ -7485,6 +7526,13 @@ export class DesktopBackendRegistry {
             await this.restoreWithClient(client, request.threadId),
           )
         : await this.restoreWithClient(this.grokClient, request.threadId);
+    if (backend === "codex") {
+      await this.overlayStore.setThreadArchiveTombstone({
+        backend,
+        threadId: result.threadId,
+        archivedAt: undefined,
+      });
+    }
     this.invalidateThreadListCache(backend);
     this.clearArchivedMessagingCleanupCache({
       backend,
@@ -12937,11 +12985,14 @@ export class DesktopBackendRegistry {
       backend: "codex",
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
+    const visibleThreads = threadsWithPending.filter(
+      (thread) => overlaysByThreadId[thread.id]?.archiveTombstonedAt === undefined,
+    );
     const reconciledOverlaysByThreadId =
       await this.reconcileCodexDirectoryRelationshipsFromSource({
         diagnostics,
         overlaysByThreadId,
-        threads: threadsWithPending,
+        threads: visibleThreads,
       });
     Object.assign(overlaysByThreadId, reconciledOverlaysByThreadId);
     if (
@@ -12953,13 +13004,13 @@ export class DesktopBackendRegistry {
         await this.backfillMissingCodexDirectoryRelationships({
           diagnostics,
           overlaysByThreadId,
-          threads: threadsWithPending,
+          threads: visibleThreads,
         });
       Object.assign(overlaysByThreadId, updatedOverlaysByThreadId);
     }
 
     const enrichedThreads = await Promise.all(
-      threadsWithPending.map(async (thread) => {
+      visibleThreads.map(async (thread) => {
         const overlay = overlaysByThreadId[thread.id];
         const cwd = resolveThreadWorkspaceCwd(
           thread,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4238,6 +4238,7 @@ type MessagingArchiveCleaner = {
 };
 
 type MessagingArchiveCleanupResult = {
+  error?: string;
   notifiedCount?: number;
   pendingIntentCount: number;
   revokedCount: number;
@@ -7418,6 +7419,7 @@ export class DesktopBackendRegistry {
 
     let result: { threadId: string };
     let archivedAt: number;
+    let codexRolloutMissing = false;
     try {
       result =
         backend === "codex"
@@ -7435,12 +7437,8 @@ export class DesktopBackendRegistry {
       }
 
       archivedAt = Date.now();
-      await this.overlayStore.setThreadArchiveTombstone({
-        backend,
-        threadId: request.threadId,
-        archivedAt,
-      });
-      backendRegistryLog.warn("codex archive tombstoned missing rollout", {
+      codexRolloutMissing = true;
+      backendRegistryLog.warn("codex archive continuing cleanup for missing rollout", {
         backend,
         threadId: request.threadId,
         error: error instanceof Error ? error.message : String(error),
@@ -7448,16 +7446,26 @@ export class DesktopBackendRegistry {
       result = { threadId: request.threadId };
     }
     this.invalidateThreadListCache(backend);
-    await this.cleanupMessagingForArchivedThread({
+    const messagingCleanup = await this.cleanupMessagingForArchivedThread({
       backend,
       threadId: result.threadId,
       origin: "thread-archive",
     });
-    await this.ungroupChildrenOfArchivedThread({
-      backend,
-      activeThreads: cleanupMetadata?.activeThreads ?? [],
-      parentThreadId: result.threadId,
-    });
+    let ungroupError: string | undefined;
+    try {
+      await this.ungroupChildrenOfArchivedThread({
+        backend,
+        activeThreads: cleanupMetadata?.activeThreads ?? [],
+        parentThreadId: result.threadId,
+      });
+    } catch (error) {
+      ungroupError = error instanceof Error ? error.message : String(error);
+      backendRegistryLog.warn("archive thread child ungrouping failed", {
+        backend,
+        threadId: result.threadId,
+        error: ungroupError,
+      });
+    }
     const cleanup = cleanupMetadata
       ? await this.archiveThreadWorktrees({
           backend,
@@ -7470,6 +7478,44 @@ export class DesktopBackendRegistry {
           threadId: result.threadId,
           error: cleanupMetadataError,
         });
+    if (codexRolloutMissing) {
+      const cleanupFailures = [
+        cleanupMetadataError
+          ? `metadata lookup failed: ${cleanupMetadataError}`
+          : undefined,
+        messagingCleanup.error
+          ? `messaging cleanup failed: ${messagingCleanup.error}`
+          : undefined,
+        ungroupError
+          ? `child ungrouping failed: ${ungroupError}`
+          : undefined,
+        ...cleanup.map((item) => {
+          if (!item.error) {
+            return undefined;
+          }
+          const worktreeContext = item.worktreePath
+            ? ` for ${item.worktreePath}`
+            : "";
+          return `worktree cleanup failed${worktreeContext}: ${item.error}`;
+        }),
+      ].filter((failure): failure is string => Boolean(failure));
+      if (cleanupFailures.length > 0) {
+        throw new Error(
+          `Codex rollout is already missing, but PwrAgent archive cleanup did not complete: ${cleanupFailures.join("; ")}`,
+        );
+      }
+
+      await this.overlayStore.setThreadArchiveTombstone({
+        backend,
+        threadId: result.threadId,
+        archivedAt,
+      });
+      this.invalidateThreadListCache(backend);
+      backendRegistryLog.warn("codex archive tombstoned missing rollout", {
+        backend,
+        threadId: result.threadId,
+      });
+    }
 
     return {
       backend,
@@ -12909,13 +12955,18 @@ export class DesktopBackendRegistry {
         revokedCount: bindings.length,
       };
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       backendRegistryLog.warn("archived thread messaging cleanup failed", {
         backend: params.backend,
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
         origin: params.origin,
         threadId: params.threadId,
       });
-      return { pendingIntentCount: 0, revokedCount: 0 };
+      return {
+        error: message,
+        pendingIntentCount: 0,
+        revokedCount: 0,
+      };
     }
   }
 

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1425,6 +1425,26 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async setThreadArchiveTombstone(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    archivedAt?: number;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      archiveTombstonedAt: params.archivedAt,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
   async setThreadPin(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -3566,6 +3586,7 @@ export type OverlayStoreLike = Pick<
   | "readRecentThreadToolInvocations"
   | "upsertThreadSubAgent"
   | "setThreadReaction"
+  | "setThreadArchiveTombstone"
   | "setThreadPin"
   | "setThreadParent"
   | "setThreadAgent"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1217,6 +1217,13 @@ export type ThreadOverlayState = {
   lastSeenUpdatedAt?: number;
   dismissedAt?: number;
   snoozedUntil?: number;
+  /**
+   * Records a local archive tombstone when Codex reports that the thread's
+   * rollout is already missing. Codex can continue returning stale metadata
+   * for that thread from `thread/list`; PwrAgent filters tombstoned rows so
+   * they do not reappear after refresh or restart.
+   */
+  archiveTombstonedAt?: number;
   retainedBranchDriftPairs?: ThreadBranchDriftPair[];
   extraLinkedDirectories: LinkedDirectorySummary[];
   worktreeSnapshots?: WorktreeSnapshotSummary[];


### PR DESCRIPTION
## Summary

- treat Codex archive failures that report an already-missing rollout as an idempotent archive
- run messaging, child-grouping, and worktree cleanup as independent best-effort steps
- persist a PwrAgent-owned archive tombstone only after required cleanup succeeds
- leave stale metadata visible and retryable when cleanup is interrupted or fails
- clear the tombstone when the thread is restored
- preserve normal error behavior for unrelated archive failures

## Root cause

Codex could retain thread metadata after the corresponding rollout had already disappeared. PwrAgent continued materializing that metadata in navigation, while `thread/archive` failed with `no rollout found`, leaving the user unable to remove the stale thread.

## Impact

Users can archive these stale Codex rows normally. Cleanup failures do not prevent later cleanup steps from running, and they do not permanently hide the thread before the user can retry. The fix remains protocol-first and does not read or modify Codex-owned rollout or database storage.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 368 passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- focused ESLint run — 0 errors
