### PR TITLE
feat(desktop): add AI provider context info

### DIFF
--- a/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
+++ b/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
@@ -31,8 +31,8 @@ test("shows linked directory path tooltips in the context rail", async () => {
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",
     });
-    // Open the Thread info tab to reveal the linked-directories panel.
-    await contextRail.getByRole("tab", { name: "Thread info" }).click();
+    // Directory paths live together in the dedicated Linked Projects tab.
+    await contextRail.getByRole("tab", { name: "Linked projects" }).click();
     await expect(
       contextRail.getByLabel("Path for PwrAgent", { exact: true })
     ).toBeVisible();

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -1083,7 +1083,7 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     const contextRail = app.window.getByRole("complementary", {
       name: "Thread context",
     });
-    await contextRail.getByRole("tab", { name: "Thread info" }).click();
+    await contextRail.getByRole("tab", { name: "Linked projects" }).click();
     await expect(
       contextRail.getByLabel("Path for worktree FixtureRepo", { exact: true }),
     ).toBeVisible();

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1064,7 +1064,7 @@ describe("AcpBackendAdapter", () => {
             end: "2026-08-03T00:00:00Z",
           },
         },
-        subscriptionTier: "SuperGrok Heavy",
+        subscription_tier: "SuperGrok Heavy",
       },
     });
     const agent: AcpInstalledAgentRecord = {
@@ -1081,6 +1081,7 @@ describe("AcpBackendAdapter", () => {
         env: {},
       },
     };
+    const emit = vi.fn(async () => undefined);
     const adapter = new AcpBackendAdapter({
       acpAgentStore: {
         getInstalledAgent: () => agent,
@@ -1095,12 +1096,24 @@ describe("AcpBackendAdapter", () => {
       captureStores: [],
       createAcpTransport: () => transport,
       discoverLocalAcpAgents: async () => [],
-      emit: vi.fn(async () => undefined),
+      emit,
       handleServerRequest: async () => ({ decision: "accept" }),
       isAcpAgentEnabled: () => true,
     });
 
     await adapter.getClient(backendId);
+    const [initialSummary] = await adapter.describeInstalledBackends();
+    expect(initialSummary?.account).toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(emit).toHaveBeenCalledWith({
+        backend: backendId,
+        notification: {
+          method: "backend/providerStatus/updated",
+          params: { backend: backendId },
+        },
+      });
+    });
     const [summary] = await adapter.describeInstalledBackends();
 
     expect(summary).toMatchObject({
@@ -1122,6 +1135,55 @@ describe("AcpBackendAdapter", () => {
       params: {},
       timeoutMs: 20_000,
     });
+    expect(
+      transport.requests.filter((request) => request.method === "_x.ai/billing"),
+    ).toHaveLength(1);
+
+    await adapter.close();
+  });
+
+  it("does not block backend discovery while Grok billing is pending", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+    };
+    const readProviderStatus = vi.fn(
+      async () => await new Promise<never>(() => undefined),
+    );
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => [],
+        getSession: () => undefined,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: () =>
+        ({
+          initialize: vi.fn(async () => undefined),
+          readProviderStatus,
+          dispose: vi.fn(async () => undefined),
+        }) as never,
+      discoverLocalAcpAgents: async () => [],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.getClient(backendId);
+    const [summary] = await adapter.describeInstalledBackends();
+    await adapter.describeInstalledBackends();
+
+    expect(summary?.kind).toBe(backendId);
+    expect(summary?.account).toBeUndefined();
+    expect(readProviderStatus).toHaveBeenCalledTimes(1);
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1046,6 +1046,86 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("adds Grok billing metadata from an active ACP connection", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentInfo: {
+          name: "Grok",
+          version: "0.2.113",
+        },
+      },
+      "_x.ai/billing": {
+        config: {
+          creditUsagePercent: 42.5,
+          currentPeriod: {
+            type: "USAGE_PERIOD_TYPE_WEEKLY",
+            end: "2026-08-03T00:00:00Z",
+          },
+        },
+        subscriptionTier: "SuperGrok Heavy",
+      },
+    });
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: ["agent", "stdio"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => [],
+        getSession: () => undefined,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      discoverLocalAcpAgents: async () => [],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: async () => ({ decision: "accept" }),
+      isAcpAgentEnabled: () => true,
+    });
+
+    await adapter.getClient(backendId);
+    const [summary] = await adapter.describeInstalledBackends();
+
+    expect(summary).toMatchObject({
+      account: {
+        type: "provider",
+        label: "Grok account",
+        planType: "SuperGrok Heavy",
+      },
+      rateLimits: [
+        {
+          name: "Weekly limit",
+          usedPercent: 42.5,
+          resetAt: Date.parse("2026-08-03T00:00:00Z"),
+        },
+      ],
+    });
+    expect(transport.requests).toContainEqual({
+      method: "_x.ai/billing",
+      params: {},
+      timeoutMs: 20_000,
+    });
+
+    await adapter.close();
+  });
+
   it("registers the agent-tool HTTP MCP from initialize capabilities", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-provider-status.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-provider-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeGrokBillingStatus } from "../acp-provider-status";
+import { normalizeGrokBillingStatus } from "../acp/acp-provider-status";
 
 describe("normalizeGrokBillingStatus", () => {
   it("normalizes the current percentage-based weekly billing shape", () => {
@@ -13,7 +13,7 @@ describe("normalizeGrokBillingStatus", () => {
             end: "2026-07-27T00:00:00Z",
           },
         },
-        subscriptionTier: "SuperGrok Heavy",
+        subscription_tier: "SuperGrok Heavy",
       }),
     ).toEqual({
       account: {
@@ -28,6 +28,21 @@ describe("normalizeGrokBillingStatus", () => {
           resetAt: Date.parse("2026-07-27T00:00:00Z"),
         },
       ],
+    });
+  });
+
+  it("keeps camel-case subscription tiers as a compatibility fallback", () => {
+    expect(
+      normalizeGrokBillingStatus({
+        config: null,
+        subscriptionTier: "SuperGrok",
+      }),
+    ).toEqual({
+      account: {
+        type: "provider",
+        label: "Grok account",
+        planType: "SuperGrok",
+      },
     });
   });
 

--- a/apps/desktop/src/main/acp/__tests__/acp-provider-status.test.ts
+++ b/apps/desktop/src/main/acp/__tests__/acp-provider-status.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGrokBillingStatus } from "../acp-provider-status";
+
+describe("normalizeGrokBillingStatus", () => {
+  it("normalizes the current percentage-based weekly billing shape", () => {
+    expect(
+      normalizeGrokBillingStatus({
+        config: {
+          creditUsagePercent: 42.5,
+          currentPeriod: {
+            type: "USAGE_PERIOD_TYPE_WEEKLY",
+            start: "2026-07-20T00:00:00Z",
+            end: "2026-07-27T00:00:00Z",
+          },
+        },
+        subscriptionTier: "SuperGrok Heavy",
+      }),
+    ).toEqual({
+      account: {
+        type: "provider",
+        label: "Grok account",
+        planType: "SuperGrok Heavy",
+      },
+      rateLimits: [
+        {
+          name: "Weekly limit",
+          usedPercent: 42.5,
+          resetAt: Date.parse("2026-07-27T00:00:00Z"),
+        },
+      ],
+    });
+  });
+
+  it("supports the legacy monthly cent limit shape and result wrapper", () => {
+    expect(
+      normalizeGrokBillingStatus({
+        result: {
+          config: {
+            monthlyLimit: { val: 2_000 },
+            used: { val: 500 },
+            billingPeriodEnd: "2026-08-01T00:00:00Z",
+          },
+        },
+      }),
+    ).toEqual({
+      account: {
+        type: "provider",
+        label: "Grok account",
+      },
+      rateLimits: [
+        {
+          name: "Included credits",
+          usedPercent: 25,
+          resetAt: Date.parse("2026-08-01T00:00:00Z"),
+        },
+      ],
+    });
+  });
+
+  it("returns no provider status when billing is unavailable", () => {
+    expect(normalizeGrokBillingStatus({ config: null })).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -27,6 +27,10 @@ import {
   normalizeAcpRuntimeCapabilities,
 } from "./acp-runtime-capabilities.js";
 import {
+  normalizeGrokBillingStatus,
+  type AcpProviderStatus,
+} from "./acp-provider-status.js";
+import {
   readAcpToolCommand,
   readAcpToolContentCommand,
   readAcpToolText,
@@ -67,6 +71,7 @@ export type AcpJsonRpcTransport = {
 
 const ACP_PROTOCOL_VERSION = 1;
 const ACP_PROMPT_REQUEST_TIMEOUT_MS = 60 * 60_000;
+const ACP_PROVIDER_STATUS_REQUEST_TIMEOUT_MS = 20_000;
 
 export type AcpMcpServerConfig =
   | {
@@ -273,6 +278,21 @@ export class AcpAgentClient {
     this.appSessionIdsByAgentSessionId.clear();
     this.loadedSessionCwds.clear();
     await this.options.transport.close?.();
+  }
+
+  async readProviderStatus(): Promise<AcpProviderStatus | undefined> {
+    if (this.options.backendId !== "acp:grok") {
+      return undefined;
+    }
+    // ACP serializes extension methods with a leading underscore on the wire.
+    // Grok's internal ExtRequest names this `x.ai/billing`, but stdio clients
+    // must send `_x.ai/billing`.
+    const result = await this.options.transport.request(
+      "_x.ai/billing",
+      {},
+      ACP_PROVIDER_STATUS_REQUEST_TIMEOUT_MS,
+    );
+    return normalizeGrokBillingStatus(result);
   }
 
   async startSession(params: {

--- a/apps/desktop/src/main/acp/acp-provider-status.ts
+++ b/apps/desktop/src/main/acp/acp-provider-status.ts
@@ -21,7 +21,9 @@ export function normalizeGrokBillingStatus(
     return undefined;
   }
   const config = asRecord(root.config);
-  const subscriptionTier = readString(root, "subscriptionTier");
+  const subscriptionTier =
+    readString(root, "subscription_tier")
+    ?? readString(root, "subscriptionTier");
   const account: BackendAccountSummary = {
     type: "provider",
     label: "Grok account",

--- a/apps/desktop/src/main/acp/acp-provider-status.ts
+++ b/apps/desktop/src/main/acp/acp-provider-status.ts
@@ -1,0 +1,123 @@
+import type {
+  BackendAccountSummary,
+  BackendRateLimitSummary,
+} from "@pwragent/shared";
+
+export type AcpProviderStatus = {
+  account?: BackendAccountSummary;
+  rateLimits?: BackendRateLimitSummary[];
+};
+
+/**
+ * Normalize Grok's `x.ai/billing` ACP extension into the same provider
+ * metadata contract used by Codex. Newer Grok builds report a percentage and
+ * typed current period; older builds used dollar-cent limit/usage fields.
+ */
+export function normalizeGrokBillingStatus(
+  value: unknown,
+): AcpProviderStatus | undefined {
+  const root = unwrapResult(asRecord(value));
+  if (!root) {
+    return undefined;
+  }
+  const config = asRecord(root.config);
+  const subscriptionTier = readString(root, "subscriptionTier");
+  const account: BackendAccountSummary = {
+    type: "provider",
+    label: "Grok account",
+    ...(subscriptionTier ? { planType: subscriptionTier } : {}),
+  };
+  if (!config) {
+    return subscriptionTier ? { account } : undefined;
+  }
+
+  const currentPeriod = asRecord(config.currentPeriod);
+  const rawUsedPercent =
+    readFiniteNumber(config, "creditUsagePercent")
+    ?? deriveUsedPercent(config);
+  const usedPercent =
+    rawUsedPercent === undefined
+      ? undefined
+      : Math.max(0, Math.min(100, rawUsedPercent));
+  const resetAt = parseTimestamp(
+    readString(currentPeriod, "end")
+    ?? readString(config, "billingPeriodEnd"),
+  );
+  const rateLimits =
+    usedPercent === undefined
+      ? undefined
+      : [
+          {
+            name: formatPeriodLimitName(readString(currentPeriod, "type")),
+            usedPercent,
+            ...(resetAt !== undefined ? { resetAt } : {}),
+          },
+        ];
+
+  return {
+    account,
+    ...(rateLimits ? { rateLimits } : {}),
+  };
+}
+
+function unwrapResult(
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  return asRecord(value?.result) ?? value;
+}
+
+function deriveUsedPercent(
+  config: Record<string, unknown>,
+): number | undefined {
+  const limit = readCentValue(config.monthlyLimit);
+  const used = readCentValue(config.used);
+  if (limit === undefined || used === undefined || limit <= 0) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(100, (used / limit) * 100));
+}
+
+function readCentValue(value: unknown): number | undefined {
+  return readFiniteNumber(asRecord(value), "val");
+}
+
+function formatPeriodLimitName(periodType: string | undefined): string {
+  const normalized = periodType?.toLowerCase() ?? "";
+  if (normalized.includes("weekly")) {
+    return "Weekly limit";
+  }
+  if (normalized.includes("monthly")) {
+    return "Monthly limit";
+  }
+  return "Included credits";
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readFiniteNumber(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -35,6 +35,7 @@ import {
   type AcpMcpServerRegistration,
   type AcpPromptContentBlock,
 } from "../acp/acp-client";
+import type { AcpProviderStatus } from "../acp/acp-provider-status";
 import {
   acpRuntimeSupportsHttpMcp,
   buildAutomationInspectionAcpMcpServers,
@@ -95,6 +96,7 @@ export const ACP_LIVE_HANDOFF_UNSUPPORTED_ERROR =
   "This ACP agent cannot hand off a workspace after the first message in a thread. Start a new thread in the target workspace instead.";
 
 const acpBackendAdapterLog = getMainLogger("pwragent:acp-backend-adapter");
+const ACP_PROVIDER_STATUS_CACHE_TTL_MS = 60_000;
 
 export type AcpRuntimeClient = Pick<
   AcpAgentClient,
@@ -800,6 +802,10 @@ export class AcpBackendAdapter {
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, Promise<AcpRuntimeClient>>();
   private readonly liveNotificationFingerprints = new Map<string, string>();
+  private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
+  private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
+  private readonly providerStatusRefreshes = new Map<AcpBackendId, Promise<void>>();
+  private closed = false;
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -872,39 +878,76 @@ export class AcpBackendAdapter {
           ? this.isAcpAgentEnabled(agent.registryId)
           : acpAgentEnabledFor(config, agent.registryId),
       );
-    return await Promise.all(
-      enabledAgents.map(async (agent) => {
-        const summary = describeInstalledAcpBackend(agent);
-        if (agent.registryId !== "grok" || !summary.available) {
-          return summary;
-        }
-        // Do not launch an otherwise-idle ACP process merely to decorate the
-        // provider panel. Once Grok is active, its initialize notification
-        // refreshes backend summaries and this cached connection can serve the
-        // vendor billing extension without another process.
-        const clientPromise = this.acpClients.get(agent.backendId);
-        if (!clientPromise) {
-          return summary;
-        }
-        try {
-          const client = await clientPromise;
-          const providerStatus = await client.readProviderStatus?.();
-          return providerStatus
-            ? {
-                ...summary,
-                account: providerStatus.account,
-                rateLimits: providerStatus.rateLimits,
-              }
-            : summary;
-        } catch (error) {
-          acpBackendAdapterLog.debug("acp_provider_status_unavailable", {
-            backend: agent.backendId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return summary;
-        }
-      }),
-    );
+    return enabledAgents.map((agent) => {
+      const summary = describeInstalledAcpBackend(agent);
+      if (agent.registryId !== "grok" || !summary.available) {
+        return summary;
+      }
+      // Backend discovery is also used by launchpad and messaging flows.
+      // Merge only cached decoration here; vendor billing must never delay it.
+      const providerStatus = this.providerStatuses.get(agent.backendId);
+      this.refreshProviderStatusInBackground(agent.backendId);
+      return providerStatus
+        ? {
+            ...summary,
+            account: providerStatus.account,
+            rateLimits: providerStatus.rateLimits,
+          }
+        : summary;
+    });
+  }
+
+  private refreshProviderStatusInBackground(backend: AcpBackendId): void {
+    const clientPromise = this.acpClients.get(backend);
+    if (
+      this.closed
+      || !clientPromise
+      || this.providerStatusRefreshes.has(backend)
+    ) {
+      return;
+    }
+    const now = Date.now();
+    const lastAttempt = this.providerStatusRefreshAttempts.get(backend);
+    if (
+      lastAttempt !== undefined
+      && now - lastAttempt < ACP_PROVIDER_STATUS_CACHE_TTL_MS
+    ) {
+      return;
+    }
+    this.providerStatusRefreshAttempts.set(backend, now);
+    const refreshPromise = this.refreshProviderStatus(backend, clientPromise);
+    this.providerStatusRefreshes.set(backend, refreshPromise);
+    void refreshPromise.finally(() => {
+      if (this.providerStatusRefreshes.get(backend) === refreshPromise) {
+        this.providerStatusRefreshes.delete(backend);
+      }
+    });
+  }
+
+  private async refreshProviderStatus(
+    backend: AcpBackendId,
+    clientPromise: Promise<AcpRuntimeClient>,
+  ): Promise<void> {
+    try {
+      const client = await clientPromise;
+      const providerStatus = await client.readProviderStatus?.();
+      if (!providerStatus || this.closed) {
+        return;
+      }
+      this.providerStatuses.set(backend, providerStatus);
+      await this.emit({
+        backend,
+        notification: {
+          method: "backend/providerStatus/updated",
+          params: { backend },
+        },
+      });
+    } catch (error) {
+      acpBackendAdapterLog.debug("acp_provider_status_unavailable", {
+        backend,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   invalidateLocalAgentDiscovery(): void {
@@ -1366,9 +1409,13 @@ export class AcpBackendAdapter {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     const acpClients = [...this.acpClients.values()];
     this.acpClients.clear();
     this.liveNotificationFingerprints.clear();
+    this.providerStatuses.clear();
+    this.providerStatusRefreshAttempts.clear();
+    this.providerStatusRefreshes.clear();
     await Promise.all(
       acpClients.map(async (clientPromise) => {
         const client = await clientPromise.catch(() => undefined);

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -108,7 +108,12 @@ export type AcpRuntimeClient = Pick<
   | "startPrompt"
   | "startSession"
 > &
-  Partial<Pick<AcpAgentClient, "sendControlPrompt" | "setRuntimeOption">>;
+  Partial<
+    Pick<
+      AcpAgentClient,
+      "readProviderStatus" | "sendControlPrompt" | "setRuntimeOption"
+    >
+  >;
 
 export type AcpClientFactory = (agent: AcpInstalledAgentRecord) => AcpRuntimeClient;
 export type AcpTransportFactory = (
@@ -861,13 +866,45 @@ export class AcpBackendAdapter {
   async describeInstalledBackends(): Promise<BackendSummary[]> {
     const config = readDesktopSettingsConfigSafe();
     const installedAgents = await this.listAvailableAgents();
-    return installedAgents
+    const enabledAgents = installedAgents
       .filter((agent) =>
         this.isAcpAgentEnabled
           ? this.isAcpAgentEnabled(agent.registryId)
           : acpAgentEnabledFor(config, agent.registryId),
-      )
-      .map((agent) => describeInstalledAcpBackend(agent));
+      );
+    return await Promise.all(
+      enabledAgents.map(async (agent) => {
+        const summary = describeInstalledAcpBackend(agent);
+        if (agent.registryId !== "grok" || !summary.available) {
+          return summary;
+        }
+        // Do not launch an otherwise-idle ACP process merely to decorate the
+        // provider panel. Once Grok is active, its initialize notification
+        // refreshes backend summaries and this cached connection can serve the
+        // vendor billing extension without another process.
+        const clientPromise = this.acpClients.get(agent.backendId);
+        if (!clientPromise) {
+          return summary;
+        }
+        try {
+          const client = await clientPromise;
+          const providerStatus = await client.readProviderStatus?.();
+          return providerStatus
+            ? {
+                ...summary,
+                account: providerStatus.account,
+                rateLimits: providerStatus.rateLimits,
+              }
+            : summary;
+        } catch (error) {
+          acpBackendAdapterLog.debug("acp_provider_status_unavailable", {
+            backend: agent.backendId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return summary;
+        }
+      }),
+    );
   }
 
   invalidateLocalAgentDiscovery(): void {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -994,9 +994,9 @@ describe("App", () => {
     expect(screen.getByText("Render plan card")).toBeInTheDocument();
     expect(screen.getByText("Explored 2 files, ran 1 command")).toBeInTheDocument();
     const context = screen.getByLabelText("Thread context");
-    fireEvent.click(within(context).getByRole("tab", { name: "Thread info" }));
+    fireEvent.click(within(context).getByRole("tab", { name: "Linked projects" }));
     expect(
-      await screen.findByRole("heading", { level: 3, name: "Linked directories" })
+      await screen.findByRole("heading", { level: 3, name: "Linked projects" })
     ).toBeInTheDocument();
     fireEvent.click(
       within(context).getByRole("button", { name: "Copy path for PwrAgent" })
@@ -1007,9 +1007,10 @@ describe("App", () => {
     expect(copyText).toHaveBeenNthCalledWith(1, "/Users/huntharo/pwrdrvr/PwrAgent");
     expect(copyText).toHaveBeenNthCalledWith(2, "/Users/huntharo/.codex/worktrees/0f38/PwrAgent");
     expect(screen.getAllByText("Codex app server").length).toBeGreaterThan(0);
+    fireEvent.click(within(context).getByRole("tab", { name: "Thread info" }));
     expect(screen.getByText("darwin")).toBeInTheDocument();
     // Provider availability now lives under its own context-rail tab.
-    fireEvent.click(within(context).getByRole("tab", { name: "Provider status" }));
+    fireEvent.click(within(context).getByRole("tab", { name: "AI provider info" }));
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -68,6 +68,7 @@ type ContextTab = {
 
 const CONTEXT_TABS: ContextTab[] = [
   { id: "info", label: "Thread info", Icon: InfoIcon },
+  { id: "providers", label: "AI provider info", Icon: ServerIcon },
   { id: "edits", label: "Edits", Icon: EditsIcon },
   { id: "pricing", label: "Pricing", Icon: PricingIcon },
   { id: "actions", label: "Actions", Icon: TerminalIcon },
@@ -75,7 +76,6 @@ const CONTEXT_TABS: ContextTab[] = [
   { id: "automations", label: "Automations", Icon: AutomationsIcon },
   { id: "prs", label: "Pull requests", Icon: PullRequestIcon },
   { id: "projects", label: "Linked projects", Icon: ProjectsIcon },
-  { id: "providers", label: "Provider status", Icon: ServerIcon, bottom: true },
 ];
 
 type ThreadContextPanelProps = {
@@ -643,9 +643,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             backends={props.backends}
             platform={props.platform}
             desktopApi={props.desktopApi}
-            worktreeArchiveError={props.worktreeArchiveError}
             onRefreshNavigation={props.onRefreshNavigation}
-            onRestoreWorktree={props.onRestoreWorktree}
             showTooltip={showRailTooltip}
             hideTooltip={hideRailTooltip}
           />
@@ -720,7 +718,9 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <LinkedProjectsPanel
             desktopApi={props.desktopApi}
             onRefreshNavigation={props.onRefreshNavigation}
+            onRestoreWorktree={props.onRestoreWorktree}
             thread={props.thread}
+            worktreeArchiveError={props.worktreeArchiveError}
             showTooltip={showRailTooltip}
             hideTooltip={hideRailTooltip}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -24,10 +24,10 @@ import { collectEditedFileGroups } from "../edited-file-groups";
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
 // When the rail is open, the active tab's panel content renders. The
-// default tab is "info"; its first (unconditional) section heading is a
+// default tab is "info"; its execution-context heading is a
 // stable "the panel is revealed" signal. There is no separate panel title
 // anymore — each panel's own section <h3> is the title.
-const REVEALED_SIGNAL = "Linked directories";
+const REVEALED_SIGNAL = "Execution context";
 
 afterEach(() => {
   cleanup();
@@ -575,19 +575,20 @@ describe("ThreadContextPanel", () => {
     renderPanel({ pinned: true });
 
     const info = screen.getByRole("tab", { name: "Thread info" });
-    const edits = screen.getByRole("tab", { name: "Edits" });
     info.focus();
     expect(document.activeElement).toBe(info);
 
     fireEvent.keyDown(info, { key: "ArrowDown" });
-    expect(document.activeElement).toBe(edits);
+    expect(document.activeElement).toBe(
+      screen.getByRole("tab", { name: "AI provider info" }),
+    );
 
-    fireEvent.keyDown(edits, { key: "ArrowUp" });
+    fireEvent.keyDown(document.activeElement!, { key: "ArrowUp" });
     expect(document.activeElement).toBe(info);
 
     fireEvent.keyDown(info, { key: "End" });
     expect(document.activeElement).toBe(
-      screen.getByRole("tab", { name: "Provider status" }),
+      screen.getByRole("tab", { name: "Linked projects" }),
     );
   });
 
@@ -2198,6 +2199,7 @@ describe("ThreadContextPanel", () => {
 
   it("shows path tooltips on linked directory labels and kind badges", () => {
     renderPanel({
+      activeTab: "projects",
       pinned: true,
       thread: {
         ...baseThread,
@@ -2397,7 +2399,7 @@ describe("ThreadContextPanel", () => {
     expect(detachDirectoryFromThread).not.toHaveBeenCalled();
   });
 
-  it("shows regular and Spark rate limits together on the Provider status tab", () => {
+  it("shows regular and Spark rate limits together on the AI provider info tab", () => {
     renderPanel({ activeTab: "providers", pinned: true });
 
     expect(screen.getByText(/5h limit: 93% left/)).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -354,11 +354,10 @@ describe("ThreadView", () => {
     expect(document.querySelector(".thread-header__title")).toBeNull();
     expect(document.querySelector(".thread-header__summary")).toBeNull();
     expect(screen.getAllByText("OpenAI").length).toBeGreaterThan(0);
-    // The context rail is a tabbed activity bar now; clicking the Thread
-    // info tab reveals its panel (linked directories + execution context).
+    // Thread info stays focused on thread metadata; directories have their
+    // own Linked Projects tab.
     fireEvent.click(screen.getByRole("tab", { name: "Thread info" }));
 
-    expect(screen.getByText("No linked directory")).toBeInTheDocument();
     expect(
       screen.getByText("The desktop client now reads the full transcript.")
     ).toBeInTheDocument();
@@ -367,10 +366,8 @@ describe("ThreadView", () => {
     expect(screen.getByText("Explored 2 files")).toBeInTheDocument();
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 3, name: "Execution context" })).toBeInTheDocument();
-    // Backend availability + account + rate limits now live under their own
-    // Provider status tab (covered in ProviderStatusPanel.test.tsx). Here we
-    // just confirm the tab is present in the rail.
-    expect(screen.getByRole("tab", { name: "Provider status" })).toBeInTheDocument();
+    // Backend availability + account + rate limits live under their own tab.
+    expect(screen.getByRole("tab", { name: "AI provider info" })).toBeInTheDocument();
     expect(screen.getByLabelText("Reply")).toBeEnabled();
     expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
   });
@@ -1429,7 +1426,7 @@ describe("ThreadView", () => {
     );
   });
 
-  it("shows missing recorded working directory details and copies the thread id", async () => {
+  it("shows and copies missing recorded working directory details", async () => {
     const copyText = vi.fn(async () => undefined);
     Object.defineProperty(window, "pwragent", {
       configurable: true,
@@ -1440,6 +1437,7 @@ describe("ThreadView", () => {
 
     render(
       <ThreadView
+        activeContextTab="projects"
         addOptimisticUserMessage={(_text) => "optimistic-1"}
         backends={[
           {
@@ -1513,14 +1511,16 @@ describe("ThreadView", () => {
       "This thread is linked to a directory that no longer exists: /Users/huntharo/.codex/worktrees/be87/search-product"
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Thread info" }));
-
     expect(screen.getByText("Recorded working directory is no longer available.")).toBeInTheDocument();
     expect(screen.getByText("search-product")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy thread id" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy recorded working directory" }),
+    );
 
-    expect(copyText).toHaveBeenCalledWith("019d88a2-0e0b-77f0-bfce-130ae8e37d8f");
+    expect(copyText).toHaveBeenCalledWith(
+      "/Users/huntharo/.codex/worktrees/be87/search-product",
+    );
   });
 
   it("opens transcript image previews in a lightbox and dismisses them with Escape", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -6,8 +6,10 @@ import { PrChip } from "../../pr-status/PrChip";
 import {
   CopyValueButton,
   TooltipValue,
+  formatTimestamp,
   handleCopyPath,
   openExternalUrl,
+  pathBaseName,
   type HideRailTooltip,
   type ShowRailTooltip,
 } from "./context-rail-shared";
@@ -18,7 +20,13 @@ type LinkedProjectsPanelProps = {
     "attachDirectoryToThread" | "detachDirectoryFromThread" | "pickDirectoryFromDisk"
   >;
   onRefreshNavigation?: () => Promise<void>;
+  onRestoreWorktree?: (
+    thread: NavigationThreadSummary,
+    snapshotRef: string,
+    worktreePath: string,
+  ) => Promise<void>;
   thread: NavigationThreadSummary;
+  worktreeArchiveError?: string;
   showTooltip: ShowRailTooltip;
   hideTooltip: HideRailTooltip;
 };
@@ -132,14 +140,14 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
                   <div className="context-list__label">
                     <CopyValueButton
                       label={`Copy path for ${directory.label}`}
-                      value={worktreePath}
+                      value={directory.path}
                       onBlur={props.hideTooltip}
                       onCopy={handleCopyPath}
                       onShowTooltip={props.showTooltip}
                     />
                     <TooltipValue
                       label={`Path for ${directory.label}`}
-                      value={worktreePath}
+                      value={directory.path}
                       onBlur={props.hideTooltip}
                       onShowTooltip={props.showTooltip}
                     >
@@ -169,7 +177,23 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
                 <dl className="linked-project__facts">
                   <div>
                     <dt>Kind</dt>
-                    <dd>{directory.kind === "worktree" ? "Worktree" : "Directory"}</dd>
+                    <dd className="context-value-row">
+                      <CopyValueButton
+                        label={`Copy path for ${directory.kind} ${directory.label}`}
+                        value={worktreePath}
+                        onBlur={props.hideTooltip}
+                        onCopy={handleCopyPath}
+                        onShowTooltip={props.showTooltip}
+                      />
+                      <TooltipValue
+                        label={`Path for ${directory.kind} ${directory.label}`}
+                        value={worktreePath}
+                        onBlur={props.hideTooltip}
+                        onShowTooltip={props.showTooltip}
+                      >
+                        {directory.kind === "worktree" ? "Worktree" : "Directory"}
+                      </TooltipValue>
+                    </dd>
                   </div>
                   {branch ? (
                     <div>
@@ -186,6 +210,44 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
             );
           })}
         </ul>
+      ) : props.thread.projectKey?.trim() ? (
+        <>
+          <ul className="context-list linked-projects-list">
+            <li className="linked-project">
+              <div className="linked-project__heading">
+                <div className="context-list__label">
+                  <CopyValueButton
+                    label="Copy recorded working directory"
+                    value={props.thread.projectKey}
+                    onBlur={props.hideTooltip}
+                    onCopy={handleCopyPath}
+                    onShowTooltip={props.showTooltip}
+                  />
+                  <TooltipValue
+                    label="Recorded working directory path"
+                    value={props.thread.projectKey}
+                    onBlur={props.hideTooltip}
+                    onShowTooltip={props.showTooltip}
+                  >
+                    <span aria-hidden="true" className="context-list__icon">
+                      <FolderIcon size={14} />
+                    </span>
+                    {pathBaseName(props.thread.projectKey)}
+                  </TooltipValue>
+                </div>
+              </div>
+              <dl className="linked-project__facts">
+                <div>
+                  <dt>Kind</dt>
+                  <dd>Missing directory</dd>
+                </div>
+              </dl>
+            </li>
+          </ul>
+          <p className="context-empty">
+            Recorded working directory is no longer available.
+          </p>
+        </>
       ) : (
         <p className="context-empty">No linked projects.</p>
       )}
@@ -211,6 +273,66 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
             ))}
           </ul>
         </div>
+      ) : null}
+
+      {props.thread.worktreeSnapshots?.some(
+        (snapshot) => snapshot.state === "archived",
+      ) ? (
+        <div className="linked-projects__snapshots">
+          <h4 className="context-subheading">Worktree snapshots</h4>
+          <ul className="context-list">
+            {props.thread.worktreeSnapshots
+              .filter((snapshot) => snapshot.state === "archived")
+              .map((snapshot) => (
+                <li key={snapshot.id} className="context-list__item">
+                  <button
+                    aria-label={`Copy snapshot ref ${snapshot.snapshotRef}`}
+                    className="context-list__label path-copy-target"
+                    type="button"
+                    onBlur={props.hideTooltip}
+                    onClick={(event) => {
+                      void handleCopyPath(event, snapshot.snapshotRef);
+                    }}
+                    onFocus={(event) => props.showTooltip(event, snapshot.snapshotRef)}
+                    onMouseEnter={(event) => props.showTooltip(event, snapshot.snapshotRef)}
+                    onMouseLeave={props.hideTooltip}
+                  >
+                    <span aria-hidden="true" className="context-list__icon">
+                      <WorktreeIcon size={14} />
+                    </span>
+                    {pathBaseName(snapshot.worktreePath)}
+                  </button>
+                  <div className="context-list__actions">
+                    {props.onRestoreWorktree ? (
+                      <button
+                        className="context-list__action"
+                        type="button"
+                        onClick={() => {
+                          void props.onRestoreWorktree?.(
+                            props.thread,
+                            snapshot.snapshotRef,
+                            snapshot.worktreePath,
+                          );
+                        }}
+                      >
+                        Restore
+                      </button>
+                    ) : null}
+                    <span className="context-list__meta">
+                      {snapshot.archivedAt
+                        ? formatTimestamp(snapshot.archivedAt)
+                        : "archived"}
+                    </span>
+                  </div>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : null}
+      {props.worktreeArchiveError ? (
+        <p className="context-empty context-empty--error">
+          {props.worktreeArchiveError}
+        </p>
       ) : null}
     </section>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
@@ -1,9 +1,11 @@
+import { useEffect } from "react";
 import type { BackendSummary } from "@pwragent/shared";
 import {
   formatBackendAccountText,
   formatRateLimitLine,
   selectVisibleRateLimits,
 } from "../../../lib/backend-status-format";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
 
 type ProviderStatusPanelProps = {
   backends: BackendSummary[];
@@ -11,14 +13,18 @@ type ProviderStatusPanelProps = {
 };
 
 /**
- * Provider Status tab — availability, account, plan, and rate-limit
- * lines for every configured app server (OpenAI, AgentCore-Grok, …).
+ * AI Provider Info tab — availability, runtime, authentication, account,
+ * plan, and rate-limit lines for every configured agent backend.
  * Moved out of the old single-scroll context panel into its own tab.
  */
 export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
+  useEffect(() => {
+    window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+  }, []);
+
   return (
     <section className="context-panel__section">
-      <h3>App servers</h3>
+      <h3>AI providers</h3>
       {props.backendError ? (
         <p className="context-empty">{props.backendError}</p>
       ) : props.backends.length > 0 ? (
@@ -39,16 +45,29 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
                   ? "Available"
                   : backend.unavailableReason ?? "Unavailable"}
               </p>
-              {backend.available &&
-              (backend.account || (backend.rateLimits?.length ?? 0) > 0) ? (
+              {backend.available && hasProviderMetadata(backend) ? (
                 <div className="backend-status-list__metadata">
-                  {backend.account ? (
+                  {backendVersion(backend) || backend.acp || backend.account ? (
                     <dl className="backend-status-list__metadata-grid">
-                      <div>
-                        <dt>Account</dt>
-                        <dd>{formatBackendAccountText(backend.account)}</dd>
-                      </div>
-                      {backend.account.planType ? (
+                      {backendVersion(backend) ? (
+                        <div>
+                          <dt>Version</dt>
+                          <dd>{backendVersion(backend)}</dd>
+                        </div>
+                      ) : null}
+                      {backend.acp ? (
+                        <div>
+                          <dt>Authentication</dt>
+                          <dd>{formatAcpAuthStatus(backend.acp.authStatus)}</dd>
+                        </div>
+                      ) : null}
+                      {backend.account ? (
+                        <div>
+                          <dt>Account</dt>
+                          <dd>{formatBackendAccountText(backend.account)}</dd>
+                        </div>
+                      ) : null}
+                      {backend.account?.planType ? (
                         <div>
                           <dt>Plan</dt>
                           <dd>{backend.account.planType}</dd>
@@ -75,4 +94,38 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
       )}
     </section>
   );
+}
+
+function hasProviderMetadata(backend: BackendSummary): boolean {
+  return Boolean(
+    backendVersion(backend)
+    || backend.acp
+    || backend.account
+    || backend.rateLimits?.length,
+  );
+}
+
+function backendVersion(backend: BackendSummary): string | undefined {
+  return (
+    backend.acp?.runtime?.agentInfo?.version
+    ?? backend.acp?.version
+    ?? backend.serverVersion
+  );
+}
+
+function formatAcpAuthStatus(
+  status: NonNullable<BackendSummary["acp"]>["authStatus"],
+): string {
+  switch (status) {
+    case "authenticated":
+      return "Signed in";
+    case "required":
+      return "Sign-in required";
+    case "in-progress":
+      return "Signing in";
+    case "failed":
+      return "Sign-in failed";
+    case "not-required":
+      return "Managed by provider";
+  }
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -1,17 +1,13 @@
 import { useEffect, useState } from "react";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
-import { FolderIcon, WorktreeIcon } from "../../../icons";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { formatBackendLabel } from "../../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../../lib/execution-mode";
 import {
   CopyValueButton,
-  TooltipValue,
-  findSnapshotForWorktree,
   formatAgentInstructionSummary,
   formatTimestamp,
   handleCopyPath,
-  pathBaseName,
   type HideRailTooltip,
   type ShowRailTooltip,
 } from "./context-rail-shared";
@@ -21,22 +17,16 @@ type ThreadInfoPanelProps = {
   backends: BackendSummary[];
   platform?: string;
   desktopApi?: DesktopApi;
-  worktreeArchiveError?: string;
   onRefreshNavigation?: () => Promise<void>;
-  onRestoreWorktree?: (
-    thread: NavigationThreadSummary,
-    snapshotRef: string,
-    worktreePath: string,
-  ) => Promise<void>;
   showTooltip: ShowRailTooltip;
   hideTooltip: HideRailTooltip;
 };
 
 /**
- * Thread Info tab — the thread-scoped surfaces: linked directories,
- * the Agent marker, archived worktree snapshots, and the execution
- * context grid. Owns its own Agent-save state; tooltip portal state is
- * owned by the rail and threaded in via `showTooltip` / `hideTooltip`.
+ * Thread Info tab — the Agent marker and execution context grid. Directory
+ * and worktree surfaces live together in the dedicated Linked Projects tab.
+ * Owns its own Agent-save state; tooltip portal state is owned by the rail
+ * and threaded in via `showTooltip` / `hideTooltip`.
  */
 export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
   const [agentSaving, setAgentSaving] = useState(false);
@@ -69,142 +59,6 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
 
   return (
     <>
-      <section className="context-panel__section">
-        <h3>Linked directories</h3>
-        {props.thread.linkedDirectories.length > 0 ? (
-          <ul className="context-list">
-            {props.thread.linkedDirectories.map((directory) => {
-              const worktreePath = directory.worktreePath ?? directory.path;
-              const snapshot = findSnapshotForWorktree(
-                props.thread.worktreeSnapshots,
-                worktreePath,
-              );
-              const canRestore =
-                directory.kind === "worktree" &&
-                snapshot?.state === "archived" &&
-                Boolean(props.onRestoreWorktree);
-
-              return (
-                <li key={directory.id} className="context-list__item">
-                  <div className="context-list__label">
-                    <CopyValueButton
-                      label={`Copy path for ${directory.label}`}
-                      value={directory.path}
-                      onBlur={props.hideTooltip}
-                      onCopy={handleCopyPath}
-                      onShowTooltip={props.showTooltip}
-                    />
-                    <TooltipValue
-                      label={`Path for ${directory.label}`}
-                      value={directory.path}
-                      onBlur={props.hideTooltip}
-                      onShowTooltip={props.showTooltip}
-                    >
-                      <span aria-hidden="true" className="context-list__icon">
-                        {directory.kind === "worktree" ? (
-                          <WorktreeIcon size={14} />
-                        ) : (
-                          <FolderIcon size={14} />
-                        )}
-                      </span>
-                      {directory.label}
-                    </TooltipValue>
-                  </div>
-                  <div className="context-list__actions">
-                    {canRestore && snapshot ? (
-                      <button
-                        className="context-list__action"
-                        type="button"
-                        onClick={() => {
-                          void props.onRestoreWorktree?.(
-                            props.thread,
-                            snapshot.snapshotRef,
-                            snapshot.worktreePath,
-                          );
-                        }}
-                      >
-                        Restore
-                      </button>
-                    ) : null}
-                    <span className="context-list__meta">
-                      <CopyValueButton
-                        label={`Copy path for ${directory.kind} ${directory.label}`}
-                        value={worktreePath}
-                        onBlur={props.hideTooltip}
-                        onCopy={handleCopyPath}
-                        onShowTooltip={props.showTooltip}
-                      />
-                      <TooltipValue
-                        label={`Path for ${
-                          snapshot?.state === "archived" ? "archived" : directory.kind
-                        } ${directory.label}`}
-                        value={worktreePath}
-                        onBlur={props.hideTooltip}
-                        onShowTooltip={props.showTooltip}
-                      >
-                        {snapshot?.state === "archived" ? "archived" : directory.kind}
-                      </TooltipValue>
-                    </span>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        ) : props.thread.projectKey?.trim() ? (
-          <>
-            <ul className="context-list">
-              <li className="context-list__item">
-                <div className="context-list__label">
-                  <CopyValueButton
-                    label="Copy recorded working directory"
-                    value={props.thread.projectKey!}
-                    onBlur={props.hideTooltip}
-                    onCopy={handleCopyPath}
-                    onShowTooltip={props.showTooltip}
-                  />
-                  <TooltipValue
-                    label="Recorded working directory path"
-                    value={props.thread.projectKey!}
-                    onBlur={props.hideTooltip}
-                    onShowTooltip={props.showTooltip}
-                  >
-                    <span aria-hidden="true" className="context-list__icon">
-                      <FolderIcon size={14} />
-                    </span>
-                    {pathBaseName(props.thread.projectKey)}
-                  </TooltipValue>
-                </div>
-                <span className="context-list__meta">
-                  <CopyValueButton
-                    label="Copy missing working directory path"
-                    value={props.thread.projectKey!}
-                    onBlur={props.hideTooltip}
-                    onCopy={handleCopyPath}
-                    onShowTooltip={props.showTooltip}
-                  />
-                  <TooltipValue
-                    label="Missing working directory path"
-                    value={props.thread.projectKey!}
-                    onBlur={props.hideTooltip}
-                    onShowTooltip={props.showTooltip}
-                  >
-                    missing
-                  </TooltipValue>
-                </span>
-              </li>
-            </ul>
-            <p className="context-empty">Recorded working directory is no longer available.</p>
-          </>
-        ) : (
-          <p className="context-empty">No linked directory</p>
-        )}
-        {props.worktreeArchiveError ? (
-          <p className="context-empty context-empty--error">
-            {props.worktreeArchiveError}
-          </p>
-        ) : null}
-      </section>
-
       <section className="context-panel__section">
         <h3>Agent</h3>
         {props.thread.agent ? (
@@ -243,59 +97,6 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
           </p>
         ) : null}
       </section>
-
-      {props.thread.worktreeSnapshots?.some(
-        (snapshot) => snapshot.state === "archived",
-      ) ? (
-        <section className="context-panel__section">
-          <h3>Worktree snapshots</h3>
-          <ul className="context-list">
-            {props.thread.worktreeSnapshots
-              .filter((snapshot) => snapshot.state === "archived")
-              .map((snapshot) => (
-                <li key={snapshot.id} className="context-list__item">
-                  <button
-                    aria-label={`Copy snapshot ref ${snapshot.snapshotRef}`}
-                    className="context-list__label path-copy-target"
-                    type="button"
-                    onBlur={props.hideTooltip}
-                    onClick={(event) => {
-                      void handleCopyPath(event, snapshot.snapshotRef);
-                    }}
-                    onFocus={(event) => props.showTooltip(event, snapshot.snapshotRef)}
-                    onMouseEnter={(event) => props.showTooltip(event, snapshot.snapshotRef)}
-                    onMouseLeave={props.hideTooltip}
-                  >
-                    <span aria-hidden="true" className="context-list__icon">
-                      <WorktreeIcon size={14} />
-                    </span>
-                    {pathBaseName(snapshot.worktreePath)}
-                  </button>
-                  <div className="context-list__actions">
-                    <button
-                      className="context-list__action"
-                      type="button"
-                      onClick={() => {
-                        void props.onRestoreWorktree?.(
-                          props.thread,
-                          snapshot.snapshotRef,
-                          snapshot.worktreePath,
-                        );
-                      }}
-                    >
-                      Restore
-                    </button>
-                    <span className="context-list__meta">
-                      {snapshot.archivedAt
-                        ? formatTimestamp(snapshot.archivedAt)
-                        : "archived"}
-                    </span>
-                  </div>
-                </li>
-              ))}
-          </ul>
-        </section>
-      ) : null}
 
       <section className="context-panel__section">
         <h3>Execution context</h3>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
@@ -1,8 +1,9 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BackendSummary } from "@pwragent/shared";
 import { ProviderStatusPanel } from "../ProviderStatusPanel";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../../lib/useBackendSummaries";
 
 afterEach(() => {
   cleanup();
@@ -65,7 +66,61 @@ const grokBackend: BackendSummary = {
   unavailableReason: "XAI_API_KEY is not set",
 };
 
+const kimiBackend: BackendSummary = {
+  ...codexBackend,
+  kind: "acp:kimi",
+  source: "acp",
+  label: "Kimi",
+  account: undefined,
+  rateLimits: undefined,
+  acp: {
+    registryId: "kimi",
+    version: "0.29.2",
+    distributionKinds: ["local"],
+    installStatus: "installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+  },
+};
+
+const grokAcpBackend: BackendSummary = {
+  ...codexBackend,
+  kind: "acp:grok",
+  source: "acp",
+  label: "Grok",
+  account: {
+    type: "provider",
+    label: "Grok account",
+    planType: "SuperGrok Heavy",
+  },
+  rateLimits: [
+    {
+      name: "Included credits",
+      usedPercent: 42.5,
+    },
+  ],
+  acp: {
+    registryId: "grok",
+    version: "0.2.112",
+    distributionKinds: ["local"],
+    installStatus: "installed",
+    authStatus: "authenticated",
+    verificationStatus: "not-applicable",
+  },
+};
+
 describe("ProviderStatusPanel", () => {
+  it("refreshes account usage whenever the provider tab opens", () => {
+    const onRefresh = vi.fn();
+    window.addEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, onRefresh, {
+      once: true,
+    });
+
+    render(<ProviderStatusPanel backends={[]} />);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
   it("renders account, plan, and rate limits for an available backend", () => {
     render(<ProviderStatusPanel backends={[codexBackend]} />);
 
@@ -82,6 +137,22 @@ describe("ProviderStatusPanel", () => {
 
     expect(screen.getByText("Grok app server")).toBeInTheDocument();
     expect(screen.getByText("XAI_API_KEY is not set")).toBeInTheDocument();
+  });
+
+  it("shows ACP runtime and authentication metadata without a limits API", () => {
+    render(<ProviderStatusPanel backends={[kimiBackend]} />);
+
+    expect(screen.getByRole("heading", { name: "AI providers" })).toBeInTheDocument();
+    expect(screen.getByText("0.29.2")).toBeInTheDocument();
+    expect(screen.getByText("Managed by provider")).toBeInTheDocument();
+  });
+
+  it("shows Grok subscription and included-credit usage from ACP billing", () => {
+    render(<ProviderStatusPanel backends={[grokAcpBackend]} />);
+
+    expect(screen.getByText("Grok account")).toBeInTheDocument();
+    expect(screen.getByText("SuperGrok Heavy")).toBeInTheDocument();
+    expect(screen.getByText(/Included credits: 58% left/)).toBeInTheDocument();
   });
 
   it("renders a backend error when status is unavailable", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -12,6 +12,7 @@ afterEach(() => {
 describe("backend status formatting", () => {
   it("keeps regular and Spark rate limits visible", () => {
     const backend = {
+      kind: "codex",
       rateLimits: [
         { name: "GPT-5.3-Codex-Spark Weekly limit", usedPercent: 1 },
         { name: "Weekly limit", usedPercent: 39 },
@@ -26,6 +27,21 @@ describe("backend status formatting", () => {
       "Weekly limit",
       "GPT-5.3-Codex-Spark 5h limit",
       "GPT-5.3-Codex-Spark Weekly limit",
+    ]);
+  });
+
+  it("keeps provider-defined Grok rate limits visible", () => {
+    const backend = {
+      kind: "acp:grok",
+      rateLimits: [
+        { name: "Included credits", usedPercent: 2 },
+        { name: "other limit", usedPercent: 50 },
+      ],
+    } as BackendSummary;
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "Included credits",
+      "other limit",
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -11,7 +11,7 @@ afterEach(() => {
 
 describe("backend status formatting", () => {
   it("keeps regular and Spark rate limits visible", () => {
-    const backend = {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
       kind: "codex",
       rateLimits: [
         { name: "GPT-5.3-Codex-Spark Weekly limit", usedPercent: 1 },
@@ -20,7 +20,7 @@ describe("backend status formatting", () => {
         { name: "5h limit", usedPercent: 26 },
         { name: "other limit", usedPercent: 50 },
       ],
-    } as BackendSummary;
+    };
 
     expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
       "5h limit",
@@ -31,13 +31,13 @@ describe("backend status formatting", () => {
   });
 
   it("keeps provider-defined Grok rate limits visible", () => {
-    const backend = {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
       kind: "acp:grok",
       rateLimits: [
         { name: "Included credits", usedPercent: 2 },
         { name: "other limit", usedPercent: 50 },
       ],
-    } as BackendSummary;
+    };
 
     expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
       "Included credits",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -104,6 +104,40 @@ describe("useBackendSummaries", () => {
     expect(listBackends).toHaveBeenCalledTimes(2);
   });
 
+  it("refreshes backend details when ACP provider status updates", async () => {
+    let eventHandler: ((event: AgentEvent) => void) | undefined;
+    const listBackends = vi
+      .fn<NonNullable<DesktopApi["listBackends"]>>()
+      .mockResolvedValue({
+        fetchedAt: 1,
+        backends: [],
+      });
+    const desktopApi: DesktopApi = {
+      listBackends,
+      onAgentEvent: (callback) => {
+        eventHandler = callback;
+        return () => undefined;
+      },
+    };
+
+    renderHook(() => useBackendSummaries(desktopApi));
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(1);
+    });
+    eventHandler?.({
+      backend: "acp:grok",
+      notification: {
+        method: "backend/providerStatus/updated",
+        params: { backend: "acp:grok" },
+      },
+    });
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("refreshes backend details when Codex rate limits update", async () => {
     let eventHandler: ((event: AgentEvent) => void) | undefined;
     const listBackends = vi

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -5,11 +5,17 @@ export type BackendRateLimitSummary = NonNullable<BackendSummary["rateLimits"]>[
 export function formatBackendAccountText(
   account: NonNullable<BackendSummary["account"]>,
 ): string {
+  if (account.label?.trim()) {
+    return account.label.trim();
+  }
   if (account.type === "chatgpt" && account.email?.trim()) {
     return account.email.trim();
   }
   if (account.type === "apiKey") {
     return "API key";
+  }
+  if (account.type === "provider") {
+    return "Signed in";
   }
   if (account.requiresOpenaiAuth === false) {
     return "Not required";
@@ -25,6 +31,9 @@ export function selectVisibleRateLimits(
 ): BackendRateLimitSummary[] {
   return [...(backend.rateLimits ?? [])]
     .filter((limit) => {
+      if (backend.kind !== "codex") {
+        return true;
+      }
       const { label } = splitRateLimitName(limit.name);
       return label === "5h limit" || label === "Weekly limit";
     })

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -27,7 +27,7 @@ export function formatBackendAccountText(
 }
 
 export function selectVisibleRateLimits(
-  backend: BackendSummary,
+  backend: Pick<BackendSummary, "kind" | "rateLimits">,
 ): BackendRateLimitSummary[] {
   return [...(backend.rateLimits ?? [])]
     .filter((limit) => {

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -114,7 +114,8 @@ export function useBackendSummaries(
         (event.backend === "codex" &&
           (event.notification.method === "account/rateLimits/updated" ||
             event.notification.method === "account/updated")) ||
-        event.notification.method === "backend/acpRuntimeCapabilities/updated"
+        event.notification.method === "backend/acpRuntimeCapabilities/updated" ||
+        event.notification.method === "backend/providerStatus/updated"
       ) {
         void refresh();
       }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11614,10 +11614,8 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
-/* The tablist fills the spine so the spacer can push the bottom-anchored
-   tab (Provider status) down. Every role="tab" must live inside this
-   role="tablist" (axe aria-required-parent), so bottom tabs render here
-   too — only the pin toggle sits in the footer below. */
+/* The tablist fills the spine so any bottom-anchored tabs remain inside the
+   role="tablist" (axe aria-required-parent). */
 .context-rail__tablist {
   display: flex;
   flex: 1 1 auto;

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -181,7 +181,8 @@ export type BackendLaunchpadOptions = {
 };
 
 export type BackendAccountSummary = {
-  type?: "apiKey" | "chatgpt";
+  type?: "apiKey" | "chatgpt" | "provider";
+  label?: string;
   email?: string;
   planType?: string;
   requiresOpenaiAuth?: boolean;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1078,6 +1078,12 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "backend/providerStatus/updated";
+      params: {
+        backend: AppServerBackendKind;
+      };
+    }
+  | {
       method: "item/commandExecution/outputDelta";
       params: {
         threadId: string;


### PR DESCRIPTION
## Summary

- split AI provider metadata into a dedicated, scrollable **AI Provider Info** right-rail tab
- remove linked-directory details from **Context Info** and consolidate them, including worktree snapshots and restore actions, under **Linked Projects**
- show provider availability, version, authentication, account, plan, and rate-limit information when available
- add Grok account-level usage through its ACP billing extension

## Why

The Context Info tab duplicated directory information that already had a dedicated tab, while provider profile and account-limit information was scattered or unavailable in the thread detail view. This gives each concern a clearer home and makes provider status visible without leaving the active thread.

## Grok billing fix

Grok names its Rust ACP extension `x.ai/billing`, but ACP extension methods are serialized on the stdio wire with a leading underscore. PwrAgent now requests `_x.ai/billing`, normalizes both the current percentage-based response and the legacy cents-based response, and refreshes provider summaries whenever the tab opens.

Unsupported providers continue to show their available runtime metadata without manufacturing account or limit data.

## Validation

- live Grok 0.2.112 ACP probe returned the weekly account-usage window and usage percentage
- focused Vitest suites: 146 tests passed during the full context-rail implementation pass; final Grok/provider pass: 29 tests passed
- focused Electron E2E: 15 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
- manually verified Grok usage in the relaunched development app
