### PR TITLE
fix(agent-core): gate Grok live config resolution

### DIFF
--- a/packages/agent-core/src/__tests__/grok-live.test.ts
+++ b/packages/agent-core/src/__tests__/grok-live.test.ts
@@ -5,18 +5,19 @@ import { CodexAppServer } from "../app-server/codex-app-server.js";
 import { resolveGrokAppServerRuntimeConfig } from "../config/grok-app-server-config.js";
 import type { AppServerNotification } from "../app-server/internal-contract.js";
 import { GrokProvider } from "../providers/grok-provider.js";
-import { resolveLiveAgentCoreSkipReason } from "../testing/live-test-gate.js";
+import { resolveLiveAgentCoreTestConfig } from "../testing/live-test-gate.js";
 import { createTemporaryTestDirectory } from "../testing/test-harness.js";
 
-const runtimeConfig = resolveGrokAppServerRuntimeConfig();
-const xaiApiKey = runtimeConfig.apiKey?.trim();
-const xaiBaseUrl = runtimeConfig.baseUrl?.trim() || "https://api.x.ai/v1";
-const grokModel = runtimeConfig.model?.trim() || "grok-4.20-reasoning";
-const liveSkipReason = resolveLiveAgentCoreSkipReason({
-  apiKey: xaiApiKey,
-  configPath: runtimeConfig.configPath,
+const liveTestConfig = resolveLiveAgentCoreTestConfig({
   lifecycleEvent: process.env.npm_lifecycle_event,
+  resolveRuntimeConfig: resolveGrokAppServerRuntimeConfig,
 });
+const xaiApiKey = liveTestConfig.runtimeConfig?.apiKey?.trim();
+const xaiBaseUrl =
+  liveTestConfig.runtimeConfig?.baseUrl?.trim() || "https://api.x.ai/v1";
+const grokModel =
+  liveTestConfig.runtimeConfig?.model?.trim() || "grok-4.20-reasoning";
+const liveSkipReason = liveTestConfig.skipReason;
 
 const itLive = liveSkipReason ? it.skip : it;
 const liveNotificationTimeoutMs = 60_000;

--- a/packages/agent-core/src/__tests__/live-test-gate.test.ts
+++ b/packages/agent-core/src/__tests__/live-test-gate.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { resolveLiveAgentCoreSkipReason } from "../testing/live-test-gate.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveLiveAgentCoreSkipReason,
+  resolveLiveAgentCoreTestConfig,
+} from "../testing/live-test-gate.js";
 
 describe("Grok live test gate", () => {
   it("skips ambient credentials during the ordinary workspace test lifecycle", () => {
@@ -29,5 +32,41 @@ describe("Grok live test gate", () => {
         lifecycleEvent: "test:live",
       }),
     ).toContain("XAI_API_KEY is not set");
+  });
+
+  it("does not resolve ambient runtime config during ordinary workspace tests", () => {
+    const resolveRuntimeConfig = vi.fn(() => {
+      throw new Error("ambient runtime config must not be parsed");
+    });
+
+    expect(
+      resolveLiveAgentCoreTestConfig({
+        lifecycleEvent: "test",
+        resolveRuntimeConfig,
+      }),
+    ).toEqual({
+      skipReason: expect.stringContaining(
+        "only through the explicit agent-core test:live script",
+      ),
+    });
+    expect(resolveRuntimeConfig).not.toHaveBeenCalled();
+  });
+
+  it("resolves and validates runtime config for the explicit live script", () => {
+    const runtimeConfig = {
+      configPath: "/home/test/.config/grok-app-server/config.toml",
+    };
+    const resolveRuntimeConfig = vi.fn(() => runtimeConfig);
+
+    expect(
+      resolveLiveAgentCoreTestConfig({
+        lifecycleEvent: "test:live",
+        resolveRuntimeConfig,
+      }),
+    ).toEqual({
+      runtimeConfig,
+      skipReason: expect.stringContaining("XAI_API_KEY is not set"),
+    });
+    expect(resolveRuntimeConfig).toHaveBeenCalledOnce();
   });
 });

--- a/packages/agent-core/src/testing/live-test-gate.ts
+++ b/packages/agent-core/src/testing/live-test-gate.ts
@@ -1,13 +1,60 @@
+const LIVE_TEST_LIFECYCLE_EVENT = "test:live";
+const LIVE_TEST_LIFECYCLE_SKIP_REASON =
+  "Grok live tests run only through the explicit agent-core test:live script";
+
+type LiveAgentCoreRuntimeConfig = {
+  apiKey?: string;
+  configPath: string;
+};
+
+function resolveLiveAgentCoreLifecycleSkipReason(
+  lifecycleEvent?: string,
+): string | undefined {
+  if (lifecycleEvent !== LIVE_TEST_LIFECYCLE_EVENT) {
+    return LIVE_TEST_LIFECYCLE_SKIP_REASON;
+  }
+  return undefined;
+}
+
 export function resolveLiveAgentCoreSkipReason(params: {
   apiKey?: string;
   configPath: string;
   lifecycleEvent?: string;
 }): string | undefined {
-  if (params.lifecycleEvent !== "test:live") {
-    return "Grok live tests run only through the explicit agent-core test:live script";
-  }
+  const lifecycleSkipReason = resolveLiveAgentCoreLifecycleSkipReason(
+    params.lifecycleEvent,
+  );
+  if (lifecycleSkipReason) return lifecycleSkipReason;
+
   if (!params.apiKey?.trim()) {
     return `XAI_API_KEY is not set in the environment or runtime config at ${params.configPath}`;
   }
   return undefined;
+}
+
+export function resolveLiveAgentCoreTestConfig<
+  RuntimeConfig extends LiveAgentCoreRuntimeConfig,
+>(params: {
+  lifecycleEvent?: string;
+  resolveRuntimeConfig: () => RuntimeConfig;
+}): {
+  runtimeConfig?: RuntimeConfig;
+  skipReason?: string;
+} {
+  const lifecycleSkipReason = resolveLiveAgentCoreLifecycleSkipReason(
+    params.lifecycleEvent,
+  );
+  if (lifecycleSkipReason) {
+    return { skipReason: lifecycleSkipReason };
+  }
+
+  const runtimeConfig = params.resolveRuntimeConfig();
+  return {
+    runtimeConfig,
+    skipReason: resolveLiveAgentCoreSkipReason({
+      apiKey: runtimeConfig.apiKey,
+      configPath: runtimeConfig.configPath,
+      lifecycleEvent: params.lifecycleEvent,
+    }),
+  };
 }


### PR DESCRIPTION
## Summary

- I moved Grok live-test runtime configuration resolution behind the explicit
  `test:live` lifecycle gate, so ordinary workspace test runs never parse
  ambient `~/.config/grok-app-server/config.toml`.
- I added focused regression coverage proving ordinary runs do not invoke the
  config resolver and explicit live runs still resolve and validate their
  configuration.

## Verification

- `pnpm --filter @pwragent/agent-core test` — 216 passed, 3 live tests skipped
- `pnpm test packages/agent-core/src/__tests__/live-test-gate.test.ts packages/agent-core/src/__tests__/grok-live.test.ts`
  — 5 passed, 3 live tests skipped
- Ordinary `pnpm test` with an unsupported TOML table under an isolated
  `XDG_CONFIG_HOME` — live suite skipped without parsing the file
- Explicit `test:live` with the same unsupported TOML table — config parsing
  ran and rejected the table as expected
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warnings only
- `pnpm lint:boundaries`

## Notes

- I based this branch directly on `origin/main`; it does not modify or depend
  on PR #1044.
