### PR TITLE
test(desktop): harden Grok process cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/grok-process-boundary.integration.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-process-boundary.integration.test.ts
@@ -117,7 +117,7 @@ describe("Grok child app-server process boundary", () => {
       ]);
       await secondClient.close();
     } finally {
-      await fs.rm(tempRoot, { recursive: true, force: true });
+      await removeTempRoot(tempRoot);
     }
   });
 
@@ -218,7 +218,7 @@ describe("Grok child app-server process boundary", () => {
       await client.close();
       xaiServer.close();
       await once(xaiServer, "close");
-      await fs.rm(tempRoot, { recursive: true, force: true });
+      await removeTempRoot(tempRoot);
     }
   });
 
@@ -286,7 +286,7 @@ describe("Grok child app-server process boundary", () => {
       });
     } finally {
       await client.close();
-      await fs.rm(tempRoot, { recursive: true, force: true });
+      await removeTempRoot(tempRoot);
     }
   });
 
@@ -303,6 +303,18 @@ describe("Grok child app-server process boundary", () => {
     await client.close();
   });
 });
+
+async function removeTempRoot(tempRoot: string): Promise<void> {
+  // Windows can release child-process and filesystem handles shortly after
+  // their awaited close completes. POSIX removes the directory on this first
+  // attempt; Windows gets a bounded retry window for transient EBUSY failures.
+  await fs.rm(tempRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+}
 
 function makeAiSdkXaiResponse(
   text: string,


### PR DESCRIPTION
## Summary

- centralize temporary-root removal in the Grok process-boundary integration test
- retry transient Windows `EBUSY` cleanup failures with the repository-standard `maxRetries: 5` and `retryDelay: 100`
- apply the cleanup helper to all three temporary roots while preserving first-attempt POSIX removal

## Root cause

The failure occurs after the clients have completed shutdown, not because the Grok child remains alive. `GrokAppServerClient.close()` awaits `JsonRpcConnection.close()`, which awaits the Grok stdio transport; the transport resolves only after the child process emits `close`. Existing focused transport coverage also verifies that `close()` remains pending until that event.

Windows can retain a just-closed process or filesystem working-directory handle briefly after the awaited operation completes. The first recursive `rm` can therefore receive `EBUSY`, while POSIX removes the directory immediately. This matches the repository's existing temp-directory cleanup precedent.

## Validation

- 20 consecutive runs of `pnpm test apps/desktop/src/main/__tests__/grok-process-boundary.integration.test.ts --reporter=dot` (80 test cases)
- `pnpm test apps/desktop/src/main/__tests__/grok-process-boundary.integration.test.ts apps/desktop/src/main/__tests__/grok-stdio-transport.test.ts` (7 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm lint:boundaries`
- `git diff --check`
