### PR TITLE
fix(desktop): detect Codex Fast mode from service tiers

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1649,6 +1649,80 @@ describe("CodexAppServerClient", () => {
     expect(byId.get("gpt-5.4")?.supportsImage).toBe(false);
   });
 
+  it("derives Fast support from Codex model service tiers", async () => {
+    MockTransport.modelListResult = {
+      data: [
+        {
+          id: "gpt-5.6-sol",
+          serviceTiers: [
+            {
+              id: "priority",
+              name: "Fast",
+              description: "1.5x speed, increased usage",
+            },
+          ],
+          additionalSpeedTiers: ["fast"],
+        },
+        {
+          id: "gpt-5.6-terra",
+          service_tiers: [
+            {
+              id: "priority",
+              name: "Fast",
+              description: "1.5x speed, increased usage",
+            },
+          ],
+        },
+        {
+          id: "gpt-5.6-luna",
+          additionalSpeedTiers: ["fast"],
+        },
+        {
+          id: "gpt-5.5",
+          additional_speed_tiers: ["fast"],
+        },
+        {
+          id: "gpt-5.4",
+          serviceTiers: [],
+          supportsFast: true,
+        },
+        {
+          id: "gpt-5.4-mini",
+          serviceTiers: [
+            {
+              id: "flex",
+              name: "Flex",
+              description: "Lower-cost asynchronous processing",
+            },
+          ],
+        },
+        {
+          id: "gpt-5.2",
+          supports_fast: true,
+        },
+      ],
+    };
+
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    const models = await client.listModels();
+    expect(
+      models.map((model) => ({
+        id: model.id,
+        supportsFast: model.supportsFast,
+      })),
+    ).toEqual([
+      { id: "gpt-5.6-sol", supportsFast: true },
+      { id: "gpt-5.6-terra", supportsFast: true },
+      { id: "gpt-5.6-luna", supportsFast: true },
+      { id: "gpt-5.5", supportsFast: true },
+      { id: "gpt-5.4", supportsFast: false },
+      { id: "gpt-5.4-mini", supportsFast: false },
+      { id: "gpt-5.2", supportsFast: true },
+    ]);
+  });
+
   it("normalizes 10080 minute rate-limit windows as weekly limits", async () => {
     MockTransport.rateLimitsResult = {
       rateLimitsByLimitId: {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1684,7 +1684,6 @@ describe("CodexAppServerClient", () => {
         {
           id: "gpt-5.4",
           serviceTiers: [],
-          supportsFast: true,
         },
         {
           id: "gpt-5.4-mini",
@@ -1696,10 +1695,7 @@ describe("CodexAppServerClient", () => {
             },
           ],
         },
-        {
-          id: "gpt-5.2",
-          supports_fast: true,
-        },
+        { id: "gpt-5.2" },
       ],
     };
 
@@ -1719,7 +1715,7 @@ describe("CodexAppServerClient", () => {
       { id: "gpt-5.5", supportsFast: true },
       { id: "gpt-5.4", supportsFast: false },
       { id: "gpt-5.4-mini", supportsFast: false },
-      { id: "gpt-5.2", supportsFast: true },
+      { id: "gpt-5.2", supportsFast: undefined },
     ]);
   });
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4170,6 +4170,65 @@ function pickStringArray(value: unknown): string[] | undefined {
   return strings.length > 0 ? strings : undefined;
 }
 
+function pickModelServiceTierIds(
+  record: Record<string, unknown>,
+): string[] | undefined {
+  const value = record.serviceTiers ?? record.service_tiers;
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return [
+    ...new Set(
+      value
+        .map((item) =>
+          typeof item === "string"
+            ? item
+            : pickString(asRecord(item) ?? {}, ["id"]),
+        )
+        .map((tier) => tier?.trim().toLowerCase())
+        .filter((tier): tier is string => Boolean(tier)),
+    ),
+  ];
+}
+
+function pickModelAdditionalSpeedTiers(
+  record: Record<string, unknown>,
+): string[] | undefined {
+  const value = record.additionalSpeedTiers ?? record.additional_speed_tiers;
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return [
+    ...new Set(
+      value
+        .filter((item): item is string => typeof item === "string")
+        .map((tier) => tier.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+}
+
+function pickModelSupportsFast(
+  record: Record<string, unknown>,
+): boolean | undefined {
+  const serviceTierIds = pickModelServiceTierIds(record);
+  const additionalSpeedTiers = pickModelAdditionalSpeedTiers(record);
+  // Current Codex model/list responses advertise structured service tiers and
+  // retain additionalSpeedTiers for older clients. A present empty array is
+  // authoritative; only app-server versions that omit both fields need the
+  // legacy supportsFast/model-id fallback.
+  if (serviceTierIds !== undefined || additionalSpeedTiers !== undefined) {
+    return Boolean(
+      serviceTierIds?.includes("priority")
+      || additionalSpeedTiers?.includes("fast"),
+    );
+  }
+
+  return pickBoolean(record, ["supportsFast", "supports_fast"]);
+}
+
 function pickReasoningEfforts(record: Record<string, unknown>): string[] | undefined {
   const value =
     record.supportedReasoningEfforts ?? record.supported_reasoning_efforts;
@@ -4229,7 +4288,7 @@ function extractModelOptions(value: unknown): BackendModelOption[] {
           "supportsReasoning",
           "supports_reasoning",
         ]),
-        supportsFast: pickBoolean(modelRecord, ["supportsFast", "supports_fast"]),
+        supportsFast: pickModelSupportsFast(modelRecord),
         supportsSteering: pickBoolean(modelRecord, [
           "supportsSteering",
           "supports_steering",
@@ -4283,7 +4342,10 @@ function summarizeRawModelList(value: unknown): Array<Record<string, unknown>> {
             "defaultReasoningEffort",
             "default_reasoning_effort",
           ]) ?? null,
-        supportsFast: pickBoolean(modelRecord, ["supportsFast", "supports_fast"]) ?? null,
+        additionalSpeedTiers:
+          pickModelAdditionalSpeedTiers(modelRecord) ?? null,
+        serviceTiers: pickModelServiceTierIds(modelRecord) ?? null,
+        supportsFast: pickModelSupportsFast(modelRecord) ?? null,
       },
     ];
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4217,8 +4217,8 @@ function pickModelSupportsFast(
   const additionalSpeedTiers = pickModelAdditionalSpeedTiers(record);
   // Current Codex model/list responses advertise structured service tiers and
   // retain additionalSpeedTiers for older clients. A present empty array is
-  // authoritative; only app-server versions that omit both fields need the
-  // legacy supportsFast/model-id fallback.
+  // authoritative. When older app-server versions omit both fields, leave the
+  // capability unknown so the backend registry can use its model-id fallback.
   if (serviceTierIds !== undefined || additionalSpeedTiers !== undefined) {
     return Boolean(
       serviceTierIds?.includes("priority")
@@ -4226,7 +4226,7 @@ function pickModelSupportsFast(
     );
   }
 
-  return pickBoolean(record, ["supportsFast", "supports_fast"]);
+  return undefined;
 }
 
 function pickReasoningEfforts(record: Record<string, unknown>): string[] | undefined {

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -329,7 +329,7 @@ describe("token usage pricing", () => {
   });
 
   it("estimates Fast Codex Credits with model-specific speed multipliers", () => {
-    const credits = estimateOpenAiCodexCreditUsage({
+    const gpt54Credits = estimateOpenAiCodexCreditUsage({
       cachedInputTokens: 1_000,
       fastMode: true,
       model: "gpt-5.4",
@@ -337,10 +337,24 @@ describe("token usage pricing", () => {
       uncachedInputTokens: 3_000,
     });
 
-    expect(credits).toMatchObject({
+    expect(gpt54Credits).toMatchObject({
       rateId: "openai:2026-06-16:codex-credits:gpt-5.4:priority",
       serviceTier: "priority",
       totalCreditMicros: 1_887_500,
+    });
+
+    const gpt55Credits = estimateOpenAiCodexCreditUsage({
+      cachedInputTokens: 1_000,
+      fastMode: true,
+      model: "gpt-5.5",
+      outputTokens: 2_000,
+      uncachedInputTokens: 3_000,
+    });
+
+    expect(gpt55Credits).toMatchObject({
+      rateId: "openai:2026-06-16:codex-credits:gpt-5.5:priority",
+      serviceTier: "priority",
+      totalCreditMicros: 4_718_750,
     });
   });
 

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -49,6 +49,21 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("uses the observed service tier ahead of configured fast-mode intent", () => {
+    expect(
+      resolveOpenAiPricingServiceTier({
+        fastMode: true,
+        serviceTier: "default",
+      }),
+    ).toBe("standard");
+    expect(
+      resolveOpenAiPricingServiceTier({
+        fastMode: false,
+        serviceTier: "priority",
+      }),
+    ).toBe("priority");
+  });
+
   it("bills separately reported reasoning tokens at the output rate", () => {
     const cost = estimateOpenAiTokenUsageCost({
       cachedInputTokens: 0,
@@ -329,29 +344,44 @@ describe("token usage pricing", () => {
     });
   });
 
-  it("estimates GPT-5.6 Codex Credits", () => {
-    const credits = estimateOpenAiCodexCreditUsage({
-      at: Date.UTC(2026, 6, 12),
-      cachedInputTokens: 1_000_000,
-      fastMode: true,
-      model: "gpt-5.6-terra",
-      outputTokens: 1_000_000,
-      uncachedInputTokens: 1_000_000,
-    });
+  it("estimates GPT-5.6 Fast Codex Credits at 2.5x Standard", () => {
+    const cases = [
+      ["gpt-5.6-sol", "GPT-5.6 Sol Fast", 312.5, 31.25, 1875, 2_218_750_000],
+      ["gpt-5.6-terra", "GPT-5.6 Terra Fast", 156.25, 15.625, 937.5, 1_109_375_000],
+      ["gpt-5.6-luna", "GPT-5.6 Luna Fast", 62.5, 6.25, 375, 443_750_000],
+    ] as const;
 
-    expect(credits).toMatchObject({
-      catalogId: "openai-codex-credits",
-      catalogVersion: "2026-07-09",
-      displayName: "GPT-5.6 Terra Fast",
-      inputCreditsPerMillion: 125,
-      cachedInputCreditsPerMillion: 12.5,
-      outputCreditsPerMillion: 750,
-      provider: "openai",
-      rateId: "openai:2026-07-09:codex-credits:gpt-5.6-terra:priority",
-      serviceTier: "priority",
-      totalCreditMicros: 887_500_000,
-      totalCredits: 887.5,
-    });
+    for (const [
+      model,
+      displayName,
+      inputCreditsPerMillion,
+      cachedInputCreditsPerMillion,
+      outputCreditsPerMillion,
+      totalCreditMicros,
+    ] of cases) {
+      const credits = estimateOpenAiCodexCreditUsage({
+        at: Date.UTC(2026, 6, 27),
+        cachedInputTokens: 1_000_000,
+        model,
+        outputTokens: 1_000_000,
+        serviceTier: "priority",
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(credits).toMatchObject({
+        catalogId: "openai-codex-credits",
+        catalogVersion: "2026-07-27",
+        displayName,
+        inputCreditsPerMillion,
+        cachedInputCreditsPerMillion,
+        outputCreditsPerMillion,
+        provider: "openai",
+        rateId: `openai:2026-07-27:codex-credits:${model}:priority`,
+        serviceTier: "priority",
+        totalCreditMicros,
+        totalCredits: totalCreditMicros / 1_000_000,
+      });
+    }
   });
 
   it("does not invent Codex Credit rates for unsupported Fast models", () => {

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -223,13 +223,19 @@ type CodexCreditsCatalogEntry = {
   displayTier: string;
   effectiveFrom: number;
   effectiveTo?: number;
-  fastRateMultiplier?: number;
   inputCreditsPerMillion: number;
   model: string;
   outputCreditsPerMillion: number;
   provider: "openai";
   serviceTier: TokenUsagePricingServiceTier;
 };
+
+type CodexCreditsStandardRates = Pick<
+  CodexCreditsCatalogEntry,
+  | "cachedInputCreditsPerMillion"
+  | "inputCreditsPerMillion"
+  | "outputCreditsPerMillion"
+>;
 
 const OPENAI_PRICING_CATALOG_ID = "openai-api";
 const OPENAI_PRICING_CATALOG_VERSION = "2026-06-16";
@@ -240,9 +246,16 @@ const OPENAI_GPT56_PRICING_CATALOG_VERSION = "2026-07-09";
 const OPENAI_GPT56_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 9);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
-// https://learn.chatgpt.com/docs/agent-configuration/speed.md
-// GPT-5.6 Fast consumes Codex Credits at 2.5x the Standard rate.
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
+// ChatGPT/Codex Fast credit multipliers are separate from API Priority rates.
+// https://learn.chatgpt.com/docs/agent-configuration/speed.md currently says
+// GPT-5.6 consumes 2.5x credits, while API Priority remains 2x. Keep the
+// disputed GPT-5.6 assumption here so one value controls every derived rate.
+const OPENAI_CODEX_FAST_RATE_MULTIPLIERS = {
+  "gpt-5.4": 2,
+  "gpt-5.5": 2.5,
+  "gpt-5.6": 2.5,
+} as const;
 const XAI_PRICING_CATALOG_ID = "xai-api";
 const XAI_PRICING_CATALOG_VERSION = "2026-07-17";
 const XAI_GROK45_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 8);
@@ -433,155 +446,120 @@ const TOKEN_USAGE_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   ...XAI_PRICING_CATALOG,
 ];
 
+function buildCodexCreditsCatalogEntries(params: {
+  catalogVersion: string;
+  displayModel: string;
+  effectiveFrom: number;
+  fastRateMultiplier?: number;
+  model: string;
+  standardRates: CodexCreditsStandardRates;
+}): CodexCreditsCatalogEntry[] {
+  const standardEntry: CodexCreditsCatalogEntry = {
+    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    catalogVersion: params.catalogVersion,
+    model: params.model,
+    displayModel: params.displayModel,
+    displayTier: "Standard",
+    effectiveFrom: params.effectiveFrom,
+    provider: "openai",
+    serviceTier: "standard",
+    ...params.standardRates,
+  };
+  if (params.fastRateMultiplier === undefined) {
+    return [standardEntry];
+  }
+
+  return [
+    standardEntry,
+    {
+      ...standardEntry,
+      displayTier: "Fast",
+      serviceTier: "priority",
+      inputCreditsPerMillion:
+        params.standardRates.inputCreditsPerMillion
+        * params.fastRateMultiplier,
+      cachedInputCreditsPerMillion:
+        params.standardRates.cachedInputCreditsPerMillion
+        * params.fastRateMultiplier,
+      outputCreditsPerMillion:
+        params.standardRates.outputCreditsPerMillion
+        * params.fastRateMultiplier,
+    },
+  ];
+}
+
 const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.6-sol",
     displayModel: "GPT-5.6 Sol",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 125,
-    cachedInputCreditsPerMillion: 12.5,
-    outputCreditsPerMillion: 750,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
-    catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
-    model: "gpt-5.6-sol",
-    displayModel: "GPT-5.6 Sol",
-    displayTier: "Fast",
-    effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2.5,
-    provider: "openai",
-    serviceTier: "priority",
-    inputCreditsPerMillion: 312.5,
-    cachedInputCreditsPerMillion: 31.25,
-    outputCreditsPerMillion: 1875,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
+    standardRates: {
+      inputCreditsPerMillion: 125,
+      cachedInputCreditsPerMillion: 12.5,
+      outputCreditsPerMillion: 750,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.6-terra",
     displayModel: "GPT-5.6 Terra",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 62.5,
-    cachedInputCreditsPerMillion: 6.25,
-    outputCreditsPerMillion: 375,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
-    catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
-    model: "gpt-5.6-terra",
-    displayModel: "GPT-5.6 Terra",
-    displayTier: "Fast",
-    effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2.5,
-    provider: "openai",
-    serviceTier: "priority",
-    inputCreditsPerMillion: 156.25,
-    cachedInputCreditsPerMillion: 15.625,
-    outputCreditsPerMillion: 937.5,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
+    standardRates: {
+      inputCreditsPerMillion: 62.5,
+      cachedInputCreditsPerMillion: 6.25,
+      outputCreditsPerMillion: 375,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.6-luna",
     displayModel: "GPT-5.6 Luna",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 25,
-    cachedInputCreditsPerMillion: 2.5,
-    outputCreditsPerMillion: 150,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
-    catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
-    model: "gpt-5.6-luna",
-    displayModel: "GPT-5.6 Luna",
-    displayTier: "Fast",
-    effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2.5,
-    provider: "openai",
-    serviceTier: "priority",
-    inputCreditsPerMillion: 62.5,
-    cachedInputCreditsPerMillion: 6.25,
-    outputCreditsPerMillion: 375,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
+    standardRates: {
+      inputCreditsPerMillion: 25,
+      cachedInputCreditsPerMillion: 2.5,
+      outputCreditsPerMillion: 150,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.5",
     displayModel: "GPT-5.5",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 125,
-    cachedInputCreditsPerMillion: 12.5,
-    outputCreditsPerMillion: 750,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
-    catalogVersion: OPENAI_CODEX_CREDITS_CATALOG_VERSION,
-    model: "gpt-5.5",
-    displayModel: "GPT-5.5",
-    displayTier: "Fast",
-    effectiveFrom: OPENAI_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2.5,
-    provider: "openai",
-    serviceTier: "priority",
-    inputCreditsPerMillion: 312.5,
-    cachedInputCreditsPerMillion: 31.25,
-    outputCreditsPerMillion: 1875,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.5"],
+    standardRates: {
+      inputCreditsPerMillion: 125,
+      cachedInputCreditsPerMillion: 12.5,
+      outputCreditsPerMillion: 750,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.4",
     displayModel: "GPT-5.4",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 62.5,
-    cachedInputCreditsPerMillion: 6.25,
-    outputCreditsPerMillion: 375,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
-    catalogVersion: OPENAI_CODEX_CREDITS_CATALOG_VERSION,
-    model: "gpt-5.4",
-    displayModel: "GPT-5.4",
-    displayTier: "Fast",
-    effectiveFrom: OPENAI_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2,
-    provider: "openai",
-    serviceTier: "priority",
-    inputCreditsPerMillion: 125,
-    cachedInputCreditsPerMillion: 12.5,
-    outputCreditsPerMillion: 750,
-  },
-  {
-    catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.4"],
+    standardRates: {
+      inputCreditsPerMillion: 62.5,
+      cachedInputCreditsPerMillion: 6.25,
+      outputCreditsPerMillion: 375,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.4-mini",
     displayModel: "GPT-5.4 mini",
-    displayTier: "Standard",
     effectiveFrom: OPENAI_PRICING_EFFECTIVE_FROM,
-    provider: "openai",
-    serviceTier: "standard",
-    inputCreditsPerMillion: 18.75,
-    cachedInputCreditsPerMillion: 1.875,
-    outputCreditsPerMillion: 113,
-  },
+    standardRates: {
+      inputCreditsPerMillion: 18.75,
+      cachedInputCreditsPerMillion: 1.875,
+      outputCreditsPerMillion: 113,
+    },
+  }),
 ];
 
 export function listOpenAiTokenUsagePricingRates(): TokenUsagePricingCatalogRate[] {

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -234,11 +234,15 @@ type CodexCreditsCatalogEntry = {
 const OPENAI_PRICING_CATALOG_ID = "openai-api";
 const OPENAI_PRICING_CATALOG_VERSION = "2026-06-16";
 const OPENAI_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 3, 23);
+// Standard: https://developers.openai.com/api/docs/models
+// Priority: https://openai.com/api-priority-processing/
 const OPENAI_GPT56_PRICING_CATALOG_VERSION = "2026-07-09";
 const OPENAI_GPT56_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 9);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
-const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-09";
+// https://learn.chatgpt.com/docs/agent-configuration/speed.md
+// GPT-5.6 Fast consumes Codex Credits at 2.5x the Standard rate.
+const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
 const XAI_PRICING_CATALOG_ID = "xai-api";
 const XAI_PRICING_CATALOG_VERSION = "2026-07-17";
 const XAI_GROK45_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 8);
@@ -450,12 +454,12 @@ const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
     displayModel: "GPT-5.6 Sol",
     displayTier: "Fast",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2,
+    fastRateMultiplier: 2.5,
     provider: "openai",
     serviceTier: "priority",
-    inputCreditsPerMillion: 250,
-    cachedInputCreditsPerMillion: 25,
-    outputCreditsPerMillion: 1500,
+    inputCreditsPerMillion: 312.5,
+    cachedInputCreditsPerMillion: 31.25,
+    outputCreditsPerMillion: 1875,
   },
   {
     catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
@@ -477,12 +481,12 @@ const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
     displayModel: "GPT-5.6 Terra",
     displayTier: "Fast",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2,
+    fastRateMultiplier: 2.5,
     provider: "openai",
     serviceTier: "priority",
-    inputCreditsPerMillion: 125,
-    cachedInputCreditsPerMillion: 12.5,
-    outputCreditsPerMillion: 750,
+    inputCreditsPerMillion: 156.25,
+    cachedInputCreditsPerMillion: 15.625,
+    outputCreditsPerMillion: 937.5,
   },
   {
     catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
@@ -504,12 +508,12 @@ const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
     displayModel: "GPT-5.6 Luna",
     displayTier: "Fast",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
-    fastRateMultiplier: 2,
+    fastRateMultiplier: 2.5,
     provider: "openai",
     serviceTier: "priority",
-    inputCreditsPerMillion: 50,
-    cachedInputCreditsPerMillion: 5,
-    outputCreditsPerMillion: 300,
+    inputCreditsPerMillion: 62.5,
+    cachedInputCreditsPerMillion: 6.25,
+    outputCreditsPerMillion: 375,
   },
   {
     catalogId: OPENAI_CODEX_CREDITS_CATALOG_ID,
@@ -803,18 +807,19 @@ export function resolveOpenAiPricingServiceTier(params: {
   fastMode?: boolean;
   serviceTier?: string;
 }): "standard" | "priority" | undefined {
-  if (params.fastMode === true) {
-    return "priority";
-  }
-
+  // Prefer an explicit tier over the legacy Boolean intent so callers that can
+  // observe an effective response tier can override the requested Fast mode.
   const serviceTier = params.serviceTier?.trim().toLowerCase();
-  if (!serviceTier || serviceTier === "default" || serviceTier === "standard") {
+  if (serviceTier === "default" || serviceTier === "standard") {
     return "standard";
   }
   if (serviceTier === "fast" || serviceTier === "priority") {
     return "priority";
   }
-  return undefined;
+  if (serviceTier) {
+    return undefined;
+  }
+  return params.fastMode === true ? "priority" : "standard";
 }
 
 function resolveXaiPricingServiceTier(


### PR DESCRIPTION
## Summary

- derive Codex Fast-mode support from `model/list` structured `serviceTiers` metadata
- retain compatibility with the real deprecated `additionalSpeedTiers` field and existing model-id inference for older app servers that omit tier metadata
- remove parsing and test references to the nonexistent `supportsFast` app-server field
- include service-tier metadata in model-list diagnostics
- align GPT-5.6 accounting with current OpenAI sources: API Priority at 2x Standard token rates and provisionally Codex Fast at 2.5x Standard credit rates
- centralize the 5.4, 5.5, and 5.6 Codex Fast multipliers and derive every Fast credit rate from its Standard rate
- prefer an explicit service tier over legacy `fastMode` intent when selecting a pricing rate
- add regression coverage for GPT-5.6 capability detection, explicit unsupported tiers, all three GPT-5.6 Fast credit rates, and effective-tier precedence

## Root cause

PwrAgent looked for a `supportsFast` boolean that the Codex app-server protocol does not emit. It then fell back to a model-ID allowlist containing GPT-5.5 and GPT-5.4, so the GPT-5.6 family did not show the Fast-mode control even though Codex advertises the `priority` service tier for those models.

The GPT-5.6 Codex Credits catalog also used the API Priority multiplier of 2x. Codex Fast is a separate ChatGPT credit feature and currently consumes GPT-5.6 credits at 2.5x Standard.

## Impact

PwrAgent now follows the Codex catalog as the capability source of truth. GPT-5.6 Sol, Terra, and Luna show Fast mode when their model metadata advertises the `priority` tier, while models with an explicitly empty or non-priority tier list remain unsupported. Future catalog changes no longer require a PwrAgent model-ID update.

Pricing remains source-specific:

- API Standard rates: https://developers.openai.com/api/docs/models
- API Priority rates: https://openai.com/api-priority-processing/
- Codex Fast credit multiplier: https://learn.chatgpt.com/docs/agent-configuration/speed.md

The Codex app-server token-usage notification currently carries token counts and configured thread settings, but not the effective service tier returned by the upstream Responses API. Therefore, PwrAgent cannot distinguish a rare Priority request that OpenAI downgrades to Standard under ramp limiting. The pricing resolver now treats any explicit effective tier as authoritative, so it will account for that correctly if Codex exposes the response tier in the protocol later.

## Validation

- `pnpm test packages/shared/src/__tests__/token-usage-pricing.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts` (189 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

