### PR TITLE
fix(desktop): resync live thread reference titles

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -190,4 +190,37 @@ describe("thread links in transcript markdown", () => {
       .not.toBeInTheDocument();
     expect(screen.getByText("See").parentElement).toBe(markdownNode);
   });
+
+  it("updates when navigation reuses its thread collection across a rename", () => {
+    const text = `See [Untitled thread](pwragent://thread/${CHILD_THREAD_ID})`;
+    const onShowThread = vi.fn();
+    const threads = [
+      threadSummary({ title: "Untitled thread", titleSource: "fallback" }),
+    ];
+    const { rerender } = render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={threads}>
+        <ThreadMarkdown text={text} />
+      </ThreadLinkProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open thread Untitled thread" }),
+    ).toBeInTheDocument();
+    const markdownNode = screen.getByText("See").parentElement;
+
+    // A snapshot producer may retain its collection while replacing a changed
+    // summary. Consumers reading the collection directly see the new title;
+    // the chip metadata store must also resync.
+    threads[0] = threadSummary({ title: "Named child thread" });
+    rerender(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={threads}>
+        <ThreadMarkdown text={text} />
+      </ThreadLinkProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Open thread Named child thread" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("See").parentElement).toBe(markdownNode);
+  });
 });

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -59,6 +59,17 @@ function sameThreadLink(
   );
 }
 
+function threadLinkMetadataKey(threads: NavigationThreadSummary[]): string {
+  return JSON.stringify(
+    threads.map((thread) => [
+      thread.source,
+      thread.id,
+      thread.title,
+      thread.gitBranch ?? null,
+    ]),
+  );
+}
+
 /**
  * A narrowly-scoped external store for mutable thread-link metadata.
  *
@@ -167,10 +178,13 @@ export function ThreadLinkProvider(props: {
     metadataStoreRef.current = new ThreadLinkMetadataStore(threads);
   }
   const metadataStore = metadataStoreRef.current;
+  const threadsRef = useRef(threads);
+  threadsRef.current = threads;
+  const metadataKey = threadLinkMetadataKey(threads);
 
   useLayoutEffect(() => {
-    metadataStore.update(threads);
-  }, [metadataStore, threads]);
+    metadataStore.update(threadsRef.current);
+  }, [metadataKey, metadataStore]);
 
   // `threads` is `navigation.threads` — a fresh array on every snapshot patch
   // (unread flips, updatedAt bumps, title generation). This provider wraps the
@@ -188,8 +202,6 @@ export function ThreadLinkProvider(props: {
 
   // Read the latest inputs through refs so the value can be rebuilt from
   // current data at each membership change without listing them as deps.
-  const threadsRef = useRef(threads);
-  threadsRef.current = threads;
   const onShowThreadRef = useRef(onShowThread);
   onShowThreadRef.current = onShowThread;
 


### PR DESCRIPTION
## Summary

- resynchronize transcript thread-reference metadata when link-relevant thread fields change, even if navigation retains the outer thread collection
- preserve the stable context and per-thread subscription path so markdown is not reparsed and unrelated transcript content does not rerender
- add a regression test that starts with an `Untitled thread`, replaces its summary inside the same collection, and verifies the mounted markdown node stays intact while the chip title updates

## Root cause

The live metadata store introduced for #1006 was synchronized only when the `threads` array identity changed. A navigation update can retain that outer collection while replacing a changed thread summary, leaving the external store—and therefore an already-rendered transcript chip—stale until a new app instance hydrates it again.

## Impact

Handed-off thread chips now update from `Untitled thread` to the current thread name in an existing app instance. The provider computes a small O(n) fingerprint over link-relevant metadata per provider render; the external store still compares individual thread summaries and notifies only subscribers for changed thread IDs, avoiding transcript-wide markdown reparsing.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx` (11/11)
- `pnpm exec eslint apps/desktop/src/renderer/src/lib/thread-links.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx`
- `pnpm typecheck`
- `git diff --check`
