### PR TITLE
fix(desktop): harden launchpad branch loading

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4350,14 +4350,23 @@ describe("app server ipc", () => {
 
     registerAppServerIpcHandlers();
 
-    await handlers.get(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL)?.({}, {
+    const response = await handlers.get(
+      NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
+    )?.({}, {
       directoryKey: "directory:/repo/app",
       directoryKind: "directory",
       directoryLabel: "app",
-      directoryPath: "/repo/app",
+      directoryPath: "/repo/missing-worktree",
+      gitStatusSourcePath: "/repo/app",
       currentBranch: "stale-branch",
     });
 
+    expect(readDirectoryStatusEntries).toHaveBeenCalledWith([
+      expect.objectContaining({
+        key: "directory:/repo/app",
+        path: "/repo/app",
+      }),
+    ]);
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
         directoryKey: "directory:/repo/app",
@@ -4367,7 +4376,15 @@ describe("app server ipc", () => {
     expect(writeDirectoryGitStatusCacheEntry).toHaveBeenCalledWith(
       expect.objectContaining({
         directoryKey: "directory:/repo/app",
+        directoryPath: "/repo/missing-worktree",
         gitStatus: expect.objectContaining({ currentBranch: "fresh-branch" }),
+      }),
+    );
+    expect(response).toEqual(
+      expect.objectContaining({
+        gitStatus: expect.objectContaining({
+          currentBranch: "fresh-branch",
+        }),
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -353,6 +353,38 @@ describe("GitDirectoryService", () => {
     expect(forEachRefCalls).toBe(2);
   });
 
+  it("retries branch inventory after a required ref scan fails", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    let failBaseRefScan = true;
+    const runGitWithFailure = async (cwd: string, args: string[]) => {
+      if (
+        failBaseRefScan &&
+        args[0] === "for-each-ref" &&
+        args.includes("refs/remotes")
+      ) {
+        failBaseRefScan = false;
+        throw new Error("simulated branch inventory failure");
+      }
+      return execFileSync("git", ["-C", cwd, ...args], {
+        encoding: "utf8",
+      }).trim();
+    };
+    const service = new GitDirectoryService({
+      cacheTtlMs: 0,
+      runGit: runGitWithFailure,
+    });
+
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      syncState: "status-unavailable",
+      statusUnavailableReason: "simulated branch inventory failure",
+    });
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      branches: expect.arrayContaining(["main", "release"]),
+      syncState: "untracked",
+    });
+  });
+
   it("streams directory status lookups with bounded concurrency", async () => {
     const service = new GitDirectoryService({
       statusConcurrency: 2,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -922,13 +922,28 @@ export class GitDirectoryService {
       return cached.inventory;
     }
 
-    const inFlight = this.loadBranchInventory(params.repoRoot).then((inventory) => {
-      this.branchInventoryCache.set(params.commonGitDir, {
-        expiresAt: Date.now() + this.cacheTtlMs,
-        inventory,
+    const inFlight = this.loadBranchInventory(params.repoRoot)
+      .then((inventory) => {
+        this.branchInventoryCache.set(params.commonGitDir, {
+          expiresAt: Date.now() + this.cacheTtlMs,
+          inventory,
+        });
+        return inventory;
+      })
+      .catch((error) => {
+        const current = this.branchInventoryCache.get(params.commonGitDir);
+        if (current?.inFlight === inFlight) {
+          if (current.inventory) {
+            this.branchInventoryCache.set(params.commonGitDir, {
+              expiresAt: current.expiresAt,
+              inventory: current.inventory,
+            });
+          } else {
+            this.branchInventoryCache.delete(params.commonGitDir);
+          }
+        }
+        throw error;
       });
-      return inventory;
-    });
     this.branchInventoryCache.set(params.commonGitDir, {
       expiresAt: cached?.expiresAt ?? 0,
       inFlight,
@@ -956,7 +971,7 @@ export class GitDirectoryService {
           "--format=%(refname:short)%09%(committerdate:unix)",
         ],
         gitEnv,
-      ).catch(() => ""),
+      ),
       runGit(
         repoRoot,
         [
@@ -967,7 +982,7 @@ export class GitDirectoryService {
           "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
         ],
         gitEnv,
-      ).catch(() => ""),
+      ),
       runGit(
         repoRoot,
         ["symbolic-ref", "refs/remotes/origin/HEAD", "--short"],

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1666,51 +1666,111 @@ class DesktopAppServerService {
 
   private async refreshLaunchpadDirectoryGitStatus(
     request: EnsureDirectoryLaunchpadRequest,
-  ): Promise<EnsureDirectoryLaunchpadRequest> {
-    const directoryPath = request.directoryPath?.trim();
-    if (!directoryPath) {
-      return request;
+  ): Promise<{
+    gitStatus?: NavigationDirectoryGitStatus | null;
+    request: EnsureDirectoryLaunchpadRequest;
+  }> {
+    const launchpadPath = request.directoryPath?.trim();
+    const statusSourcePath =
+      request.gitStatusSourcePath?.trim() || launchpadPath;
+    if (!statusSourcePath) {
+      return { request };
     }
 
     const cachedDirectory = this.lastDirectoriesByKey.get(request.directoryKey);
-    const directory: NavigationSnapshot["directories"][number] = {
+    const statusDirectory: NavigationSnapshot["directories"][number] = {
       key: request.directoryKey,
       kind: request.directoryKind,
       label: request.directoryLabel,
-      path: directoryPath,
+      path: statusSourcePath,
       threadKeys: [],
       needsAttentionCount: 0,
       ...(cachedDirectory?.latestUpdatedAt !== undefined
         ? { latestUpdatedAt: cachedDirectory.latestUpdatedAt }
         : {}),
     };
+    const cacheDirectory = {
+      ...statusDirectory,
+      path: launchpadPath ?? statusSourcePath,
+    };
 
     try {
       const registry = getDesktopBackendRegistry();
-      for await (const entry of registry.readDirectoryStatusEntries([directory])) {
+      for await (const entry of registry.readDirectoryStatusEntries([statusDirectory])) {
         const fetchedAt = Date.now();
-        await this.writeDirectoryGitStatusEntry({
-          directory,
-          directoryKey: entry.directoryKey,
-          fetchedAt,
-          gitStatus: entry.gitStatus,
-        });
-        if (!entry.gitStatus?.currentBranch) {
-          return request;
+        let gitStatus = entry.gitStatus;
+        if (!gitStatus && request.gitStatusSourcePath) {
+          gitStatus = {
+            syncState: "status-unavailable",
+            statusUnavailableReason:
+              `Git branch information is unavailable for ${statusSourcePath}.`,
+          };
+        }
+        try {
+          await this.writeDirectoryGitStatusEntry({
+            directory: cacheDirectory,
+            directoryKey: entry.directoryKey,
+            fetchedAt,
+            gitStatus,
+          });
+        } catch (error) {
+          appServerLog.warn("failed to persist launchpad branch status", {
+            directoryKey: request.directoryKey,
+            error: error instanceof Error ? error.message : String(error),
+            statusSourcePath,
+          });
+        }
+        if (gitStatus?.syncState === "status-unavailable") {
+          appServerLog.warn("launchpad branch status unavailable", {
+            directoryKey: request.directoryKey,
+            error: gitStatus.statusUnavailableReason,
+            statusSourcePath,
+          });
         }
         return {
-          ...request,
-          currentBranch: entry.gitStatus.currentBranch,
+          gitStatus: gitStatus ?? null,
+          request: gitStatus?.currentBranch
+            ? {
+                ...request,
+                currentBranch: gitStatus.currentBranch,
+              }
+            : request,
         };
       }
     } catch (error) {
-      logDebug("directoryGitStatusRefresh:launchpadRefreshFailed", {
+      const message = error instanceof Error ? error.message : String(error);
+      appServerLog.warn("launchpad branch status refresh failed", {
         directoryKey: request.directoryKey,
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
+        statusSourcePath,
       });
+      return {
+        gitStatus: {
+          syncState: "status-unavailable",
+          statusUnavailableReason: message,
+        },
+        request,
+      };
     }
 
-    return request;
+    if (request.gitStatusSourcePath) {
+      const statusUnavailableReason =
+        `Git branch information is unavailable for ${statusSourcePath}.`;
+      appServerLog.warn("launchpad branch status unavailable", {
+        directoryKey: request.directoryKey,
+        error: statusUnavailableReason,
+        statusSourcePath,
+      });
+      return {
+        gitStatus: {
+          syncState: "status-unavailable",
+          statusUnavailableReason,
+        },
+        request,
+      };
+    }
+
+    return { gitStatus: null, request };
   }
 
   private async refreshDirectoryGitStatuses(
@@ -3732,8 +3792,16 @@ class DesktopAppServerService {
   async ensureDirectoryLaunchpad(
     request: EnsureDirectoryLaunchpadRequest,
   ): Promise<EnsureDirectoryLaunchpadResponse> {
-    const refreshedRequest = await this.refreshLaunchpadDirectoryGitStatus(request);
-    return await getDesktopBackendRegistry().ensureDirectoryLaunchpad(refreshedRequest);
+    const refreshed = await this.refreshLaunchpadDirectoryGitStatus(request);
+    const response = await getDesktopBackendRegistry().ensureDirectoryLaunchpad(
+      refreshed.request,
+    );
+    return {
+      ...response,
+      ...(refreshed.gitStatus !== undefined
+        ? { gitStatus: refreshed.gitStatus }
+        : {}),
+    };
   }
 
   async updateDirectoryLaunchpad(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6595,6 +6595,39 @@ export function Composer(props: ComposerProps) {
         : [],
     [props.launchpad, props.directory],
   );
+  const launchpadBranchStatusError =
+    props.launchpad?.workMode === "worktree" &&
+    props.directory?.gitStatus?.syncState === "status-unavailable"
+      ? props.directory.gitStatus.statusUnavailableReason ??
+        "Git did not return branch information."
+      : undefined;
+  const launchpadBranchStatusDirectoryKey = props.launchpad?.directoryKey;
+  const launchpadBranchStatusDirectoryLabel = props.launchpad?.directoryLabel;
+  const showLaunchpadBranchStatusNotice = props.onShowNotice;
+  useEffect(() => {
+    if (
+      !launchpadBranchStatusError ||
+      !launchpadBranchStatusDirectoryKey ||
+      !launchpadBranchStatusDirectoryLabel ||
+      !showLaunchpadBranchStatusNotice
+    ) {
+      return;
+    }
+
+    showLaunchpadBranchStatusNotice({
+      autoDismiss: false,
+      id: `launchpad-branches-unavailable:${launchpadBranchStatusDirectoryKey}:${launchpadBranchStatusError}`,
+      title: "Branches unavailable",
+      message: `PwrAgent couldn't load branches for ${launchpadBranchStatusDirectoryLabel}.`,
+      detail: launchpadBranchStatusError,
+      tone: "warning",
+    });
+  }, [
+    launchpadBranchStatusError,
+    launchpadBranchStatusDirectoryKey,
+    launchpadBranchStatusDirectoryLabel,
+    showLaunchpadBranchStatusNotice,
+  ]);
   const launchpadCodexEnvironmentOptions =
     props.launchpad?.codexEnvironmentOptions ?? [];
   const selectedCodexEnvironment = launchpadCodexEnvironmentOptions.find(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6596,7 +6596,8 @@ export function Composer(props: ComposerProps) {
     [props.launchpad, props.directory],
   );
   const launchpadBranchStatusError =
-    props.launchpad?.workMode === "worktree" &&
+    props.launchpad?.directoryKind === "directory" &&
+    !isSameWorktreeSubthreadLaunchpad(props.launchpad.directoryKey) &&
     props.directory?.gitStatus?.syncState === "status-unavailable"
       ? props.directory.gitStatus.statusUnavailableReason ??
         "Git did not return branch information."

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9272,6 +9272,56 @@ describe("Composer", () => {
     });
   });
 
+  it("shows a sticky toast when branch status removes worktree mode", async () => {
+    const onShowNotice = vi.fn();
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/repo/app",
+          kind: "directory",
+          label: "app",
+          path: "/repo/app",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            syncState: "status-unavailable",
+            statusUnavailableReason: "fatal: unable to enumerate refs",
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/repo/app",
+          directoryKind: "directory",
+          directoryLabel: "app",
+          directoryPath: "/repo/app",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onShowNotice={onShowNotice}
+        skills={[]}
+      />
+    );
+
+    expect(screen.getByLabelText("Workspace mode")).toHaveValue("local");
+    expect(
+      screen.queryByRole("option", { name: "New worktree" }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(onShowNotice).toHaveBeenCalledWith({
+        autoDismiss: false,
+        id: expect.stringContaining("launchpad-branches-unavailable:"),
+        title: "Branches unavailable",
+        message: "PwrAgent couldn't load branches for app.",
+        detail: "fatal: unable to enumerate refs",
+        tone: "warning",
+      });
+    });
+  });
+
   it("shows recency, current, and in-use metadata in the branch picker and filters by query", () => {
     const nowSeconds = Math.floor(Date.now() / 1000);
     render(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -9224,6 +9224,54 @@ describe("Composer", () => {
     ).toHaveAttribute("aria-selected", "true");
   });
 
+  it("shows a sticky toast when worktree branch status is unavailable", async () => {
+    const onShowNotice = vi.fn();
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "subthread:codex:thread-parent:new-worktree",
+          kind: "directory",
+          label: "giphy-services",
+          path: "/missing/giphy-services",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            syncState: "status-unavailable",
+            statusUnavailableReason: "fatal: unable to enumerate refs",
+          },
+        }}
+        launchpad={{
+          directoryKey: "subthread:codex:thread-parent:new-worktree",
+          directoryKind: "directory",
+          directoryLabel: "giphy-services",
+          directoryPath: "/missing/giphy-services",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "deleted-parent-branch",
+          parentThreadId: "thread-parent",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onShowNotice={onShowNotice}
+        skills={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onShowNotice).toHaveBeenCalledWith({
+        autoDismiss: false,
+        id: expect.stringContaining("launchpad-branches-unavailable:"),
+        title: "Branches unavailable",
+        message: "PwrAgent couldn't load branches for giphy-services.",
+        detail: "fatal: unable to enumerate refs",
+        tone: "warning",
+      });
+    });
+  });
+
   it("shows recency, current, and in-use metadata in the branch picker and filters by query", () => {
     const nowSeconds = Math.floor(Date.now() / 1000);
     render(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5606,7 +5606,7 @@ describe("useThreadNavigation", () => {
       directoryKey: "subthread:codex:thread-parent:new-worktree",
       patch: expect.objectContaining({
         workMode: "worktree",
-        directoryPath: "/repo/app/.worktrees/parent/app",
+        directoryPath: "/repo/app",
         branchName: "feature/parent",
         parentThreadId: "thread-parent",
       }),
@@ -5747,7 +5747,7 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedDirectory?.threadKeys).toEqual([]);
   });
 
-  it("uses branch status returned while ensuring a new-worktree sub-thread", async () => {
+  it("uses the live repository to materialize a new-worktree sub-thread from a missing parent worktree", async () => {
     const repoPath = "/repo/app";
     const parentWorktreePath = "/repo/app/.worktrees/missing-parent/app";
     const directoryKey = "subthread:codex:thread-parent:new-worktree";
@@ -5806,7 +5806,7 @@ describe("useThreadNavigation", () => {
         directoryKey,
         directoryKind: "directory" as const,
         directoryLabel: "app",
-        directoryPath: parentWorktreePath,
+        directoryPath: repoPath,
         workMode: "worktree" as const,
         backend: "codex" as const,
         executionMode: "default" as const,
@@ -5861,10 +5861,18 @@ describe("useThreadNavigation", () => {
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
         directoryKey,
-        directoryPath: parentWorktreePath,
+        directoryPath: repoPath,
         gitStatusSourcePath: repoPath,
       }),
     );
+    expect(updateDirectoryLaunchpad).toHaveBeenCalledWith({
+      directoryKey,
+      patch: expect.objectContaining({
+        directoryPath: repoPath,
+        workMode: "worktree",
+      }),
+    });
+    expect(result.current.selectedLaunchpad?.directoryPath).toBe(repoPath);
     expect(result.current.selectedDirectory?.gitStatus).toEqual(gitStatus);
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5072,6 +5072,7 @@ describe("useThreadNavigation", () => {
       directoryKind: "directory",
       directoryLabel: "app",
       directoryPath: "/repo/app",
+      gitStatusSourcePath: "/repo/app",
       parentThreadId: "thread-parent",
       parentThreadTitle: "Local parent",
       preferredBackend: "codex",
@@ -5746,6 +5747,127 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedDirectory?.threadKeys).toEqual([]);
   });
 
+  it("uses branch status returned while ensuring a new-worktree sub-thread", async () => {
+    const repoPath = "/repo/app";
+    const parentWorktreePath = "/repo/app/.worktrees/missing-parent/app";
+    const directoryKey = "subthread:codex:thread-parent:new-worktree";
+    const parentThread = {
+      id: "thread-parent",
+      title: "Worktree parent",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      executionMode: "default" as const,
+      linkedDirectories: [
+        {
+          id: parentWorktreePath,
+          label: "app",
+          path: repoPath,
+          worktreePath: parentWorktreePath,
+          kind: "worktree" as const,
+        },
+      ],
+      gitBranch: "deleted-remote-branch",
+      observedGitBranch: "deleted-remote-branch",
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    };
+    const gitStatus = {
+      currentBranch: "main",
+      defaultBranch: "main",
+      branches: ["main", "release"],
+      baseBranches: ["main", "origin/main", "release", "origin/release"],
+      syncState: "in-sync" as const,
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey,
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: parentWorktreePath,
+        workMode: "local" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      gitStatus,
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async () => ({
+      launchpad: {
+        directoryKey,
+        directoryKind: "directory" as const,
+        directoryLabel: "app",
+        directoryPath: parentWorktreePath,
+        workMode: "worktree" as const,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        branchName: "deleted-remote-branch",
+        parentThreadId: "thread-parent",
+        parentThreadTitle: "Worktree parent",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      ensureDirectoryLaunchpad,
+      getNavigationSnapshot: async () => ({
+        backend: "all" as const,
+        fetchedAt: Date.now(),
+        unchanged: false,
+        inboxThreadKeys: ["codex:thread-parent"],
+        threads: [parentThread],
+        directories: [
+          {
+            key: `directory:${repoPath}`,
+            kind: "directory" as const,
+            label: "app",
+            path: repoPath,
+            threadKeys: ["codex:thread-parent"],
+            needsAttentionCount: 0,
+          },
+        ],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      }),
+      onAgentEvent: () => () => undefined,
+      updateDirectoryLaunchpad,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-parent");
+    });
+
+    await act(async () => {
+      await result.current.createSubthread(parentThread, "new-worktree");
+    });
+
+    expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey,
+        directoryPath: parentWorktreePath,
+        gitStatusSourcePath: repoPath,
+      }),
+    );
+    expect(result.current.selectedDirectory?.gitStatus).toEqual(gitStatus);
+  });
+
   it("keeps launchpad git status streamed before the sub-thread directory exists", async () => {
     const repoPath = "/repo/app";
     const parentWorktreePath = "/repo/app/.worktrees/parent/app";
@@ -5994,6 +6116,7 @@ describe("useThreadNavigation", () => {
       directoryKind: "directory",
       directoryLabel: "app",
       directoryPath: "/repo/app/.worktrees/parent/app",
+      gitStatusSourcePath: "/repo/app",
       parentThreadId: "thread-parent",
       parentThreadTitle: "Worktree parent",
       preferredBackend: "codex",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3991,6 +3991,10 @@ export function useThreadNavigation(
       }
 
       const directory = selectThreadWorkspace(parent, mode);
+      const launchpadDirectoryPath =
+        mode === "new-worktree"
+          ? directory.gitStatusSourcePath ?? directory.directoryPath
+          : directory.directoryPath;
       // Key the launchpad on the clicked card so each source gets its own
       // composer (two children of one root must not collide), but link the new
       // thread to the group root and remember the source for in-place insertion.
@@ -4010,7 +4014,7 @@ export function useThreadNavigation(
           directoryKey,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
-          directoryPath: directory.directoryPath,
+          directoryPath: launchpadDirectoryPath,
           gitStatusSourcePath: directory.gitStatusSourcePath,
           parentThreadId: groupRoot.id,
           parentThreadTitle: groupRoot.title,
@@ -4028,7 +4032,7 @@ export function useThreadNavigation(
           executionMode: parent.executionMode ?? response.launchpad.executionMode,
           workMode: directory.workMode,
           directoryLabel: directory.directoryLabel,
-          directoryPath: directory.directoryPath,
+          directoryPath: launchpadDirectoryPath,
           ...(directory.branchName ? { branchName: directory.branchName } : {}),
           parentThreadId: groupRoot.id,
           parentThreadTitle: groupRoot.title,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3819,14 +3819,18 @@ export function useThreadNavigation(
           [directoryKey]: launchpad,
         }));
         const pendingGitStatus = takePendingDirectoryGitStatus(directoryKey);
+        const ensuredGitStatus =
+          response.gitStatus !== undefined
+            ? response.gitStatus
+            : pendingGitStatus;
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(
             current.response,
             launchpad,
             defaults,
-            pendingGitStatus !== undefined
-              ? { gitStatus: pendingGitStatus }
+            ensuredGitStatus !== undefined
+              ? { gitStatus: ensuredGitStatus }
               : undefined,
           ),
         }));
@@ -4007,6 +4011,7 @@ export function useThreadNavigation(
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
           directoryPath: directory.directoryPath,
+          gitStatusSourcePath: directory.gitStatusSourcePath,
           parentThreadId: groupRoot.id,
           parentThreadTitle: groupRoot.title,
           preferredBackend: parent.source,
@@ -4046,11 +4051,15 @@ export function useThreadNavigation(
           [directoryKey]: launchpad,
         }));
         const pendingGitStatus = takePendingDirectoryGitStatus(directoryKey);
+        const ensuredGitStatus =
+          response.gitStatus !== undefined
+            ? response.gitStatus
+            : pendingGitStatus;
         setState((current) => ({
           ...current,
           response: applyLaunchpadUpdate(current.response, launchpad, defaults, {
-            ...(pendingGitStatus !== undefined
-              ? { gitStatus: pendingGitStatus }
+            ...(ensuredGitStatus !== undefined
+              ? { gitStatus: ensuredGitStatus }
               : {}),
             gitStatusSourcePath: directory.gitStatusSourcePath,
           }),

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -18,6 +18,7 @@ import type {
 import type {
   DirectorySummaryKind,
   LaunchpadWorkMode,
+  NavigationDirectoryGitStatus,
   NavigationLaunchpadDraft,
   NavigationLaunchpadDefaults,
 } from "./navigation";
@@ -435,6 +436,11 @@ export type EnsureDirectoryLaunchpadRequest = {
   directoryKind: DirectorySummaryKind;
   directoryLabel: string;
   directoryPath?: string;
+  /**
+   * Existing repository/worktree path to probe for branch choices when the
+   * launchpad's target path is stale, missing, or has not been created yet.
+   */
+  gitStatusSourcePath?: string;
   currentBranch?: string;
   parentThreadId?: string;
   parentThreadTitle?: string;
@@ -445,6 +451,11 @@ export type EnsureDirectoryLaunchpadRequest = {
 export type EnsureDirectoryLaunchpadResponse = {
   launchpad: NavigationLaunchpadDraft;
   defaults: NavigationLaunchpadDefaults;
+  /**
+   * Status read while ensuring the launchpad. Returning it directly keeps the
+   * branch picker independent of notification/render ordering.
+   */
+  gitStatus?: NavigationDirectoryGitStatus | null;
 };
 
 export type UpdateDirectoryLaunchpadRequest = {


### PR DESCRIPTION
## Summary

- Return launchpad Git status directly from ensureDirectoryLaunchpad instead of relying solely on asynchronous notification ordering.
- Probe branch inventory through the stable source repository when a new-worktree launchpad path is stale or missing.
- Log unexpected branch-loading failures, show a persistent warning toast, and allow failed inventory reads to retry.
- Add main-process and renderer regression coverage for stale worktrees, failed ref scans, and error notices.

## Root cause

Git successfully enumerated the repository branches, but the new-worktree composer could lose or miss that valid status while reconciling the asynchronous directory-status notification. This left the picker with only its selected branch. Essential for-each-ref failures were also swallowed, and a rejected in-flight inventory read could poison subsequent attempts.

## User impact

Sub-thread-in-new-worktree branch selection now receives the full inventory even when the prior branch or launchpad path is stale. Unexpected Git failures are retryable, logged, and shown to the user instead of silently producing an incomplete picker.

## Validation

- Focused Vitest suite: 384 tests passed.
- pnpm typecheck
- pnpm lint:eslint: 0 errors, 139 baseline warnings.
- pnpm lint:boundaries
- git diff --check