### PR TITLE
fix(messaging): guard Telegram shutdown rejection

### DIFF
--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -523,6 +523,7 @@ describe("bootstrapApp", () => {
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     disposeDesktopMessagingRuntimeMock.mockReset();
+    disposeDesktopMessagingRuntimeMock.mockResolvedValue(undefined);
     registerMessagingStatusIpcHandlersMock.mockReset();
     disposeMessagingStatusIpcHandlersMock.mockReset();
     setApplicationMenuMock.mockReset();
@@ -1091,6 +1092,24 @@ describe("bootstrapApp", () => {
       disposeAppStateMock.mock.invocationCallOrder[0],
     );
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles messaging runtime disposal failures during shutdown", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    disposeDesktopMessagingRuntimeMock.mockRejectedValueOnce(
+      new Error("adapter stop failed"),
+    );
+
+    await import("../index");
+    await flushMicrotasks();
+
+    appEventHandlers.get("will-quit")?.();
+    await flushMicrotasks();
+
+    expect(mainLogWarnMock).toHaveBeenCalledWith(
+      "messaging runtime disposal failed during shutdown",
+      { error: "adapter stop failed" },
+    );
   });
 
   it("routes closing the last window through the shared quit flow", async () => {

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -216,6 +216,49 @@ describe("TelegramAdapter", () => {
     expect(reasons).toHaveLength(0);
   });
 
+  it("absorbs a failed final getUpdates request during stop()", async () => {
+    const api = createApi();
+    const logger = {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    };
+    let resolveStart: (() => void) | undefined;
+    const startPromise = new Promise<void>((resolve) => {
+      resolveStart = resolve;
+    });
+    const stopError = new Error("Network request for 'getUpdates' failed!");
+    const bot: TelegramBotLike = {
+      api: api as unknown as TelegramBotApi,
+      catch: vi.fn(),
+      on: vi.fn(),
+      start: vi.fn(async () => startPromise),
+      stop: vi.fn(async () => {
+        resolveStart?.();
+        throw stopError;
+      }),
+    };
+    const adapter = new TelegramAdapter({
+      bot,
+      config: {
+        channel: "telegram",
+        botToken: "12345:test-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      logger,
+      now: () => 1000,
+    });
+    const reasons: string[] = [];
+    adapter.onRuntimeError((reason) => reasons.push(reason));
+
+    await adapter.start(async () => {});
+    await expect(adapter.stop()).resolves.toBeUndefined();
+
+    expect(reasons).toHaveLength(0);
+    expect(logger.warn).toHaveBeenCalledWith("telegram bot stop failed", {
+      error: "Network request for 'getUpdates' failed!",
+    });
+  });
+
   it("normalizes /resume and renders a thread picker with inline keyboard handles", async () => {
     const harness = await createControllerHarness();
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -409,7 +409,11 @@ function disposeMainProcessResourcesSync(): void {
     getExistingRuntimeMessagingLeaseCoordinator() ??
     (isAppStateInitialized() ? getRuntimeMessagingLeaseCoordinator() : null);
   runtimeMessagingLeaseCoordinator?.shutdownSync();
-  void disposeDesktopMessagingRuntime();
+  void disposeDesktopMessagingRuntime().catch((error) => {
+    mainLog.warn("messaging runtime disposal failed during shutdown", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
   void disposeAppServerIpcHandlers();
   disposeAppState();
 }

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -734,13 +734,28 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   async stop(): Promise<void> {
     this.stopping = true;
     this.stopTypingSignals();
-    await this.bot.stop?.();
-    await this.startPromise?.catch(() => undefined);
-    this.startPromise = undefined;
-    this.listener = undefined;
-    this.botUsername = undefined;
-    this.runtimeErrorListeners.clear();
-    this.stopping = false;
+    try {
+      try {
+        await this.bot.stop?.();
+      } catch (error) {
+        // grammy aborts the active long poll before making one final
+        // getUpdates request to save the update offset. That confirmation
+        // request can fail when the network is already disappearing during
+        // app shutdown, but polling is stopped regardless. Cleanup must stay
+        // best-effort instead of turning that expected network failure into
+        // an unhandled rejection in the host process.
+        this.options.logger?.warn?.("telegram bot stop failed", {
+          error: errorMessage(error),
+        });
+      }
+      await this.startPromise?.catch(() => undefined);
+    } finally {
+      this.startPromise = undefined;
+      this.listener = undefined;
+      this.botUsername = undefined;
+      this.runtimeErrorListeners.clear();
+      this.stopping = false;
+    }
   }
 
   async downloadAttachment(


### PR DESCRIPTION
## Summary

- treat grammy’s final shutdown `getUpdates` failure as best-effort cleanup
- catch and log detached messaging runtime disposal failures at the app shutdown boundary
- add regression coverage for both rejection paths

## Verification

- `pnpm test apps/desktop/src/main/__tests__/telegram-adapter.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm exec eslint packages/messaging/providers/telegram/src/telegram-adapter.ts apps/desktop/src/main/index.ts apps/desktop/src/main/__tests__/telegram-adapter.test.ts apps/desktop/src/main/__tests__/index.test.ts`
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`