### PR TITLE
fix(desktop): keep provider info tab bottom-pinned

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -68,7 +68,6 @@ type ContextTab = {
 
 const CONTEXT_TABS: ContextTab[] = [
   { id: "info", label: "Thread info", Icon: InfoIcon },
-  { id: "providers", label: "AI provider info", Icon: ServerIcon },
   { id: "edits", label: "Edits", Icon: EditsIcon },
   { id: "pricing", label: "Pricing", Icon: PricingIcon },
   { id: "actions", label: "Actions", Icon: TerminalIcon },
@@ -76,6 +75,7 @@ const CONTEXT_TABS: ContextTab[] = [
   { id: "automations", label: "Automations", Icon: AutomationsIcon },
   { id: "prs", label: "Pull requests", Icon: PullRequestIcon },
   { id: "projects", label: "Linked projects", Icon: ProjectsIcon },
+  { id: "providers", label: "AI provider info", Icon: ServerIcon, bottom: true },
 ];
 
 type ThreadContextPanelProps = {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -580,7 +580,7 @@ describe("ThreadContextPanel", () => {
 
     fireEvent.keyDown(info, { key: "ArrowDown" });
     expect(document.activeElement).toBe(
-      screen.getByRole("tab", { name: "AI provider info" }),
+      screen.getByRole("tab", { name: "Edits" }),
     );
 
     fireEvent.keyDown(document.activeElement!, { key: "ArrowUp" });
@@ -588,7 +588,7 @@ describe("ThreadContextPanel", () => {
 
     fireEvent.keyDown(info, { key: "End" });
     expect(document.activeElement).toBe(
-      screen.getByRole("tab", { name: "Linked projects" }),
+      screen.getByRole("tab", { name: "AI provider info" }),
     );
   });
 


### PR DESCRIPTION
## Summary

- keep the expanded AI provider profile, account, and rate-limit information introduced by #1042
- restore the AI Provider Info tab to the bottom-pinned rail position
- update roving keyboard-navigation expectations for the restored tab order

## Why

The provider panel is useful as a distinct utility view, but moving it into the main context-tab sequence made the rail feel less coherent. This restores its previous bottom anchor without removing any of the provider-status functionality.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx` (51 tests passed)
- `pnpm typecheck`
- `git diff --check`
