### PR TITLE
feat(desktop): refresh ACP models and expose Kimi thinking

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -8,6 +8,7 @@ import {
   AcpBackendAdapter,
   describeInstalledAcpBackend,
   isAcpSessionMissingForProjectError,
+  withAcpModelRuntimeSelection,
   type AcpSessionMetadata,
 } from "../app-server/acp-backend-adapter";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
@@ -84,6 +85,125 @@ describe("describeInstalledAcpBackend", () => {
           supportsReasoning: true,
         },
       ],
+    });
+  });
+
+  it("advertises discovered Kimi 3 thinking levels in launchpad options", () => {
+    const backend = describeInstalledAcpBackend({
+      ...buildInstalledAgent(),
+      backendId: "acp:kimi" as AcpBackendId,
+      registryId: "kimi",
+      name: "Kimi Code CLI",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        checkedAt: 1000,
+        models: {
+          currentModelId: "kimi-code/kimi-for-coding",
+          availableModels: [
+            {
+              id: "kimi-code/kimi-for-coding",
+              label: "K2.7 Coding",
+              supportsReasoning: false,
+            },
+            {
+              id: "kimi-code/k3",
+              label: "K3",
+              defaultReasoningEffort: "high",
+              reasoningEfforts: ["low", "high", "max"],
+              supportsReasoning: true,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(backend.launchpadOptions).toEqual({
+      models: [
+        {
+          id: "kimi-code/kimi-for-coding",
+          label: "K2.7 Coding",
+          current: true,
+          defaultReasoningEffort: undefined,
+          reasoningEfforts: undefined,
+          supportsReasoning: false,
+        },
+        {
+          id: "kimi-code/k3",
+          label: "K3",
+          current: false,
+          defaultReasoningEffort: "high",
+          reasoningEfforts: ["low", "high", "max"],
+          supportsReasoning: true,
+        },
+      ],
+    });
+  });
+
+  it("projects Kimi model reasoning into its thought-level config option", () => {
+    expect(
+      withAcpModelRuntimeSelection({
+        runtime: {
+          configValues: {
+            model: "kimi-code/kimi-for-coding",
+            thinking: "on",
+          },
+          updatedAt: 500,
+        },
+        runtimeCapabilities: {
+          schemaVersion: 1,
+          status: "discovered",
+          checkedAt: 1000,
+          configOptions: [
+            {
+              id: "model",
+              label: "Model",
+              category: "model",
+              type: "select",
+              currentValue: "kimi-code/kimi-for-coding",
+              values: [
+                {
+                  value: "kimi-code/kimi-for-coding",
+                  label: "K2.7 Coding",
+                },
+                { value: "kimi-code/k3", label: "K3" },
+              ],
+            },
+            {
+              id: "thinking",
+              label: "Thinking",
+              category: "thought_level",
+              type: "select",
+              currentValue: "on",
+              values: [
+                { value: "low", label: "Low" },
+                { value: "high", label: "High" },
+                { value: "max", label: "Max" },
+              ],
+            },
+          ],
+          models: {
+            currentModelId: "kimi-code/kimi-for-coding",
+            availableModels: [
+              {
+                id: "kimi-code/k3",
+                reasoningEfforts: ["low", "high", "max"],
+                supportsReasoning: true,
+              },
+            ],
+          },
+        },
+        model: "kimi-code/k3",
+        reasoningEffort: "max",
+        now: 1000,
+      }),
+    ).toEqual({
+      configValues: {
+        model: "kimi-code/k3",
+        thinking: "max",
+      },
+      reasoningEffort: "max",
+      updatedAt: 1000,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1148,6 +1148,111 @@ describe("AcpAgentClient", () => {
     });
   });
 
+  it("sets Kimi model and thinking through advertised config options", async () => {
+    const transport = new FakeAcpAgentTransport({
+      "session/new": {
+        sessionId: "kimi-session",
+        configOptions: [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "kimi-code/kimi-for-coding",
+            options: [
+              {
+                value: "kimi-code/kimi-for-coding",
+                name: "K2.7 Coding",
+              },
+              { value: "kimi-code/k3", name: "K3" },
+            ],
+          },
+          {
+            id: "thinking",
+            name: "Thinking",
+            category: "thought_level",
+            currentValue: "on",
+            options: [{ value: "on", name: "On" }],
+          },
+        ],
+      },
+      "session/set_config_option": {
+        configOptions: [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            currentValue: "kimi-code/k3",
+            options: [
+              {
+                value: "kimi-code/kimi-for-coding",
+                name: "K2.7 Coding",
+              },
+              { value: "kimi-code/k3", name: "K3" },
+            ],
+          },
+          {
+            id: "thinking",
+            name: "Thinking",
+            category: "thought_level",
+            currentValue: "high",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "high", name: "High" },
+              { value: "max", name: "Max" },
+            ],
+          },
+        ],
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:kimi",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+
+    await expect(
+      client.setRuntimeOption({
+        sessionId: session.sessionId,
+        source: "model",
+        optionId: "model",
+        value: "kimi-code/k3",
+        reasoningEffort: "high",
+      }),
+    ).resolves.toMatchObject({
+      currentModelId: "kimi-code/k3",
+      configValues: {
+        model: "kimi-code/k3",
+        thinking: "high",
+      },
+      reasoningEffort: "high",
+    });
+    expect(transport.requests.slice(-2)).toEqual([
+      {
+        method: "session/set_config_option",
+        params: {
+          sessionId: "kimi-session",
+          configId: "model",
+          value: "kimi-code/k3",
+        },
+      },
+      {
+        method: "session/set_config_option",
+        params: {
+          sessionId: "kimi-session",
+          configId: "thinking",
+          value: "high",
+        },
+      },
+    ]);
+  });
+
   it("keeps requested ACP config-option mode when response reports stale current mode", async () => {
     const transport = new FakeAcpAgentTransport({
       "session/new": {

--- a/apps/desktop/src/main/__tests__/acp-runtime-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-runtime-discovery.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AcpBackendId } from "@pwragent/shared";
+import type { AcpJsonRpcTransport } from "../acp/acp-client";
+import { discoverAcpRuntimeCapabilities } from "../acp/acp-runtime-discovery";
+import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
+
+describe("discoverAcpRuntimeCapabilities", () => {
+  it("discovers dynamic per-model thinking levels and restores the original model", async () => {
+    let selectedModel = "kimi-code/kimi-for-coding";
+    const request = vi.fn(
+      async (
+        method: string,
+        params?: Record<string, unknown>,
+      ): Promise<unknown> => {
+        if (method === "initialize") {
+          return {
+            protocolVersion: 1,
+            agentInfo: {
+              name: "Kimi Code CLI",
+              version: "0.29.2",
+            },
+          };
+        }
+        if (method === "session/new") {
+          return {
+            sessionId: "kimi-session",
+            configOptions: buildKimiConfigOptions(selectedModel),
+          };
+        }
+        if (method === "session/set_config_option") {
+          if (params?.configId === "model") {
+            selectedModel = String(params.value);
+          }
+          return {
+            configOptions: buildKimiConfigOptions(selectedModel),
+          };
+        }
+        return {};
+      },
+    );
+    const close = vi.fn(async () => undefined);
+    const transport: AcpJsonRpcTransport = {
+      request,
+      close,
+      onNotification: () => () => undefined,
+    };
+
+    const result = await discoverAcpRuntimeCapabilities(
+      buildKimiAgent(),
+      {
+        cwd: "/repo",
+        now: () => 1000,
+        transportFactory: () => transport,
+      },
+    );
+
+    expect(result.runtimeCapabilities?.models).toEqual({
+      currentModelId: "kimi-code/kimi-for-coding",
+      availableModels: [
+        {
+          id: "kimi-code/kimi-for-coding",
+          label: "K2.7 Coding",
+          current: true,
+          supportsReasoning: false,
+        },
+        {
+          id: "kimi-code/k3",
+          label: "K3",
+          current: false,
+          supportsReasoning: true,
+          reasoningEfforts: ["low", "high", "max"],
+          defaultReasoningEffort: "high",
+        },
+        {
+          id: "kimi-code/k3-256k",
+          label: "K3-256k",
+          current: false,
+          supportsReasoning: true,
+          reasoningEfforts: ["low", "high", "max"],
+          defaultReasoningEffort: "high",
+        },
+      ],
+    });
+    expect(
+      request.mock.calls
+        .filter(([method]) => method === "session/set_config_option")
+        .map(([, params]) => params),
+    ).toEqual([
+      {
+        sessionId: "kimi-session",
+        configId: "model",
+        value: "kimi-code/k3",
+      },
+      {
+        sessionId: "kimi-session",
+        configId: "model",
+        value: "kimi-code/k3-256k",
+      },
+      {
+        sessionId: "kimi-session",
+        configId: "model",
+        value: "kimi-code/kimi-for-coding",
+      },
+    ]);
+    expect(selectedModel).toBe("kimi-code/kimi-for-coding");
+    expect(close).toHaveBeenCalledOnce();
+  });
+});
+
+function buildKimiConfigOptions(selectedModel: string) {
+  const supportsEffort = selectedModel.startsWith("kimi-code/k3");
+  return [
+    {
+      type: "select",
+      id: "model",
+      name: "Model",
+      category: "model",
+      currentValue: selectedModel,
+      options: [
+        {
+          value: "kimi-code/kimi-for-coding",
+          name: "K2.7 Coding",
+        },
+        {
+          value: "kimi-code/k3",
+          name: "K3",
+        },
+        {
+          value: "kimi-code/k3-256k",
+          name: "K3-256k",
+        },
+      ],
+    },
+    {
+      type: "select",
+      id: "thinking",
+      name: "Thinking",
+      category: "thought_level",
+      currentValue: supportsEffort ? "high" : "on",
+      options: supportsEffort
+        ? [
+            { value: "low", name: "Low" },
+            { value: "high", name: "High" },
+            { value: "max", name: "Max" },
+          ]
+        : [{ value: "on", name: "On" }],
+    },
+  ];
+}
+
+function buildKimiAgent(): AcpInstalledAgentRecord {
+  const backendId = "acp:kimi" as AcpBackendId;
+  return {
+    backendId,
+    registryId: "kimi",
+    name: "Kimi Code CLI",
+    version: "0.29.2",
+    distributionKind: "local",
+    distributionSource: "kimi acp",
+    installStatus: "installed",
+    authStatus: "authenticated",
+    verificationStatus: "not-applicable",
+    allowlistRuleId: "local-kimi-cli",
+    installedAt: 1000,
+    updatedAt: 1000,
+    launchDescriptor: {
+      backendId,
+      registryId: "kimi",
+      distributionKind: "local",
+      command: "kimi",
+      args: ["acp"],
+      env: {},
+    },
+  };
+}

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadReplay,
   AppServerThreadMessagePart,
   BackendAcpRuntimeCapabilities,
+  BackendAcpRuntimeConfigOption,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
   ThreadExecutionMode,
@@ -564,6 +565,8 @@ export class AcpAgentClient {
       result,
     });
     const responseRuntimeState = acpSessionRuntimeStateFromResponse(result, now);
+    const modelConfigOption = this.runtimeConfigOption("model");
+    const thoughtLevelConfigOption = this.runtimeConfigOption("thought_level");
     const requestedRuntimeState: BackendAcpSessionRuntimeState =
       params.source === "configOption"
         ? {
@@ -580,6 +583,19 @@ export class AcpAgentClient {
             }
           : {
               currentModelId: params.value,
+              ...(modelConfigOption
+                ? {
+                    configValues: {
+                      [modelConfigOption.id]: params.value,
+                      ...(params.reasoningEffort && thoughtLevelConfigOption
+                        ? {
+                            [thoughtLevelConfigOption.id]:
+                              params.reasoningEffort,
+                          }
+                        : {}),
+                    },
+                  }
+                : {}),
               reasoningEffort:
                 responseRuntimeState?.reasoningEffort ??
                 params.reasoningEffort,
@@ -600,9 +616,15 @@ export class AcpAgentClient {
 
   private isRuntimeModeConfigOption(optionId: string): boolean {
     return (
-      this.runtimeCapabilities?.configOptions?.some(
-        (option) => option.id === optionId && option.category === "mode",
-      ) ?? false
+      this.runtimeConfigOption("mode")?.id === optionId
+    );
+  }
+
+  private runtimeConfigOption(
+    category: string,
+  ): BackendAcpRuntimeConfigOption | undefined {
+    return this.runtimeCapabilities?.configOptions?.find(
+      (option) => option.category === category,
     );
   }
 
@@ -626,6 +648,31 @@ export class AcpAgentClient {
         sessionId: params.protocolSessionId,
         modeId: params.value,
       });
+    }
+
+    const modelConfigOption = this.runtimeConfigOption("model");
+    if (modelConfigOption) {
+      let result = await this.options.transport.request(
+        "session/set_config_option",
+        {
+          sessionId: params.protocolSessionId,
+          configId: modelConfigOption.id,
+          value: params.value,
+        },
+      );
+      const thoughtLevelConfigOption =
+        this.runtimeConfigOption("thought_level");
+      if (params.reasoningEffort && thoughtLevelConfigOption) {
+        result = await this.options.transport.request(
+          "session/set_config_option",
+          {
+            sessionId: params.protocolSessionId,
+            configId: thoughtLevelConfigOption.id,
+            value: params.reasoningEffort,
+          },
+        );
+      }
+      return result;
     }
 
     return await this.options.transport.request("session/set_model", {

--- a/apps/desktop/src/main/acp/acp-runtime-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-runtime-discovery.ts
@@ -1,6 +1,8 @@
 import type {
   AcpBackendId,
   BackendAcpRuntimeCapabilities,
+  BackendAcpRuntimeConfigOption,
+  BackendAcpRuntimeModel,
   BackendAcpSessionRuntimeState,
 } from "@pwragent/shared";
 import { AcpAgentClient, type AcpJsonRpcTransport } from "./acp-client.js";
@@ -52,15 +54,111 @@ export async function discoverAcpRuntimeCapabilities(
 
   try {
     await client.initialize();
-    await client.startSession({
+    const session = await client.startSession({
       cwd: options.cwd,
       executionMode: "default",
       title: "ACP capability discovery",
+    });
+    runtimeCapabilities = await discoverModelReasoningCapabilities({
+      client,
+      readRuntimeCapabilities: () => runtimeCapabilities,
+      sessionId: session.sessionId,
     });
     return { runtimeCapabilities, runtimeState };
   } finally {
     await client.dispose();
   }
+}
+
+async function discoverModelReasoningCapabilities(params: {
+  client: AcpAgentClient;
+  readRuntimeCapabilities: () => BackendAcpRuntimeCapabilities | undefined;
+  sessionId: string;
+}): Promise<BackendAcpRuntimeCapabilities | undefined> {
+  const initial = params.readRuntimeCapabilities();
+  const modelOption = findConfigOption(initial, "model");
+  const thoughtLevelOption = findConfigOption(initial, "thought_level");
+  if (!modelOption || !thoughtLevelOption || modelOption.values.length === 0) {
+    return initial;
+  }
+
+  const originalModel = modelOption.currentValue;
+  let selectedModel = originalModel;
+  const models: BackendAcpRuntimeModel[] = [];
+  try {
+    for (const model of modelOption.values) {
+      if (model.value !== selectedModel) {
+        try {
+          await params.client.setRuntimeOption({
+            sessionId: params.sessionId,
+            source: "configOption",
+            optionId: modelOption.id,
+            value: model.value,
+          });
+          selectedModel = model.value;
+        } catch {
+          models.push({
+            id: model.value,
+            label: model.label,
+          });
+          continue;
+        }
+      }
+
+      const currentCapabilities = params.readRuntimeCapabilities();
+      const currentThoughtLevel =
+        findConfigOption(currentCapabilities, "thought_level");
+      const reasoningEfforts =
+        currentThoughtLevel?.values.map((value) => value.value) ?? [];
+      const supportsReasoning = reasoningEfforts.length > 1;
+      models.push({
+        id: model.value,
+        label: model.label,
+        current: model.value === originalModel,
+        ...(supportsReasoning
+          ? {
+              supportsReasoning: true,
+              reasoningEfforts,
+              ...(currentThoughtLevel?.currentValue
+                ? {
+                    defaultReasoningEffort:
+                      currentThoughtLevel.currentValue,
+                  }
+                : {}),
+            }
+          : { supportsReasoning: false }),
+      });
+    }
+  } finally {
+    if (originalModel && selectedModel !== originalModel) {
+      await params.client.setRuntimeOption({
+        sessionId: params.sessionId,
+        source: "configOption",
+        optionId: modelOption.id,
+        value: originalModel,
+      }).catch(() => undefined);
+    }
+  }
+
+  const restored = params.readRuntimeCapabilities() ?? initial;
+  return restored
+    ? {
+        ...restored,
+        models: {
+          availableModels: models,
+          ...(originalModel ? { currentModelId: originalModel } : {}),
+        },
+      }
+    : restored;
+}
+
+function findConfigOption(
+  capabilities: BackendAcpRuntimeCapabilities | undefined,
+  category: string,
+): BackendAcpRuntimeConfigOption | undefined {
+  return capabilities?.configOptions?.find(
+    (option) => option.category === category,
+  );
 }
 
 class MemoryAcpSessionStore implements Pick<

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -477,10 +477,19 @@ export function findAcpModelConfigOption(
   );
 }
 
+export function findAcpThoughtLevelConfigOption(
+  runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined,
+) {
+  return runtimeCapabilities?.configOptions?.find(
+    (option) => option.category === "thought_level",
+  );
+}
+
 export function withAcpModelRuntimeSelection(params: {
   runtime: BackendAcpSessionRuntimeState | undefined;
   runtimeCapabilities: BackendAcpRuntimeCapabilities | undefined;
   model: string | undefined;
+  reasoningEffort?: string;
   now: number;
 }): BackendAcpSessionRuntimeState | undefined {
   const model = params.model?.trim();
@@ -495,18 +504,33 @@ export function withAcpModelRuntimeSelection(params: {
       (option) => option.id === model,
     ) ?? false;
   const shouldSetCurrentModelId =
-    hasAdvertisedModel || (!modelConfigOption && !hasModelList);
+    !modelConfigOption && (hasAdvertisedModel || !hasModelList);
   const configValues = modelConfigOption
     ? {
         ...(params.runtime?.configValues ?? {}),
         [modelConfigOption.id]: model,
       }
     : params.runtime?.configValues;
+  const thoughtLevelConfigOption = findAcpThoughtLevelConfigOption(
+    params.runtimeCapabilities,
+  );
+  const configValuesWithReasoning =
+    params.reasoningEffort && thoughtLevelConfigOption
+      ? {
+          ...(configValues ?? {}),
+          [thoughtLevelConfigOption.id]: params.reasoningEffort,
+        }
+      : configValues;
 
   return {
     ...params.runtime,
     ...(shouldSetCurrentModelId ? { currentModelId: model } : {}),
-    ...(configValues ? { configValues } : {}),
+    ...(params.reasoningEffort
+      ? { reasoningEffort: params.reasoningEffort }
+      : {}),
+    ...(configValuesWithReasoning
+      ? { configValues: configValuesWithReasoning }
+      : {}),
     updatedAt: Math.max(params.runtime?.updatedAt ?? 0, params.now),
   };
 }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -207,6 +207,8 @@ import {
   acpRuntimeValueLooksPrivileged,
   acpSessionHasConversationHistory,
   acpSessionToThreadSummary,
+  findAcpModelConfigOption,
+  findAcpThoughtLevelConfigOption,
   formatAcpRuntimeLabel,
   inputToAcpPrompt,
   acpAdvertisesRuntimeModeSelector,
@@ -6871,11 +6873,29 @@ export class DesktopBackendRegistry {
         sessionForTurn = await this.rebindAcpSessionForWorkspace(client, sessionForTurn);
       }
     }
+    const runtimeCapabilities =
+      this.acpBackend.getInstalledAgent(params.backend)?.runtimeCapabilities;
+    const modelConfigOption =
+      findAcpModelConfigOption(runtimeCapabilities);
+    const thoughtLevelConfigOption =
+      findAcpThoughtLevelConfigOption(runtimeCapabilities);
+    const currentModel =
+      (modelConfigOption
+        ? sessionForTurn.acpRuntime?.configValues?.[modelConfigOption.id]
+        : undefined) ??
+      sessionForTurn.acpRuntime?.currentModelId;
+    const currentReasoningEffort =
+      (thoughtLevelConfigOption
+        ? sessionForTurn.acpRuntime?.configValues?.[
+            thoughtLevelConfigOption.id
+          ]
+        : undefined) ??
+      sessionForTurn.acpRuntime?.reasoningEffort;
     if (
       params.model &&
       (
-        sessionForTurn.acpRuntime?.currentModelId !== params.model ||
-        sessionForTurn.acpRuntime?.reasoningEffort !== params.reasoningEffort
+        currentModel !== params.model ||
+        currentReasoningEffort !== params.reasoningEffort
       )
     ) {
       await client.setRuntimeOption?.({
@@ -8249,6 +8269,7 @@ export class DesktopBackendRegistry {
           runtime: acpRuntimeWithDefaults,
           runtimeCapabilities: acpRuntimeCapabilities,
           model: modelSettings.model,
+          reasoningEffort: modelSettings.reasoningEffort,
           now: acpRuntimeStartedAt,
         })
       : acpRuntimeWithDefaults;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -584,6 +584,19 @@ function DesktopAppShell(props: {
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
   });
+  const refreshAcpAgents = backendSummaries.refreshAcpAgents;
+  const refreshSelectedAcpProvider = useCallback(
+    async (
+      backend: AppServerBackendKind,
+    ) => {
+      if (!backend.startsWith("acp:")) {
+        return undefined;
+      }
+      const refreshedBackends = await refreshAcpAgents();
+      return refreshedBackends.find((candidate) => candidate.kind === backend);
+    },
+    [refreshAcpAgents],
+  );
   const pullRequests = usePullRequestRefresh({
     desktopApi,
     onRefreshNavigation: navigation.refresh,
@@ -963,11 +976,7 @@ function DesktopAppShell(props: {
     composerDraftStore,
     desktopApi,
     launchpadError: navigation.launchpadError,
-    onProviderSelected: (backend: AppServerBackendKind) => {
-      if (backend.startsWith("acp:")) {
-        void backendSummaries.refreshAcpAgents();
-      }
-    },
+    onProviderSelected: refreshSelectedAcpProvider,
     onShowNotice: setComposerNotice,
     loading: session.loading,
     loadingMore: session.loadingMore,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -963,6 +963,11 @@ function DesktopAppShell(props: {
     composerDraftStore,
     desktopApi,
     launchpadError: navigation.launchpadError,
+    onProviderSelected: (backend: AppServerBackendKind) => {
+      if (backend.startsWith("acp:")) {
+        void backendSummaries.refreshAcpAgents();
+      }
+    },
     onShowNotice: setComposerNotice,
     loading: session.loading,
     loadingMore: session.loadingMore,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6253,6 +6253,8 @@ export function Composer(props: ComposerProps) {
     activeAcpLaunchpadRefreshKeyRef.current = refreshKey;
     const adoptRefreshedDefault =
       pendingProviderSelectionKeyRef.current === refreshKey;
+    const automaticModel = launchpad.model;
+    const automaticReasoningEffort = launchpad.reasoningEffort;
     if (adoptRefreshedDefault) {
       pendingProviderSelectionKeyRef.current = undefined;
     }
@@ -6271,9 +6273,13 @@ export function Composer(props: ComposerProps) {
           return;
         }
 
+        const shouldAdoptRefreshedDefault =
+          adoptRefreshedDefault
+          && latestLaunchpad.model === automaticModel
+          && latestLaunchpad.reasoningEffort === automaticReasoningEffort;
         const refreshedModels = refreshedBackend.launchpadOptions?.models ?? [];
         const nextModelOption =
-          (adoptRefreshedDefault
+          (shouldAdoptRefreshedDefault
             ? undefined
             : refreshedModels.find(
                 (model) => model.id === latestLaunchpad.model,
@@ -6283,7 +6289,7 @@ export function Composer(props: ComposerProps) {
           return;
         }
         const nextReasoningEffort = nextModelOption.supportsReasoning
-          ? adoptRefreshedDefault
+          ? shouldAdoptRefreshedDefault
             ? getDefaultReasoningEffort(refreshedBackend, nextModelOption)
             : getReasoningEffortValue(
                 refreshedBackend,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -127,7 +127,7 @@ type ComposerProps = {
   onShowNotice?: (notice: AppNoticeToastNotice) => void;
   onProviderSelected?: (
     backend: NavigationLaunchpadDraft["backend"],
-  ) => void;
+  ) => BackendSummary | undefined | Promise<BackendSummary | undefined>;
   directory?: NavigationDirectorySummary;
   /**
    * Full set of currently-tracked directories from the navigation
@@ -2508,6 +2508,11 @@ export function Composer(props: ComposerProps) {
   const slashListboxId = useId();
   const directoryRefListboxId = useId();
   const hydratedLaunchpadKeyRef = useRef<string | undefined>(undefined);
+  const activeAcpLaunchpadRefreshKeyRef = useRef<string | undefined>(undefined);
+  const pendingProviderSelectionKeyRef = useRef<string | undefined>(undefined);
+  const latestLaunchpadRef =
+    useRef<NavigationLaunchpadDraft | undefined>(props.launchpad);
+  latestLaunchpadRef.current = props.launchpad;
   const pendingProgrammaticComposerChangeRef =
     useRef<PendingProgrammaticComposerChange | undefined>(undefined);
   const composerScopeKey = props.launchpad
@@ -6233,6 +6238,83 @@ export function Composer(props: ComposerProps) {
     }, 0);
   };
 
+  useEffect(() => {
+    const launchpad = props.launchpad;
+    const backend = launchpad?.backend;
+    if (!launchpad || !backend?.startsWith("acp:")) {
+      activeAcpLaunchpadRefreshKeyRef.current = undefined;
+      return;
+    }
+
+    const refreshKey = `${launchpad.directoryKey}:${backend}`;
+    if (activeAcpLaunchpadRefreshKeyRef.current === refreshKey) {
+      return;
+    }
+    activeAcpLaunchpadRefreshKeyRef.current = refreshKey;
+    const adoptRefreshedDefault =
+      pendingProviderSelectionKeyRef.current === refreshKey;
+    if (adoptRefreshedDefault) {
+      pendingProviderSelectionKeyRef.current = undefined;
+    }
+
+    let cancelled = false;
+    void Promise.resolve(props.onProviderSelected?.(backend)).then(
+      async (refreshedBackend) => {
+        if (cancelled || !refreshedBackend || !props.onUpdateLaunchpad) {
+          return;
+        }
+        const latestLaunchpad = latestLaunchpadRef.current;
+        if (
+          latestLaunchpad?.directoryKey !== launchpad.directoryKey ||
+          latestLaunchpad.backend !== backend
+        ) {
+          return;
+        }
+
+        const refreshedModels = refreshedBackend.launchpadOptions?.models ?? [];
+        const nextModelOption =
+          (adoptRefreshedDefault
+            ? undefined
+            : refreshedModels.find(
+                (model) => model.id === latestLaunchpad.model,
+              )) ??
+          getDefaultModelOption(refreshedBackend);
+        if (!nextModelOption) {
+          return;
+        }
+        const nextReasoningEffort = nextModelOption.supportsReasoning
+          ? getDefaultReasoningEffort(refreshedBackend, nextModelOption)
+          : undefined;
+        if (
+          latestLaunchpad.model === nextModelOption.id &&
+          latestLaunchpad.reasoningEffort === nextReasoningEffort
+        ) {
+          return;
+        }
+
+        await props.onUpdateLaunchpad(
+          latestLaunchpad.directoryKey,
+          {
+            model: nextModelOption.id,
+            reasoningEffort: nextReasoningEffort,
+          },
+          {
+            stickySettingsChanged: true,
+          },
+        );
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    props.launchpad?.backend,
+    props.launchpad?.directoryKey,
+    props.onProviderSelected,
+    props.onUpdateLaunchpad,
+  ]);
+
   const runThreadCodexEnvironmentAction = async (): Promise<void> => {
     if (
       !props.thread ||
@@ -7978,10 +8060,15 @@ export function Composer(props: ComposerProps) {
                   return;
                 }
                 const nextBackend = value as NavigationLaunchpadDraft["backend"];
+                if (nextBackend.startsWith("acp:")) {
+                  pendingProviderSelectionKeyRef.current =
+                    `${props.launchpad.directoryKey}:${nextBackend}`;
+                } else {
+                  pendingProviderSelectionKeyRef.current = undefined;
+                }
                 handleLaunchpadPatch({
                   backend: nextBackend,
                 });
-                props.onProviderSelected?.(nextBackend);
               }}
             />
           ) : props.thread ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -125,6 +125,9 @@ type ComposerProps = {
    * AppNoticeToast stack in App.tsx.
    */
   onShowNotice?: (notice: AppNoticeToastNotice) => void;
+  onProviderSelected?: (
+    backend: NavigationLaunchpadDraft["backend"],
+  ) => void;
   directory?: NavigationDirectorySummary;
   /**
    * Full set of currently-tracked directories from the navigation
@@ -7978,6 +7981,7 @@ export function Composer(props: ComposerProps) {
                 handleLaunchpadPatch({
                   backend: nextBackend,
                 });
+                props.onProviderSelected?.(nextBackend);
               }}
             />
           ) : props.thread ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6283,7 +6283,13 @@ export function Composer(props: ComposerProps) {
           return;
         }
         const nextReasoningEffort = nextModelOption.supportsReasoning
-          ? getDefaultReasoningEffort(refreshedBackend, nextModelOption)
+          ? adoptRefreshedDefault
+            ? getDefaultReasoningEffort(refreshedBackend, nextModelOption)
+            : getReasoningEffortValue(
+                refreshedBackend,
+                nextModelOption,
+                latestLaunchpad.reasoningEffort,
+              )
           : undefined;
         if (
           latestLaunchpad.model === nextModelOption.id &&
@@ -8060,7 +8066,10 @@ export function Composer(props: ComposerProps) {
                   return;
                 }
                 const nextBackend = value as NavigationLaunchpadDraft["backend"];
-                if (nextBackend.startsWith("acp:")) {
+                const hasRememberedModel = Boolean(
+                  props.launchpad.providerSettings?.[nextBackend]?.model,
+                );
+                if (nextBackend.startsWith("acp:") && !hasRememberedModel) {
                   pendingProviderSelectionKeyRef.current =
                     `${props.launchpad.directoryKey}:${nextBackend}`;
                 } else {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1542,15 +1542,112 @@ describe("Composer", () => {
     expect(screen.queryByRole("option", { name: "Default" })).not.toBeInTheDocument();
   });
 
-  it("requests fresh ACP discovery when the provider is selected", () => {
-    const onProviderSelected = vi.fn();
+  it("adopts the refreshed ACP default when the provider is selected", async () => {
+    const staleKimi = {
+      ...backendSummary("acp:kimi", {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "Kimi-k2.6",
+            current: true,
+          },
+        ],
+      }),
+      label: "Kimi",
+    };
+    const refreshedKimi = {
+      ...staleKimi,
+      launchpadOptions: {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "K2.7 Coding",
+          },
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            current: true,
+          },
+        ],
+      },
+    };
+    const onProviderSelected = vi.fn(async () => refreshedKimi);
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const composer = (nextLaunchpad: NavigationLaunchpadDraft) => (
+      <Composer
+        backends={[backendSummary("codex"), staleKimi]}
+        launchpad={nextLaunchpad}
+        onProviderSelected={onProviderSelected}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+    const { rerender } = render(composer(launchpad));
+
+    chooseDropdownOption("Provider", "Kimi");
+    rerender(
+      composer({
+        ...launchpad,
+        backend: "acp:kimi",
+        model: "kimi-code/kimi-for-coding",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onProviderSelected).toHaveBeenCalledWith("acp:kimi");
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          model: "kimi-code/k3",
+          reasoningEffort: undefined,
+        }),
+        { stickySettingsChanged: true },
+      );
+    });
+  });
+
+  it("refreshes a persisted ACP launchpad and replaces a removed model", async () => {
+    const refreshedKimi = {
+      ...backendSummary("acp:kimi", {
+        models: [
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            current: true,
+          },
+        ],
+      }),
+      label: "Kimi",
+    };
+    const onProviderSelected = vi.fn(async () => refreshedKimi);
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
 
     render(
       <Composer
         backends={[
-          backendSummary("codex"),
           {
-            ...backendSummary("acp:kimi"),
+            ...backendSummary("acp:kimi", {
+              models: [
+                {
+                  id: "kimi-code/kimi-for-coding",
+                  label: "Kimi-k2.6",
+                  current: true,
+                },
+              ],
+            }),
             label: "Kimi",
           },
         ]}
@@ -1559,8 +1656,9 @@ describe("Composer", () => {
           directoryKind: "directory",
           directoryLabel: "Repo",
           directoryPath: "/repo",
-          backend: "codex",
+          backend: "acp:kimi",
           executionMode: "default",
+          model: "kimi-code/kimi-for-coding",
           prompt: "",
           workMode: "local",
           branchName: "main",
@@ -1568,14 +1666,22 @@ describe("Composer", () => {
           updatedAt: 1,
         }}
         onProviderSelected={onProviderSelected}
-        onUpdateLaunchpad={async () => undefined}
+        onUpdateLaunchpad={onUpdateLaunchpad}
         skills={[]}
       />,
     );
 
-    chooseDropdownOption("Provider", "Kimi");
-
-    expect(onProviderSelected).toHaveBeenCalledWith("acp:kimi");
+    await waitFor(() => {
+      expect(onProviderSelected).toHaveBeenCalledTimes(1);
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          model: "kimi-code/k3",
+          reasoningEffort: undefined,
+        }),
+        { stickySettingsChanged: true },
+      );
+    });
   });
 
   it("hides reasoning controls for Grok 4.20 models", () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1619,6 +1619,101 @@ describe("Composer", () => {
     });
   });
 
+  it("preserves a model and reasoning choice made while ACP discovery runs", async () => {
+    const staleKimi = {
+      ...backendSummary("acp:kimi", {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "K2.7 Coding",
+            current: true,
+          },
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "high", "max"],
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      label: "Kimi",
+    };
+    const refreshedKimi = {
+      ...staleKimi,
+      launchpadOptions: {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "K2.7 Coding",
+            current: true,
+          },
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "high", "max"],
+            supportsReasoning: true,
+          },
+        ],
+      },
+    };
+    const discovery = createDeferred<BackendSummary | undefined>();
+    const onProviderSelected = vi.fn(() => discovery.promise);
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const composer = (nextLaunchpad: NavigationLaunchpadDraft) => (
+      <Composer
+        backends={[backendSummary("codex"), staleKimi]}
+        launchpad={nextLaunchpad}
+        onProviderSelected={onProviderSelected}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />
+    );
+    const { rerender } = render(composer(launchpad));
+
+    chooseDropdownOption("Provider", "Kimi");
+    rerender(
+      composer({
+        ...launchpad,
+        backend: "acp:kimi",
+        model: "kimi-code/kimi-for-coding",
+      }),
+    );
+    await waitFor(() => {
+      expect(onProviderSelected).toHaveBeenCalledWith("acp:kimi");
+    });
+    onUpdateLaunchpad.mockClear();
+
+    rerender(
+      composer({
+        ...launchpad,
+        backend: "acp:kimi",
+        model: "kimi-code/k3",
+        reasoningEffort: "max",
+      }),
+    );
+    await act(async () => {
+      discovery.resolve(refreshedKimi);
+      await discovery.promise;
+    });
+
+    expect(onUpdateLaunchpad).not.toHaveBeenCalled();
+  });
+
   it("refreshes a persisted ACP launchpad and replaces a removed model", async () => {
     const refreshedKimi = {
       ...backendSummary("acp:kimi", {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1684,6 +1684,93 @@ describe("Composer", () => {
     });
   });
 
+  it("remembers Kimi thinking effort separately for each model", async () => {
+    const kimiBackend = {
+      ...backendSummary("acp:kimi", {
+        models: [
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            current: true,
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "high", "max"],
+            supportsReasoning: true,
+          },
+          {
+            id: "kimi-code/k3-256k",
+            label: "K3-256k",
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "high", "max"],
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      label: "Kimi",
+    };
+    const initialLaunchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "acp:kimi",
+      executionMode: "default",
+      model: "kimi-code/k3",
+      reasoningEffort: "max",
+      providerSettings: {
+        "acp:kimi": {
+          model: "kimi-code/k3",
+          reasoningEffort: "max",
+          reasoningEffortsByModel: {
+            "kimi-code/k3": "max",
+            "kimi-code/k3-256k": "low",
+          },
+        },
+      },
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    function KimiThinkingHarness(): React.JSX.Element {
+      const [launchpad, setLaunchpad] = useState(initialLaunchpad);
+      return (
+        <Composer
+          backends={[kimiBackend]}
+          launchpad={launchpad}
+          onUpdateLaunchpad={async (_directoryKey, patch) => {
+            setLaunchpad((current) =>
+              applyNavigationLaunchpadProviderSettingsPatch<
+                NavigationLaunchpadDraft
+              >(current, patch),
+            );
+          }}
+          skills={[]}
+        />
+      );
+    }
+
+    render(<KimiThinkingHarness />);
+
+    expect(screen.getByLabelText("Reasoning")).toHaveValue("max");
+    chooseDropdownOption("Model", "K3-256k");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("low");
+    });
+
+    chooseDropdownOption("Reasoning", "high");
+    chooseDropdownOption("Model", "K3");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("max");
+    });
+
+    chooseDropdownOption("Model", "K3-256k");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reasoning")).toHaveValue("high");
+    });
+  });
+
   it("hides reasoning controls for Grok 4.20 models", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1542,6 +1542,42 @@ describe("Composer", () => {
     expect(screen.queryByRole("option", { name: "Default" })).not.toBeInTheDocument();
   });
 
+  it("requests fresh ACP discovery when the provider is selected", () => {
+    const onProviderSelected = vi.fn();
+
+    render(
+      <Composer
+        backends={[
+          backendSummary("codex"),
+          {
+            ...backendSummary("acp:kimi"),
+            label: "Kimi",
+          },
+        ]}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          branchName: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onProviderSelected={onProviderSelected}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />,
+    );
+
+    chooseDropdownOption("Provider", "Kimi");
+
+    expect(onProviderSelected).toHaveBeenCalledWith("acp:kimi");
+  });
+
   it("hides reasoning controls for Grok 4.20 models", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -5,6 +5,7 @@ import type {
   DesktopSettingsValue,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import { SettingsField, SettingsSection } from "./SettingsLayout";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
@@ -75,6 +76,9 @@ export function AcpAgentsSettings(props: {
       });
       setEntries(response.entries);
       setError(response.error);
+      if (refreshRegistry) {
+        window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+      }
     } catch (refreshError) {
       setError(refreshError instanceof Error ? refreshError.message : String(refreshError));
     } finally {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import { AcpAgentsSettings } from "../AcpAgentsSettings";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
 
 afterEach(() => {
   cleanup();
@@ -30,6 +31,7 @@ function geminiEntry(): AcpAgentSettingsEntry {
 
 describe("AcpAgentsSettings", () => {
   it("keeps cached ACP agents visible while background discovery refreshes", async () => {
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     let resolveRefresh:
       | ((value: { fetchedAt: number; entries: AcpAgentSettingsEntry[] }) => void)
       | undefined;
@@ -105,6 +107,11 @@ describe("AcpAgentsSettings", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Refresh" })).toBeEnabled();
     });
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: BACKEND_SUMMARIES_REFRESH_EVENT,
+      }),
+    );
   });
 
   it("renders multiple installs with a 'Use' action and the active one as 'Using'", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -722,6 +722,9 @@ export type ThreadViewProps = {
   desktopApi?: DesktopApi;
   launchpadError?: string;
   onShowNotice?: (notice: AppNoticeToastNotice) => void;
+  onProviderSelected?: (
+    backend: NavigationLaunchpadDraft["backend"],
+  ) => void;
   archiveThreadError?: string;
   loading: boolean;
   loadingMore: boolean;
@@ -2394,6 +2397,7 @@ export function ThreadView(props: ThreadViewProps) {
               applications={props.applications}
               desktopApi={props.desktopApi}
               onShowNotice={props.onShowNotice}
+              onProviderSelected={props.onProviderSelected}
               composerImplementation={props.composerImplementation}
               draftStore={props.composerDraftStore}
               directory={props.selectedDirectory}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -724,7 +724,7 @@ export type ThreadViewProps = {
   onShowNotice?: (notice: AppNoticeToastNotice) => void;
   onProviderSelected?: (
     backend: NavigationLaunchpadDraft["backend"],
-  ) => void;
+  ) => BackendSummary | undefined | Promise<BackendSummary | undefined>;
   archiveThreadError?: string;
   loading: boolean;
   loadingMore: boolean;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentEvent } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
@@ -8,6 +8,99 @@ import {
 } from "../useBackendSummaries";
 
 describe("useBackendSummaries", () => {
+  it("refreshes cached ACP models only when explicitly requested", async () => {
+    const listAcpAgents = vi
+      .fn<NonNullable<DesktopApi["listAcpAgents"]>>()
+      .mockResolvedValue({
+        fetchedAt: 2,
+        entries: [],
+      });
+    const staleKimi = {
+      kind: "acp:kimi" as const,
+      source: "acp" as const,
+      label: "Kimi",
+      available: true,
+      methods: [],
+      capabilities: {
+        listThreads: true,
+        createThread: true,
+        resumeThread: true,
+        renameThread: true,
+        readThread: true,
+        startTurn: true,
+        interruptTurn: true,
+        steerTurn: false,
+        transcriptPagination: false,
+        toolUse: true,
+        approvalRequests: true,
+        multiDirectoryThreads: true,
+      },
+      executionModes: [],
+      launchpadOptions: {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "Kimi-k2.6",
+            current: true,
+          },
+        ],
+      },
+    };
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValueOnce({
+        fetchedAt: 1,
+        backends: [staleKimi],
+      })
+      .mockResolvedValue({
+        fetchedAt: 2,
+        backends: [
+          {
+            ...staleKimi,
+            launchpadOptions: {
+              models: [
+                {
+                  id: "kimi-code/kimi-for-coding",
+                  label: "K2.7 Coding",
+                  current: true,
+                },
+                {
+                  id: "kimi-code/k3",
+                  label: "K3",
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+    const desktopApi: DesktopApi = {
+      listAcpAgents,
+      listBackends,
+    };
+    const { result } = renderHook(() => useBackendSummaries(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.backends[0]?.launchpadOptions?.models).toEqual([
+        expect.objectContaining({ label: "Kimi-k2.6" }),
+      ]);
+    });
+    expect(listAcpAgents).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refreshAcpAgents();
+    });
+
+    await waitFor(() => {
+      expect(result.current.backends[0]?.launchpadOptions?.models).toEqual([
+        expect.objectContaining({ label: "K2.7 Coding" }),
+        expect.objectContaining({ label: "K3" }),
+      ]);
+    });
+    expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true });
+    expect(listBackends).toHaveBeenCalledTimes(2);
+  });
+
   it("refreshes backend details when Codex rate limits update", async () => {
     let eventHandler: ((event: AgentEvent) => void) | undefined;
     const listBackends = vi

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -97,7 +97,10 @@ describe("useBackendSummaries", () => {
         expect.objectContaining({ label: "K3" }),
       ]);
     });
-    expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true });
+    expect(listAcpAgents).toHaveBeenCalledWith({
+      refresh: true,
+      force: true,
+    });
     expect(listBackends).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -70,7 +70,10 @@ export function useBackendSummaries(
 
     const refreshPromise = (async () => {
       try {
-        await desktopApi.listAcpAgents?.({ refresh: true });
+        await desktopApi.listAcpAgents?.({
+          refresh: true,
+          force: true,
+        });
         return await refresh();
       } catch {
         // ACP discovery is best-effort. Keep the cached backend summaries

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -8,7 +8,7 @@ type BackendSummaryData = {
 };
 
 type BackendSummaryState = BackendSummaryData & {
-  refreshAcpAgents: () => Promise<void>;
+  refreshAcpAgents: () => Promise<BackendSummary[]>;
 };
 
 export const BACKEND_SUMMARIES_REFRESH_EVENT =
@@ -22,15 +22,16 @@ export function useBackendSummaries(
   const [state, setState] = useState<BackendSummaryData>({
     backends: []
   });
-  const acpRefreshPromiseRef = useRef<Promise<void> | undefined>(undefined);
+  const acpRefreshPromiseRef =
+    useRef<Promise<BackendSummary[]> | undefined>(undefined);
 
-  const refresh = useCallback(async (): Promise<void> => {
+  const refresh = useCallback(async (): Promise<BackendSummary[]> => {
     if (!enabled) {
       setState({
         backends: [],
         error: undefined
       });
-      return;
+      return [];
     }
 
     if (!desktopApi?.listBackends) {
@@ -38,7 +39,7 @@ export function useBackendSummaries(
         backends: [],
         error: undefined
       });
-      return;
+      return [];
     }
 
     try {
@@ -49,17 +50,19 @@ export function useBackendSummaries(
         backends: response.backends,
         error: undefined
       });
+      return response.backends;
     } catch (error) {
       setState({
         backends: [],
         error: error instanceof Error ? error.message : String(error)
       });
+      return [];
     }
   }, [desktopApi, enabled]);
 
-  const refreshAcpAgents = useCallback(async (): Promise<void> => {
+  const refreshAcpAgents = useCallback(async (): Promise<BackendSummary[]> => {
     if (!enabled || !desktopApi?.listAcpAgents) {
-      return;
+      return [];
     }
     if (acpRefreshPromiseRef.current) {
       return await acpRefreshPromiseRef.current;
@@ -68,10 +71,11 @@ export function useBackendSummaries(
     const refreshPromise = (async () => {
       try {
         await desktopApi.listAcpAgents?.({ refresh: true });
-        await refresh();
+        return await refresh();
       } catch {
         // ACP discovery is best-effort. Keep the cached backend summaries
         // usable when one local CLI cannot be probed.
+        return [];
       }
     })();
     acpRefreshPromiseRef.current = refreshPromise;

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -1,10 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { BackendSummary } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
 
-type BackendSummaryState = {
+type BackendSummaryData = {
   backends: BackendSummary[];
   error?: string;
+};
+
+type BackendSummaryState = BackendSummaryData & {
+  refreshAcpAgents: () => Promise<void>;
 };
 
 export const BACKEND_SUMMARIES_REFRESH_EVENT =
@@ -15,9 +19,10 @@ export function useBackendSummaries(
   options: { enabled?: boolean } = {},
 ): BackendSummaryState {
   const enabled = options.enabled ?? true;
-  const [state, setState] = useState<BackendSummaryState>({
+  const [state, setState] = useState<BackendSummaryData>({
     backends: []
   });
+  const acpRefreshPromiseRef = useRef<Promise<void> | undefined>(undefined);
 
   const refresh = useCallback(async (): Promise<void> => {
     if (!enabled) {
@@ -52,6 +57,33 @@ export function useBackendSummaries(
     }
   }, [desktopApi, enabled]);
 
+  const refreshAcpAgents = useCallback(async (): Promise<void> => {
+    if (!enabled || !desktopApi?.listAcpAgents) {
+      return;
+    }
+    if (acpRefreshPromiseRef.current) {
+      return await acpRefreshPromiseRef.current;
+    }
+
+    const refreshPromise = (async () => {
+      try {
+        await desktopApi.listAcpAgents?.({ refresh: true });
+        await refresh();
+      } catch {
+        // ACP discovery is best-effort. Keep the cached backend summaries
+        // usable when one local CLI cannot be probed.
+      }
+    })();
+    acpRefreshPromiseRef.current = refreshPromise;
+    try {
+      return await refreshPromise;
+    } finally {
+      if (acpRefreshPromiseRef.current === refreshPromise) {
+        acpRefreshPromiseRef.current = undefined;
+      }
+    }
+  }, [desktopApi, enabled, refresh]);
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -82,5 +114,8 @@ export function useBackendSummaries(
     });
   }, [desktopApi, enabled, refresh]);
 
-  return state;
+  return {
+    ...state,
+    refreshAcpAgents,
+  };
 }


### PR DESCRIPTION
## Summary

- refresh locally advertised ACP models once when an ACP launchpad becomes active or Settings discovery runs
- reconcile persisted launchpad models after refresh without overwriting valid per-provider selections
- probe ACP model selectors during explicit discovery to learn dynamic per-model thought levels
- expose Kimi K3 and K3-256k Low / High / Max Thinking through the existing Reasoning dropdown
- send Kimi model and Thinking selections through its advertised `session/set_config_option` protocol and remember Thinking independently per model

## Why

Kimi Code can update itself and advertise a newer model catalog over ACP, while PwrAgent may still hold a fresh-looking persisted capability record from the previous CLI version. Kimi 0.29.2 also changes its `thought_level` config option dynamically: K2.7 reports fixed Thinking On, while K3 models report Low / High / Max with High as the default.

This keeps Kimi ACP responses as the source of truth without introducing a provider-specific model allowlist or periodic polling that would overlap broader model-refresh work.

## Token usage finding

A live Kimi 0.29.2 ACP turn returned only `stopReason` from `session/prompt` and no token counts in its session updates. Kimi advertises a human-facing `/usage` command, but its ACP capability/method documentation does not expose a structured usage notification. PwrAgent already consumes ACP `turn_completed.usage` when an agent supplies it, so there is no reliable Kimi payload to connect to pricing yet and this PR does not scrape command text.

## User impact

Selecting Kimi for a new launchpad, reopening a persisted Kimi launchpad, or running Settings discovery refreshes the locally advertised catalog once. K3 models now show the Reasoning selector with Low / High / Max, default to High, transmit the selection to Kimi, and restore the last selected level independently for each Kimi model.

## Validation

- live protocol probes against installed Kimi Code CLI 0.29.2
- 282 focused ACP and composer tests
- 9 ACP refresh/settings tests
- focused backend-registry launchpad model regression
- `pnpm --filter @pwragent/desktop typecheck`
- focused ESLint (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
