### PR TITLE
fix(desktop): persist and price Qwen ACP turn usage

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AcpBackendId,
@@ -13,6 +16,11 @@ import {
 } from "../app-server/acp-backend-adapter";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
 import { FakeAcpAgentTransport } from "../acp/testing/fake-acp-agent";
+
+const fixtureDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures/acp-transcripts",
+);
 
 describe("describeInstalledAcpBackend", () => {
   it("does not advertise session/load when the agent reports it is unsupported", () => {
@@ -872,6 +880,109 @@ describe("AcpBackendAdapter", () => {
           event.notification.params.delta === "I should run the build first.",
       ),
     ).toEqual([]);
+
+    await adapter.close();
+  });
+
+  it("emits cumulative Qwen usage across fixture-backed model calls", async () => {
+    const backendId = "acp:qwen" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport();
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "qwen",
+      name: "Qwen Code",
+      launchDescriptor: {
+        backendId,
+        registryId: "qwen",
+        distributionKind: "local",
+        command: "qwen",
+        args: ["--experimental-acp"],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backendId, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          if (index >= 0) {
+            sessions[index] = metadata;
+          } else {
+            sessions.push(metadata);
+          }
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => transport,
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: async () => ({ decision: "accept" }),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const session = await client.startSession({
+      cwd: "/repo",
+      executionMode: "full-access",
+      acpRuntime: {
+        currentModelId: "qwen3-coder-plus",
+      },
+    });
+    client.startPrompt({
+      sessionId: session.sessionId,
+      prompt: "What is this project?",
+      turnId: "turn-usage",
+    });
+    const updates = JSON.parse(
+      readFileSync(path.join(fixtureDir, "qwen-tool-usage.json"), "utf8"),
+    ) as Array<Record<string, unknown>>;
+    for (const update of updates) {
+      transport.emitSessionUpdate(session.sessionId, update);
+    }
+
+    await vi.waitFor(() => {
+      expect(
+        events.filter(
+          (event) =>
+            event.notification.method === "thread/tokenUsage/updated",
+        ),
+      ).toHaveLength(1);
+    });
+    const usageEvents = events.filter(
+      (event) => event.notification.method === "thread/tokenUsage/updated",
+    );
+    expect(usageEvents.at(-1)).toEqual({
+      backend: backendId,
+      notification: {
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: session.sessionId,
+          turnId: "turn-usage",
+          model: "qwen3-coder-plus",
+          tokenUsage: {
+            last_token_usage: {
+              input_tokens: 48_851,
+              cached_input_tokens: 20_000,
+              output_tokens: 322,
+              reasoning_output_tokens: 49,
+              total_tokens: 49_173,
+            },
+          },
+        },
+      },
+    });
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -332,7 +332,7 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual([]);
   });
 
-  it("returns suppressed Qwen usage emitted on an agent message chunk", async () => {
+  it("aggregates suppressed Qwen model-call usage and preserves its selected model", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
       "session/prompt": promptResponse.promise,
@@ -348,6 +348,9 @@ describe("AcpAgentClient", () => {
     const session = await client.startSession({
       cwd: "/repo",
       executionMode: "default",
+      acpRuntime: {
+        currentModelId: "qwen3-coder-plus",
+      },
     });
     const controlPrompt = client.sendControlPrompt({
       sessionId: session.sessionId,
@@ -366,16 +369,30 @@ describe("AcpAgentClient", () => {
         },
       },
     });
+    transport.emitSessionUpdate(session.sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "" },
+      _meta: {
+        usage: {
+          inputTokens: 120,
+          outputTokens: 8,
+          totalTokens: 128,
+          thoughtTokens: 3,
+          cachedReadTokens: 20,
+        },
+      },
+    });
     promptResponse.resolve({ stopReason: "end_turn" });
 
     await expect(controlPrompt).resolves.toEqual({
       text: '{ "title": "Favorite cereal" }',
+      model: "qwen3-coder-plus",
       tokenUsage: {
-        inputTokens: 23_851,
-        cachedInputTokens: 0,
-        outputTokens: 222,
-        reasoningOutputTokens: 29,
-        totalTokens: 24_073,
+        inputTokens: 23_971,
+        cachedInputTokens: 20,
+        outputTokens: 230,
+        reasoningOutputTokens: 32,
+        totalTokens: 24_201,
       },
     });
     expect(client.readReplay(session.sessionId).messages).toEqual([]);

--- a/apps/desktop/src/main/__tests__/acp-usage.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-usage.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  foldAcpTurnUsage,
+  readAcpSelectedModel,
+  readAcpUsageEnvelope,
+  type AcpTokenUsage,
+} from "../acp/acp-usage";
+
+const fixturePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures/acp-transcripts/qwen-tool-usage.json",
+);
+
+describe("ACP usage normalization", () => {
+  it("aggregates every Qwen model-call envelope in a tool-using turn", () => {
+    const updates = JSON.parse(readFileSync(fixturePath, "utf8")) as Array<
+      Record<string, unknown>
+    >;
+    const envelopes = updates.flatMap((update) => {
+      const envelope = readAcpUsageEnvelope(update);
+      return envelope ? [envelope] : [];
+    });
+
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]).toMatchObject({
+      scope: "model-call",
+      tokenUsage: {
+        cachedInputTokens: 0,
+        inputTokens: 23_851,
+        outputTokens: 222,
+        reasoningOutputTokens: 29,
+        totalTokens: 24_073,
+      },
+    });
+    expect(
+      envelopes.reduce<AcpTokenUsage | undefined>(
+        (total, envelope) => foldAcpTurnUsage(total, envelope),
+        undefined,
+      ),
+    ).toEqual({
+      cachedInputTokens: 20_000,
+      inputTokens: 48_851,
+      outputTokens: 322,
+      reasoningOutputTokens: 49,
+      totalTokens: 49_173,
+    });
+  });
+
+  it("treats Grok turn_completed usage as an authoritative turn total", () => {
+    const envelope = readAcpUsageEnvelope({
+      sessionUpdate: "turn_completed",
+      usage: {
+        inputTokens: 1_200,
+        cachedReadTokens: 1_000,
+        outputTokens: 50,
+        reasoningTokens: 10,
+        totalTokens: 1_250,
+        modelUsage: {
+          "grok-4.5-build": {},
+        },
+      },
+    });
+
+    expect(envelope).toMatchObject({
+      model: "grok-4.5-build",
+      scope: "turn",
+    });
+    expect(
+      envelope
+        ? foldAcpTurnUsage(
+            {
+              inputTokens: 999,
+              totalTokens: 1_000,
+            },
+            envelope,
+          )
+        : undefined,
+    ).toEqual({
+      cachedInputTokens: 1_000,
+      inputTokens: 1_200,
+      outputTokens: 50,
+      reasoningOutputTokens: 10,
+      totalTokens: 1_250,
+    });
+  });
+
+  it("recovers the selected ACP model from session runtime state", () => {
+    expect(
+      readAcpSelectedModel({
+        currentModelId: "qwen3-coder-plus",
+      }),
+    ).toBe("qwen3-coder-plus");
+    expect(
+      readAcpSelectedModel({
+        configValues: {
+          model: "qwen3-coder-flash",
+        },
+      }),
+    ).toBe("qwen3-coder-flash");
+  });
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14201,6 +14201,68 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists priced Qwen 3.7 Plus ModelStudio usage", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.publishLocalEvent({
+      backend: "acp:qwen",
+      notification: {
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "qwen-thread",
+          turnId: "qwen-turn",
+          model: "qwen3.7-plus(openai)",
+          tokenUsage: {
+            last_token_usage: {
+              input_tokens: 39_286,
+              cached_input_tokens: 0,
+              output_tokens: 90,
+              reasoning_output_tokens: 49,
+              total_tokens: 39_376,
+            },
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "acp:qwen",
+      threadId: "qwen-thread",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputCostMicros: 0,
+      inputTokens: 39_286,
+      model: "qwen3.7-plus(openai)",
+      outputCostMicros: 144,
+      outputTokens: 90,
+      priceStatus: "priced",
+      pricingCatalogId: "qwen-modelstudio-international",
+      pricingCatalogVersion: "2026-07-15",
+      pricingRateId:
+        "qwen:2026-07-15:qwen3.7-plus:standard:input-lte-256k",
+      provider: "qwen",
+      reasoningOutputTokens: 49,
+      totalCostMicros: 15_858,
+      totalTokens: 39_376,
+      turnId: "qwen-turn",
+      turnUsageAttributed: true,
+      uncachedInputCostMicros: 15_714,
+    });
+
+    await registry.close();
+  });
+
   it("marks a whole-thread total with no per-request usage as unattributed", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14143,6 +14143,64 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("persists Qwen turn usage as an unpriced card when no catalog rate exists", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    await registry.publishLocalEvent({
+      backend: "acp:qwen",
+      notification: {
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "qwen-thread",
+          turnId: "qwen-turn",
+          model: "qwen3-coder-plus",
+          tokenUsage: {
+            last_token_usage: {
+              input_tokens: 48_851,
+              cached_input_tokens: 20_000,
+              output_tokens: 322,
+              reasoning_output_tokens: 49,
+              total_tokens: 49_173,
+            },
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "acp:qwen",
+      threadId: "qwen-thread",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputTokens: 20_000,
+      inputTokens: 48_851,
+      model: "qwen3-coder-plus",
+      outputTokens: 322,
+      priceStatus: "unpriced",
+      priceUnavailableReason: "missing-rate",
+      provider: "qwen",
+      reasoningOutputTokens: 49,
+      totalCostMicros: 0,
+      totalTokens: 49_173,
+      turnId: "qwen-turn",
+      turnUsageAttributed: true,
+    });
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("marks a whole-thread total with no per-request usage as unattributed", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/fixtures/acp-transcripts/qwen-tool-usage.json
+++ b/apps/desktop/src/main/__tests__/fixtures/acp-transcripts/qwen-tool-usage.json
@@ -1,0 +1,50 @@
+[
+  {
+    "sessionUpdate": "agent_message_chunk",
+    "content": {
+      "type": "text",
+      "text": ""
+    },
+    "_meta": {
+      "usage": {
+        "inputTokens": 23851,
+        "outputTokens": 222,
+        "totalTokens": 24073,
+        "thoughtTokens": 29,
+        "cachedReadTokens": 0
+      }
+    }
+  },
+  {
+    "sessionUpdate": "tool_call",
+    "toolCallId": "call_read_readme",
+    "status": "in_progress",
+    "title": "ReadFile: README.md",
+    "kind": "read"
+  },
+  {
+    "sessionUpdate": "tool_call_update",
+    "toolCallId": "call_read_readme",
+    "status": "completed",
+    "content": {
+      "type": "text",
+      "text": "# PwrAgent"
+    }
+  },
+  {
+    "sessionUpdate": "agent_message_chunk",
+    "content": {
+      "type": "text",
+      "text": "PwrAgent is an open-source coding agent."
+    },
+    "_meta": {
+      "usage": {
+        "inputTokens": 25000,
+        "outputTokens": 100,
+        "totalTokens": 25100,
+        "thoughtTokens": 20,
+        "cachedReadTokens": 20000
+      }
+    }
+  }
+]

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -843,6 +843,53 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("reprices persisted Qwen ACP usage under the Qwen provider", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        backend: "acp:qwen",
+        cachedInputTokens: 0,
+        completedAt: Date.UTC(2026, 6, 28),
+        createdAt: Date.UTC(2026, 6, 28),
+        inputTokens: 39_286,
+        model: "qwen3.7-plus(openai)",
+        outputTokens: 90,
+        priceStatus: "unpriced",
+        priceUnavailableReason: "missing-rate",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        provider: "qwen",
+        reasoningOutputTokens: 49,
+        totalCostMicros: 0,
+        totalTokens: 39_376,
+        uncachedInputTokens: 39_286,
+        usageLineId: "line-qwen3-7-plus",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "acp:qwen",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "priced",
+      pricingCatalogId: "qwen-modelstudio-international",
+      pricingCatalogVersion: "2026-07-15",
+      pricingRateId:
+        "qwen:2026-07-15:qwen3.7-plus:standard:input-lte-256k",
+      provider: "qwen",
+      totalCostMicros: 15_858,
+    });
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      pricedUsageLineCount: 1,
+      provider: "qwen",
+      totalCostMicros: 15_858,
+      unpricedUsageLineCount: 0,
+    });
+  });
+
   it("records one provider-scoped usage turn for multiple usage lines from the same turn", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -44,6 +44,12 @@ import {
   type AcpRolloutRecord,
   type AcpRolloutStoreAppendParams,
 } from "./acp-rollout-store.js";
+import {
+  foldAcpTurnUsage,
+  readAcpSelectedModel,
+  readAcpUsageEnvelope,
+  type AcpTokenUsage,
+} from "./acp-usage.js";
 import type { JsonRpcId } from "@pwrdrvr/agent-transport";
 import { getMainLogger } from "../log.js";
 
@@ -129,13 +135,7 @@ type AcpSuppressedControlPrompt = {
   fallbackOutputText?: string;
   finalTextChunks: string[];
   model?: string;
-  tokenUsage?: {
-    cachedInputTokens?: number;
-    inputTokens?: number;
-    outputTokens?: number;
-    reasoningOutputTokens?: number;
-    totalTokens?: number;
-  };
+  tokenUsage?: AcpTokenUsage;
 };
 
 type AcpHydratedSessionHistory = {
@@ -560,7 +560,14 @@ export class AcpAgentClient {
     tokenUsage?: AcpSuppressedControlPrompt["tokenUsage"];
   }> {
     const protocolSessionId = this.protocolSessionIdFor(params.sessionId);
-    const suppression: AcpSuppressedControlPrompt = { finalTextChunks: [] };
+    const selectedModel = readAcpSelectedModel(
+      this.options.store.getSession(this.options.backendId, params.sessionId)
+        ?.acpRuntime,
+    );
+    const suppression: AcpSuppressedControlPrompt = {
+      finalTextChunks: [],
+      ...(selectedModel ? { model: selectedModel } : {}),
+    };
     this.suppressedControlPromptSessions.set(protocolSessionId, suppression);
     try {
       await this.options.transport.request(
@@ -755,10 +762,14 @@ export class AcpAgentClient {
           suppressedControlPrompt.fallbackOutputText = text;
         }
       }
-      const usage = readControlPromptUsage(update);
+      const usage = readAcpUsageEnvelope(update);
       if (usage) {
-        suppressedControlPrompt.tokenUsage = usage.tokenUsage;
-        suppressedControlPrompt.model = usage.model;
+        suppressedControlPrompt.tokenUsage = foldAcpTurnUsage(
+          suppressedControlPrompt.tokenUsage,
+          usage,
+        );
+        suppressedControlPrompt.model =
+          usage.model ?? suppressedControlPrompt.model;
       }
       return;
     }
@@ -1273,55 +1284,6 @@ function readUpdateKind(update: Record<string, unknown>): string | undefined {
   const kind =
     update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
-}
-
-function readControlPromptUsage(
-  update: Record<string, unknown>,
-): Pick<AcpSuppressedControlPrompt, "model" | "tokenUsage"> | undefined {
-  const kind = readUpdateKind(update);
-  const usage =
-    kind === "turn_completed"
-      ? asRecord(update.usage)
-      : kind === "agent_message_chunk"
-        ? asRecord(asRecord(update._meta)?.usage)
-        : undefined;
-  if (!usage) {
-    return undefined;
-  }
-  const inputTokens = readFiniteNumber(usage.inputTokens);
-  const cachedInputTokens = readFiniteNumber(usage.cachedReadTokens);
-  const outputTokens = readFiniteNumber(usage.outputTokens);
-  const reasoningOutputTokens =
-    readFiniteNumber(usage.reasoningTokens) ??
-    readFiniteNumber(usage.thoughtTokens);
-  const totalTokens = readFiniteNumber(usage.totalTokens);
-  if (
-    inputTokens === undefined &&
-    outputTokens === undefined &&
-    totalTokens === undefined
-  ) {
-    return undefined;
-  }
-  const modelUsage = asRecord(usage.modelUsage);
-  const model = modelUsage ? Object.keys(modelUsage)[0] : undefined;
-  return {
-    ...(model ? { model } : {}),
-    tokenUsage: {
-      ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
-      ...(inputTokens !== undefined ? { inputTokens } : {}),
-      ...(outputTokens !== undefined ? { outputTokens } : {}),
-      ...(reasoningOutputTokens !== undefined
-        ? { reasoningOutputTokens }
-        : {}),
-      ...(totalTokens !== undefined ? { totalTokens } : {}),
-    },
-  };
-}
-
-function readFiniteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
 }
 
 function isConversationHistoryUpdate(update: Record<string, unknown>): boolean {

--- a/apps/desktop/src/main/acp/acp-live-notifications.ts
+++ b/apps/desktop/src/main/acp/acp-live-notifications.ts
@@ -9,6 +9,12 @@ import {
   readAcpWebSearch,
 } from "./acp-command-extraction.js";
 import { sanitizeAcpToolOutput } from "./acp-tool-output.js";
+import {
+  foldAcpTurnUsage,
+  readAcpUsageEnvelope,
+  type AcpTokenUsage,
+  type AcpUsageEnvelope,
+} from "./acp-usage.js";
 
 export function acpToolUpdateNotifications(params: {
   threadId: string;
@@ -41,32 +47,19 @@ export function acpToolUpdateNotifications(params: {
   ];
 }
 
-export function acpTurnCompletedUsageNotification(params: {
+export function acpUsageNotification(params: {
+  envelope: AcpUsageEnvelope;
+  model?: string;
   threadId: string;
+  totalTokenUsage: AcpTokenUsage;
   turnId?: string;
-  update: Record<string, unknown>;
 }): AppServerNotification | undefined {
-  if (!params.turnId || readKind(params.update) !== "turn_completed") {
+  if (!params.turnId) {
     return undefined;
   }
-  const usage = asRecord(params.update.usage);
-  if (!usage) {
-    return undefined;
-  }
-  const inputTokens = readNumber(usage, "inputTokens");
-  const cachedInputTokens = readNumber(usage, "cachedReadTokens");
-  const outputTokens = readNumber(usage, "outputTokens");
-  const reasoningOutputTokens = readNumber(usage, "reasoningTokens");
-  const totalTokens = readNumber(usage, "totalTokens");
-  if (
-    inputTokens === undefined &&
-    outputTokens === undefined &&
-    totalTokens === undefined
-  ) {
-    return undefined;
-  }
-  const modelUsage = asRecord(usage.modelUsage);
-  const model = modelUsage ? Object.keys(modelUsage)[0] : undefined;
+  const model = params.envelope.model ?? params.model;
+  const latest = tokenUsageNotificationBreakdown(params.envelope.tokenUsage);
+  const total = tokenUsageNotificationBreakdown(params.totalTokenUsage);
   return {
     method: "thread/tokenUsage/updated",
     params: {
@@ -74,20 +67,52 @@ export function acpTurnCompletedUsageNotification(params: {
       turnId: params.turnId,
       ...(model ? { model } : {}),
       tokenUsage: {
-        last_token_usage: {
-          ...(inputTokens !== undefined ? { input_tokens: inputTokens } : {}),
-          ...(cachedInputTokens !== undefined
-            ? { cached_input_tokens: cachedInputTokens }
-            : {}),
-          ...(outputTokens !== undefined ? { output_tokens: outputTokens } : {}),
-          ...(reasoningOutputTokens !== undefined
-            ? { reasoning_output_tokens: reasoningOutputTokens }
-            : {}),
-          ...(totalTokens !== undefined ? { total_tokens: totalTokens } : {}),
-        },
+        last_token_usage: latest,
+        ...(params.envelope.scope === "model-call"
+          ? { total_token_usage: total }
+          : {}),
       },
     },
   } as AppServerNotification;
+}
+
+export function acpTurnCompletedUsageNotification(params: {
+  threadId: string;
+  turnId?: string;
+  update: Record<string, unknown>;
+}): AppServerNotification | undefined {
+  const envelope = readAcpUsageEnvelope(params.update);
+  if (!envelope || envelope.scope !== "turn") {
+    return undefined;
+  }
+  return acpUsageNotification({
+    envelope,
+    threadId: params.threadId,
+    totalTokenUsage: foldAcpTurnUsage(undefined, envelope),
+    turnId: params.turnId,
+  });
+}
+
+function tokenUsageNotificationBreakdown(
+  usage: AcpTokenUsage,
+): Record<string, number> {
+  return {
+    ...(usage.inputTokens !== undefined
+      ? { input_tokens: usage.inputTokens }
+      : {}),
+    ...(usage.cachedInputTokens !== undefined
+      ? { cached_input_tokens: usage.cachedInputTokens }
+      : {}),
+    ...(usage.outputTokens !== undefined
+      ? { output_tokens: usage.outputTokens }
+      : {}),
+    ...(usage.reasoningOutputTokens !== undefined
+      ? { reasoning_output_tokens: usage.reasoningOutputTokens }
+      : {}),
+    ...(usage.totalTokens !== undefined
+      ? { total_tokens: usage.totalTokens }
+      : {}),
+  };
 }
 
 function liveItemForAcpToolUpdate(
@@ -228,22 +253,6 @@ function readString(
 ): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function readNumber(
-  record: Record<string, unknown>,
-  key: string,
-): number | undefined {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 function readFirstLocationPath(record: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/main/acp/acp-usage.ts
+++ b/apps/desktop/src/main/acp/acp-usage.ts
@@ -1,0 +1,135 @@
+import type { BackendAcpSessionRuntimeState } from "@pwragent/shared";
+
+export type AcpTokenUsage = {
+  cachedInputTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningOutputTokens?: number;
+  totalTokens?: number;
+};
+
+export type AcpUsageEnvelope = {
+  model?: string;
+  scope: "model-call" | "turn";
+  tokenUsage: AcpTokenUsage;
+};
+
+export function readAcpUsageEnvelope(
+  update: Record<string, unknown>,
+): AcpUsageEnvelope | undefined {
+  const kind = readAcpUpdateKind(update);
+  const usage =
+    kind === "turn_completed"
+      ? readRecord(update.usage)
+      : kind === "agent_message_chunk"
+        ? readRecord(readRecord(update._meta)?.usage)
+        : undefined;
+  if (!usage) {
+    return undefined;
+  }
+
+  const inputTokens = readFiniteNumber(usage.inputTokens);
+  const cachedInputTokens =
+    readFiniteNumber(usage.cachedInputTokens) ??
+    readFiniteNumber(usage.cachedReadTokens);
+  const outputTokens = readFiniteNumber(usage.outputTokens);
+  const reasoningOutputTokens =
+    readFiniteNumber(usage.reasoningOutputTokens) ??
+    readFiniteNumber(usage.reasoningTokens) ??
+    readFiniteNumber(usage.thoughtTokens);
+  const totalTokens = readFiniteNumber(usage.totalTokens);
+  if (
+    inputTokens === undefined &&
+    cachedInputTokens === undefined &&
+    outputTokens === undefined &&
+    reasoningOutputTokens === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined;
+  }
+
+  const modelUsage = readRecord(usage.modelUsage);
+  const model =
+    readNonEmptyString(usage.model) ??
+    readNonEmptyString(usage.modelId) ??
+    readNonEmptyString(usage.model_id) ??
+    (modelUsage ? Object.keys(modelUsage)[0] : undefined);
+  return {
+    ...(model ? { model } : {}),
+    scope: kind === "turn_completed" ? "turn" : "model-call",
+    tokenUsage: {
+      ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+      ...(inputTokens !== undefined ? { inputTokens } : {}),
+      ...(outputTokens !== undefined ? { outputTokens } : {}),
+      ...(reasoningOutputTokens !== undefined
+        ? { reasoningOutputTokens }
+        : {}),
+      ...(totalTokens !== undefined ? { totalTokens } : {}),
+    },
+  };
+}
+
+export function foldAcpTurnUsage(
+  previous: AcpTokenUsage | undefined,
+  envelope: AcpUsageEnvelope,
+): AcpTokenUsage {
+  if (envelope.scope === "turn") {
+    return envelope.tokenUsage;
+  }
+  if (!previous) {
+    return envelope.tokenUsage;
+  }
+  return {
+    ...sumPresentUsageField(previous, envelope.tokenUsage, "cachedInputTokens"),
+    ...sumPresentUsageField(previous, envelope.tokenUsage, "inputTokens"),
+    ...sumPresentUsageField(previous, envelope.tokenUsage, "outputTokens"),
+    ...sumPresentUsageField(previous, envelope.tokenUsage, "reasoningOutputTokens"),
+    ...sumPresentUsageField(previous, envelope.tokenUsage, "totalTokens"),
+  };
+}
+
+export function readAcpSelectedModel(
+  runtime: BackendAcpSessionRuntimeState | undefined,
+): string | undefined {
+  return (
+    readNonEmptyString(runtime?.currentModelId) ??
+    readNonEmptyString(runtime?.configValues?.model)
+  );
+}
+
+function sumPresentUsageField<K extends keyof AcpTokenUsage>(
+  previous: AcpTokenUsage,
+  next: AcpTokenUsage,
+  key: K,
+): Pick<AcpTokenUsage, K> | undefined {
+  const previousValue = previous[key];
+  const nextValue = next[key];
+  if (previousValue === undefined && nextValue === undefined) {
+    return undefined;
+  }
+  return {
+    [key]: (previousValue ?? 0) + (nextValue ?? 0),
+  } as Pick<AcpTokenUsage, K>;
+}
+
+function readAcpUpdateKind(update: Record<string, unknown>): string | undefined {
+  const kind =
+    update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
+  return typeof kind === "string" ? kind : undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -51,8 +51,14 @@ import {
 } from "../settings/desktop-config";
 import {
   acpToolUpdateNotifications,
-  acpTurnCompletedUsageNotification,
+  acpUsageNotification,
 } from "../acp/acp-live-notifications";
+import {
+  foldAcpTurnUsage,
+  readAcpSelectedModel,
+  readAcpUsageEnvelope,
+  type AcpTokenUsage,
+} from "../acp/acp-usage.js";
 import {
   AcpRolloutStore,
   isPwrAgentSyntheticAcpUpdate,
@@ -126,6 +132,11 @@ export type LocalAcpDiscovery = () => Promise<AcpInstalledAgentRecord[]>;
 export type AcpSessionStoreLike =
   Pick<AcpSessionStoreContract, "getSession" | "listSessions"> &
   Partial<Pick<AcpSessionStoreContract, "upsertSession">>;
+
+type AcpLiveTurnUsage = {
+  model?: string;
+  tokenUsage: AcpTokenUsage;
+};
 
 export type AcpPromptPayload = {
   prompt: string;
@@ -692,6 +703,19 @@ function mergeAcpReplayWithSyntheticHistory(
   };
 }
 
+function selectedAcpModel(
+  agent: AcpInstalledAgentRecord,
+  session: AcpSessionMetadata | undefined,
+): string | undefined {
+  return (
+    readAcpSelectedModel(session?.acpRuntime) ??
+    agent.runtimeCapabilities?.models?.currentModelId ??
+    agent.runtimeCapabilities?.configOptions?.find(
+      (option) => option.category === "model",
+    )?.currentValue
+  );
+}
+
 export function isAcpSessionMissingForProjectError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -806,6 +830,7 @@ export class AcpBackendAdapter {
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
   private readonly providerStatusRefreshes = new Map<AcpBackendId, Promise<void>>();
   private closed = false;
+  private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
   constructor(options: AcpBackendAdapterOptions) {
@@ -1416,6 +1441,7 @@ export class AcpBackendAdapter {
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
+    this.liveTurnUsage.clear();
     await Promise.all(
       acpClients.map(async (clientPromise) => {
         const client = await clientPromise.catch(() => undefined);
@@ -1505,6 +1531,44 @@ export class AcpBackendAdapter {
         update,
       }) => {
         const updateKind = readAcpUpdateKind(update);
+        const usageEnvelope = readAcpUsageEnvelope(update);
+        if (usageEnvelope && turnId) {
+          const usageKey = [agent.backendId, sessionId, turnId].join(":");
+          const previousUsage = this.liveTurnUsage.get(usageKey);
+          this.liveTurnUsage.set(usageKey, {
+            model:
+              usageEnvelope.model ??
+              previousUsage?.model ??
+              selectedAcpModel(
+                agent,
+                this.getSession(agent.backendId, sessionId),
+              ),
+            tokenUsage: foldAcpTurnUsage(
+              previousUsage?.tokenUsage,
+              usageEnvelope,
+            ),
+          });
+        }
+        const completedUsage =
+          updateKind === "turn_finished" && turnId
+            ? this.liveTurnUsage.get(
+                [agent.backendId, sessionId, turnId].join(":"),
+              )
+            : undefined;
+        const usageNotification = completedUsage
+          ? acpUsageNotification({
+              envelope: {
+                ...(completedUsage.model
+                  ? { model: completedUsage.model }
+                  : {}),
+                scope: "turn",
+                tokenUsage: completedUsage.tokenUsage,
+              },
+              threadId: sessionId,
+              totalTokenUsage: completedUsage.tokenUsage,
+              turnId,
+            })
+          : undefined;
         if (title) {
           await this.emit({
             backend: agent.backendId,
@@ -1597,11 +1661,6 @@ export class AcpBackendAdapter {
             notification,
           });
         }
-        const usageNotification = acpTurnCompletedUsageNotification({
-          threadId: sessionId,
-          turnId,
-          update,
-        });
         if (usageNotification) {
           await this.emit({
             backend: agent.backendId,
@@ -1609,6 +1668,9 @@ export class AcpBackendAdapter {
           });
         }
         if (updateKind === "turn_finished" && turnId) {
+          this.liveTurnUsage.delete(
+            [agent.backendId, sessionId, turnId].join(":"),
+          );
           this.clearLiveToolNotificationFingerprints({
             backend: agent.backendId,
             threadId: sessionId,
@@ -1646,6 +1708,9 @@ export class AcpBackendAdapter {
         });
       },
       onPromptError: async ({ sessionId, turnId, error }) => {
+        this.liveTurnUsage.delete(
+          [agent.backendId, sessionId, turnId].join(":"),
+        );
         await this.emit({
           backend: agent.backendId,
           notification: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3393,7 +3393,7 @@ function buildTaskMonitorUsageLine(params: {
     parentThreadId: params.parentThreadId,
     priceStatus: cost ? "priced" : "unpriced",
     ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
-    provider: cost?.provider ?? "openai",
+    provider: cost?.provider ?? fallbackUsageProvider(params.backend),
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
     ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
@@ -3622,7 +3622,7 @@ function buildLiveThreadUsageLine(params: {
     outputTokens,
     priceStatus: cost ? "priced" : "unpriced",
     ...(priceUnavailableReason ? { priceUnavailableReason } : {}),
-    provider: cost?.provider ?? "openai",
+    provider: cost?.provider ?? fallbackUsageProvider(params.backend),
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
     ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
@@ -3651,6 +3651,10 @@ function buildLiveThreadUsageLine(params: {
       "live-token-usage",
     ].join(":"),
   };
+}
+
+function fallbackUsageProvider(backend: AppServerBackendKind): string {
+  return backend === "acp:qwen" ? "qwen" : "openai";
 }
 
 /**

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -3197,7 +3197,10 @@ function mergeUsageSettingValue<T extends string>(
 }
 
 function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRecord {
-  if (line.provider !== "openai") {
+  if (
+    line.provider !== "openai"
+    && line.provider !== "qwen"
+  ) {
     return line;
   }
   // Fork-baseline lines carry inherited context that was billed on the parent

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1621,7 +1621,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          service_tier,
          uncached_input_tokens
        FROM thread_usage_lines
-       WHERE provider = 'openai'
+       WHERE provider IN ('openai', 'qwen')
          AND scope != 'fork-baseline'`,
     )
     .all() as Array<{

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -249,6 +249,67 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices Qwen ACP ModelStudio usage with the International list rate", () => {
+    const cost = estimateTokenUsageCost({
+      at: Date.UTC(2026, 6, 28),
+      cachedInputTokens: 0,
+      model: "qwen3.7-plus(openai)",
+      outputTokens: 90,
+      reasoningOutputTokens: 49,
+      uncachedInputTokens: 39_286,
+    });
+
+    expect(cost).toMatchObject({
+      cachedInputCostMicros: 0,
+      cachedInputUsdPerMillion: 0.08,
+      catalogId: "qwen-modelstudio-international",
+      catalogVersion: "2026-07-15",
+      displayName: "Qwen 3.7 Plus International (<=256K input)",
+      inputUsdPerMillion: 0.4,
+      model: "qwen3.7-plus(openai)",
+      outputCostMicros: 144,
+      outputTokensIncludeReasoning: true,
+      outputUsdPerMillion: 1.6,
+      provider: "qwen",
+      rateId:
+        "qwen:2026-07-15:qwen3.7-plus:standard:input-lte-256k",
+      serviceTier: "standard",
+      totalCostMicros: 15_858,
+      totalUsd: 0.015858,
+      uncachedInputCostMicros: 15_714,
+    });
+  });
+
+  it("uses Qwen's 20% implicit-cache rate without double billing reasoning", () => {
+    const cost = estimateTokenUsageCost({
+      at: Date.UTC(2026, 6, 28),
+      cachedInputTokens: 20_000,
+      model: "qwen3.7-plus-2026-05-26",
+      outputTokens: 322,
+      reasoningOutputTokens: 49,
+      uncachedInputTokens: 28_851,
+    });
+
+    expect(cost).toMatchObject({
+      cachedInputCostMicros: 1_600,
+      outputCostMicros: 515,
+      totalCostMicros: 13_655,
+      uncachedInputCostMicros: 11_540,
+    });
+  });
+
+  it("leaves Qwen turns above the safely attributable input tier unpriced", () => {
+    expect(
+      estimateTokenUsageCost({
+        at: Date.UTC(2026, 6, 28),
+        cachedInputTokens: 0,
+        model: "qwen3.7-plus(openai)",
+        outputTokens: 100,
+        uncachedInputTokens: 256_001,
+      }),
+    ).toBeUndefined();
+  });
+
   it("returns undefined for unsupported models or service tiers", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -301,6 +362,20 @@ describe("token usage pricing", () => {
         outputUsdPerMillion: 6,
         provider: "xai",
         rateId: "xai:2026-07-17:grok-4.5:standard",
+      }),
+    );
+    expect(listTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        cachedInputUsdPerMillion: 0.08,
+        catalogId: "qwen-modelstudio-international",
+        catalogVersion: "2026-07-15",
+        displayName: "Qwen 3.7 Plus International (<=256K input)",
+        inputUsdPerMillion: 0.4,
+        model: "qwen3.7-plus",
+        outputUsdPerMillion: 1.6,
+        provider: "qwen",
+        rateId:
+          "qwen:2026-07-15:qwen3.7-plus:standard:input-lte-256k",
       }),
     );
   });

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -1,6 +1,6 @@
 export type TokenUsagePricingServiceTier = "standard" | "priority";
 
-export type TokenUsagePricingProvider = "openai" | "xai";
+export type TokenUsagePricingProvider = "openai" | "qwen" | "xai";
 
 export type TokenUsagePriceStatus = "priced" | "unpriced";
 
@@ -208,10 +208,12 @@ type PricingCatalogEntry = {
   effectiveFrom: number;
   effectiveTo?: number;
   inputUsdPerMillion: number;
+  maximumInputTokens?: number;
   model: string;
   outputUsdPerMillion: number;
   outputTokensIncludeReasoning?: boolean;
   provider: TokenUsagePricingProvider;
+  rateBandId?: string;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -259,6 +261,13 @@ const OPENAI_CODEX_FAST_RATE_MULTIPLIERS = {
 const XAI_PRICING_CATALOG_ID = "xai-api";
 const XAI_PRICING_CATALOG_VERSION = "2026-07-17";
 const XAI_GROK45_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 8);
+// ModelStudio Standard, Singapore / International list pricing:
+// https://www.alibabacloud.com/help/en/model-studio/model-pricing
+// Implicit-cache hits cost 20% of the normal input-token rate:
+// https://www.alibabacloud.com/help/en/model-studio/context-cache
+const QWEN_PRICING_CATALOG_ID = "qwen-modelstudio-international";
+const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
+const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   {
@@ -441,9 +450,40 @@ const XAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   },
 ];
 
+const QWEN_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  {
+    aliases: [
+      "qwen3.7-plus(openai)",
+      "qwen3.7-plus (openai)",
+      "qwen3.7-plus-2026-05-26",
+      "qwen3.7-plus-2026-05-26(openai)",
+      "qwen3.7-plus-2026-05-26 (openai)",
+    ],
+    cachedInputUsdPerMillion: 0.08,
+    catalogId: QWEN_PRICING_CATALOG_ID,
+    catalogVersion: QWEN_PRICING_CATALOG_VERSION,
+    displayModel: "Qwen 3.7 Plus",
+    displayTier: "International (<=256K input)",
+    effectiveFrom: QWEN37_PLUS_PRICING_EFFECTIVE_FROM,
+    inputUsdPerMillion: 0.4,
+    // ModelStudio selects a pricing tier from each request's input count. ACP
+    // usage is persisted as a multi-call turn aggregate, so an aggregate at or
+    // below this boundary proves every call used the first tier. Larger turns
+    // stay unpriced until ACP carries enough per-call detail to price safely.
+    maximumInputTokens: 256_000,
+    model: "qwen3.7-plus",
+    outputTokensIncludeReasoning: true,
+    outputUsdPerMillion: 1.6,
+    provider: "qwen",
+    rateBandId: "input-lte-256k",
+    serviceTier: "standard",
+  },
+];
+
 const TOKEN_USAGE_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   ...OPENAI_PRICING_CATALOG,
   ...XAI_PRICING_CATALOG,
+  ...QWEN_PRICING_CATALOG,
 ];
 
 function buildCodexCreditsCatalogEntries(params: {
@@ -620,12 +660,16 @@ function estimateTokenUsageCostFromCatalog(
   const matchingEntries = catalog.filter(
     (candidate) =>
       pricingEntryMatchesModel(candidate, model)
-      && pricingEntryAppliesAt(candidate, params.at),
+      && pricingEntryAppliesAt(candidate, params.at)
+      && pricingEntryMatchesInputTokens(
+        candidate,
+        params.cachedInputTokens + params.uncachedInputTokens,
+      ),
   );
   const provider = matchingEntries[0]?.provider;
   const serviceTier =
-    provider === "xai"
-      ? resolveXaiPricingServiceTier(params.serviceTier)
+    provider === "xai" || provider === "qwen"
+      ? resolveStandardOnlyPricingServiceTier(params.serviceTier)
       : resolveOpenAiPricingServiceTier({
           fastMode: params.fastMode,
           serviceTier: params.serviceTier,
@@ -643,7 +687,11 @@ function estimateTokenUsageCostFromCatalog(
       candidate.model === entry.model
       && candidate.provider === entry.provider
       && candidate.serviceTier === "standard"
-      && pricingEntryAppliesAt(candidate, params.at),
+      && pricingEntryAppliesAt(candidate, params.at)
+      && pricingEntryMatchesInputTokens(
+        candidate,
+        params.cachedInputTokens + params.uncachedInputTokens,
+      ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
     params.uncachedInputTokens,
@@ -800,7 +848,7 @@ export function resolveOpenAiPricingServiceTier(params: {
   return params.fastMode === true ? "priority" : "standard";
 }
 
-function resolveXaiPricingServiceTier(
+function resolveStandardOnlyPricingServiceTier(
   serviceTier: string | undefined,
 ): TokenUsagePricingServiceTier | undefined {
   const normalized = serviceTier?.trim().toLowerCase();
@@ -917,13 +965,24 @@ function pricingEntryMatchesModel(
   return entry.model === model || entry.aliases?.includes(model) === true;
 }
 
+function pricingEntryMatchesInputTokens(
+  entry: PricingCatalogEntry,
+  inputTokens: number,
+): boolean {
+  return (
+    entry.maximumInputTokens === undefined
+    || inputTokens <= entry.maximumInputTokens
+  );
+}
+
 function buildPricingRateId(entry: PricingCatalogEntry): string {
   return [
     entry.provider,
     entry.catalogVersion,
     entry.model,
     entry.serviceTier,
-  ].join(":");
+    entry.rateBandId,
+  ].filter(Boolean).join(":");
 }
 
 function buildCodexCreditRateId(entry: CodexCreditsCatalogEntry): string {


### PR DESCRIPTION
## What changed

- Centralize ACP usage-envelope normalization for Grok `turn_completed.usage` and Qwen `agent_message_chunk._meta.usage`.
- Include Qwen `thoughtTokens` as reasoning output tokens.
- Accumulate every per-model-call Qwen envelope and emit one standard `thread/tokenUsage/updated` event for the completed turn.
- Preserve the selected Qwen model from session/runtime capability state when the usage envelope omits it.
- Add the official Qwen 3.7 Plus ModelStudio International list rate for the safely attributable `<=256K` input band: $0.40/M uncached input, $0.08/M implicit-cache input, and $1.60/M output.
- Treat Qwen reasoning tokens as already included in output token billing.
- Reprice existing unpriced Qwen rows on read/startup, while retaining unpriced cards for unknown models and turns above the safely attributable band.
- Reuse the same normalization and aggregation for suppressed ACP title-helper prompts.

## Why

Qwen reports usage at the end of each model call rather than in a single terminal turn envelope. Normal ACP turns previously ignored those events entirely. Forwarding each raw snapshot would overwrite the stable turn usage line with only the latest call, while summing a cumulative downstream payload would double-count it.

The adapter now folds raw model-call envelopes once and publishes one turn-total snapshot through the existing usage persistence path. The pricing catalog uses Alibaba Cloud ModelStudio list pricing rather than promotional discounts:

- https://www.alibabacloud.com/help/en/model-studio/model-pricing
- https://www.alibabacloud.com/help/en/model-studio/context-cache

## Pricing limitations

- Qwen ACP exposes the selected model but not the ModelStudio deployment region. The catalog entry is explicitly the Singapore / International list rate; Beijing and Global deployments have different list rates.
- ModelStudio chooses the pricing tier per model request, while PwrAgent persists a multi-call turn aggregate. An aggregate at or below 256K proves that every request used the first tier, so those turns are priced safely. Larger aggregates remain unpriced until the protocol preserves enough per-call detail for exact tiered pricing.
- Limited-time ModelStudio discounts are intentionally excluded from the list-price estimate.

## Impact

Normal Qwen turns now produce token/usage cards, including tool-using turns with multiple model calls. The two example rows with 39,286 uncached input tokens and 90 output tokens total $0.015858 at the International list rate, which the panel displays as $0.02.

This was originally stacked on #1043. That PR merged during development, so GitHub retargeted this draft to `main` and the branch was rebased onto current `main`.

## Validation

- focused pricing/ACP/state suite: 474 tests passed across 6 files
- `pnpm typecheck`
- `pnpm lint:sql`
- `pnpm lint:eslint` (0 errors; repository warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`