### PR TITLE
fix(desktop): qualify cross-repository PR chips

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -121,7 +121,6 @@ export function ThreadRow(props: ThreadRowProps) {
   // chips render instantly on app launch and stay in sync without any
   // renderer-side cache.
   const prs = props.thread.prs ?? [];
-  const showRepoPrefix = needsRepoPrefix(prs);
   const openPr = props.onOpenPullRequest ?? defaultOpenPullRequest;
   // Hover prefetch: 750ms intent timer — long enough that simply scrolling
   // past doesn't fire, short enough that a deliberate hover beats the
@@ -294,7 +293,7 @@ export function ThreadRow(props: ThreadRowProps) {
             <PrChip
               key={pr.url}
               pr={pr}
-              showRepoPrefix={showRepoPrefix}
+              showRepoPrefix={needsRepoPrefix(props.thread, pr, prs)}
               onOpen={openPr}
               onOpenContextMenu={
                 props.onOpenPullRequestContextMenu
@@ -777,12 +776,83 @@ function formatConversationType(binding: MessagingThreadBindingSummary): string 
   }
 }
 
-function needsRepoPrefix(prs: PrSummary[]): boolean {
+type RepositoryIdentity = {
+  provider: string;
+  org: string;
+  repo: string;
+};
+
+function needsRepoPrefix(
+  thread: NavigationThreadSummary,
+  pr: PrSummary,
+  prs: PrSummary[],
+): boolean {
+  const primaryRepository = parseRepositoryIdentity(thread.gitOriginUrl);
+  if (primaryRepository) {
+    return repositoryIdentityKey(primaryRepository) !== repositoryIdentityKey(pr);
+  }
+
   if (prs.length <= 1) {
     return false;
   }
   const firstKey = `${prs[0]!.org}/${prs[0]!.repo}`;
   return prs.some((pr) => `${pr.org}/${pr.repo}` !== firstKey);
+}
+
+function parseRepositoryIdentity(
+  remoteUrl?: string,
+): RepositoryIdentity | undefined {
+  const value = remoteUrl?.trim();
+  if (!value) {
+    return undefined;
+  }
+
+  const scpLike = value.match(/^[^@/]+@([^:]+):(.+)$/);
+  let provider: string;
+  let path: string;
+  if (scpLike) {
+    provider = scpLike[1]!;
+    path = scpLike[2]!;
+  } else {
+    try {
+      const parsed = new URL(value);
+      if (!parsed.hostname) {
+        return undefined;
+      }
+      provider = parsed.hostname;
+      path = parsed.pathname;
+    } catch {
+      return undefined;
+    }
+  }
+
+  const segments = path
+    .replace(/^\/+/, "")
+    .replace(/\.git$/i, "")
+    .replace(/\/+$/, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length < 2) {
+    return undefined;
+  }
+
+  const repo = segments.at(-1);
+  const org = segments.slice(0, -1).join("/");
+  if (!org || !repo) {
+    return undefined;
+  }
+
+  return { provider, org, repo };
+}
+
+function repositoryIdentityKey(identity: RepositoryIdentity): string {
+  return [
+    identity.provider,
+    identity.org,
+    identity.repo,
+  ]
+    .map((part) => part.trim().toLowerCase())
+    .join("/");
 }
 
 function defaultOpenPullRequest(url: string): void {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -787,6 +787,13 @@ function needsRepoPrefix(
   pr: PrSummary,
   prs: PrSummary[],
 ): boolean {
+  // Deleted fork heads can leave retained PRs without repository metadata.
+  // Never opt those chips into a prefix: PrChip would otherwise render the
+  // malformed `/#123` instead of preserving the unqualified fallback.
+  if (!pr.org.trim() || !pr.repo.trim()) {
+    return false;
+  }
+
   const primaryRepository = parseRepositoryIdentity(thread.gitOriginUrl);
   if (primaryRepository) {
     return repositoryIdentityKey(primaryRepository) !== repositoryIdentityKey(pr);
@@ -847,12 +854,20 @@ function parseRepositoryIdentity(
 
 function repositoryIdentityKey(identity: RepositoryIdentity): string {
   return [
-    identity.provider,
+    normalizeRepositoryProvider(identity.provider),
     identity.org,
     identity.repo,
   ]
     .map((part) => part.trim().toLowerCase())
     .join("/");
+}
+
+function normalizeRepositoryProvider(provider: string): string {
+  const normalized = provider.trim().toLowerCase();
+  // GitHub documents ssh.github.com:443 as an alternate SSH transport for
+  // networks that block port 22. PR URLs still identify that forge as
+  // github.com, so compare both hostnames as the same provider.
+  return normalized === "ssh.github.com" ? "github.com" : normalized;
 }
 
 function defaultOpenPullRequest(url: string): void {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -426,6 +426,80 @@ describe("ThreadRow chip flow", () => {
     );
   });
 
+  it("qualifies a PR from outside the thread's primary repository", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitOriginUrl: "git@github.com:xai-org/grok-build.git",
+        prs: [
+          {
+            provider: "github.com",
+            number: 1024,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/1024",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("pwrdrvr/PwrAgent#1024")).toBeInTheDocument();
+    expect(screen.queryByText("#1024")).not.toBeInTheDocument();
+  });
+
+  it("keeps primary-repository PR chips unqualified", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitOriginUrl: "https://github.com/pwrdrvr/PwrAgent.git",
+        prs: [
+          {
+            provider: "github.com",
+            number: 1024,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/1024",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("#1024")).toBeInTheDocument();
+    expect(screen.queryByText("pwrdrvr/PwrAgent#1024")).not.toBeInTheDocument();
+  });
+
+  it("qualifies only the cross-repository PR in a mixed PR row", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitOriginUrl: "ssh://git@github.com/xai-org/grok-build.git",
+        prs: [
+          {
+            provider: "github.com",
+            number: 42,
+            org: "xai-org",
+            repo: "grok-build",
+            state: "passing",
+            url: "https://github.com/xai-org/grok-build/pull/42",
+          },
+          {
+            provider: "github.com",
+            number: 1024,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/1024",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("#42")).toBeInTheDocument();
+    expect(screen.getByText("pwrdrvr/PwrAgent#1024")).toBeInTheDocument();
+  });
+
   it("dismisses the PR tooltip on window blur (cmd-tab away leaves no mouseleave)", () => {
     renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -470,6 +470,50 @@ describe("ThreadRow chip flow", () => {
     expect(screen.queryByText("pwrdrvr/PwrAgent#1024")).not.toBeInTheDocument();
   });
 
+  it("keeps PR chips with missing repository metadata unqualified", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitOriginUrl: "git@github.com:pwrdrvr/PwrAgent.git",
+        prs: [
+          {
+            provider: "github.com",
+            number: 123,
+            org: "",
+            repo: "",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/123",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("#123")).toBeInTheDocument();
+    expect(screen.queryByText("/#123")).not.toBeInTheDocument();
+  });
+
+  it("matches GitHub's alternate SSH hostname to github.com PRs", () => {
+    renderRow({
+      thread: {
+        ...baseThread,
+        gitOriginUrl: "ssh://git@ssh.github.com:443/pwrdrvr/PwrAgent.git",
+        prs: [
+          {
+            provider: "github.com",
+            number: 1024,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            state: "passing",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/1024",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText("#1024")).toBeInTheDocument();
+    expect(screen.queryByText("pwrdrvr/PwrAgent#1024")).not.toBeInTheDocument();
+  });
+
   it("qualifies only the cross-repository PR in a mixed PR row", () => {
     renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -5,7 +5,7 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
 
 type PrChipProps = {
   pr: PrSummary;
-  /** When the thread spans multiple repos, render the org/repo prefix. */
+  /** Render the org/repo prefix when the PR needs repository context. */
   showRepoPrefix: boolean;
   /**
    * Set when the chip is rendered next to explicit status pills (the Pull


### PR DESCRIPTION
## Summary

- qualify sidebar PR chips with `org/repo` when the PR does not belong to the thread's primary Git repository
- keep the compact `#number` shorthand for PRs in the primary repository
- preserve the unqualified fallback for retained PRs whose deleted fork leaves repository metadata unavailable
- normalize GitHub's `ssh.github.com:443` transport hostname to the `github.com` forge identity
- preserve the existing multi-repository fallback when the primary remote is unavailable
- add regression coverage for single cross-repository PRs, mixed primary/secondary PR rows, missing PR repository metadata, and GitHub SSH-over-443 remotes

## Why

An unqualified PR number is naturally read relative to the thread's primary project. A thread rooted in `grok-build` could therefore display `#1024` for a retained PR in `pwrdrvr/PwrAgent`, making the chip misleading until the user hovered it.

The renderer previously qualified chips only when two or more attached PRs came from different repositories. A single cross-repository PR was always rendered as `#number`, even though the navigation snapshot already carried the primary repository's Git remote.

## User impact

Cross-repository PRs now remain identifiable while scanning the sidebar. Primary-repository PRs retain the existing compact label, and mixed rows qualify only the PRs that need additional context. Deleted-fork PRs cannot produce malformed `/#number` labels, and GitHub's alternate SSH endpoint does not cause false cross-repository qualification.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx` (38 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
