### PR TITLE
feat(desktop): attribute injected thread messages

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18,6 +18,7 @@ import type {
   AppServerPendingRequestNotification,
   AppServerSkillSummary,
   AppServerThreadReplay,
+  AppServerThreadMessageOrigin,
   AppServerThreadSummary,
   AppServerReviewTarget,
   AppServerTurnInputItem,
@@ -278,6 +279,20 @@ function createOverlayStoreMock(params?: {
     Object.entries(params?.overlays ?? {})
   );
   const usageLines = new Map<string, ThreadUsageLineRecord>();
+  const messageOrigins = new Map<string, AppServerThreadMessageOrigin>();
+  const upsertThreadMessageOrigin = vi.fn(async ({
+    backend,
+    threadId,
+    turnId,
+    origin,
+  }: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    origin: AppServerThreadMessageOrigin;
+  }) => {
+    messageOrigins.set(`${backend}:${threadId}:${turnId}`, origin);
+  });
   let launchpadDefaults: NavigationLaunchpadDefaults = {
     backend: "codex",
     executionMode: "default",
@@ -337,6 +352,22 @@ function createOverlayStoreMock(params?: {
       ),
       summaries: [],
     }),
+    upsertThreadMessageOrigin,
+    readThreadMessageOrigins: async ({
+      backend,
+      threadId,
+      turnIds,
+    }: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      turnIds: string[];
+    }) =>
+      Object.fromEntries(
+        turnIds.flatMap((turnId) => {
+          const origin = messageOrigins.get(`${backend}:${threadId}:${turnId}`);
+          return origin ? [[turnId, origin]] : [];
+        }),
+      ),
     setAcpWorktreeDirectory: async ({
       backend,
       threadId,
@@ -20857,12 +20888,13 @@ script = "printf setup"
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
     });
+    const overlayStore = createOverlayStoreMock();
     const registry = new DesktopBackendRegistry({
       codexClient,
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
       threadTitleGenerationService: null,
     });
     await registry.publishLocalEvent({
@@ -20933,6 +20965,91 @@ script = "printf setup"
       fastMode: true,
       approvalPolicy: "never",
       sandbox: "danger-full-access",
+    });
+    expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "target-thread",
+      turnId: "turn-1",
+      origin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("hydrates persisted injected-message origins onto replay messages", async () => {
+    const replay: AppServerThreadReplay = {
+      entries: [
+        {
+          type: "message",
+          id: "message-injected",
+          role: "user",
+          text: "Please pick up the CI failure.",
+          turn: {
+            id: "turn-injected",
+            status: "completed",
+          },
+        },
+      ],
+      messages: [
+        {
+          id: "message-injected",
+          role: "user",
+          text: "Please pick up the CI failure.",
+        },
+      ],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertThreadMessageOrigin!({
+      backend: "codex",
+      threadId: "target-thread",
+      turnId: "turn-injected",
+      origin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ replay }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+
+    expect(response.replay.entries[0]).toMatchObject({
+      id: "message-injected",
+      origin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+        },
+      },
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      id: "message-injected",
+      origin: {
+        kind: "agent",
+      },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -283,15 +283,15 @@ function createOverlayStoreMock(params?: {
   const upsertThreadMessageOrigin = vi.fn(async ({
     backend,
     threadId,
-    turnId,
+    messageId,
     origin,
   }: {
     backend: AppServerBackendKind;
     threadId: string;
-    turnId: string;
+    messageId: string;
     origin: AppServerThreadMessageOrigin;
   }) => {
-    messageOrigins.set(`${backend}:${threadId}:${turnId}`, origin);
+    messageOrigins.set(`${backend}:${threadId}:${messageId}`, origin);
   });
   let launchpadDefaults: NavigationLaunchpadDefaults = {
     backend: "codex",
@@ -356,16 +356,16 @@ function createOverlayStoreMock(params?: {
     readThreadMessageOrigins: async ({
       backend,
       threadId,
-      turnIds,
+      messageIds,
     }: {
       backend: AppServerBackendKind;
       threadId: string;
-      turnIds: string[];
+      messageIds: string[];
     }) =>
       Object.fromEntries(
-        turnIds.flatMap((turnId) => {
-          const origin = messageOrigins.get(`${backend}:${threadId}:${turnId}`);
-          return origin ? [[turnId, origin]] : [];
+        messageIds.flatMap((messageId) => {
+          const origin = messageOrigins.get(`${backend}:${threadId}:${messageId}`);
+          return origin ? [[messageId, origin]] : [];
         }),
       ),
     setAcpWorktreeDirectory: async ({
@@ -12802,6 +12802,107 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("attributes a messaging steer to its own completed user item", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/steer"] },
+    });
+    const overlayStore = createOverlayStoreMock({ executionMode: "full-access" });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Start active work" }],
+      messageOrigin: { kind: "automation" },
+    });
+    await registry.steerTurn(
+      {
+        backend: "codex",
+        threadId: "thread-1",
+        expectedTurnId: "turn-1",
+        input: [{ type: "text", text: "Course correct from messaging" }],
+      },
+      { kind: "messaging" },
+    );
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "message-steer",
+          type: "userMessage",
+          text: "Course correct from messaging",
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "message-start",
+          type: "userMessage",
+          text: "Start active work",
+        },
+      },
+    });
+
+    expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      messageId: "message-steer",
+      origin: { kind: "messaging" },
+    });
+    expect(
+      events.find(
+        (event) =>
+          event.notification.method === "item/completed"
+          && (
+            event.notification.params.item as { id?: string } | undefined
+          )?.id === "message-steer",
+      ),
+    ).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            origin: { kind: "messaging" },
+          },
+        },
+      },
+    });
+    expect(
+      events.find(
+        (event) =>
+          event.notification.method === "item/completed"
+          && (
+            event.notification.params.item as { id?: string } | undefined
+          )?.id === "message-start",
+      ),
+    ).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            origin: { kind: "automation" },
+          },
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
   it("does not retry Codex title generation for a thread after one generated attempt", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({
@@ -20897,6 +20998,10 @@ script = "printf setup"
       overlayStore,
       threadTitleGenerationService: null,
     });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
     await registry.publishLocalEvent({
       backend: "codex",
       notification: {
@@ -20966,10 +21071,45 @@ script = "printf setup"
       approvalPolicy: "never",
       sandbox: "danger-full-access",
     });
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "target-thread",
+        turnId: "turn-1",
+        item: {
+          id: "message-injected",
+          type: "userMessage",
+          text: "Please pick up the CI failure.",
+        },
+      },
+    });
+    expect(
+      events.find(
+        (event) =>
+          event.notification.method === "item/completed"
+          && (
+            event.notification.params.item as { id?: string } | undefined
+          )?.id === "message-injected",
+      ),
+    ).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            origin: {
+              kind: "agent",
+              sourceThread: {
+                backend: "codex",
+                threadId: "parent-thread",
+              },
+            },
+          },
+        },
+      },
+    });
     expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "target-thread",
-      turnId: "turn-1",
+      messageId: "message-injected",
       origin: {
         kind: "agent",
         sourceThread: {
@@ -20982,7 +21122,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("hydrates persisted injected-message origins onto replay messages", async () => {
+  it("hydrates persisted origins onto Grok replay messages without turn metadata", async () => {
     const replay: AppServerThreadReplay = {
       entries: [
         {
@@ -20990,6 +21130,12 @@ script = "printf setup"
           id: "message-injected",
           role: "user",
           text: "Please pick up the CI failure.",
+        },
+        {
+          type: "message",
+          id: "message-manual-steer",
+          role: "user",
+          text: "A manual follow-up in the same turn.",
           turn: {
             id: "turn-injected",
             status: "completed",
@@ -21002,6 +21148,11 @@ script = "printf setup"
           role: "user",
           text: "Please pick up the CI failure.",
         },
+        {
+          id: "message-manual-steer",
+          role: "user",
+          text: "A manual follow-up in the same turn.",
+        },
       ],
       pagination: {
         supportsPagination: false,
@@ -21010,9 +21161,9 @@ script = "printf setup"
     };
     const overlayStore = createOverlayStoreMock();
     await overlayStore.upsertThreadMessageOrigin!({
-      backend: "codex",
+      backend: "grok",
       threadId: "target-thread",
-      turnId: "turn-injected",
+      messageId: "message-injected",
       origin: {
         kind: "agent",
         sourceThread: {
@@ -21022,16 +21173,14 @@ script = "printf setup"
       },
     });
     const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({ replay }),
-      grokClient: new MockBackendClient({
-        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
-      }),
+      codexClient: new MockBackendClient({}),
+      grokClient: new MockBackendClient({ replay }),
       overlayStore,
       threadTitleGenerationService: null,
     });
 
     const response = await registry.readThread({
-      backend: "codex",
+      backend: "grok",
       threadId: "target-thread",
     });
 
@@ -21049,6 +21198,176 @@ script = "printf setup"
       id: "message-injected",
       origin: {
         kind: "agent",
+      },
+    });
+    expect(response.replay.entries[1]).not.toHaveProperty("origin");
+    expect(response.replay.messages[1]).not.toHaveProperty("origin");
+
+    await registry.close();
+  });
+
+  it("does not copy one message origin to another user message in the same turn", async () => {
+    const userEntries: AppServerThreadReplay["entries"] = [
+      {
+        type: "message",
+        id: "message-injected",
+        role: "user",
+        text: "Injected prompt.",
+        turn: { id: "turn-1", status: "completed" },
+      },
+      {
+        type: "message",
+        id: "message-manual",
+        role: "user",
+        text: "Manual steer.",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    ];
+    const replay: AppServerThreadReplay = {
+      entries: userEntries,
+      messages: userEntries.map((entry) => {
+        if (entry.type !== "message") {
+          throw new Error("expected message entry");
+        }
+        return {
+          id: entry.id,
+          role: entry.role,
+          text: entry.text,
+        };
+      }),
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+    const overlayStore = createOverlayStoreMock();
+    await overlayStore.upsertThreadMessageOrigin!({
+      backend: "codex",
+      threadId: "target-thread",
+      messageId: "message-injected",
+      origin: { kind: "automation" },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ replay }),
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+
+    expect(response.replay.entries[0]).toMatchObject({
+      id: "message-injected",
+      origin: { kind: "automation" },
+    });
+    expect(response.replay.entries[1]).not.toHaveProperty("origin");
+    expect(response.replay.messages[1]).not.toHaveProperty("origin");
+
+    await registry.close();
+  });
+
+  it("applies the legacy handoff fallback only on a page containing the thread start", async () => {
+    const laterPage: AppServerThreadReplay = {
+      entries: [
+        {
+          type: "message",
+          id: "message-later",
+          role: "user",
+          text: "A later manual follow-up.",
+        },
+      ],
+      messages: [
+        {
+          id: "message-later",
+          role: "user",
+          text: "A later manual follow-up.",
+        },
+      ],
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: true,
+        previousCursor: "older",
+      },
+    };
+    const initialPage: AppServerThreadReplay = {
+      entries: [
+        {
+          type: "message",
+          id: "message-initial",
+          role: "user",
+          text: "The delegated task.",
+        },
+      ],
+      messages: [
+        {
+          id: "message-initial",
+          role: "user",
+          text: "The delegated task.",
+        },
+      ],
+      pagination: {
+        supportsPagination: true,
+        hasPreviousPage: false,
+      },
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        readThreadReplays: [laterPage, initialPage],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:target-thread": {
+            backend: "codex",
+            threadId: "target-thread",
+            extraLinkedDirectories: [],
+            handoffOrigin: {
+              sourceBackend: "codex",
+              sourceThreadId: "parent-thread",
+              sourceTitle: "Parent thread",
+              seedMode: "clean",
+              groupingMode: "none",
+              createdAt: 1_000,
+              workspace: {
+                mode: "none",
+                git: {
+                  kind: "none",
+                  worktreeCreationAvailable: false,
+                  unavailableReason: "No workspace requested.",
+                },
+              },
+            },
+          },
+        },
+      }),
+      threadTitleGenerationService: null,
+    });
+
+    const later = await registry.readThread({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+    expect(later.replay.entries[0]).not.toHaveProperty("origin");
+
+    const initial = await registry.readThread({
+      backend: "codex",
+      threadId: "target-thread",
+      before: "older",
+    });
+    expect(initial.replay.entries[0]).toMatchObject({
+      id: "message-initial",
+      origin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+          title: "Parent thread",
+        },
       },
     });
 

--- a/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-app-server-client.test.ts
@@ -184,6 +184,64 @@ describe("GrokAppServerClient", () => {
     await client.close();
   });
 
+  it("preserves Grok item identities when building replay messages", async () => {
+    const fake = createFakeServer();
+    const client = new GrokAppServerClient({
+      server: {
+        ...fake.server,
+        request: async (method, params) =>
+          method === "thread/read"
+            ? {
+                threadId: "thread-1",
+                messages: [],
+                items: [
+                  {
+                    id: "grok-user-item-17",
+                    type: "userMessage",
+                    text: "Injected prompt",
+                  },
+                  {
+                    id: "grok-agent-item-18",
+                    type: "agentMessage",
+                    text: "Handled",
+                  },
+                ],
+              }
+            : await fake.server.request(method, params),
+      },
+    });
+
+    const replay = await client.readThread({ threadId: "thread-1" });
+    expect(replay.messages).toEqual([
+        {
+          id: "grok-user-item-17",
+          role: "user",
+          text: "Injected prompt",
+        },
+        {
+          id: "grok-agent-item-18",
+          role: "assistant",
+          text: "Handled",
+        },
+    ]);
+    expect(replay.entries.slice(0, 2)).toEqual([
+      {
+        type: "message",
+        id: "grok-user-item-17",
+        role: "user",
+        text: "Injected prompt",
+      },
+      {
+        type: "message",
+        id: "grok-agent-item-18",
+        role: "assistant",
+        text: "Handled",
+      },
+    ]);
+
+    await client.close();
+  });
+
   it("forwards child notifications and bidirectional server requests", async () => {
     const fake = createFakeServer();
     const client = new GrokAppServerClient({ server: fake.server });

--- a/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
@@ -191,4 +191,42 @@ describe("SqliteOverlayStore - thread Agent metadata", () => {
     ).resolves.toMatchObject({ handoffOrigin });
     reopenedDb.close();
   });
+
+  it("persists injected message origins by turn across sqlite handles", async () => {
+    await store.upsertThreadMessageOrigin({
+      backend: "codex",
+      threadId: "child-thread",
+      turnId: "turn-injected",
+      origin: {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+          title: "Branch picker error handling",
+        },
+      },
+      createdAt: 1_773_000_000_000,
+    });
+    stateDb.close();
+
+    const reopenedDb = StateDb.open(path.join(tempDir, "state.db"));
+    const reopenedStore = new SqliteOverlayStore(reopenedDb);
+    await expect(
+      reopenedStore.readThreadMessageOrigins({
+        backend: "codex",
+        threadId: "child-thread",
+        turnIds: ["turn-injected", "turn-other"],
+      }),
+    ).resolves.toEqual({
+      "turn-injected": {
+        kind: "agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "parent-thread",
+          title: "Branch picker error handling",
+        },
+      },
+    });
+    reopenedDb.close();
+  });
 });

--- a/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-agent.test.ts
@@ -192,11 +192,11 @@ describe("SqliteOverlayStore - thread Agent metadata", () => {
     reopenedDb.close();
   });
 
-  it("persists injected message origins by turn across sqlite handles", async () => {
+  it("persists injected message origins by message across sqlite handles", async () => {
     await store.upsertThreadMessageOrigin({
       backend: "codex",
       threadId: "child-thread",
-      turnId: "turn-injected",
+      messageId: "message-injected",
       origin: {
         kind: "agent",
         sourceThread: {
@@ -215,10 +215,10 @@ describe("SqliteOverlayStore - thread Agent metadata", () => {
       reopenedStore.readThreadMessageOrigins({
         backend: "codex",
         threadId: "child-thread",
-        turnIds: ["turn-injected", "turn-other"],
+        messageIds: ["message-injected", "message-other"],
       }),
     ).resolves.toEqual({
-      "turn-injected": {
+      "message-injected": {
         kind: "agent",
         sourceThread: {
           backend: "codex",

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -109,6 +109,19 @@ describe("StateDb", () => {
     );
   });
 
+  it("creates the thread message origin table", () => {
+    const table = stateDb.raw
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      )
+      .get("thread_message_origins") as { name: string } | undefined;
+
+    expect(table?.name).toBe("thread_message_origins");
+    expect(indexNames("thread_message_origins")).toContain(
+      "idx_thread_message_origins_thread",
+    );
+  });
+
   it("carries observed context-replay columns on both the turn and the line", () => {
     // The tally's source of truth is thread_usage_turns. The line columns are a
     // DEPRECATED dual-write (issue #947) kept so older locally-run builds — which
@@ -1400,7 +1413,10 @@ function columnNames(
 }
 
 function indexNames(
-  tableName: "thread_tool_invocations" | "thread_usage_lines",
+  tableName:
+    | "thread_message_origins"
+    | "thread_tool_invocations"
+    | "thread_usage_lines",
 ): string[] {
   return (
     stateDb.raw.prepare(`PRAGMA index_list(${tableName})`).all() as Array<{

--- a/apps/desktop/src/main/__tests__/state-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/state-migration.test.ts
@@ -115,6 +115,47 @@ describe("state migration", () => {
     }
   });
 
+  it("replaces the v30 turn-keyed message origin table", () => {
+    const root = createTempRoot();
+    const dbPath = path.join(root, "state.db");
+    StateDb.open(dbPath).close();
+    const raw = new Database(dbPath);
+    raw.exec(`
+DROP INDEX idx_thread_message_origins_thread;
+DROP TABLE thread_message_origins;
+CREATE TABLE thread_message_origins (
+  backend     TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  turn_id     TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  payload     TEXT NOT NULL,
+  PRIMARY KEY (backend, thread_id, turn_id)
+);
+CREATE INDEX idx_thread_message_origins_thread
+  ON thread_message_origins(backend, thread_id, created_at, turn_id);
+INSERT INTO thread_message_origins
+VALUES ('codex', 'thread-1', 'turn-1', 1000, '{"kind":"messaging"}');
+`);
+    raw.pragma("user_version = 30");
+    raw.close();
+
+    const stateDb = StateDb.open(dbPath);
+    try {
+      const columns = stateDb.raw
+        .prepare("PRAGMA table_info(thread_message_origins)")
+        .all() as Array<{ name: string }>;
+      expect(columns.map((column) => column.name)).toContain("message_id");
+      expect(columns.map((column) => column.name)).not.toContain("turn_id");
+      expect(
+        stateDb.raw
+          .prepare("SELECT COUNT(*) AS count FROM thread_message_origins")
+          .get(),
+      ).toEqual({ count: 0 });
+    } finally {
+      stateDb.close();
+    }
+  });
+
   it("does not copy legacy default settings into a new named profile", () => {
     const root = createTempRoot();
     const pwragentHome = path.join(root, "pwragent");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4604,25 +4604,20 @@ function mergeImmutableUsageActivities(params: {
 
 function mergeThreadMessageOrigins(
   replay: AppServerThreadReplay,
-  originsByTurnId: Record<string, AppServerThreadMessageOrigin>,
+  originsByMessageId: Record<string, AppServerThreadMessageOrigin>,
 ): AppServerThreadReplay {
-  if (Object.keys(originsByTurnId).length === 0) {
+  if (Object.keys(originsByMessageId).length === 0) {
     return replay;
   }
-  const originsByMessageId = new Map<string, AppServerThreadMessageOrigin>();
   const entries = replay.entries.map((entry): AppServerThreadEntry => {
-    if (entry.type !== "message" || entry.role !== "user" || !entry.turn?.id) {
+    if (entry.type !== "message" || entry.role !== "user") {
       return entry;
     }
-    const origin = originsByTurnId[entry.turn.id];
-    if (!origin) {
-      return entry;
-    }
-    originsByMessageId.set(entry.id, origin);
-    return { ...entry, origin };
+    const origin = originsByMessageId[entry.id];
+    return origin ? { ...entry, origin } : entry;
   });
   const messages = replay.messages.map((message) => {
-    const origin = originsByMessageId.get(message.id);
+    const origin = originsByMessageId[message.id];
     return origin && message.role === "user" ? { ...message, origin } : message;
   });
   return {
@@ -5385,6 +5380,16 @@ function buildWorkspaceMoveFailurePrompt(params: {
   ].join("\n");
 }
 
+type PendingThreadMessageOrigin = {
+  backend: AppServerBackendKind;
+  createdAt: number;
+  id: string;
+  origin: AppServerThreadMessageOrigin;
+  text?: string;
+  threadId: string;
+  turnId?: string;
+};
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -5451,6 +5456,10 @@ export class DesktopBackendRegistry {
   private readonly pendingTitleGenerationInputs = new Map<
     string,
     AppServerTurnInputItem[]
+  >();
+  private readonly pendingThreadMessageOrigins = new Map<
+    string,
+    PendingThreadMessageOrigin
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
@@ -8162,28 +8171,33 @@ export class DesktopBackendRegistry {
             replay: replayWithEnvironment,
             activities: overlay?.immutableUsageActivities,
           });
-    const messageTurnIds = replayWithImmutableUsage.entries.flatMap((entry) =>
-      entry.type === "message" && entry.turn?.id ? [entry.turn.id] : [],
-    );
+    const messageIds = [
+      ...replayWithImmutableUsage.entries.flatMap((entry) =>
+        entry.type === "message" && entry.role === "user" ? [entry.id] : [],
+      ),
+      ...replayWithImmutableUsage.messages.flatMap((message) =>
+        message.role === "user" ? [message.id] : [],
+      ),
+    ];
     const persistedMessageOrigins =
       typeof this.overlayStore.readThreadMessageOrigins === "function"
         ? await this.overlayStore.readThreadMessageOrigins({
             backend,
             threadId: request.threadId,
-            turnIds: messageTurnIds,
+            messageIds,
           })
         : {};
     const messageOrigins = { ...persistedMessageOrigins };
     const firstUserMessage = replayWithImmutableUsage.entries.find(
-      (entry) => entry.type === "message" && entry.role === "user" && entry.turn?.id,
+      (entry) => entry.type === "message" && entry.role === "user",
     );
     if (
       overlay?.handoffOrigin
+      && replayWithImmutableUsage.pagination.hasPreviousPage === false
       && firstUserMessage?.type === "message"
-      && firstUserMessage.turn?.id
-      && !messageOrigins[firstUserMessage.turn.id]
+      && !messageOrigins[firstUserMessage.id]
     ) {
-      messageOrigins[firstUserMessage.turn.id] = {
+      messageOrigins[firstUserMessage.id] = {
         kind: "agent",
         sourceThread: {
           backend: overlay.handoffOrigin.sourceBackend,
@@ -9034,6 +9048,7 @@ export class DesktopBackendRegistry {
         throw new Error("A turn is already active for this thread.");
       }
       this.reservedAcpStartThreadKeys.add(reservationKey);
+      let pendingMessageOriginId: string | undefined;
       try {
         if (this.usesSlashControlledAcpExecutionModes(params.backend)) {
           await this.flushQueuedExecutionModeIfPresent(
@@ -9045,6 +9060,12 @@ export class DesktopBackendRegistry {
           params.backend,
           params.threadId,
         );
+        pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+          backend: params.backend,
+          threadId: params.threadId,
+          origin: resolveThreadMessageOrigin(params),
+          text: extractFirstMeaningfulTextInput(params.input),
+        });
         const result = await this.startAcpTurn({
           backend: params.backend,
           threadId: params.threadId,
@@ -9057,13 +9078,21 @@ export class DesktopBackendRegistry {
           threadId: result.threadId,
           input: params.input,
         });
+        this.bindPendingThreadMessageOrigin(
+          pendingMessageOriginId,
+          result.turnId,
+        );
         await this.persistThreadMessageOrigin({
           backend: params.backend,
           threadId: result.threadId,
-          turnId: result.turnId,
+          messageId: `user:${result.turnId}`,
           origin: resolveThreadMessageOrigin(params),
         });
+        this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
         return result;
+      } catch (error) {
+        this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+        throw error;
       } finally {
         this.reservedAcpStartThreadKeys.delete(reservationKey);
       }
@@ -9144,6 +9173,12 @@ export class DesktopBackendRegistry {
       params.threadId,
     );
     this.pendingTitleGenerationInputs.set(titleGenerationKey, params.input);
+    const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+      backend: params.backend,
+      threadId: params.threadId,
+      origin: resolveThreadMessageOrigin(params),
+      text: extractFirstMeaningfulTextInput(params.input),
+    });
     try {
       result =
         params.backend === "codex"
@@ -9201,8 +9236,10 @@ export class DesktopBackendRegistry {
         this.reservedCodexStartThreadIds.delete(params.threadId);
       }
       this.pendingTitleGenerationInputs.delete(titleGenerationKey);
+      this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
       throw error;
     }
+    this.bindPendingThreadMessageOrigin(pendingMessageOriginId, result.turnId);
     this.activeCodexTurnModes.delete(
       buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
     );
@@ -9235,12 +9272,6 @@ export class DesktopBackendRegistry {
         executionMode: params.executionMode,
       });
     }
-    await this.persistThreadMessageOrigin({
-      backend: params.backend,
-      threadId: result.threadId,
-      turnId: result.turnId,
-      origin: resolveThreadMessageOrigin(params),
-    });
     const response = {
       backend: params.backend,
       threadId: result.threadId,
@@ -9263,10 +9294,164 @@ export class DesktopBackendRegistry {
     return response;
   }
 
+  private registerPendingThreadMessageOrigin(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    origin?: AppServerThreadMessageOrigin;
+    text?: string;
+    turnId?: string;
+  }): string | undefined {
+    if (!params.origin) {
+      return undefined;
+    }
+    const oldestAllowed = Date.now() - 10 * 60 * 1000;
+    for (const [id, pending] of this.pendingThreadMessageOrigins) {
+      if (pending.createdAt < oldestAllowed) {
+        this.pendingThreadMessageOrigins.delete(id);
+      }
+    }
+    const id = randomUUID();
+    this.pendingThreadMessageOrigins.set(id, {
+      backend: params.backend,
+      createdAt: Date.now(),
+      id,
+      origin: params.origin,
+      ...(params.text ? { text: params.text } : {}),
+      threadId: params.threadId,
+      ...(params.turnId ? { turnId: params.turnId } : {}),
+    });
+    return id;
+  }
+
+  private bindPendingThreadMessageOrigin(
+    id: string | undefined,
+    turnId: string,
+  ): void {
+    if (!id) {
+      return;
+    }
+    const pending = this.pendingThreadMessageOrigins.get(id);
+    if (pending) {
+      pending.turnId = turnId;
+    }
+  }
+
+  private forgetPendingThreadMessageOrigin(id: string | undefined): void {
+    if (id) {
+      this.pendingThreadMessageOrigins.delete(id);
+    }
+  }
+
+  private findPendingThreadMessageOrigin(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    text?: string;
+    turnId?: string;
+  }): PendingThreadMessageOrigin | undefined {
+    const candidates = [...this.pendingThreadMessageOrigins.values()]
+      .filter(
+        (pending) =>
+          pending.backend === params.backend
+          && pending.threadId === params.threadId
+          && (
+            !pending.turnId
+            || !params.turnId
+            || pending.turnId === params.turnId
+          ),
+      )
+      .sort((left, right) => left.createdAt - right.createdAt);
+    return (
+      candidates.find(
+        (pending) =>
+          pending.text
+          && params.text
+          && pending.text.trim() === params.text.trim(),
+      )
+      ?? candidates.find(
+        (pending) => pending.turnId && pending.turnId === params.turnId,
+      )
+      ?? candidates.find((pending) => !pending.turnId)
+    );
+  }
+
+  private async withThreadMessageOrigin(event: AgentEvent): Promise<AgentEvent> {
+    if (event.notification.method === "turn/started") {
+      const notification = event.notification as {
+        method: "turn/started";
+        params: {
+          threadId: string;
+          turnId?: string;
+          turn: { id: string };
+        };
+      };
+      const pending = this.findPendingThreadMessageOrigin({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId:
+          notification.params.turnId
+          ?? notification.params.turn.id,
+      });
+      if (pending && !pending.turnId) {
+        pending.turnId =
+          notification.params.turnId
+          ?? notification.params.turn.id;
+      }
+      return event;
+    }
+    if (event.notification.method !== "item/completed") {
+      return event;
+    }
+    const notification = event.notification as {
+      method: "item/completed";
+      params: {
+        threadId: string;
+        turnId?: string;
+        item: {
+          id: string;
+          type: string;
+          origin?: AppServerThreadMessageOrigin;
+          text?: string;
+        };
+      };
+    };
+    if (notification.params.item.type !== "userMessage") {
+      return event;
+    }
+    const pending = this.findPendingThreadMessageOrigin({
+      backend: event.backend,
+      threadId: notification.params.threadId,
+      text: notification.params.item.text,
+      turnId: notification.params.turnId,
+    });
+    if (!pending) {
+      return event;
+    }
+    await this.persistThreadMessageOrigin({
+      backend: event.backend,
+      threadId: notification.params.threadId,
+      messageId: notification.params.item.id,
+      origin: pending.origin,
+    });
+    this.pendingThreadMessageOrigins.delete(pending.id);
+    return {
+      ...event,
+      notification: {
+        ...notification,
+        params: {
+          ...notification.params,
+          item: {
+            ...notification.params.item,
+            origin: pending.origin,
+          },
+        },
+      } as AppServerNotification,
+    };
+  }
+
   private async persistThreadMessageOrigin(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    turnId: string;
+    messageId: string;
     origin?: AppServerThreadMessageOrigin;
   }): Promise<void> {
     if (
@@ -9279,15 +9464,15 @@ export class DesktopBackendRegistry {
       await this.overlayStore.upsertThreadMessageOrigin({
         backend: params.backend,
         threadId: params.threadId,
-        turnId: params.turnId,
+        messageId: params.messageId,
         origin: params.origin,
       });
     } catch (error) {
       backendRegistryLog.warn("failed to persist injected message origin", {
         backend: params.backend,
         error: error instanceof Error ? error.message : String(error),
+        messageId: params.messageId,
         threadId: params.threadId,
-        turnId: params.turnId,
       });
     }
   }
@@ -9588,7 +9773,17 @@ export class DesktopBackendRegistry {
     };
   }
 
-  async steerTurn(params: SteerTurnRequest): Promise<SteerTurnResponse> {
+  async steerTurn(
+    params: SteerTurnRequest,
+    messageOrigin?: AppServerThreadMessageOrigin,
+  ): Promise<SteerTurnResponse> {
+    const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
+      backend: params.backend,
+      threadId: params.threadId,
+      turnId: params.expectedTurnId,
+      origin: messageOrigin,
+      text: extractFirstMeaningfulTextInput(params.input),
+    });
     const steerWithClient = async (
       client: BackendClient,
     ): Promise<{ threadId: string; turnId: string }> => {
@@ -9602,10 +9797,16 @@ export class DesktopBackendRegistry {
       });
     };
 
-    const result =
-      params.backend === "codex"
-        ? await this.withActiveCodexThreadClient(params.threadId, steerWithClient)
-        : await steerWithClient(this.grokClient);
+    let result: { threadId: string; turnId: string };
+    try {
+      result =
+        params.backend === "codex"
+          ? await this.withActiveCodexThreadClient(params.threadId, steerWithClient)
+          : await steerWithClient(this.grokClient);
+    } catch (error) {
+      this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
+      throw error;
+    }
 
     return {
       backend: params.backend,
@@ -20950,6 +21151,7 @@ export class DesktopBackendRegistry {
   }
 
   private async emit(event: AgentEvent): Promise<void> {
+    event = await this.withThreadMessageOrigin(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -40,6 +40,7 @@ import {
   type AppServerThreadActivityEntry,
   type AppServerThreadEntry,
   type AppServerThreadMessage,
+  type AppServerThreadMessageOrigin,
   type AppServerToolRequestUserInputResponse,
   type AppServerThreadReplay,
   type AppServerThreadStatus,
@@ -4601,6 +4602,49 @@ function mergeImmutableUsageActivities(params: {
   };
 }
 
+function mergeThreadMessageOrigins(
+  replay: AppServerThreadReplay,
+  originsByTurnId: Record<string, AppServerThreadMessageOrigin>,
+): AppServerThreadReplay {
+  if (Object.keys(originsByTurnId).length === 0) {
+    return replay;
+  }
+  const originsByMessageId = new Map<string, AppServerThreadMessageOrigin>();
+  const entries = replay.entries.map((entry): AppServerThreadEntry => {
+    if (entry.type !== "message" || entry.role !== "user" || !entry.turn?.id) {
+      return entry;
+    }
+    const origin = originsByTurnId[entry.turn.id];
+    if (!origin) {
+      return entry;
+    }
+    originsByMessageId.set(entry.id, origin);
+    return { ...entry, origin };
+  });
+  const messages = replay.messages.map((message) => {
+    const origin = originsByMessageId.get(message.id);
+    return origin && message.role === "user" ? { ...message, origin } : message;
+  });
+  return {
+    ...replay,
+    entries,
+    messages,
+  };
+}
+
+function resolveThreadMessageOrigin(params: {
+  origin?: ThreadTurnQueueOrigin;
+  messageOrigin?: AppServerThreadMessageOrigin;
+}): AppServerThreadMessageOrigin | undefined {
+  if (params.messageOrigin) {
+    return params.messageOrigin;
+  }
+  if (params.origin === "automation" || params.origin === "messaging") {
+    return { kind: params.origin };
+  }
+  return undefined;
+}
+
 function extractFirstMeaningfulTextInput(input: AppServerTurnInputItem[]): string | undefined {
   const text = input
     .filter((item): item is Extract<AppServerTurnInputItem, { type: "text" }> => item.type === "text")
@@ -5173,6 +5217,7 @@ function pageNormalizedReplay(
             role: entry.role,
             text: entry.text,
             ...(entry.parts ? { parts: entry.parts } : {}),
+            ...(entry.origin ? { origin: entry.origin } : {}),
             ...(entry.createdAt ? { createdAt: entry.createdAt } : {}),
           },
         ]
@@ -8117,6 +8162,42 @@ export class DesktopBackendRegistry {
             replay: replayWithEnvironment,
             activities: overlay?.immutableUsageActivities,
           });
+    const messageTurnIds = replayWithImmutableUsage.entries.flatMap((entry) =>
+      entry.type === "message" && entry.turn?.id ? [entry.turn.id] : [],
+    );
+    const persistedMessageOrigins =
+      typeof this.overlayStore.readThreadMessageOrigins === "function"
+        ? await this.overlayStore.readThreadMessageOrigins({
+            backend,
+            threadId: request.threadId,
+            turnIds: messageTurnIds,
+          })
+        : {};
+    const messageOrigins = { ...persistedMessageOrigins };
+    const firstUserMessage = replayWithImmutableUsage.entries.find(
+      (entry) => entry.type === "message" && entry.role === "user" && entry.turn?.id,
+    );
+    if (
+      overlay?.handoffOrigin
+      && firstUserMessage?.type === "message"
+      && firstUserMessage.turn?.id
+      && !messageOrigins[firstUserMessage.turn.id]
+    ) {
+      messageOrigins[firstUserMessage.turn.id] = {
+        kind: "agent",
+        sourceThread: {
+          backend: overlay.handoffOrigin.sourceBackend,
+          threadId: overlay.handoffOrigin.sourceThreadId,
+          ...(overlay.handoffOrigin.sourceTitle
+            ? { title: overlay.handoffOrigin.sourceTitle }
+            : {}),
+        },
+      };
+    }
+    const replayWithMessageOrigins = mergeThreadMessageOrigins(
+      replayWithImmutableUsage,
+      messageOrigins,
+    );
     if (!request.before && shouldAppendTranscriptOverlays) {
       await this.persistReplayUsageLines(replayWithEnvironment);
     }
@@ -8141,10 +8222,10 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),
-      ...(replayWithImmutableUsage.threadStatus
-        ? { threadStatus: replayWithImmutableUsage.threadStatus }
+      ...(replayWithMessageOrigins.threadStatus
+        ? { threadStatus: replayWithMessageOrigins.threadStatus }
         : {}),
-      replay: replayWithImmutableUsage,
+      replay: replayWithMessageOrigins,
     };
   }
 
@@ -8800,6 +8881,7 @@ export class DesktopBackendRegistry {
     reasoningEffort?: string;
     fastMode?: boolean;
     automationRunId?: string;
+    messageOrigin?: AppServerThreadMessageOrigin;
   }): Promise<ThreadTurnQueueSubmissionResult> {
     const { origin = "manual", ...entry } = params;
     return await this.threadTurnQueue.submit({
@@ -8913,6 +8995,7 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    messageOrigin?: AppServerThreadMessageOrigin;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     return await this.startTurnNow(params);
   }
@@ -8930,6 +9013,7 @@ export class DesktopBackendRegistry {
     serviceTier?: string;
     reasoningEffort?: string;
     fastMode?: boolean;
+    messageOrigin?: AppServerThreadMessageOrigin;
   }): Promise<{ backend: AppServerBackendKind; threadId: string; turnId: string }> {
     this.assertNotBootstrap("startTurn");
     if (isAcpBackendId(params.backend)) {
@@ -8972,6 +9056,12 @@ export class DesktopBackendRegistry {
           backend: params.backend,
           threadId: result.threadId,
           input: params.input,
+        });
+        await this.persistThreadMessageOrigin({
+          backend: params.backend,
+          threadId: result.threadId,
+          turnId: result.turnId,
+          origin: resolveThreadMessageOrigin(params),
         });
         return result;
       } finally {
@@ -9145,6 +9235,12 @@ export class DesktopBackendRegistry {
         executionMode: params.executionMode,
       });
     }
+    await this.persistThreadMessageOrigin({
+      backend: params.backend,
+      threadId: result.threadId,
+      turnId: result.turnId,
+      origin: resolveThreadMessageOrigin(params),
+    });
     const response = {
       backend: params.backend,
       threadId: result.threadId,
@@ -9165,6 +9261,35 @@ export class DesktopBackendRegistry {
     }
 
     return response;
+  }
+
+  private async persistThreadMessageOrigin(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId: string;
+    origin?: AppServerThreadMessageOrigin;
+  }): Promise<void> {
+    if (
+      !params.origin
+      || typeof this.overlayStore.upsertThreadMessageOrigin !== "function"
+    ) {
+      return;
+    }
+    try {
+      await this.overlayStore.upsertThreadMessageOrigin({
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId: params.turnId,
+        origin: params.origin,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("failed to persist injected message origin", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+        turnId: params.turnId,
+      });
+    }
   }
 
   private scheduleCompletedTurnFromReplay(params: {
@@ -17635,6 +17760,7 @@ export class DesktopBackendRegistry {
       backend: move.backend,
       threadId: move.threadId,
       input: [{ type: "text", text: prompt }],
+      messageOrigin: { kind: "pwragent" },
     });
     this.updatePendingThreadWorkspaceMove(params.moveId, {
       status: params.kind === "success" ? "completed" : "failed",
@@ -17712,6 +17838,13 @@ export class DesktopBackendRegistry {
         backend,
         threadId,
         input: [{ type: "text", text: prompt }],
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: request.context.backend,
+            threadId: request.context.threadId,
+          },
+        },
         executionMode: request.args.executionMode,
         model: request.args.model,
         reasoningEffort: request.args.reasoningEffort,
@@ -18235,6 +18368,14 @@ export class DesktopBackendRegistry {
         backend,
         threadId,
         input: [{ type: "text", text: prompt }],
+        messageOrigin: {
+          kind: "agent",
+          sourceThread: {
+            backend: sourceBackend,
+            threadId: sourceThreadId,
+            ...(sourceThread?.title ? { title: sourceThread.title } : {}),
+          },
+        },
         executionMode,
         model: inheritedSettings.model,
         reasoningEffort: inheritedSettings.reasoningEffort,
@@ -21236,6 +21377,7 @@ function toThreadReadMessageSummary(
   return {
     id: message.id,
     role: message.role,
+    ...(message.origin ? { origin: message.origin } : {}),
     ...(message.createdAt !== undefined ? { createdAt: message.createdAt } : {}),
     text: text.value,
     ...(text.truncated ? { truncated: true } : {}),
@@ -21256,6 +21398,7 @@ function toThreadReadEntrySummary(
         type: "message",
         id: entry.id,
         role: entry.role,
+        ...(entry.origin ? { origin: entry.origin } : {}),
         text: text.value,
         ...(entry.createdAt !== undefined ? { createdAt: entry.createdAt } : {}),
         ...(entry.phase ? { phase: entry.phase } : {}),

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
   AppServerBackendKind,
   AppServerCollaborationModeRequest,
+  AppServerThreadMessageOrigin,
   AppServerTurnInputItem,
   ThreadExecutionMode,
   ThreadIdentifier,
@@ -14,6 +15,7 @@ export type ThreadTurnQueueEntry = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   origin: ThreadTurnQueueOrigin;
+  messageOrigin?: AppServerThreadMessageOrigin;
   input: AppServerTurnInputItem[];
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;

--- a/apps/desktop/src/main/grok-app-server/client.ts
+++ b/apps/desktop/src/main/grok-app-server/client.ts
@@ -457,7 +457,13 @@ function extractStructuredMessageParts(value: unknown): AppServerThreadMessagePa
 }
 
 function normalizeRawMessages(
-  rawMessages: Array<{ role?: unknown; text?: unknown; parts?: unknown }>,
+  rawMessages: Array<{
+    id?: unknown;
+    messageId?: unknown;
+    role?: unknown;
+    text?: unknown;
+    parts?: unknown;
+  }>,
 ): ReplayMessage[] {
   return rawMessages.flatMap((message, index) => {
     if (!message || typeof message !== "object") {
@@ -476,7 +482,12 @@ function normalizeRawMessages(
 
     return [
       {
-        id: `message-${index + 1}`,
+        id:
+          typeof message.id === "string"
+            ? message.id
+            : typeof message.messageId === "string"
+              ? message.messageId
+              : `message-${index + 1}`,
         role,
         text: text ?? "",
         ...(parts.length > 0 ? { parts } : {}),
@@ -542,7 +553,14 @@ function extractReplayFromItems(
   items: Record<string, unknown>[],
   pagination: AppServerThreadReplay["pagination"],
 ): AppServerThreadReplay | undefined {
-  if (!items.some((item) => isActivityReplayItem(item) || isReviewReplayItem(item))) {
+  if (
+    !items.some(
+      (item) =>
+        Boolean(itemToMessage(item, 0))
+        || isActivityReplayItem(item)
+        || isReviewReplayItem(item),
+    )
+  ) {
     return undefined;
   }
 
@@ -657,7 +675,12 @@ function itemToMessage(item: Record<string, unknown>, index: number): ReplayMess
     return undefined;
   }
   return {
-    id: `message-${index}`,
+    id:
+      typeof item.id === "string"
+        ? item.id
+        : typeof item.messageId === "string"
+          ? item.messageId
+          : `message-${index}`,
     role,
     text: text ?? "",
     ...(parts.length > 0 ? { parts } : {}),

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -211,7 +211,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   }
 
   async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {
-    return await this.registry.steerTurn(request);
+    return await this.registry.steerTurn(request, { kind: "messaging" });
   }
 
   async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1297,7 +1297,7 @@ export class SqliteOverlayStore {
   async upsertThreadMessageOrigin(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
-    turnId: string;
+    messageId: string;
     origin: AppServerThreadMessageOrigin;
     createdAt?: number;
   }): Promise<void> {
@@ -1306,18 +1306,18 @@ export class SqliteOverlayStore {
         `INSERT INTO thread_message_origins(
            backend,
            thread_id,
-           turn_id,
+           message_id,
            created_at,
            payload
          ) VALUES (?, ?, ?, ?, ?)
-         ON CONFLICT(backend, thread_id, turn_id) DO UPDATE SET
+         ON CONFLICT(backend, thread_id, message_id) DO UPDATE SET
            created_at = excluded.created_at,
            payload = excluded.payload`,
       )
       .run(
         params.backend,
         params.threadId,
-        params.turnId,
+        params.messageId,
         params.createdAt ?? Date.now(),
         JSON.stringify(params.origin),
       );
@@ -1326,31 +1326,31 @@ export class SqliteOverlayStore {
   async readThreadMessageOrigins(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
-    turnIds: string[];
+    messageIds: string[];
   }): Promise<Record<string, AppServerThreadMessageOrigin>> {
-    const turnIds = [
+    const messageIds = [
       ...new Set(
-        params.turnIds.map((turnId) => turnId.trim()).filter(Boolean),
+        params.messageIds.map((messageId) => messageId.trim()).filter(Boolean),
       ),
     ];
-    if (turnIds.length === 0) {
+    if (messageIds.length === 0) {
       return {};
     }
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT turn_id, payload
+        `SELECT message_id, payload
          FROM thread_message_origins
          WHERE backend = ?
            AND thread_id = ?
-           AND turn_id IN (SELECT value FROM json_each(?))`,
+           AND message_id IN (SELECT value FROM json_each(?))`,
       )
-      .all(params.backend, params.threadId, JSON.stringify(turnIds)) as Array<{
+      .all(params.backend, params.threadId, JSON.stringify(messageIds)) as Array<{
+        message_id: string;
         payload: string;
-        turn_id: string;
       }>;
     return Object.fromEntries(
       rows.map((row) => [
-        row.turn_id,
+        row.message_id,
         JSON.parse(row.payload) as AppServerThreadMessageOrigin,
       ]),
     );

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type {
   AppServerBackendScope,
+  AppServerThreadMessageOrigin,
   AppServerThreadSummary,
   AutomationThreadSummary,
   DirectoryLaunchpadOverlayState,
@@ -1291,6 +1292,68 @@ export class SqliteOverlayStore {
         toolName: params.toolName,
       }) as ThreadToolInvocationRow[];
     return rows.map(threadToolInvocationFromRow);
+  }
+
+  async upsertThreadMessageOrigin(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    turnId: string;
+    origin: AppServerThreadMessageOrigin;
+    createdAt?: number;
+  }): Promise<void> {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO thread_message_origins(
+           backend,
+           thread_id,
+           turn_id,
+           created_at,
+           payload
+         ) VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(backend, thread_id, turn_id) DO UPDATE SET
+           created_at = excluded.created_at,
+           payload = excluded.payload`,
+      )
+      .run(
+        params.backend,
+        params.threadId,
+        params.turnId,
+        params.createdAt ?? Date.now(),
+        JSON.stringify(params.origin),
+      );
+  }
+
+  async readThreadMessageOrigins(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    turnIds: string[];
+  }): Promise<Record<string, AppServerThreadMessageOrigin>> {
+    const turnIds = [
+      ...new Set(
+        params.turnIds.map((turnId) => turnId.trim()).filter(Boolean),
+      ),
+    ];
+    if (turnIds.length === 0) {
+      return {};
+    }
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT turn_id, payload
+         FROM thread_message_origins
+         WHERE backend = ?
+           AND thread_id = ?
+           AND turn_id IN (SELECT value FROM json_each(?))`,
+      )
+      .all(params.backend, params.threadId, JSON.stringify(turnIds)) as Array<{
+        payload: string;
+        turn_id: string;
+      }>;
+    return Object.fromEntries(
+      rows.map((row) => [
+        row.turn_id,
+        JSON.parse(row.payload) as AppServerThreadMessageOrigin,
+      ]),
+    );
   }
 
   // Per-turn metadata lives on thread_usage_turns. The turn record is refreshed
@@ -3638,4 +3701,6 @@ export type OverlayStoreLike = Pick<
 > & {
   setThreadCodexEnvironmentRuntime?: SqliteOverlayStore["setThreadCodexEnvironmentRuntime"];
   listThreadOverlaysWithCodexEnvironmentRuntime?: SqliteOverlayStore["listThreadOverlaysWithCodexEnvironmentRuntime"];
+  upsertThreadMessageOrigin?: SqliteOverlayStore["upsertThreadMessageOrigin"];
+  readThreadMessageOrigins?: SqliteOverlayStore["readThreadMessageOrigins"];
 };

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 29;
+export const CURRENT_STATE_DB_USER_VERSION = 30;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -703,6 +703,19 @@ CREATE INDEX IF NOT EXISTS idx_thread_tool_invocation_alerts_read_thread
   ON thread_tool_invocation_alerts(backend, thread_id, updated_at DESC, alert_id DESC);
 `;
 
+const THREAD_MESSAGE_ORIGIN_SCHEMA = `
+CREATE TABLE IF NOT EXISTS thread_message_origins (
+  backend     TEXT NOT NULL,
+  thread_id   TEXT NOT NULL,
+  turn_id     TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  payload     TEXT NOT NULL,
+  PRIMARY KEY (backend, thread_id, turn_id)
+);
+CREATE INDEX IF NOT EXISTS idx_thread_message_origins_thread
+  ON thread_message_origins(backend, thread_id, created_at, turn_id);
+`;
+
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
@@ -939,6 +952,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 29) {
       db.transaction(() => {
         repairTokenUsagePricing(db);
+        db.pragma("user_version = 29");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 30) {
+      db.transaction(() => {
+        db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1095,6 +1114,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
+    db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 30;
+export const CURRENT_STATE_DB_USER_VERSION = 31;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -707,13 +707,13 @@ const THREAD_MESSAGE_ORIGIN_SCHEMA = `
 CREATE TABLE IF NOT EXISTS thread_message_origins (
   backend     TEXT NOT NULL,
   thread_id   TEXT NOT NULL,
-  turn_id     TEXT NOT NULL,
+  message_id  TEXT NOT NULL,
   created_at  INTEGER NOT NULL,
   payload     TEXT NOT NULL,
-  PRIMARY KEY (backend, thread_id, turn_id)
+  PRIMARY KEY (backend, thread_id, message_id)
 );
 CREATE INDEX IF NOT EXISTS idx_thread_message_origins_thread
-  ON thread_message_origins(backend, thread_id, created_at, turn_id);
+  ON thread_message_origins(backend, thread_id, created_at, message_id);
 `;
 
 const DELIVERIES_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
@@ -957,7 +957,13 @@ export class StateDb {
     }
     if ((db.pragma("user_version", { simple: true }) as number) < 30) {
       db.transaction(() => {
-        db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
+        ensureThreadMessageOriginSchema(db);
+        db.pragma("user_version = 30");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 31) {
+      db.transaction(() => {
+        ensureThreadMessageOriginSchema(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1114,7 +1120,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
-    db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
+    ensureThreadMessageOriginSchema(db);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
       db.pragma("user_version = 4");
     }
@@ -1914,6 +1920,7 @@ function tableColumnExists(
     | "automation_runs"
     | "pr_lookup_cache"
     | "pr_status_cache"
+    | "thread_message_origins"
     | "thread_pricing_summaries"
     | "thread_search_fts"
     | "thread_usage_lines"
@@ -1924,6 +1931,26 @@ function tableColumnExists(
   return rows.some((row) => row.name === columnName);
 }
 
+function ensureThreadMessageOriginSchema(db: BetterSqlite3.Database): void {
+  if (
+    tableColumnExists(db, "thread_message_origins", "turn_id")
+    && !tableColumnExists(db, "thread_message_origins", "message_id")
+  ) {
+    // v30 briefly keyed injected-message origins by turn. One turn can contain
+    // several user messages, so those rows cannot be migrated without guessing
+    // which message they describe. Recreate this unreleased metadata table with
+    // the concrete provider message identity instead.
+    db.exec(`
+DROP INDEX IF EXISTS idx_thread_message_origins_thread;
+ALTER TABLE thread_message_origins RENAME TO thread_message_origins_v30;
+`);
+    db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
+    db.exec("DROP TABLE thread_message_origins_v30");
+    return;
+  }
+  db.exec(THREAD_MESSAGE_ORIGIN_SCHEMA);
+}
+
 function readTableInfo(
   db: BetterSqlite3.Database,
   tableName:
@@ -1931,6 +1958,7 @@ function readTableInfo(
     | "automation_runs"
     | "pr_lookup_cache"
     | "pr_status_cache"
+    | "thread_message_origins"
     | "thread_pricing_summaries"
     | "thread_search_fts"
     | "thread_usage_lines"
@@ -1951,6 +1979,10 @@ function readTableInfo(
       }>;
     case "pr_status_cache":
       return db.prepare("PRAGMA table_info(pr_status_cache)").all() as Array<{
+        name: string;
+      }>;
+    case "thread_message_origins":
+      return db.prepare("PRAGMA table_info(thread_message_origins)").all() as Array<{
         name: string;
       }>;
     case "thread_pricing_summaries":

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -4,10 +4,13 @@ import type {
   AppServerSkillSummary,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadMessageOrigin,
   AppServerThreadMessagePart,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
+import { ThreadChip } from "./ThreadChip";
 import { TranscriptImage } from "./TranscriptImage";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
@@ -25,6 +28,10 @@ type TranscriptMessageProps = {
 };
 
 export const TranscriptMessage = memo(function TranscriptMessage(props: TranscriptMessageProps) {
+  const threadLinks = useThreadLinks();
+  const sourceThreadLink = props.message.origin?.sourceThread
+    ? threadLinks?.resolve(props.message.origin.sourceThread)
+    : undefined;
   const contentParts =
     props.message.parts && props.message.parts.length > 0
       ? props.message.parts
@@ -40,12 +47,14 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
   if (messageSegments.length === 0) {
     return (
       <article
-        className={`transcript-message transcript-message--${props.message.role}`}
+        className={`transcript-message ${messageToneClass(props.message)}`}
       >
         {renderMessageHeader({
           continuation: false,
           desktopApi: props.desktopApi,
           message: props.message,
+          sourceThreadLink,
+          threadLinks,
           text: messageCopyText,
         })}
       </article>
@@ -58,7 +67,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
         <article
           className={[
             "transcript-message",
-            `transcript-message--${props.message.role}`,
+            messageToneClass(props.message),
             segment.type === "table" ? "transcript-message--table" : undefined,
             segment.type === "table" && segment.wide
               ? "transcript-message--table-wide"
@@ -73,6 +82,8 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
             continuation: index > 0,
             desktopApi: props.desktopApi,
             message: props.message,
+            sourceThreadLink,
+            threadLinks,
             text: messageCopyText,
           })}
           <div className="transcript-message__text">
@@ -443,6 +454,8 @@ function renderMessageHeader(params: {
   continuation: boolean;
   desktopApi?: Pick<DesktopApi, "copyText">;
   message: AppServerThreadMessageEntry;
+  sourceThreadLink?: ResolvedThreadLink;
+  threadLinks: ReturnType<typeof useThreadLinks>;
   text: string;
 }): ReactNode {
   if (params.continuation) {
@@ -451,7 +464,22 @@ function renderMessageHeader(params: {
 
   return (
     <header className="transcript-message__header">
-      <span className="transcript-message__role">{labelForRole(params.message.role)}</span>
+      <span className="transcript-message__attribution">
+        <span className="transcript-message__role">
+          {labelForMessage(params.message)}
+        </span>
+        {params.sourceThreadLink && params.threadLinks ? (
+          <ThreadChip
+            fallbackLabel={params.message.origin?.sourceThread?.title}
+            link={params.sourceThreadLink}
+            onOpen={params.threadLinks.show}
+          />
+        ) : params.message.origin?.sourceThread?.title ? (
+          <span className="transcript-message__source">
+            {params.message.origin.sourceThread.title}
+          </span>
+        ) : null}
+      </span>
       <span className="transcript-message__header-actions">
         {params.text ? (
           <TranscriptCopyButton
@@ -477,11 +505,30 @@ function renderMessageHeader(params: {
   );
 }
 
-function labelForRole(role: AppServerThreadMessageEntry["role"]): string {
-  if (role === "assistant") {
+function messageToneClass(message: AppServerThreadMessageEntry): string {
+  return message.origin
+    ? "transcript-message--injected"
+    : `transcript-message--${message.role}`;
+}
+
+function labelForMessage(message: AppServerThreadMessageEntry): string {
+  if (message.role === "assistant") {
     return "Assistant";
   }
-  return "User";
+  return message.origin ? labelForOrigin(message.origin) : "User";
+}
+
+function labelForOrigin(origin: AppServerThreadMessageOrigin): string {
+  if (origin.kind === "agent") {
+    return "Agent";
+  }
+  if (origin.kind === "automation") {
+    return "Automation";
+  }
+  if (origin.kind === "messaging") {
+    return "Messaging";
+  }
+  return "PwrAgent";
 }
 
 function buildMessageCopyText(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom/vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { buildAutomationCardActivityEntries } from "../automation-card-entries";
 import { TranscriptList } from "../TranscriptList";
 
@@ -147,6 +149,57 @@ describe("TranscriptList", () => {
     expect(
       screen.getByText("Channel bound: Telegram - PwrDrvr / PwrDrvr/Topic")
     ).toBeInTheDocument();
+  });
+
+  it("attributes an injected Agent message and links its source thread", () => {
+    const onShowThread = vi.fn();
+    const sourceThread = {
+      id: "source-thread",
+      title: "Branch picker error handling",
+      titleSource: "derived",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: true, unread: false },
+    } as NavigationThreadSummary;
+
+    const { container } = render(
+      <ThreadLinkProvider onShowThread={onShowThread} threads={[sourceThread]}>
+        <TranscriptList
+          entries={[
+            {
+              type: "message",
+              id: "message-injected",
+              role: "user",
+              text: "Please take this through publication now.",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  threadId: "source-thread",
+                },
+              },
+            },
+          ]}
+          loading={false}
+          loadingMore={false}
+          onLoadOlder={async () => undefined}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+    expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open thread Branch picker error handling",
+      }),
+    );
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "source-thread",
+    });
   });
 
   it("renders transcript history and exposes incremental history loading when available", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -676,6 +676,14 @@ describe("useThreadSessionState", () => {
             item: {
               id: "user-message-1",
               type: "userMessage",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  threadId: "parent-thread",
+                  title: "Parent thread",
+                },
+              },
               content: [
                 {
                   type: "text",
@@ -705,6 +713,14 @@ describe("useThreadSessionState", () => {
     ).toEqual([
       expect.objectContaining({
         id: "user-message-1",
+        origin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "parent-thread",
+            title: "Parent thread",
+          },
+        },
       }),
     ]);
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -13,6 +13,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
+  AppServerThreadMessageOrigin,
   AppServerThreadMessagePart,
   AppServerThreadReviewEntry,
   AppServerThreadTurnMetadata,
@@ -2793,6 +2794,7 @@ function userMessageEntryFromCompletedItem(params: {
     fallbackId: typeof params.turnId === "string" ? params.turnId : undefined,
     fallbackStatus: "in_progress",
   });
+  const origin = threadMessageOriginFromUnknown(record.origin);
 
   return {
     type: "message",
@@ -2800,8 +2802,47 @@ function userMessageEntryFromCompletedItem(params: {
     role: "user",
     text: content.text,
     ...(content.parts ? { parts: content.parts } : {}),
+    ...(origin ? { origin } : {}),
     ...(turn ? { turn } : {}),
     createdAt: Date.now(),
+  };
+}
+
+function threadMessageOriginFromUnknown(
+  value: unknown,
+): AppServerThreadMessageOrigin | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.kind !== "agent"
+    && record.kind !== "automation"
+    && record.kind !== "messaging"
+    && record.kind !== "pwragent"
+  ) {
+    return undefined;
+  }
+  const source = record.sourceThread;
+  if (!source || typeof source !== "object" || Array.isArray(source)) {
+    return { kind: record.kind };
+  }
+  const sourceRecord = source as Record<string, unknown>;
+  if (
+    typeof sourceRecord.backend !== "string"
+    || typeof sourceRecord.threadId !== "string"
+  ) {
+    return { kind: record.kind };
+  }
+  return {
+    kind: record.kind,
+    sourceThread: {
+      backend: sourceRecord.backend as AppServerBackendKind,
+      threadId: sourceRecord.threadId,
+      ...(typeof sourceRecord.title === "string"
+        ? { title: sourceRecord.title }
+        : {}),
+    },
   };
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8556,6 +8556,12 @@ textarea,
   background: var(--bg-panel);
 }
 
+.transcript-message--injected {
+  align-self: flex-end;
+  border-color: var(--border-strong);
+  background: var(--bg-panel-elevated);
+}
+
 .transcript-message--table-wide {
   width: 100%;
   max-width: 100%;
@@ -8634,6 +8640,25 @@ textarea,
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
+}
+
+.transcript-message__attribution {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.transcript-message__attribution .thread-chip {
+  height: 20px;
+}
+
+.transcript-message__source {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .transcript-message__header-actions {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -321,7 +321,23 @@ export type AppServerThreadMessage = {
   role: "user" | "assistant";
   text: string;
   parts?: AppServerThreadMessagePart[];
+  origin?: AppServerThreadMessageOrigin;
   createdAt?: number;
+};
+
+export type AppServerThreadMessageOriginKind =
+  | "agent"
+  | "automation"
+  | "messaging"
+  | "pwragent";
+
+export type AppServerThreadMessageOrigin = {
+  kind: AppServerThreadMessageOriginKind;
+  sourceThread?: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    title?: string;
+  };
 };
 
 export type AppServerThreadTextPart = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -969,6 +969,7 @@ export type AppServerNotification =
           id: string;
           type: string;
           text?: string;
+          origin?: AppServerThreadMessageOrigin;
           review?: string;
           command?: string;
           commandAction?: AppServerCommandAction;

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -343,7 +343,7 @@ export type PendingThreadWorkspaceMoveSummary = {
 
 export type ThreadReadMessageSummary = Pick<
   AppServerThreadMessage,
-  "id" | "role" | "createdAt"
+  "id" | "role" | "origin" | "createdAt"
 > & {
   text: string;
   truncated?: boolean;
@@ -354,6 +354,7 @@ export type ThreadReadEntrySummary =
       type: "message";
       id: string;
       role: AppServerThreadMessage["role"];
+      origin?: AppServerThreadMessage["origin"];
       text: string;
       createdAt?: number;
       phase?: "commentary" | "final";


### PR DESCRIPTION
## Summary

- persist per-turn provenance for prompts injected by Agent tools, automations, messaging, and internal PwrAgent continuations
- render injected prompts with distinct Agent, Automation, Messaging, or PwrAgent attribution instead of labeling them as User
- show a safe in-app source-thread chip when Agent provenance includes a resolvable originating thread
- recover attribution for the initial prompt in existing handoff-created threads from durable handoff metadata
- expose provenance through normalized thread inspection responses

## Why

PwrAgent previously normalized every prompt entering a provider turn as a user-role message. That made prompts injected by `send_message_to_thread`, handoffs, automations, and messaging visually indistinguishable from prompts typed by the operator. The provider role remains `user` for protocol compatibility, while PwrAgent now carries its own durable provenance alongside the transcript.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-agent.test.ts apps/desktop/src/main/__tests__/state-db.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (471 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (warnings only, no errors)
- `pnpm lint:sql`
- `pnpm lint:colors`
- `pnpm lint:codex-storage`
- `pnpm lint:boundaries`
- `git diff --check`
