### PR TITLE
fix(desktop): preserve launchpads in navigation history

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -589,23 +589,28 @@ function DesktopAppShell(props: {
     onRefreshNavigation: navigation.refresh,
     selectedThread: navigation.selectedThread,
   });
-  // Browser-style back/forward across threads and the search view. The
-  // tracked location is (mainView, selected thread); Settings, Automations,
-  // and launchpads stay untracked — they're modal-ish chrome, not places
-  // you navigate back to (see useNavigationHistory). Search query/results
-  // live up here so Back lands on a still-populated results list after
-  // opening a result unmounts the panel.
+  // Browser-style back/forward across threads, project launchpads, and the
+  // search view. Settings and Automations stay untracked because they're
+  // modal-ish chrome. Search query/results live up here so Back lands on a
+  // still-populated results list after opening a result unmounts the panel.
   const threadSearchState = useThreadSearchPanelState();
   const historyLocation = useMemo<NavigationHistoryLocation | undefined>(() => {
     if (mainView === "search") {
       return { view: "search" };
     }
+    if (mainView === "thread" && navigation.selectedLaunchpad) {
+      return {
+        view: "launchpad",
+        directoryKey: navigation.selectedLaunchpad.directoryKey,
+      };
+    }
     if (mainView === "thread" && navigation.selectedThreadKey) {
       return { view: "thread", threadKey: navigation.selectedThreadKey };
     }
     return undefined;
-  }, [mainView, navigation.selectedThreadKey]);
+  }, [mainView, navigation.selectedLaunchpad, navigation.selectedThreadKey]);
   const showThread = navigation.showThread;
+  const selectDirectoryLaunchpad = navigation.selectDirectoryLaunchpad;
   // Target of `pwragent://thread/…` chips in the transcript. Navigation-only:
   // the scheme never carries an action, so this is the entire surface it can
   // reach. Mirrors the tray/notification `onShowThreadRequested` path below.
@@ -623,12 +628,16 @@ function DesktopAppShell(props: {
         return;
       }
       setMainView("thread");
+      if (location.view === "launchpad") {
+        selectDirectoryLaunchpad(location.directoryKey);
+        return;
+      }
       const parts = parseThreadIdentityKey(location.threadKey);
       if (parts) {
         void showThread(parts);
       }
     },
-    [showThread],
+    [selectDirectoryLaunchpad, showThread],
   );
   // Undefined while the snapshot is empty/loading so a transient blank
   // thread list can't wipe the stacks; otherwise dead threads (archived,
@@ -644,8 +653,20 @@ function DesktopAppShell(props: {
         : undefined,
     [navigation.threads],
   );
+  const liveLaunchpadKeys = useMemo<ReadonlySet<string> | undefined>(
+    () =>
+      navigation.loaded
+        ? new Set(
+            navigation.directories
+              .filter((directory) => directory.launchpad)
+              .map((directory) => directory.key),
+          )
+        : undefined,
+    [navigation.directories, navigation.loaded],
+  );
   const history = useNavigationHistory({
     current: historyLocation,
+    liveLaunchpadKeys,
     liveThreadKeys,
     restore: restoreHistoryLocation,
   });

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3260,6 +3260,234 @@ describe("App", () => {
     });
   });
 
+  it("restores an unsubmitted project launchpad from thread history", async () => {
+    const directoryKey = "directory:/Users/huntharo/pwrdrvr/PwrAgent";
+    let launchpad = {
+      directoryKey,
+      directoryKind: "directory" as const,
+      directoryLabel: "PwrAgent",
+      directoryPath: "/Users/huntharo/pwrdrvr/PwrAgent",
+      backend: "codex" as const,
+      executionMode: "full-access" as const,
+      prompt: "",
+      workMode: "worktree" as const,
+      branchName: "feature/history-launchpad",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad,
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const updateDirectoryLaunchpad = vi.fn(
+      async ({
+        patch,
+      }: {
+        directoryKey: string;
+        patch: Record<string, unknown>;
+      }) => {
+        launchpad = {
+          ...launchpad,
+          ...patch,
+          updatedAt: launchpad.updatedAt + 1,
+        };
+        return {
+          launchpad,
+          defaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        };
+      },
+    );
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        ping: () => "pong",
+        listSkills: async () => ({
+          backend: "codex" as const,
+          fetchedAt: Date.now(),
+          data: [],
+        }),
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex",
+              label: "Codex app server",
+              available: true,
+              methods: ["thread/list", "thread/read", "turn/start"],
+              capabilities: {
+                listThreads: true,
+                createThread: true,
+                resumeThread: true,
+                renameThread: false,
+                readThread: true,
+                startTurn: true,
+                interruptTurn: true,
+                steerTurn: false,
+                transcriptPagination: true,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: true,
+              },
+              executionModes: [
+                {
+                  mode: "default",
+                  label: "Default Access",
+                  available: true,
+                  isDefault: true,
+                },
+                {
+                  mode: "full-access",
+                  label: "Full Access",
+                  available: true,
+                },
+              ],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:thread-1", "codex:thread-2"],
+          threads: [
+            {
+              id: "thread-1",
+              title: "First project thread",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [
+                {
+                  id: "/Users/huntharo/pwrdrvr/PwrAgent",
+                  label: "PwrAgent",
+                  path: "/Users/huntharo/pwrdrvr/PwrAgent",
+                  kind: "local" as const,
+                },
+              ],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread" as const,
+              },
+              updatedAt: 1_000,
+            },
+            {
+              id: "thread-2",
+              title: "Second project thread",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [
+                {
+                  id: "/Users/huntharo/pwrdrvr/PwrAgent",
+                  label: "PwrAgent",
+                  path: "/Users/huntharo/pwrdrvr/PwrAgent",
+                  kind: "local" as const,
+                },
+              ],
+              inbox: {
+                inInbox: true,
+                reason: "new-thread" as const,
+              },
+              updatedAt: 900,
+            },
+          ],
+          directories: [
+            {
+              key: directoryKey,
+              kind: "directory" as const,
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              threadKeys: ["codex:thread-1", "codex:thread-2"],
+              needsAttentionCount: 2,
+            },
+          ],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        markThreadSeen: async ({
+          backend,
+          threadId,
+        }: {
+          backend: "codex";
+          threadId: string;
+        }) => ({
+          backend,
+          threadId,
+          seenAt: Date.now(),
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+        readThread: async ({
+          backend,
+          threadId,
+        }: {
+          backend: "codex";
+          threadId: string;
+        }) => ({
+          backend,
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        updateDirectoryLaunchpad,
+        platform: "darwin",
+        versions: {
+          electron: "41.2.1",
+        },
+      },
+    });
+
+    render(<App />);
+
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First project thread",
+    });
+    fireEvent.click(
+      screen.getByRole("tab", { name: /^Directories/ }),
+    );
+    await clickButton("Open new thread launchpad for PwrAgent");
+    await screen.findByRole("heading", { level: 2, name: "PwrAgent" });
+
+    const composer = screen.getByRole("textbox", { name: "New thread" });
+    pasteComposerText(composer, "Keep this configured project draft.");
+    await waitFor(() => {
+      expect(getComposerValueHost(composer)).toHaveAttribute(
+        "data-value",
+        "Keep this configured project draft.",
+      );
+    });
+
+    await clickButton(/Second project thread/i);
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second project thread",
+    });
+    await clickButton("Back");
+
+    await screen.findByRole("heading", { level: 2, name: "PwrAgent" });
+    expect(
+      getComposerValueHost(screen.getByRole("textbox", { name: "New thread" })),
+    ).toHaveAttribute("data-value", "Keep this configured project draft.");
+    expect(screen.getAllByText("Full Access").length).toBeGreaterThan(0);
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+  });
+
   it("renames the selected thread from the sidebar actions menu", async () => {
     let threadTitle = "Build Codex client";
     const renameThread = vi.fn(

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3486,6 +3486,16 @@ describe("App", () => {
     ).toHaveAttribute("data-value", "Keep this configured project draft.");
     expect(screen.getAllByText("Full Access").length).toBeGreaterThan(0);
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+
+    await clickButton("Cancel");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
+    });
+    await clickButton("Back");
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "First project thread",
+    });
   });
 
   it("renames the selected thread from the sidebar actions menu", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
@@ -9,10 +9,15 @@ function thread(threadKey: string): NavigationHistoryLocation {
   return { view: "thread", threadKey };
 }
 
+function launchpad(directoryKey: string): NavigationHistoryLocation {
+  return { view: "launchpad", directoryKey };
+}
+
 const SEARCH: NavigationHistoryLocation = { view: "search" };
 
 type HistoryHookProps = {
   current: NavigationHistoryLocation | undefined;
+  liveLaunchpadKeys?: ReadonlySet<string>;
   liveThreadKeys?: ReadonlySet<string>;
 };
 
@@ -40,6 +45,9 @@ function renderHistory(initial: NavigationHistoryLocation | undefined) {
   const setLiveThreadKeys = (keys: ReadonlySet<string> | undefined): void => {
     update({ liveThreadKeys: keys });
   };
+  const setLiveLaunchpadKeys = (keys: ReadonlySet<string> | undefined): void => {
+    update({ liveLaunchpadKeys: keys });
+  };
   // Apply what restore asked for, like App's setMainView/showThread would.
   const settle = (): void => {
     const location = restore.mock.lastCall?.[0] as
@@ -49,7 +57,14 @@ function renderHistory(initial: NavigationHistoryLocation | undefined) {
       navigate(location);
     }
   };
-  return { hook, navigate, restore, setLiveThreadKeys, settle };
+  return {
+    hook,
+    navigate,
+    restore,
+    setLiveLaunchpadKeys,
+    setLiveThreadKeys,
+    settle,
+  };
 }
 
 describe("useNavigationHistory", () => {
@@ -105,10 +120,10 @@ describe("useNavigationHistory", () => {
     expect(hook.result.current.canGoBack).toBe(false);
   });
 
-  it("holds the cursor across untracked surfaces (settings, launchpads)", () => {
+  it("holds the cursor across untracked overlay surfaces", () => {
     const { hook, navigate } = renderHistory(thread("codex:a"));
     navigate(thread("codex:b"));
-    navigate(undefined); // e.g. Settings overlay opens
+    navigate(undefined); // e.g. Settings opens
     navigate(thread("codex:b")); // ...and closes back onto the same thread
     expect(hook.result.current.canGoBack).toBe(true);
 
@@ -120,7 +135,7 @@ describe("useNavigationHistory", () => {
   it("returns to the last tracked location from an untracked surface without consuming an entry", () => {
     const { hook, navigate, restore, settle } = renderHistory(thread("codex:a"));
     navigate(thread("codex:b"));
-    navigate(undefined); // launchpad in front
+    navigate(undefined); // Settings in front
     expect(hook.result.current.canGoBack).toBe(true);
 
     act(() => hook.result.current.goBack());
@@ -137,7 +152,7 @@ describe("useNavigationHistory", () => {
     navigate(thread("codex:b"));
     act(() => hook.result.current.goBack());
     settle(); // at a, forward = [b]
-    navigate(undefined); // launchpad in front
+    navigate(undefined); // Settings in front
 
     act(() => hook.result.current.goForward());
     expect(restore).toHaveBeenLastCalledWith(thread("codex:b"));
@@ -151,6 +166,75 @@ describe("useNavigationHistory", () => {
     act(() => hook.result.current.goBack());
     act(() => hook.result.current.goForward());
     expect(restore).not.toHaveBeenCalled();
+  });
+
+  it("returns to an unsubmitted project launchpad with its live draft", () => {
+    const { hook, navigate, restore, settle } =
+      renderHistory(thread("codex:a"));
+    navigate(launchpad("directory:/repo"));
+    navigate(thread("codex:b"));
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(launchpad("directory:/repo"));
+    settle();
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+  });
+
+  it("keeps only the newest history position for each project launchpad", () => {
+    const { hook, navigate, restore, settle } =
+      renderHistory(thread("codex:a"));
+    navigate(launchpad("directory:/repo-a"));
+    navigate(thread("codex:b"));
+    navigate(launchpad("directory:/repo-b"));
+    navigate(thread("codex:c"));
+    navigate(launchpad("directory:/repo-a"));
+    navigate(thread("codex:d"));
+
+    const expected = [
+      launchpad("directory:/repo-a"),
+      thread("codex:c"),
+      launchpad("directory:/repo-b"),
+      thread("codex:b"),
+      thread("codex:a"),
+    ];
+    for (const location of expected) {
+      act(() => hook.result.current.goBack());
+      expect(restore).toHaveBeenLastCalledWith(location);
+      settle();
+    }
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
+  it("removes a submitted launchpad without removing other project launchpads", () => {
+    const {
+      hook,
+      navigate,
+      restore,
+      setLiveLaunchpadKeys,
+      settle,
+    } = renderHistory(thread("codex:a"));
+    setLiveLaunchpadKeys(
+      new Set(["directory:/repo-a", "directory:/repo-b"]),
+    );
+    navigate(launchpad("directory:/repo-b"));
+    navigate(thread("codex:b"));
+    navigate(launchpad("directory:/repo-a"));
+
+    // Submission clears repo-a's launchpad before selecting its new thread.
+    setLiveLaunchpadKeys(new Set(["directory:/repo-b"]));
+    navigate(thread("codex:new"));
+    navigate(thread("codex:c"));
+
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:new"));
+    settle();
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:b"));
+    settle();
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(launchpad("directory:/repo-b"));
   });
 
   it("prunes vanished threads from both stacks so Back never lands on a dead thread", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx
@@ -237,6 +237,28 @@ describe("useNavigationHistory", () => {
     expect(restore).toHaveBeenLastCalledWith(launchpad("directory:/repo-b"));
   });
 
+  it("restores the prior thread after cancelling the active launchpad", () => {
+    const {
+      hook,
+      navigate,
+      restore,
+      setLiveLaunchpadKeys,
+      settle,
+    } = renderHistory(thread("codex:a"));
+    setLiveLaunchpadKeys(new Set(["directory:/repo"]));
+    navigate(launchpad("directory:/repo"));
+
+    // Cancellation removes the draft and clears the shell selection.
+    setLiveLaunchpadKeys(new Set());
+    navigate(undefined);
+
+    expect(hook.result.current.canGoBack).toBe(true);
+    act(() => hook.result.current.goBack());
+    expect(restore).toHaveBeenLastCalledWith(thread("codex:a"));
+    settle();
+    expect(hook.result.current.canGoBack).toBe(false);
+  });
+
   it("prunes vanished threads from both stacks so Back never lands on a dead thread", () => {
     const { hook, navigate, restore, setLiveThreadKeys, settle } =
       renderHistory(thread("codex:a"));

--- a/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
+++ b/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
@@ -2,13 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * One entry in the renderer's browser-style navigation history. Only the
- * two "content" surfaces are recorded: an open thread (by identity key)
- * and the thread-search view. Overlay-ish surfaces — Settings,
- * Automations, launchpads, the empty no-selection state — are deliberately
- * untracked: they behave like modal chrome, not places you navigate back
- * to. The caller signals those by passing `current: undefined`.
+ * three "content" surfaces are recorded: an open thread (by identity key),
+ * a project launchpad (by directory key), and the thread-search view.
+ * Overlay-ish surfaces — Settings, Automations, and the empty no-selection
+ * state — are deliberately untracked: they behave like modal chrome, not
+ * places you navigate back to. The caller signals those by passing
+ * `current: undefined`.
  */
 export type NavigationHistoryLocation =
+  | { view: "launchpad"; directoryKey: string }
   | { view: "search" }
   | { view: "thread"; threadKey: string };
 
@@ -22,19 +24,31 @@ function sameLocation(
   if (a.view === "search") {
     return b.view === "search";
   }
+  if (a.view === "launchpad") {
+    return b.view === "launchpad" && a.directoryKey === b.directoryKey;
+  }
   return b.view === "thread" && a.threadKey === b.threadKey;
 }
 
-/** Append with consecutive-duplicate dedup + depth cap. */
+/**
+ * Append with consecutive-duplicate dedup + depth cap. Launchpads are
+ * singletons: revisiting a project's still-unsubmitted launchpad moves its
+ * one history entry to the newest position instead of preserving stale
+ * visits to the same live draft.
+ */
 function appendLocation(
   stack: NavigationHistoryLocation[],
   location: NavigationHistoryLocation,
 ): NavigationHistoryLocation[] {
-  const top = stack[stack.length - 1];
+  const base =
+    location.view === "launchpad"
+      ? stack.filter((candidate) => !sameLocation(candidate, location))
+      : stack;
+  const top = base[base.length - 1];
   if (top !== undefined && sameLocation(top, location)) {
-    return stack;
+    return base;
   }
-  return [...stack, location].slice(-MAX_HISTORY_DEPTH);
+  return [...base, location].slice(-MAX_HISTORY_DEPTH);
 }
 
 /**
@@ -66,8 +80,8 @@ type HistoryStacks = {
   back: NavigationHistoryLocation[];
   /**
    * The history cursor: the last tracked location the user was on. Stays
-   * put while an untracked surface (Settings, a launchpad) is in front,
-   * so returning to the same thread afterwards never records a hop.
+   * put while an untracked surface (Settings, Automations) is in front, so
+   * returning to the same location afterwards never records a hop.
    */
   cursor: NavigationHistoryLocation | undefined;
   forward: NavigationHistoryLocation[];
@@ -101,6 +115,12 @@ export function useNavigationHistory(args: {
    * a transient blank list can't wipe the history.
    */
   liveThreadKeys?: ReadonlySet<string>;
+  /**
+   * Directory keys whose unsubmitted launchpads still exist. A successful
+   * submission or discard removes the key and prunes that launchpad from
+   * both directions of history.
+   */
+  liveLaunchpadKeys?: ReadonlySet<string>;
 }): {
   canGoBack: boolean;
   canGoForward: boolean;
@@ -129,11 +149,15 @@ export function useNavigationHistory(args: {
       // Same place (or our own goBack/goForward restore) — nothing to record.
       return;
     }
+    const baseBack =
+      current.view === "launchpad"
+        ? prev.back.filter((location) => !sameLocation(location, current))
+        : prev.back;
     const next: HistoryStacks = {
       back:
         prev.cursor !== undefined
-          ? appendLocation(prev.back, prev.cursor)
-          : prev.back,
+          ? appendLocation(baseBack, prev.cursor)
+          : baseBack,
       cursor: current,
       forward: [],
     };
@@ -142,25 +166,43 @@ export function useNavigationHistory(args: {
   }, [current]);
 
   const liveThreadKeys = args.liveThreadKeys;
+  const liveLaunchpadKeys = args.liveLaunchpadKeys;
   useEffect(() => {
-    if (liveThreadKeys === undefined) {
+    if (liveThreadKeys === undefined && liveLaunchpadKeys === undefined) {
       return;
     }
     const prev = stacksRef.current;
-    const isLive = (location: NavigationHistoryLocation): boolean =>
-      location.view !== "thread" || liveThreadKeys.has(location.threadKey);
+    const isLive = (location: NavigationHistoryLocation): boolean => {
+      if (location.view === "thread") {
+        return liveThreadKeys === undefined
+          || liveThreadKeys.has(location.threadKey);
+      }
+      if (location.view === "launchpad") {
+        return liveLaunchpadKeys === undefined
+          || liveLaunchpadKeys.has(location.directoryKey);
+      }
+      return true;
+    };
     const back = pruneStack(prev.back, isLive);
     const forward = pruneStack(prev.forward, isLive);
-    if (back === prev.back && forward === prev.forward) {
+    const cursor =
+      prev.cursor !== undefined && isLive(prev.cursor)
+        ? prev.cursor
+        : undefined;
+    if (
+      back === prev.back
+      && cursor === prev.cursor
+      && forward === prev.forward
+    ) {
       return;
     }
-    // The cursor mirrors the live selection and is left alone — if the
-    // selected thread itself vanishes, the shell moves the selection and
-    // the tracking effect above follows it.
-    const next: HistoryStacks = { back, cursor: prev.cursor, forward };
+    // Drop a dead cursor too. This matters during launch submission: the
+    // launchpad can disappear one render before its materialized thread is
+    // selected, and that stale cursor must not be appended on the next hop.
+    const next: HistoryStacks = { back, cursor, forward };
     stacksRef.current = next;
     setStacks(next);
-  }, [liveThreadKeys]);
+  }, [liveLaunchpadKeys, liveThreadKeys]);
 
   const goBack = useCallback((): void => {
     const prev = stacksRef.current;

--- a/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
+++ b/apps/desktop/src/renderer/src/lib/useNavigationHistory.ts
@@ -183,12 +183,23 @@ export function useNavigationHistory(args: {
       }
       return true;
     };
-    const back = pruneStack(prev.back, isLive);
+    let back = pruneStack(prev.back, isLive);
     const forward = pruneStack(prev.forward, isLive);
-    const cursor =
+    let cursor =
       prev.cursor !== undefined && isLive(prev.cursor)
         ? prev.cursor
         : undefined;
+    if (
+      prev.cursor !== undefined
+      && cursor === undefined
+      && back.length > 0
+    ) {
+      // A cancelled launchpad clears the shell selection, making `current`
+      // untracked. Preserve a usable Back target by promoting the newest live
+      // entry into the cursor that untracked-surface navigation restores.
+      cursor = back[back.length - 1];
+      back = back.slice(0, -1);
+    }
     if (
       back === prev.back
       && cursor === prev.cursor
@@ -196,9 +207,9 @@ export function useNavigationHistory(args: {
     ) {
       return;
     }
-    // Drop a dead cursor too. This matters during launch submission: the
-    // launchpad can disappear one render before its materialized thread is
-    // selected, and that stale cursor must not be appended on the next hop.
+    // Drop a dead cursor too. During launch submission, the materialized
+    // thread becomes the next cursor; during cancellation, the promotion
+    // above preserves the prior live location for Back.
     const next: HistoryStacks = { back, cursor, forward };
     stacksRef.current = next;
     setStacks(next);

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2215,6 +2215,8 @@ export function useThreadNavigation(
   clearPickDirectoryError: () => void;
   resetDirectoryLaunchpad: (directoryKey: string) => Promise<void>;
   removeDirectory: (directoryKey: string) => Promise<void>;
+  /** Select an existing launchpad without creating or resetting its draft. */
+  selectDirectoryLaunchpad: (directoryKey: string) => void;
   selectedDirectory?: NavigationDirectorySummary;
   selectedItemKey?: string;
   selectedLaunchpad?: NavigationLaunchpadDraft;
@@ -3750,6 +3752,15 @@ export function useThreadNavigation(
     },
     [refresh, selectThread, state.response?.threads],
   );
+
+  const selectDirectoryLaunchpad = useCallback((directoryKey: string): void => {
+    setCreateThreadError(undefined);
+    setLaunchpadError(undefined);
+    setArchiveThreadError(undefined);
+    setSetThreadExecutionModeError(undefined);
+    setSetThreadModelSettingsError(undefined);
+    setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
+  }, []);
 
   const createThread = useCallback(
     async (
@@ -5793,6 +5804,7 @@ export function useThreadNavigation(
     clearPickDirectoryError,
     resetDirectoryLaunchpad,
     removeDirectory,
+    selectDirectoryLaunchpad,
     selectedDirectory,
     selectedItemKey,
     selectedLaunchpad,


### PR DESCRIPTION
## Summary

- track unsubmitted project launchpads as first-class Back/Forward history locations
- keep only the newest history position for each project launchpad while preserving its live draft and settings
- prune a launchpad from both history directions when it is submitted or discarded
- restore an existing launchpad selection directly so Back does not recreate or reset the draft

## Root cause

The renderer navigation history intentionally treated launchpads as untracked overlay chrome. Leaving an unsubmitted launchpad therefore kept the cursor on the previously selected born thread, so Back skipped the launchpad and returned there instead.

## User impact

An operator can compose and configure a project launchpad, open another thread, and use Back to return to the same live draft. After starting that thread, the consumed launchpad is removed from history: Back returns to the newly created thread first and then to the previous valid thread or another project's live launchpad.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useNavigationHistory.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (37 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors; existing warning baseline remains)
- `git diff --check`
