### PR TITLE
fix(desktop): hydrate bare PR references

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1216,7 +1216,11 @@ function DesktopAppShell(props: {
   };
 
   return (
-    <TranscriptLinkProvider onShowThread={showThreadFromLink} threads={navigation.threads}>
+    <TranscriptLinkProvider
+      activeThread={navigation.selectedThread}
+      onShowThread={showThreadFromLink}
+      threads={navigation.threads}
+    >
       <AppTitleBar
         desktopApi={desktopApi}
         onOpenMessagingActivity={openMessagingActivityWindow}

--- a/apps/desktop/src/renderer/src/features/pr-status/PullRequestLinkChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PullRequestLinkChip.tsx
@@ -1,5 +1,9 @@
 import type { PrSummary } from "@pwragent/shared";
-import { useLivePullRequest } from "../../lib/pull-request-links";
+import type { ReactNode } from "react";
+import {
+  useLivePullRequest,
+  useLivePullRequestNumber,
+} from "../../lib/pull-request-links";
 import { PrChip } from "./PrChip";
 
 export function PullRequestLinkChip(props: { pr: PrSummary }) {
@@ -12,6 +16,14 @@ export function PullRequestLinkChip(props: { pr: PrSummary }) {
       onOpen={openPullRequest}
     />
   );
+}
+
+export function PullRequestNumberLinkChip(props: {
+  children: ReactNode;
+  number: number;
+}) {
+  const pr = useLivePullRequestNumber(props.number);
+  return pr ? <PullRequestLinkChip pr={pr} /> : <>{props.children}</>;
 }
 
 function openPullRequest(url: string): void {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -37,8 +37,15 @@ import {
 } from "../../lib/pull-request-links";
 import { expandTildePath, tildifyPath } from "../../lib/tildify-path";
 import { SkillChip } from "../composer/SkillChip";
-import { PullRequestLinkChip } from "../pr-status/PullRequestLinkChip";
+import {
+  PullRequestLinkChip,
+  PullRequestNumberLinkChip,
+} from "../pr-status/PullRequestLinkChip";
 import { ThreadChip } from "./ThreadChip";
+import {
+  parsePullRequestNumberHref,
+  remarkPullRequestReferences,
+} from "./remark-pull-request-references";
 import { remarkTableProfile } from "./remark-table-profile";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
 
@@ -216,6 +223,15 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
           // the author's text rather than an anchor that goes nowhere — and
           // never let `pwragent:` reach the external-open path below.
           return <>{anchorProps.children}</>;
+        }
+
+        const pullRequestNumber = parsePullRequestNumberHref(href);
+        if (pullRequestNumber) {
+          return (
+            <PullRequestNumberLinkChip number={pullRequestNumber}>
+              {anchorProps.children}
+            </PullRequestNumberLinkChip>
+          );
         }
 
         const pullRequest = resolvePullRequestHref(href, pullRequestLinks);
@@ -469,7 +485,12 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
     >
       <ReactMarkdown
         components={components}
-        remarkPlugins={[remarkBreaks, remarkGfm, remarkTableProfile]}
+        remarkPlugins={[
+          remarkBreaks,
+          remarkGfm,
+          remarkPullRequestReferences,
+          remarkTableProfile,
+        ]}
         urlTransform={normalizeMarkdownUrl}
       >
         {markdownText}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -27,7 +27,10 @@ function prSummary(overrides: Partial<PrSummary> = {}): PrSummary {
   };
 }
 
-function threadSummary(prs: PrSummary[]): NavigationThreadSummary {
+function threadSummary(
+  prs: PrSummary[],
+  overrides: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
   return {
     id: "thread-pr-link",
     title: "EMR JDK 17 guidance",
@@ -36,6 +39,7 @@ function threadSummary(prs: PrSummary[]): NavigationThreadSummary {
     linkedDirectories: [],
     inbox: { inInbox: true, unread: false },
     prs,
+    ...overrides,
   } as NavigationThreadSummary;
 }
 
@@ -43,11 +47,34 @@ function renderWithPullRequests(
   text: string,
   prs: PrSummary[],
 ) {
+  const thread = threadSummary(prs);
   return render(
-    <PullRequestLinkProvider threads={[threadSummary(prs)]}>
+    <PullRequestLinkProvider activeThread={thread} threads={[thread]}>
       <ThreadMarkdown text={text} />
     </PullRequestLinkProvider>,
   );
+}
+
+function projectThread(params: {
+  id: string;
+  path: string;
+  prs?: PrSummary[];
+  worktreePath?: string;
+}): NavigationThreadSummary {
+  const worktreePath = params.worktreePath ?? `${params.path}-${params.id}`;
+  return threadSummary(params.prs ?? [], {
+    id: params.id,
+    projectKey: worktreePath,
+    linkedDirectories: [
+      {
+        id: worktreePath,
+        kind: "worktree",
+        label: params.path.split("/").pop() ?? params.path,
+        path: params.path,
+        worktreePath,
+      },
+    ],
+  });
 }
 
 afterEach(() => {
@@ -70,6 +97,182 @@ describe("pull request links in transcript markdown", () => {
 
     fireEvent.click(chip);
     expect(open).toHaveBeenCalledWith(PR_URL, "_blank", "noopener,noreferrer");
+  });
+
+  it("hydrates the exact draft-PR link shape emitted by a completed thread", () => {
+    renderWithPullRequests(
+      `Draft PR: [#13290 — Document JDK 17 for EMR jobs](${PR_URL})`,
+      [prSummary()],
+    );
+
+    expect(screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    })).toHaveTextContent("Giphy/giphy-services#13290");
+    expect(screen.queryByRole("link", {
+      name: "#13290 — Document JDK 17 for EMR jobs",
+    })).not.toBeInTheDocument();
+  });
+
+  it("hydrates a bare PR number known on the active thread", () => {
+    renderWithPullRequests("Rebased onto current origin/main, including #13290.", [
+      prSummary(),
+    ]);
+
+    expect(screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    })).toBeInTheDocument();
+  });
+
+  it("hydrates a bare PR number known by a sibling thread in the same repository", () => {
+    const activeThread = projectThread({
+      id: "thread-active",
+      path: "/repos/giphy-services",
+    });
+    const siblingThread = projectThread({
+      id: "thread-sibling",
+      path: "/repos/giphy-services",
+      prs: [prSummary()],
+    });
+
+    render(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, siblingThread]}
+      >
+        <ThreadMarkdown text="The related fix landed in #13290." />
+      </PullRequestLinkProvider>,
+    );
+
+    expect(screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    })).toBeInTheDocument();
+  });
+
+  it("leaves a bare number plain when the known PR belongs to another project", () => {
+    const activeThread = projectThread({
+      id: "thread-active",
+      path: "/repos/current-project",
+    });
+    const unrelatedThread = projectThread({
+      id: "thread-unrelated",
+      path: "/repos/giphy-services",
+      prs: [prSummary()],
+    });
+
+    render(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, unrelatedThread]}
+      >
+        <ThreadMarkdown text="Do not guess at #13290." />
+      </PullRequestLinkProvider>,
+    );
+
+    expect(screen.queryByRole("button", {
+      name: /Giphy\/giphy-services#13290/,
+    })).not.toBeInTheDocument();
+    expect(screen.getByText(/#13290/)).toBeInTheDocument();
+  });
+
+  it("leaves a bare number plain when it is ambiguous across linked repositories", () => {
+    const firstPath = "/repos/giphy-services";
+    const secondPath = "/repos/analytics";
+    const activeThread = threadSummary([], {
+      id: "thread-active",
+      linkedDirectories: [
+        {
+          id: "active-first",
+          kind: "worktree",
+          label: "giphy-services",
+          path: firstPath,
+          worktreePath: "/worktrees/active-first",
+        },
+        {
+          id: "active-second",
+          kind: "worktree",
+          label: "analytics",
+          path: secondPath,
+          worktreePath: "/worktrees/active-second",
+        },
+      ],
+    });
+    const firstSibling = projectThread({
+      id: "thread-first",
+      path: firstPath,
+      prs: [prSummary()],
+    });
+    const secondSibling = projectThread({
+      id: "thread-second",
+      path: secondPath,
+      prs: [
+        prSummary({
+          org: "Giphy",
+          repo: "analytics",
+          url: "https://github.com/Giphy/analytics/pull/13290",
+        }),
+      ],
+    });
+
+    render(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, firstSibling, secondSibling]}
+      >
+        <ThreadMarkdown text="Ambiguous reference #13290 stays plain." />
+      </PullRequestLinkProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
+    expect(screen.getByText(/#13290/)).toBeInTheDocument();
+  });
+
+  it("does not hydrate PR-style text inside code or an authored non-PR link", () => {
+    renderWithPullRequests(
+      "Keep `#13290` literal and [issue #13290](https://github.com/Giphy/giphy-services/issues/13290) linked.",
+      [prSummary()],
+    );
+
+    expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
+    expect(screen.getByText("#13290", { selector: "code" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "issue #13290" })).toBeInTheDocument();
+  });
+
+  it("hydrates a bare number when same-project PR metadata arrives later", () => {
+    const activeThread = projectThread({
+      id: "thread-active",
+      path: "/repos/giphy-services",
+    });
+    const siblingWithoutPr = projectThread({
+      id: "thread-sibling",
+      path: "/repos/giphy-services",
+    });
+    const { rerender } = render(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, siblingWithoutPr]}
+      >
+        <ThreadMarkdown text="Waiting on #13290." />
+      </PullRequestLinkProvider>,
+    );
+    expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
+
+    const siblingWithPr = projectThread({
+      id: "thread-sibling",
+      path: "/repos/giphy-services",
+      prs: [prSummary()],
+    });
+    rerender(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, siblingWithPr]}
+      >
+        <ThreadMarkdown text="Waiting on #13290." />
+      </PullRequestLinkProvider>,
+    );
+
+    expect(screen.getByRole("button", {
+      name: /Open Giphy\/giphy-services#13290 \(draft · checks pending\) in browser/,
+    })).toBeInTheDocument();
   });
 
   it("updates chip modes and a visible tooltip from live PR status metadata", () => {
@@ -196,6 +399,14 @@ describe("pull request links in transcript markdown", () => {
 
     expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "#13290" })).toBeInTheDocument();
+  });
+
+  it("leaves bare PR-style text plain on surfaces without navigation metadata", () => {
+    render(<ThreadMarkdown text="Related: #13290." />);
+
+    expect(screen.queryByRole("button", { name: /#13290/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "#13290" })).not.toBeInTheDocument();
+    expect(screen.getByText(/#13290/)).toBeInTheDocument();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -148,6 +148,52 @@ describe("pull request links in transcript markdown", () => {
     })).toBeInTheDocument();
   });
 
+  it("excludes PRs from a sibling that also links repositories outside the active scope", () => {
+    const activeThread = projectThread({
+      id: "thread-active",
+      path: "/repos/giphy-services",
+    });
+    const multiRepositorySibling = threadSummary([
+      prSummary({
+        org: "Giphy",
+        repo: "analytics",
+        url: "https://github.com/Giphy/analytics/pull/13290",
+      }),
+    ], {
+      id: "thread-multi-repository",
+      linkedDirectories: [
+        {
+          id: "sibling-giphy-services",
+          kind: "worktree",
+          label: "giphy-services",
+          path: "/repos/giphy-services",
+          worktreePath: "/worktrees/sibling-giphy-services",
+        },
+        {
+          id: "sibling-analytics",
+          kind: "worktree",
+          label: "analytics",
+          path: "/repos/analytics",
+          worktreePath: "/worktrees/sibling-analytics",
+        },
+      ],
+    });
+
+    render(
+      <PullRequestLinkProvider
+        activeThread={activeThread}
+        threads={[activeThread, multiRepositorySibling]}
+      >
+        <ThreadMarkdown text="Do not cross repositories for #13290." />
+      </PullRequestLinkProvider>,
+    );
+
+    expect(screen.queryByRole("button", {
+      name: /Giphy\/analytics#13290/,
+    })).not.toBeInTheDocument();
+    expect(screen.getByText(/#13290/)).toBeInTheDocument();
+  });
+
   it("leaves a bare number plain when the known PR belongs to another project", () => {
     const activeThread = projectThread({
       id: "thread-active",

--- a/apps/desktop/src/renderer/src/features/thread-detail/remark-pull-request-references.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/remark-pull-request-references.ts
@@ -1,0 +1,111 @@
+type MdastNode = {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+};
+
+type RemarkPlugin = () => (tree: MdastNode) => void;
+
+const PULL_REQUEST_REFERENCE_HOST = "pull-request";
+const PULL_REQUEST_REFERENCE_PREFIX =
+  `pwragent://${PULL_REQUEST_REFERENCE_HOST}/`;
+const SKIPPED_PARENT_TYPES = new Set([
+  "code",
+  "definition",
+  "html",
+  "image",
+  "imageReference",
+  "inlineCode",
+  "link",
+  "linkReference",
+]);
+
+/**
+ * Mark bare `#123` text as an in-app PR reference without guessing whether it
+ * is actually a PR. The renderer resolves the number against live,
+ * repository-scoped metadata and falls back to the authored text when there is
+ * no unique match.
+ *
+ * Existing links and code are deliberately left alone. Full PR URLs already
+ * have their own link hydration path, while code should stay literal.
+ */
+export const remarkPullRequestReferences: RemarkPlugin = () => (tree) => {
+  replacePullRequestReferences(tree);
+};
+
+export function parsePullRequestNumberHref(href: string): number | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(href);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    parsed.protocol !== "pwragent:"
+    || parsed.hostname !== PULL_REQUEST_REFERENCE_HOST
+  ) {
+    return undefined;
+  }
+
+  const numberText = parsed.pathname.replace(/^\/+/, "");
+  if (!/^[1-9]\d*$/.test(numberText)) {
+    return undefined;
+  }
+  const number = Number.parseInt(numberText, 10);
+  return Number.isSafeInteger(number) ? number : undefined;
+}
+
+function replacePullRequestReferences(node: MdastNode): void {
+  if (!node.children || SKIPPED_PARENT_TYPES.has(node.type)) {
+    return;
+  }
+
+  const nextChildren: MdastNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      nextChildren.push(...splitPullRequestReferences(child.value));
+      continue;
+    }
+    replacePullRequestReferences(child);
+    nextChildren.push(child);
+  }
+  node.children = nextChildren;
+}
+
+function splitPullRequestReferences(value: string): MdastNode[] {
+  const nodes: MdastNode[] = [];
+  const pattern = /(^|[^\w#])#([1-9]\d*)\b/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(value)) !== null) {
+    const prefix = match[1] ?? "";
+    const numberText = match[2] ?? "";
+    const number = Number.parseInt(numberText, 10);
+    if (!Number.isSafeInteger(number)) {
+      continue;
+    }
+
+    const referenceStart = match.index + prefix.length;
+    if (referenceStart > cursor) {
+      nodes.push({ type: "text", value: value.slice(cursor, referenceStart) });
+    }
+    const label = `#${numberText}`;
+    nodes.push({
+      type: "link",
+      url: `${PULL_REQUEST_REFERENCE_PREFIX}${numberText}`,
+      children: [{ type: "text", value: label }],
+    });
+    cursor = referenceStart + label.length;
+  }
+
+  if (cursor === 0) {
+    return [{ type: "text", value }];
+  }
+  if (cursor < value.length) {
+    nodes.push({ type: "text", value: value.slice(cursor) });
+  }
+  return nodes;
+}

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -207,13 +207,12 @@ function pullRequestsByNumberForActiveProject(params: {
       thread.source === params.activeThread?.source
       && thread.id === params.activeThread.id,
   ) ?? params.activeThread;
-  const projectKeys = threadProjectKeys(activeThread);
   const candidatesByNumber = new Map<number, Map<string, PrSummary>>();
 
   for (const thread of params.threads) {
     const sameThread =
       thread.source === activeThread.source && thread.id === activeThread.id;
-    if (!sameThread && !sharesProjectKey(projectKeys, threadProjectKeys(thread))) {
+    if (!sameThread && !siblingPullRequestsAreInScope(activeThread, thread)) {
       continue;
     }
     for (const pr of thread.prs ?? []) {
@@ -236,33 +235,42 @@ function pullRequestsByNumberForActiveProject(params: {
   return resolved;
 }
 
-function threadProjectKeys(thread: NavigationThreadSummary): Set<string> {
-  const keys = new Set<string>();
-  const projectKey = normalizeProjectPath(thread.projectKey);
-  if (projectKey) {
-    keys.add(projectKey);
+function siblingPullRequestsAreInScope(
+  activeThread: NavigationThreadSummary,
+  siblingThread: NavigationThreadSummary,
+): boolean {
+  const activeRepositories = threadRepositoryPaths(activeThread);
+  const siblingRepositories = threadRepositoryPaths(siblingThread);
+  if (siblingRepositories.size > 0) {
+    return (
+      activeRepositories.size > 0
+      && [...siblingRepositories].every((path) => activeRepositories.has(path))
+    );
   }
+
+  const activeProjectKey = normalizeProjectPath(activeThread.projectKey);
+  const siblingProjectKey = normalizeProjectPath(siblingThread.projectKey);
+  return Boolean(
+    activeProjectKey
+    && siblingProjectKey
+    && activeProjectKey === siblingProjectKey,
+  );
+}
+
+function threadRepositoryPaths(thread: NavigationThreadSummary): Set<string> {
+  const paths = new Set<string>();
   for (const directory of thread.linkedDirectories ?? []) {
     const directoryPath = normalizeProjectPath(directory.path);
     if (directoryPath) {
-      keys.add(directoryPath);
+      paths.add(directoryPath);
     }
   }
-  return keys;
+  return paths;
 }
 
 function normalizeProjectPath(value: string | undefined): string | undefined {
   const trimmed = value?.trim().replace(/\/+$/, "");
   return trimmed || undefined;
-}
-
-function sharesProjectKey(left: Set<string>, right: Set<string>): boolean {
-  for (const key of left) {
-    if (right.has(key)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 const PullRequestLinkContext =

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -16,8 +16,10 @@ import {
 
 type PullRequestLinkContextValue = {
   getSnapshot: (fallback: PrSummary) => PrSummary;
+  getNumberSnapshot: (number: number) => PrSummary | undefined;
   resolve: (href: string) => PrSummary | undefined;
   subscribe: (pr: PrSummary, listener: () => void) => () => void;
+  subscribeNumber: (number: number, listener: () => void) => () => void;
 };
 
 function samePullRequestChip(
@@ -48,10 +50,20 @@ function samePullRequestChip(
 class PullRequestLinkMetadataStore {
   private hydratedSnapshots = new WeakMap<PrSummary, Map<string, PrSummary>>();
   private listeners = new Map<string, Set<() => void>>();
+  private numberListeners = new Map<number, Set<() => void>>();
   private prs = new Map<string, PrSummary>();
+  private shorthandPrs = new Map<number, PrSummary>();
 
-  constructor(threads: NavigationThreadSummary[]) {
+  constructor(
+    threads: NavigationThreadSummary[],
+    activeThread: NavigationThreadSummary | undefined,
+  ) {
     this.prs = pullRequestsByKey(threads);
+    this.shorthandPrs = pullRequestsByNumberForActiveProject({
+      activeThread,
+      prsByKey: this.prs,
+      threads,
+    });
   }
 
   getSnapshot(fallback: PrSummary): PrSummary {
@@ -94,7 +106,27 @@ class PullRequestLinkMetadataStore {
     };
   }
 
-  update(threads: NavigationThreadSummary[]): void {
+  getNumberSnapshot(number: number): PrSummary | undefined {
+    return this.shorthandPrs.get(number);
+  }
+
+  subscribeNumber(number: number, listener: () => void): () => void {
+    const listeners = this.numberListeners.get(number) ?? new Set();
+    listeners.add(listener);
+    this.numberListeners.set(number, listeners);
+
+    return () => {
+      listeners.delete(listener);
+      if (listeners.size === 0) {
+        this.numberListeners.delete(number);
+      }
+    };
+  }
+
+  update(
+    threads: NavigationThreadSummary[],
+    activeThread: NavigationThreadSummary | undefined,
+  ): void {
     const candidates = pullRequestsByKey(threads);
     const nextPrs = new Map<string, PrSummary>();
     const changedKeys = new Set<string>();
@@ -114,9 +146,32 @@ class PullRequestLinkMetadataStore {
       }
     }
 
+    const nextShorthandPrs = pullRequestsByNumberForActiveProject({
+      activeThread,
+      prsByKey: nextPrs,
+      threads,
+    });
+    const changedNumbers = new Set<number>();
+    for (const [number, candidate] of nextShorthandPrs) {
+      if (!samePullRequestChip(this.shorthandPrs.get(number), candidate)) {
+        changedNumbers.add(number);
+      }
+    }
+    for (const number of this.shorthandPrs.keys()) {
+      if (!nextShorthandPrs.has(number)) {
+        changedNumbers.add(number);
+      }
+    }
+
     this.prs = nextPrs;
+    this.shorthandPrs = nextShorthandPrs;
     for (const key of changedKeys) {
       for (const listener of this.listeners.get(key) ?? []) {
+        listener();
+      }
+    }
+    for (const number of changedNumbers) {
+      for (const listener of this.numberListeners.get(number) ?? []) {
         listener();
       }
     }
@@ -138,27 +193,106 @@ function pullRequestsByKey(
   return prs;
 }
 
+function pullRequestsByNumberForActiveProject(params: {
+  activeThread: NavigationThreadSummary | undefined;
+  prsByKey: Map<string, PrSummary>;
+  threads: NavigationThreadSummary[];
+}): Map<number, PrSummary> {
+  if (!params.activeThread) {
+    return new Map();
+  }
+
+  const activeThread = params.threads.find(
+    (thread) =>
+      thread.source === params.activeThread?.source
+      && thread.id === params.activeThread.id,
+  ) ?? params.activeThread;
+  const projectKeys = threadProjectKeys(activeThread);
+  const candidatesByNumber = new Map<number, Map<string, PrSummary>>();
+
+  for (const thread of params.threads) {
+    const sameThread =
+      thread.source === activeThread.source && thread.id === activeThread.id;
+    if (!sameThread && !sharesProjectKey(projectKeys, threadProjectKeys(thread))) {
+      continue;
+    }
+    for (const pr of thread.prs ?? []) {
+      const key = buildPullRequestStatusKey(pr);
+      const byKey = candidatesByNumber.get(pr.number) ?? new Map();
+      byKey.set(key, params.prsByKey.get(key) ?? pr);
+      candidatesByNumber.set(pr.number, byKey);
+    }
+  }
+
+  const resolved = new Map<number, PrSummary>();
+  for (const [number, candidates] of candidatesByNumber) {
+    if (candidates.size === 1) {
+      const [pr] = candidates.values();
+      if (pr) {
+        resolved.set(number, pr);
+      }
+    }
+  }
+  return resolved;
+}
+
+function threadProjectKeys(thread: NavigationThreadSummary): Set<string> {
+  const keys = new Set<string>();
+  const projectKey = normalizeProjectPath(thread.projectKey);
+  if (projectKey) {
+    keys.add(projectKey);
+  }
+  for (const directory of thread.linkedDirectories ?? []) {
+    const directoryPath = normalizeProjectPath(directory.path);
+    if (directoryPath) {
+      keys.add(directoryPath);
+    }
+  }
+  return keys;
+}
+
+function normalizeProjectPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/\/+$/, "");
+  return trimmed || undefined;
+}
+
+function sharesProjectKey(left: Set<string>, right: Set<string>): boolean {
+  for (const key of left) {
+    if (right.has(key)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const PullRequestLinkContext =
   createContext<PullRequestLinkContextValue | undefined>(undefined);
 
 export function PullRequestLinkProvider(props: {
+  activeThread?: NavigationThreadSummary;
   children: ReactNode;
   threads: NavigationThreadSummary[];
 }) {
   const storeRef = useRef<PullRequestLinkMetadataStore | null>(null);
   if (!storeRef.current) {
-    storeRef.current = new PullRequestLinkMetadataStore(props.threads);
+    storeRef.current = new PullRequestLinkMetadataStore(
+      props.threads,
+      props.activeThread,
+    );
   }
   const store = storeRef.current;
 
   useLayoutEffect(() => {
-    store.update(props.threads);
-  }, [props.threads, store]);
+    store.update(props.threads, props.activeThread);
+  }, [props.activeThread, props.threads, store]);
 
   const value = useMemo<PullRequestLinkContextValue>(
     () => ({
       getSnapshot(fallback) {
         return store.getSnapshot(fallback);
+      },
+      getNumberSnapshot(number) {
+        return store.getNumberSnapshot(number);
       },
       resolve(href) {
         // Keep the parsed unknown summary as the chip's durable fallback. The
@@ -168,6 +302,9 @@ export function PullRequestLinkProvider(props: {
       },
       subscribe(pr, listener) {
         return store.subscribe(pr, listener);
+      },
+      subscribeNumber(number, listener) {
+        return store.subscribeNumber(number, listener);
       },
     }),
     [store],
@@ -199,6 +336,25 @@ export function useLivePullRequest(pr: PrSummary): PrSummary {
     subscribe,
     getSnapshot,
     () => pr,
+  );
+}
+
+export function useLivePullRequestNumber(number: number): PrSummary | undefined {
+  const links = usePullRequestLinks();
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      links?.subscribeNumber(number, listener) ?? (() => {}),
+    [links, number],
+  );
+  const getSnapshot = useCallback(
+    () => links?.getNumberSnapshot(number),
+    [links, number],
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => undefined,
   );
 }
 

--- a/apps/desktop/src/renderer/src/lib/transcript-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/transcript-links.tsx
@@ -7,6 +7,7 @@ import { PullRequestLinkProvider } from "./pull-request-links";
 import { ThreadLinkProvider } from "./thread-links";
 
 export function TranscriptLinkProvider(props: {
+  activeThread?: NavigationThreadSummary;
   children: ReactNode;
   onShowThread: (request: {
     backend: AppServerBackendKind;
@@ -19,7 +20,10 @@ export function TranscriptLinkProvider(props: {
       onShowThread={props.onShowThread}
       threads={props.threads}
     >
-      <PullRequestLinkProvider threads={props.threads}>
+      <PullRequestLinkProvider
+        activeThread={props.activeThread}
+        threads={props.threads}
+      >
         {props.children}
       </PullRequestLinkProvider>
     </ThreadLinkProvider>


### PR DESCRIPTION
## Summary

- recognize bare `#123` transcript text as a potential pull request reference
- hydrate it from live PR metadata when exactly one PR matches within the active thread's linked repository scope
- keep cross-project matches, multi-repository collisions, code spans, authored non-PR links, and non-navigation surfaces unchanged
- update existing shorthand references when matching PR metadata arrives later

## Why

PwrAgent already subscribes to PR metadata, but transcript hydration only upgraded explicit `/pull/<number>` links. Assistant messages that referred to an already-known PR as `#1025` therefore stayed plain text even when the current project made the identity unambiguous.

The renderer now marks PR-style shorthand without assuming it is a PR, then resolves it against repository-scoped live metadata. This keeps the convenient shorthand while avoiding global number guesses and issue-like false positives.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (67 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- changed-file ESLint (no errors)
- `pnpm lint:boundaries`
- `git diff --check`
