### PR TITLE
fix(desktop): consume typed Codex responses

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client-recording.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client-recording.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
+import type { InitializeResponse } from "@pwrdrvr/codex-app-server-protocol";
 import { ProtocolCaptureStore } from "../testing/capture-store";
 import { createProtocolCaptureObserver } from "../testing/protocol-capture";
 
@@ -34,16 +35,17 @@ class MockTransport implements JsonRpcTransport {
     const payload = JSON.parse(message) as { id?: string; method?: string };
 
     if (payload.method === "initialize") {
+      const result: InitializeResponse = {
+        userAgent: "codex_cli_rs/1.0.0 (Mac OS 26.0; arm64)",
+        codexHome: "/Users/huntharo/.codex",
+        platformFamily: "unix",
+        platformOs: "macos",
+      };
       this.emitRaw(
         JSON.stringify({
           jsonrpc: "2.0",
           id: payload.id,
-          result: {
-            serverInfo: {
-              name: "Codex App Server",
-              version: "1.0.0"
-            }
-          }
+          result,
         })
       );
       return;

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4,7 +4,17 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
-import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
+import type { InitializeResponse } from "@pwrdrvr/codex-app-server-protocol";
+import type {
+  ConfigWriteResponse,
+  DynamicToolSpec,
+  Model,
+  ModelListResponse,
+  ThreadArchiveResponse,
+  ThreadSetNameResponse,
+  ThreadSettingsUpdateResponse,
+  TurnInterruptResponse,
+} from "@pwrdrvr/codex-app-server-protocol/v2";
 
 const codexClientLogError = vi.hoisted(() => vi.fn());
 const codexClientLogDebug = vi.hoisted(() => vi.fn());
@@ -19,6 +29,40 @@ vi.mock("../log", () => ({
     warn: codexClientLogWarn,
   })),
 }));
+
+function createCodexModel(
+  overrides: Pick<Model, "id"> & Partial<Model>,
+): Model {
+  const { id, ...modelOverrides } = overrides;
+  return {
+    id,
+    model: id,
+    upgrade: null,
+    upgradeInfo: null,
+    availabilityNux: null,
+    displayName: overrides.id,
+    description: "",
+    hidden: false,
+    supportedReasoningEfforts: [
+      { reasoningEffort: "medium", description: "Balanced" },
+    ],
+    defaultReasoningEffort: "medium",
+    inputModalities: ["text", "image"],
+    supportsPersonality: false,
+    additionalSpeedTiers: [],
+    serviceTiers: [],
+    defaultServiceTier: null,
+    isDefault: false,
+    ...modelOverrides,
+  };
+}
+
+function createModelListResponse(models: Model[]): ModelListResponse {
+  return {
+    data: models,
+    nextCursor: null,
+  };
+}
 
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
@@ -55,14 +99,7 @@ class MockTransport implements JsonRpcTransport {
     }
   };
   static turnStartPreResponseNotification: unknown | null = null;
-  static turnInterruptResult: unknown = {
-    thread: {
-      id: "thread-2"
-    },
-    turn: {
-      id: "turn-1"
-    }
-  };
+  static turnInterruptResult: TurnInterruptResponse = {};
   static reviewStartResult: unknown = {
     reviewThreadId: "thread-2",
     turn: {
@@ -70,27 +107,19 @@ class MockTransport implements JsonRpcTransport {
       status: "inProgress"
     }
   };
-  static threadArchiveResult: unknown = {
-    thread: {
-      id: "thread-2"
-    }
-  };
+  static threadArchiveResult: ThreadArchiveResponse = {};
   static threadUnarchiveResult: unknown = {
     thread: {
       id: "thread-2"
     }
   };
-  static threadNameSetResult: unknown = {
-    thread: {
-      id: "thread-2"
-    }
-  };
-  static modelListResult: unknown = {
-    data: []
-  };
-  static configValueWriteResult: unknown = {
+  static threadNameSetResult: ThreadSetNameResponse = {};
+  static modelListResult: unknown = createModelListResponse([]);
+  static configValueWriteResult: ConfigWriteResponse = {
     status: "ok",
-    filePath: "/Users/huntharo/.codex/config.toml"
+    version: "1",
+    filePath: "/Users/huntharo/.codex/config.toml",
+    overriddenMetadata: null,
   };
   static lastConfigValueWritePayload: unknown;
   static rateLimitsResult: unknown = {
@@ -129,17 +158,18 @@ class MockTransport implements JsonRpcTransport {
     };
 
     if (payload.method === "initialize") {
+      const result: InitializeResponse = {
+        userAgent:
+          `codex_cli_rs/${MockTransport.serverVersion} (Mac OS 26.0; arm64)`,
+        codexHome: "/Users/huntharo/.codex",
+        platformFamily: "unix",
+        platformOs: "macos",
+      };
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
           id: payload.id,
-          result: {
-            userAgent:
-              `codex_cli_rs/${MockTransport.serverVersion} (Mac OS 26.0; arm64)`,
-            codexHome: "/Users/huntharo/.codex",
-            platformFamily: "unix",
-            platformOs: "macos",
-          }
+          result,
         })
       );
       return;
@@ -836,11 +866,12 @@ class MockTransport implements JsonRpcTransport {
     }
 
     if (payload.method === "thread/settings/update") {
+      const result: ThreadSettingsUpdateResponse = {};
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
           id: payload.id,
-          result: {},
+          result,
         })
       );
       return;
@@ -1012,30 +1043,15 @@ describe("CodexAppServerClient", () => {
         status: "inProgress"
       }
     };
-    MockTransport.turnInterruptResult = {
-      thread: {
-        id: "thread-2"
-      },
-      turn: {
-        id: "turn-1"
-      }
-    };
-    MockTransport.threadArchiveResult = {
-      thread: {
-        id: "thread-2"
-      }
-    };
-    MockTransport.threadNameSetResult = {
-      thread: {
-        id: "thread-2"
-      }
-    };
-    MockTransport.modelListResult = {
-      data: []
-    };
+    MockTransport.turnInterruptResult = {};
+    MockTransport.threadArchiveResult = {};
+    MockTransport.threadNameSetResult = {};
+    MockTransport.modelListResult = createModelListResponse([]);
     MockTransport.configValueWriteResult = {
       status: "ok",
-      filePath: "/Users/huntharo/.codex/config.toml"
+      version: "1",
+      filePath: "/Users/huntharo/.codex/config.toml",
+      overriddenMetadata: null,
     };
     MockTransport.lastConfigValueWritePayload = undefined;
     MockTransport.rateLimitsResult = {
@@ -1494,6 +1510,7 @@ describe("CodexAppServerClient", () => {
   });
 
   it("filters Codex models to the supported picker set and orders them", async () => {
+    MockTransport.serverVersion = "0.143.0";
     MockTransport.modelListResult = {
       data: [
         {
@@ -1626,6 +1643,7 @@ describe("CodexAppServerClient", () => {
   });
 
   it("keeps available Spark models image-disabled and honors an explicit image-support protocol flag", async () => {
+    MockTransport.serverVersion = "0.143.0";
     MockTransport.modelListResult = {
       data: [
         { id: "gpt-5.5", supportsReasoning: true },
@@ -1650,54 +1668,52 @@ describe("CodexAppServerClient", () => {
   });
 
   it("derives Fast support from Codex model service tiers", async () => {
-    MockTransport.modelListResult = {
-      data: [
-        {
-          id: "gpt-5.6-sol",
-          serviceTiers: [
-            {
-              id: "priority",
-              name: "Fast",
-              description: "1.5x speed, increased usage",
-            },
-          ],
-          additionalSpeedTiers: ["fast"],
-        },
-        {
-          id: "gpt-5.6-terra",
-          service_tiers: [
-            {
-              id: "priority",
-              name: "Fast",
-              description: "1.5x speed, increased usage",
-            },
-          ],
-        },
-        {
-          id: "gpt-5.6-luna",
-          additionalSpeedTiers: ["fast"],
-        },
-        {
-          id: "gpt-5.5",
-          additional_speed_tiers: ["fast"],
-        },
-        {
-          id: "gpt-5.4",
-          serviceTiers: [],
-        },
-        {
-          id: "gpt-5.4-mini",
-          serviceTiers: [
-            {
-              id: "flex",
-              name: "Flex",
-              description: "Lower-cost asynchronous processing",
-            },
-          ],
-        },
-        { id: "gpt-5.2" },
-      ],
-    };
+    MockTransport.modelListResult = createModelListResponse([
+      createCodexModel({
+        id: "gpt-5.6-sol",
+        serviceTiers: [
+          {
+            id: "priority",
+            name: "Fast",
+            description: "1.5x speed, increased usage",
+          },
+        ],
+        additionalSpeedTiers: ["fast"],
+      }),
+      createCodexModel({
+        id: "gpt-5.6-terra",
+        serviceTiers: [
+          {
+            id: "priority",
+            name: "Fast",
+            description: "1.5x speed, increased usage",
+          },
+        ],
+      }),
+      createCodexModel({
+        id: "gpt-5.6-luna",
+        additionalSpeedTiers: ["fast"],
+      }),
+      createCodexModel({
+        id: "gpt-5.5",
+        additionalSpeedTiers: ["fast"],
+      }),
+      createCodexModel({
+        id: "gpt-5.4",
+        serviceTiers: [],
+      }),
+      createCodexModel({
+        id: "gpt-5.4-mini",
+        serviceTiers: [
+          {
+            id: "flex",
+            name: "Flex",
+            description: "Lower-cost asynchronous processing",
+          },
+        ],
+      }),
+      createCodexModel({ id: "gpt-5.2" }),
+    ]);
 
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const client = new CodexAppServerClient({ command: "codex" });
@@ -1715,7 +1731,52 @@ describe("CodexAppServerClient", () => {
       { id: "gpt-5.5", supportsFast: true },
       { id: "gpt-5.4", supportsFast: false },
       { id: "gpt-5.4-mini", supportsFast: false },
-      { id: "gpt-5.2", supportsFast: undefined },
+      { id: "gpt-5.2", supportsFast: false },
+    ]);
+  });
+
+  it("rejects invented fields in modern model/list responses", async () => {
+    MockTransport.modelListResult = {
+      data: [
+        {
+          id: "gpt-5.6-sol",
+          supportsFast: true,
+        },
+      ],
+      nextCursor: null,
+    };
+
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    await expect(client.listModels()).rejects.toThrow(
+      "model/list response does not provide the generated fields PwrAgent consumes",
+    );
+  });
+
+  it("keeps legacy model aliases behind the pre-0.144 compatibility path", async () => {
+    MockTransport.serverVersion = "0.143.0";
+    MockTransport.modelListResult = {
+      data: [
+        {
+          id: "gpt-5.5",
+          additional_speed_tiers: ["fast"],
+          supports_image: false,
+          supports_reasoning: true,
+        },
+      ],
+    };
+
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    await expect(client.listModels()).resolves.toEqual([
+      expect.objectContaining({
+        id: "gpt-5.5",
+        supportsFast: true,
+        supportsImage: false,
+        supportsReasoning: true,
+      }),
     ]);
   });
 
@@ -5133,7 +5194,6 @@ describe("CodexAppServerClient", () => {
         payloadKeys: ["cwd", "reason"],
         listenerCount: 1,
         initialized: true,
-        serverAdvertisesSkillsList: false,
         expectedFollowup: "call skills/list when refreshed skill metadata is needed",
         payload: {
           cwd: "/Users/huntharo/pwrdrvr/PwrAgent",

--- a/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveCodexProtocolCompatibility,
+  usesGeneratedCodexModelListResponse,
 } from "../codex-app-server/protocol-compatibility";
 
 describe("Codex App Server protocol compatibility", () => {
@@ -48,4 +49,16 @@ describe("Codex App Server protocol compatibility", () => {
   ])("negotiates the wire features for $version", ({ version, expected }) => {
     expect(resolveCodexProtocolCompatibility(version)).toEqual(expected);
   });
+
+  it.each([
+    { version: undefined, expected: false },
+    { version: "codex-cli 0.143.0", expected: false },
+    { version: "codex-cli 0.144.0", expected: true },
+    { version: "codex-cli 1.0.0", expected: true },
+  ])(
+    "selects generated model/list fields for $version",
+    ({ version, expected }) => {
+      expect(usesGeneratedCodexModelListResponse(version)).toBe(expected);
+    },
+  );
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -367,6 +367,7 @@ type InitializeResult = {
     version?: string;
   };
   methods?: string[];
+  userAgent?: string;
 };
 
 const isDevelopment = process.env.NODE_ENV !== "production";

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -58,7 +58,9 @@ import type {
 } from "@pwrdrvr/codex-app-server-protocol";
 import type {
   ConfigValueWriteParams as CodexConfigValueWriteParams,
+  Model as CodexModel,
   ModelListParams as CodexModelListParams,
+  ModelListResponse as CodexModelListResponse,
   SandboxMode as CodexSandboxMode,
   SandboxPolicy as CodexSandboxPolicy,
   ReviewStartParams as CodexReviewStartParams,
@@ -97,6 +99,7 @@ import {
   normalizeCompatibleApprovalPolicy,
   resolveCodexProtocolCompatibility,
   serializeCompatibleDynamicTools,
+  usesGeneratedCodexModelListResponse,
   type CodexProtocolCompatibility,
   type CompatibleApprovalPolicy,
   type CompatibleDynamicToolSpec,
@@ -195,13 +198,7 @@ export class CodexBootstrapDeferredError extends Error {
   }
 }
 
-type InitializeResult = Partial<CodexInitializeResponse> & {
-  serverInfo?: {
-    name?: string;
-    version?: string;
-  };
-  methods?: string[];
-};
+type InitializeResult = Partial<CodexInitializeResponse>;
 
 type RawCodexThreadSummary = Omit<
   AppServerThreadSummary,
@@ -415,14 +412,12 @@ function logSkillsChangedNotification(params: {
   payload: unknown;
   listenerCount: number;
   initialized: boolean;
-  serverAdvertisesSkillsList: boolean;
 }): void {
   codexClientLog.warn("codex skills changed notification received", {
     method: "skills/changed",
     ...describePayloadShape(params.payload),
     listenerCount: params.listenerCount,
     initialized: params.initialized,
-    serverAdvertisesSkillsList: params.serverAdvertisesSkillsList,
     expectedFollowup: "call skills/list when refreshed skill metadata is needed",
     payload: params.payload,
   });
@@ -4215,10 +4210,10 @@ function pickModelSupportsFast(
 ): boolean | undefined {
   const serviceTierIds = pickModelServiceTierIds(record);
   const additionalSpeedTiers = pickModelAdditionalSpeedTiers(record);
-  // Current Codex model/list responses advertise structured service tiers and
-  // retain additionalSpeedTiers for older clients. A present empty array is
-  // authoritative. When older app-server versions omit both fields, leave the
-  // capability unknown so the backend registry can use its model-id fallback.
+  // Legacy responses used both structured service tiers and speed-tier
+  // aliases. A present empty array is authoritative. When an old app-server
+  // omits both fields, leave the capability unknown so the registry can use
+  // its model-id fallback.
   if (serviceTierIds !== undefined || additionalSpeedTiers !== undefined) {
     return Boolean(
       serviceTierIds?.includes("priority")
@@ -4349,6 +4344,159 @@ function summarizeRawModelList(value: unknown): Array<Record<string, unknown>> {
       },
     ];
   });
+}
+
+function parseInitializeResponse(value: unknown): CodexInitializeResponse {
+  const record = asRecord(value);
+  if (
+    !record
+    || typeof record.userAgent !== "string"
+    || typeof record.codexHome !== "string"
+    || typeof record.platformFamily !== "string"
+    || typeof record.platformOs !== "string"
+  ) {
+    throw new Error(
+      "codex app server initialize response does not match the generated protocol",
+    );
+  }
+
+  return value as CodexInitializeResponse;
+}
+
+type ConsumedCodexModel = Pick<
+  CodexModel,
+  | "additionalSpeedTiers"
+  | "defaultReasoningEffort"
+  | "displayName"
+  | "hidden"
+  | "id"
+  | "inputModalities"
+  | "isDefault"
+> & {
+  serviceTiers: Array<
+    Pick<CodexModel["serviceTiers"][number], "id">
+  >;
+  supportedReasoningEfforts: Array<
+    Pick<CodexModel["supportedReasoningEfforts"][number], "reasoningEffort">
+  >;
+};
+
+type ConsumedCodexModelListResponse = Pick<
+  CodexModelListResponse,
+  "nextCursor"
+> & {
+  data: ConsumedCodexModel[];
+};
+
+function isConsumedCodexModel(value: unknown): value is ConsumedCodexModel {
+  const record = asRecord(value);
+  return Boolean(
+    record
+    && typeof record.id === "string"
+    && typeof record.displayName === "string"
+    && typeof record.hidden === "boolean"
+    && Array.isArray(record.supportedReasoningEfforts)
+    && record.supportedReasoningEfforts.every((effort) => {
+      const effortRecord = asRecord(effort);
+      return Boolean(
+        effortRecord
+        && typeof effortRecord.reasoningEffort === "string",
+      );
+    })
+    && typeof record.defaultReasoningEffort === "string"
+    && Array.isArray(record.inputModalities)
+    && record.inputModalities.every(
+      (modality) => modality === "text" || modality === "image",
+    )
+    && Array.isArray(record.additionalSpeedTiers)
+    && record.additionalSpeedTiers.every((tier) => typeof tier === "string")
+    && Array.isArray(record.serviceTiers)
+    && record.serviceTiers.every((tier) => {
+      const tierRecord = asRecord(tier);
+      return Boolean(tierRecord && typeof tierRecord.id === "string");
+    })
+    && typeof record.isDefault === "boolean",
+  );
+}
+
+function parseConsumedCodexModelListResponse(
+  value: unknown,
+): ConsumedCodexModelListResponse {
+  const record = asRecord(value);
+  if (
+    !record
+    || !Array.isArray(record.data)
+    || !record.data.every(isConsumedCodexModel)
+    || (
+      record.nextCursor !== null
+      && typeof record.nextCursor !== "string"
+    )
+  ) {
+    throw new Error(
+      "codex app server model/list response does not provide the generated fields PwrAgent consumes",
+    );
+  }
+
+  return value as ConsumedCodexModelListResponse;
+}
+
+function extractGeneratedModelOptions(
+  response: ConsumedCodexModelListResponse,
+): BackendModelOption[] {
+  const models = response.data.flatMap((model): BackendModelOption[] => {
+    if (!SUPPORTED_CODEX_MODELS.has(model.id.toLowerCase()) || model.hidden) {
+      return [];
+    }
+
+    const serviceTierIds = model.serviceTiers.map((tier) =>
+      tier.id.trim().toLowerCase()
+    );
+    const additionalSpeedTiers = model.additionalSpeedTiers.map((tier) =>
+      tier.trim().toLowerCase()
+    );
+    return [
+      {
+        id: model.id,
+        label: formatCodexModelLabel(model.id),
+        current: model.isDefault,
+        defaultReasoningEffort: model.defaultReasoningEffort,
+        reasoningEfforts: model.supportedReasoningEfforts.map(
+          (effort) => effort.reasoningEffort,
+        ),
+        supportsReasoning: model.supportedReasoningEfforts.length > 0,
+        supportsFast:
+          serviceTierIds.includes("priority")
+          || additionalSpeedTiers.includes("fast"),
+        supportsImage: model.inputModalities.includes("image"),
+      },
+    ];
+  });
+
+  return sortCodexModels(models);
+}
+
+function summarizeGeneratedModelList(
+  response: ConsumedCodexModelListResponse,
+): Array<Record<string, unknown>> {
+  return response.data.map((model) => ({
+    id: model.id,
+    displayName: model.displayName,
+    current: model.isDefault,
+    hidden: model.hidden,
+    supportsReasoning: model.supportedReasoningEfforts.length > 0,
+    supportedReasoningEfforts: model.supportedReasoningEfforts.map(
+      (effort) => effort.reasoningEffort,
+    ),
+    defaultReasoningEffort: model.defaultReasoningEffort,
+    additionalSpeedTiers: model.additionalSpeedTiers,
+    serviceTiers: model.serviceTiers.map((tier) => tier.id),
+    supportsFast:
+      model.serviceTiers.some((tier) => tier.id.trim().toLowerCase() === "priority")
+      || model.additionalSpeedTiers.some(
+        (tier) => tier.trim().toLowerCase() === "fast",
+      ),
+    inputModalities: model.inputModalities,
+  }));
 }
 
 function isSparkModelId(id: string): boolean {
@@ -5539,8 +5687,6 @@ export class CodexAppServerClient {
           payload: params,
           listenerCount: this.notificationListeners.size,
           initialized: this.initialized,
-          serverAdvertisesSkillsList:
-            this.initializeResult?.methods?.includes("skills/list") ?? false,
         });
       }
 
@@ -5644,8 +5790,7 @@ export class CodexAppServerClient {
 
   private getProtocolCompatibility(): CodexProtocolCompatibility {
     return resolveCodexProtocolCompatibility(
-      this.initializeResult?.userAgent
-        ?? this.initializeResult?.serverInfo?.version,
+      this.initializeResult?.userAgent,
     );
   }
 
@@ -5740,8 +5885,8 @@ export class CodexAppServerClient {
   private async setThreadNameWithCodex(params: {
     threadId: string;
     name: string;
-  }): Promise<unknown> {
-    return await requestWithFallbacks({
+  }): Promise<void> {
+    await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/name/set"],
       payloads: [{ threadId: params.threadId, name: params.name }],
@@ -6146,6 +6291,16 @@ export class CodexAppServerClient {
       payloads: [payload],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     });
+
+    if (usesGeneratedCodexModelListResponse(this.initializeResult?.userAgent)) {
+      const parsedResult = parseConsumedCodexModelListResponse(result);
+      const models = extractGeneratedModelOptions(parsedResult);
+      codexClientLog.info("model/list", {
+        rawModels: summarizeGeneratedModelList(parsedResult),
+        normalizedModelIds: models.map((model) => model.id),
+      });
+      return models;
+    }
 
     const models = extractModelOptions(result);
     codexClientLog.info("model/list", {
@@ -6647,7 +6802,7 @@ export class CodexAppServerClient {
   async archiveThread(params: { threadId: string }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
 
-    const result = await requestWithFallbacks({
+    await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/archive"],
       payloads: [{ threadId: params.threadId }],
@@ -6655,7 +6810,7 @@ export class CodexAppServerClient {
     });
 
     return {
-      threadId: extractThreadIdFromValue(result) ?? params.threadId,
+      threadId: params.threadId,
     };
   }
 
@@ -6680,12 +6835,11 @@ export class CodexAppServerClient {
   }): Promise<{ threadId: string }> {
     await this.ensureInitialized();
 
-    const result = await this.setThreadNameWithCodex(params);
-    const threadId = extractThreadIdFromValue(result) ?? params.threadId;
-    this.recordedThreadNames.set(threadId, params.name);
+    await this.setThreadNameWithCodex(params);
+    this.recordedThreadNames.set(params.threadId, params.name);
 
     return {
-      threadId,
+      threadId: params.threadId,
     };
   }
 
@@ -6739,7 +6893,7 @@ export class CodexAppServerClient {
         threadId: params.threadId,
         turnId: params.turnId,
       };
-      const result = await requestWithFallbacks({
+      await requestWithFallbacks({
         client: this.connection,
         methods: ["turn/interrupt"],
         payloads: [payload],
@@ -6747,8 +6901,8 @@ export class CodexAppServerClient {
       });
 
       return {
-        threadId: extractThreadIdFromValue(result) ?? params.threadId,
-        turnId: extractTurnIdFromValue(result) ?? params.turnId,
+        threadId: params.threadId,
+        turnId: params.turnId,
       };
     } catch (error) {
       if (!isRequestTimeoutError(error, "turn/interrupt")) {
@@ -6787,7 +6941,7 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     }).catch(() => undefined);
 
-    const result = await requestWithFallbacks({
+    await requestWithFallbacks({
       client: this.connection,
       methods: ["thread/compact/start"],
       payloads: [
@@ -6798,12 +6952,9 @@ export class CodexAppServerClient {
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     });
 
-    const threadId = extractThreadIdFromValue(result) ?? params.threadId;
-    const turnId = extractTurnIdFromValue(result) ?? `compact:${threadId}`;
     return {
-      threadId,
-      turnId,
-      itemId: extractStringProperty(result, "itemId", "item_id"),
+      threadId: params.threadId,
+      turnId: `compact:${params.threadId}`,
     };
   }
 
@@ -6878,7 +7029,7 @@ export class CodexAppServerClient {
           capabilities: { experimentalApi: true, requestAttestation: false }
         };
         const result = await this.connection.request("initialize", initializeParams);
-        this.initializeResult = (asRecord(result) ?? {}) as InitializeResult;
+        this.initializeResult = parseInitializeResponse(result);
       } catch (error) {
         if (!isAlreadyInitializedError(error)) {
           throw error;

--- a/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
+++ b/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
@@ -3,6 +3,7 @@ import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
 const PERSIST_EXTENDED_HISTORY_REMOVED_VERSION = [0, 137, 0] as const;
 const NAMESPACED_DYNAMIC_TOOLS_MIN_VERSION = [0, 141, 0] as const;
 const ON_FAILURE_APPROVAL_REMOVED_VERSION = [0, 143, 0] as const;
+const GENERATED_MODEL_LIST_MIN_VERSION = [0, 144, 0] as const;
 
 export type CodexProtocolCompatibility = {
   dynamicToolFormat: "flat" | "namespaced";
@@ -59,6 +60,16 @@ export function resolveCodexProtocolCompatibility(
     supportsOnFailureApprovalPolicy:
       !isAtLeast(ON_FAILURE_APPROVAL_REMOVED_VERSION),
   };
+}
+
+export function usesGeneratedCodexModelListResponse(
+  serverVersion?: string,
+): boolean {
+  const version = parseSemanticVersion(serverVersion);
+  return Boolean(
+    version
+    && compareSemanticVersions(version, GENERATED_MODEL_LIST_MIN_VERSION) >= 0,
+  );
 }
 
 export function serializeCompatibleDynamicTools(


### PR DESCRIPTION
## Summary

- keep Codex wire method identifiers literal and searchable at each call site
- validate `initialize` against the generated response fields before storing it
- for Codex 0.144+, normalize `model/list` only from generated fields PwrAgent consumes (`serviceTiers`, `additionalSpeedTiers`, `supportedReasoningEfforts`, `inputModalities`, and `isDefault`)
- retain pre-0.144 model aliases in an explicitly version-gated legacy path
- stop reading invented result IDs from generated empty responses for archive, rename, interrupt, and compact operations; those methods now return their request IDs
- type modern initialize/model/config/empty-response fixtures so invented wire fields fail compilation
- let the neutral backend initialization contract recognize Codex `userAgent`; the Codex client no longer claims `serverInfo` or `methods`

## Audit findings

The transport should continue returning untrusted JSON-RPC results as `unknown`. The correctness issue was converting protocol-owned responses into permissive records and then guessing fields that the generated package says do not exist. In particular, generated archive, rename, interrupt, and compact responses are empty, while modern model capabilities have a concrete generated shape.

This change does not introduce a generic request-descriptor registry. The installed generated package provides the request method/params union and individual response types, but no authoritative method-to-response mapping. A local descriptor table would therefore add indirection without proving the pairing.

Intentional dynamic parsing remains for older model aliases and for response surfaces that PwrAgent deliberately normalizes across historical or semi-structured shapes: thread list/read/start/resume/fork/review/unarchive/metadata results, skills, account/rate-limit variants, replay items, notifications, and helper structured output.

## Validation

- focused Codex client, recording, compatibility, and backend registry suites: 501 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

Targets `main` after parent PR #1033 was merged.