### PR TITLE
fix(desktop): discover current ACP CLI models

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-instance-discovery.test.ts
@@ -141,6 +141,45 @@ describe("discoverAcpAgentInstances", () => {
     ]);
   });
 
+  it("recognizes current Qwen help without requiring the hidden ACP flag", async () => {
+    const discover = vi.fn(
+      async (_options?: LocalAcpDiscoveryOptions) => [],
+    );
+
+    await discoverLocalAcpAgentRecords({
+      discover,
+      enabledRegistryIds: ["qwen"],
+    });
+
+    const qwen = discover.mock.calls[0]?.[0]?.strategies?.[0];
+    expect(qwen?.id).toBe("qwen");
+    expect(qwen?.discoveryProbe.helpMatches).toBeDefined();
+    expect(
+      qwen?.discoveryProbe.helpMatches?.test(
+        "Qwen Code - Launch an interactive CLI, use -p/--prompt",
+      ),
+    ).toBe(true);
+  });
+
+  it("passes a hydrated shell environment to the discovery kit", async () => {
+    const discover = vi.fn(async () => []);
+    const env = {
+      PATH: "/opt/homebrew/bin:/usr/bin",
+    };
+
+    await discoverLocalAcpAgentRecords({
+      discover,
+      enabledRegistryIds: ["qwen"],
+      env,
+    });
+
+    expect(discover).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env,
+      }),
+    );
+  });
+
   it("omits agents with no installed instances", async () => {
     const discover = vi.fn(async () => [group("gemini", [])]);
     const result = await discoverAcpAgentInstances({ discover });

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -901,9 +901,12 @@ describe("settings ipc", () => {
     const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
     const service = new DesktopSettingsService({
       configPath: path.join(tempRoot, "config.toml"),
-      env: {},
+      env: { PATH: "/electron/bin:/usr/bin" },
       secretStore: new MemoryDesktopSecretStore(),
       now: () => 20,
+      resolveCodexShellEnv: () => ({
+        PATH: "/opt/homebrew/bin:/usr/bin",
+      }),
     });
 
     initializeAppState();
@@ -920,6 +923,9 @@ describe("settings ipc", () => {
             grok: { overridePath: "/opt/pwragent/bin/grok" },
             qwen: { overridePath: "/opt/pwragent/bin/qwen" },
           },
+          env: expect.objectContaining({
+            PATH: "/opt/homebrew/bin:/usr/bin",
+          }),
         }),
       );
     } finally {

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -29,6 +29,24 @@ import type {
   AcpRegistryAgent,
 } from "./acp-registry-types.js";
 
+// Qwen Code 0.21 still supports `--acp`, but no longer advertises that hidden
+// flag in `qwen --help`. The upstream strategy's `--acp` text match therefore
+// rejects the current CLI and can make discovery fall through to an older
+// installation. Match the stable product identity instead; the version probe
+// and successful help invocation still guard against unrelated `qwen`
+// executables.
+const ACP_DISCOVERY_STRATEGIES = BUILT_IN_ACP_STRATEGIES.map((strategy) =>
+  strategy.id === "qwen"
+    ? {
+        ...strategy,
+        discoveryProbe: {
+          ...strategy.discoveryProbe,
+          helpMatches: /Qwen Code/i,
+        },
+      }
+    : strategy,
+);
+
 export type AcpInstanceDiscovery = {
   /** Every installed instance, in candidate order (override → PATH → fallback). */
   instances: AcpAgentInstance[];
@@ -202,8 +220,8 @@ function strategiesForEnabledRegistryIds(
   enabledRegistryIds: readonly string[] | undefined,
 ): readonly AcpAgentStrategy[] | undefined {
   if (enabledRegistryIds === undefined) {
-    return undefined;
+    return ACP_DISCOVERY_STRATEGIES;
   }
   const enabled = new Set(enabledRegistryIds);
-  return BUILT_IN_ACP_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
+  return ACP_DISCOVERY_STRATEGIES.filter((strategy) => enabled.has(strategy.id));
 }

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -139,6 +139,7 @@ export type AcpBackendAdapterOptions = {
   createAcpClient?: AcpClientFactory;
   createAcpTransport?: AcpTransportFactory;
   discoverLocalAcpAgents?: LocalAcpDiscovery;
+  resolveLocalAcpDiscoveryEnv?: () => Promise<NodeJS.ProcessEnv>;
   isAcpAgentEnabled?: (registryId: string) => boolean;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
@@ -843,9 +844,11 @@ export class AcpBackendAdapter {
             preferences[registryId] = { overridePath: override };
           }
         }
+        const env = await options.resolveLocalAcpDiscoveryEnv?.();
         const records = await discoverLocalAcpAgentRecords({
           enabledRegistryIds,
           ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
+          ...(env ? { env } : {}),
         });
         return records;
       });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5715,6 +5715,9 @@ export class DesktopBackendRegistry {
       captureStores: this.captureStores,
       createAcpClient: options?.createAcpClient,
       discoverLocalAcpAgents: options?.discoverLocalAcpAgents,
+      resolveLocalAcpDiscoveryEnv: settingsService
+        ? async () => await settingsService.resolveTerminalSpawnEnvAsync()
+        : undefined,
       isAcpAgentEnabled: options?.isAcpAgentEnabled,
       emit: async (event) => await this.emit(event),
       handleServerRequest: async (backend, request) =>

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -148,15 +148,16 @@ let inFlightAcpRefreshForced = false;
 
 async function listAcpAgentSettings(
   request: ListAcpAgentSettingsRequest = {},
+  service?: DesktopSettingsService,
 ): Promise<ListAcpAgentSettingsResponse> {
   if (request.refresh === false) {
-    return await listAcpAgentSettingsImpl(request);
+    return await listAcpAgentSettingsImpl(request, service);
   }
   const wantsForce = request.force === true;
   if (inFlightAcpRefresh && (!wantsForce || inFlightAcpRefreshForced)) {
     return await inFlightAcpRefresh;
   }
-  const run = listAcpAgentSettingsImpl(request).finally(() => {
+  const run = listAcpAgentSettingsImpl(request, service).finally(() => {
     if (inFlightAcpRefresh === run) {
       inFlightAcpRefresh = undefined;
       inFlightAcpRefreshForced = false;
@@ -169,6 +170,7 @@ async function listAcpAgentSettings(
 
 async function listAcpAgentSettingsImpl(
   request: ListAcpAgentSettingsRequest = {},
+  service?: DesktopSettingsService,
 ): Promise<ListAcpAgentSettingsResponse> {
   const store = new AcpAgentStore(getAppStateDb());
   const registryService = new AcpRegistryService();
@@ -185,9 +187,24 @@ async function listAcpAgentSettingsImpl(
   }
 
   snapshot ??= store.readRegistrySnapshot();
+  let discoveryEnv: NodeJS.ProcessEnv | undefined;
+  if (request.refresh === true) {
+    try {
+      // Electron and package managers can prepend transient Node bin
+      // directories to the app process PATH. Discover ACP CLIs from the same
+      // hydrated login-shell environment used by the integrated terminal so
+      // `qwen`, `kimi`, etc. resolve to the binaries the operator invokes.
+      discoveryEnv = await getService(service).resolveTerminalSpawnEnvAsync();
+    } catch (envError) {
+      settingsIpcLog.debug("acp_discovery_shell_env_failed", {
+        error: envError instanceof Error ? envError.message : String(envError),
+      });
+    }
+  }
   const installed = await listInstalledAndLocalAcpAgents(store, {
     refreshLocal: request.refresh === true,
     ...(request.force === true ? { force: true } : {}),
+    ...(discoveryEnv ? { env: discoveryEnv } : {}),
   });
   const entries = snapshot
     ? registryService
@@ -292,7 +309,11 @@ function placeholderAcpAgentSettingsEntry(
 
 async function listInstalledAndLocalAcpAgents(
   store: AcpAgentStore,
-  options?: { refreshLocal?: boolean; force?: boolean },
+  options?: {
+    refreshLocal?: boolean;
+    force?: boolean;
+    env?: NodeJS.ProcessEnv;
+  },
 ): Promise<AcpInstalledAgentRecord[]> {
   const installed = store.listInstalledAgents();
   let discovered: AcpInstalledAgentRecord[] = [];
@@ -312,6 +333,7 @@ async function listInstalledAndLocalAcpAgents(
       discovered = await discoverLocalAcpAgentRecords({
         enabledRegistryIds,
         ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
+        ...(options?.env ? { env: options.env } : {}),
       });
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();
       const now = Date.now();
@@ -877,7 +899,8 @@ export function registerSettingsIpcHandlers(
     async (
       _event,
       request?: ListAcpAgentSettingsRequest,
-    ): Promise<ListAcpAgentSettingsResponse> => await listAcpAgentSettings(request),
+    ): Promise<ListAcpAgentSettingsResponse> =>
+      await listAcpAgentSettings(request, service),
   );
 
   ipcMain.removeHandler(SETTINGS_READ_CHANNEL);


### PR DESCRIPTION
## Summary

- discover ACP agents with the hydrated login-shell environment used by PwrAgent's integrated terminal
- recognize current Qwen Code releases even though `qwen --help` no longer advertises the hidden `--acp` flag
- apply the same discovery environment to settings refreshes and fresh chat-side discovery

## Root cause

Qwen Code 0.21.0 still accepts `--acp` and reports its current model catalog over ACP, but it removed `--acp` from ordinary help output. The upstream discovery strategy rejected that binary and fell through to an older Qwen installation exposed by the Electron/pnpm process PATH. As a result, PwrAgent cached the older CLI's model list.

## User impact

On this machine the corrected discovery resolves `/opt/homebrew/bin/qwen` 0.21.0 and exposes the six models advertised by Qwen ACP, including `qwen3.7-plus` and `qwen3.7-max`.

## Validation

- live end-to-end ACP probe against Qwen Code 0.21.0
- 430 focused desktop main-process tests
- desktop TypeScript typecheck
- ESLint (0 errors; existing warnings only)
- dependency boundary validation
