### PR TITLE
fix(desktop): quiet benign agent warnings

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14868,6 +14868,96 @@ command = "pnpm dev"
     }
   });
 
+  it("ignores receiverless Codex native wait calls without warning", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    mainLoggerMock.warn.mockClear();
+
+    for (const method of ["item/started", "item/completed"] as const) {
+      await codexClient.emit({
+        method,
+        params: {
+          threadId: "thread-parent",
+          turnId: "turn-1",
+          item: {
+            id: "collab-wait-1",
+            type: "collabAgentToolCall",
+            tool: "wait",
+            status: method === "item/started" ? "inProgress" : "completed",
+            receiverThreadIds: [],
+          },
+        },
+      } as AppServerNotification);
+    }
+
+    expect(
+      mainLoggerMock.warn.mock.calls.some(
+        ([message]) =>
+          message === "codex native subagent call missing receiver thread ids",
+      ),
+    ).toBe(false);
+    expect(
+      (
+        await overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-parent",
+        })
+      )?.subAgents,
+    ).toBeUndefined();
+
+    await registry.close();
+  });
+
+  it("warns when a directed Codex native sub-agent call has no receiver", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    mainLoggerMock.warn.mockClear();
+
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-1",
+        item: {
+          id: "collab-close-1",
+          type: "collabAgentToolCall",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: [],
+        },
+      },
+    } as AppServerNotification);
+
+    expect(mainLoggerMock.warn).toHaveBeenCalledWith(
+      "codex native subagent call missing receiver thread ids",
+      {
+        itemId: "collab-close-1",
+        method: "item/completed",
+        threadId: "thread-parent",
+        tool: "closeAgent",
+      },
+    );
+
+    await registry.close();
+  });
+
   it("updates Codex native sub-agent summaries from later wait calls", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-automation-service.test.ts
@@ -8,6 +8,17 @@ import { DesktopAutomationService } from "../automations/desktop-automation-serv
 import { AutomationStore } from "../automations/automation-store";
 import { StateDb } from "../state/state-db";
 
+const automationLoggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("../log", () => ({
+  getMainLogger: vi.fn(() => automationLoggerMock),
+}));
+
 let tempDir: string;
 let stateDb: StateDb;
 let store: AutomationStore;
@@ -891,6 +902,43 @@ describe("DesktopAutomationService", () => {
         }),
       },
     });
+  });
+
+  it("quietly ignores terminal backend turns that are not automations", async () => {
+    const service = new DesktopAutomationService({ registry, store });
+    service.start();
+    automationLoggerMock.debug.mockClear();
+    automationLoggerMock.warn.mockClear();
+
+    await Promise.all(
+      registryListeners.map((listener) =>
+        listener({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "ordinary-thread",
+              turnId: "ordinary-turn",
+              turn: {
+                id: "ordinary-turn",
+                status: "completed",
+              },
+            },
+          },
+        } as AgentEvent),
+      ),
+    );
+
+    expect(automationLoggerMock.warn).not.toHaveBeenCalled();
+    expect(automationLoggerMock.debug).toHaveBeenCalledWith(
+      "terminal backend turn was not an automation",
+      {
+        backend: "codex",
+        method: "turn/completed",
+        threadId: "ordinary-thread",
+        turnId: "ordinary-turn",
+      },
+    );
   });
 
   it("recovers automation completion from a structured assistant final when terminal correlation is missed", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14165,6 +14165,11 @@ export class DesktopBackendRegistry {
         continue;
       }
       if (call.receiverThreadIds.length === 0) {
+        // Codex also uses receiverless waits as timed yield operations. There
+        // is no native sub-agent card to update in that case.
+        if (call.tool === "wait") {
+          continue;
+        }
         backendRegistryLog.warn("codex native subagent call missing receiver thread ids", {
           itemId: call.itemId,
           method: event.notification.method,

--- a/apps/desktop/src/main/automations/desktop-automation-service.ts
+++ b/apps/desktop/src/main/automations/desktop-automation-service.ts
@@ -557,7 +557,7 @@ export class DesktopAutomationService {
         });
         return;
       }
-      automationServiceLog.warn("terminal backend turn did not match a running automation", {
+      automationServiceLog.debug("terminal backend turn was not an automation", {
         backend: event.backend,
         method: event.notification.method,
         threadId: event.notification.params.threadId,


### PR DESCRIPTION
## Summary

- treat receiverless Codex native `wait` calls as expected timed yields instead of missing-subagent warnings
- keep warnings for directed native sub-agent calls that unexpectedly omit receiver thread IDs
- downgrade unmatched terminal backend turns to debug logging because ordinary and monitor turns are expected to reach the automation service
- add regression coverage for both warning classifications

## Root cause

Codex 0.144.4 emits receiverless `wait` collaboration items while yielding for PwrAgent-managed monitor work. PwrAgent classified every receiverless collaboration item as a malformed native sub-agent call. Separately, the automation service subscribes to every backend terminal event but warned whenever the turn was not associated with an automation, making ordinary completions look exceptional.

## Impact

The main log no longer reports warnings for valid 30-second Codex waits or normal non-automation turn completions. Unexpected receiverless directed sub-agent calls still produce diagnostics.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/desktop-automation-service.test.ts` (400 passed)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
