### PR TITLE
fix(desktop): minimize and price Grok title helpers

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -270,6 +270,68 @@ describe("AcpAgentClient", () => {
     expect(client.readReplay("session-1").messages).toEqual([]);
   });
 
+  it("returns suppressed control prompt usage without adding it to the transcript", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const sessionUpdates: string[] = [];
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+      onSessionUpdate: ({ sessionId }) => {
+        sessionUpdates.push(sessionId);
+      },
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "name this thread",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: '{ "title": "Favorite cereal" }' },
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "turn_completed",
+      usage: {
+        inputTokens: 120,
+        outputTokens: 8,
+        totalTokens: 128,
+        cachedReadTokens: 20,
+        reasoningTokens: 3,
+        modelUsage: {
+          "grok-4.5-build": {
+            inputTokens: 120,
+            outputTokens: 8,
+          },
+        },
+      },
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await expect(controlPrompt).resolves.toEqual({
+      text: '{ "title": "Favorite cereal" }',
+      model: "grok-4.5-build",
+      tokenUsage: {
+        inputTokens: 120,
+        cachedInputTokens: 20,
+        outputTokens: 8,
+        reasoningOutputTokens: 3,
+        totalTokens: 128,
+      },
+    });
+    expect(client.readReplay(session.sessionId).messages).toEqual([]);
+    expect(sessionUpdates).toEqual([]);
+  });
+
   it("preserves split JSON control prompt chunks without inserted newlines", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -466,6 +466,53 @@ describe("AcpAgentClient", () => {
     });
   });
 
+  it("starts minimal helper sessions without configured MCP servers", async () => {
+    const mcpServers = vi.fn(() => [
+      {
+        name: "pwragent",
+        command: "pwragent-mcp",
+      },
+    ]);
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1000,
+      mcpServers,
+    });
+
+    await client.initialize();
+    await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+      mcpServers: "none",
+      sessionMeta: {
+        agentProfile: {
+          discoverSkills: false,
+          toolConfig: { tools: [] },
+        },
+        systemPromptOverride: "Return only the requested result.",
+      },
+    });
+
+    expect(mcpServers).not.toHaveBeenCalled();
+    expect(transport.requests[1]).toEqual({
+      method: "session/new",
+      params: {
+        cwd: "/repo",
+        mcpServers: [],
+        _meta: {
+          agentProfile: {
+            discoverSkills: false,
+            toolConfig: { tools: [] },
+          },
+          systemPromptOverride: "Return only the requested result.",
+        },
+      },
+    });
+  });
+
   it("binds a pending HTTP MCP registration after session/new returns", async () => {
     const transport = new FakeAcpAgentTransport();
     const bindThread = vi.fn();

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -332,6 +332,55 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual([]);
   });
 
+  it("returns suppressed Qwen usage emitted on an agent message chunk", async () => {
+    const promptResponse = createDeferred<unknown>();
+    const transport = new FakeAcpAgentTransport({
+      "session/prompt": promptResponse.promise,
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:qwen",
+      store,
+      transport,
+      now: () => 1000,
+    });
+
+    await client.initialize();
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "default",
+    });
+    const controlPrompt = client.sendControlPrompt({
+      sessionId: session.sessionId,
+      prompt: "name this thread",
+    });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: '{ "title": "Favorite cereal" }' },
+      _meta: {
+        usage: {
+          inputTokens: 23_851,
+          outputTokens: 222,
+          totalTokens: 24_073,
+          thoughtTokens: 29,
+          cachedReadTokens: 0,
+        },
+      },
+    });
+    promptResponse.resolve({ stopReason: "end_turn" });
+
+    await expect(controlPrompt).resolves.toEqual({
+      text: '{ "title": "Favorite cereal" }',
+      tokenUsage: {
+        inputTokens: 23_851,
+        cachedInputTokens: 0,
+        outputTokens: 222,
+        reasoningOutputTokens: 29,
+        totalTokens: 24_073,
+      },
+    });
+    expect(client.readReplay(session.sessionId).messages).toEqual([]);
+  });
+
   it("preserves split JSON control prompt chunks without inserted newlines", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
@@ -25,8 +25,17 @@ describe("AcpThreadTitleGenerator", () => {
       hidden: true,
       status: "idle" as const,
     }));
+    const configureHelperSession = vi.fn(async () => undefined);
     const generator = new AcpThreadTitleGenerator({
       backend,
+      configureHelperSession,
+      helperSession: {
+        mcpServers: "none",
+        reasoningEffort: "low",
+        sessionMeta: {
+          systemPromptOverride: "Return only the requested result.",
+        },
+      },
       getClient: async () => ({
         cancelSession: vi.fn(),
         dispose: vi.fn(),
@@ -65,6 +74,7 @@ describe("AcpThreadTitleGenerator", () => {
       object: { title: " Favorite cereal question " },
       helperThreadId: "qwen-title-helper",
       model: "qwen3.6-plus",
+      reasoningEffort: "low",
       tokenUsage: {
         inputTokens: 120,
         cachedInputTokens: 20,
@@ -76,7 +86,16 @@ describe("AcpThreadTitleGenerator", () => {
       expect.objectContaining({
         executionMode: "default",
         hidden: true,
+        mcpServers: "none",
+        sessionMeta: {
+          systemPromptOverride: "Return only the requested result.",
+        },
         title: "Name this thread",
+      }),
+    );
+    expect(configureHelperSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoningEffort: "low",
       }),
     );
     expect(sendControlPrompt).toHaveBeenCalledWith({

--- a/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-thread-title-generator.test.ts
@@ -7,6 +7,13 @@ describe("AcpThreadTitleGenerator", () => {
     const backend = "acp:qwen" as AcpBackendId;
     const sendControlPrompt = vi.fn(async () => ({
       text: '{"title": "\nFavorite cereal question\n"}',
+      model: "qwen3.6-plus",
+      tokenUsage: {
+        inputTokens: 120,
+        cachedInputTokens: 20,
+        outputTokens: 8,
+        totalTokens: 128,
+      },
     }));
     const startSession = vi.fn(async () => ({
       backendId: backend,
@@ -57,6 +64,13 @@ describe("AcpThreadTitleGenerator", () => {
       status: "ok",
       object: { title: " Favorite cereal question " },
       helperThreadId: "qwen-title-helper",
+      model: "qwen3.6-plus",
+      tokenUsage: {
+        inputTokens: 120,
+        cachedInputTokens: 20,
+        outputTokens: 8,
+        totalTokens: 128,
+      },
     });
     expect(startSession).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12395,6 +12395,102 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists title helper usage when the generated title is invalid", async () => {
+    const titleService = {
+      generateTitle: vi.fn(async () => ({
+        status: "invalid" as const,
+        reason: "title_too_many_words",
+        helperThreadId: "invalid-title-helper-thread",
+        helperTurnId: "invalid-title-helper-turn",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        tokenUsage: {
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          outputTokens: 10,
+          totalTokens: 110,
+        },
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const upsertUsageLineSpy = vi.spyOn(overlayStore, "upsertThreadUsageLine");
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "thread/name/set"] },
+      threads: [
+        {
+          id: "thread-invalid-title-helper",
+          title: "Make button",
+          titleSource: "derived",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-invalid-title-helper",
+      input: [{ type: "text", text: "Make button" }],
+    });
+    await waitForCondition(() =>
+      upsertSubAgentSpy.mock.calls.some(
+        ([call]) => call.subAgent.status === "failed",
+      ),
+    );
+
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-invalid-title-helper",
+      subAgent: expect.objectContaining({
+        monitorId: "system:title-helper:codex:thread-invalid-title-helper",
+        status: "failed",
+        outcome: "failure",
+        monitorThreadId: "invalid-title-helper-thread",
+        monitorTurnId: "invalid-title-helper-turn",
+        preferredModel: "gpt-5.4-mini",
+        preferredReasoningEffort: "low",
+        lastMessage: "Title generation failed: title_too_many_words",
+        monitorUsage: expect.objectContaining({
+          model: "gpt-5.4-mini",
+          tokenUsage: {
+            inputTokens: 100,
+            cachedInputTokens: 20,
+            uncachedInputTokens: 80,
+            outputTokens: 10,
+            reasoningOutputTokens: 0,
+            totalTokens: 110,
+          },
+        }),
+      }),
+    });
+    expect(upsertUsageLineSpy).toHaveBeenCalledWith({
+      line: expect.objectContaining({
+        backend: "codex",
+        parentThreadId: "thread-invalid-title-helper",
+        threadId: "invalid-title-helper-thread",
+        turnId: "invalid-title-helper-turn",
+        scope: "monitor",
+        source: "monitor",
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 110,
+      }),
+    });
+    expect(codexClient.lastRenameThreadParams).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("logs title helper sub-agent persistence failures without retrying the same write", async () => {
     mainLoggerMock.warn.mockClear();
     const titleService = {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13080,8 +13080,23 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("does not start a redundant title helper for Grok ACP sessions", async () => {
+  it("uses a minimal low-reasoning title helper for Grok ACP sessions", async () => {
     const acpBackendId = "acp:grok" as AcpBackendId;
+    const helperSession: AcpSessionMetadata = {
+      backendId: acpBackendId,
+      sessionId: "grok-title-helper",
+      title: "Name this thread",
+      cwd: "/repo/project",
+      createdAt: 1001,
+      updatedAt: 1001,
+      executionMode: "default",
+      acpRuntime: {
+        currentModelId: "grok-4.5",
+        updatedAt: 1001,
+      },
+      hidden: true,
+      status: "idle",
+    };
     const sessions: AcpSessionMetadata[] = [
       {
         backendId: acpBackendId,
@@ -13102,16 +13117,26 @@ command = "pnpm dev"
     const acpClient = {
       initialize: vi.fn(async () => undefined),
       dispose: vi.fn(),
-      startSession: vi.fn(),
+      startSession: vi.fn(async () => helperSession),
       ensureSession: vi.fn(async () => undefined),
       loadSession: vi.fn(),
       refreshSession: vi.fn(async () => undefined),
       cancelSession: vi.fn(),
+      setRuntimeOption: vi.fn(async () => helperSession.acpRuntime),
       startPrompt: vi.fn(() => ({
         sessionId: "grok-session-1",
         turnId: "turn-1",
       })),
-      sendControlPrompt: vi.fn(),
+      sendControlPrompt: vi.fn(async () => ({
+        text: '{ "title": "Favorite cereal" }',
+        model: "grok-4.5-build",
+        tokenUsage: {
+          inputTokens: 200,
+          cachedInputTokens: 40,
+          outputTokens: 10,
+          totalTokens: 210,
+        },
+      })),
       readReplay: vi.fn((): AppServerThreadReplay => ({
         entries: [],
         messages: [],
@@ -13145,11 +13170,42 @@ command = "pnpm dev"
       input: [{ type: "text", text: "What is your favorite cereal?" }],
     });
     await emitCompletedTurn(registry, acpBackendId, "grok-session-1");
-    await flushAsync();
+    await waitForCondition(() => sessions[0]?.title === "Favorite cereal");
 
-    expect(acpClient.startSession).not.toHaveBeenCalled();
-    expect(acpClient.sendControlPrompt).not.toHaveBeenCalled();
-    expect(upsertSubAgentSpy).not.toHaveBeenCalled();
+    expect(acpClient.startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hidden: true,
+        mcpServers: "none",
+        sessionMeta: {
+          agentProfile: expect.objectContaining({
+            agentsMd: false,
+            discoverSkills: false,
+            injectDefaultTools: false,
+            mcpInheritance: "none",
+            tools: ["read_file"],
+          }),
+          systemPromptOverride: expect.stringContaining(
+            "do not use tools",
+          ),
+        },
+        title: "Name this thread",
+      }),
+    );
+    expect(acpClient.setRuntimeOption).toHaveBeenCalledWith({
+      sessionId: "grok-title-helper",
+      source: "model",
+      optionId: "model",
+      value: "grok-4.5",
+      reasoningEffort: "low",
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "grok-session-1",
+      subAgent: expect.objectContaining({
+        preferredReasoningEffort: "low",
+        status: "success",
+      }),
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -12946,6 +12946,13 @@ command = "pnpm dev"
     ];
     const sendControlPrompt = vi.fn(async () => ({
       text: '{ "title": "Favorite cereal" }',
+      model: "kimi-k2-0711-preview",
+      tokenUsage: {
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 110,
+      },
     }));
     const helperSession: AcpSessionMetadata = {
       backendId: acpBackendId,
@@ -12989,6 +12996,7 @@ command = "pnpm dev"
     };
     const overlayStore = createOverlayStoreMock();
     const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const upsertUsageLineSpy = vi.spyOn(overlayStore, "upsertThreadUsageLine");
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
@@ -13047,6 +13055,25 @@ command = "pnpm dev"
         monitorThreadId: "kimi-title-helper",
         lastMessage: "Generated title: Favorite cereal",
         outcome: "success",
+        monitorUsage: expect.objectContaining({
+          model: "kimi-k2-0711-preview",
+          tokenUsage: expect.objectContaining({
+            cachedInputTokens: 20,
+            inputTokens: 100,
+            outputTokens: 10,
+            totalTokens: 110,
+            uncachedInputTokens: 80,
+          }),
+        }),
+      }),
+    });
+    expect(upsertUsageLineSpy).toHaveBeenCalledWith({
+      line: expect.objectContaining({
+        backend: acpBackendId,
+        parentThreadId: "kimi-session-1",
+        scope: "monitor",
+        sourceItemId: "system:title-helper:acp:kimi:kimi-session-1",
+        threadId: "kimi-title-helper",
       }),
     });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13080,6 +13080,80 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("does not start a redundant title helper for Grok ACP sessions", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "grok-session-1",
+        title: "What is your favorite cereal?",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        acpRuntime: {
+          currentModelId: "grok-4.5",
+          updatedAt: 1000,
+        },
+        status: "idle",
+      },
+    ];
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(),
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      startPrompt: vi.fn(() => ({
+        sessionId: "grok-session-1",
+        turnId: "turn-1",
+      })),
+      sendControlPrompt: vi.fn(),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          ...createKimiAgentRecord(acpBackendId),
+          registryId: "grok",
+          name: "Grok",
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "grok-session-1",
+      input: [{ type: "text", text: "What is your favorite cereal?" }],
+    });
+    await emitCompletedTurn(registry, acpBackendId, "grok-session-1");
+    await flushAsync();
+
+    expect(acpClient.startSession).not.toHaveBeenCalled();
+    expect(acpClient.sendControlPrompt).not.toHaveBeenCalled();
+    expect(upsertSubAgentSpy).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
   it("reports the generated candidate when an ACP durable title arrives first", async () => {
     const acpBackendId = "acp:grok" as AcpBackendId;
     const prompt = "What is your favorite cereal?";

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13053,6 +13053,157 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("reports the generated candidate when an ACP durable title arrives first", async () => {
+    const acpBackendId = "acp:grok" as AcpBackendId;
+    const prompt = "What is your favorite cereal?";
+    const titleGeneration = createDeferred<{
+      status: "generated";
+      title: string;
+      helperThreadId: string;
+      model: string;
+      tokenUsage: {
+        inputTokens: number;
+        cachedInputTokens: number;
+        outputTokens: number;
+        totalTokens: number;
+      };
+    }>();
+    const titleService = {
+      generateTitle: vi.fn(async () => await titleGeneration.promise),
+    };
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "grok-session-1",
+        title: prompt,
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        acpRuntime: {
+          currentModelId: "grok-4.5",
+          updatedAt: 1000,
+        },
+        status: "idle",
+      },
+    ];
+    const acpClient = {
+      initialize: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+      startSession: vi.fn(async () => sessions[0]!),
+      ensureSession: vi.fn(async () => undefined),
+      loadSession: vi.fn(),
+      refreshSession: vi.fn(async () => undefined),
+      cancelSession: vi.fn(),
+      startPrompt: vi.fn(() => ({
+        sessionId: "grok-session-1",
+        turnId: "turn-1",
+      })),
+      readReplay: vi.fn((): AppServerThreadReplay => ({
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      })),
+    };
+    const overlayStore = createOverlayStoreMock();
+    const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
+    const upsertUsageLineSpy = vi.spyOn(overlayStore, "upsertThreadUsageLine");
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          ...createKimiAgentRecord(acpBackendId),
+          registryId: "grok",
+          name: "Grok",
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+      createAcpClient: () => acpClient,
+      threadTitleGenerationService: titleService,
+    });
+
+    await registry.startTurn({
+      backend: acpBackendId,
+      threadId: "grok-session-1",
+      input: [{ type: "text", text: prompt }],
+    });
+    await waitForCondition(() => titleService.generateTitle.mock.calls.length === 1);
+
+    sessions[0] = {
+      ...sessions[0]!,
+      title: "Favorite Cereal Preference Personal Question",
+      titleSource: "derived",
+      updatedAt: 2000,
+    };
+    await (
+      registry as unknown as { emit(event: AgentEvent): Promise<void> }
+    ).emit({
+      backend: acpBackendId,
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "grok-session-1",
+          threadName: "Favorite Cereal Preference Personal Question",
+        },
+      },
+    });
+    titleGeneration.resolve({
+      status: "generated",
+      title: "Favorite Breakfast Cereal",
+      helperThreadId: "grok-title-helper",
+      model: "grok-4.5",
+      tokenUsage: {
+        inputTokens: 100,
+        cachedInputTokens: 20,
+        outputTokens: 10,
+        totalTokens: 110,
+      },
+    });
+    await waitForCondition(() =>
+      upsertSubAgentSpy.mock.calls.some(
+        ([call]) => call.subAgent.status === "cancelled",
+      ),
+    );
+
+    expect(sessions[0]).toMatchObject({
+      title: "Favorite Cereal Preference Personal Question",
+      titleSource: "derived",
+    });
+    expect(upsertSubAgentSpy).toHaveBeenCalledWith({
+      backend: acpBackendId,
+      threadId: "grok-session-1",
+      subAgent: expect.objectContaining({
+        status: "cancelled",
+        monitorThreadId: "grok-title-helper",
+        preferredModel: "grok-4.5",
+        lastMessage:
+          "Generated title: Favorite Breakfast Cereal. Not applied: ACP provided a durable title first: Favorite Cereal Preference Personal Question.",
+        outcome: "cancelled",
+        monitorUsage: expect.objectContaining({
+          model: "grok-4.5",
+        }),
+      }),
+    });
+    expect(upsertUsageLineSpy).toHaveBeenCalledWith({
+      line: expect.objectContaining({
+        backend: acpBackendId,
+        source: "monitor",
+        sourceItemId: "system:title-helper:acp:grok:grok-session-1",
+        parentThreadId: "grok-session-1",
+        threadId: "grok-title-helper",
+      }),
+    });
+
+    await registry.close();
+  });
+
   it("does not replace an existing ACP prompt-derived fallback title with a later prompt", async () => {
     const acpBackendId = "acp:qwen" as AcpBackendId;
     const sessions: AcpSessionMetadata[] = [

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13113,6 +13113,7 @@ command = "pnpm dev"
     const overlayStore = createOverlayStoreMock();
     const upsertSubAgentSpy = vi.spyOn(overlayStore, "upsertThreadSubAgent");
     const upsertUsageLineSpy = vi.spyOn(overlayStore, "upsertThreadUsageLine");
+    const events: AgentEvent[] = [];
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
@@ -13127,6 +13128,9 @@ command = "pnpm dev"
       acpSessionStore: createAcpSessionStoreMock(sessions),
       createAcpClient: () => acpClient,
       threadTitleGenerationService: titleService,
+    });
+    registry.onEvent((event) => {
+      events.push(event);
     });
 
     await registry.startTurn({
@@ -13168,7 +13172,12 @@ command = "pnpm dev"
     });
     await waitForCondition(() =>
       upsertSubAgentSpy.mock.calls.some(
-        ([call]) => call.subAgent.status === "cancelled",
+        ([call]) => call.subAgent.status === "success",
+      ),
+    );
+    await waitForCondition(() =>
+      events.some(
+        (event) => event.notification.method === "thread/pricing/updated",
       ),
     );
 
@@ -13180,12 +13189,15 @@ command = "pnpm dev"
       backend: acpBackendId,
       threadId: "grok-session-1",
       subAgent: expect.objectContaining({
-        status: "cancelled",
+        status: "success",
         monitorThreadId: "grok-title-helper",
         preferredModel: "grok-4.5",
         lastMessage:
           "Generated title: Favorite Breakfast Cereal. Not applied: ACP provided a durable title first: Favorite Cereal Preference Personal Question.",
-        outcome: "cancelled",
+        outcome: "success",
+        completionSource: expect.objectContaining({
+          terminalStatus: "completed",
+        }),
         monitorUsage: expect.objectContaining({
           model: "grok-4.5",
         }),
@@ -13199,6 +13211,26 @@ command = "pnpm dev"
         parentThreadId: "grok-session-1",
         threadId: "grok-title-helper",
       }),
+    });
+    expect(events).toContainEqual({
+      backend: acpBackendId,
+      notification: {
+        method: "thread/pricing/updated",
+        params: {
+          threadId: "grok-session-1",
+          pricing: expect.objectContaining({
+            lines: expect.arrayContaining([
+              expect.objectContaining({
+                parentThreadId: "grok-session-1",
+                scope: "monitor",
+                sourceItemId:
+                  "system:title-helper:acp:grok:grok-session-1",
+                threadId: "grok-title-helper",
+              }),
+            ]),
+          }),
+        },
+      },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -260,6 +260,7 @@ describe("ThreadTitleGenerationService", () => {
     ).resolves.toEqual({
       status: "invalid",
       reason: "title_too_long",
+      cachedTokens: 12,
     });
     await expect(
       wordyTitleService.generateTitle({
@@ -269,6 +270,48 @@ describe("ThreadTitleGenerationService", () => {
     ).resolves.toEqual({
       status: "invalid",
       reason: "title_too_many_words",
+      cachedTokens: 12,
+    });
+  });
+
+  it("preserves helper metadata when a generated title is invalid", async () => {
+    const tokenUsage = {
+      inputTokens: 120,
+      cachedInputTokens: 20,
+      outputTokens: 8,
+      totalTokens: 128,
+    };
+    const service = new ThreadTitleGenerationService({
+      generators: {
+        codex: {
+          generateTitle: vi.fn(async () => ({
+            status: "ok" as const,
+            object: { title: "One two three four five six seven" },
+            helperThreadId: "title-helper-thread",
+            helperTurnId: "title-helper-turn",
+            model: "gpt-5.4-mini",
+            reasoningEffort: "low",
+            serviceTier: "priority",
+            tokenUsage,
+          })),
+        },
+      },
+    });
+
+    await expect(
+      service.generateTitle({
+        backend: "codex",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "invalid",
+      reason: "title_too_many_words",
+      helperThreadId: "title-helper-thread",
+      helperTurnId: "title-helper-turn",
+      model: "gpt-5.4-mini",
+      reasoningEffort: "low",
+      serviceTier: "priority",
+      tokenUsage,
     });
   });
 
@@ -287,6 +330,7 @@ describe("ThreadTitleGenerationService", () => {
     ).resolves.toEqual({
       status: "invalid",
       reason: "title_must_be_string",
+      cachedTokens: 12,
     });
   });
 

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -290,15 +290,21 @@ export class AcpAgentClient {
     createdAt?: number;
     acpRuntime?: BackendAcpSessionRuntimeState;
     hidden?: boolean;
+    mcpServers?: "default" | "none";
+    sessionMeta?: Record<string, unknown>;
   }): Promise<AcpSessionMetadata> {
     const cwd = params.cwd ?? process.cwd();
-    const mcpRegistration = await this.buildMcpServers({
-      cwd,
-      sessionId: params.sessionId,
-    });
+    const mcpRegistration =
+      params.mcpServers === "none"
+        ? { servers: [] }
+        : await this.buildMcpServers({
+            cwd,
+            sessionId: params.sessionId,
+          });
     const result = await this.options.transport.request("session/new", {
       cwd,
       mcpServers: mcpRegistration.servers,
+      ...(params.sessionMeta ? { _meta: params.sessionMeta } : {}),
     });
     const now = this.now();
     const record = asRecord(result);

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -688,10 +688,10 @@ export class AcpAgentClient {
           suppressedControlPrompt.fallbackOutputText = text;
         }
       }
-      const completedUsage = readCompletedControlPromptUsage(update);
-      if (completedUsage) {
-        suppressedControlPrompt.tokenUsage = completedUsage.tokenUsage;
-        suppressedControlPrompt.model = completedUsage.model;
+      const usage = readControlPromptUsage(update);
+      if (usage) {
+        suppressedControlPrompt.tokenUsage = usage.tokenUsage;
+        suppressedControlPrompt.model = usage.model;
       }
       return;
     }
@@ -1208,20 +1208,25 @@ function readUpdateKind(update: Record<string, unknown>): string | undefined {
   return typeof kind === "string" ? kind : undefined;
 }
 
-function readCompletedControlPromptUsage(
+function readControlPromptUsage(
   update: Record<string, unknown>,
 ): Pick<AcpSuppressedControlPrompt, "model" | "tokenUsage"> | undefined {
-  if (readUpdateKind(update) !== "turn_completed") {
-    return undefined;
-  }
-  const usage = asRecord(update.usage);
+  const kind = readUpdateKind(update);
+  const usage =
+    kind === "turn_completed"
+      ? asRecord(update.usage)
+      : kind === "agent_message_chunk"
+        ? asRecord(asRecord(update._meta)?.usage)
+        : undefined;
   if (!usage) {
     return undefined;
   }
   const inputTokens = readFiniteNumber(usage.inputTokens);
   const cachedInputTokens = readFiniteNumber(usage.cachedReadTokens);
   const outputTokens = readFiniteNumber(usage.outputTokens);
-  const reasoningOutputTokens = readFiniteNumber(usage.reasoningTokens);
+  const reasoningOutputTokens =
+    readFiniteNumber(usage.reasoningTokens) ??
+    readFiniteNumber(usage.thoughtTokens);
   const totalTokens = readFiniteNumber(usage.totalTokens);
   if (
     inputTokens === undefined &&

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -122,6 +122,14 @@ type AcpSessionLoadState = {
 type AcpSuppressedControlPrompt = {
   fallbackOutputText?: string;
   finalTextChunks: string[];
+  model?: string;
+  tokenUsage?: {
+    cachedInputTokens?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    reasoningOutputTokens?: number;
+    totalTokens?: number;
+  };
 };
 
 type AcpHydratedSessionHistory = {
@@ -519,7 +527,11 @@ export class AcpAgentClient {
   async sendControlPrompt(params: {
     sessionId: string;
     prompt: string;
-  }): Promise<{ text: string }> {
+  }): Promise<{
+    text: string;
+    model?: string;
+    tokenUsage?: AcpSuppressedControlPrompt["tokenUsage"];
+  }> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
     const suppression: AcpSuppressedControlPrompt = { finalTextChunks: [] };
     this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
@@ -537,6 +549,10 @@ export class AcpAgentClient {
           suppression.finalTextChunks.join("").trim() ||
           suppression.fallbackOutputText?.trim() ||
           "",
+        ...(suppression.model ? { model: suppression.model } : {}),
+        ...(suppression.tokenUsage
+          ? { tokenUsage: suppression.tokenUsage }
+          : {}),
       };
     } finally {
       this.suppressedControlPromptSessions.delete(protocolSessionId);
@@ -665,6 +681,11 @@ export class AcpAgentClient {
         if (text) {
           suppressedControlPrompt.fallbackOutputText = text;
         }
+      }
+      const completedUsage = readCompletedControlPromptUsage(update);
+      if (completedUsage) {
+        suppressedControlPrompt.tokenUsage = completedUsage.tokenUsage;
+        suppressedControlPrompt.model = completedUsage.model;
       }
       return;
     }
@@ -1179,6 +1200,50 @@ function readUpdateKind(update: Record<string, unknown>): string | undefined {
   const kind =
     update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
+}
+
+function readCompletedControlPromptUsage(
+  update: Record<string, unknown>,
+): Pick<AcpSuppressedControlPrompt, "model" | "tokenUsage"> | undefined {
+  if (readUpdateKind(update) !== "turn_completed") {
+    return undefined;
+  }
+  const usage = asRecord(update.usage);
+  if (!usage) {
+    return undefined;
+  }
+  const inputTokens = readFiniteNumber(usage.inputTokens);
+  const cachedInputTokens = readFiniteNumber(usage.cachedReadTokens);
+  const outputTokens = readFiniteNumber(usage.outputTokens);
+  const reasoningOutputTokens = readFiniteNumber(usage.reasoningTokens);
+  const totalTokens = readFiniteNumber(usage.totalTokens);
+  if (
+    inputTokens === undefined &&
+    outputTokens === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined;
+  }
+  const modelUsage = asRecord(usage.modelUsage);
+  const model = modelUsage ? Object.keys(modelUsage)[0] : undefined;
+  return {
+    ...(model ? { model } : {}),
+    tokenUsage: {
+      ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+      ...(inputTokens !== undefined ? { inputTokens } : {}),
+      ...(outputTokens !== undefined ? { outputTokens } : {}),
+      ...(reasoningOutputTokens !== undefined
+        ? { reasoningOutputTokens }
+        : {}),
+      ...(totalTokens !== undefined ? { totalTokens } : {}),
+    },
+  };
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 function isConversationHistoryUpdate(update: Record<string, unknown>): boolean {

--- a/apps/desktop/src/main/acp/minimal-helper-session.ts
+++ b/apps/desktop/src/main/acp/minimal-helper-session.ts
@@ -1,0 +1,31 @@
+export type MinimalGrokHelperSessionPolicy = {
+  mcpServers: "none";
+  reasoningEffort: "low";
+  sessionMeta: Record<string, unknown>;
+};
+
+export function buildMinimalGrokHelperSessionPolicy(params: {
+  description: string;
+  name: string;
+  systemPrompt: string;
+}): MinimalGrokHelperSessionPolicy {
+  return {
+    mcpServers: "none",
+    reasoningEffort: "low",
+    sessionMeta: {
+      agentProfile: {
+        agentsMd: false,
+        description: params.description,
+        discoverSkills: false,
+        inheritSkills: false,
+        injectDefaultTools: false,
+        mcpInheritance: "none",
+        name: params.name,
+        permissionMode: "dontAsk",
+        skills: [],
+        tools: ["read_file"],
+      },
+      systemPromptOverride: params.systemPrompt,
+    },
+  };
+}

--- a/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
+++ b/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
@@ -14,8 +14,14 @@ export type AcpThreadTitleGeneratorOptions = {
   configureHelperSession?: (params: {
     client: AcpRuntimeClient;
     parentSession?: AcpSessionMetadata;
+    reasoningEffort?: string;
     session: AcpSessionMetadata;
   }) => Promise<void>;
+  helperSession?: {
+    mcpServers?: "default" | "none";
+    reasoningEffort?: string;
+    sessionMeta?: Record<string, unknown>;
+  };
   getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
   getSession: (
     backend: AcpBackendId,
@@ -28,8 +34,10 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
   private readonly configureHelperSession?: (params: {
     client: AcpRuntimeClient;
     parentSession?: AcpSessionMetadata;
+    reasoningEffort?: string;
     session: AcpSessionMetadata;
   }) => Promise<void>;
+  private readonly helperSession?: AcpThreadTitleGeneratorOptions["helperSession"];
   private readonly getClient: (backend: AcpBackendId) => Promise<AcpRuntimeClient>;
   private readonly getSession: (
     backend: AcpBackendId,
@@ -39,6 +47,7 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
   constructor(options: AcpThreadTitleGeneratorOptions) {
     this.backend = options.backend;
     this.configureHelperSession = options.configureHelperSession;
+    this.helperSession = options.helperSession;
     this.getClient = options.getClient;
     this.getSession = options.getSession;
   }
@@ -70,10 +79,17 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
         title: "Name this thread",
         acpRuntime: parentSession?.acpRuntime,
         hidden: true,
+        ...(this.helperSession?.mcpServers
+          ? { mcpServers: this.helperSession.mcpServers }
+          : {}),
+        ...(this.helperSession?.sessionMeta
+          ? { sessionMeta: this.helperSession.sessionMeta }
+          : {}),
       });
       await this.configureHelperSession?.({
         client,
         parentSession,
+        reasoningEffort: this.helperSession?.reasoningEffort,
         session: helperSession,
       });
       const response = await client.sendControlPrompt({
@@ -89,6 +105,9 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
         object: parseAcpTitleObject(response.text),
         helperThreadId: helperSession.sessionId,
         ...(usageModel ? { model: usageModel } : {}),
+        ...(this.helperSession?.reasoningEffort
+          ? { reasoningEffort: this.helperSession.reasoningEffort }
+          : {}),
         ...(response.tokenUsage ? { tokenUsage: response.tokenUsage } : {}),
       };
     } catch {

--- a/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
+++ b/apps/desktop/src/main/app-server/acp-thread-title-generator.ts
@@ -83,11 +83,13 @@ export class AcpThreadTitleGenerator implements ThreadTitleGenerator {
       const model = resolveAcpTitleModel(
         helperSession.acpRuntime ?? parentSession?.acpRuntime,
       );
+      const usageModel = response.model ?? model;
       return {
         status: "ok",
         object: parseAcpTitleObject(response.text),
         helperThreadId: helperSession.sessionId,
-        ...(model ? { model } : {}),
+        ...(usageModel ? { model: usageModel } : {}),
+        ...(response.tokenUsage ? { tokenUsage: response.tokenUsage } : {}),
       };
     } catch {
       return {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4622,6 +4622,11 @@ function titleHelperSubAgentMessage(params: {
       : "Generated a title.";
   }
   if (params.status === "cancelled") {
+    if (params.result?.title) {
+      return params.reason
+        ? `Generated title: ${params.result.title}. Not applied: ${params.reason}`
+        : `Generated title: ${params.result.title}. Not applied.`;
+    }
     return params.reason
       ? `Title generation cancelled: ${params.reason}`
       : "Title generation cancelled.";
@@ -4718,6 +4723,19 @@ function buildTitleEligibilityLogDetails(
       ? isInjectedContextPlaceholderTitle(thread.title)
       : null,
   };
+}
+
+function buildLateTitleCancellationReason(
+  backend: AppServerBackendKind,
+  thread: AppServerThreadSummary,
+): string {
+  if (thread.titleSource === "explicit") {
+    return `The thread was explicitly renamed first: ${thread.title}.`;
+  }
+  if (isAcpBackendId(backend)) {
+    return `ACP provided a durable title first: ${thread.title}.`;
+  }
+  return `A newer thread title was already present: ${thread.title}.`;
 }
 
 function createReplayThreadTitleService(): ThreadTitleService | undefined {
@@ -15861,6 +15879,7 @@ export class DesktopBackendRegistry {
         await this.safePersistExistingTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
+          result,
           status: "cancelled",
           reason: "Title generation became stale.",
         });
@@ -15882,8 +15901,12 @@ export class DesktopBackendRegistry {
         await this.safePersistExistingTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
+          result,
           status: "cancelled",
-          reason: "Latest title is no longer eligible.",
+          reason: buildLateTitleCancellationReason(
+            params.backend,
+            latestThread,
+          ),
         });
         return;
       }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4617,9 +4617,12 @@ function titleHelperSubAgentMessage(params: {
     return params.reason ?? "Generating a title.";
   }
   if (params.status === "success") {
-    return params.result?.title
-      ? `Generated title: ${params.result.title}`
-      : "Generated a title.";
+    if (params.result?.title) {
+      return params.reason
+        ? `Generated title: ${params.result.title}. Not applied: ${params.reason}`
+        : `Generated title: ${params.result.title}`;
+    }
+    return "Generated a title.";
   }
   if (params.status === "cancelled") {
     if (params.result?.title) {
@@ -15880,7 +15883,7 @@ export class DesktopBackendRegistry {
           backend: params.backend,
           threadId: params.threadId,
           result,
-          status: "cancelled",
+          status: "success",
           reason: "Title generation became stale.",
         });
         return;
@@ -15902,7 +15905,7 @@ export class DesktopBackendRegistry {
           backend: params.backend,
           threadId: params.threadId,
           result,
-          status: "cancelled",
+          status: "success",
           reason: buildLateTitleCancellationReason(
             params.backend,
             latestThread,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -322,6 +322,7 @@ import {
   type ThreadTitleGenerationResult,
 } from "./thread-title-generation-service";
 import { AcpThreadTitleGenerator } from "./acp-thread-title-generator";
+import { buildMinimalGrokHelperSessionPolicy } from "../acp/minimal-helper-session";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getDesktopNotificationService } from "../notifications/desktop-notification-service";
@@ -387,6 +388,12 @@ const ACTIVE_TURN_HANDOFF_ERROR =
  */
 const MAX_QUEUE_FLUSH_ATTEMPTS = 3;
 const backendRegistryLog = getMainLogger("pwragent:backend-registry");
+const GROK_TITLE_HELPER_SESSION_POLICY = buildMinimalGrokHelperSessionPolicy({
+  description: "Generate a concise title for a PwrAgent thread.",
+  name: "pwragent-title-helper",
+  systemPrompt:
+    "Generate the requested thread title. Follow the user prompt exactly, do not use tools, and return only the requested JSON object.",
+});
 const ATTENTION_NOTIFICATION_METHODS = new Set([
   "turn/requestApproval",
   "review/requestApproval",
@@ -5778,24 +5785,33 @@ export class DesktopBackendRegistry {
                     : undefined,
                 },
                 generatorResolver: (backend) => {
-                  if (!isAcpBackendId(backend) || backend === "acp:grok") {
-                    // Grok emits its own durable title through ACP. Starting a
-                    // full coding session solely to race that title is redundant.
+                  if (!isAcpBackendId(backend)) {
                     return undefined;
                   }
+                  const helperSession =
+                    backend === "acp:grok"
+                      ? GROK_TITLE_HELPER_SESSION_POLICY
+                      : undefined;
                   return new AcpThreadTitleGenerator({
                     backend,
                     configureHelperSession: async ({
                       client,
                       parentSession,
+                      reasoningEffort,
                       session,
                     }) => {
+                      const runtime = mergeAcpRuntimeState(
+                        parentSession?.acpRuntime ?? {},
+                        session.acpRuntime ?? {},
+                      );
                       await this.applyAcpRuntimeSelection(
                         client,
                         session.sessionId,
-                        session.acpRuntime ?? parentSession?.acpRuntime,
+                        runtime,
+                        reasoningEffort,
                       );
                     },
+                    helperSession,
                     getClient: (acpBackend) =>
                       this.acpBackend.getClient(acpBackend),
                     getSession: (acpBackend, threadId) =>
@@ -16181,12 +16197,14 @@ export class DesktopBackendRegistry {
         ? session.acpRuntime.configValues.model
         : undefined);
     const reasoningEffort =
-      session?.acpRuntime?.reasoningEffort ??
-      (typeof session?.acpRuntime?.configValues?.reasoningEffort === "string"
-        ? session.acpRuntime.configValues.reasoningEffort
-        : typeof session?.acpRuntime?.configValues?.reasoning_effort === "string"
-          ? session.acpRuntime.configValues.reasoning_effort
-          : undefined);
+      params.backend === "acp:grok"
+        ? GROK_TITLE_HELPER_SESSION_POLICY.reasoningEffort
+        : session?.acpRuntime?.reasoningEffort ??
+          (typeof session?.acpRuntime?.configValues?.reasoningEffort === "string"
+            ? session.acpRuntime.configValues.reasoningEffort
+            : typeof session?.acpRuntime?.configValues?.reasoning_effort === "string"
+              ? session.acpRuntime.configValues.reasoning_effort
+              : undefined);
     return {
       ...(model ? { model } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5777,27 +5777,31 @@ export class DesktopBackendRegistry {
                       })
                     : undefined,
                 },
-                generatorResolver: (backend) =>
-                  isAcpBackendId(backend)
-                    ? new AcpThreadTitleGenerator({
-                        backend,
-                        configureHelperSession: async ({
-                          client,
-                          parentSession,
-                          session,
-                        }) => {
-                          await this.applyAcpRuntimeSelection(
-                            client,
-                            session.sessionId,
-                            session.acpRuntime ?? parentSession?.acpRuntime,
-                          );
-                        },
-                        getClient: (acpBackend) =>
-                          this.acpBackend.getClient(acpBackend),
-                        getSession: (acpBackend, threadId) =>
-                          this.acpBackend.getSession(acpBackend, threadId),
-                      })
-                    : undefined,
+                generatorResolver: (backend) => {
+                  if (!isAcpBackendId(backend) || backend === "acp:grok") {
+                    // Grok emits its own durable title through ACP. Starting a
+                    // full coding session solely to race that title is redundant.
+                    return undefined;
+                  }
+                  return new AcpThreadTitleGenerator({
+                    backend,
+                    configureHelperSession: async ({
+                      client,
+                      parentSession,
+                      session,
+                    }) => {
+                      await this.applyAcpRuntimeSelection(
+                        client,
+                        session.sessionId,
+                        session.acpRuntime ?? parentSession?.acpRuntime,
+                      );
+                    },
+                    getClient: (acpBackend) =>
+                      this.acpBackend.getClient(acpBackend),
+                    getSession: (acpBackend, threadId) =>
+                      this.acpBackend.getSession(acpBackend, threadId),
+                  });
+                },
               }));
     this.threadInspectionSearchService =
       options && "threadSearchService" in options

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1430,6 +1430,11 @@ type ThreadTitleGenerationLogStatus =
   | "requesting"
   | "skipped";
 
+type ThreadTitleHelperResult = Extract<
+  ThreadTitleGenerationResult,
+  { status: "generated" | "invalid" }
+>;
+
 type WorktreeArchiveCandidate = {
   repositoryPath: string;
   worktreePath: string;
@@ -4613,7 +4618,7 @@ function titleHelperSubAgentId(
 }
 
 function titleHelperSubAgentMessage(params: {
-  result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+  result?: ThreadTitleHelperResult;
   status: "pending" | "running" | "success" | "failed" | "cancelled";
   reason?: string;
 }): string {
@@ -4624,18 +4629,22 @@ function titleHelperSubAgentMessage(params: {
     return params.reason ?? "Generating a title.";
   }
   if (params.status === "success") {
-    if (params.result?.title) {
+    const title =
+      params.result?.status === "generated" ? params.result.title : undefined;
+    if (title) {
       return params.reason
-        ? `Generated title: ${params.result.title}. Not applied: ${params.reason}`
-        : `Generated title: ${params.result.title}`;
+        ? `Generated title: ${title}. Not applied: ${params.reason}`
+        : `Generated title: ${title}`;
     }
     return "Generated a title.";
   }
   if (params.status === "cancelled") {
-    if (params.result?.title) {
+    const title =
+      params.result?.status === "generated" ? params.result.title : undefined;
+    if (title) {
       return params.reason
-        ? `Generated title: ${params.result.title}. Not applied: ${params.reason}`
-        : `Generated title: ${params.result.title}. Not applied.`;
+        ? `Generated title: ${title}. Not applied: ${params.reason}`
+        : `Generated title: ${title}. Not applied.`;
     }
     return params.reason
       ? `Title generation cancelled: ${params.reason}`
@@ -15876,6 +15885,7 @@ export class DesktopBackendRegistry {
         await this.safePersistExistingTitleHelperSubAgent({
           backend: params.backend,
           threadId: params.threadId,
+          ...(result?.status === "invalid" ? { result } : {}),
           status: "failed",
           reason: result?.reason ?? "title_generation_unavailable",
         });
@@ -15982,7 +15992,7 @@ export class DesktopBackendRegistry {
   private async safePersistTitleHelperSubAgent(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    result?: ThreadTitleHelperResult;
     status: "pending" | "running" | "success" | "failed" | "cancelled";
     model?: string;
     reasoningEffort?: string;
@@ -16004,7 +16014,7 @@ export class DesktopBackendRegistry {
   private async safePersistExistingTitleHelperSubAgent(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    result?: ThreadTitleHelperResult;
     status: "running" | "success" | "failed" | "cancelled";
     model?: string;
     reasoningEffort?: string;
@@ -16060,7 +16070,7 @@ export class DesktopBackendRegistry {
   private async persistTitleHelperSubAgent(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    result?: Extract<ThreadTitleGenerationResult, { status: "generated" }>;
+    result?: ThreadTitleHelperResult;
     status: "pending" | "running" | "success" | "failed" | "cancelled";
     model?: string;
     reasoningEffort?: string;

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -57,21 +57,28 @@ export type ThreadTitleGenerator = {
 };
 
 export type ThreadTitleGenerationResult =
-  | {
+  | ({
       status: "generated";
       title: string;
-      cachedTokens?: number;
-      helperThreadId?: string;
-      helperTurnId?: string;
-      model?: string;
-      reasoningEffort?: string;
-      serviceTier?: string;
-      tokenUsage?: unknown;
-    }
+    } & ThreadTitleGenerationMetadata)
+  | ({
+      status: "invalid";
+      reason: string;
+    } & ThreadTitleGenerationMetadata)
   | {
-      status: "unavailable" | "invalid" | "failed";
+      status: "unavailable" | "failed";
       reason: string;
     };
+
+export type ThreadTitleGenerationMetadata = {
+  cachedTokens?: number;
+  helperThreadId?: string;
+  helperTurnId?: string;
+  model?: string;
+  reasoningEffort?: string;
+  serviceTier?: string;
+  tokenUsage?: unknown;
+};
 
 export type ThreadTitleGenerationServiceOptions = {
   generators?: Partial<Record<AppServerBackendKind, ThreadTitleGenerator>>;
@@ -141,23 +148,19 @@ export class ThreadTitleGenerationService {
     }
 
     const normalized = normalizeThreadTitleObject(result.object);
+    const metadata = threadTitleGenerationMetadata(result);
     if (!normalized.title) {
       return {
         status: "invalid",
         reason: normalized.reason,
+        ...metadata,
       };
     }
 
     return {
       status: "generated",
       title: normalized.title,
-      ...(result.cachedTokens !== undefined ? { cachedTokens: result.cachedTokens } : {}),
-      ...(result.helperThreadId ? { helperThreadId: result.helperThreadId } : {}),
-      ...(result.helperTurnId ? { helperTurnId: result.helperTurnId } : {}),
-      ...(result.model ? { model: result.model } : {}),
-      ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
-      ...(result.serviceTier ? { serviceTier: result.serviceTier } : {}),
-      ...(result.tokenUsage !== undefined ? { tokenUsage: result.tokenUsage } : {}),
+      ...metadata,
     };
   }
 }
@@ -233,6 +236,20 @@ function normalizeThreadTitleObject(
   return {
     title: cleaned,
     reason: "ok",
+  };
+}
+
+function threadTitleGenerationMetadata(
+  result: Extract<ThreadTitleAdapterResult, { status: "ok" }>,
+): ThreadTitleGenerationMetadata {
+  return {
+    ...(result.cachedTokens !== undefined ? { cachedTokens: result.cachedTokens } : {}),
+    ...(result.helperThreadId ? { helperThreadId: result.helperThreadId } : {}),
+    ...(result.helperTurnId ? { helperTurnId: result.helperTurnId } : {}),
+    ...(result.model ? { model: result.model } : {}),
+    ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
+    ...(result.serviceTier ? { serviceTier: result.serviceTier } : {}),
+    ...(result.tokenUsage !== undefined ? { tokenUsage: result.tokenUsage } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- keep proactive PwrAgent title generation enabled for Grok ACP threads
- run Grok title helpers with a minimal custom agent profile, no PwrAgent MCP registration, no AGENTS or skill discovery, and low reasoning
- retain generated title candidates and usage when a durable ACP title wins or title validation rejects the result
- mark completed helpers as completed and include all attempted-helper usage in the parent thread's Pricing total

## Root cause

Grok 4.5 emits a durable `session_summary_generated` title through ACP near the end of the first turn, while PwrAgent also starts a separate Grok session to generate a competing title. That helper was receiving the normal Grok coding harness:

- a 4,142-character coding system prompt
- an 11,578-character available-skills reminder
- MCP connection reminders for the tasks and PwrAgent servers
- high reasoning effort
- the 1,645-character PwrAgent naming prompt

The captured helper consumed 14,788 input tokens, including 9,412 uncached tokens, and cost $0.022. The parent turn itself used 14,364 input tokens, including 3,228 uncached tokens, and cost $0.011.

## Fix

Grok title generation remains enabled, but its helper now receives a reusable minimal-session policy:

- a 129-character title-only system prompt
- AGENTS loading, skill discovery, inherited skills, and default tools disabled
- the smallest Grok-accepted curated tool profile (`read_file` only), with tool use forbidden by the prompt
- no MCP servers registered by PwrAgent and no MCP inheritance
- the parent's selected model with reasoning forced to `low`

The full PwrAgent naming rubric remains unchanged and is still sent as the user prompt. Only Grok's normal coding system prompt is replaced.

The ACP client exposes these controls generically so the same policy builder can be reused by future lightweight helpers such as monitor sub-agents.

Grok 0.2.112 rejects a curated profile with a literally empty tool list. It also still injects its own 309-character built-in `tasks` MCP reminder despite `mcpServers: []` and `mcpInheritance: "none"`. There is no exposed ACP per-session switch for that process-owned server, so this PR does not mutate the operator's global Grok configuration.

## Measured result

A live Grok 4.5 ACP naming session using the production policy generated:

`{"title": "Favorite breakfast drink"}`

Its usage was:

- 1,635 input tokens, including 1,507 uncached and 128 cached
- 95 output tokens, including 87 reasoning
- one model call at low reasoning

That is an 88.9% reduction in total input tokens and an 84.0% reduction in uncached input tokens compared with the captured helper. The saved session contained no skills reminder, no PwrAgent MCP reminder, and the 129-character custom system prompt.

## Reporting and pricing

Completed title helpers retain their generated candidate, helper identity, model, reasoning effort, and token usage even when Grok's durable ACP title remains authoritative. Their hidden transcript stays suppressed, but the completed helper appears in Sub-agents and contributes an explicit Pricing row to the parent thread's running total.

Rejected helper output now retains the same metadata and usage. An empty, overlong, or overly wordy generated title therefore produces a failed helper card and pricing row rather than silently discarding the consumed tokens.

Suppressed ACP title helpers accept usage from both Grok's `turn_completed.usage` envelope and Qwen's `agent_message_chunk._meta.usage` envelope, including Qwen `thoughtTokens`.

Normal-turn Qwen pricing is being handled separately because a tool-using Qwen turn can emit multiple per-model-call usage envelopes that must be accumulated rather than allowed to overwrite one turn card.

Already-finished helpers cannot be retroactively repaired when their ACP usage notification was discarded and no helper rollout was persisted.

## Validation

- live Grok 4.5 ACP benchmark and saved-session audit
- `pnpm test apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (445 tests)
- `pnpm lint:eslint` (no errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
