### PR TITLE
feat(desktop): add AI provider model defaults

### DIFF
--- a/apps/desktop/e2e/provider-model-selectors.spec.ts
+++ b/apps/desktop/e2e/provider-model-selectors.spec.ts
@@ -124,8 +124,8 @@ test("OpenAI new-thread selector uses concrete model and reasoning defaults", as
 
     const settings = app.window.getByLabel("New thread settings");
     const providerSelect = settings.getByLabel("Provider");
-    const modelSelect = settings.getByLabel("Model");
-    const reasoningSelect = settings.getByLabel("Reasoning");
+    const modelSelect = settings.getByLabel("Model", { exact: true });
+    const reasoningSelect = settings.getByLabel("Reasoning", { exact: true });
     await expect(providerSelect).toHaveAttribute("data-value", "codex");
     await expect(modelSelect).toHaveAttribute("data-value", "gpt-5.5");
     await expect(reasoningSelect).toHaveAttribute("data-value", "medium");
@@ -164,7 +164,7 @@ test("OpenAI new-thread launchpad wins when sticky Grok defaults are unavailable
 
     const settings = app.window.getByLabel("New thread settings");
     const providerSelect = settings.getByLabel("Provider");
-    const modelSelect = settings.getByLabel("Model");
+    const modelSelect = settings.getByLabel("Model", { exact: true });
     const prompt = app.window.getByRole("textbox", { name: "New thread" });
 
     await expect(providerSelect).toHaveAttribute("data-value", "codex");
@@ -202,10 +202,12 @@ test("Grok new-thread selector hides reasoning for Grok 4.20 models", async () =
 
     const settings = app.window.getByLabel("New thread settings");
     const providerSelect = settings.getByLabel("Provider");
-    const modelSelect = settings.getByLabel("Model");
+    const modelSelect = settings.getByLabel("Model", { exact: true });
     await expect(providerSelect).toHaveAttribute("data-value", "grok");
     await expect(modelSelect).toHaveAttribute("data-value", "grok-4.20-reasoning");
-    await expect(settings.getByLabel("Reasoning")).toHaveCount(0);
+    await expect(
+      settings.getByLabel("Reasoning", { exact: true }),
+    ).toHaveCount(0);
     await expect(settings.getByRole("option", { name: /^Default$/ })).toHaveCount(0);
     await assertTangerineFocusRing(providerSelect);
     await assertTangerineFocusRing(modelSelect);
@@ -215,14 +217,18 @@ test("Grok new-thread selector hides reasoning for Grok 4.20 models", async () =
       window: app.window,
       option: "Grok 4.20 Non-Reasoning",
     });
-    await expect(settings.getByLabel("Reasoning")).toHaveCount(0);
+    await expect(
+      settings.getByLabel("Reasoning", { exact: true }),
+    ).toHaveCount(0);
 
     await selectComposerOption({
       select: modelSelect,
       window: app.window,
       option: "Grok 4.20 Reasoning",
     });
-    await expect(settings.getByLabel("Reasoning")).toHaveCount(0);
+    await expect(
+      settings.getByLabel("Reasoning", { exact: true }),
+    ).toHaveCount(0);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -30,6 +30,7 @@ import type {
   BackendModelOption,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
+  DesktopProviderThreadModelMigration,
   LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -8457,11 +8458,12 @@ script = "echo setup"
 
   it("applies each provider thread migration once and lets a later revision supersede it", async () => {
     const overlayStore = createOverlayStoreMock();
-    let migrations = {
+    let migrations: Record<string, DesktopProviderThreadModelMigration> = {
       codex: {
         revision: "migration-1",
         model: "gpt-5.6-sol",
         reasoningEffort: "high",
+        sourceModels: ["gpt-5.5"],
         createdAt: 1,
       },
     };
@@ -8476,6 +8478,15 @@ script = "echo setup"
           linkedDirectories: [],
           createdAt: 0,
           model: "gpt-5.5",
+        },
+        {
+          id: "new-turn-thread",
+          title: "New turn thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          createdAt: 2,
+          model: "gpt-5.6-terra",
         },
       ],
       models: [
@@ -8513,16 +8524,50 @@ script = "echo setup"
       model: "gpt-5.6-sol",
       reasoningEffort: "high",
     });
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "new-turn-thread",
+      input: [{ type: "text", text: "Keep the newer thread unchanged" }],
+      model: "gpt-5.6-terra",
+      reasoningEffort: "xhigh",
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      model: "gpt-5.6-terra",
+      reasoningEffort: "xhigh",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "new-turn-thread",
+    })).resolves.toMatchObject({
+      modelMigrationRevision: "migration-1",
+    });
 
     await expect(registry.applyThreadModelMigration({
       backend: "codex",
       threadId: "thread-1",
       threadCreatedAt: 0,
+      threadModel: "gpt-5.5",
     })).resolves.toMatchObject({
       status: "applied",
       revision: "migration-1",
       model: "gpt-5.6-sol",
       reasoningEffort: "high",
+    });
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "terra-thread",
+      threadCreatedAt: 0,
+      threadModel: "gpt-5.6-terra",
+    })).resolves.toMatchObject({
+      status: "acknowledged-source-model",
+      revision: "migration-1",
+      model: "gpt-5.6-terra",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "terra-thread",
+    })).resolves.toMatchObject({
+      modelMigrationRevision: "migration-1",
     });
     await expect(registry.applyThreadModelMigration({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -504,6 +504,8 @@ function createOverlayStoreMock(params?: {
       reasoningEffort?: string;
       serviceTier?: string;
       fastMode?: boolean;
+      modelMigrationRevision?: string;
+      modelSettingsManuallyUpdatedAt?: number;
     }) => {
       const key = `${settings.backend}:${settings.threadId}`;
       const current = overlays.get(key);
@@ -524,6 +526,20 @@ function createOverlayStoreMock(params?: {
       } as ThreadOverlayState;
       overlays.set(key, next);
       return next;
+    },
+    turnOffCodexFastEverywhere: async () => {
+      let threadCount = 0;
+      for (const [key, overlay] of overlays) {
+        if (overlay.backend !== "codex" || overlay.fastMode === false) {
+          continue;
+        }
+        overlays.set(key, { ...overlay, fastMode: false });
+        threadCount += 1;
+      }
+      return {
+        launchpadCount: 0,
+        threadCount,
+      };
     },
     setThreadParent: async ({
       backend,
@@ -8432,6 +8448,187 @@ script = "echo setup"
       "gpt-5.6-luna": "medium",
       "gpt-5.6-sol": "ultra",
     });
+
+    await registry.close();
+  });
+
+  it("applies each provider thread migration once and lets a later revision supersede it", async () => {
+    const overlayStore = createOverlayStoreMock();
+    let migrations = {
+      codex: {
+        revision: "migration-1",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        createdAt: 1,
+      },
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          label: "GPT-5.6-Sol",
+          defaultReasoningEffort: "medium",
+          reasoningEfforts: ["low", "medium", "high", "xhigh"],
+          supportsReasoning: true,
+        },
+        {
+          id: "gpt-5.6-terra",
+          label: "GPT-5.6-Terra",
+          defaultReasoningEffort: "medium",
+          reasoningEfforts: ["low", "medium", "high", "xhigh"],
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      resolveProviderThreadModelMigrations: () => migrations,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "turn-thread",
+      input: [{ type: "text", text: "Use the migrated model" }],
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      status: "applied",
+      revision: "migration-1",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "new-thread",
+      threadCreatedAt: 2,
+    })).resolves.toMatchObject({
+      status: "acknowledged-new-thread",
+      revision: "migration-1",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "new-thread",
+    })).resolves.toMatchObject({
+      modelMigrationRevision: "migration-1",
+    });
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      status: "already-applied",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+
+    await registry.setThreadModelSettings({
+      backend: "codex",
+      threadId: "thread-1",
+      model: "gpt-5.6-terra",
+      reasoningEffort: "xhigh",
+    });
+    const customized = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(customized).toMatchObject({
+      model: "gpt-5.6-terra",
+      reasoningEffort: "xhigh",
+      modelMigrationRevision: "migration-1",
+    });
+
+    migrations = {
+      codex: {
+        revision: "migration-2",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        createdAt:
+          (customized?.modelSettingsManuallyUpdatedAt ?? Date.now()) + 1,
+      },
+    };
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      status: "applied",
+      revision: "migration-2",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+
+    migrations = {
+      codex: {
+        revision: "migration-3",
+        model: "retired-model",
+        reasoningEffort: "high",
+        createdAt: Date.now() + 1,
+      },
+    };
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      status: "unavailable",
+      revision: "migration-3",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      modelMigrationRevision: "migration-2",
+    });
+
+    await registry.close();
+  });
+
+  it("forces Codex Fast off when the profile policy prohibits it", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.6-sol",
+            label: "GPT-5.6-Sol",
+            supportsFast: true,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexFastAllowed: () => false,
+    });
+
+    await expect(registry.setThreadModelSettings({
+      backend: "codex",
+      threadId: "thread-1",
+      model: "gpt-5.6-sol",
+      serviceTier: "priority",
+      fastMode: true,
+    })).resolves.toMatchObject({
+      model: "gpt-5.6-sol",
+      fastMode: false,
+    });
+    const launchpad = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+    expect(launchpad.launchpad.fastMode).not.toBe(true);
+    expect(launchpad.launchpad.serviceTier).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -529,16 +529,19 @@ function createOverlayStoreMock(params?: {
     },
     turnOffCodexFastEverywhere: async () => {
       let threadCount = 0;
+      const updatedThreadIds: string[] = [];
       for (const [key, overlay] of overlays) {
         if (overlay.backend !== "codex" || overlay.fastMode === false) {
           continue;
         }
         overlays.set(key, { ...overlay, fastMode: false });
+        updatedThreadIds.push(overlay.threadId);
         threadCount += 1;
       }
       return {
         launchpadCount: 0,
         threadCount,
+        updatedThreadIds,
       };
     },
     setThreadParent: async ({
@@ -12094,6 +12097,67 @@ command = "pnpm dev"
       fastMode: false,
     });
 
+    await registry.close();
+  });
+
+  it("emits model settings updates when turning Codex Fast off everywhere", async () => {
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-fast": {
+          backend: "codex",
+          threadId: "thread-fast",
+          executionMode: "default",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          fastMode: true,
+          extraLinkedDirectories: [],
+        },
+        "codex:thread-standard": {
+          backend: "codex",
+          threadId: "thread-standard",
+          executionMode: "default",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          fastMode: false,
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await expect(registry.turnOffCodexFastEverywhere()).resolves.toEqual({
+      launchpadCount: 0,
+      threadCount: 1,
+    });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/modelSettings/updated",
+        params: {
+          threadId: "thread-fast",
+          fastMode: false,
+        },
+      },
+    });
+    expect(events).not.toContainEqual(
+      expect.objectContaining({
+        notification: expect.objectContaining({
+          params: expect.objectContaining({
+            threadId: "thread-standard",
+          }),
+        }),
+      }),
+    );
+
+    unsubscribe();
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7965,6 +7965,40 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("refreshes a selected provider model catalog on request", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start"],
+      },
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listBackends({ includeUnavailable: true });
+    await registry.listBackends({ includeUnavailable: true });
+    expect(codexClient.listModelsCallCount).toBe(1);
+
+    await registry.listBackends({
+      includeUnavailable: true,
+      refreshModels: "codex",
+    });
+    expect(codexClient.listModelsCallCount).toBe(2);
+
+    await registry.close();
+  });
+
   it("assumes Codex can create threads when initialize omits methods", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
@@ -8025,6 +8059,171 @@ script = "echo setup"
 
     expect(updated.defaults.workMode).toBe("worktree");
     expect(next.launchpad.workMode).toBe("worktree");
+
+    await registry.close();
+  });
+
+  it("seeds empty launchpad defaults from the profile provider baseline", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.5",
+            current: true,
+            defaultReasoningEffort: "low",
+            reasoningEfforts: ["low", "high"],
+            supportsReasoning: true,
+          },
+          {
+            id: "gpt-5.6-sol",
+            defaultReasoningEffort: "low",
+            reasoningEfforts: ["low", "high", "xhigh"],
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      resolveProviderModelDefaults: () => ({
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffortsByModel: {
+            "gpt-5.6-sol": "high",
+          },
+        },
+      }),
+    });
+
+    const opened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(opened.launchpad).toMatchObject({
+      backend: "codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+    expect(opened.defaults.providerSettings?.codex).toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    });
+
+    await registry.close();
+  });
+
+  it("keeps learned provider choices ahead of the profile baseline", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.5",
+            defaultReasoningEffort: "low",
+            reasoningEfforts: ["low", "high"],
+            supportsReasoning: true,
+          },
+          {
+            id: "gpt-5.6-sol",
+            defaultReasoningEffort: "low",
+            reasoningEfforts: ["low", "high", "xhigh"],
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        launchpadDefaults: {
+          backend: "codex",
+          executionMode: "default",
+          workMode: "local",
+          model: "gpt-5.5",
+          reasoningEffort: "low",
+          providerSettings: {
+            codex: {
+              executionMode: "default",
+              model: "gpt-5.5",
+              reasoningEffort: "low",
+            },
+          },
+        },
+      }),
+      resolveProviderModelDefaults: () => ({
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffortsByModel: {
+            "gpt-5.6-sol": "high",
+          },
+        },
+      }),
+    });
+
+    const opened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(opened.launchpad).toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+    });
+
+    await registry.close();
+  });
+
+  it("keeps an unavailable profile model suspended instead of learning the fallback", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+        models: [
+          {
+            id: "gpt-5.5",
+            current: true,
+            defaultReasoningEffort: "low",
+            reasoningEfforts: ["low", "high"],
+            supportsReasoning: true,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      resolveProviderModelDefaults: () => ({
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffortsByModel: {
+            "gpt-5.6-sol": "high",
+          },
+        },
+      }),
+    });
+
+    const opened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(opened.launchpad).toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+    });
+    const learnedDefaults = await overlayStore.getLaunchpadDefaults();
+    expect(learnedDefaults.backend).toBe("codex");
+    expect(learnedDefaults.model).toBeUndefined();
+    expect(learnedDefaults.reasoningEffort).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -531,7 +531,7 @@ function createOverlayStoreMock(params?: {
       let threadCount = 0;
       const updatedThreadIds: string[] = [];
       for (const [key, overlay] of overlays) {
-        if (overlay.backend !== "codex" || overlay.fastMode === false) {
+        if (overlay.backend !== "codex" || overlay.fastMode !== true) {
           continue;
         }
         overlays.set(key, { ...overlay, fastMode: false });
@@ -8467,6 +8467,17 @@ script = "echo setup"
     };
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start", "turn/start"] },
+      threads: [
+        {
+          id: "turn-thread",
+          title: "Turn thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          createdAt: 0,
+          model: "gpt-5.5",
+        },
+      ],
       models: [
         {
           id: "gpt-5.6-sol",
@@ -8506,6 +8517,7 @@ script = "echo setup"
     await expect(registry.applyThreadModelMigration({
       backend: "codex",
       threadId: "thread-1",
+      threadCreatedAt: 0,
     })).resolves.toMatchObject({
       status: "applied",
       revision: "migration-1",
@@ -8529,6 +8541,7 @@ script = "echo setup"
     await expect(registry.applyThreadModelMigration({
       backend: "codex",
       threadId: "thread-1",
+      threadCreatedAt: 0,
     })).resolves.toMatchObject({
       status: "already-applied",
       model: "gpt-5.6-sol",
@@ -8563,6 +8576,7 @@ script = "echo setup"
     await expect(registry.applyThreadModelMigration({
       backend: "codex",
       threadId: "thread-1",
+      threadCreatedAt: 0,
     })).resolves.toMatchObject({
       status: "applied",
       revision: "migration-2",
@@ -8581,6 +8595,7 @@ script = "echo setup"
     await expect(registry.applyThreadModelMigration({
       backend: "codex",
       threadId: "thread-1",
+      threadCreatedAt: 0,
     })).resolves.toMatchObject({
       status: "unavailable",
       revision: "migration-3",
@@ -8592,6 +8607,14 @@ script = "echo setup"
       model: "gpt-5.6-sol",
       reasoningEffort: "high",
       modelMigrationRevision: "migration-2",
+    });
+
+    await expect(registry.applyThreadModelMigration({
+      backend: "codex",
+      threadId: "missing-metadata-thread",
+    })).resolves.toMatchObject({
+      status: "metadata-unavailable",
+      revision: "migration-3",
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
@@ -5,6 +5,84 @@ import {
 } from "../settings/desktop-config";
 import { applyTomlEdits, parseTomlTables } from "../settings/toml-editor";
 
+describe("desktop config provider model defaults", () => {
+  it("round-trips provider models and per-model reasoning", () => {
+    const edits = desktopSettingsPatchToEdits({
+      models: {
+        providerDefaults: {
+          codex: {
+            model: "gpt-5.6-sol",
+            reasoningEffortsByModel: {
+              "gpt-5.6-sol": "high",
+              "gpt-5.6-terra": "xhigh",
+            },
+          },
+          "acp:kimi": {
+            model: "kimi-k3",
+            reasoningEffortsByModel: {
+              "kimi-k3": "thinking",
+            },
+          },
+        },
+      },
+    });
+    const written = applyTomlEdits("", edits);
+
+    expect(written).toContain("[[models.provider_defaults]]");
+    expect(parseDesktopSettingsToml(written, "test.toml").models).toEqual({
+      providerDefaults: {
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffortsByModel: {
+            "gpt-5.6-sol": "high",
+            "gpt-5.6-terra": "xhigh",
+          },
+        },
+        "acp:kimi": {
+          model: "kimi-k3",
+          reasoningEffortsByModel: {
+            "kimi-k3": "thinking",
+          },
+        },
+      },
+    });
+  });
+
+  it("keeps unavailable preferences and replaces the full defaults array", () => {
+    const existing = applyTomlEdits(
+      "",
+      desktopSettingsPatchToEdits({
+        models: {
+          providerDefaults: {
+            codex: {
+              model: "retired-model",
+              reasoningEffortsByModel: {
+                "retired-model": "high",
+              },
+            },
+          },
+        },
+      }),
+    );
+    const written = applyTomlEdits(
+      existing,
+      desktopSettingsPatchToEdits(
+        {
+          models: {
+            providerDefaults: {},
+          },
+        },
+        parseTomlTables(existing, "test.toml"),
+      ),
+    );
+
+    expect(written).not.toContain("[[models.provider_defaults]]");
+    expect(
+      parseDesktopSettingsToml(written, "test.toml").models,
+    ).toBeUndefined();
+  });
+});
+
 // Regression: the `[ui]` window-layout section (sidebar hidden, context-rail
 // pinned, active tab, edited-files dock) must survive the read path.
 // `pruneEmptyConfig` reconstructs the config section-by-section, so a newly

--- a/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
@@ -81,6 +81,51 @@ describe("desktop config provider model defaults", () => {
       parseDesktopSettingsToml(written, "test.toml").models,
     ).toBeUndefined();
   });
+
+  it("round-trips thread migration revisions and the Codex Fast policy", () => {
+    const edits = desktopSettingsPatchToEdits({
+      models: {
+        providerThreadMigrations: {
+          codex: {
+            revision: "migration-2",
+            model: "gpt-5.6-sol",
+            reasoningEffort: "high",
+            createdAt: 2_000,
+          },
+          "acp:kimi": {
+            revision: "migration-1",
+            model: "kimi-k3",
+            createdAt: 1_000,
+          },
+        },
+        codex: {
+          allowFast: false,
+        },
+      },
+    });
+    const written = applyTomlEdits("", edits);
+
+    expect(written).toContain("allow_fast = false");
+    expect(written).toContain("[[models.provider_thread_migrations]]");
+    expect(parseDesktopSettingsToml(written, "test.toml").models).toEqual({
+      providerThreadMigrations: {
+        codex: {
+          revision: "migration-2",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          createdAt: 2_000,
+        },
+        "acp:kimi": {
+          revision: "migration-1",
+          model: "kimi-k3",
+          createdAt: 1_000,
+        },
+      },
+      codex: {
+        allowFast: false,
+      },
+    });
+  });
 });
 
 // Regression: the `[ui]` window-layout section (sidebar hidden, context-rail

--- a/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-ui.test.ts
@@ -90,6 +90,8 @@ describe("desktop config provider model defaults", () => {
             revision: "migration-2",
             model: "gpt-5.6-sol",
             reasoningEffort: "high",
+            sourceModels: ["gpt-5.4", "gpt-5.5"],
+            includeThreadsWithoutModel: true,
             createdAt: 2_000,
           },
           "acp:kimi": {
@@ -113,6 +115,8 @@ describe("desktop config provider model defaults", () => {
           revision: "migration-2",
           model: "gpt-5.6-sol",
           reasoningEffort: "high",
+          sourceModels: ["gpt-5.4", "gpt-5.5"],
+          includeThreadsWithoutModel: true,
           createdAt: 2_000,
         },
         "acp:kimi": {

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -162,6 +162,7 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
     await expect(store.turnOffCodexFastEverywhere()).resolves.toEqual({
       launchpadCount: 1,
       threadCount: 1,
+      updatedThreadIds: ["codex-fast"],
     });
     await expect(store.getThreadOverlayState({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -101,6 +101,103 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
     expect(listDefaultKeys()).not.toContain("serviceTier");
   });
 
+  it("turns Fast off across Codex threads, launchpads, and sticky defaults", async () => {
+    await store.setThreadModelSettings({
+      backend: "codex",
+      threadId: "codex-fast",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      fastMode: true,
+    });
+    await store.setThreadModelSettings({
+      backend: "acp:kimi",
+      threadId: "kimi-thinking",
+      model: "kimi-k2.6",
+      reasoningEffort: "on",
+      fastMode: true,
+    });
+    await store.upsertDirectoryLaunchpad({
+      directoryKey: "directory:/codex",
+      directoryKind: "directory",
+      directoryLabel: "Codex",
+      directoryPath: "/codex",
+      backend: "codex",
+      executionMode: "default",
+      workMode: "local",
+      prompt: "keep me",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      fastMode: true,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await store.upsertDirectoryLaunchpad({
+      directoryKey: "directory:/kimi",
+      directoryKind: "directory",
+      directoryLabel: "Kimi",
+      directoryPath: "/kimi",
+      backend: "acp:kimi",
+      executionMode: "default",
+      workMode: "local",
+      prompt: "leave me alone",
+      model: "kimi-k2.6",
+      reasoningEffort: "on",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+    await store.setLaunchpadDefaults({
+      backend: "codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      fastMode: true,
+      providerSettings: {
+        codex: {
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          fastMode: true,
+        },
+      },
+    });
+
+    await expect(store.turnOffCodexFastEverywhere()).resolves.toEqual({
+      launchpadCount: 1,
+      threadCount: 1,
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "codex-fast",
+    })).resolves.toMatchObject({
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      fastMode: false,
+    });
+    await expect(store.getThreadOverlayState({
+      backend: "acp:kimi",
+      threadId: "kimi-thinking",
+    })).resolves.toMatchObject({
+      fastMode: true,
+    });
+    await expect(store.getDirectoryLaunchpad({
+      directoryKey: "directory:/codex",
+    })).resolves.toMatchObject({
+      prompt: "keep me",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      fastMode: false,
+    });
+    await expect(store.getDirectoryLaunchpad({
+      directoryKey: "directory:/kimi",
+    })).resolves.toMatchObject({
+      prompt: "leave me alone",
+      model: "kimi-k2.6",
+    });
+    const defaults = await store.getLaunchpadDefaults();
+    expect(defaults.model).toBe("gpt-5.6-sol");
+    expect(defaults.reasoningEffort).toBe("high");
+    expect(defaults.fastMode).not.toBe(true);
+    expect(defaults.providerSettings?.codex?.fastMode).not.toBe(true);
+  });
+
   it("remembers launchpad reasoning effort per selected model", async () => {
     await store.setLaunchpadDefaults({
       model: "gpt-5.6-terra",

--- a/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-launchpad-defaults.test.ts
@@ -116,6 +116,12 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
       reasoningEffort: "on",
       fastMode: true,
     });
+    await store.setThreadModelSettings({
+      backend: "codex",
+      threadId: "codex-unset",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+    });
     await store.upsertDirectoryLaunchpad({
       directoryKey: "directory:/codex",
       directoryKind: "directory",
@@ -130,6 +136,20 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
       fastMode: true,
       createdAt: 1,
       updatedAt: 1,
+    });
+    await store.upsertDirectoryLaunchpad({
+      directoryKey: "directory:/codex-unset",
+      directoryKind: "directory",
+      directoryLabel: "Codex unset",
+      directoryPath: "/codex-unset",
+      backend: "codex",
+      executionMode: "default",
+      workMode: "local",
+      prompt: "do not touch me",
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      createdAt: 1,
+      updatedAt: 7,
     });
     await store.upsertDirectoryLaunchpad({
       directoryKey: "directory:/kimi",
@@ -173,6 +193,21 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
       fastMode: false,
     });
     await expect(store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "codex-unset",
+    })).resolves.toMatchObject({
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+    });
+    expect(
+      (
+        await store.getThreadOverlayState({
+          backend: "codex",
+          threadId: "codex-unset",
+        })
+      )?.fastMode,
+    ).toBeUndefined();
+    await expect(store.getThreadOverlayState({
       backend: "acp:kimi",
       threadId: "kimi-thinking",
     })).resolves.toMatchObject({
@@ -186,6 +221,20 @@ describe("SqliteOverlayStore - launchpad defaults", () => {
       reasoningEffort: "high",
       fastMode: false,
     });
+    await expect(store.getDirectoryLaunchpad({
+      directoryKey: "directory:/codex-unset",
+    })).resolves.toMatchObject({
+      prompt: "do not touch me",
+      model: "gpt-5.5",
+      updatedAt: 7,
+    });
+    expect(
+      (
+        await store.getDirectoryLaunchpad({
+          directoryKey: "directory:/codex-unset",
+        })
+      )?.fastMode,
+    ).toBeUndefined();
     await expect(store.getDirectoryLaunchpad({
       directoryKey: "directory:/kimi",
     })).resolves.toMatchObject({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11333,7 +11333,23 @@ export class DesktopBackendRegistry {
   }
 
   async turnOffCodexFastEverywhere(): Promise<TurnOffCodexFastEverywhereResponse> {
-    return await this.overlayStore.turnOffCodexFastEverywhere();
+    const result = await this.overlayStore.turnOffCodexFastEverywhere();
+    for (const threadId of result.updatedThreadIds) {
+      await this.emit({
+        backend: "codex",
+        notification: {
+          method: "thread/modelSettings/updated",
+          params: {
+            threadId,
+            fastMode: false,
+          },
+        },
+      });
+    }
+    return {
+      launchpadCount: result.launchpadCount,
+      threadCount: result.threadCount,
+    };
   }
 
   async checkThreadBranchDrift(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -64,6 +64,7 @@ import {
   type BackendModelOption,
   type BackendRateLimitSummary,
   type BackendSummary,
+  type DesktopProviderModelDefaults,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
   type ForkThreadRequest,
@@ -5632,6 +5633,10 @@ export class DesktopBackendRegistry {
    */
   private readonly isCodexBootstrapDeferredFn: () => boolean;
   private readonly resolveCodexDefaultModeRequestUserInputFn: () => boolean;
+  private readonly resolveProviderModelDefaultsFn: () => Record<
+    string,
+    DesktopProviderModelDefaults
+  >;
   /**
    * Reports whether the registry is running inside the throwaway
    * bootstrap profile (`.bootstrap/`). When `true`, `listThreads`
@@ -5671,6 +5676,10 @@ export class DesktopBackendRegistry {
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
     resolveCodexDefaultModeRequestUserInput?: () => boolean;
+    resolveProviderModelDefaults?: () => Record<
+      string,
+      DesktopProviderModelDefaults
+    >;
     resolveGrokApiKey?: () => string | undefined;
     acpWorktreeRepositoryResolver?: (
       cwd: string,
@@ -5731,6 +5740,9 @@ export class DesktopBackendRegistry {
           return false;
         }
       });
+    this.resolveProviderModelDefaultsFn =
+      options?.resolveProviderModelDefaults ??
+      (() => settingsService?.resolveProviderModelDefaults() ?? {});
     const codexCommand = settingsService?.resolveCodexCommandPreference();
     const codexEnv =
       typeof settingsService?.resolveCodexSpawnEnv === "function"
@@ -6359,6 +6371,14 @@ export class DesktopBackendRegistry {
   async listBackends(
     request: ListBackendsRequest = {}
   ): Promise<ListBackendsResponse> {
+    if (request.refreshModels === true) {
+      this.modelCatalog.invalidate();
+      this.invalidateAcpBackendDiscovery();
+    } else if (request.refreshModels === "codex" || request.refreshModels === "grok") {
+      this.modelCatalog.invalidate(request.refreshModels);
+    } else if (request.refreshModels && isAcpBackendId(request.refreshModels)) {
+      this.invalidateAcpBackendDiscovery();
+    }
     const agentCoreGrokEnabled = resolveAgentCoreGrokEnabled();
     // When the experimental agent-core Grok feature is off, omit the backend
     // entirely rather than emitting a disabled placeholder — a turned-off
@@ -12796,10 +12816,42 @@ export class DesktopBackendRegistry {
             fastMode: undefined,
             acpRuntime: undefined,
           });
-    const modelSettings = await this.resolveLaunchpadModelSettings(
+    const configuredDefaults =
+      this.resolveProviderModelDefaultsFn()[backend.kind];
+    const configuredModel = configuredDefaults?.model;
+    const configuredReasoningEffort = configuredModel
+      ? configuredDefaults.reasoningEffortsByModel[configuredModel]
+      : undefined;
+    const appliedConfiguredModel =
+      backendDefaults.model === undefined && configuredModel !== undefined;
+    const appliedConfiguredReasoning =
+      backendDefaults.reasoningEffort === undefined
+      && (
+        configuredDefaults?.reasoningEffortsByModel[
+          backendDefaults.model ?? configuredModel ?? ""
+        ] !== undefined
+      );
+    let modelSettings = await this.resolveLaunchpadModelSettings(
       backend,
-      backendDefaults,
+      {
+        ...backendDefaults,
+        model: backendDefaults.model ?? configuredModel,
+        reasoningEffort:
+          backendDefaults.reasoningEffort ??
+          (backendDefaults.model
+            ? configuredDefaults?.reasoningEffortsByModel[backendDefaults.model]
+            : configuredReasoningEffort),
+      },
     );
+    if (appliedConfiguredModel && modelSettings.model !== configuredModel) {
+      // Do not carry the missing model's reasoning preference onto the
+      // provider fallback merely because the fallback accepts the same effort
+      // label.
+      modelSettings = await this.resolveLaunchpadModelSettings(
+        backend,
+        backendDefaults,
+      );
+    }
     const resolvedDefaults: NavigationLaunchpadDefaults = {
       ...backendDefaults,
       backend: backend.kind,
@@ -12819,6 +12871,23 @@ export class DesktopBackendRegistry {
 
     if (launchpadDefaultsEqual(projectedDefaults, resolvedDefaults)) {
       return projectedDefaults;
+    }
+    if (
+      (appliedConfiguredModel && modelSettings.model !== configuredModel)
+      || (
+        appliedConfiguredReasoning
+        && modelSettings.reasoningEffort !== (
+          configuredDefaults?.reasoningEffortsByModel[
+            backendDefaults.model ?? configuredModel ?? ""
+          ]
+        )
+      )
+    ) {
+      // Keep unavailable profile preferences suspended in config instead of
+      // learning the provider fallback as a new sticky choice. If the model
+      // or effort returns after a provider upgrade, new launchpads can use the
+      // explicit preference again.
+      return resolvedDefaults;
     }
 
     return await this.overlayStore.setLaunchpadDefaults(resolvedDefaults);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -65,6 +65,7 @@ import {
   type BackendRateLimitSummary,
   type BackendSummary,
   type DesktopProviderModelDefaults,
+  type DesktopProviderThreadModelMigration,
   type CheckThreadBranchDriftRequest,
   type CheckThreadBranchDriftResponse,
   type ForkThreadRequest,
@@ -112,6 +113,9 @@ import {
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
   type SetThreadModelSettingsResponse,
+  type ApplyThreadModelMigrationRequest,
+  type ApplyThreadModelMigrationResponse,
+  type TurnOffCodexFastEverywhereResponse,
   type QueueThreadExecutionModeRequest,
   type QueueThreadExecutionModeResponse,
   type CancelThreadExecutionModeQueueRequest,
@@ -5637,6 +5641,11 @@ export class DesktopBackendRegistry {
     string,
     DesktopProviderModelDefaults
   >;
+  private readonly resolveProviderThreadModelMigrationsFn: () => Record<
+    string,
+    DesktopProviderThreadModelMigration
+  >;
+  private readonly resolveCodexFastAllowedFn: () => boolean;
   /**
    * Reports whether the registry is running inside the throwaway
    * bootstrap profile (`.bootstrap/`). When `true`, `listThreads`
@@ -5680,6 +5689,11 @@ export class DesktopBackendRegistry {
       string,
       DesktopProviderModelDefaults
     >;
+    resolveProviderThreadModelMigrations?: () => Record<
+      string,
+      DesktopProviderThreadModelMigration
+    >;
+    resolveCodexFastAllowed?: () => boolean;
     resolveGrokApiKey?: () => string | undefined;
     acpWorktreeRepositoryResolver?: (
       cwd: string,
@@ -5743,6 +5757,12 @@ export class DesktopBackendRegistry {
     this.resolveProviderModelDefaultsFn =
       options?.resolveProviderModelDefaults ??
       (() => settingsService?.resolveProviderModelDefaults() ?? {});
+    this.resolveProviderThreadModelMigrationsFn =
+      options?.resolveProviderThreadModelMigrations ??
+      (() => settingsService?.resolveProviderThreadModelMigrations() ?? {});
+    this.resolveCodexFastAllowedFn =
+      options?.resolveCodexFastAllowed ??
+      (() => settingsService?.resolveCodexFastAllowed() ?? true);
     const codexCommand = settingsService?.resolveCodexCommandPreference();
     const codexEnv =
       typeof settingsService?.resolveCodexSpawnEnv === "function"
@@ -8623,16 +8643,24 @@ export class DesktopBackendRegistry {
         codexEnvironmentRuntime,
       });
     }
+    const currentMigration =
+      this.resolveProviderThreadModelMigrationsFn()[backend];
     if (
       modelSettings.model !== undefined ||
       modelSettings.reasoningEffort !== undefined ||
       modelSettings.serviceTier !== undefined ||
-      modelSettings.fastMode !== undefined
+      modelSettings.fastMode !== undefined ||
+      currentMigration !== undefined
     ) {
       await this.overlayStore.setThreadModelSettings({
         backend,
         threadId: result.threadId,
         ...modelSettings,
+        ...(currentMigration
+          ? {
+              modelMigrationRevision: currentMigration.revision,
+            }
+          : {}),
       });
     }
 
@@ -8850,16 +8878,24 @@ export class DesktopBackendRegistry {
         threadId: result.threadId,
         executionMode,
       });
+      const currentMigration =
+        this.resolveProviderThreadModelMigrationsFn()[backend];
       if (
         modelSettings.model !== undefined ||
         modelSettings.reasoningEffort !== undefined ||
         modelSettings.serviceTier !== undefined ||
-        modelSettings.fastMode !== undefined
+        modelSettings.fastMode !== undefined ||
+        currentMigration !== undefined
       ) {
         await this.overlayStore.setThreadModelSettings({
           backend,
           threadId: result.threadId,
           ...modelSettings,
+          ...(currentMigration
+            ? {
+                modelMigrationRevision: currentMigration.revision,
+              }
+            : {}),
         });
       }
       if (forkedCodexEnvironmentRuntime) {
@@ -9105,14 +9141,23 @@ export class DesktopBackendRegistry {
     messageOrigin?: AppServerThreadMessageOrigin;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     this.assertNotBootstrap("startTurn");
+    const migrationResult = await this.applyThreadModelMigration({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const migrationApplied = migrationResult.status === "applied";
     if (isAcpBackendId(params.backend)) {
       const overlay = await this.overlayStore.getThreadOverlayState({
         backend: params.backend,
         threadId: params.threadId,
       });
       const modelSettings = await this.resolveModelSettings(params.backend, {
-        model: params.model ?? overlay?.model,
-        reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+        model: migrationApplied
+          ? overlay?.model
+          : params.model ?? overlay?.model,
+        reasoningEffort: migrationApplied
+          ? overlay?.reasoningEffort
+          : params.reasoningEffort ?? overlay?.reasoningEffort,
         reasoningEffortsByModel: overlay?.reasoningEffortsByModel,
       });
       const reservationKey = buildTurnStartReservationKey(
@@ -9204,9 +9249,13 @@ export class DesktopBackendRegistry {
       });
       turnParams = await this.resolveModelSettings(params.backend, {
         ...params,
-        model: params.model ?? overlay?.model,
+        model: migrationApplied
+          ? overlay?.model
+          : params.model ?? overlay?.model,
         serviceTier: params.serviceTier ?? overlay?.serviceTier,
-        reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+        reasoningEffort: migrationApplied
+          ? overlay?.reasoningEffort
+          : params.reasoningEffort ?? overlay?.reasoningEffort,
         fastMode: params.backend === "codex" ? params.fastMode ?? overlay?.fastMode : undefined,
       });
       cwd =
@@ -11059,6 +11108,24 @@ export class DesktopBackendRegistry {
   async setThreadModelSettings(
     params: SetThreadModelSettingsRequest
   ): Promise<SetThreadModelSettingsResponse> {
+    const modelSettingsManuallyUpdatedAt =
+      "model" in params || "reasoningEffort" in params
+        ? Date.now()
+        : undefined;
+    return await this.setThreadModelSettingsInternal(params, {
+      ...(modelSettingsManuallyUpdatedAt !== undefined
+        ? { modelSettingsManuallyUpdatedAt }
+        : {}),
+    });
+  }
+
+  private async setThreadModelSettingsInternal(
+    params: SetThreadModelSettingsRequest,
+    metadata: {
+      modelMigrationRevision?: string;
+      modelSettingsManuallyUpdatedAt?: number;
+    },
+  ): Promise<SetThreadModelSettingsResponse> {
     const current = await this.overlayStore.getThreadOverlayState({
       backend: params.backend,
       threadId: params.threadId,
@@ -11095,6 +11162,7 @@ export class DesktopBackendRegistry {
         backend: params.backend,
         threadId: params.threadId,
         ...modelSettings,
+        ...metadata,
       });
     };
     if (acpBackend && modelSettings.model && acpRuntimeModelChanged) {
@@ -11143,6 +11211,129 @@ export class DesktopBackendRegistry {
       threadId: params.threadId,
       ...modelSettings,
     };
+  }
+
+  async applyThreadModelMigration(
+    params: ApplyThreadModelMigrationRequest,
+  ): Promise<ApplyThreadModelMigrationResponse> {
+    const migration =
+      this.resolveProviderThreadModelMigrationsFn()[params.backend];
+    if (!migration) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "none",
+      };
+    }
+
+    const current = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (current?.modelMigrationRevision === migration.revision) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "already-applied",
+        revision: migration.revision,
+        model: current.model,
+        reasoningEffort: current.reasoningEffort,
+      };
+    }
+
+    if (
+      params.threadCreatedAt !== undefined
+      && params.threadCreatedAt > migration.createdAt
+    ) {
+      await this.overlayStore.setThreadModelSettings({
+        backend: params.backend,
+        threadId: params.threadId,
+        model: current?.model,
+        reasoningEffort: current?.reasoningEffort,
+        serviceTier: current?.serviceTier,
+        fastMode: current?.fastMode,
+        modelMigrationRevision: migration.revision,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "acknowledged-new-thread",
+        revision: migration.revision,
+        model: current?.model,
+        reasoningEffort: current?.reasoningEffort,
+      };
+    }
+
+    if (
+      current?.modelSettingsManuallyUpdatedAt !== undefined
+      && current.modelSettingsManuallyUpdatedAt >= migration.createdAt
+    ) {
+      await this.overlayStore.setThreadModelSettings({
+        backend: params.backend,
+        threadId: params.threadId,
+        model: current.model,
+        reasoningEffort: current.reasoningEffort,
+        serviceTier: current.serviceTier,
+        fastMode: current.fastMode,
+        modelMigrationRevision: migration.revision,
+        modelSettingsManuallyUpdatedAt:
+          current.modelSettingsManuallyUpdatedAt,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "acknowledged-manual-change",
+        revision: migration.revision,
+        model: current.model,
+        reasoningEffort: current.reasoningEffort,
+      };
+    }
+
+    const resolved = await this.resolveModelSettings(
+      params.backend,
+      {
+        model: migration.model,
+        reasoningEffort: migration.reasoningEffort,
+      },
+      "settings-refresh",
+    );
+    if (
+      resolved.model !== migration.model
+      || (
+        migration.reasoningEffort !== undefined
+        && resolved.reasoningEffort !== migration.reasoningEffort
+      )
+    ) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "unavailable",
+        revision: migration.revision,
+        model: migration.model,
+        reasoningEffort: migration.reasoningEffort,
+      };
+    }
+
+    const response = await this.setThreadModelSettingsInternal(
+      {
+        backend: params.backend,
+        threadId: params.threadId,
+        model: migration.model,
+        reasoningEffort: resolved.reasoningEffort,
+      },
+      {
+        modelMigrationRevision: migration.revision,
+      },
+    );
+    return {
+      ...response,
+      status: "applied",
+      revision: migration.revision,
+    };
+  }
+
+  async turnOffCodexFastEverywhere(): Promise<TurnOffCodexFastEverywhereResponse> {
+    return await this.overlayStore.turnOffCodexFastEverywhere();
   }
 
   async checkThreadBranchDrift(
@@ -12667,11 +12858,19 @@ export class DesktopBackendRegistry {
     settings: ModelSettings,
     callerReason: BackendModelCatalogCallerReason = "thread-start-defaults",
   ): Promise<ModelSettings> {
-    return resolveModelSettingsFromOptions(
+    const resolved = resolveModelSettingsFromOptions(
       backend,
       await this.getBackendLaunchpadOptions(backend, callerReason),
       settings,
     );
+    if (backend !== "codex" || this.resolveCodexFastAllowedFn()) {
+      return resolved;
+    }
+    return {
+      ...resolved,
+      serviceTier: undefined,
+      fastMode: false,
+    };
   }
 
   private async resolveReviewModelSettings(
@@ -12861,6 +13060,13 @@ export class DesktopBackendRegistry {
       ),
       ...modelSettings,
     };
+    if (
+      resolvedDefaults.backend === "codex"
+      && !this.resolveCodexFastAllowedFn()
+    ) {
+      resolvedDefaults.fastMode = false;
+      delete resolvedDefaults.serviceTier;
+    }
     if (
       resolvedDefaults.backend === "codex" &&
       (resolvedDefaults.serviceTier === "fast" ||

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11241,15 +11241,50 @@ export class DesktopBackendRegistry {
       };
     }
 
-    const threadCreatedAt =
-      params.threadCreatedAt
-      ?? (
-        await this.findThreadForWorkspaceHandoff({
+    if (
+      current?.modelSettingsManuallyUpdatedAt !== undefined
+      && current.modelSettingsManuallyUpdatedAt >= migration.createdAt
+    ) {
+      await this.overlayStore.setThreadModelSettings({
+        backend: params.backend,
+        threadId: params.threadId,
+        model: current.model,
+        reasoningEffort: current.reasoningEffort,
+        serviceTier: current.serviceTier,
+        fastMode: current.fastMode,
+        modelMigrationRevision: migration.revision,
+        modelSettingsManuallyUpdatedAt:
+          current.modelSettingsManuallyUpdatedAt,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "acknowledged-manual-change",
+        revision: migration.revision,
+        model: current.model,
+        reasoningEffort: current.reasoningEffort,
+      };
+    }
+
+    const migrationUsesSourceFilter =
+      migration.sourceModels !== undefined
+      || migration.includeThreadsWithoutModel === true;
+    const needsThreadSummary =
+      params.threadCreatedAt === undefined
+      || (
+        migrationUsesSourceFilter
+        && current?.model === undefined
+        && params.threadModel === undefined
+      );
+    const threadSummary = needsThreadSummary
+      ? await this.findThreadForWorkspaceHandoff({
           backend: params.backend,
           callerReason: "thread-model-migration",
           threadId: params.threadId,
         })
-      )?.createdAt;
+      : undefined;
+    const threadCreatedAt =
+      params.threadCreatedAt ?? threadSummary?.createdAt;
     if (threadCreatedAt === undefined) {
       return {
         backend: params.backend,
@@ -11281,28 +11316,34 @@ export class DesktopBackendRegistry {
       };
     }
 
-    if (
-      current?.modelSettingsManuallyUpdatedAt !== undefined
-      && current.modelSettingsManuallyUpdatedAt >= migration.createdAt
-    ) {
+    const sourceModel =
+      current?.model
+      ?? params.threadModel
+      ?? threadSummary?.model;
+    const sourceModelSelected =
+      !migrationUsesSourceFilter
+      || (
+        sourceModel
+          ? migration.sourceModels?.includes(sourceModel) === true
+          : migration.includeThreadsWithoutModel === true
+      );
+    if (!sourceModelSelected) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
         threadId: params.threadId,
-        model: current.model,
-        reasoningEffort: current.reasoningEffort,
-        serviceTier: current.serviceTier,
-        fastMode: current.fastMode,
+        model: current?.model,
+        reasoningEffort: current?.reasoningEffort,
+        serviceTier: current?.serviceTier,
+        fastMode: current?.fastMode,
         modelMigrationRevision: migration.revision,
-        modelSettingsManuallyUpdatedAt:
-          current.modelSettingsManuallyUpdatedAt,
       });
       return {
         backend: params.backend,
         threadId: params.threadId,
-        status: "acknowledged-manual-change",
+        status: "acknowledged-source-model",
         revision: migration.revision,
-        model: current.model,
-        reasoningEffort: current.reasoningEffort,
+        model: current?.model ?? sourceModel,
+        reasoningEffort: current?.reasoningEffort,
       };
     }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11241,10 +11241,27 @@ export class DesktopBackendRegistry {
       };
     }
 
-    if (
-      params.threadCreatedAt !== undefined
-      && params.threadCreatedAt > migration.createdAt
-    ) {
+    const threadCreatedAt =
+      params.threadCreatedAt
+      ?? (
+        await this.findThreadForWorkspaceHandoff({
+          backend: params.backend,
+          callerReason: "thread-model-migration",
+          threadId: params.threadId,
+        })
+      )?.createdAt;
+    if (threadCreatedAt === undefined) {
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        status: "metadata-unavailable",
+        revision: migration.revision,
+        model: current?.model,
+        reasoningEffort: current?.reasoningEffort,
+      };
+    }
+
+    if (threadCreatedAt > migration.createdAt) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
         threadId: params.threadId,

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -3,6 +3,8 @@ import { subscribersForChannel } from "../window-channels";
 import {
   sanitizeRendererPayload,
   type AgentEvent,
+  type ApplyThreadModelMigrationRequest,
+  type ApplyThreadModelMigrationResponse,
   type CancelThreadExecutionModeQueueRequest,
   type CancelThreadExecutionModeQueueResponse,
   type CheckThreadBranchDriftRequest,
@@ -34,6 +36,7 @@ import {
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
   type SetThreadModelSettingsResponse,
+  type TurnOffCodexFastEverywhereResponse,
   type SteerTurnRequest,
   type SteerTurnResponse,
   type StartReviewRequest,
@@ -54,6 +57,7 @@ import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
+  AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
   AGENT_EVENT_CHANNEL,
   AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
@@ -69,6 +73,7 @@ import {
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
+  AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
@@ -568,6 +573,25 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL);
+  ipcMain.handle(
+    AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
+    async (
+      _event,
+      request: ApplyThreadModelMigrationRequest,
+    ): Promise<ApplyThreadModelMigrationResponse> => {
+      return await registry.applyThreadModelMigration(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL);
+  ipcMain.handle(
+    AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
+    async (): Promise<TurnOffCodexFastEverywhereResponse> => {
+      return await registry.turnOffCodexFastEverywhere();
+    },
+  );
+
   ipcMain.removeHandler(AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL);
   ipcMain.handle(
     AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -696,6 +720,8 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL);
+  ipcMain.removeHandler(AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL);
+  ipcMain.removeHandler(AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL);
   ipcMain.removeHandler(AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL);
   ipcMain.removeHandler(AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL);
   ipcMain.removeHandler(AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL);

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -206,6 +206,13 @@ async function listAcpAgentSettingsImpl(
     ...(request.force === true ? { force: true } : {}),
     ...(discoveryEnv ? { env: discoveryEnv } : {}),
   });
+  if (request.refresh === true) {
+    // The settings discovery path updates the durable ACP capability cache.
+    // Drop the backend adapter's in-memory discovery result so the next
+    // backend summary immediately reflects newly added models and reasoning
+    // options.
+    getDesktopBackendRegistry().invalidateAcpBackendDiscovery();
+  }
   const entries = snapshot
     ? registryService
         .applyAllowlist(snapshot)

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -1249,6 +1249,12 @@ export function desktopSettingsPatchToEdits(
         ...(migration.reasoningEffort
           ? { reasoning_effort: migration.reasoningEffort }
           : {}),
+        ...(migration.sourceModels
+          ? { source_models: migration.sourceModels }
+          : {}),
+        ...(migration.includeThreadsWithoutModel
+          ? { include_threads_without_model: true }
+          : {}),
         created_at: migration.createdAt,
       }));
     if (entries.length > 0) {
@@ -2194,6 +2200,9 @@ function normalizeProviderThreadModelMigrations(
       const revision = migration.revision.trim();
       const model = migration.model.trim();
       const reasoningEffort = migration.reasoningEffort?.trim() || undefined;
+      const sourceModels = migration.sourceModels
+        ?.map((sourceModel) => sourceModel.trim())
+        .filter(Boolean);
       if (
         !normalizedProvider
         || !revision
@@ -2208,6 +2217,10 @@ function normalizeProviderThreadModelMigrations(
           revision,
           model,
           ...(reasoningEffort ? { reasoningEffort } : {}),
+          ...(sourceModels ? { sourceModels: [...new Set(sourceModels)] } : {}),
+          ...(migration.includeThreadsWithoutModel
+            ? { includeThreadsWithoutModel: true }
+            : {}),
           createdAt: migration.createdAt,
         },
       ]];
@@ -2233,6 +2246,11 @@ function readProviderThreadModelMigrations(
       typeof item.reasoning_effort === "string"
         ? item.reasoning_effort.trim()
         : "";
+    const sourceModels = readStringArray(item.source_models)
+      ?.map((sourceModel) => sourceModel.trim())
+      .filter(Boolean);
+    const includeThreadsWithoutModel =
+      item.include_threads_without_model === true;
     const createdAt =
       typeof item.created_at === "number" && Number.isFinite(item.created_at)
         ? item.created_at
@@ -2244,6 +2262,10 @@ function readProviderThreadModelMigrations(
       revision,
       model,
       ...(reasoningEffort ? { reasoningEffort } : {}),
+      ...(sourceModels ? { sourceModels: [...new Set(sourceModels)] } : {}),
+      ...(includeThreadsWithoutModel
+        ? { includeThreadsWithoutModel: true }
+        : {}),
       createdAt,
     };
   }

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -21,6 +21,7 @@ import type {
   DesktopMessagingSlackGroupDmAccessMode,
   DesktopOnboardingCompletedSource,
   DesktopProviderModelDefaults,
+  DesktopProviderThreadModelMigration,
   DesktopSettingsConfigPatch,
   DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
@@ -213,9 +214,14 @@ export type DesktopSettingsConfig = {
   };
   models?: {
     providerDefaults?: Record<string, DesktopProviderModelDefaults>;
+    providerThreadMigrations?: Record<
+      string,
+      DesktopProviderThreadModelMigration
+    >;
     codex?: {
       path?: string;
       profile?: string;
+      allowFast?: boolean;
     };
   };
   acpAgents?: {
@@ -1203,6 +1209,9 @@ export function desktopSettingsPatchToEdits(
   if (patch.models?.codex?.profile !== undefined) {
     set(["models", "codex", "profile"], patch.models.codex.profile);
   }
+  if (patch.models?.codex?.allowFast !== undefined) {
+    set(["models", "codex", "allow_fast"], patch.models.codex.allowFast);
+  }
   if (patch.models?.providerDefaults !== undefined) {
     const providerDefaults = normalizeProviderModelDefaults(
       patch.models.providerDefaults,
@@ -1224,6 +1233,34 @@ export function desktopSettingsPatchToEdits(
       edits.push({
         op: "deleteTableArray",
         path: ["models", "provider_defaults"],
+      });
+    }
+  }
+  if (patch.models?.providerThreadMigrations !== undefined) {
+    const providerThreadMigrations = normalizeProviderThreadModelMigrations(
+      patch.models.providerThreadMigrations,
+    );
+    const entries = Object.entries(providerThreadMigrations)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([provider, migration]) => ({
+        provider,
+        revision: migration.revision,
+        model: migration.model,
+        ...(migration.reasoningEffort
+          ? { reasoning_effort: migration.reasoningEffort }
+          : {}),
+        created_at: migration.createdAt,
+      }));
+    if (entries.length > 0) {
+      edits.push({
+        op: "setTableArray",
+        path: ["models", "provider_thread_migrations"],
+        value: entries,
+      });
+    } else {
+      edits.push({
+        op: "deleteTableArray",
+        path: ["models", "provider_thread_migrations"],
       });
     }
   }
@@ -1546,9 +1583,13 @@ function normalizeDesktopConfig(
     },
     models: {
       providerDefaults: readProviderModelDefaults(models?.provider_defaults),
+      providerThreadMigrations: readProviderThreadModelMigrations(
+        models?.provider_thread_migrations,
+      ),
       codex: {
         path: readString(codex?.path),
         profile: readString(codex?.profile),
+        allowFast: readBoolean(codex?.allow_fast),
       },
     },
     acpAgents: {
@@ -1780,14 +1821,25 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
 
   const codex = config.models?.codex;
   const providerDefaults = config.models?.providerDefaults;
+  const providerThreadMigrations = config.models?.providerThreadMigrations;
   if (
     (codex && hasDefinedValue(codex))
     || (providerDefaults && Object.keys(providerDefaults).length > 0)
+    || (
+      providerThreadMigrations
+      && Object.keys(providerThreadMigrations).length > 0
+    )
   ) {
     pruned.models = {
       ...(providerDefaults && Object.keys(providerDefaults).length > 0
         ? { providerDefaults }
         : {}),
+      ...(
+        providerThreadMigrations
+        && Object.keys(providerThreadMigrations).length > 0
+          ? { providerThreadMigrations }
+          : {}
+      ),
       ...(codex && hasDefinedValue(codex) ? { codex } : {}),
     };
   }
@@ -2131,6 +2183,71 @@ function readProviderModelDefaults(
     }
   }
   return defaults;
+}
+
+function normalizeProviderThreadModelMigrations(
+  value: Record<string, DesktopProviderThreadModelMigration>,
+): Record<string, DesktopProviderThreadModelMigration> {
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([provider, migration]) => {
+      const normalizedProvider = provider.trim();
+      const revision = migration.revision.trim();
+      const model = migration.model.trim();
+      const reasoningEffort = migration.reasoningEffort?.trim() || undefined;
+      if (
+        !normalizedProvider
+        || !revision
+        || !model
+        || !Number.isFinite(migration.createdAt)
+      ) {
+        return [];
+      }
+      return [[
+        normalizedProvider,
+        {
+          revision,
+          model,
+          ...(reasoningEffort ? { reasoningEffort } : {}),
+          createdAt: migration.createdAt,
+        },
+      ]];
+    }),
+  );
+}
+
+function readProviderThreadModelMigrations(
+  value: TomlScalar | undefined,
+): Record<string, DesktopProviderThreadModelMigration> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const migrations: Record<string, DesktopProviderThreadModelMigration> = {};
+  for (const item of value) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      continue;
+    }
+    const provider =
+      typeof item.provider === "string" ? item.provider.trim() : "";
+    const revision =
+      typeof item.revision === "string" ? item.revision.trim() : "";
+    const model = typeof item.model === "string" ? item.model.trim() : "";
+    const reasoningEffort =
+      typeof item.reasoning_effort === "string"
+        ? item.reasoning_effort.trim()
+        : "";
+    const createdAt =
+      typeof item.created_at === "number" && Number.isFinite(item.created_at)
+        ? item.created_at
+        : undefined;
+    if (!provider || !revision || !model || createdAt === undefined) {
+      continue;
+    }
+    migrations[provider] = {
+      revision,
+      model,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
+      createdAt,
+    };
+  }
+  return migrations;
 }
 
 function readAuthorizedContacts(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -20,6 +20,7 @@ import type {
   DesktopMessagingSlackDmAccessMode,
   DesktopMessagingSlackGroupDmAccessMode,
   DesktopOnboardingCompletedSource,
+  DesktopProviderModelDefaults,
   DesktopSettingsConfigPatch,
   DesktopUpdateChannel,
   DesktopWorktreeStorageLocation,
@@ -211,6 +212,7 @@ export type DesktopSettingsConfig = {
     };
   };
   models?: {
+    providerDefaults?: Record<string, DesktopProviderModelDefaults>;
     codex?: {
       path?: string;
       profile?: string;
@@ -1201,6 +1203,30 @@ export function desktopSettingsPatchToEdits(
   if (patch.models?.codex?.profile !== undefined) {
     set(["models", "codex", "profile"], patch.models.codex.profile);
   }
+  if (patch.models?.providerDefaults !== undefined) {
+    const providerDefaults = normalizeProviderModelDefaults(
+      patch.models.providerDefaults,
+    );
+    const entries = Object.entries(providerDefaults)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([provider, defaults]) => ({
+        provider,
+        ...(defaults.model ? { model: defaults.model } : {}),
+        reasoning_efforts: JSON.stringify(defaults.reasoningEffortsByModel),
+      }));
+    if (entries.length > 0) {
+      edits.push({
+        op: "setTableArray",
+        path: ["models", "provider_defaults"],
+        value: entries,
+      });
+    } else {
+      edits.push({
+        op: "deleteTableArray",
+        path: ["models", "provider_defaults"],
+      });
+    }
+  }
   if (patch.acpAgents?.gemini?.cliPath !== undefined) {
     set(["acp_agents", "gemini", "cli_path"], patch.acpAgents.gemini.cliPath);
   }
@@ -1271,6 +1297,7 @@ function normalizeDesktopConfig(
   const slack = tables["messaging.slack"];
   const feishu = tables["messaging.feishu"];
   const line = tables["messaging.line"];
+  const models = tables["models"];
   const codex = tables["models.codex"];
   const acpAgentsGemini = tables["acp_agents.gemini"];
   const acpAgentsGrok = tables["acp_agents.grok"];
@@ -1518,6 +1545,7 @@ function normalizeDesktopConfig(
       },
     },
     models: {
+      providerDefaults: readProviderModelDefaults(models?.provider_defaults),
       codex: {
         path: readString(codex?.path),
         profile: readString(codex?.profile),
@@ -1751,8 +1779,17 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   }
 
   const codex = config.models?.codex;
-  if (codex && hasDefinedValue(codex)) {
-    pruned.models = { codex };
+  const providerDefaults = config.models?.providerDefaults;
+  if (
+    (codex && hasDefinedValue(codex))
+    || (providerDefaults && Object.keys(providerDefaults).length > 0)
+  ) {
+    pruned.models = {
+      ...(providerDefaults && Object.keys(providerDefaults).length > 0
+        ? { providerDefaults }
+        : {}),
+      ...(codex && hasDefinedValue(codex) ? { codex } : {}),
+    };
   }
 
   const acpAgentsGemini = config.acpAgents?.gemini;
@@ -2021,6 +2058,79 @@ function readStringArray(value: TomlScalar | undefined): string[] | undefined {
     return undefined;
   }
   return value.map((item) => item.trim()).filter(Boolean);
+}
+
+function normalizeProviderModelDefaults(
+  value: Record<string, DesktopProviderModelDefaults>,
+): Record<string, DesktopProviderModelDefaults> {
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([provider, defaults]) => {
+      const normalizedProvider = provider.trim();
+      if (!normalizedProvider) return [];
+      const model = defaults.model?.trim() || undefined;
+      const reasoningEffortsByModel = Object.fromEntries(
+        Object.entries(defaults.reasoningEffortsByModel ?? {}).flatMap(
+          ([modelId, effort]) => {
+            const normalizedModel = modelId.trim();
+            const normalizedEffort = effort.trim();
+            return normalizedModel && normalizedEffort
+              ? [[normalizedModel, normalizedEffort]]
+              : [];
+          },
+        ),
+      );
+      if (!model && Object.keys(reasoningEffortsByModel).length === 0) {
+        return [];
+      }
+      return [[
+        normalizedProvider,
+        {
+          ...(model ? { model } : {}),
+          reasoningEffortsByModel,
+        },
+      ]];
+    }),
+  );
+}
+
+function readProviderModelDefaults(
+  value: TomlScalar | undefined,
+): Record<string, DesktopProviderModelDefaults> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const defaults: Record<string, DesktopProviderModelDefaults> = {};
+  for (const item of value) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      continue;
+    }
+    const provider =
+      typeof item.provider === "string" ? item.provider.trim() : "";
+    if (!provider) continue;
+    const model = typeof item.model === "string" ? item.model.trim() : "";
+    let reasoningEffortsByModel: Record<string, string> = {};
+    if (typeof item.reasoning_efforts === "string") {
+      try {
+        const parsed = JSON.parse(item.reasoning_efforts) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          reasoningEffortsByModel = Object.fromEntries(
+            Object.entries(parsed).flatMap(([modelId, effort]) =>
+              typeof effort === "string" && modelId.trim() && effort.trim()
+                ? [[modelId.trim(), effort.trim()]]
+                : [],
+            ),
+          );
+        }
+      } catch {
+        reasoningEffortsByModel = {};
+      }
+    }
+    if (model || Object.keys(reasoningEffortsByModel).length > 0) {
+      defaults[provider] = {
+        ...(model ? { model } : {}),
+        reasoningEffortsByModel,
+      };
+    }
+  }
+  return defaults;
 }
 
 function readAuthorizedContacts(

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -943,9 +943,15 @@ export class DesktopSettingsService {
       },
       models: {
         providerDefaults: config.models?.providerDefaults ?? {},
+        providerThreadMigrations:
+          config.models?.providerThreadMigrations ?? {},
         codex: {
           path: this.resolveString(config.models?.codex?.path, CODEX_COMMAND_ENV),
           profile: this.resolveConfigString(config.models?.codex?.profile),
+          allowFast: this.resolveConfigBoolean(
+            config.models?.codex?.allowFast,
+            true,
+          ),
           discovery: codexDiscovery,
           profiles: codexProfiles,
         },
@@ -1333,6 +1339,17 @@ export class DesktopSettingsService {
 
   resolveProviderModelDefaults() {
     return this.readConfig().config.models?.providerDefaults ?? {};
+  }
+
+  resolveProviderThreadModelMigrations() {
+    return this.readConfig().config.models?.providerThreadMigrations ?? {};
+  }
+
+  resolveCodexFastAllowed(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.models?.codex?.allowFast,
+      true,
+    ).value;
   }
 
   resolveCodexSpawnEnv(): NodeJS.ProcessEnv {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -942,6 +942,7 @@ export class DesktopSettingsService {
         },
       },
       models: {
+        providerDefaults: config.models?.providerDefaults ?? {},
         codex: {
           path: this.resolveString(config.models?.codex?.path, CODEX_COMMAND_ENV),
           profile: this.resolveConfigString(config.models?.codex?.profile),
@@ -1328,6 +1329,10 @@ export class DesktopSettingsService {
       || this.readConfig().config.models?.codex?.path
       || undefined
     );
+  }
+
+  resolveProviderModelDefaults() {
+    return this.readConfig().config.models?.providerDefaults ?? {};
   }
 
   resolveCodexSpawnEnv(): NodeJS.ProcessEnv {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2179,6 +2179,8 @@ export class SqliteOverlayStore {
     reasoningEffort?: string;
     serviceTier?: string;
     fastMode?: boolean;
+    modelMigrationRevision?: string;
+    modelSettingsManuallyUpdatedAt?: number;
   }): Promise<ThreadOverlayState> {
     const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
     const current = this.getThread(threadKey) ?? {
@@ -2201,6 +2203,11 @@ export class SqliteOverlayStore {
         Object.keys(reasoningEffortsByModel).length > 0
           ? reasoningEffortsByModel
           : undefined,
+      modelMigrationRevision:
+        params.modelMigrationRevision ?? current.modelMigrationRevision,
+      modelSettingsManuallyUpdatedAt:
+        params.modelSettingsManuallyUpdatedAt
+        ?? current.modelSettingsManuallyUpdatedAt,
       serviceTier: params.serviceTier,
       fastMode: params.fastMode,
     };
@@ -2226,6 +2233,65 @@ export class SqliteOverlayStore {
     };
     this.putThread(threadKey, nextState);
     return nextState;
+  }
+
+  async turnOffCodexFastEverywhere(): Promise<{
+    launchpadCount: number;
+    threadCount: number;
+  }> {
+    const rows = this.stateDb.raw
+      .prepare("SELECT thread_id, payload FROM threads")
+      .all() as Array<{ thread_id: string; payload: string }>;
+    let threadCount = 0;
+    for (const row of rows) {
+      try {
+        const thread = JSON.parse(row.payload) as ThreadOverlayState;
+        if (thread.backend !== "codex" || thread.fastMode === false) {
+          continue;
+        }
+        this.putThread(row.thread_id, {
+          ...thread,
+          fastMode: false,
+        });
+        threadCount += 1;
+      } catch {
+        // Ignore malformed cache rows. A later reconciliation can repair them.
+      }
+    }
+
+    const launchpads = await this.listDirectoryLaunchpads();
+    let launchpadCount = 0;
+    for (const launchpad of launchpads) {
+      if (launchpad.backend !== "codex" || launchpad.fastMode === false) {
+        continue;
+      }
+      await this.upsertDirectoryLaunchpad({
+        ...launchpad,
+        fastMode: false,
+        updatedAt: Date.now(),
+      });
+      launchpadCount += 1;
+    }
+
+    const defaults = await this.getLaunchpadDefaults();
+    await this.setLaunchpadDefaults({
+      providerSettings: {
+        ...(defaults.providerSettings ?? {}),
+        codex: {
+          ...(defaults.providerSettings?.codex ?? {}),
+          fastMode: false,
+          serviceTier: undefined,
+        },
+      },
+      ...(defaults.backend === "codex"
+        ? {
+            fastMode: false,
+            serviceTier: undefined,
+          }
+        : {}),
+    });
+
+    return { launchpadCount, threadCount };
   }
 
   async setThreadExpectedBranch(params: {
@@ -3700,6 +3766,7 @@ export type OverlayStoreLike = Pick<
   | "upsertWorktreeSnapshot"
   | "setThreadExecutionMode"
   | "setThreadModelSettings"
+  | "turnOffCodexFastEverywhere"
   | "setThreadExpectedBranch"
   | "setThreadObservedBranch"
   | "retainThreadBranchDrift"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2238,11 +2238,13 @@ export class SqliteOverlayStore {
   async turnOffCodexFastEverywhere(): Promise<{
     launchpadCount: number;
     threadCount: number;
+    updatedThreadIds: string[];
   }> {
     const rows = this.stateDb.raw
       .prepare("SELECT thread_id, payload FROM threads")
       .all() as Array<{ thread_id: string; payload: string }>;
     let threadCount = 0;
+    const updatedThreadIds: string[] = [];
     for (const row of rows) {
       try {
         const thread = JSON.parse(row.payload) as ThreadOverlayState;
@@ -2253,6 +2255,7 @@ export class SqliteOverlayStore {
           ...thread,
           fastMode: false,
         });
+        updatedThreadIds.push(thread.threadId);
         threadCount += 1;
       } catch {
         // Ignore malformed cache rows. A later reconciliation can repair them.
@@ -2291,7 +2294,7 @@ export class SqliteOverlayStore {
         : {}),
     });
 
-    return { launchpadCount, threadCount };
+    return { launchpadCount, threadCount, updatedThreadIds };
   }
 
   async setThreadExpectedBranch(params: {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2248,7 +2248,7 @@ export class SqliteOverlayStore {
     for (const row of rows) {
       try {
         const thread = JSON.parse(row.payload) as ThreadOverlayState;
-        if (thread.backend !== "codex" || thread.fastMode === false) {
+        if (thread.backend !== "codex" || thread.fastMode !== true) {
           continue;
         }
         this.putThread(row.thread_id, {
@@ -2265,7 +2265,7 @@ export class SqliteOverlayStore {
     const launchpads = await this.listDirectoryLaunchpads();
     let launchpadCount = 0;
     for (const launchpad of launchpads) {
-      if (launchpad.backend !== "codex" || launchpad.fastMode === false) {
+      if (launchpad.backend !== "codex" || launchpad.fastMode !== true) {
         continue;
       }
       await this.upsertDirectoryLaunchpad({

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,8 @@
 import { clipboard, contextBridge, ipcRenderer, webUtils } from "electron";
 import type {
   AgentEvent,
+  ApplyThreadModelMigrationRequest,
+  ApplyThreadModelMigrationResponse,
   AutomationIdRequest,
   AutomationMutationResponse,
   ArchiveWorktreeRequest,
@@ -40,6 +42,7 @@ import type {
   SetThreadAgentResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  TurnOffCodexFastEverywhereResponse,
   SteerTurnRequest,
   SteerTurnResponse,
   AppServerListSkillsRequest,
@@ -269,6 +272,7 @@ import type {
 } from "../shared/integrated-terminal";
 import {
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
+  AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
   AGENT_EVENT_CHANNEL,
   AGENT_FORK_THREAD_CHANNEL,
   AGENT_LATEST_CODEX_CONFIG_WARNING_CHANNEL,
@@ -285,6 +289,7 @@ import {
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
+  AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
   AGENT_START_TURN_CHANNEL,
@@ -1074,6 +1079,18 @@ const desktopApi = Object.freeze({
     request: SetThreadModelSettingsRequest
   ): Promise<SetThreadModelSettingsResponse> =>
     await ipcRenderer.invoke(AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL, request),
+  applyThreadModelMigration: async (
+    request: ApplyThreadModelMigrationRequest,
+  ): Promise<ApplyThreadModelMigrationResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
+      request,
+    ),
+  turnOffCodexFastEverywhere:
+    async (): Promise<TurnOffCodexFastEverywhereResponse> =>
+      await ipcRenderer.invoke(
+        AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
+      ),
   checkThreadBranchDrift: async (
     request: CheckThreadBranchDriftRequest
   ): Promise<CheckThreadBranchDriftResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1481,7 +1481,6 @@ function DesktopAppShell(props: {
                 profiles={profiles}
                 settings={settings}
                 onClose={() => setMainView("thread")}
-                onRefreshNavigation={() => navigation.refresh()}
                 onOpenMessagingActivity={openMessagingActivityWindow}
               />
             </Suspense>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -978,6 +978,7 @@ function DesktopAppShell(props: {
     backendError: backendSummaries.error,
     backends: backendSummaries.backends,
     applications: settings.snapshot?.applications,
+    providerModelDefaults: settings.snapshot?.models?.providerDefaults,
     archiveThreadError: navigation.archiveThreadError,
     clearPendingRequest: session.clearPendingRequest,
     composerDisabled:

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1481,6 +1481,7 @@ function DesktopAppShell(props: {
                 profiles={profiles}
                 settings={settings}
                 onClose={() => setMainView("thread")}
+                onRefreshNavigation={() => navigation.refresh()}
                 onOpenMessagingActivity={openMessagingActivityWindow}
               />
             </Suspense>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1476,6 +1476,7 @@ function DesktopAppShell(props: {
             <Suspense fallback={null}>
               <LazySettingsScreen
                 appearanceController={props.appearanceController}
+                cachedBackends={backendSummaries.backends}
                 desktopApi={desktopApi}
                 initialSection={settingsInitialSection}
                 profiles={profiles}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -978,7 +978,11 @@ function DesktopAppShell(props: {
     backendError: backendSummaries.error,
     backends: backendSummaries.backends,
     applications: settings.snapshot?.applications,
+    codexFastAllowed:
+      settings.snapshot?.models?.codex.allowFast?.value ?? true,
     providerModelDefaults: settings.snapshot?.models?.providerDefaults,
+    providerThreadMigrations:
+      settings.snapshot?.models?.providerThreadMigrations,
     archiveThreadError: navigation.archiveThreadError,
     clearPendingRequest: session.clearPendingRequest,
     composerDisabled:

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -28,6 +28,7 @@ import type {
   DesktopApplicationDiscoveryCandidate,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
+  DesktopProviderModelDefaults,
   HandoffThreadWorkspaceRequest,
   NavigationDirectorySummary,
   NavigationGitCommitSummary,
@@ -123,6 +124,7 @@ type ComposerProps = {
   ) => string;
   backends?: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
+  providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
   desktopApi?: DesktopApi;
   /**
    * Surface a transient app-level toast (image attachment limit reached,
@@ -6383,6 +6385,33 @@ export function Composer(props: ComposerProps) {
         currentSettings?.reasoningEffort,
       )
     : undefined;
+  const profileModelDefaults = backend
+    ? props.providerModelDefaults?.[backend.kind]
+    : undefined;
+  const profileModelOption =
+    modelOptions.find((option) => option.id === profileModelDefaults?.model)
+    ?? getDefaultModelOption(backend);
+  const profileReasoningOptions = getReasoningEffortsForModel(
+    backend,
+    profileModelOption,
+  );
+  const configuredProfileReasoning = profileModelOption
+    ? profileModelDefaults?.reasoningEffortsByModel[profileModelOption.id]
+    : undefined;
+  const profileReasoningEffort =
+    configuredProfileReasoning
+    && profileReasoningOptions.includes(configuredProfileReasoning)
+      ? configuredProfileReasoning
+      : getDefaultReasoningEffort(backend, profileModelOption);
+  const launchpadDiffersFromProfileDefaults =
+    Boolean(props.launchpad && profileModelOption)
+    && (
+      props.launchpad?.model !== profileModelOption?.id
+      || (
+        profileReasoningOptions.length > 0
+        && props.launchpad?.reasoningEffort !== profileReasoningEffort
+      )
+    );
   const supportsFast =
     backend?.kind === "codex"
       ? selectedModelOption?.supportsFast ??
@@ -8337,6 +8366,29 @@ export function Composer(props: ComposerProps) {
                 handleThreadModelSettingsPatch({ reasoningEffort });
               }}
             />
+          ) : null}
+
+          {props.launchpad &&
+          profileModelOption &&
+          launchpadDiffersFromProfileDefaults ? (
+            <button
+              aria-label="Reset model and reasoning to profile default"
+              className="composer__toggle tooltip-target"
+              data-tooltip="Reset model and reasoning to the AI Providers default"
+              disabled={launchpadSubmitting}
+              type="button"
+              onClick={() => {
+                handleLaunchpadPatch({
+                  model: profileModelOption.id,
+                  reasoningEffort:
+                    profileReasoningOptions.length > 0
+                      ? profileReasoningEffort
+                      : undefined,
+                });
+              }}
+            >
+              <span aria-hidden="true">↺</span>
+            </button>
           ) : null}
 
           {(props.launchpad || props.thread) && backend?.launchpadOptions?.serviceTiers?.length ? (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6173,9 +6173,13 @@ export function Composer(props: ComposerProps) {
           && latestLaunchpad.model === automaticModel
           && latestLaunchpad.reasoningEffort === automaticReasoningEffort;
         const refreshedModels = refreshedBackend.launchpadOptions?.models ?? [];
+        const configuredDefaults = props.providerModelDefaults?.[backend];
+        const configuredModelOption = refreshedModels.find(
+          (model) => model.id === configuredDefaults?.model,
+        );
         const nextModelOption =
           (shouldAdoptRefreshedDefault
-            ? undefined
+            ? configuredModelOption
             : refreshedModels.find(
                 (model) => model.id === latestLaunchpad.model,
               )) ??
@@ -6183,9 +6187,18 @@ export function Composer(props: ComposerProps) {
         if (!nextModelOption) {
           return;
         }
+        const configuredReasoningEffort =
+          configuredDefaults?.reasoningEffortsByModel[nextModelOption.id];
+        const refreshedReasoningEfforts = getReasoningEffortsForModel(
+          refreshedBackend,
+          nextModelOption,
+        );
         const nextReasoningEffort = nextModelOption.supportsReasoning
           ? shouldAdoptRefreshedDefault
-            ? getDefaultReasoningEffort(refreshedBackend, nextModelOption)
+            ? configuredReasoningEffort
+              && refreshedReasoningEfforts.includes(configuredReasoningEffort)
+                ? configuredReasoningEffort
+                : getDefaultReasoningEffort(refreshedBackend, nextModelOption)
             : getReasoningEffortValue(
                 refreshedBackend,
                 nextModelOption,
@@ -6220,6 +6233,7 @@ export function Composer(props: ComposerProps) {
     props.launchpad?.directoryKey,
     props.onProviderSelected,
     props.onUpdateLaunchpad,
+    props.providerModelDefaults,
   ]);
 
   const runThreadCodexEnvironmentAction = async (): Promise<void> => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -124,6 +124,7 @@ type ComposerProps = {
   ) => string;
   backends?: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
+  codexFastAllowed?: boolean;
   providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
   desktopApi?: DesktopApi;
   /**
@@ -6428,6 +6429,7 @@ export function Composer(props: ComposerProps) {
     );
   const supportsFast =
     backend?.kind === "codex"
+    && props.codexFastAllowed !== false
       ? selectedModelOption?.supportsFast ??
         backend.launchpadOptions?.supportsFastMode ??
         false

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -15,6 +15,7 @@ import { createPortal, flushSync } from "react-dom";
 import type { JSONContent } from "@tiptap/react";
 import type {
   AppServerAvailableCommandSummary,
+  AppServerBackendKind,
   AppServerCollaborationModeRequest,
   AppServerReviewTarget,
   AppServerSkillSummary,
@@ -59,6 +60,7 @@ import { ImageLightbox } from "../thread-detail/ImageLightbox";
 import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
 import { formatBackendLabel } from "../../lib/backend-label";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import {
   acpRuntimeModeRequiresFullAccess,
   formatExecutionModeLabel,
@@ -272,6 +274,33 @@ type ComposerProps = {
   ) => Promise<void>;
   threadModelSettingsError?: string;
 };
+
+const providerCatalogsRefreshedThisSession = new Set<AppServerBackendKind>();
+
+async function refreshProviderCatalogOnFirstSelection(
+  desktopApi: DesktopApi | undefined,
+  backend: AppServerBackendKind,
+): Promise<void> {
+  if (
+    providerCatalogsRefreshedThisSession.has(backend)
+    || !desktopApi?.listBackends
+  ) {
+    return;
+  }
+  providerCatalogsRefreshedThisSession.add(backend);
+  try {
+    if (backend.startsWith("acp:") && desktopApi.listAcpAgents) {
+      await desktopApi.listAcpAgents({ refresh: true });
+    }
+    await desktopApi.listBackends({
+      includeUnavailable: true,
+      refreshModels: backend,
+    });
+    window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
+  } catch {
+    providerCatalogsRefreshedThisSession.delete(backend);
+  }
+}
 
 type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy;
 
@@ -7978,6 +8007,15 @@ export function Composer(props: ComposerProps) {
                     `${props.launchpad.directoryKey}:${nextBackend}`;
                 } else {
                   pendingProviderSelectionKeyRef.current = undefined;
+                }
+                if (
+                  !nextBackend.startsWith("acp:")
+                  || !props.onProviderSelected
+                ) {
+                  void refreshProviderCatalogOnFirstSelection(
+                    props.desktopApi,
+                    nextBackend,
+                  );
                 }
                 handleLaunchpadPatch({
                   backend: nextBackend,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5499,6 +5499,41 @@ describe("Composer", () => {
     });
   });
 
+  it("hides Fast controls when the profile prohibits Codex Fast mode", () => {
+    render(
+      <Composer
+        backends={[
+          backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.6-sol",
+                label: "GPT-5.6-Sol",
+                current: true,
+                supportsFast: true,
+              },
+            ],
+            supportsFastMode: true,
+          }),
+        ]}
+        codexFastAllowed={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Fast prohibited",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          model: "gpt-5.6-sol",
+          fastMode: true,
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Fast mode")).not.toBeInTheDocument();
+  });
+
   it("routes slash review to startReview instead of startTurn", async () => {
     const startTurn = vi.fn();
     const addOptimisticReviewEntry = vi.fn(() => "review-optimistic-1");

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1619,6 +1619,93 @@ describe("Composer", () => {
     });
   });
 
+  it("prefers a valid profile baseline over the refreshed ACP recommendation", async () => {
+    const staleKimi = {
+      ...backendSummary("acp:kimi", {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "Kimi-k2.6",
+            current: true,
+          },
+        ],
+      }),
+      label: "Kimi",
+    };
+    const refreshedKimi = {
+      ...staleKimi,
+      launchpadOptions: {
+        models: [
+          {
+            id: "kimi-code/kimi-for-coding",
+            label: "K2.7 Coding",
+            current: true,
+          },
+          {
+            id: "kimi-code/k3",
+            label: "K3",
+            defaultReasoningEffort: "high",
+            reasoningEfforts: ["low", "high", "max"],
+            supportsReasoning: true,
+          },
+        ],
+      },
+    };
+    const onProviderSelected = vi.fn(async () => refreshedKimi);
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+    const launchpad: NavigationLaunchpadDraft = {
+      directoryKey: "directory:/repo",
+      directoryKind: "directory",
+      directoryLabel: "Repo",
+      directoryPath: "/repo",
+      backend: "codex",
+      executionMode: "default",
+      prompt: "",
+      workMode: "local",
+      branchName: "main",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const composer = (nextLaunchpad: NavigationLaunchpadDraft) => (
+      <Composer
+        backends={[backendSummary("codex"), staleKimi]}
+        launchpad={nextLaunchpad}
+        onProviderSelected={onProviderSelected}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        providerModelDefaults={{
+          "acp:kimi": {
+            model: "kimi-code/k3",
+            reasoningEffortsByModel: {
+              "kimi-code/k3": "max",
+            },
+          },
+        }}
+        skills={[]}
+      />
+    );
+    const { rerender } = render(composer(launchpad));
+
+    chooseDropdownOption("Provider", "Kimi");
+    rerender(
+      composer({
+        ...launchpad,
+        backend: "acp:kimi",
+        model: "kimi-code/kimi-for-coding",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          model: "kimi-code/k3",
+          reasoningEffort: "max",
+        }),
+        { stickySettingsChanged: true },
+      );
+    });
+  });
+
   it("preserves a model and reasoning choice made while ACP discovery runs", async () => {
     const staleKimi = {
       ...backendSummary("acp:kimi", {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -11246,6 +11246,87 @@ describe("Composer", () => {
     });
   });
 
+  it("resets one launchpad to the profile model and reasoning baseline", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[
+          backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                defaultReasoningEffort: "low",
+                reasoningEfforts: ["low", "high"],
+                supportsReasoning: true,
+              },
+              {
+                id: "gpt-5.6-sol",
+                label: "GPT-5.6-Sol",
+                defaultReasoningEffort: "low",
+                reasoningEfforts: ["low", "high", "xhigh"],
+                supportsReasoning: true,
+              },
+            ],
+          }),
+        ]}
+        directory={{
+          key: "directory:/repo",
+          kind: "directory",
+          label: "Repo",
+          path: "/repo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+        }}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "full-access",
+          model: "gpt-5.5",
+          reasoningEffort: "low",
+          prompt: "keep this prompt",
+          workMode: "worktree",
+          branchName: "feature/defaults",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        providerModelDefaults={{
+          codex: {
+            model: "gpt-5.6-sol",
+            reasoningEffortsByModel: {
+              "gpt-5.6-sol": "high",
+            },
+          },
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reset model and reasoning to profile default",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onUpdateLaunchpad).toHaveBeenCalledWith(
+        "directory:/repo",
+        expect.objectContaining({
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          prompt: "keep this prompt",
+        }),
+        { stickySettingsChanged: true },
+      );
+    });
+  });
+
   it("marks ACP privileged launchpad modes as full-access before materialization", async () => {
     const onUpdateLaunchpad = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2105,12 +2105,24 @@ describe("Composer", () => {
       updatedAt: 1,
     };
     const providerPatches: Array<Partial<NavigationLaunchpadDraft>> = [];
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1,
+      entries: [],
+    }));
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: 1,
+      backends: [codexBackend, grokBackend],
+    }));
 
     function ProviderSwitchHarness(): React.JSX.Element {
       const [launchpad, setLaunchpad] = useState(initialLaunchpad);
       return (
         <Composer
           backends={[codexBackend, grokBackend]}
+          desktopApi={{
+            listAcpAgents,
+            listBackends,
+          }}
           directory={{
             key: "directory:/repo",
             kind: "directory",
@@ -2157,6 +2169,13 @@ describe("Composer", () => {
     chooseDropdownOption("Provider", "Grok");
     await waitFor(() => {
       expect(screen.getByLabelText("Provider")).toHaveValue("acp:grok");
+    });
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true });
+      expect(listBackends).toHaveBeenCalledWith({
+        includeUnavailable: true,
+        refreshModels: "acp:grok",
+      });
     });
     expect(providerPatches.at(-1)).toEqual({
       backend: "acp:grok",

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -10,6 +10,7 @@ import { SettingsField, SettingsSection } from "./SettingsLayout";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { acpStatusLabel } from "./acp-agent-copy";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 
 /** Look up the persisted CLI-path override for an agent by its registry id. */
 function cliPathSnapshotFor(

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -10,7 +10,6 @@ import { SettingsField, SettingsSection } from "./SettingsLayout";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
 import { SettingsSwitch } from "./SettingsSwitch";
 import { acpStatusLabel } from "./acp-agent-copy";
-import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 
 /** Look up the persisted CLI-path override for an agent by its registry id. */
 function cliPathSnapshotFor(

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -621,6 +621,27 @@ function ProviderModelDefaultsSettings(props: {
             pendingMigration?.backend.kind === backend.kind
               ? pendingMigration
               : undefined;
+          const fastMode =
+            backend.kind === "codex"
+              ? {
+                  allowed: props.codexFastAllowed,
+                  pending: pendingFastAction,
+                  onAllowChange: (allowed: boolean) => {
+                    if (allowed) {
+                      void props.onSaveCodexFastAllowed(true).then((saved) => {
+                        if (!saved) {
+                          setStatus("Could not save the Codex Fast policy.");
+                        }
+                      });
+                    } else {
+                      void previewFastAction("disable");
+                    }
+                  },
+                  onCancel: () => setPendingFastAction(undefined),
+                  onConfirm: () => void applyFastAction(),
+                  onTurnOffEverywhere: () => void previewFastAction("turn-off"),
+                }
+              : undefined;
           return (
             <ProviderModelDefaultField
               key={backend.kind}
@@ -633,6 +654,7 @@ function ProviderModelDefaultsSettings(props: {
                 || Boolean(providerPendingMigration)
               }
               applying={applying}
+              fastMode={fastMode}
               pendingApply={providerPendingApply}
               pendingMigration={providerPendingMigration}
               onApply={(model, reasoningEffort) => {
@@ -649,65 +671,6 @@ function ProviderModelDefaultsSettings(props: {
             />
           );
         })}
-        <SettingsField
-          label="Codex Fast mode"
-          sub={
-            props.codexFastAllowed
-              ? "Allowed for this profile. Turn it off everywhere without preventing later per-thread use."
-              : "Prohibited for this profile. Codex turns and launchpads are forced to non-Fast."
-          }
-          control={
-            <div className="settings-paths">
-              {pendingFastAction ? (
-                <InlineActionConfirmation
-                  applying={applying}
-                  confirmLabel="Turn Fast off"
-                  label={
-                    pendingFastAction.kind === "disable"
-                      ? "Prohibit Fast for this profile?"
-                      : "Turn Fast off everywhere?"
-                  }
-                  sub={`This will set ${pendingFastAction.threadCount} existing Codex thread${
-                    pendingFastAction.threadCount === 1 ? "" : "s"
-                  } and future launchpads to non-Fast. Models, reasoning, prompts, and access settings stay unchanged.`}
-                  onCancel={() => setPendingFastAction(undefined)}
-                  onConfirm={() => void applyFastAction()}
-                />
-              ) : (
-                <div className="settings-inline-actions">
-                  <SettingsSwitch
-                    checked={props.codexFastAllowed}
-                    disabled={props.saving || applying}
-                    label="Allow Codex Fast mode"
-                    onChange={(allowed) => {
-                      if (allowed) {
-                        void props.onSaveCodexFastAllowed(true).then((saved) => {
-                          if (!saved) {
-                            setStatus("Could not save the Codex Fast policy.");
-                          }
-                        });
-                      } else {
-                        void previewFastAction("disable");
-                      }
-                    }}
-                  />
-                  <button
-                    className="button button--secondary"
-                    disabled={
-                      props.saving
-                      || applying
-                      || !props.codexFastAllowed
-                    }
-                    type="button"
-                    onClick={() => void previewFastAction("turn-off")}
-                  >
-                    Turn Fast off everywhere
-                  </button>
-                </div>
-              )}
-            </div>
-          }
-        />
         {providers.length === 0 ? (
           <SettingsField
             label="Discovered models"
@@ -754,6 +717,17 @@ function ProviderModelDefaultField(props: {
   defaults?: DesktopProviderModelDefaults;
   disabled: boolean;
   applying: boolean;
+  fastMode?: {
+    allowed: boolean;
+    pending?: {
+      kind: "disable" | "turn-off";
+      threadCount: number;
+    };
+    onAllowChange: (allowed: boolean) => void;
+    onCancel: () => void;
+    onConfirm: () => void;
+    onTurnOffEverywhere: () => void;
+  };
   pendingApply?: {
     count: number;
   };
@@ -795,76 +769,78 @@ function ProviderModelDefaultField(props: {
       }
       control={
         <div className="settings-paths">
-          <select
-            aria-label={`${props.backend.label} default model`}
-            className="settings-select"
-            disabled={props.disabled}
-            value={selectedModel}
-            onChange={(event) => {
-              const model = event.currentTarget.value;
-              if (!model) {
-                props.onChange(undefined);
-                return;
-              }
-              const option = models.find((candidate) => candidate.id === model);
-              const reasoningEffortsByModel = {
-                ...(props.defaults?.reasoningEffortsByModel ?? {}),
-              };
-              if (
-                option?.defaultReasoningEffort
-                && !reasoningEffortsByModel[model]
-              ) {
-                reasoningEffortsByModel[model] = option.defaultReasoningEffort;
-              }
-              props.onChange({ model, reasoningEffortsByModel });
-            }}
-          >
-            <option value="">Provider advertised default</option>
-            {selectedModel && !modelOption ? (
-              <option value={selectedModel}>{selectedModel} (unavailable)</option>
-            ) : null}
-            {models.map((model) => (
-              <option key={model.id} value={model.id}>
-                {model.label ?? model.id}
-              </option>
-            ))}
-          </select>
-          {selectedModel && reasoningOptions.length > 0 ? (
+          <div className="settings-provider-defaults__selectors">
             <select
-              aria-label={`${props.backend.label} default reasoning`}
-              className="settings-select"
+              aria-label={`${props.backend.label} default model`}
+              className="settings-select settings-select--chip"
               disabled={props.disabled}
-              value={selectedReasoning}
+              value={selectedModel}
               onChange={(event) => {
+                const model = event.currentTarget.value;
+                if (!model) {
+                  props.onChange(undefined);
+                  return;
+                }
+                const option = models.find((candidate) => candidate.id === model);
                 const reasoningEffortsByModel = {
                   ...(props.defaults?.reasoningEffortsByModel ?? {}),
                 };
-                const effort = event.currentTarget.value;
-                if (effort) {
-                  reasoningEffortsByModel[selectedModel] = effort;
-                } else {
-                  delete reasoningEffortsByModel[selectedModel];
+                if (
+                  option?.defaultReasoningEffort
+                  && !reasoningEffortsByModel[model]
+                ) {
+                  reasoningEffortsByModel[model] = option.defaultReasoningEffort;
                 }
-                props.onChange({
-                  model: selectedModel,
-                  reasoningEffortsByModel,
-                });
+                props.onChange({ model, reasoningEffortsByModel });
               }}
             >
-              <option value="">Provider advertised reasoning</option>
-              {selectedReasoning
-              && !reasoningOptions.includes(selectedReasoning) ? (
-                <option value={selectedReasoning}>
-                  {selectedReasoning} (unavailable)
-                </option>
+              <option value="">Provider advertised default</option>
+              {selectedModel && !modelOption ? (
+                <option value={selectedModel}>{selectedModel} (unavailable)</option>
               ) : null}
-              {reasoningOptions.map((effort) => (
-                <option key={effort} value={effort}>
-                  {effort}
+              {models.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.label ?? model.id}
                 </option>
               ))}
             </select>
-          ) : null}
+            {selectedModel && reasoningOptions.length > 0 ? (
+              <select
+                aria-label={`${props.backend.label} default reasoning`}
+                className="settings-select settings-select--chip"
+                disabled={props.disabled}
+                value={selectedReasoning}
+                onChange={(event) => {
+                  const reasoningEffortsByModel = {
+                    ...(props.defaults?.reasoningEffortsByModel ?? {}),
+                  };
+                  const effort = event.currentTarget.value;
+                  if (effort) {
+                    reasoningEffortsByModel[selectedModel] = effort;
+                  } else {
+                    delete reasoningEffortsByModel[selectedModel];
+                  }
+                  props.onChange({
+                    model: selectedModel,
+                    reasoningEffortsByModel,
+                  });
+                }}
+              >
+                <option value="">Provider advertised reasoning</option>
+                {selectedReasoning
+                && !reasoningOptions.includes(selectedReasoning) ? (
+                  <option value={selectedReasoning}>
+                    {selectedReasoning} (unavailable)
+                  </option>
+                ) : null}
+                {reasoningOptions.map((effort) => (
+                  <option key={effort} value={effort}>
+                    {effort}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+          </div>
           {props.pendingApply ? (
             <InlineActionConfirmation
               applying={props.applying}
@@ -919,6 +895,52 @@ function ProviderModelDefaultField(props: {
               >
                 Reset
               </button>
+            </div>
+          ) : null}
+          {props.fastMode ? (
+            <div className="settings-provider-defaults__fast">
+              <div className="settings-provider-defaults__fast-copy">
+                <strong>Fast mode</strong>
+                <span>
+                  {props.fastMode.allowed
+                    ? "Allowed for this profile. Existing threads keep their own choice."
+                    : "Prohibited for this profile. Codex is forced to non-Fast."}
+                </span>
+              </div>
+              {props.fastMode.pending ? (
+                <InlineActionConfirmation
+                  applying={props.applying}
+                  confirmLabel="Turn Fast off"
+                  label={
+                    props.fastMode.pending.kind === "disable"
+                      ? "Prohibit Fast for this profile?"
+                      : "Turn Fast off everywhere?"
+                  }
+                  sub={`This will set ${props.fastMode.pending.threadCount} existing Codex thread${
+                    props.fastMode.pending.threadCount === 1 ? "" : "s"
+                  } and future launchpads to non-Fast. Models, reasoning, prompts, and access settings stay unchanged.`}
+                  onCancel={props.fastMode.onCancel}
+                  onConfirm={props.fastMode.onConfirm}
+                />
+              ) : (
+                <div className="settings-inline-actions">
+                  <SettingsSwitch
+                    checked={props.fastMode.allowed}
+                    disabled={props.disabled}
+                    label="Allow Codex Fast mode"
+                    onChange={props.fastMode.onAllowChange}
+                  />
+                  <button
+                    aria-label="Turn Fast off everywhere"
+                    className="button button--secondary"
+                    disabled={props.disabled || !props.fastMode.allowed}
+                    type="button"
+                    onClick={props.fastMode.onTurnOffEverywhere}
+                  >
+                    Turn off everywhere
+                  </button>
+                </div>
+              )}
             </div>
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -33,6 +33,7 @@ import { SettingsSwitch } from "./SettingsSwitch";
 type CodexPathMode = "auto" | "specified";
 
 export function ModelsSettings(props: {
+  cachedBackends?: BackendSummary[];
   desktopApi?: DesktopApi;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
@@ -61,7 +62,9 @@ export function ModelsSettings(props: {
     props.snapshot.models.codex.path.value.trim() ? "specified" : "auto",
   );
   const [grokKey, setGrokKey] = useState("");
-  const [backends, setBackends] = useState<BackendSummary[]>([]);
+  const [backends, setBackends] = useState<BackendSummary[]>(
+    props.cachedBackends ?? [],
+  );
   const [catalogError, setCatalogError] = useState<string | undefined>();
   const [refreshingCatalog, setRefreshingCatalog] = useState(false);
   const codex = props.snapshot.models.codex;
@@ -86,6 +89,12 @@ export function ModelsSettings(props: {
     setCodexPath(codex.path.value);
     setCodexMode(codex.path.value.trim() || envForced ? "specified" : "auto");
   }, [codex.path.value, envForced]);
+
+  useEffect(() => {
+    if (props.cachedBackends) {
+      setBackends(props.cachedBackends);
+    }
+  }, [props.cachedBackends]);
 
   const refreshCatalog = async (
     force = false,

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -35,6 +35,7 @@ type CodexPathMode = "auto" | "specified";
 const UNSPECIFIED_SOURCE_MODEL_KEY = "\0unspecified";
 
 type ThreadMigrationSourceGroup = {
+  acknowledgedCurrentRevisionCount: number;
   count: number;
   key: string;
   label: string;
@@ -43,11 +44,38 @@ type ThreadMigrationSourceGroup = {
 
 type PendingThreadMigration = {
   backend: BackendSummary;
+  justScheduled?: boolean;
   model: string;
   reasoningEffort?: string;
   selectedSourceKeys: string[];
   sourceGroups: ThreadMigrationSourceGroup[];
 };
+
+function migrationMatchesSelection(
+  migration: DesktopProviderThreadModelMigration | undefined,
+  pending: PendingThreadMigration,
+): boolean {
+  if (
+    !migration
+    || migration.model !== pending.model
+    || migration.reasoningEffort !== pending.reasoningEffort
+    || migration.sourceModels === undefined
+  ) {
+    return false;
+  }
+  const selectedKeys = new Set(pending.selectedSourceKeys);
+  const selectedModels = pending.sourceGroups
+    .filter((group) => group.model && selectedKeys.has(group.key))
+    .map((group) => group.model as string)
+    .sort();
+  const migrationModels = [...migration.sourceModels].sort();
+  return (
+    selectedModels.length === migrationModels.length
+    && selectedModels.every((model, index) => model === migrationModels[index])
+    && selectedKeys.has(UNSPECIFIED_SOURCE_MODEL_KEY)
+      === (migration.includeThreadsWithoutModel === true)
+  );
+}
 
 export function ModelsSettings(props: {
   cachedBackends?: BackendSummary[];
@@ -541,28 +569,50 @@ function ProviderModelDefaultsSettings(props: {
         option.label ?? option.id,
       ]),
     );
-    const sourceCounts = new Map<string, number>();
+    const currentMigration = props.migrations[backend.kind];
+    const sourceCounts = new Map<string, {
+      acknowledgedCurrentRevisionCount: number;
+      count: number;
+    }>();
     for (const thread of threads) {
       const key = thread.model?.trim() || UNSPECIFIED_SOURCE_MODEL_KEY;
-      sourceCounts.set(key, (sourceCounts.get(key) ?? 0) + 1);
+      const current = sourceCounts.get(key) ?? {
+        acknowledgedCurrentRevisionCount: 0,
+        count: 0,
+      };
+      sourceCounts.set(key, {
+        acknowledgedCurrentRevisionCount:
+          current.acknowledgedCurrentRevisionCount
+          + (
+            thread.modelMigrationRevision === currentMigration?.revision
+              ? 1
+              : 0
+          ),
+        count: current.count + 1,
+      });
     }
     const sourceGroups = [...sourceCounts.entries()]
-      .map(([key, count]): ThreadMigrationSourceGroup => {
+      .map(([key, counts]): ThreadMigrationSourceGroup => {
         if (key === UNSPECIFIED_SOURCE_MODEL_KEY) {
           return {
-            count,
+            ...counts,
             key,
             label: "Provider default / unknown",
           };
         }
         return {
-          count,
+          ...counts,
           key,
           label: modelLabels.get(key) ?? key,
           model: key,
         };
       })
       .sort((left, right) => left.label.localeCompare(right.label));
+    const currentMigrationTargetsSelection =
+      currentMigration?.model === model
+      && currentMigration.reasoningEffort === reasoningEffort
+      && currentMigration.sourceModels !== undefined;
+    const currentSourceModels = new Set(currentMigration?.sourceModels ?? []);
     setStatus(undefined);
     setPendingApply(undefined);
     setPendingFastAction(undefined);
@@ -570,9 +620,17 @@ function ProviderModelDefaultsSettings(props: {
       backend,
       model,
       reasoningEffort,
-      selectedSourceKeys: sourceGroups
-        .filter((group) => group.model !== model)
-        .map((group) => group.key),
+      selectedSourceKeys: currentMigrationTargetsSelection
+        ? sourceGroups
+            .filter((group) =>
+              group.model
+                ? currentSourceModels.has(group.model)
+                : currentMigration?.includeThreadsWithoutModel === true
+            )
+            .map((group) => group.key)
+        : sourceGroups
+            .filter((group) => group.model !== model)
+            .map((group) => group.key),
       sourceGroups,
     });
   };
@@ -588,6 +646,19 @@ function ProviderModelDefaultsSettings(props: {
       0,
     );
     if (threadCount === 0) return;
+    if (
+      migrationMatchesSelection(
+        props.migrations[pendingMigration.backend.kind],
+        pendingMigration,
+      )
+    ) {
+      setStatus(
+        `This ${pendingMigration.backend.label} migration is already scheduled. `
+        + "Pending threads will adopt it when next opened.",
+      );
+      setPendingMigration(undefined);
+      return;
+    }
     setApplying(true);
     try {
       const createdAt = Date.now();
@@ -613,11 +684,22 @@ function ProviderModelDefaultsSettings(props: {
         return;
       }
       setStatus(
-        `${threadCount} ${pendingMigration.backend.label} thread${
+        `Scheduled ${threadCount} ${pendingMigration.backend.label} thread${
           threadCount === 1 ? "" : "s"
-        } will adopt ${pendingMigration.model} when next opened.`,
+        } to adopt ${pendingMigration.model} when next opened.`,
       );
-      setPendingMigration(undefined);
+      setPendingMigration((current) =>
+        current
+          ? {
+              ...current,
+              justScheduled: true,
+              sourceGroups: current.sourceGroups.map((group) => ({
+                ...group,
+                acknowledgedCurrentRevisionCount: 0,
+              })),
+            }
+          : current,
+      );
     } catch (error) {
       setStatus(error instanceof Error ? error.message : String(error));
     } finally {
@@ -776,12 +858,15 @@ function ProviderModelDefaultsSettings(props: {
       {pendingMigration ? (
         <ThreadMigrationDialog
           applying={applying}
+          currentMigration={props.migrations[pendingMigration.backend.kind]}
           migration={pendingMigration}
           onCancel={() => setPendingMigration(undefined)}
           onConfirm={() => void createThreadMigration()}
           onSelectionChange={(selectedSourceKeys) => {
             setPendingMigration((current) =>
-              current ? { ...current, selectedSourceKeys } : current,
+              current
+                ? { ...current, justScheduled: false, selectedSourceKeys }
+                : current,
             );
           }}
         />
@@ -792,6 +877,7 @@ function ProviderModelDefaultsSettings(props: {
 
 function ThreadMigrationDialog(props: {
   applying: boolean;
+  currentMigration?: DesktopProviderThreadModelMigration;
   migration: PendingThreadMigration;
   onCancel: () => void;
   onConfirm: () => void;
@@ -807,6 +893,27 @@ function ThreadMigrationDialog(props: {
       count + (selectedSourceKeys.has(group.key) ? group.count : 0),
     0,
   );
+  const alreadyScheduled =
+    props.migration.justScheduled === true
+    || migrationMatchesSelection(props.currentMigration, props.migration);
+  const selectedAcknowledgedThreadCount =
+    props.migration.sourceGroups.reduce(
+      (count, group) =>
+        count
+        + (
+          selectedSourceKeys.has(group.key)
+            ? group.acknowledgedCurrentRevisionCount
+            : 0
+        ),
+      0,
+    );
+  const acknowledgedThreadCount = props.migration.sourceGroups.reduce(
+    (count, group) =>
+      count + group.acknowledgedCurrentRevisionCount,
+    0,
+  );
+  const pendingThreadCount =
+    Math.max(0, selectedThreadCount - selectedAcknowledgedThreadCount);
 
   useEffect(() => {
     dialogRef.current?.focus();
@@ -867,17 +974,27 @@ function ThreadMigrationDialog(props: {
           {props.migration.reasoningEffort
             ? ` with ${props.migration.reasoningEffort} reasoning`
             : ""}
-          . Each selected thread changes once when next opened. Newer threads and
-          unselected models stay unchanged.
+          . This schedules a one-time change when each selected thread is next
+          opened. Newer threads and unselected models stay unchanged.
         </p>
+        {alreadyScheduled ? (
+          <p className="settings-thread-migration-dialog__scheduled">
+            This exact migration is already scheduled. {pendingThreadCount} thread
+            {pendingThreadCount === 1 ? " is" : "s are"} still pending;{" "}
+            {acknowledgedThreadCount} already acknowledged this revision.
+          </p>
+        ) : null}
         <div className="settings-thread-migration-dialog__toolbar">
           <span>
-            {selectedThreadCount} of{" "}
+            {alreadyScheduled
+              ? `${pendingThreadCount} pending`
+              : `${selectedThreadCount} selected`}{" "}
+            of{" "}
             {props.migration.sourceGroups.reduce(
               (count, group) => count + group.count,
               0,
             )}{" "}
-            threads selected
+            threads
           </span>
           <div className="settings-inline-actions">
             <button
@@ -951,15 +1068,21 @@ function ThreadMigrationDialog(props: {
           </button>
           <button
             className="button button--primary"
-            disabled={props.applying || selectedThreadCount === 0}
+            disabled={
+              props.applying
+              || selectedThreadCount === 0
+              || alreadyScheduled
+            }
             type="button"
             onClick={props.onConfirm}
           >
             {props.applying
               ? "Creating migration…"
-              : `Update ${selectedThreadCount} thread${
-                  selectedThreadCount === 1 ? "" : "s"
-                }`}
+              : alreadyScheduled
+                ? "Already scheduled"
+                : `Schedule ${selectedThreadCount} thread${
+                    selectedThreadCount === 1 ? "" : "s"
+                  }`}
           </button>
         </div>
       </div>
@@ -1124,7 +1247,7 @@ function ProviderModelDefaultField(props: {
                   selectedReasoning || undefined,
                 )}
               >
-                Apply to existing threads…
+                Schedule existing threads…
               </button>
               <button
                 className="button button--ghost"

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -458,6 +458,8 @@ function ProviderModelDefaultsSettings(props: {
       return;
     }
     setStatus(undefined);
+    setPendingMigration(undefined);
+    setPendingFastAction(undefined);
     setPendingApply({
       backend,
       count: directoryKeys.length,
@@ -610,21 +612,43 @@ function ProviderModelDefaultsSettings(props: {
       description="These profile-wide baselines fill new launchpads that do not already have a directory or learned provider choice."
     >
       <div className="settings-fields">
-        {providers.map((backend) => (
-          <ProviderModelDefaultField
-            key={backend.kind}
-            backend={backend}
-            defaults={props.defaults[backend.kind]}
-            disabled={props.saving || applying}
-            onApply={(model, reasoningEffort) => {
-              void previewApply(backend, model, reasoningEffort);
-            }}
-            onMigrate={(model, reasoningEffort) => {
-              void previewThreadMigration(backend, model, reasoningEffort);
-            }}
-            onChange={(next) => saveProvider(backend, next)}
-          />
-        ))}
+        {providers.map((backend) => {
+          const providerPendingApply =
+            pendingApply?.backend.kind === backend.kind
+              ? pendingApply
+              : undefined;
+          const providerPendingMigration =
+            pendingMigration?.backend.kind === backend.kind
+              ? pendingMigration
+              : undefined;
+          return (
+            <ProviderModelDefaultField
+              key={backend.kind}
+              backend={backend}
+              defaults={props.defaults[backend.kind]}
+              disabled={
+                props.saving
+                || applying
+                || Boolean(providerPendingApply)
+                || Boolean(providerPendingMigration)
+              }
+              applying={applying}
+              pendingApply={providerPendingApply}
+              pendingMigration={providerPendingMigration}
+              onApply={(model, reasoningEffort) => {
+                void previewApply(backend, model, reasoningEffort);
+              }}
+              onCancelApply={() => setPendingApply(undefined)}
+              onConfirmApply={() => void applyToLaunchpads()}
+              onCancelMigration={() => setPendingMigration(undefined)}
+              onConfirmMigration={() => void createThreadMigration()}
+              onMigrate={(model, reasoningEffort) => {
+                void previewThreadMigration(backend, model, reasoningEffort);
+              }}
+              onChange={(next) => saveProvider(backend, next)}
+            />
+          );
+        })}
         <SettingsField
           label="Codex Fast mode"
           sub={
@@ -633,35 +657,54 @@ function ProviderModelDefaultsSettings(props: {
               : "Prohibited for this profile. Codex turns and launchpads are forced to non-Fast."
           }
           control={
-            <div className="settings-inline-actions">
-              <SettingsSwitch
-                checked={props.codexFastAllowed}
-                disabled={props.saving || applying}
-                label="Allow Codex Fast mode"
-                onChange={(allowed) => {
-                  if (allowed) {
-                    void props.onSaveCodexFastAllowed(true).then((saved) => {
-                      if (!saved) {
-                        setStatus("Could not save the Codex Fast policy.");
-                      }
-                    });
-                  } else {
-                    void previewFastAction("disable");
+            <div className="settings-paths">
+              {pendingFastAction ? (
+                <InlineActionConfirmation
+                  applying={applying}
+                  confirmLabel="Turn Fast off"
+                  label={
+                    pendingFastAction.kind === "disable"
+                      ? "Prohibit Fast for this profile?"
+                      : "Turn Fast off everywhere?"
                   }
-                }}
-              />
-              <button
-                className="button button--secondary"
-                disabled={
-                  props.saving
-                  || applying
-                  || !props.codexFastAllowed
-                }
-                type="button"
-                onClick={() => void previewFastAction("turn-off")}
-              >
-                Turn Fast off everywhere
-              </button>
+                  sub={`This will set ${pendingFastAction.threadCount} existing Codex thread${
+                    pendingFastAction.threadCount === 1 ? "" : "s"
+                  } and future launchpads to non-Fast. Models, reasoning, prompts, and access settings stay unchanged.`}
+                  onCancel={() => setPendingFastAction(undefined)}
+                  onConfirm={() => void applyFastAction()}
+                />
+              ) : (
+                <div className="settings-inline-actions">
+                  <SettingsSwitch
+                    checked={props.codexFastAllowed}
+                    disabled={props.saving || applying}
+                    label="Allow Codex Fast mode"
+                    onChange={(allowed) => {
+                      if (allowed) {
+                        void props.onSaveCodexFastAllowed(true).then((saved) => {
+                          if (!saved) {
+                            setStatus("Could not save the Codex Fast policy.");
+                          }
+                        });
+                      } else {
+                        void previewFastAction("disable");
+                      }
+                    }}
+                  />
+                  <button
+                    className="button button--secondary"
+                    disabled={
+                      props.saving
+                      || applying
+                      || !props.codexFastAllowed
+                    }
+                    type="button"
+                    onClick={() => void previewFastAction("turn-off")}
+                  >
+                    Turn Fast off everywhere
+                  </button>
+                </div>
+              )}
             </div>
           }
         />
@@ -700,94 +743,6 @@ function ProviderModelDefaultsSettings(props: {
             }
           />
         )}
-        {pendingApply ? (
-          <SettingsField
-            label={`Apply to ${pendingApply.count} launchpad${
-              pendingApply.count === 1 ? "" : "s"
-            }?`}
-            sub="Prompts, attachments, work mode, access, Fast/service tier, and Codex Environment will stay unchanged."
-            control={
-              <div className="settings-inline-actions">
-                <button
-                  className="button button--primary"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => void applyToLaunchpads()}
-                >
-                  {applying ? "Applying…" : "Apply"}
-                </button>
-                <button
-                  className="button button--ghost"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => setPendingApply(undefined)}
-                >
-                  Cancel
-                </button>
-              </div>
-            }
-          />
-        ) : null}
-        {pendingMigration ? (
-          <SettingsField
-            label={`Migrate ${pendingMigration.count} existing thread${
-              pendingMigration.count === 1 ? "" : "s"
-            }?`}
-            sub="Each matching thread will adopt this model and reasoning once when next opened. Manual changes made afterward will stick until you create another migration."
-            control={
-              <div className="settings-inline-actions">
-                <button
-                  className="button button--primary"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => void createThreadMigration()}
-                >
-                  {applying ? "Creating…" : "Create migration"}
-                </button>
-                <button
-                  className="button button--ghost"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => setPendingMigration(undefined)}
-                >
-                  Cancel
-                </button>
-              </div>
-            }
-          />
-        ) : null}
-        {pendingFastAction ? (
-          <SettingsField
-            label={
-              pendingFastAction.kind === "disable"
-                ? "Prohibit Fast for this profile?"
-                : "Turn Fast off everywhere?"
-            }
-            sub={`This will set ${pendingFastAction.threadCount} existing Codex thread${
-              pendingFastAction.threadCount === 1 ? "" : "s"
-            } and future launchpads to non-Fast. Models, reasoning, prompts, and access settings stay unchanged.`}
-            control={
-              <div className="settings-inline-actions">
-                <button
-                  className="button button--primary"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => void applyFastAction()}
-                >
-                  {applying ? "Updating…" : "Turn Fast off"}
-                </button>
-                <button
-                  className="button button--ghost"
-                  disabled={applying}
-                  type="button"
-                  onClick={() => setPendingFastAction(undefined)}
-                >
-                  Cancel
-                </button>
-              </div>
-            }
-          />
-        ) : null}
         {status ? <p className="settings-empty">{status}</p> : null}
       </div>
     </SettingsSection>
@@ -798,7 +753,18 @@ function ProviderModelDefaultField(props: {
   backend: BackendSummary;
   defaults?: DesktopProviderModelDefaults;
   disabled: boolean;
+  applying: boolean;
+  pendingApply?: {
+    count: number;
+  };
+  pendingMigration?: {
+    count: number;
+  };
   onApply: (model: string, reasoningEffort?: string) => void;
+  onCancelApply: () => void;
+  onConfirmApply: () => void;
+  onCancelMigration: () => void;
+  onConfirmMigration: () => void;
   onMigrate: (model: string, reasoningEffort?: string) => void;
   onChange: (defaults: DesktopProviderModelDefaults | undefined) => void;
 }) {
@@ -899,7 +865,29 @@ function ProviderModelDefaultField(props: {
               ))}
             </select>
           ) : null}
-          {selectedModel ? (
+          {props.pendingApply ? (
+            <InlineActionConfirmation
+              applying={props.applying}
+              confirmLabel="Apply"
+              label={`Apply to ${props.pendingApply.count} launchpad${
+                props.pendingApply.count === 1 ? "" : "s"
+              }?`}
+              sub="Prompts, attachments, work mode, access, Fast/service tier, and Codex Environment will stay unchanged."
+              onCancel={props.onCancelApply}
+              onConfirm={props.onConfirmApply}
+            />
+          ) : props.pendingMigration ? (
+            <InlineActionConfirmation
+              applying={props.applying}
+              confirmLabel="Create migration"
+              label={`Migrate ${props.pendingMigration.count} existing thread${
+                props.pendingMigration.count === 1 ? "" : "s"
+              }?`}
+              sub="Each matching thread will adopt this model and reasoning once when next opened. Manual changes made afterward will stick until you create another migration."
+              onCancel={props.onCancelMigration}
+              onConfirm={props.onConfirmMigration}
+            />
+          ) : selectedModel ? (
             <div className="settings-inline-actions">
               <button
                 className="button button--secondary"
@@ -936,6 +924,45 @@ function ProviderModelDefaultField(props: {
         </div>
       }
     />
+  );
+}
+
+function InlineActionConfirmation(props: {
+  applying: boolean;
+  confirmLabel: string;
+  label: string;
+  sub: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div
+      aria-live="polite"
+      className="settings-action-confirmation"
+    >
+      <div className="settings-action-confirmation__copy">
+        <strong>{props.label}</strong>
+        <span>{props.sub}</span>
+      </div>
+      <div className="settings-inline-actions">
+        <button
+          className="button button--primary"
+          disabled={props.applying}
+          type="button"
+          onClick={props.onConfirm}
+        >
+          {props.applying ? "Updating…" : props.confirmLabel}
+        </button>
+        <button
+          className="button button--ghost"
+          disabled={props.applying}
+          type="button"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -5,6 +5,7 @@ import type {
   DesktopCodexAuthProfileCandidate,
   DesktopCodexDiscoveryCandidate,
   DesktopProviderModelDefaults,
+  DesktopProviderThreadModelMigration,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
@@ -27,6 +28,7 @@ import {
   CodexAuthProfileLoginButton,
 } from "./CodexAuthProfileSelect";
 import { AcpAgentsSettings } from "./AcpAgentsSettings";
+import { SettingsSwitch } from "./SettingsSwitch";
 
 type CodexPathMode = "auto" | "specified";
 
@@ -45,6 +47,10 @@ export function ModelsSettings(props: {
   onSaveProviderDefaults: (
     defaults: Record<string, DesktopProviderModelDefaults>,
   ) => Promise<void>;
+  onSaveProviderThreadMigrations: (
+    migrations: Record<string, DesktopProviderThreadModelMigration>,
+  ) => Promise<boolean>;
+  onSaveCodexFastAllowed: (allowed: boolean) => Promise<boolean>;
   /** Persist a per-ACP-agent CLI-path override (also pins a discovered install). */
   onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<void>;
   /** Persist a per-ACP-agent enabled flag (off = hidden from the model picker). */
@@ -143,11 +149,15 @@ export function ModelsSettings(props: {
         backends={backends}
         desktopApi={props.desktopApi}
         defaults={props.snapshot.models.providerDefaults ?? {}}
+        migrations={props.snapshot.models.providerThreadMigrations ?? {}}
+        codexFastAllowed={props.snapshot.models.codex.allowFast?.value ?? true}
         error={catalogError}
         refreshing={refreshingCatalog}
         saving={props.saving}
         onRefresh={() => refreshCatalog(true, true)}
         onSave={props.onSaveProviderDefaults}
+        onSaveMigrations={props.onSaveProviderThreadMigrations}
+        onSaveCodexFastAllowed={props.onSaveCodexFastAllowed}
       />
 
       <SettingsSection eyebrow="Models" title="Codex">
@@ -380,6 +390,8 @@ function ProviderModelDefaultsSettings(props: {
   backends: BackendSummary[];
   desktopApi?: DesktopApi;
   defaults: Record<string, DesktopProviderModelDefaults>;
+  migrations: Record<string, DesktopProviderThreadModelMigration>;
+  codexFastAllowed: boolean;
   error?: string;
   refreshing: boolean;
   saving: boolean;
@@ -387,6 +399,10 @@ function ProviderModelDefaultsSettings(props: {
   onSave: (
     defaults: Record<string, DesktopProviderModelDefaults>,
   ) => Promise<void>;
+  onSaveMigrations: (
+    migrations: Record<string, DesktopProviderThreadModelMigration>,
+  ) => Promise<boolean>;
+  onSaveCodexFastAllowed: (allowed: boolean) => Promise<boolean>;
 }) {
   const [pendingApply, setPendingApply] = useState<{
     backend: BackendSummary;
@@ -394,6 +410,16 @@ function ProviderModelDefaultsSettings(props: {
     directoryKeys: string[];
     model: string;
     reasoningEffort?: string;
+  }>();
+  const [pendingMigration, setPendingMigration] = useState<{
+    backend: BackendSummary;
+    count: number;
+    model: string;
+    reasoningEffort?: string;
+  }>();
+  const [pendingFastAction, setPendingFastAction] = useState<{
+    kind: "disable" | "turn-off";
+    threadCount: number;
   }>();
   const [applying, setApplying] = useState(false);
   const [status, setStatus] = useState<string | undefined>();
@@ -468,6 +494,115 @@ function ProviderModelDefaultsSettings(props: {
     }
   };
 
+  const previewThreadMigration = async (
+    backend: BackendSummary,
+    model: string,
+    reasoningEffort?: string,
+  ): Promise<void> => {
+    if (!props.desktopApi?.getNavigationSnapshot) {
+      setStatus("Thread migration is unavailable in this build.");
+      return;
+    }
+    const navigation = await props.desktopApi.getNavigationSnapshot();
+    const count = navigation.threads.filter(
+      (thread) => thread.source === backend.kind,
+    ).length;
+    if (count === 0) {
+      setStatus(`No existing ${backend.label} threads need a migration.`);
+      return;
+    }
+    setStatus(undefined);
+    setPendingApply(undefined);
+    setPendingFastAction(undefined);
+    setPendingMigration({
+      backend,
+      count,
+      model,
+      reasoningEffort,
+    });
+  };
+
+  const createThreadMigration = async (): Promise<void> => {
+    if (!pendingMigration) return;
+    setApplying(true);
+    try {
+      const createdAt = Date.now();
+      const saved = await props.onSaveMigrations({
+        ...props.migrations,
+        [pendingMigration.backend.kind]: {
+          revision: `${createdAt}-${crypto.randomUUID()}`,
+          model: pendingMigration.model,
+          ...(pendingMigration.reasoningEffort
+            ? { reasoningEffort: pendingMigration.reasoningEffort }
+            : {}),
+          createdAt,
+        },
+      });
+      if (!saved) {
+        setStatus("Could not save the thread migration.");
+        return;
+      }
+      setStatus(
+        `${pendingMigration.count} ${pendingMigration.backend.label} thread${
+          pendingMigration.count === 1 ? "" : "s"
+        } will adopt ${pendingMigration.model} when next opened.`,
+      );
+      setPendingMigration(undefined);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const previewFastAction = async (
+    kind: "disable" | "turn-off",
+  ): Promise<void> => {
+    if (!props.desktopApi?.getNavigationSnapshot) {
+      setStatus("Codex Fast cleanup is unavailable in this build.");
+      return;
+    }
+    const navigation = await props.desktopApi.getNavigationSnapshot();
+    setStatus(undefined);
+    setPendingApply(undefined);
+    setPendingMigration(undefined);
+    setPendingFastAction({
+      kind,
+      threadCount: navigation.threads.filter(
+        (thread) => thread.source === "codex",
+      ).length,
+    });
+  };
+
+  const applyFastAction = async (): Promise<void> => {
+    if (!pendingFastAction || !props.desktopApi?.turnOffCodexFastEverywhere) {
+      return;
+    }
+    setApplying(true);
+    try {
+      if (pendingFastAction.kind === "disable") {
+        const saved = await props.onSaveCodexFastAllowed(false);
+        if (!saved) {
+          setStatus("Could not save the Codex Fast policy.");
+          return;
+        }
+      }
+      const result = await props.desktopApi.turnOffCodexFastEverywhere();
+      setStatus(
+        `Fast is off for ${result.threadCount} Codex thread${
+          result.threadCount === 1 ? "" : "s"
+        } and ${result.launchpadCount} saved launchpad${
+          result.launchpadCount === 1 ? "" : "s"
+        }. Future Codex launchpads will also start non-Fast.`,
+      );
+      setPendingFastAction(undefined);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setApplying(false);
+    }
+  };
+
   return (
     <SettingsSection
       eyebrow="Defaults"
@@ -484,9 +619,52 @@ function ProviderModelDefaultsSettings(props: {
             onApply={(model, reasoningEffort) => {
               void previewApply(backend, model, reasoningEffort);
             }}
+            onMigrate={(model, reasoningEffort) => {
+              void previewThreadMigration(backend, model, reasoningEffort);
+            }}
             onChange={(next) => saveProvider(backend, next)}
           />
         ))}
+        <SettingsField
+          label="Codex Fast mode"
+          sub={
+            props.codexFastAllowed
+              ? "Allowed for this profile. Turn it off everywhere without preventing later per-thread use."
+              : "Prohibited for this profile. Codex turns and launchpads are forced to non-Fast."
+          }
+          control={
+            <div className="settings-inline-actions">
+              <SettingsSwitch
+                checked={props.codexFastAllowed}
+                disabled={props.saving || applying}
+                label="Allow Codex Fast mode"
+                onChange={(allowed) => {
+                  if (allowed) {
+                    void props.onSaveCodexFastAllowed(true).then((saved) => {
+                      if (!saved) {
+                        setStatus("Could not save the Codex Fast policy.");
+                      }
+                    });
+                  } else {
+                    void previewFastAction("disable");
+                  }
+                }}
+              />
+              <button
+                className="button button--secondary"
+                disabled={
+                  props.saving
+                  || applying
+                  || !props.codexFastAllowed
+                }
+                type="button"
+                onClick={() => void previewFastAction("turn-off")}
+              >
+                Turn Fast off everywhere
+              </button>
+            </div>
+          }
+        />
         {providers.length === 0 ? (
           <SettingsField
             label="Discovered models"
@@ -550,6 +728,66 @@ function ProviderModelDefaultsSettings(props: {
             }
           />
         ) : null}
+        {pendingMigration ? (
+          <SettingsField
+            label={`Migrate ${pendingMigration.count} existing thread${
+              pendingMigration.count === 1 ? "" : "s"
+            }?`}
+            sub="Each matching thread will adopt this model and reasoning once when next opened. Manual changes made afterward will stick until you create another migration."
+            control={
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--primary"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => void createThreadMigration()}
+                >
+                  {applying ? "Creating…" : "Create migration"}
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => setPendingMigration(undefined)}
+                >
+                  Cancel
+                </button>
+              </div>
+            }
+          />
+        ) : null}
+        {pendingFastAction ? (
+          <SettingsField
+            label={
+              pendingFastAction.kind === "disable"
+                ? "Prohibit Fast for this profile?"
+                : "Turn Fast off everywhere?"
+            }
+            sub={`This will set ${pendingFastAction.threadCount} existing Codex thread${
+              pendingFastAction.threadCount === 1 ? "" : "s"
+            } and future launchpads to non-Fast. Models, reasoning, prompts, and access settings stay unchanged.`}
+            control={
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--primary"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => void applyFastAction()}
+                >
+                  {applying ? "Updating…" : "Turn Fast off"}
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => setPendingFastAction(undefined)}
+                >
+                  Cancel
+                </button>
+              </div>
+            }
+          />
+        ) : null}
         {status ? <p className="settings-empty">{status}</p> : null}
       </div>
     </SettingsSection>
@@ -561,6 +799,7 @@ function ProviderModelDefaultField(props: {
   defaults?: DesktopProviderModelDefaults;
   disabled: boolean;
   onApply: (model: string, reasoningEffort?: string) => void;
+  onMigrate: (model: string, reasoningEffort?: string) => void;
   onChange: (defaults: DesktopProviderModelDefaults | undefined) => void;
 }) {
   const models = props.backend.launchpadOptions?.models ?? [];
@@ -672,6 +911,17 @@ function ProviderModelDefaultField(props: {
                 )}
               >
                 Apply to launchpads
+              </button>
+              <button
+                className="button button--secondary"
+                disabled={props.disabled || !selectionAvailable}
+                type="button"
+                onClick={() => props.onMigrate(
+                  selectedModel,
+                  selectedReasoning || undefined,
+                )}
+              >
+                Apply to existing threads
               </button>
               <button
                 className="button button--ghost"

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
 import type {
+  BackendModelOption,
+  BackendSummary,
   DesktopCodexAuthProfileCandidate,
   DesktopCodexDiscoveryCandidate,
+  DesktopProviderModelDefaults,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -38,6 +42,9 @@ export function ModelsSettings(props: {
   onRefresh: () => Promise<void>;
   onSaveCodexPath: (path: string) => Promise<void>;
   onSaveCodexProfile: (profile: string) => Promise<void>;
+  onSaveProviderDefaults: (
+    defaults: Record<string, DesktopProviderModelDefaults>,
+  ) => Promise<void>;
   /** Persist a per-ACP-agent CLI-path override (also pins a discovered install). */
   onAcpCliPathChange: (registryId: string, cliPath: string) => Promise<void>;
   /** Persist a per-ACP-agent enabled flag (off = hidden from the model picker). */
@@ -48,6 +55,9 @@ export function ModelsSettings(props: {
     props.snapshot.models.codex.path.value.trim() ? "specified" : "auto",
   );
   const [grokKey, setGrokKey] = useState("");
+  const [backends, setBackends] = useState<BackendSummary[]>([]);
+  const [catalogError, setCatalogError] = useState<string | undefined>();
+  const [refreshingCatalog, setRefreshingCatalog] = useState(false);
   const codex = props.snapshot.models.codex;
   const grok = props.snapshot.models.grok.apiKey;
   const envForced = codex.path.source === "env";
@@ -71,6 +81,52 @@ export function ModelsSettings(props: {
     setCodexMode(codex.path.value.trim() || envForced ? "specified" : "auto");
   }, [codex.path.value, envForced]);
 
+  const refreshCatalog = async (
+    force = false,
+    refreshModels = false,
+  ): Promise<void> => {
+    if (!props.desktopApi?.listBackends) {
+      setCatalogError("Provider model discovery is unavailable in this build.");
+      return;
+    }
+    setRefreshingCatalog(true);
+    try {
+      if (force && props.desktopApi.listAcpAgents) {
+        await props.desktopApi.listAcpAgents({
+          refresh: true,
+          force: true,
+        });
+      }
+      const response = await props.desktopApi.listBackends({
+        includeUnavailable: true,
+        ...(force || refreshModels ? { refreshModels: true } : {}),
+      });
+      setBackends(response.backends);
+      setCatalogError(undefined);
+    } catch (error) {
+      setCatalogError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setRefreshingCatalog(false);
+    }
+  };
+
+  useEffect(() => {
+    void refreshCatalog(false, true);
+    // The settings surface is itself a catalog refresh boundary.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.desktopApi]);
+
+  useEffect(() => {
+    const refresh = (): void => {
+      void refreshCatalog(false);
+    };
+    window.addEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, refresh);
+    return () => {
+      window.removeEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, refresh);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.desktopApi]);
+
   const saveCodexPath = (path: string): void => {
     void props.onSaveCodexPath(path.trim());
   };
@@ -79,8 +135,19 @@ export function ModelsSettings(props: {
     <SettingsSectionStack paneId="models" aria-label="Model settings">
       <SettingsPanelHead
         eyebrow="Models"
-        title="Backends & credentials"
-        help="PwrAgent drives Codex and Grok. Use Auto Discovery to track the newest binary on disk, or pin a specific path."
+        title="AI providers"
+        help="Choose profile-wide model baselines, inspect discovered models, and configure provider credentials."
+      />
+
+      <ProviderModelDefaultsSettings
+        backends={backends}
+        desktopApi={props.desktopApi}
+        defaults={props.snapshot.models.providerDefaults ?? {}}
+        error={catalogError}
+        refreshing={refreshingCatalog}
+        saving={props.saving}
+        onRefresh={() => refreshCatalog(true, true)}
+        onSave={props.onSaveProviderDefaults}
       />
 
       <SettingsSection eyebrow="Models" title="Codex">
@@ -307,6 +374,327 @@ export function ModelsSettings(props: {
       />
     </SettingsSectionStack>
   );
+}
+
+function ProviderModelDefaultsSettings(props: {
+  backends: BackendSummary[];
+  desktopApi?: DesktopApi;
+  defaults: Record<string, DesktopProviderModelDefaults>;
+  error?: string;
+  refreshing: boolean;
+  saving: boolean;
+  onRefresh: () => Promise<void>;
+  onSave: (
+    defaults: Record<string, DesktopProviderModelDefaults>,
+  ) => Promise<void>;
+}) {
+  const [pendingApply, setPendingApply] = useState<{
+    backend: BackendSummary;
+    count: number;
+    directoryKeys: string[];
+    model: string;
+    reasoningEffort?: string;
+  }>();
+  const [applying, setApplying] = useState(false);
+  const [status, setStatus] = useState<string | undefined>();
+  const providers = props.backends.filter(
+    (backend) => (backend.launchpadOptions?.models?.length ?? 0) > 0,
+  );
+
+  const saveProvider = (
+    backend: BackendSummary,
+    next: DesktopProviderModelDefaults | undefined,
+  ): void => {
+    const updated = { ...props.defaults };
+    if (next) {
+      updated[backend.kind] = next;
+    } else {
+      delete updated[backend.kind];
+    }
+    void props.onSave(updated);
+  };
+
+  const previewApply = async (
+    backend: BackendSummary,
+    model: string,
+    reasoningEffort?: string,
+  ): Promise<void> => {
+    if (!props.desktopApi?.getNavigationSnapshot) {
+      setStatus("Launchpad updates are unavailable in this build.");
+      return;
+    }
+    const navigation = await props.desktopApi.getNavigationSnapshot();
+    const directoryKeys = navigation.directories
+      .filter((directory) => directory.launchpad?.backend === backend.kind)
+      .map((directory) => directory.key);
+    if (directoryKeys.length === 0) {
+      setStatus(`No ${backend.label} launchpads need updating.`);
+      return;
+    }
+    setStatus(undefined);
+    setPendingApply({
+      backend,
+      count: directoryKeys.length,
+      directoryKeys,
+      model,
+      reasoningEffort,
+    });
+  };
+
+  const applyToLaunchpads = async (): Promise<void> => {
+    if (!pendingApply || !props.desktopApi?.updateDirectoryLaunchpad) return;
+    setApplying(true);
+    try {
+      for (const directoryKey of pendingApply.directoryKeys) {
+        await props.desktopApi.updateDirectoryLaunchpad({
+          directoryKey,
+          patch: {
+            model: pendingApply.model,
+            reasoningEffort: pendingApply.reasoningEffort,
+          },
+          stickySettingsChanged: true,
+        });
+      }
+      setStatus(
+        `Updated ${pendingApply.count} ${pendingApply.backend.label} launchpad${
+          pendingApply.count === 1 ? "" : "s"
+        }. Existing threads were not changed.`,
+      );
+      setPendingApply(undefined);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      eyebrow="Defaults"
+      title="New thread defaults"
+      description="These profile-wide baselines fill new launchpads that do not already have a directory or learned provider choice."
+    >
+      <div className="settings-fields">
+        {providers.map((backend) => (
+          <ProviderModelDefaultField
+            key={backend.kind}
+            backend={backend}
+            defaults={props.defaults[backend.kind]}
+            disabled={props.saving || applying}
+            onApply={(model, reasoningEffort) => {
+              void previewApply(backend, model, reasoningEffort);
+            }}
+            onChange={(next) => saveProvider(backend, next)}
+          />
+        ))}
+        {providers.length === 0 ? (
+          <SettingsField
+            label="Discovered models"
+            sub={props.error ?? "No provider has reported a model catalog yet."}
+            control={
+              <button
+                className="button button--secondary"
+                disabled={props.refreshing}
+                type="button"
+                onClick={() => void props.onRefresh()}
+              >
+                {props.refreshing ? "Refreshing…" : "Refresh models"}
+              </button>
+            }
+          />
+        ) : (
+          <SettingsField
+            label="Model catalog"
+            sub={
+              props.error
+                ? `Last refresh failed: ${props.error}`
+                : "Refresh after installing or upgrading a provider CLI."
+            }
+            control={
+              <button
+                className="button button--secondary"
+                disabled={props.refreshing}
+                type="button"
+                onClick={() => void props.onRefresh()}
+              >
+                {props.refreshing ? "Refreshing…" : "Refresh models"}
+              </button>
+            }
+          />
+        )}
+        {pendingApply ? (
+          <SettingsField
+            label={`Apply to ${pendingApply.count} launchpad${
+              pendingApply.count === 1 ? "" : "s"
+            }?`}
+            sub="Prompts, attachments, work mode, access, Fast/service tier, and Codex Environment will stay unchanged."
+            control={
+              <div className="settings-inline-actions">
+                <button
+                  className="button button--primary"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => void applyToLaunchpads()}
+                >
+                  {applying ? "Applying…" : "Apply"}
+                </button>
+                <button
+                  className="button button--ghost"
+                  disabled={applying}
+                  type="button"
+                  onClick={() => setPendingApply(undefined)}
+                >
+                  Cancel
+                </button>
+              </div>
+            }
+          />
+        ) : null}
+        {status ? <p className="settings-empty">{status}</p> : null}
+      </div>
+    </SettingsSection>
+  );
+}
+
+function ProviderModelDefaultField(props: {
+  backend: BackendSummary;
+  defaults?: DesktopProviderModelDefaults;
+  disabled: boolean;
+  onApply: (model: string, reasoningEffort?: string) => void;
+  onChange: (defaults: DesktopProviderModelDefaults | undefined) => void;
+}) {
+  const models = props.backend.launchpadOptions?.models ?? [];
+  const selectedModel = props.defaults?.model ?? "";
+  const modelOption = models.find((model) => model.id === selectedModel);
+  const reasoningOptions = reasoningOptionsFor(
+    modelOption,
+    props.backend.launchpadOptions?.reasoningEfforts,
+  );
+  const selectedReasoning = selectedModel
+    ? props.defaults?.reasoningEffortsByModel[selectedModel] ?? ""
+    : "";
+  const selectionAvailable =
+    Boolean(modelOption)
+    && (
+      !selectedReasoning
+      || reasoningOptions.includes(selectedReasoning)
+    );
+
+  return (
+    <SettingsField
+      label={props.backend.label}
+      sub={
+        props.backend.available
+          ? `${models.length} discovered model${models.length === 1 ? "" : "s"}`
+          : props.backend.unavailableReason ?? "Provider unavailable"
+      }
+      control={
+        <div className="settings-paths">
+          <select
+            aria-label={`${props.backend.label} default model`}
+            className="settings-select"
+            disabled={props.disabled}
+            value={selectedModel}
+            onChange={(event) => {
+              const model = event.currentTarget.value;
+              if (!model) {
+                props.onChange(undefined);
+                return;
+              }
+              const option = models.find((candidate) => candidate.id === model);
+              const reasoningEffortsByModel = {
+                ...(props.defaults?.reasoningEffortsByModel ?? {}),
+              };
+              if (
+                option?.defaultReasoningEffort
+                && !reasoningEffortsByModel[model]
+              ) {
+                reasoningEffortsByModel[model] = option.defaultReasoningEffort;
+              }
+              props.onChange({ model, reasoningEffortsByModel });
+            }}
+          >
+            <option value="">Provider advertised default</option>
+            {selectedModel && !modelOption ? (
+              <option value={selectedModel}>{selectedModel} (unavailable)</option>
+            ) : null}
+            {models.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.label ?? model.id}
+              </option>
+            ))}
+          </select>
+          {selectedModel && reasoningOptions.length > 0 ? (
+            <select
+              aria-label={`${props.backend.label} default reasoning`}
+              className="settings-select"
+              disabled={props.disabled}
+              value={selectedReasoning}
+              onChange={(event) => {
+                const reasoningEffortsByModel = {
+                  ...(props.defaults?.reasoningEffortsByModel ?? {}),
+                };
+                const effort = event.currentTarget.value;
+                if (effort) {
+                  reasoningEffortsByModel[selectedModel] = effort;
+                } else {
+                  delete reasoningEffortsByModel[selectedModel];
+                }
+                props.onChange({
+                  model: selectedModel,
+                  reasoningEffortsByModel,
+                });
+              }}
+            >
+              <option value="">Provider advertised reasoning</option>
+              {selectedReasoning
+              && !reasoningOptions.includes(selectedReasoning) ? (
+                <option value={selectedReasoning}>
+                  {selectedReasoning} (unavailable)
+                </option>
+              ) : null}
+              {reasoningOptions.map((effort) => (
+                <option key={effort} value={effort}>
+                  {effort}
+                </option>
+              ))}
+            </select>
+          ) : null}
+          {selectedModel ? (
+            <div className="settings-inline-actions">
+              <button
+                className="button button--secondary"
+                disabled={props.disabled || !selectionAvailable}
+                type="button"
+                onClick={() => props.onApply(
+                  selectedModel,
+                  selectedReasoning || undefined,
+                )}
+              >
+                Apply to launchpads
+              </button>
+              <button
+                className="button button--ghost"
+                disabled={props.disabled}
+                type="button"
+                onClick={() => props.onChange(undefined)}
+              >
+                Reset
+              </button>
+            </div>
+          ) : null}
+        </div>
+      }
+    />
+  );
+}
+
+function reasoningOptionsFor(
+  model: BackendModelOption | undefined,
+  fallback: string[] | undefined,
+): string[] {
+  if (model?.supportsReasoning === false) return [];
+  return model?.reasoningEfforts ?? fallback ?? [];
 }
 
 function CodexProfileRow(props: {

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -42,6 +42,7 @@ export function ModelsSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onRefresh: () => Promise<void>;
+  onRefreshNavigation?: () => Promise<void>;
   onSaveCodexPath: (path: string) => Promise<void>;
   onSaveCodexProfile: (profile: string) => Promise<void>;
   onSaveProviderDefaults: (
@@ -155,6 +156,7 @@ export function ModelsSettings(props: {
         refreshing={refreshingCatalog}
         saving={props.saving}
         onRefresh={() => refreshCatalog(true, true)}
+        onRefreshNavigation={props.onRefreshNavigation}
         onSave={props.onSaveProviderDefaults}
         onSaveMigrations={props.onSaveProviderThreadMigrations}
         onSaveCodexFastAllowed={props.onSaveCodexFastAllowed}
@@ -396,6 +398,7 @@ function ProviderModelDefaultsSettings(props: {
   refreshing: boolean;
   saving: boolean;
   onRefresh: () => Promise<void>;
+  onRefreshNavigation?: () => Promise<void>;
   onSave: (
     defaults: Record<string, DesktopProviderModelDefaults>,
   ) => Promise<void>;
@@ -590,6 +593,7 @@ function ProviderModelDefaultsSettings(props: {
         }
       }
       const result = await props.desktopApi.turnOffCodexFastEverywhere();
+      await props.onRefreshNavigation?.();
       setStatus(
         `Fast is off for ${result.threadCount} Codex thread${
           result.threadCount === 1 ? "" : "s"

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -42,7 +42,6 @@ export function ModelsSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onRefresh: () => Promise<void>;
-  onRefreshNavigation?: () => Promise<void>;
   onSaveCodexPath: (path: string) => Promise<void>;
   onSaveCodexProfile: (profile: string) => Promise<void>;
   onSaveProviderDefaults: (
@@ -156,7 +155,6 @@ export function ModelsSettings(props: {
         refreshing={refreshingCatalog}
         saving={props.saving}
         onRefresh={() => refreshCatalog(true, true)}
-        onRefreshNavigation={props.onRefreshNavigation}
         onSave={props.onSaveProviderDefaults}
         onSaveMigrations={props.onSaveProviderThreadMigrations}
         onSaveCodexFastAllowed={props.onSaveCodexFastAllowed}
@@ -398,7 +396,6 @@ function ProviderModelDefaultsSettings(props: {
   refreshing: boolean;
   saving: boolean;
   onRefresh: () => Promise<void>;
-  onRefreshNavigation?: () => Promise<void>;
   onSave: (
     defaults: Record<string, DesktopProviderModelDefaults>,
   ) => Promise<void>;
@@ -593,7 +590,6 @@ function ProviderModelDefaultsSettings(props: {
         }
       }
       const result = await props.desktopApi.turnOffCodexFastEverywhere();
-      await props.onRefreshNavigation?.();
       setStatus(
         `Fast is off for ${result.threadCount} Codex thread${
           result.threadCount === 1 ? "" : "s"

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   BackendModelOption,
   BackendSummary,
@@ -31,6 +31,23 @@ import { AcpAgentsSettings } from "./AcpAgentsSettings";
 import { SettingsSwitch } from "./SettingsSwitch";
 
 type CodexPathMode = "auto" | "specified";
+
+const UNSPECIFIED_SOURCE_MODEL_KEY = "\0unspecified";
+
+type ThreadMigrationSourceGroup = {
+  count: number;
+  key: string;
+  label: string;
+  model?: string;
+};
+
+type PendingThreadMigration = {
+  backend: BackendSummary;
+  model: string;
+  reasoningEffort?: string;
+  selectedSourceKeys: string[];
+  sourceGroups: ThreadMigrationSourceGroup[];
+};
 
 export function ModelsSettings(props: {
   cachedBackends?: BackendSummary[];
@@ -420,12 +437,8 @@ function ProviderModelDefaultsSettings(props: {
     model: string;
     reasoningEffort?: string;
   }>();
-  const [pendingMigration, setPendingMigration] = useState<{
-    backend: BackendSummary;
-    count: number;
-    model: string;
-    reasoningEffort?: string;
-  }>();
+  const [pendingMigration, setPendingMigration] =
+    useState<PendingThreadMigration>();
   const [pendingFastAction, setPendingFastAction] = useState<{
     kind: "disable" | "turn-off";
     threadCount: number;
@@ -515,26 +528,66 @@ function ProviderModelDefaultsSettings(props: {
       return;
     }
     const navigation = await props.desktopApi.getNavigationSnapshot();
-    const count = navigation.threads.filter(
+    const threads = navigation.threads.filter(
       (thread) => thread.source === backend.kind,
-    ).length;
-    if (count === 0) {
+    );
+    if (threads.length === 0) {
       setStatus(`No existing ${backend.label} threads need a migration.`);
       return;
     }
+    const modelLabels = new Map(
+      (backend.launchpadOptions?.models ?? []).map((option) => [
+        option.id,
+        option.label ?? option.id,
+      ]),
+    );
+    const sourceCounts = new Map<string, number>();
+    for (const thread of threads) {
+      const key = thread.model?.trim() || UNSPECIFIED_SOURCE_MODEL_KEY;
+      sourceCounts.set(key, (sourceCounts.get(key) ?? 0) + 1);
+    }
+    const sourceGroups = [...sourceCounts.entries()]
+      .map(([key, count]): ThreadMigrationSourceGroup => {
+        if (key === UNSPECIFIED_SOURCE_MODEL_KEY) {
+          return {
+            count,
+            key,
+            label: "Provider default / unknown",
+          };
+        }
+        return {
+          count,
+          key,
+          label: modelLabels.get(key) ?? key,
+          model: key,
+        };
+      })
+      .sort((left, right) => left.label.localeCompare(right.label));
     setStatus(undefined);
     setPendingApply(undefined);
     setPendingFastAction(undefined);
     setPendingMigration({
       backend,
-      count,
       model,
       reasoningEffort,
+      selectedSourceKeys: sourceGroups
+        .filter((group) => group.model !== model)
+        .map((group) => group.key),
+      sourceGroups,
     });
   };
 
   const createThreadMigration = async (): Promise<void> => {
     if (!pendingMigration) return;
+    const selectedSourceKeys = new Set(pendingMigration.selectedSourceKeys);
+    const selectedGroups = pendingMigration.sourceGroups.filter(
+      (group) => selectedSourceKeys.has(group.key),
+    );
+    const threadCount = selectedGroups.reduce(
+      (count, group) => count + group.count,
+      0,
+    );
+    if (threadCount === 0) return;
     setApplying(true);
     try {
       const createdAt = Date.now();
@@ -546,6 +599,12 @@ function ProviderModelDefaultsSettings(props: {
           ...(pendingMigration.reasoningEffort
             ? { reasoningEffort: pendingMigration.reasoningEffort }
             : {}),
+          sourceModels: selectedGroups.flatMap((group) =>
+            group.model ? [group.model] : [],
+          ),
+          ...(selectedSourceKeys.has(UNSPECIFIED_SOURCE_MODEL_KEY)
+            ? { includeThreadsWithoutModel: true }
+            : {}),
           createdAt,
         },
       });
@@ -554,8 +613,8 @@ function ProviderModelDefaultsSettings(props: {
         return;
       }
       setStatus(
-        `${pendingMigration.count} ${pendingMigration.backend.label} thread${
-          pendingMigration.count === 1 ? "" : "s"
+        `${threadCount} ${pendingMigration.backend.label} thread${
+          threadCount === 1 ? "" : "s"
         } will adopt ${pendingMigration.model} when next opened.`,
       );
       setPendingMigration(undefined);
@@ -580,7 +639,7 @@ function ProviderModelDefaultsSettings(props: {
     setPendingFastAction({
       kind,
       threadCount: navigation.threads.filter(
-        (thread) => thread.source === "codex",
+        (thread) => thread.source === "codex" && thread.fastMode === true,
       ).length,
     });
   };
@@ -665,14 +724,11 @@ function ProviderModelDefaultsSettings(props: {
               applying={applying}
               fastMode={fastMode}
               pendingApply={providerPendingApply}
-              pendingMigration={providerPendingMigration}
               onApply={(model, reasoningEffort) => {
                 void previewApply(backend, model, reasoningEffort);
               }}
               onCancelApply={() => setPendingApply(undefined)}
               onConfirmApply={() => void applyToLaunchpads()}
-              onCancelMigration={() => setPendingMigration(undefined)}
-              onConfirmMigration={() => void createThreadMigration()}
               onMigrate={(model, reasoningEffort) => {
                 void previewThreadMigration(backend, model, reasoningEffort);
               }}
@@ -717,7 +773,197 @@ function ProviderModelDefaultsSettings(props: {
         )}
         {status ? <p className="settings-empty">{status}</p> : null}
       </div>
+      {pendingMigration ? (
+        <ThreadMigrationDialog
+          applying={applying}
+          migration={pendingMigration}
+          onCancel={() => setPendingMigration(undefined)}
+          onConfirm={() => void createThreadMigration()}
+          onSelectionChange={(selectedSourceKeys) => {
+            setPendingMigration((current) =>
+              current ? { ...current, selectedSourceKeys } : current,
+            );
+          }}
+        />
+      ) : null}
     </SettingsSection>
+  );
+}
+
+function ThreadMigrationDialog(props: {
+  applying: boolean;
+  migration: PendingThreadMigration;
+  onCancel: () => void;
+  onConfirm: () => void;
+  onSelectionChange: (selectedSourceKeys: string[]) => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const selectionAnchorRef = useRef<number | undefined>(undefined);
+  const applying = props.applying;
+  const onCancel = props.onCancel;
+  const selectedSourceKeys = new Set(props.migration.selectedSourceKeys);
+  const selectedThreadCount = props.migration.sourceGroups.reduce(
+    (count, group) =>
+      count + (selectedSourceKeys.has(group.key) ? group.count : 0),
+    0,
+  );
+
+  useEffect(() => {
+    dialogRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape" && !applying) {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [applying, onCancel]);
+
+  const toggleSourceGroup = (index: number, shiftKey: boolean): void => {
+    const group = props.migration.sourceGroups[index];
+    if (!group) return;
+    const next = new Set(selectedSourceKeys);
+    const shouldSelect = !next.has(group.key);
+    if (shiftKey && selectionAnchorRef.current !== undefined) {
+      const start = Math.min(selectionAnchorRef.current, index);
+      const end = Math.max(selectionAnchorRef.current, index);
+      for (
+        const rangeGroup of
+        props.migration.sourceGroups.slice(start, end + 1)
+      ) {
+        if (shouldSelect) {
+          next.add(rangeGroup.key);
+        } else {
+          next.delete(rangeGroup.key);
+        }
+      }
+    } else if (shouldSelect) {
+      next.add(group.key);
+    } else {
+      next.delete(group.key);
+    }
+    selectionAnchorRef.current = index;
+    props.onSelectionChange([...next]);
+  };
+
+  return (
+    <div className="settings-confirm-modal" role="presentation">
+      <div
+        ref={dialogRef}
+        aria-describedby="thread-migration-description"
+        aria-labelledby="thread-migration-heading"
+        aria-modal="true"
+        className="settings-confirm-dialog settings-thread-migration-dialog"
+        role="dialog"
+        tabIndex={-1}
+      >
+        <h2 id="thread-migration-heading">
+          Choose {props.migration.backend.label} threads to update
+        </h2>
+        <p id="thread-migration-description">
+          Select the models currently used by threads that should adopt{" "}
+          <strong>{props.migration.model}</strong>
+          {props.migration.reasoningEffort
+            ? ` with ${props.migration.reasoningEffort} reasoning`
+            : ""}
+          . Each selected thread changes once when next opened. Newer threads and
+          unselected models stay unchanged.
+        </p>
+        <div className="settings-thread-migration-dialog__toolbar">
+          <span>
+            {selectedThreadCount} of{" "}
+            {props.migration.sourceGroups.reduce(
+              (count, group) => count + group.count,
+              0,
+            )}{" "}
+            threads selected
+          </span>
+          <div className="settings-inline-actions">
+            <button
+              className="button button--ghost"
+              disabled={props.applying}
+              type="button"
+              onClick={() => props.onSelectionChange(
+                props.migration.sourceGroups.map((group) => group.key),
+              )}
+            >
+              Select all
+            </button>
+            <button
+              className="button button--ghost"
+              disabled={props.applying}
+              type="button"
+              onClick={() => props.onSelectionChange([])}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+        <div
+          aria-label="Current thread models"
+          aria-multiselectable="true"
+          className="settings-thread-migration-dialog__list"
+          role="listbox"
+        >
+          {props.migration.sourceGroups.map((group, index) => {
+            const selected = selectedSourceKeys.has(group.key);
+            return (
+              <button
+                key={group.key}
+                aria-selected={selected}
+                className="settings-thread-migration-dialog__option"
+                disabled={props.applying}
+                role="option"
+                type="button"
+                onClick={(event) => toggleSourceGroup(index, event.shiftKey)}
+              >
+                <span
+                  aria-hidden="true"
+                  className="settings-thread-migration-dialog__check"
+                >
+                  {selected ? "✓" : ""}
+                </span>
+                <span className="settings-thread-migration-dialog__model">
+                  {group.label}
+                  {group.model === props.migration.model ? (
+                    <small>destination model</small>
+                  ) : null}
+                </span>
+                <span className="settings-thread-migration-dialog__count">
+                  {group.count} thread{group.count === 1 ? "" : "s"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <p className="settings-thread-migration-dialog__hint">
+          Click or ⌘-click to toggle a model. Shift-click selects a range.
+        </p>
+        <div className="settings-confirm-dialog__actions">
+          <button
+            className="button button--secondary"
+            disabled={props.applying}
+            type="button"
+            onClick={props.onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            className="button button--primary"
+            disabled={props.applying || selectedThreadCount === 0}
+            type="button"
+            onClick={props.onConfirm}
+          >
+            {props.applying
+              ? "Creating migration…"
+              : `Update ${selectedThreadCount} thread${
+                  selectedThreadCount === 1 ? "" : "s"
+                }`}
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -740,14 +986,9 @@ function ProviderModelDefaultField(props: {
   pendingApply?: {
     count: number;
   };
-  pendingMigration?: {
-    count: number;
-  };
   onApply: (model: string, reasoningEffort?: string) => void;
   onCancelApply: () => void;
   onConfirmApply: () => void;
-  onCancelMigration: () => void;
-  onConfirmMigration: () => void;
   onMigrate: (model: string, reasoningEffort?: string) => void;
   onChange: (defaults: DesktopProviderModelDefaults | undefined) => void;
 }) {
@@ -861,17 +1102,6 @@ function ProviderModelDefaultField(props: {
               onCancel={props.onCancelApply}
               onConfirm={props.onConfirmApply}
             />
-          ) : props.pendingMigration ? (
-            <InlineActionConfirmation
-              applying={props.applying}
-              confirmLabel="Create migration"
-              label={`Migrate ${props.pendingMigration.count} existing thread${
-                props.pendingMigration.count === 1 ? "" : "s"
-              }?`}
-              sub="Each matching thread will adopt this model and reasoning once when next opened. Manual changes made afterward will stick until you create another migration."
-              onCancel={props.onCancelMigration}
-              onConfirm={props.onConfirmMigration}
-            />
           ) : selectedModel ? (
             <div className="settings-inline-actions">
               <button
@@ -894,7 +1124,7 @@ function ProviderModelDefaultField(props: {
                   selectedReasoning || undefined,
                 )}
               >
-                Apply to existing threads
+                Apply to existing threads…
               </button>
               <button
                 className="button button--ghost"

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -670,6 +670,11 @@ function SettingsSectionBody(props: {
           },
         });
       }}
+      onSaveProviderDefaults={async (providerDefaults) => {
+        await props.settings.writeConfig({
+          models: { providerDefaults },
+        });
+      }}
       onAcpCliPathChange={async (registryId, cliPath) => {
         await props.settings.writeConfig({
           acpAgents: { [registryId]: { cliPath } } as NonNullable<

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -675,6 +675,18 @@ function SettingsSectionBody(props: {
           models: { providerDefaults },
         });
       }}
+      onSaveProviderThreadMigrations={async (providerThreadMigrations) => {
+        return await props.settings.writeConfig({
+          models: { providerThreadMigrations },
+        });
+      }}
+      onSaveCodexFastAllowed={async (allowFast) => {
+        return await props.settings.writeConfig({
+          models: {
+            codex: { allowFast },
+          },
+        });
+      }}
       onAcpCliPathChange={async (registryId, cliPath) => {
         await props.settings.writeConfig({
           acpAgents: { [registryId]: { cliPath } } as NonNullable<

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -1,4 +1,5 @@
 import type {
+  BackendSummary,
   DesktopHotCpuProfileStartDelayMs,
   DesktopHotCpuProfileTriggerMode,
   DesktopSettingsConfigPatch,
@@ -92,6 +93,7 @@ export function SettingsScreen(props: {
    *  it without compile errors — the Appearance UI is hidden there
    *  anyway because the snapshot is unavailable. */
   appearanceController?: AppearanceController;
+  cachedBackends?: BackendSummary[];
   desktopApi?: DesktopApi;
   profiles?: PwrAgentProfilesState;
   settings: DesktopSettingsState;
@@ -277,6 +279,7 @@ export function SettingsScreen(props: {
           ) : snapshot ? (
             <SettingsSectionBody
               appearanceController={props.appearanceController}
+              cachedBackends={props.cachedBackends}
               desktopApi={props.desktopApi}
               profiles={props.profiles}
               section={section}
@@ -297,6 +300,7 @@ export function SettingsScreen(props: {
 
 function SettingsSectionBody(props: {
   appearanceController?: AppearanceController;
+  cachedBackends?: BackendSummary[];
   desktopApi?: DesktopApi;
   profiles?: PwrAgentProfilesState;
   section: SettingsSection;
@@ -650,6 +654,7 @@ function SettingsSectionBody(props: {
 
   return (
     <ModelsSettings
+      cachedBackends={props.cachedBackends}
       desktopApi={props.desktopApi}
       saving={props.settings.saving}
       snapshot={props.snapshot}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -98,6 +98,9 @@ export function SettingsScreen(props: {
   /** Initial section to render. Defaults to Applications. */
   initialSection?: SettingsSection;
   onClose?: () => void;
+  /** Refreshes the live thread/launchpad state after Settings performs a
+   *  bulk mutation that bypasses the normal composer update path. */
+  onRefreshNavigation?: () => Promise<void>;
   /** Fired from the title-bar messaging controller.
    *  The App-level handler closes the Settings overlay and opens the
    *  Messaging Activity overlay (its own top-level mainView). */
@@ -282,6 +285,7 @@ export function SettingsScreen(props: {
               section={section}
               settings={props.settings}
               snapshot={snapshot}
+              onRefreshNavigation={props.onRefreshNavigation}
             />
           ) : (
             <p className="settings-empty">Settings are unavailable.</p>
@@ -302,6 +306,7 @@ function SettingsSectionBody(props: {
   section: SettingsSection;
   settings: DesktopSettingsState;
   snapshot: DesktopSettingsSnapshot;
+  onRefreshNavigation?: () => Promise<void>;
 }) {
   if (props.section === "about") {
     return <AboutSettings desktopApi={props.desktopApi} />;
@@ -656,6 +661,7 @@ function SettingsSectionBody(props: {
       onClearSecret={props.settings.clearSecret}
       onReplaceSecret={props.settings.replaceSecret}
       onRefresh={props.settings.refresh}
+      onRefreshNavigation={props.onRefreshNavigation}
       onSaveCodexPath={async (path) => {
         await props.settings.writeConfig({
           models: {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -98,9 +98,6 @@ export function SettingsScreen(props: {
   /** Initial section to render. Defaults to Applications. */
   initialSection?: SettingsSection;
   onClose?: () => void;
-  /** Refreshes the live thread/launchpad state after Settings performs a
-   *  bulk mutation that bypasses the normal composer update path. */
-  onRefreshNavigation?: () => Promise<void>;
   /** Fired from the title-bar messaging controller.
    *  The App-level handler closes the Settings overlay and opens the
    *  Messaging Activity overlay (its own top-level mainView). */
@@ -285,7 +282,6 @@ export function SettingsScreen(props: {
               section={section}
               settings={props.settings}
               snapshot={snapshot}
-              onRefreshNavigation={props.onRefreshNavigation}
             />
           ) : (
             <p className="settings-empty">Settings are unavailable.</p>
@@ -306,7 +302,6 @@ function SettingsSectionBody(props: {
   section: SettingsSection;
   settings: DesktopSettingsState;
   snapshot: DesktopSettingsSnapshot;
-  onRefreshNavigation?: () => Promise<void>;
 }) {
   if (props.section === "about") {
     return <AboutSettings desktopApi={props.desktopApi} />;
@@ -661,7 +656,6 @@ function SettingsSectionBody(props: {
       onClearSecret={props.settings.clearSecret}
       onReplaceSecret={props.settings.replaceSecret}
       onRefresh={props.settings.refresh}
-      onRefreshNavigation={props.onRefreshNavigation}
       onSaveCodexPath={async (path) => {
         await props.settings.writeConfig({
           models: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1679,6 +1679,16 @@ describe("SettingsScreen", () => {
                   reasoningEfforts: ["low", "high", "xhigh"],
                   supportsReasoning: true,
                 },
+                {
+                  id: "gpt-5.6-terra",
+                  label: "GPT-5.6-Terra",
+                  supportsReasoning: true,
+                },
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  supportsReasoning: true,
+                },
               ],
             },
           },
@@ -1738,6 +1748,8 @@ describe("SettingsScreen", () => {
             updatedAt: 1,
             linkedDirectories: [],
             source: "codex" as const,
+            model: "gpt-5.5",
+            fastMode: true,
             inbox: { inInbox: true },
           },
           {
@@ -1747,6 +1759,19 @@ describe("SettingsScreen", () => {
             updatedAt: 1,
             linkedDirectories: [],
             source: "codex" as const,
+            model: "gpt-5.6-terra",
+            fastMode: true,
+            inbox: { inInbox: true },
+          },
+          {
+            id: "codex-3",
+            title: "Codex three",
+            createdAt: 1,
+            updatedAt: 1,
+            linkedDirectories: [],
+            source: "codex" as const,
+            model: "gpt-5.6-sol",
+            fastMode: false,
             inbox: { inInbox: true },
           },
           {
@@ -1823,18 +1848,49 @@ describe("SettingsScreen", () => {
     ).toHaveClass("settings-select--chip");
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Apply to existing threads" }),
+      screen.getByRole("button", { name: "Apply to existing threads…" }),
     );
-    const migrationConfirmation =
-      await screen.findByText("Migrate 2 existing threads?");
-    expect(migrationConfirmation.closest(".settings-field")).toHaveTextContent(
-      "Codex",
+    const migrationDialog = await screen.findByRole("dialog", {
+      name: "Choose Codex threads to update",
+    });
+    expect(
+      within(migrationDialog).getByText("2 of 3 threads selected"),
+    ).toBeInTheDocument();
+    const terraGroup = within(migrationDialog).getByRole("option", {
+      name: /GPT-5.6-Terra.*1 thread/,
+    });
+    const oldModelGroup = within(migrationDialog).getByRole("option", {
+      name: /GPT-5.5.*1 thread/,
+    });
+    const destinationGroup = within(migrationDialog).getByRole("option", {
+      name: /GPT-5.6-Sol.*destination model.*1 thread/,
+    });
+    expect(terraGroup).toHaveAttribute("aria-selected", "true");
+    expect(destinationGroup).toHaveAttribute("aria-selected", "false");
+    fireEvent.click(
+      within(migrationDialog).getByRole("button", { name: "Clear" }),
     );
     expect(
-      screen.queryByRole("button", { name: "Apply to existing threads" }),
-    ).not.toBeInTheDocument();
+      within(migrationDialog).getByText("0 of 3 threads selected"),
+    ).toBeInTheDocument();
+    fireEvent.click(oldModelGroup);
+    fireEvent.click(destinationGroup, { shiftKey: true });
+    expect(
+      within(migrationDialog).getByText("2 of 3 threads selected"),
+    ).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Create migration" }),
+      within(migrationDialog).getByRole("button", { name: "Clear" }),
+    );
+    fireEvent.click(oldModelGroup);
+    expect(
+      within(migrationDialog).getByText("1 of 3 threads selected"),
+    ).toBeInTheDocument();
+    expect(terraGroup).toHaveAttribute("aria-selected", "false");
+    expect(oldModelGroup).toHaveAttribute("aria-selected", "true");
+    fireEvent.click(
+      within(migrationDialog).getByRole("button", {
+        name: "Update 1 thread",
+      }),
     );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
@@ -1844,6 +1900,7 @@ describe("SettingsScreen", () => {
               revision: expect.any(String),
               model: "gpt-5.6-sol",
               reasoningEffort: "high",
+              sourceModels: ["gpt-5.5"],
               createdAt: expect.any(Number),
             },
           },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1750,6 +1750,12 @@ describe("SettingsScreen", () => {
         "Updated 1 Codex launchpad. Existing threads were not changed.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Codex default model" }),
+    ).toHaveClass("settings-select--chip");
+    expect(
+      screen.getByRole("combobox", { name: "Codex default reasoning" }),
+    ).toHaveClass("settings-select--chip");
 
     fireEvent.click(
       screen.getByRole("button", { name: "Apply to existing threads" }),
@@ -1786,7 +1792,10 @@ describe("SettingsScreen", () => {
     const fastConfirmation =
       await screen.findByText("Turn Fast off everywhere?");
     expect(fastConfirmation.closest(".settings-field")).toHaveTextContent(
-      "Codex Fast mode",
+      "Codex",
+    );
+    expect(fastConfirmation.closest(".settings-field")).toHaveTextContent(
+      "Fast mode",
     );
     expect(
       screen.queryByRole("button", { name: "Turn Fast off everywhere" }),

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1540,7 +1540,7 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
   });
 
-  it("saves per-model reasoning and explicitly applies defaults to matching launchpads", async () => {
+  it("saves defaults and confirms launchpad, thread, and Fast bulk actions", async () => {
     const snapshot = createSnapshot();
     snapshot.models.providerDefaults = {
       codex: {
@@ -1572,6 +1572,10 @@ describe("SettingsScreen", () => {
         model: request.patch.model,
         reasoningEffort: request.patch.reasoningEffort,
       },
+    }));
+    const turnOffCodexFastEverywhere = vi.fn(async () => ({
+      launchpadCount: 1,
+      threadCount: 2,
     }));
     const desktopApi = {
       listAcpAgents: vi.fn(async () => ({
@@ -1661,8 +1665,37 @@ describe("SettingsScreen", () => {
           executionMode: "default" as const,
           workMode: "local" as const,
         },
-        threads: [],
+        threads: [
+          {
+            id: "codex-1",
+            title: "Codex one",
+            createdAt: 1,
+            updatedAt: 1,
+            linkedDirectories: [],
+            source: "codex" as const,
+            inbox: { inInbox: true },
+          },
+          {
+            id: "codex-2",
+            title: "Codex two",
+            createdAt: 1,
+            updatedAt: 1,
+            linkedDirectories: [],
+            source: "codex" as const,
+            inbox: { inInbox: true },
+          },
+          {
+            id: "kimi-1",
+            title: "Kimi",
+            createdAt: 1,
+            updatedAt: 1,
+            linkedDirectories: [],
+            source: "acp:kimi" as const,
+            inbox: { inInbox: true },
+          },
+        ],
       })),
+      turnOffCodexFastEverywhere,
       updateDirectoryLaunchpad,
     } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
 
@@ -1712,6 +1745,64 @@ describe("SettingsScreen", () => {
         "Updated 1 Codex launchpad. Existing threads were not changed.",
       ),
     ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Apply to existing threads" }),
+    );
+    expect(
+      await screen.findByText("Migrate 2 existing threads?"),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create migration" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          providerThreadMigrations: {
+            codex: {
+              revision: expect.any(String),
+              model: "gpt-5.6-sol",
+              reasoningEffort: "high",
+              createdAt: expect.any(Number),
+            },
+          },
+        },
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Turn Fast off everywhere" }),
+    );
+    expect(
+      await screen.findByText("Turn Fast off everywhere?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Turn Fast off" }));
+    await waitFor(() => {
+      expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      screen.getByText(
+        "Fast is off for 2 Codex threads and 1 saved launchpad. Future Codex launchpads will also start non-Fast.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Allow Codex Fast mode" }),
+    );
+    expect(
+      await screen.findByText("Prohibit Fast for this profile?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Turn Fast off" }));
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          codex: {
+            allowFast: false,
+          },
+        },
+      });
+    });
+    expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(2);
   });
 
   it("can restart login for an existing Codex auth profile", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1577,7 +1577,6 @@ describe("SettingsScreen", () => {
       launchpadCount: 1,
       threadCount: 2,
     }));
-    const refreshNavigation = vi.fn(async () => undefined);
     const desktopApi = {
       listAcpAgents: vi.fn(async () => ({
         fetchedAt: 1000,
@@ -1705,7 +1704,6 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         initialSection="models"
         settings={settings}
-        onRefreshNavigation={refreshNavigation}
       />,
     );
 
@@ -1805,7 +1803,6 @@ describe("SettingsScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: "Turn Fast off" }));
     await waitFor(() => {
       expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(1);
-      expect(refreshNavigation).toHaveBeenCalledTimes(1);
     });
     expect(
       screen.getByText(
@@ -1830,7 +1827,6 @@ describe("SettingsScreen", () => {
       });
     });
     expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(2);
-    expect(refreshNavigation).toHaveBeenCalledTimes(2);
   });
 
   it("can restart login for an existing Codex auth profile", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1789,7 +1789,7 @@ describe("SettingsScreen", () => {
       updateDirectoryLaunchpad,
     } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
 
-    render(
+    const { rerender } = render(
       <SettingsScreen
         desktopApi={desktopApi}
         initialSection="models"
@@ -1848,13 +1848,13 @@ describe("SettingsScreen", () => {
     ).toHaveClass("settings-select--chip");
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Apply to existing threads…" }),
+      screen.getByRole("button", { name: "Schedule existing threads…" }),
     );
     const migrationDialog = await screen.findByRole("dialog", {
       name: "Choose Codex threads to update",
     });
     expect(
-      within(migrationDialog).getByText("2 of 3 threads selected"),
+      within(migrationDialog).getByText("2 selected of 3 threads"),
     ).toBeInTheDocument();
     const terraGroup = within(migrationDialog).getByRole("option", {
       name: /GPT-5.6-Terra.*1 thread/,
@@ -1871,25 +1871,25 @@ describe("SettingsScreen", () => {
       within(migrationDialog).getByRole("button", { name: "Clear" }),
     );
     expect(
-      within(migrationDialog).getByText("0 of 3 threads selected"),
+      within(migrationDialog).getByText("0 selected of 3 threads"),
     ).toBeInTheDocument();
     fireEvent.click(oldModelGroup);
     fireEvent.click(destinationGroup, { shiftKey: true });
     expect(
-      within(migrationDialog).getByText("2 of 3 threads selected"),
+      within(migrationDialog).getByText("2 selected of 3 threads"),
     ).toBeInTheDocument();
     fireEvent.click(
       within(migrationDialog).getByRole("button", { name: "Clear" }),
     );
     fireEvent.click(oldModelGroup);
     expect(
-      within(migrationDialog).getByText("1 of 3 threads selected"),
+      within(migrationDialog).getByText("1 selected of 3 threads"),
     ).toBeInTheDocument();
     expect(terraGroup).toHaveAttribute("aria-selected", "false");
     expect(oldModelGroup).toHaveAttribute("aria-selected", "true");
     fireEvent.click(
       within(migrationDialog).getByRole("button", {
-        name: "Update 1 thread",
+        name: "Schedule 1 thread",
       }),
     );
     await waitFor(() => {
@@ -1907,6 +1907,55 @@ describe("SettingsScreen", () => {
         },
       });
     });
+    expect(
+      within(migrationDialog).getByText(/This exact migration is already scheduled/),
+    ).toHaveTextContent(
+      "1 thread is still pending; 0 already acknowledged this revision.",
+    );
+    expect(
+      within(migrationDialog).getByRole("button", {
+        name: "Already scheduled",
+      }),
+    ).toBeDisabled();
+    fireEvent.click(
+      within(migrationDialog).getByRole("button", { name: "Cancel" }),
+    );
+
+    snapshot.models.providerThreadMigrations = {
+      codex: {
+        revision: "saved-migration",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+        sourceModels: ["gpt-5.5"],
+        createdAt: Date.now(),
+      },
+    };
+    rerender(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        initialSection="models"
+        settings={settings}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Schedule existing threads…" }),
+    );
+    const scheduledDialog = await screen.findByRole("dialog", {
+      name: "Choose Codex threads to update",
+    });
+    expect(
+      within(scheduledDialog).getByText(/This exact migration is already scheduled/),
+    ).toHaveTextContent(
+      "1 thread is still pending; 0 already acknowledged this revision.",
+    );
+    expect(
+      within(scheduledDialog).getByRole("button", {
+        name: "Already scheduled",
+      }),
+    ).toBeDisabled();
+    fireEvent.click(
+      within(scheduledDialog).getByRole("button", { name: "Cancel" }),
+    );
 
     fireEvent.click(
       screen.getByRole("button", { name: "Turn Fast off everywhere" }),

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1540,6 +1540,180 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
   });
 
+  it("saves per-model reasoning and explicitly applies defaults to matching launchpads", async () => {
+    const snapshot = createSnapshot();
+    snapshot.models.providerDefaults = {
+      codex: {
+        model: "gpt-5.6-sol",
+        reasoningEffortsByModel: {
+          "gpt-5.6-sol": "high",
+        },
+      },
+    };
+    const settings = createSettingsState(snapshot);
+    const updateDirectoryLaunchpad = vi.fn(async (request) => ({
+      launchpad: {
+        directoryKey: request.directoryKey,
+        directoryKind: "directory" as const,
+        directoryLabel: "Repo",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        workMode: "local" as const,
+        prompt: "",
+        model: request.patch.model,
+        reasoningEffort: request.patch.reasoningEffort,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        workMode: "local" as const,
+        model: request.patch.model,
+        reasoningEffort: request.patch.reasoningEffort,
+      },
+    }));
+    const desktopApi = {
+      listAcpAgents: vi.fn(async () => ({
+        fetchedAt: 1000,
+        entries: [],
+      })),
+      listBackends: vi.fn(async () => ({
+        fetchedAt: 1000,
+        backends: [
+          {
+            kind: "codex" as const,
+            label: "Codex",
+            available: true,
+            methods: [],
+            capabilities: {
+              listThreads: true,
+              createThread: true,
+              resumeThread: true,
+              renameThread: true,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: true,
+              steerTurn: true,
+              transcriptPagination: true,
+              toolUse: true,
+              approvalRequests: true,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [],
+            launchpadOptions: {
+              models: [
+                {
+                  id: "gpt-5.6-sol",
+                  label: "GPT-5.6-Sol",
+                  defaultReasoningEffort: "low",
+                  reasoningEfforts: ["low", "high", "xhigh"],
+                  supportsReasoning: true,
+                },
+              ],
+            },
+          },
+        ],
+      })),
+      getNavigationSnapshot: vi.fn(async () => ({
+        fetchedAt: 1000,
+        browseMode: "inbox" as const,
+        directories: [
+          {
+            key: "directory:/repo-a",
+            kind: "directory" as const,
+            label: "Repo A",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad: {
+              directoryKey: "directory:/repo-a",
+              directoryKind: "directory" as const,
+              directoryLabel: "Repo A",
+              backend: "codex" as const,
+              executionMode: "default" as const,
+              workMode: "local" as const,
+              prompt: "keep me",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          },
+          {
+            key: "directory:/repo-b",
+            kind: "directory" as const,
+            label: "Repo B",
+            threadKeys: [],
+            needsAttentionCount: 0,
+            launchpad: {
+              directoryKey: "directory:/repo-b",
+              directoryKind: "directory" as const,
+              directoryLabel: "Repo B",
+              backend: "acp:kimi" as const,
+              executionMode: "default" as const,
+              workMode: "local" as const,
+              prompt: "leave me alone",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+          workMode: "local" as const,
+        },
+        threads: [],
+      })),
+      updateDirectoryLaunchpad,
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        initialSection="models"
+        settings={settings}
+      />,
+    );
+
+    const reasoning = await screen.findByLabelText("Codex default reasoning");
+    fireEvent.change(reasoning, { target: { value: "xhigh" } });
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        models: {
+          providerDefaults: {
+            codex: {
+              model: "gpt-5.6-sol",
+              reasoningEffortsByModel: {
+                "gpt-5.6-sol": "xhigh",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply to launchpads" }));
+    expect(
+      await screen.findByText("Apply to 1 launchpad?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => {
+      expect(updateDirectoryLaunchpad).toHaveBeenCalledTimes(1);
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey: "directory:/repo-a",
+      patch: {
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+      },
+      stickySettingsChanged: true,
+    });
+    expect(
+      screen.getByText(
+        "Updated 1 Codex launchpad. Existing threads were not changed.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("can restart login for an existing Codex auth profile", async () => {
     const snapshot = createSnapshot();
     snapshot.models.codex.profiles.profiles[1]!.hasAuthFile = false;

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AppServerListThreadsResponse,
   AppServerThreadSummary,
+  BackendSummary,
   DesktopSettingsSnapshot,
   MessagingPairingEntry,
   WorktreeSnapshotSummary,
@@ -438,6 +439,70 @@ function createArchivedSnapshot(
 }
 
 describe("SettingsScreen", () => {
+  it("renders cached provider models while refreshing the catalog", async () => {
+    const cachedBackends: BackendSummary[] = [
+      {
+        kind: "codex",
+        label: "OpenAI",
+        available: true,
+        methods: [],
+        capabilities: {
+          listThreads: true,
+          createThread: true,
+          resumeThread: true,
+          renameThread: true,
+          readThread: true,
+          startTurn: true,
+          interruptTurn: true,
+          steerTurn: true,
+          transcriptPagination: true,
+          toolUse: true,
+          approvalRequests: true,
+          multiDirectoryThreads: true,
+        },
+        executionModes: [],
+        launchpadOptions: {
+          models: [
+            {
+              id: "gpt-5.6-sol",
+              label: "GPT-5.6-Sol",
+              supportsReasoning: true,
+              reasoningEfforts: ["high", "xhigh"],
+            },
+          ],
+        },
+      },
+    ];
+    const listBackends = vi.fn(
+      async () => await new Promise<never>(() => undefined),
+    );
+
+    render(
+      <SettingsScreen
+        cachedBackends={cachedBackends}
+        desktopApi={{ listBackends }}
+        initialSection="models"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText("1 discovered model")).toBeInTheDocument();
+    expect(
+      within(screen.getByLabelText("OpenAI default model")).getByRole("option", {
+        name: "GPT-5.6-Sol",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No provider has reported a model catalog yet."))
+      .not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledWith({
+        includeUnavailable: true,
+        refreshModels: true,
+      });
+    });
+  });
+
   it("clamps accidental document scroll while mounted", async () => {
     Object.defineProperty(window, "scrollX", {
       configurable: true,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1725,9 +1725,14 @@ describe("SettingsScreen", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Apply to launchpads" }));
+    const launchpadConfirmation =
+      await screen.findByText("Apply to 1 launchpad?");
+    expect(launchpadConfirmation.closest(".settings-field")).toHaveTextContent(
+      "Codex",
+    );
     expect(
-      await screen.findByText("Apply to 1 launchpad?"),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Apply to launchpads" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
     await waitFor(() => {
       expect(updateDirectoryLaunchpad).toHaveBeenCalledTimes(1);
@@ -1749,9 +1754,14 @@ describe("SettingsScreen", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Apply to existing threads" }),
     );
+    const migrationConfirmation =
+      await screen.findByText("Migrate 2 existing threads?");
+    expect(migrationConfirmation.closest(".settings-field")).toHaveTextContent(
+      "Codex",
+    );
     expect(
-      await screen.findByText("Migrate 2 existing threads?"),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Apply to existing threads" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(
       screen.getByRole("button", { name: "Create migration" }),
     );
@@ -1773,9 +1783,14 @@ describe("SettingsScreen", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Turn Fast off everywhere" }),
     );
+    const fastConfirmation =
+      await screen.findByText("Turn Fast off everywhere?");
+    expect(fastConfirmation.closest(".settings-field")).toHaveTextContent(
+      "Codex Fast mode",
+    );
     expect(
-      await screen.findByText("Turn Fast off everywhere?"),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "Turn Fast off everywhere" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Turn Fast off" }));
     await waitFor(() => {
       expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1577,6 +1577,7 @@ describe("SettingsScreen", () => {
       launchpadCount: 1,
       threadCount: 2,
     }));
+    const refreshNavigation = vi.fn(async () => undefined);
     const desktopApi = {
       listAcpAgents: vi.fn(async () => ({
         fetchedAt: 1000,
@@ -1704,6 +1705,7 @@ describe("SettingsScreen", () => {
         desktopApi={desktopApi}
         initialSection="models"
         settings={settings}
+        onRefreshNavigation={refreshNavigation}
       />,
     );
 
@@ -1803,6 +1805,7 @@ describe("SettingsScreen", () => {
     fireEvent.click(screen.getByRole("button", { name: "Turn Fast off" }));
     await waitFor(() => {
       expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(1);
+      expect(refreshNavigation).toHaveBeenCalledTimes(1);
     });
     expect(
       screen.getByText(
@@ -1827,6 +1830,7 @@ describe("SettingsScreen", () => {
       });
     });
     expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(2);
+    expect(refreshNavigation).toHaveBeenCalledTimes(2);
   });
 
   it("can restart login for an existing Codex auth profile", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1571,12 +1571,14 @@ export function ThreadView(props: ThreadViewProps) {
         backend: thread.source,
         threadId: thread.id,
         threadCreatedAt: thread.createdAt,
+        threadModel: thread.model,
       })
       .then(async (result) => {
         if (
           result.status === "applied"
           || result.status === "acknowledged-manual-change"
           || result.status === "acknowledged-new-thread"
+          || result.status === "acknowledged-source-model"
         ) {
           await migrationRefreshNavigation?.();
           return;
@@ -1588,6 +1590,17 @@ export function ThreadView(props: ThreadViewProps) {
             message:
               `${migration.model} is not currently available for `
               + `${thread.source}. This thread was left unchanged.`,
+            tone: "warning",
+          });
+          return;
+        }
+        if (result.status === "metadata-unavailable") {
+          migrationNotice?.({
+            id: `thread-model-migration-metadata:${checkKey}`,
+            title: "Thread model migration pending",
+            message:
+              "PwrAgent could not verify this thread's creation time, so it "
+              + "was left unchanged.",
             tone: "warning",
           });
         }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -30,6 +30,7 @@ import type {
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
   DesktopProviderModelDefaults,
+  DesktopProviderThreadModelMigration,
   HandoffThreadWorkspaceRequest,
   MarkdownFileViewerContext,
   MessagingChannelKind,
@@ -720,7 +721,12 @@ export type ThreadViewProps = {
   backendError?: string;
   backends: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
+  codexFastAllowed?: boolean;
   providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
+  providerThreadMigrations?: Record<
+    string,
+    DesktopProviderThreadModelMigration
+  >;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   composerDisabled: boolean;
   composerDraftStore?: ComposerDraftStore;
@@ -1534,6 +1540,75 @@ export function ThreadView(props: ThreadViewProps) {
   useEffect(() => {
     selectedThreadKeyRef.current = selectedThreadKey;
   }, [selectedThreadKey]);
+
+  const migrationDesktopApi = props.desktopApi;
+  const migrationNotice = props.onShowNotice;
+  const migrationRefreshNavigation = props.onRefreshNavigation;
+  const providerThreadMigrations = props.providerThreadMigrations;
+  const migrationCheckKeyRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const thread = selectedThread;
+    const migration = thread
+      ? providerThreadMigrations?.[thread.source]
+      : undefined;
+    if (
+      !thread
+      || selectedLaunchpad
+      || !migration
+      || thread.modelMigrationRevision === migration.revision
+      || !migrationDesktopApi?.applyThreadModelMigration
+    ) {
+      return;
+    }
+
+    const checkKey = `${thread.source}:${thread.id}:${migration.revision}`;
+    if (migrationCheckKeyRef.current === checkKey) {
+      return;
+    }
+    migrationCheckKeyRef.current = checkKey;
+    void migrationDesktopApi
+      .applyThreadModelMigration({
+        backend: thread.source,
+        threadId: thread.id,
+        threadCreatedAt: thread.createdAt,
+      })
+      .then(async (result) => {
+        if (
+          result.status === "applied"
+          || result.status === "acknowledged-manual-change"
+          || result.status === "acknowledged-new-thread"
+        ) {
+          await migrationRefreshNavigation?.();
+          return;
+        }
+        if (result.status === "unavailable") {
+          migrationNotice?.({
+            id: `thread-model-migration-unavailable:${checkKey}`,
+            title: "Thread model migration pending",
+            message:
+              `${migration.model} is not currently available for `
+              + `${thread.source}. This thread was left unchanged.`,
+            tone: "warning",
+          });
+        }
+      })
+      .catch((error) => {
+        migrationCheckKeyRef.current = undefined;
+        migrationNotice?.({
+          id: `thread-model-migration-failed:${checkKey}`,
+          title: "Thread model migration failed",
+          message: error instanceof Error ? error.message : String(error),
+          tone: "warning",
+        });
+      });
+  }, [
+    migrationDesktopApi,
+    migrationNotice,
+    migrationRefreshNavigation,
+    providerThreadMigrations,
+    selectedLaunchpad,
+    selectedThread,
+  ]);
 
   useEffect(() => {
     const thread = selectedThread;
@@ -2543,6 +2618,7 @@ export function ThreadView(props: ThreadViewProps) {
             <Composer
               backends={props.backends}
               applications={props.applications}
+              codexFastAllowed={props.codexFastAllowed}
               providerModelDefaults={props.providerModelDefaults}
               desktopApi={props.desktopApi}
               onShowNotice={props.onShowNotice}
@@ -2770,6 +2846,7 @@ export function ThreadView(props: ThreadViewProps) {
             addOptimisticUserMessage={props.addOptimisticUserMessage}
             backends={props.backends}
             applications={props.applications}
+            codexFastAllowed={props.codexFastAllowed}
             desktopApi={props.desktopApi}
             onShowNotice={props.onShowNotice}
             composerImplementation={props.composerImplementation}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -29,6 +29,7 @@ import type {
   CodexEnvironmentActionRun,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
+  DesktopProviderModelDefaults,
   HandoffThreadWorkspaceRequest,
   MarkdownFileViewerContext,
   MessagingChannelKind,
@@ -719,6 +720,7 @@ export type ThreadViewProps = {
   backendError?: string;
   backends: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
+  providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   composerDisabled: boolean;
   composerDraftStore?: ComposerDraftStore;
@@ -2541,6 +2543,7 @@ export function ThreadView(props: ThreadViewProps) {
             <Composer
               backends={props.backends}
               applications={props.applications}
+              providerModelDefaults={props.providerModelDefaults}
               desktopApi={props.desktopApi}
               onShowNotice={props.onShowNotice}
               onProviderSelected={props.onProviderSelected}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -231,6 +231,7 @@ describe("ThreadView", () => {
           title: "Old model",
           titleSource: "explicit",
           source: "codex",
+          model: "gpt-5.5",
           createdAt: 1_000,
           updatedAt: 1_500,
           linkedDirectories: [],
@@ -246,6 +247,7 @@ describe("ThreadView", () => {
         backend: "codex",
         threadId: "thread-old",
         threadCreatedAt: 1_000,
+        threadModel: "gpt-5.5",
       });
     });
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -194,6 +194,65 @@ describe("ThreadView", () => {
     });
   });
 
+  it("applies a pending provider migration when an existing thread opens", async () => {
+    const applyThreadModelMigration = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-old",
+      status: "applied" as const,
+      revision: "migration-1",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        desktopApi={{ applyThreadModelMigration }}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        onLoadOlder={async () => undefined}
+        onRefreshNavigation={onRefreshNavigation}
+        providerThreadMigrations={{
+          codex: {
+            revision: "migration-1",
+            model: "gpt-5.6-sol",
+            reasoningEffort: "high",
+            createdAt: 2_000,
+          },
+        }}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={{
+          id: "thread-old",
+          title: "Old model",
+          titleSource: "explicit",
+          source: "codex",
+          createdAt: 1_000,
+          updatedAt: 1_500,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(applyThreadModelMigration).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-old",
+        threadCreatedAt: 1_000,
+      });
+    });
+    await waitFor(() => {
+      expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("renders a directory-less thread with transcript history and context", () => {
     render(
       <ThreadView

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6968,6 +6968,56 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("adopts a bulk Fast cleanup when Settings refreshes navigation", async () => {
+    const snapshot = (fastMode: boolean): NavigationSnapshot => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "First thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+          fastMode,
+          inbox: { inInbox: true, reason: "new-thread" },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(snapshot(true))
+      .mockResolvedValueOnce(snapshot(false));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.fastMode).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.fastMode).toBe(false);
+    });
+  });
+
   it("patches the snapshot for thread/modelSettings/updated without refetching", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -6968,56 +6968,6 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("adopts a bulk Fast cleanup when Settings refreshes navigation", async () => {
-    const snapshot = (fastMode: boolean): NavigationSnapshot => ({
-      backend: "all",
-      fetchedAt: Date.now(),
-      unchanged: false,
-      inboxThreadKeys: ["codex:thread-1"],
-      threads: [
-        {
-          id: "thread-1",
-          title: "First thread",
-          titleSource: "explicit",
-          source: "codex",
-          linkedDirectories: [],
-          model: "gpt-5.6-sol",
-          reasoningEffort: "high",
-          fastMode,
-          inbox: { inInbox: true, reason: "new-thread" },
-          updatedAt: 1_000,
-        },
-      ],
-      directories: [],
-      launchpadDefaults: {
-        backend: "codex",
-        executionMode: "default",
-      },
-    });
-    const getNavigationSnapshot = vi
-      .fn()
-      .mockResolvedValueOnce(snapshot(true))
-      .mockResolvedValueOnce(snapshot(false));
-    const desktopApi: DesktopApi = {
-      getNavigationSnapshot,
-      onAgentEvent: () => () => undefined,
-    };
-
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
-
-    await waitFor(() => {
-      expect(result.current.selectedThread?.fastMode).toBe(true);
-    });
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    await waitFor(() => {
-      expect(result.current.selectedThread?.fastMode).toBe(false);
-    });
-  });
-
   it("patches the snapshot for thread/modelSettings/updated without refetching", async () => {
     const listeners = new Set<(event: any) => void>();
     const getNavigationSnapshot = vi.fn(async () => ({
@@ -7084,6 +7034,27 @@ describe("useThreadNavigation", () => {
       expect(result.current.selectedThread?.model).toBe("gpt-5.5");
       expect(result.current.selectedThread?.reasoningEffort).toBe("high");
       expect(result.current.selectedThread?.fastMode).toBe(true);
+    });
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/modelSettings/updated",
+            params: {
+              threadId: "thread-1",
+              fastMode: false,
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.model).toBe("gpt-5.5");
+      expect(result.current.selectedThread?.reasoningEffort).toBe("high");
+      expect(result.current.selectedThread?.fastMode).toBe(false);
     });
     // Push-driven patch — no full snapshot re-fetch.
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -181,6 +181,9 @@ import type {
   SetThreadAgentResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  ApplyThreadModelMigrationRequest,
+  ApplyThreadModelMigrationResponse,
+  TurnOffCodexFastEverywhereResponse,
   SteerTurnRequest,
   SteerTurnResponse,
   StartThreadRequest,
@@ -461,6 +464,11 @@ export type DesktopApi = {
   setThreadModelSettings?: (
     request: SetThreadModelSettingsRequest
   ) => Promise<SetThreadModelSettingsResponse>;
+  applyThreadModelMigration?: (
+    request: ApplyThreadModelMigrationRequest
+  ) => Promise<ApplyThreadModelMigrationResponse>;
+  turnOffCodexFastEverywhere?: (
+  ) => Promise<TurnOffCodexFastEverywhereResponse>;
   checkThreadBranchDrift?: (
     request: CheckThreadBranchDriftRequest
   ) => Promise<CheckThreadBranchDriftResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3237,28 +3237,34 @@ export function useThreadNavigation(
       }
 
       if (method === "thread/modelSettings/updated") {
-        const { threadId, model, reasoningEffort, serviceTier, fastMode } =
-          event.notification.params as {
-            threadId: string;
-            model?: string;
-            reasoningEffort?: string;
-            serviceTier?: string;
-            fastMode?: boolean;
-          };
+        const params = event.notification.params as {
+          threadId: string;
+          model?: string;
+          reasoningEffort?: string;
+          serviceTier?: string;
+          fastMode?: boolean;
+        };
+        const modelSettingsPatch = {
+          ...("model" in params ? { model: params.model } : {}),
+          ...("reasoningEffort" in params
+            ? { reasoningEffort: params.reasoningEffort }
+            : {}),
+          ...("serviceTier" in params
+            ? { serviceTier: params.serviceTier }
+            : {}),
+          ...("fastMode" in params ? { fastMode: params.fastMode } : {}),
+        };
         setState((current) => ({
           ...current,
           response: applyThreadModelSettingsUpdate(current.response, {
             backend: event.backend,
-            threadId,
-            model,
-            reasoningEffort,
-            serviceTier,
-            fastMode,
+            threadId: params.threadId,
+            ...modelSettingsPatch,
           }),
         }));
         setOptimisticThread((current) =>
-          current?.source === event.backend && current.id === threadId
-            ? { ...current, model, reasoningEffort, serviceTier, fastMode }
+          current?.source === event.backend && current.id === params.threadId
+            ? { ...current, ...modelSettingsPatch }
             : current
         );
         return;

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -312,6 +312,22 @@ describe("Tangerine Terminal theme contract", () => {
     expect(settingsSelectRule).not.toContain("line-height: 1;");
   });
 
+  it("uses composer-style compact chips for provider defaults", () => {
+    const providerSelectRule = extractRuleBody(css, ".settings-select--chip");
+    const composerSelectRule = extractRuleBody(css, ".composer-dropdown__button");
+
+    expect(providerSelectRule).toContain("height: 26px;");
+    expect(providerSelectRule).toContain("border-radius: 999px;");
+    expect(providerSelectRule).toContain("background-color: var(--bg-input);");
+    expect(providerSelectRule).toContain("font-size: 13px;");
+    expect(providerSelectRule).toContain("font-weight: 500;");
+    expect(composerSelectRule).toContain("min-height: 26px;");
+    expect(composerSelectRule).toContain("border-radius: 999px;");
+    expect(composerSelectRule).toContain("background: var(--bg-input);");
+    expect(composerSelectRule).toContain("font-size: 13px;");
+    expect(composerSelectRule).toContain("font-weight: 500;");
+  });
+
   it("keeps messaging indicators ahead of thread header title overflow", () => {
     const headerMainRule = extractRuleBody(css, ".thread-header__main");
     const statusBarRule = extractRuleBody(css, ".messaging-status-bar");

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -305,6 +305,13 @@ describe("Tangerine Terminal theme contract", () => {
     expect(compactTitleRule).not.toContain("line-height: 1;");
   });
 
+  it("keeps Settings select values tall enough for descenders", () => {
+    const settingsSelectRule = extractRuleBody(css, ".settings-select");
+
+    expect(settingsSelectRule).toContain("line-height: 1.2;");
+    expect(settingsSelectRule).not.toContain("line-height: 1;");
+  });
+
   it("keeps messaging indicators ahead of thread header title overflow", () => {
     const headerMainRule = extractRuleBody(css, ".thread-header__main");
     const statusBarRule = extractRuleBody(css, ".messaging-status-bar");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6187,7 +6187,7 @@ textarea,
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 12px;
-  line-height: 1;
+  line-height: 1.2;
 }
 
 .settings-select:focus,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6614,6 +6614,41 @@ textarea,
   gap: 8px;
 }
 
+.settings-action-confirmation {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+}
+
+.settings-action-confirmation__copy {
+  display: flex;
+  flex: 1 1 360px;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.settings-action-confirmation__copy strong {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.settings-action-confirmation__copy span {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.settings-action-confirmation > .settings-inline-actions {
+  flex: 0 0 auto;
+}
+
 /* Path-row list — canonical row for Codex discovery, Editor / Terminal
    candidates. Replaces .settings-discovery__row + .settings-application. */
 .settings-paths {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6202,6 +6202,40 @@ textarea,
   opacity: 0.55;
 }
 
+/* Provider defaults use the same compact, content-sized pill language as the
+   composer model and reasoning pickers. Keep native select semantics here;
+   `field-sizing` lets Chromium size each control to its current value. */
+.settings-provider-defaults__selectors {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-select--chip {
+  width: auto;
+  min-width: 0;
+  max-width: min(100%, 320px);
+  field-sizing: content;
+  height: 26px;
+  padding: 0 26px 0 10px;
+  border-color: var(--border-subtle);
+  border-radius: 999px;
+  background-color: var(--bg-input);
+  background-position:
+    calc(100% - 13px) 50%,
+    calc(100% - 8px) 50%;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.settings-select--chip:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  background-color: var(--bg-panel-hover);
+}
+
 .settings-input--invalid {
   border-color: var(--danger-border);
   box-shadow: 0 0 0 1px var(--status-error-ring-soft);
@@ -6609,9 +6643,39 @@ textarea,
 
 .settings-inline-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
   gap: 8px;
+}
+
+.settings-provider-defaults__fast {
+  display: grid;
+  grid-template-columns: minmax(140px, 220px) minmax(0, 1fr);
+  align-items: center;
+  gap: 8px 16px;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-provider-defaults__fast-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.settings-provider-defaults__fast-copy strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.settings-provider-defaults__fast-copy span {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .settings-action-confirmation {
@@ -6647,6 +6711,13 @@ textarea,
 
 .settings-action-confirmation > .settings-inline-actions {
   flex: 0 0 auto;
+}
+
+@media (max-width: 760px) {
+  .settings-provider-defaults__fast {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
 }
 
 /* Path-row list — canonical row for Codex discovery, Editor / Terminal

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7418,6 +7418,14 @@ textarea,
   outline: none;
 }
 
+.settings-confirm-dialog p.settings-thread-migration-dialog__scheduled {
+  padding: 8px 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
 .settings-thread-migration-dialog__toolbar {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7510,7 +7510,7 @@ textarea,
 
 .settings-thread-migration-dialog__model small {
   color: var(--text-muted);
-  font-family: var(--font-sans);
+  font-family: var(--font-sans, sans-serif);
   font-size: 11px;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7410,6 +7410,114 @@ textarea,
   margin-top: 16px;
 }
 
+.settings-thread-migration-dialog {
+  width: min(620px, calc(100vw - 48px));
+}
+
+.settings-thread-migration-dialog:focus {
+  outline: none;
+}
+
+.settings-thread-migration-dialog__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.settings-thread-migration-dialog__list {
+  overflow-y: auto;
+  max-height: min(360px, 45vh);
+  margin-top: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
+}
+
+.settings-thread-migration-dialog__option {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 42px;
+  padding: 8px 10px;
+  border: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-thread-migration-dialog__option:last-child {
+  border-bottom: 0;
+}
+
+.settings-thread-migration-dialog__option:hover,
+.settings-thread-migration-dialog__option:focus-visible {
+  background: var(--bg-panel-hover);
+  outline: none;
+}
+
+.settings-thread-migration-dialog__option[aria-selected="true"] {
+  background: var(--accent-soft);
+}
+
+.settings-thread-migration-dialog__option:disabled {
+  cursor: default;
+  opacity: 0.58;
+}
+
+.settings-thread-migration-dialog__check {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.settings-thread-migration-dialog__option[aria-selected="true"]
+  .settings-thread-migration-dialog__check {
+  border-color: var(--accent-border);
+}
+
+.settings-thread-migration-dialog__model {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.settings-thread-migration-dialog__model small {
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-size: 11px;
+}
+
+.settings-thread-migration-dialog__count {
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.settings-confirm-dialog p.settings-thread-migration-dialog__hint {
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 .settings-codex-profile-select {
   display: grid;
   gap: 6px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -37,6 +37,10 @@ export const AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL =
 export const AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL =
   "agent:set-acp-session-runtime-option";
 export const AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL = "agent:set-thread-model-settings";
+export const AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL =
+  "agent:apply-thread-model-migration";
+export const AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL =
+  "agent:turn-off-codex-fast-everywhere";
 export const AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL = "agent:check-thread-branch-drift";
 export const AGENT_UPDATE_THREAD_EXPECTED_BRANCH_CHANNEL =
   "agent:update-thread-expected-branch";

--- a/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
+++ b/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
@@ -1,0 +1,215 @@
+---
+title: AI Provider Model Catalog And Defaults - Plan
+type: feat
+date: 2026-07-27
+topic: ai-provider-model-catalog-defaults
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: requirements-only
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# AI Provider Model Catalog And Defaults - Plan
+
+## Goal Capsule
+
+- **Objective:** Give each PwrAgent profile a trustworthy provider model catalog and explicit model/reasoning baselines without erasing thread, launchpad, or learned provider choices.
+- **Product authority:** AI Providers owns discovered provider capabilities and durable baselines; the composer remains authoritative for a thread or launchpad's specific setup.
+- **Open blockers:** None.
+
+---
+
+## Product Contract
+
+### Summary
+
+AI Providers will expose current discovered models and effort/thinking options for every enabled provider that advertises them.
+Users can choose provider-specific model and per-model reasoning baselines, reset to provider recommendations, and deliberately adopt a new baseline across matching unsent launchpads.
+
+### Problem Frame
+
+Learned launchpad choices make repeated work convenient, but they also preserve stale choices indefinitely.
+A user who now prefers GPT-5.6-Sol with high reasoning can still find GPT-5.5 snapshotted into every directory launchpad, while switching models or providers can restore an unwanted reasoning level.
+
+Provider catalogs also change independently of PwrAgent.
+An installed ACP provider may expose new models and thinking options after it updates, while PwrAgent continues showing a cached catalog until discovery is triggered.
+A Settings default is only trustworthy when the catalog behind it is fresh, capability-driven, and honest about failures.
+
+### Key Decisions
+
+- **One provider catalog and defaults outcome.** (session-settled: user-directed — chosen over defaults with discovery as separate prerequisite: users need one trustworthy place to see current choices and configure them.) Governs R1-R8.
+- **Layered baseline instead of hard enforcement.** (session-settled: user-directed — chosen over Settings overriding learned choices: specific thread, draft, and provider context must remain authoritative.) Governs R13-R16.
+- **Per-profile, per-provider, per-model scope.** (session-settled: user-directed — chosen over installation-wide, Codex-auth-profile, and provider-wide reasoning defaults: the scope must work consistently across built-in and ACP providers.) Governs R9-R12.
+- **Lazy catalog refresh with manual control.** (session-settled: user-directed — chosen over probing every enabled provider at startup: unused third-party executables should not launch merely because PwrAgent started.) Governs R3-R6.
+- **Suspend invalid preferences instead of deleting them.** (session-settled: user-directed — chosen over clearing preferences on capability drift: temporary provider changes should not destroy intent.) Governs R17-R19.
+- **Confirmed bulk adoption.** (session-settled: user-directed — chosen over silent automatic rewrites and one-directory-at-a-time reset: users need a deliberate way to replace stale launchpad baselines at scale.) Governs R20-R23.
+- **Catalog required for a first launch.** (session-settled: user-directed — chosen over launching with an unknown provider default: a provider with no previously valid catalog must discover successfully before creating a thread.) Governs R7-R8.
+
+<!-- ce-section: work-relationships -->
+### How This Work Fits Together
+
+This plan owns the AI Providers catalog, explicit model/reasoning baselines, and deliberate launchpad migration as one product outcome.
+The surrounding relationships are current context, not a committed roadmap:
+
+- **Can proceed independently of:** the sibling provider-stickiness bug fix, which preserves learned launchpad settings across provider switches.
+- **Shares behavior with:** composer model/reasoning controls and provider-specific sticky state, whose precedence this plan defines but whose unrelated behavior is not redesigned here.
+- **Does not own:** provider executable upgrades or self-update behavior; PwrAgent responds by rediscovering capabilities.
+
+### Requirements
+
+**Provider catalog**
+
+- R1. AI Providers must show a model catalog for every enabled provider that advertises discoverable model choices.
+- R2. Each catalog must expose the provider-advertised model label, valid effort/thinking options, current effective recommendation, and availability needed to choose a valid baseline.
+- R3. AI Providers must show cached catalog data immediately while communicating whether it is current, refreshing, stale, unavailable, or failed.
+- R4. PwrAgent must refresh an enabled provider's catalog when AI Providers opens and the first time that provider is selected during each app session.
+- R5. Users must be able to force a provider catalog refresh and retry a failed refresh.
+- R6. Catalog refresh must update newly added, removed, and changed model and effort/thinking choices without requiring an app restart.
+- R7. A failed refresh with a previously valid catalog must preserve that catalog as visibly stale and keep it usable for new launchpads.
+- R8. A provider with no previously valid catalog must not create a new thread until discovery succeeds; discovery failure must not invalidate existing threads.
+
+**Explicit baselines**
+
+- R9. Model and reasoning baselines must be scoped to the active PwrAgent profile.
+- R10. Every provider covered by R1 must allow the user to choose one default model from its valid catalog.
+- R11. Every reasoning-capable model must allow its own effort/thinking baseline from the options valid for that model.
+- R12. Execution/access mode, Fast/service tier, Codex Environment, and other launch settings must remain outside this Settings baseline and retain their existing composer-owned behavior.
+- R13. Effective model and reasoning values must resolve in this order: restored thread state, current directory launchpad snapshot, learned per-provider sticky choice, Settings baseline, then provider-advertised recommendation.
+- R14. A Settings baseline must seed provider contexts with no higher-precedence choice and serve as the target of an explicit composer reset.
+- R15. Changing a Settings baseline alone must not rewrite learned provider choices, unsent launchpads, or existing threads.
+- R16. Resetting a launchpad to its configured baseline must update that launchpad and the provider's future sticky model/reasoning choice without changing other launchpads or existing threads.
+
+**Capability drift and reset**
+
+- R17. If a saved default model becomes unavailable, PwrAgent must retain it as a suspended preference while using the current provider-advertised recommendation.
+- R18. If a saved effort/thinking value becomes invalid or its model stops advertising reasoning, PwrAgent must retain it as a suspended preference while using the model's current advertised recommendation.
+- R19. A suspended preference must resume when it becomes valid again, while Reset in AI Providers must discard explicit model and reasoning preferences and follow the provider recommendation.
+
+**Adopt a new baseline**
+
+- R20. AI Providers must offer an explicit action to apply the configured baseline to all unsent launchpads currently using that provider.
+- R21. The bulk action must show the number of affected launchpads and require confirmation before applying.
+- R22. A confirmed bulk action must update model and reasoning on every matching launchpad and replace the provider's learned sticky model/reasoning choice for future launchpads.
+- R23. A confirmed bulk action must preserve prompt text, attachments, workspace mode, branch, access mode, Fast/service tier, Codex Environment, and every existing thread.
+
+The precedence defined by R13 is the normal resolution path:
+
+```mermaid
+flowchart TB
+  A[Restored thread state] -->|absent| B[Directory launchpad snapshot]
+  B -->|absent| C[Learned provider sticky choice]
+  C -->|absent| D[AI Providers baseline]
+  D -->|absent or suspended| E[Provider-advertised recommendation]
+```
+
+### Key Flows
+
+- F1. Inspect and configure a provider
+  - **Trigger:** The operator opens AI Providers.
+  - **Steps:** PwrAgent shows cached catalogs, refreshes enabled providers, surfaces freshness or errors, and allows valid model and per-model reasoning selections.
+  - **Outcome:** The PwrAgent profile has an explicit baseline backed by a visible provider catalog.
+  - **Covered by:** R1-R12.
+- F2. Open or switch a launchpad
+  - **Trigger:** The operator opens a directory launchpad or switches its provider.
+  - **Steps:** PwrAgent refreshes the provider on its first selection for the session and resolves model/reasoning through R13.
+  - **Outcome:** The most specific valid choice is restored without losing another provider's learned settings.
+  - **Covered by:** R4, R7-R8, R13-R19.
+- F3. Adopt a new baseline across projects
+  - **Trigger:** The operator chooses the bulk action for a configured provider baseline.
+  - **Steps:** PwrAgent shows the affected count, obtains confirmation, updates every matching unsent launchpad, and adopts the baseline for future provider stickiness.
+  - **Outcome:** Stale project launchpads move together while their prompts and unrelated setup remain intact.
+  - **Covered by:** R20-R23.
+- F4. Handle catalog drift
+  - **Trigger:** Refresh adds, removes, or changes a provider model or effort option.
+  - **Steps:** PwrAgent updates the catalog, suspends invalid explicit preferences, and resolves an effective valid recommendation.
+  - **Outcome:** New launches remain valid without silently destroying the user's saved intent.
+  - **Covered by:** R3-R8, R17-R19.
+
+### Acceptance Examples
+
+- AE1. New PwrAgent profile
+  - **Covers R3-R14.**
+  - **Given:** A new profile has no learned provider choice or explicit baseline.
+  - **When:** The operator selects a provider with a valid discovered catalog.
+  - **Then:** The launchpad uses the provider-advertised model and effort recommendation.
+- AE2. Explicit Codex baseline survives restart
+  - **Covers R9-R15.**
+  - **Given:** The operator selects GPT-5.6-Sol with high reasoning in AI Providers and no higher-precedence Codex choice exists.
+  - **When:** PwrAgent restarts and the operator opens a fresh Codex launchpad.
+  - **Then:** GPT-5.6-Sol with high reasoning is selected.
+- AE3. Existing sticky history remains specific
+  - **Covers R13-R16.**
+  - **Given:** Codex sticky history contains GPT-5.5 while Settings now names GPT-5.6-Sol with high reasoning.
+  - **When:** The operator opens a fresh Codex launchpad without resetting or bulk-adopting the new baseline.
+  - **Then:** The sticky GPT-5.5 choice remains authoritative.
+- AE4. Provider and model switching restores reasoning
+  - **Covers R11, R13-R16.**
+  - **Given:** Codex remembers GPT-5.6-Sol with high reasoning and GPT-5.6-Terra with a different effort, while another provider has its own choices.
+  - **When:** The operator switches providers and then switches between the two Codex models.
+  - **Then:** Each provider and model restores its own learned reasoning choice.
+- AE5. Bulk adoption replaces stale launchpads
+  - **Covers R20-R23.**
+  - **Given:** Multiple unsent Codex directory launchpads contain GPT-5.5 and may contain prompts or unrelated setup choices.
+  - **When:** The operator confirms applying GPT-5.6-Sol with high reasoning to all Codex launchpads.
+  - **Then:** Every unsent Codex launchpad and future Codex sticky choice uses GPT-5.6-Sol with high reasoning, while prompts, unrelated setup, and existing threads are unchanged.
+- AE6. Configured model disappears and returns
+  - **Covers R6-R8, R17, R19.**
+  - **Given:** A refreshed valid catalog no longer advertises the configured default model.
+  - **When:** The operator creates a new launchpad and the model later reappears in a successful refresh.
+  - **Then:** PwrAgent first uses the provider recommendation while showing the saved model as suspended, then resumes the saved model after it becomes valid again.
+- AE7. Reasoning option changes
+  - **Covers R11, R18-R19.**
+  - **Given:** A model's saved reasoning effort is no longer advertised.
+  - **When:** The operator uses that model.
+  - **Then:** PwrAgent uses the model's advertised reasoning recommendation while retaining the saved effort as suspended until it returns or the operator resets it.
+- AE8. Discovery failure with and without cache
+  - **Covers R3-R8.**
+  - **Given:** One provider has a previously valid cached catalog and another has never discovered successfully.
+  - **When:** Both providers fail their first-selection refresh.
+  - **Then:** The cached provider remains available with a stale warning, while the never-discovered provider blocks new thread creation and offers retry.
+- AE9. Existing thread restoration
+  - **Covers R8, R13, R15, R23.**
+  - **Given:** A thread was created with a model/reasoning combination that differs from current Settings and sticky choices.
+  - **When:** The thread is restored after navigation, restart, a Settings change, or bulk adoption.
+  - **Then:** Its saved thread settings remain authoritative and unchanged.
+
+### Scope Boundaries
+
+- This work does not upgrade, install, or control self-update behavior for provider executables.
+- This work does not mutate existing thread settings or historical turns.
+- This work does not make Settings authoritative over restored threads, directory launchpad snapshots, or learned provider choices outside explicit reset and bulk actions.
+- This work does not add Settings defaults for execution/access mode, Fast/service tier, Codex Environment, workspace mode, or branch.
+- This work does not hard-code provider model compatibility or promise a model list for providers that expose no discoverable catalog.
+- This work does not move defaults into Codex auth-profile or installation-global scope.
+- This work does not expand the sibling provider-stickiness fix.
+
+### Dependencies / Assumptions
+
+- Providers expose enough capability metadata to identify valid models, effort/thinking options, and a current recommendation.
+- PwrAgent can distinguish a previously valid catalog from an absent or unusable discovery result.
+- Unsent launchpads can be enumerated by provider without treating existing threads as migration targets.
+- Provider discovery may launch third-party executables, so refresh must remain visible, bounded, and user-retryable.
+
+### Outstanding Questions
+
+#### Deferred to Planning
+
+- Which existing discovery lifecycle should own first-selection refresh so desktop, messaging, and Settings consume one catalog result?
+- How should planning distinguish provider-advertised current/default choices from fallback ordering when providers expose incomplete metadata?
+- How should refresh work be coalesced and bounded so opening AI Providers or selecting a provider cannot launch duplicate probes?
+- What verification strategy proves that bulk adoption changes only model/reasoning and never prompt or unrelated launchpad state?
+
+### Sources / Research
+
+- `apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx`
+- `apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx`
+- `packages/shared/src/contracts/settings.ts`
+- `packages/shared/src/contracts/navigation.ts`
+- `packages/shared/src/contracts/backend.ts`
+- `apps/desktop/src/main/state/overlay-store-sqlite.ts`
+- `apps/desktop/src/main/app-server/backend-registry.ts`
+- `docs/brainstorms/2026-04-30-desktop-settings-config-requirements.md`
+- `docs/brainstorms/2026-04-20-desktop-provider-thread-model-selectors-requirements.md`
+- `docs/brainstorms/2026-04-18-directories-launchpad-requirements.md`
+- `docs/plans/2026-05-21-001-feat-acp-runtime-capability-discovery-plan.md`
+- `docs/plans/2026-06-05-001-feat-acp-durable-capability-cache-plan.md`

--- a/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
+++ b/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
@@ -99,6 +99,7 @@ The surrounding relationships are current context, not a committed roadmap:
 **Adopt a new baseline across existing threads**
 
 - R24. AI Providers must offer an explicit action that previews existing provider threads grouped by their current model and count, supports click/Command-click toggles plus Shift-click range selection, and creates a confirmed model/reasoning migration revision for only the selected source-model groups.
+- R24a. Creating a migration schedules the selected threads to change when next opened; the UI must show pending and acknowledged state for an identical saved migration and must not create duplicate revisions unless the destination, reasoning, or selected source-model set changes.
 - R25. A matching thread uses a selected source model, was created before the current migration, and has not yet acknowledged its revision. It must adopt the migration's model and reasoning once when next opened, before its next turn can start. Threads using unselected source models or created after the migration acknowledge it without being changed.
 - R26. A manual model or reasoning change made after a thread acknowledges the current migration must remain authoritative for that migration revision.
 - R27. Creating a later migration revision must make every matching existing thread eligible again, including threads manually customized before the later migration; each thread applies each revision at most once.
@@ -212,6 +213,11 @@ flowchart TB
   - **Given:** The migration dialog lists GPT-5.4, GPT-5.5, GPT-5.6-Sol, and GPT-5.6-Terra with their thread counts.
   - **When:** The operator selects GPT-5.4 and GPT-5.5 but leaves both GPT-5.6 models unselected before creating a GPT-5.6-Sol/high migration.
   - **Then:** Only threads currently using GPT-5.4 or GPT-5.5 adopt the migration; GPT-5.6-Sol and GPT-5.6-Terra threads acknowledge the revision without changing.
+- AE10b. Identical migration is not rescheduled
+  - **Covers R24-R28.**
+  - **Given:** A GPT-5.5 to GPT-5.6-Sol/high migration is already saved and some selected threads have not yet opened.
+  - **When:** The operator reopens the migration dialog without changing the destination, reasoning, or source-model selection.
+  - **Then:** The dialog reports how many threads are pending and how many acknowledged the revision, labels the action as already scheduled, and does not create another revision.
 - AE11. Post-migration manual choice sticks
   - **Covers R26-R27.**
   - **Given:** A thread acknowledged the current GPT-5.6-Sol/high migration and the operator then changes it to GPT-5.6-Terra/xhigh.

--- a/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
+++ b/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
@@ -24,7 +24,9 @@ execution: code
 ### Summary
 
 AI Providers will expose current discovered models and effort/thinking options for every enabled provider that advertises them.
-Users can choose provider-specific model and per-model reasoning baselines, reset to provider recommendations, and deliberately adopt a new baseline across matching unsent launchpads.
+Users can choose provider-specific model and per-model reasoning baselines, reset to provider recommendations, deliberately adopt a new baseline across matching unsent launchpads, and create a versioned migration that matching existing threads adopt once when next opened.
+
+Codex also has profile-scoped Fast safety controls: a hard policy can prevent Fast entirely, while a bulk-off action can clean up existing threads and future launchpad defaults without preventing later per-thread opt-in.
 
 ### Problem Frame
 
@@ -44,6 +46,8 @@ A Settings default is only trustworthy when the catalog behind it is fresh, capa
 - **Suspend invalid preferences instead of deleting them.** (session-settled: user-directed — chosen over clearing preferences on capability drift: temporary provider changes should not destroy intent.) Governs R17-R19.
 - **Confirmed bulk adoption.** (session-settled: user-directed — chosen over silent automatic rewrites and one-directory-at-a-time reset: users need a deliberate way to replace stale launchpad baselines at scale.) Governs R20-R23.
 - **Catalog required for a first launch.** (session-settled: user-directed — chosen over launching with an unknown provider default: a provider with no previously valid catalog must discover successfully before creating a thread.) Governs R7-R8.
+- **Versioned lazy existing-thread migration.** (session-settled: user-directed — chosen over eagerly rewriting every stored thread or permanently exempting manually edited threads: each migration applies once when a matching thread is next opened, and only edits made after the current migration remain authoritative.) Governs R24-R28.
+- **Codex Fast policy plus cleanup.** (session-settled: user-directed — chosen over treating Fast as only another model baseline: one profile may prohibit Fast entirely, while another may allow isolated use after deliberately turning it off across existing threads and future launchpads.) Governs R29-R33.
 
 <!-- ce-section: work-relationships -->
 ### How This Work Fits Together
@@ -73,7 +77,7 @@ The surrounding relationships are current context, not a committed roadmap:
 - R9. Model and reasoning baselines must be scoped to the active PwrAgent profile.
 - R10. Every provider covered by R1 must allow the user to choose one default model from its valid catalog.
 - R11. Every reasoning-capable model must allow its own effort/thinking baseline from the options valid for that model.
-- R12. Execution/access mode, Fast/service tier, Codex Environment, and other launch settings must remain outside this Settings baseline and retain their existing composer-owned behavior.
+- R12. Execution/access mode, Codex Environment, and other launch settings must remain outside this Settings baseline and retain their existing composer-owned behavior. Fast/service tier is not a model baseline; its Settings behavior is limited to the Codex policy and cleanup actions in R29-R33.
 - R13. Effective model and reasoning values must resolve in this order: restored thread state, current directory launchpad snapshot, learned per-provider sticky choice, Settings baseline, then provider-advertised recommendation.
 - R14. A Settings baseline must seed provider contexts with no higher-precedence choice and serve as the target of an explicit composer reset.
 - R15. Changing a Settings baseline alone must not rewrite learned provider choices, unsent launchpads, or existing threads.
@@ -91,6 +95,22 @@ The surrounding relationships are current context, not a committed roadmap:
 - R21. The bulk action must show the number of affected launchpads and require confirmation before applying.
 - R22. A confirmed bulk action must update model and reasoning on every matching launchpad and replace the provider's learned sticky model/reasoning choice for future launchpads.
 - R23. A confirmed bulk action must preserve prompt text, attachments, workspace mode, branch, access mode, Fast/service tier, Codex Environment, and every existing thread.
+
+**Adopt a new baseline across existing threads**
+
+- R24. AI Providers must offer an explicit, confirmed action that creates a new model/reasoning migration revision for the selected provider baseline.
+- R25. A matching thread created before the current migration and not yet acknowledging its revision must adopt the migration's model and reasoning once when next opened, before its next turn can start. Threads created after the migration are not eligible and acknowledge it without being changed.
+- R26. A manual model or reasoning change made after a thread acknowledges the current migration must remain authoritative for that migration revision.
+- R27. Creating a later migration revision must make every matching existing thread eligible again, including threads manually customized before the later migration; each thread applies each revision at most once.
+- R28. If the migration target is unavailable or invalid when a thread opens, PwrAgent must not stamp the revision as applied and must not silently substitute a different model or reasoning value.
+
+**Codex Fast policy and cleanup**
+
+- R29. AI Providers must expose a profile-scoped Codex policy that allows or prohibits Fast mode.
+- R30. When Fast is prohibited, PwrAgent must prevent Fast from being enabled in launchpads or threads and must force non-Fast settings before any Codex turn can start.
+- R31. Prohibiting Fast must also turn Fast off across existing Codex thread overlays and the sticky/default state used by future Codex launchpads so stale Fast choices do not reappear if the policy is later relaxed.
+- R32. When Fast remains allowed, AI Providers must offer a confirmed bulk action that turns Fast off across existing Codex threads and future Codex launchpads while preserving the ability to re-enable Fast on an individual thread afterward.
+- R33. Fast policy and cleanup actions must not change provider, model, reasoning, access mode, workspace, branch, prompt, attachments, Codex Environment, or historical turns.
 
 The precedence defined by R13 is the normal resolution path:
 
@@ -124,6 +144,16 @@ flowchart TB
   - **Steps:** PwrAgent updates the catalog, suspends invalid explicit preferences, and resolves an effective valid recommendation.
   - **Outcome:** New launches remain valid without silently destroying the user's saved intent.
   - **Covered by:** R3-R8, R17-R19.
+- F5. Adopt a baseline across existing threads
+  - **Trigger:** The operator confirms applying a provider baseline to existing threads.
+  - **Steps:** PwrAgent creates a new provider migration revision. Each matching thread adopts the target once when next opened; a later manual edit remains specific until another migration is created.
+  - **Outcome:** Old threads move forward as they are used without a synchronous rewrite of every provider session.
+  - **Covered by:** R24-R28.
+- F6. Control Codex Fast usage
+  - **Trigger:** The operator prohibits Fast for the profile or invokes Turn Fast off everywhere.
+  - **Steps:** PwrAgent enforces non-Fast turns, clears Fast from existing Codex overlays, and replaces future launchpad stickiness with Fast off. If Fast remains allowed, an individual thread may opt back in.
+  - **Outcome:** One profile can prohibit Fast entirely, while another can periodically clean up Fast usage without losing local opt-in.
+  - **Covered by:** R29-R33.
 
 ### Acceptance Examples
 
@@ -172,13 +202,40 @@ flowchart TB
   - **Given:** A thread was created with a model/reasoning combination that differs from current Settings and sticky choices.
   - **When:** The thread is restored after navigation, restart, a Settings change, or bulk adoption.
   - **Then:** Its saved thread settings remain authoritative and unchanged.
+- AE10. Existing thread adopts a migration once
+  - **Covers R24-R28.**
+  - **Given:** A Codex migration targets GPT-5.6-Sol with high reasoning and an unopened thread still uses GPT-5.5.
+  - **When:** The operator opens that thread.
+  - **Then:** The thread changes to GPT-5.6-Sol with high reasoning and records the current migration revision.
+- AE11. Post-migration manual choice sticks
+  - **Covers R26-R27.**
+  - **Given:** A thread acknowledged the current GPT-5.6-Sol/high migration and the operator then changes it to GPT-5.6-Terra/xhigh.
+  - **When:** The operator closes and reopens it before creating another migration.
+  - **Then:** GPT-5.6-Terra/xhigh remains selected.
+  - **And when:** The operator later creates a new provider migration.
+  - **Then:** The thread becomes eligible to adopt that newer revision once.
+- AE11a. New thread is not retroactively migrated
+  - **Covers R24-R27.**
+  - **Given:** A provider migration already exists and the operator creates a new thread with a different explicit model.
+  - **When:** The new thread is opened or starts its next turn.
+  - **Then:** It acknowledges the existing migration without changing its model or reasoning.
+- AE12. Fast prohibited for one profile
+  - **Covers R29-R31 and R33.**
+  - **Given:** A PwrAgent profile prohibits Codex Fast mode and previously contained Fast launchpads or threads.
+  - **When:** The policy is saved and Codex work continues.
+  - **Then:** Existing and future settings are non-Fast, Fast cannot be re-enabled, and unrelated thread settings remain unchanged.
+- AE13. Fast cleanup while opt-in remains allowed
+  - **Covers R29 and R32-R33.**
+  - **Given:** Codex Fast remains allowed and multiple existing threads or launchpads use Fast.
+  - **When:** The operator confirms Turn Fast off everywhere.
+  - **Then:** Existing threads and future launchpads use non-Fast settings, while the operator may later enable Fast on one individual thread.
 
 ### Scope Boundaries
 
 - This work does not upgrade, install, or control self-update behavior for provider executables.
-- This work does not mutate existing thread settings or historical turns.
+- This work does not eagerly rewrite provider-native sessions or historical turns; it may update PwrAgent's current settings for existing threads through the explicit migration and Fast actions in R24-R33.
 - This work does not make Settings authoritative over restored threads, directory launchpad snapshots, or learned provider choices outside explicit reset and bulk actions.
-- This work does not add Settings defaults for execution/access mode, Fast/service tier, Codex Environment, workspace mode, or branch.
+- This work does not add Settings defaults for execution/access mode, Codex Environment, workspace mode, or branch. It adds only the Codex Fast policy and cleanup behavior in R29-R33, not a general service-tier baseline.
 - This work does not hard-code provider model compatibility or promise a model list for providers that expose no discoverable catalog.
 - This work does not move defaults into Codex auth-profile or installation-global scope.
 - This work does not expand the sibling provider-stickiness fix.

--- a/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
+++ b/docs/plans/2026-07-27-001-feat-ai-provider-model-catalog-defaults-plan.md
@@ -98,8 +98,8 @@ The surrounding relationships are current context, not a committed roadmap:
 
 **Adopt a new baseline across existing threads**
 
-- R24. AI Providers must offer an explicit, confirmed action that creates a new model/reasoning migration revision for the selected provider baseline.
-- R25. A matching thread created before the current migration and not yet acknowledging its revision must adopt the migration's model and reasoning once when next opened, before its next turn can start. Threads created after the migration are not eligible and acknowledge it without being changed.
+- R24. AI Providers must offer an explicit action that previews existing provider threads grouped by their current model and count, supports click/Command-click toggles plus Shift-click range selection, and creates a confirmed model/reasoning migration revision for only the selected source-model groups.
+- R25. A matching thread uses a selected source model, was created before the current migration, and has not yet acknowledged its revision. It must adopt the migration's model and reasoning once when next opened, before its next turn can start. Threads using unselected source models or created after the migration acknowledge it without being changed.
 - R26. A manual model or reasoning change made after a thread acknowledges the current migration must remain authoritative for that migration revision.
 - R27. Creating a later migration revision must make every matching existing thread eligible again, including threads manually customized before the later migration; each thread applies each revision at most once.
 - R28. If the migration target is unavailable or invalid when a thread opens, PwrAgent must not stamp the revision as applied and must not silently substitute a different model or reasoning value.
@@ -204,9 +204,14 @@ flowchart TB
   - **Then:** Its saved thread settings remain authoritative and unchanged.
 - AE10. Existing thread adopts a migration once
   - **Covers R24-R28.**
-  - **Given:** A Codex migration targets GPT-5.6-Sol with high reasoning and an unopened thread still uses GPT-5.5.
+  - **Given:** A Codex migration targets GPT-5.6-Sol with high reasoning, includes GPT-5.5 as a selected source model, and an unopened thread still uses GPT-5.5.
   - **When:** The operator opens that thread.
   - **Then:** The thread changes to GPT-5.6-Sol with high reasoning and records the current migration revision.
+- AE10a. Current-generation model remains untouched
+  - **Covers R24-R28.**
+  - **Given:** The migration dialog lists GPT-5.4, GPT-5.5, GPT-5.6-Sol, and GPT-5.6-Terra with their thread counts.
+  - **When:** The operator selects GPT-5.4 and GPT-5.5 but leaves both GPT-5.6 models unselected before creating a GPT-5.6-Sol/high migration.
+  - **Then:** Only threads currently using GPT-5.4 or GPT-5.5 adopt the migration; GPT-5.6-Sol and GPT-5.6-Terra threads acknowledge the revision without changing.
 - AE11. Post-migration manual choice sticks
   - **Covers R26-R27.**
   - **Given:** A thread acknowledged the current GPT-5.6-Sol/high migration and the operator then changes it to GPT-5.6-Terra/xhigh.

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -285,6 +285,7 @@ describe("desktop settings contracts", () => {
         },
       },
       models: {
+        providerDefaults: {},
         codex: {
           path: { value: "", source: "default" },
           profile: { value: "", source: "default" },

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -358,6 +358,8 @@ export type ApplyThreadModelMigrationRequest = {
   threadId: ThreadIdentifier;
   /** Creation time from the provider summary, used to exclude newer threads. */
   threadCreatedAt?: number;
+  /** Current provider-reported model, used when no overlay model is recorded. */
+  threadModel?: string;
 };
 
 export type ApplyThreadModelMigrationResponse = {
@@ -368,6 +370,7 @@ export type ApplyThreadModelMigrationResponse = {
     | "already-applied"
     | "acknowledged-manual-change"
     | "acknowledged-new-thread"
+    | "acknowledged-source-model"
     | "metadata-unavailable"
     | "applied"
     | "unavailable";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -368,6 +368,7 @@ export type ApplyThreadModelMigrationResponse = {
     | "already-applied"
     | "acknowledged-manual-change"
     | "acknowledged-new-thread"
+    | "metadata-unavailable"
     | "applied"
     | "unavailable";
   revision?: string;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -353,6 +353,33 @@ export type SetThreadModelSettingsRequest = {
 
 export type SetThreadModelSettingsResponse = SetThreadModelSettingsRequest;
 
+export type ApplyThreadModelMigrationRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  /** Creation time from the provider summary, used to exclude newer threads. */
+  threadCreatedAt?: number;
+};
+
+export type ApplyThreadModelMigrationResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  status:
+    | "none"
+    | "already-applied"
+    | "acknowledged-manual-change"
+    | "acknowledged-new-thread"
+    | "applied"
+    | "unavailable";
+  revision?: string;
+  model?: string;
+  reasoningEffort?: string;
+};
+
+export type TurnOffCodexFastEverywhereResponse = {
+  launchpadCount: number;
+  threadCount: number;
+};
+
 export type SetAcpSessionRuntimeOptionRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -225,6 +225,11 @@ export type BackendSummary = {
 
 export type ListBackendsRequest = {
   includeUnavailable?: boolean;
+  /**
+   * Re-read model capabilities before describing providers. A backend id
+   * refreshes one provider; `true` refreshes every provider.
+   */
+  refreshModels?: true | AppServerBackendKind;
 };
 
 export type ListBackendsResponse = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -51,6 +51,10 @@ export type ThreadAgentMetadata = {
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
+  /** Last provider model-migration revision acknowledged by this thread. */
+  modelMigrationRevision?: string;
+  /** Last explicit model/reasoning change made outside a migration. */
+  modelSettingsManuallyUpdatedAt?: number;
   /**
    * Optional Agent/persona marker. When present, this thread is intended
    * to act as a personal Agent surface.
@@ -1236,6 +1240,10 @@ export type ThreadOverlayState = {
   model?: string;
   reasoningEffort?: string;
   reasoningEffortsByModel?: Record<string, string>;
+  /** Last provider model-migration revision acknowledged by this thread. */
+  modelMigrationRevision?: string;
+  /** Last explicit model/reasoning change made outside a migration. */
+  modelSettingsManuallyUpdatedAt?: number;
   serviceTier?: string;
   fastMode?: boolean;
   gitBranch?: string;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -119,6 +119,17 @@ export type DesktopProviderModelDefaults = {
   reasoningEffortsByModel: Record<string, string>;
 };
 
+/**
+ * One operator-created migration generation for existing threads belonging to
+ * a provider. Threads acknowledge a revision once, when next opened.
+ */
+export type DesktopProviderThreadModelMigration = {
+  revision: string;
+  model: string;
+  reasoningEffort?: string;
+  createdAt: number;
+};
+
 export type DesktopAuthorizedContact = {
   id: string;
   displayName: string;
@@ -668,9 +679,14 @@ export type DesktopSettingsSnapshot = {
   };
   models: {
     providerDefaults?: Record<string, DesktopProviderModelDefaults>;
+    providerThreadMigrations?: Record<
+      string,
+      DesktopProviderThreadModelMigration
+    >;
     codex: {
       path: DesktopSettingsValue<string>;
       profile: DesktopSettingsValue<string>;
+      allowFast?: DesktopSettingsValue<boolean>;
       discovery: DesktopCodexDiscoverySnapshot;
       profiles: DesktopCodexAuthProfileDiscoverySnapshot;
     };
@@ -878,9 +894,14 @@ export type DesktopSettingsConfigPatch = {
   };
   models?: {
     providerDefaults?: Record<string, DesktopProviderModelDefaults>;
+    providerThreadMigrations?: Record<
+      string,
+      DesktopProviderThreadModelMigration
+    >;
     codex?: {
       path?: string;
       profile?: string;
+      allowFast?: boolean;
     };
   };
   acpAgents?: {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -127,6 +127,10 @@ export type DesktopProviderThreadModelMigration = {
   revision: string;
   model: string;
   reasoningEffort?: string;
+  /** Existing thread models eligible to adopt this migration. Missing = all. */
+  sourceModels?: string[];
+  /** Whether threads with no reported current model are eligible. */
+  includeThreadsWithoutModel?: boolean;
   createdAt: number;
 };
 

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -109,6 +109,16 @@ export type DesktopSettingsValue<T> = {
   error?: string;
 };
 
+/**
+ * Explicit launchpad baseline for one backend in the active PwrAgent profile.
+ * Reasoning is remembered per model so switching models never overwrites the
+ * operator's preference for another model.
+ */
+export type DesktopProviderModelDefaults = {
+  model?: string;
+  reasoningEffortsByModel: Record<string, string>;
+};
+
 export type DesktopAuthorizedContact = {
   id: string;
   displayName: string;
@@ -657,6 +667,7 @@ export type DesktopSettingsSnapshot = {
     };
   };
   models: {
+    providerDefaults?: Record<string, DesktopProviderModelDefaults>;
     codex: {
       path: DesktopSettingsValue<string>;
       profile: DesktopSettingsValue<string>;
@@ -866,6 +877,7 @@ export type DesktopSettingsConfigPatch = {
     };
   };
   models?: {
+    providerDefaults?: Record<string, DesktopProviderModelDefaults>;
     codex?: {
       path?: string;
       profile?: string;

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -232,6 +232,9 @@ export function materializeNavigationThreads(params: {
       turnFailureLog: overlay?.turnFailureLog,
       model: overlay?.model ?? thread.model,
       reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
+      modelMigrationRevision: overlay?.modelMigrationRevision,
+      modelSettingsManuallyUpdatedAt:
+        overlay?.modelSettingsManuallyUpdatedAt,
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
       fastMode: overlay?.fastMode ?? thread.fastMode,
       codexEnvironmentRuntime:


### PR DESCRIPTION
## Summary

- I added per-profile model defaults for every AI provider with a discovered model catalog, including a separate reasoning/thinking default for each model.
- I made explicit Settings defaults seed otherwise-empty provider contexts while preserving the existing precedence of restored threads, directory launchpads, and learned provider choices.
- I added confirmed actions to apply the selected model/reasoning baseline to matching unsent launchpads or create a provider-scoped migration for existing threads.
- Existing threads adopt each migration once when next opened. Later manual choices remain sticky until a newer migration is created, and threads created after a migration are exempt.
- I added two Codex Fast controls: a profile policy that prohibits Fast and a bulk cleanup that turns Fast off across existing Codex threads and future launchpad state while still allowing later per-thread opt-in.
- I enforce the Fast prohibition in the composer and again at backend turn/start boundaries.
- I added a composer action to reset one launchpad to its configured profile baseline.
- I refresh model catalogs at bounded discovery points and on explicit manual refresh. ACP manual refresh re-probes the installed provider executable without installing or upgrading it.
- I retain unavailable model and reasoning preferences as suspended configuration and use a valid provider fallback without learning that fallback over the saved preference.
- I fixed clipped descenders in Settings model/reasoning selects by giving native select text a sufficient line box.

## Verification

- `pnpm test` — 5,122 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `pnpm lint:colors`
- `pnpm licenses:check`
- `pnpm --filter @pwragent/desktop test:e2e e2e/provider-model-selectors.spec.ts` — 3 passed
- `pnpm --filter @pwragent/desktop build`

## Notes

- I based this branch on freshly fetched `origin/main` at `dade0556172e7baf9bbf5d54c6bae42366dca79c`.
- The installed Kimi 0.11.0 ACP process currently advertises only Kimi-k2.6. Refresh accurately re-probes that executable, but PwrAgent does not invoke Kimi's interactive self-updater.
- I kept provider executable installation and upgrade behavior out of scope.
- The model migration changes PwrAgent's current model/reasoning overlay for eligible threads; it does not rewrite historical turns or eagerly mutate provider-native session history.
