### PR TITLE
fix(desktop): release queued turns after branch adoption

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28054,6 +28054,64 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("uses a concurrently adopted expected branch when a stale drift check finishes", async () => {
+    const adoptedBranch = "fix/queued-turn-release";
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "Moved thread",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      source: "codex",
+      gitBranch: "HEAD",
+      observedGitBranch: adoptedBranch,
+      updatedAt: 2,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "full-access",
+          gitBranch: "HEAD",
+          observedGitBranch: "HEAD",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    vi.spyOn(overlayStore, "setThreadObservedBranch").mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "full-access",
+      gitBranch: adoptedBranch,
+      observedGitBranch: adoptedBranch,
+      extraLinkedDirectories: [],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+        threads: [thread],
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const response = await registry.checkThreadBranchDrift({
+      backend: "codex",
+      expectedBranch: "HEAD",
+      threadId: "thread-1",
+    });
+
+    expect(response).toMatchObject({
+      expectedBranch: adoptedBranch,
+      observedBranch: adoptedBranch,
+      drifted: false,
+    });
+
+    await registry.close();
+  });
+
   it("does not persist branch drift after registry shutdown starts", async () => {
     let releaseListThreads!: () => void;
     const listThreadsDelay = new Promise<void>((resolve) => {

--- a/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-branches.test.ts
@@ -86,4 +86,32 @@ describe("SqliteOverlayStore branch metadata", () => {
       observedGitBranch: "main",
     });
   });
+
+  it("preserves a newer expected branch when a stale drift check finishes", async () => {
+    await store.setThreadExpectedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "HEAD",
+    });
+
+    await store.setThreadExpectedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/adopted-by-active-turn",
+    });
+
+    await store.setThreadObservedBranch({
+      backend: "codex",
+      threadId: "thread-1",
+      branch: "feature/adopted-by-active-turn",
+      expectedBranch: "HEAD",
+    });
+
+    await expect(
+      store.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toMatchObject({
+      gitBranch: "feature/adopted-by-active-turn",
+      observedGitBranch: "feature/adopted-by-active-turn",
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10583,7 +10583,7 @@ export class DesktopBackendRegistry {
       };
     }
 
-    await this.overlayStore.setThreadObservedBranch({
+    const persistedOverlay = await this.overlayStore.setThreadObservedBranch({
       backend: params.backend,
       threadId: params.threadId,
       branch: normalizedObservedBranch,
@@ -10592,8 +10592,18 @@ export class DesktopBackendRegistry {
           ? expectedBranch
           : undefined,
     });
+    const persistedExpectedBranch = persistedOverlay.gitBranch?.trim() || undefined;
+    const effectiveExpectedBranch = persistedExpectedBranch ?? expectedBranch;
+    const effectiveDrifted = isBranchDrifted(
+      effectiveExpectedBranch,
+      normalizedObservedBranch,
+    );
 
-    if (expectedBranchResolution.repairedDetachedHandoffBranch && expectedBranch) {
+    if (
+      expectedBranchResolution.repairedDetachedHandoffBranch &&
+      expectedBranch &&
+      effectiveExpectedBranch === expectedBranch
+    ) {
       await this.updateThreadGitBranchMetadata({
         backend: params.backend,
         threadId: params.threadId,
@@ -10611,11 +10621,11 @@ export class DesktopBackendRegistry {
       } as unknown as AgentEvent);
     }
 
-    if (drifted) {
+    if (effectiveDrifted) {
       backendRegistryLog.debug("checked thread branch drift", {
         backend: params.backend,
-        drifted,
-        expectedBranch,
+        drifted: effectiveDrifted,
+        expectedBranch: effectiveExpectedBranch,
         observedBranch: normalizedObservedBranch,
         workspaceCwd,
         threadId: params.threadId,
@@ -10625,9 +10635,9 @@ export class DesktopBackendRegistry {
     return {
       backend: params.backend,
       threadId: params.threadId,
-      expectedBranch,
+      expectedBranch: effectiveExpectedBranch,
       observedBranch: normalizedObservedBranch,
-      drifted,
+      drifted: effectiveDrifted,
       checkedAt: Date.now(),
     };
   }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2199,10 +2199,19 @@ export class SqliteOverlayStore {
         ? previousObservedBranch
         : undefined;
     const requestedExpectedBranch = params.expectedBranch?.trim() || undefined;
+    const currentExpectedBranch = current.gitBranch?.trim() || undefined;
+    const shouldApplyRequestedExpectedBranch = Boolean(
+      requestedExpectedBranch &&
+      (
+        !currentExpectedBranch
+        || requestedExpectedBranch === nextObservedBranch
+      ),
+    );
     const nextState: ThreadOverlayState = {
       ...current,
-      gitBranch: requestedExpectedBranch
-        ?? (current.gitBranch?.trim() ? current.gitBranch : fallbackExpectedBranch),
+      gitBranch: shouldApplyRequestedExpectedBranch
+        ? requestedExpectedBranch
+        : currentExpectedBranch ?? fallbackExpectedBranch,
       observedGitBranch: params.branch,
     };
     this.putThread(threadKey, nextState);

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -754,16 +754,20 @@ export class OverlayStore {
         previousObservedBranch !== nextObservedBranch
           ? previousObservedBranch
           : undefined;
-      const requestedExpectedBranch =
-        params.expectedBranch?.trim() &&
-        params.expectedBranch.trim() !== nextObservedBranch
-          ? params.expectedBranch.trim()
-          : undefined;
+      const requestedExpectedBranch = params.expectedBranch?.trim() || undefined;
+      const currentExpectedBranch = current.gitBranch?.trim() || undefined;
+      const shouldApplyRequestedExpectedBranch = Boolean(
+        requestedExpectedBranch &&
+        (
+          !currentExpectedBranch
+          || requestedExpectedBranch === nextObservedBranch
+        ),
+      );
       const nextState: ThreadOverlayState = {
         ...current,
-        gitBranch: current.gitBranch?.trim()
-          ? current.gitBranch
-          : requestedExpectedBranch ?? fallbackExpectedBranch,
+        gitBranch: shouldApplyRequestedExpectedBranch
+          ? requestedExpectedBranch
+          : currentExpectedBranch ?? fallbackExpectedBranch,
         observedGitBranch: params.branch,
       };
       data.threads[threadKey] = nextState;


### PR DESCRIPTION
## Summary

- Preserve a newly adopted expected branch when an older branch-drift observation finishes afterward.
- Recompute the drift result from the branch state that actually won the persistence race.
- Add regression coverage for both the SQLite overlay write and the registry response used by background queued-turn release.

## Root cause

A Codex turn can leave a detached worktree on a newly created named branch. At the terminal boundary, PwrAgent adopts that branch while the renderer background queued-turn release performs a drift check from its older `HEAD` snapshot.

The SQLite observed-branch write allowed that stale `HEAD` expectation to overwrite the branch that active-turn adoption had just persisted. Subsequent idle probes then correctly treated the thread as drifted and kept the message queued indefinitely. Selecting the thread repaired the expected branch, which explains why the message released only after opening it.

The write now preserves an existing newer expectation unless the caller is intentionally repairing the expectation to the observed branch. The registry also derives its returned drift state from the persisted overlay, allowing the queued turn to release immediately when active-turn adoption won the race.

## Impact

Queued or scheduled follow-up messages can release normally after a background Codex turn creates or switches to a named branch. Genuine unresolved branch drift remains guarded.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/overlay-store-branches.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx packages/agent-core/src/__tests__/overlay-store.test.ts packages/agent-core/src/__tests__/refresh-reconciliation.test.ts` (434 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`