### PR TITLE
fix(messaging): honor response mode on thread bindings

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3190,6 +3190,45 @@ describe("MessagingController", () => {
     );
   });
 
+  it("ignores response modes when the provider cannot report bot mentions", async () => {
+    const harness = await createHarness({
+      capabilityProfile: {
+        ...PERMISSIVE_CAPABILITY_PROFILE,
+        conversationInput: {
+          reportsBotMention: false,
+        },
+      },
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("500");
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:500:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      preferences: {
+        responseMode: "mention_only",
+        updatedAt: 1000,
+      },
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("continue the implementation", { channel }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue the implementation" }],
+      }),
+    );
+  });
+
   it("applies mention-only response mode to agent-thread bindings", async () => {
     const harness = await createHarness({
       responseModeForConversation: () => "mention_only",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3121,7 +3121,7 @@ describe("MessagingController", () => {
     }
   });
 
-  it("routes raw shared-channel text to a strict thread binding even in mention-only mode", async () => {
+  it("applies mention-only response mode to strict thread bindings", async () => {
     const harness = await createHarness({
       responseModeForConversation: () => "mention_only",
     });
@@ -3139,6 +3139,47 @@ describe("MessagingController", () => {
     });
 
     await harness.controller.handleInboundEvent(event);
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+
+    await harness.controller.handleInboundEvent({
+      ...event,
+      id: "event-mentioned",
+      botMention: true,
+    });
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue the implementation" }],
+      }),
+    );
+  });
+
+  it("uses a binding response-mode override before the channel default", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("500");
+    await harness.store.upsertBinding({
+      id: "binding:telegram:topic:-1001:500:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      preferences: {
+        responseMode: "every_message",
+        updatedAt: 1000,
+      },
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("continue the implementation", { channel }),
+    );
 
     expect(harness.startTurn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -14766,6 +14807,118 @@ describe("MessagingController", () => {
         text: expect.stringContaining(`Working Updates: ${expected}`),
       });
     }
+  });
+
+  it("shows and updates the binding response mode from the status card", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("510");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        channel,
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining(
+        "Responses: @mentions only (channel default)",
+      ),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:response-mode",
+          label: "Responses: @mentions",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:response-mode",
+        channel,
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Responses"),
+      choices: expect.arrayContaining([
+        expect.objectContaining({
+          id: "status:set-response-mode",
+          label: "Channel default (@mentions only) (current)",
+          value: { responseMode: "inherit" },
+        }),
+        expect.objectContaining({
+          id: "status:set-response-mode",
+          label: "Every message",
+          value: { responseMode: "every_message" },
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-response-mode",
+        channel,
+        value: { responseMode: "every_message" },
+      }),
+    );
+
+    await expect(
+      harness.store.findActiveBindingForChannel(channel),
+    ).resolves.toMatchObject({
+      preferences: {
+        responseMode: "every_message",
+      },
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining(
+        "Responses: every message (binding override)",
+      ),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ label: "Responses: all" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("continue without a mention", { channel }),
+    );
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue without a mention" }],
+      }),
+    );
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:response-mode",
+        channel,
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-response-mode",
+        channel,
+        value: { responseMode: "inherit" },
+      }),
+    );
+
+    const inheritedBinding =
+      await harness.store.findActiveBindingForChannel(channel);
+    expect(inheritedBinding?.preferences).not.toHaveProperty("responseMode");
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining(
+        "Responses: @mentions only (channel default)",
+      ),
+    });
   });
 
   it("stops an active turn through the backend bridge", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -352,7 +352,10 @@ describe("DesktopMessagingRuntime", () => {
   async function startMentionOnlyRuntime(options: {
     automationInboundHandler: MessagingAutomationInboundHandler;
     automationInboundMatches: MessagingAutomationInboundMatcher;
-  }): Promise<ReturnType<typeof createAdapter>> {
+  }): Promise<{
+    adapter: ReturnType<typeof createAdapter>;
+    bridge: ReturnType<typeof createBackendBridge>;
+  }> {
     await prepareRuntimeStore();
     const { resetInboundPreview } = await import(
       "../messaging/inbound-preview-bus"
@@ -381,7 +384,7 @@ describe("DesktopMessagingRuntime", () => {
       }),
     );
     await runtime.start();
-    return adapter;
+    return { adapter, bridge };
   }
 
   const ambientEvent = {
@@ -401,7 +404,7 @@ describe("DesktopMessagingRuntime", () => {
     // The automation's own filter matches this ambient (non-@mention) message,
     // so it must be delivered even though the channel is @mention-only.
     const automationInboundMatches = vi.fn(() => true);
-    const adapter = await startMentionOnlyRuntime({
+    const { adapter } = await startMentionOnlyRuntime({
       automationInboundHandler,
       automationInboundMatches,
     });
@@ -420,7 +423,7 @@ describe("DesktopMessagingRuntime", () => {
   it("drops ambient @mention-only messages no automation filter matches", async () => {
     const automationInboundHandler = vi.fn(async () => false);
     const automationInboundMatches = vi.fn(() => false);
-    const adapter = await startMentionOnlyRuntime({
+    const { adapter } = await startMentionOnlyRuntime({
       automationInboundHandler,
       automationInboundMatches,
     });
@@ -433,6 +436,57 @@ describe("DesktopMessagingRuntime", () => {
     expect(
       adapter.delivered.some((intent) => intent.kind === "message"),
     ).toBe(false);
+  });
+
+  it("applies channel response mode to strict bindings unless the binding overrides it", async () => {
+    const automationInboundHandler = vi.fn(async () => false);
+    const automationInboundMatches = vi.fn(() => false);
+    const { adapter, bridge } = await startMentionOnlyRuntime({
+      automationInboundHandler,
+      automationInboundMatches,
+    });
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    const store = getDesktopMessagingStore();
+    const binding = {
+      id: "binding:telegram:channel::chat-ambient:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex" as const,
+      channel: ambientEvent.channel,
+      createdAt: 1000,
+      targetKind: "thread" as const,
+      threadId: "thread-1",
+      updatedAt: 1000,
+    };
+    await store.upsertBinding(binding);
+
+    await adapter.listener?.(ambientEvent);
+
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+
+    await store.upsertBinding({
+      ...binding,
+      preferences: {
+        responseMode: "every_message",
+        updatedAt: 1001,
+      },
+      updatedAt: 1001,
+    });
+    await adapter.listener?.({
+      ...ambientEvent,
+      id: "ambient-2",
+      text: "continue without a mention",
+    });
+    await waitFor(() => vi.mocked(bridge.startTurn).mock.calls.length > 0);
+
+    expect(bridge.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue without a mention" }],
+      }),
+    );
   });
 
   it("logs inbound controller failures without rejecting the adapter listener", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -352,6 +352,7 @@ describe("DesktopMessagingRuntime", () => {
   async function startMentionOnlyRuntime(options: {
     automationInboundHandler: MessagingAutomationInboundHandler;
     automationInboundMatches: MessagingAutomationInboundMatcher;
+    reportsBotMention?: boolean;
   }): Promise<{
     adapter: ReturnType<typeof createAdapter>;
     bridge: ReturnType<typeof createBackendBridge>;
@@ -361,7 +362,19 @@ describe("DesktopMessagingRuntime", () => {
       "../messaging/inbound-preview-bus"
     );
     resetInboundPreview();
-    const adapter = createAdapter("telegram");
+    const adapter = createAdapter(
+      "telegram",
+      options.reportsBotMention === false
+        ? {
+            capabilityProfile: {
+              ...PERMISSIVE_CAPABILITY_PROFILE,
+              conversationInput: {
+                reportsBotMention: false,
+              },
+            },
+          }
+        : {},
+    );
     const bridge = createBackendBridge();
     const { DesktopMessagingRuntime: Runtime } = await import(
       "../messaging/messaging-runtime"
@@ -465,14 +478,30 @@ describe("DesktopMessagingRuntime", () => {
 
     expect(bridge.startTurn).not.toHaveBeenCalled();
 
-    await store.upsertBinding({
-      ...binding,
+    await adapter.listener?.({
+      ...buildCallbackEvent("status:response-mode", {}),
+      id: "ambient-response-mode-picker",
+      channel: ambientEvent.channel,
+    });
+    expect(adapter.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Responses"),
+    });
+
+    await adapter.listener?.({
+      ...ambientEvent,
+      id: "ambient-response-mode-choice",
+      text: "3",
+    });
+    await expect(
+      store.findActiveBindingForChannel(ambientEvent.channel),
+    ).resolves.toMatchObject({
       preferences: {
         responseMode: "every_message",
-        updatedAt: 1001,
       },
-      updatedAt: 1001,
     });
+    expect(bridge.startTurn).not.toHaveBeenCalled();
+
     await adapter.listener?.({
       ...ambientEvent,
       id: "ambient-2",
@@ -485,6 +514,41 @@ describe("DesktopMessagingRuntime", () => {
         backend: "codex",
         threadId: "thread-1",
         input: [{ type: "text", text: "continue without a mention" }],
+      }),
+    );
+  });
+
+  it("does not enforce response modes without bot-mention reporting", async () => {
+    const { adapter, bridge } = await startMentionOnlyRuntime({
+      automationInboundHandler: vi.fn(async () => false),
+      automationInboundMatches: vi.fn(() => false),
+      reportsBotMention: false,
+    });
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:telegram:channel::chat-ambient:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: ambientEvent.channel,
+      createdAt: 1000,
+      preferences: {
+        responseMode: "mention_only",
+        updatedAt: 1000,
+      },
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await adapter.listener?.(ambientEvent);
+    await waitFor(() => vi.mocked(bridge.startTurn).mock.calls.length > 0);
+
+    expect(bridge.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-1",
+        input: [{ type: "text", text: ambientEvent.text }],
       }),
     );
   });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   MessagingBindingRecord,
 } from "@pwragent/messaging-interface";
+import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/testing";
 import {
   buildBindingStatusIntent,
   buildHandoffBranchPickerIntent,
@@ -185,6 +186,7 @@ describe("buildBindingStatusIntent", () => {
     const inheritedIntent = buildBindingStatusIntent({
       id: "status-inherited-response-mode",
       binding: inheritedBinding,
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
       createdAt: 1000,
       responseModeDefault: "mention_only",
       threadState: resolveMessagingThreadState({
@@ -213,6 +215,7 @@ describe("buildBindingStatusIntent", () => {
     const overriddenIntent = buildBindingStatusIntent({
       id: "status-overridden-response-mode",
       binding: overriddenBinding,
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
       createdAt: 1000,
       responseModeDefault: "mention_only",
       threadState: resolveMessagingThreadState({
@@ -226,6 +229,44 @@ describe("buildBindingStatusIntent", () => {
     );
     expect(overriddenIntent.actions).toContainEqual(
       expect.objectContaining({ label: "Responses: all" }),
+    );
+  });
+
+  it("hides response-mode controls without bot-mention reporting", () => {
+    const binding = {
+      ...buildBinding(),
+      channel: {
+        channel: "mattermost" as const,
+        conversation: {
+          id: "channel-1",
+          kind: "channel" as const,
+        },
+      },
+      preferences: {
+        responseMode: "mention_only" as const,
+        updatedAt: 1000,
+      },
+    };
+    const intent = buildBindingStatusIntent({
+      id: "status-no-mention-reporting",
+      binding,
+      capabilityProfile: {
+        ...PERMISSIVE_CAPABILITY_PROFILE,
+        conversationInput: {
+          reportsBotMention: false,
+        },
+      },
+      createdAt: 1000,
+      responseModeDefault: "every_message",
+      threadState: resolveMessagingThreadState({
+        binding,
+        navigation: buildNavigationSnapshot(),
+      }),
+    });
+
+    expect(intent.text).not.toContain("Responses:");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "status:response-mode" }),
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -170,6 +170,65 @@ describe("buildBindingStatusIntent", () => {
     expect(intent.text).not.toContain("Rate limits:");
   });
 
+  it("shows the effective shared-conversation response mode and its source", () => {
+    const inheritedBinding = {
+      ...buildBinding(),
+      channel: {
+        channel: "slack" as const,
+        conversation: {
+          id: "C012ABCDEF0",
+          kind: "thread" as const,
+          parentId: "1712023032.123456",
+        },
+      },
+    };
+    const inheritedIntent = buildBindingStatusIntent({
+      id: "status-inherited-response-mode",
+      binding: inheritedBinding,
+      createdAt: 1000,
+      responseModeDefault: "mention_only",
+      threadState: resolveMessagingThreadState({
+        binding: inheritedBinding,
+        navigation: buildNavigationSnapshot(),
+      }),
+    });
+
+    expect(inheritedIntent.text).toContain(
+      "Responses: @mentions only (channel default)",
+    );
+    expect(inheritedIntent.actions).toContainEqual(
+      expect.objectContaining({
+        id: "status:response-mode",
+        label: "Responses: @mentions",
+      }),
+    );
+
+    const overriddenBinding = {
+      ...inheritedBinding,
+      preferences: {
+        responseMode: "every_message" as const,
+        updatedAt: 1000,
+      },
+    };
+    const overriddenIntent = buildBindingStatusIntent({
+      id: "status-overridden-response-mode",
+      binding: overriddenBinding,
+      createdAt: 1000,
+      responseModeDefault: "mention_only",
+      threadState: resolveMessagingThreadState({
+        binding: overriddenBinding,
+        navigation: buildNavigationSnapshot(),
+      }),
+    });
+
+    expect(overriddenIntent.text).toContain(
+      "Responses: every message (binding override)",
+    );
+    expect(overriddenIntent.actions).toContainEqual(
+      expect.objectContaining({ label: "Responses: all" }),
+    );
+  });
+
   it("redacts backend account email in shared conversations", () => {
     const binding = {
       ...buildBinding(),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1793,6 +1793,11 @@ export class MessagingController {
     if (event.channel.conversation.kind === "dm") {
       return true;
     }
+    if (
+      this.capabilityProfile.conversationInput?.reportsBotMention !== true
+    ) {
+      return true;
+    }
     const responseMode = resolveMessagingResponseMode(
       binding,
       await this.responseModeForConversation(event.channel),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -165,6 +165,7 @@ import {
   buildStatusModelPickerIntent,
   buildStatusPermissionsPickerIntent,
   buildStatusReasoningPickerIntent,
+  buildStatusResponseModePickerIntent,
   buildStatusToolUpdateModePickerIntent,
   formatExecutionModeLabel,
   formatMessagingToolUpdateModeLabel,
@@ -174,6 +175,7 @@ import {
   messagingStreamingResponsesEnabled,
   messagingToolUpdateModeChoices,
   nextMessagingStreamingResponseMode,
+  resolveMessagingResponseMode,
   resolveMessagingStreamingResponseMode,
   resolveMessagingToolUpdateMode,
   shouldShowStreamingControl,
@@ -1701,10 +1703,7 @@ export class MessagingController {
       return;
     }
 
-    if (
-      binding.targetKind === "agent_thread" &&
-      !await this.shouldHandleAmbientSharedMessage(event, binding)
-    ) {
+    if (!await this.shouldHandleAmbientSharedMessage(event, binding)) {
       return;
     }
 
@@ -1780,10 +1779,7 @@ export class MessagingController {
       return;
     }
 
-    if (
-      binding.targetKind === "agent_thread" &&
-      !await this.shouldHandleAmbientSharedMessage(event, binding)
-    ) {
+    if (!await this.shouldHandleAmbientSharedMessage(event, binding)) {
       return;
     }
 
@@ -1797,10 +1793,10 @@ export class MessagingController {
     if (event.channel.conversation.kind === "dm") {
       return true;
     }
-    if (binding?.targetKind === "thread") {
-      return true;
-    }
-    const responseMode = await this.responseModeForConversation(event.channel);
+    const responseMode = resolveMessagingResponseMode(
+      binding,
+      await this.responseModeForConversation(event.channel),
+    );
     return responseMode === "every_message" || event.botMention === true;
   }
 
@@ -7588,6 +7584,10 @@ export class MessagingController {
       await this.setToolUpdateMode(binding, event);
       return;
     }
+    if (actionId === "status:set-response-mode") {
+      await this.setBindingResponseMode(binding, event);
+      return;
+    }
     if (actionId === "status:fast") {
       await this.toggleFastMode(binding, event);
       return;
@@ -7615,6 +7615,10 @@ export class MessagingController {
     }
     if (actionId === "status:tool-updates") {
       await this.presentToolUpdateModePicker(binding, event);
+      return;
+    }
+    if (actionId === "status:response-mode") {
+      await this.presentResponseModePicker(binding, event);
       return;
     }
     if (actionId === "status:streaming") {
@@ -8431,6 +8435,23 @@ export class MessagingController {
         binding,
         choices: messagingToolUpdateModeChoices(currentMode),
         createdAt: this.now(),
+      }),
+      binding,
+      event,
+    );
+  }
+
+  private async presentResponseModePicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliverAndStoreStatusSubmode(
+      buildStatusResponseModePickerIntent({
+        id: this.newIntentId("status-response-mode-picker"),
+        capabilityProfile: this.capabilityProfile,
+        binding,
+        createdAt: this.now(),
+        defaultMode: await this.responseModeForConversation(binding.channel),
       }),
       binding,
       event,
@@ -9797,6 +9818,36 @@ export class MessagingController {
     await this.renderBindingStatus(updatedBinding, event);
   }
 
+  private async setBindingResponseMode(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const selected = readStringValue(event.value, "responseMode");
+    if (
+      selected !== "inherit" &&
+      selected !== "mention_only" &&
+      selected !== "every_message"
+    ) {
+      await this.deliverInvalidStatusSelection(event);
+      return;
+    }
+    const {
+      responseMode: _previousResponseMode,
+      ...preferences
+    } = binding.preferences ?? { updatedAt: this.now() };
+    const updatedBinding = await this.options.store.upsertBinding({
+      ...binding,
+      preferences: {
+        ...preferences,
+        ...(selected === "inherit" ? {} : { responseMode: selected }),
+        updatedAt: this.now(),
+      },
+      updatedAt: this.now(),
+    });
+    await this.clearActiveBindingSubmodeIntent(event, updatedBinding);
+    await this.renderBindingStatus(updatedBinding, event);
+  }
+
   private async cycleStreamingResponseMode(
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
@@ -10083,6 +10134,9 @@ export class MessagingController {
             capabilityProfile: this.capabilityProfile,
             contextUsageSummary: this.contextUsageSummaryForBinding(binding),
             createdAt: this.now(),
+            responseModeDefault: await this.responseModeForConversation(
+              binding.channel,
+            ),
             threadState: resolveMessagingThreadState({
               activeTurn: this.getActiveTurn(binding),
               binding,
@@ -10171,6 +10225,9 @@ export class MessagingController {
       handoff: this.options.backend.handoffThreadWorkspace
         ? handoffContextForBinding(binding, snapshot)
         : undefined,
+      responseModeDefault: await this.responseModeForConversation(
+        binding.channel,
+      ),
       streamingResponsesDefault: this.streamingResponsesDefault,
       showStreamingOption: await this.resolveShowStreamingOption(),
       threadState: resolveMessagingThreadState({

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -197,8 +197,9 @@ export function buildBindingStatusIntent(params: {
     params.binding,
     params.responseModeDefault,
   );
-  const isSharedConversation =
-    params.binding.channel.conversation.kind !== "dm";
+  const showResponseModeControl =
+    params.binding.channel.conversation.kind !== "dm" &&
+    params.capabilityProfile?.conversationInput?.reportsBotMention === true;
   const acpRuntimeMode = isAcpBackendId(params.binding.backend)
     ? buildMessagingAcpRuntimeModeSummary({
         backend: params.backendSummary,
@@ -243,7 +244,7 @@ export function buildBindingStatusIntent(params: {
       supportsFastMode ? `Fast mode: ${fastMode ? "on" : "off"}` : undefined,
       planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
-      isSharedConversation
+      showResponseModeControl
         ? `Responses: ${formatMessagingResponseModeLabel(responseMode)} (${
             params.binding.preferences?.responseMode
               ? "binding override"
@@ -285,7 +286,7 @@ export function buildBindingStatusIntent(params: {
       queuedExecutionMode,
       reasoning,
       responseMode,
-      showResponseModeControl: isSharedConversation,
+      showResponseModeControl,
       supportsFastMode,
       supportsReasoning,
       streamingMode,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -12,6 +12,7 @@ import type {
   MessagingBindingRecord,
   MessagingConfirmationIntent,
   MessagingJsonValue,
+  MessagingResponseMode,
   MessagingStreamingResponseMode,
   MessagingSingleSelectIntent,
   MessagingSurfaceAction,
@@ -122,6 +123,7 @@ export function buildBindingStatusIntent(params: {
   createdAt: number;
   handoff?: MessagingWorkspaceHandoffContext;
   id: string;
+  responseModeDefault?: MessagingResponseMode;
   streamingResponsesDefault?: boolean;
   showStreamingOption?: boolean;
   threadState: MessagingResolvedThreadState;
@@ -191,6 +193,12 @@ export function buildBindingStatusIntent(params: {
     streamingMode,
     params.streamingResponsesDefault,
   );
+  const responseMode = resolveMessagingResponseMode(
+    params.binding,
+    params.responseModeDefault,
+  );
+  const isSharedConversation =
+    params.binding.channel.conversation.kind !== "dm";
   const acpRuntimeMode = isAcpBackendId(params.binding.backend)
     ? buildMessagingAcpRuntimeModeSummary({
         backend: params.backendSummary,
@@ -235,6 +243,13 @@ export function buildBindingStatusIntent(params: {
       supportsFastMode ? `Fast mode: ${fastMode ? "on" : "off"}` : undefined,
       planDeliveryLine(params.capabilityProfile),
       `Permissions: ${permissionsLineLabel}`,
+      isSharedConversation
+        ? `Responses: ${formatMessagingResponseModeLabel(responseMode)} (${
+            params.binding.preferences?.responseMode
+              ? "binding override"
+              : "channel default"
+          })`
+        : undefined,
       `Working Updates: ${formatMessagingToolUpdateModeLabel(toolUpdateMode)}`,
       shouldShowStreamingControl(
         streamingMode,
@@ -269,6 +284,8 @@ export function buildBindingStatusIntent(params: {
         permissionsMode === "full-access",
       queuedExecutionMode,
       reasoning,
+      responseMode,
+      showResponseModeControl: isSharedConversation,
       supportsFastMode,
       supportsReasoning,
       streamingMode,
@@ -504,6 +521,8 @@ function buildStatusActions(params: {
   supportsLegacyPermissionsAction?: boolean;
   queuedExecutionMode?: ThreadExecutionMode;
   reasoning?: string;
+  responseMode: MessagingResponseMode;
+  showResponseModeControl: boolean;
   supportsFastMode: boolean;
   supportsReasoning: boolean;
   streamingMode: MessagingStreamingResponseMode;
@@ -575,12 +594,25 @@ function buildStatusActions(params: {
           },
         ]
       : []),
+    ...(params.showResponseModeControl
+      ? [
+          {
+            id: "status:response-mode",
+            label: `Responses: ${formatMessagingResponseModeActionLabel(
+              params.responseMode,
+            )}`,
+            style: "secondary" as const,
+            fallbackText: "responses",
+            priority: 9,
+          },
+        ]
+      : []),
     {
       id: "status:tool-updates",
       label: `Working Updates: ${formatMessagingToolUpdateModeLabel(params.toolUpdateMode)}`,
       style: "secondary",
       fallbackText: "tools",
-      priority: 9,
+      priority: 10,
     },
     ...(shouldShowStreamingControl(
       params.streamingMode,
@@ -596,7 +628,7 @@ function buildStatusActions(params: {
             )}`,
             style: "secondary" as const,
             fallbackText: "stream",
-            priority: 10,
+            priority: 11,
           },
         ]
       : []),
@@ -605,21 +637,21 @@ function buildStatusActions(params: {
       label: "Compact",
       style: "secondary",
       fallbackText: "compact",
-      priority: 11,
+      priority: 12,
     },
     {
       id: "status:sync-name",
       label: "Sync name",
       style: "secondary",
       fallbackText: "sync name",
-      priority: 12,
+      priority: 13,
     },
     {
       id: "status:skills",
       label: "Skills",
       style: "secondary",
       fallbackText: "skills",
-      priority: 13,
+      priority: 14,
     },
     {
       id: "status:stop",
@@ -702,6 +734,25 @@ export function resolveMessagingToolUpdateMode(
   defaultMode: MessagingToolUpdateMode | undefined,
 ): MessagingToolUpdateMode {
   return binding.preferences?.toolUpdateMode ?? defaultMode ?? "show_some";
+}
+
+export function resolveMessagingResponseMode(
+  binding: MessagingBindingRecord | undefined,
+  defaultMode: MessagingResponseMode | undefined,
+): MessagingResponseMode {
+  return binding?.preferences?.responseMode ?? defaultMode ?? "every_message";
+}
+
+export function formatMessagingResponseModeLabel(
+  mode: MessagingResponseMode,
+): string {
+  return mode === "mention_only" ? "@mentions only" : "every message";
+}
+
+function formatMessagingResponseModeActionLabel(
+  mode: MessagingResponseMode,
+): string {
+  return mode === "mention_only" ? "@mentions" : "all";
 }
 
 export function nextMessagingToolUpdateMode(
@@ -1430,6 +1481,71 @@ export function buildStatusToolUpdateModePickerIntent(params: {
           priority: 10 + index,
           value: {
             toolUpdateMode: choice.mode,
+          },
+        })),
+        {
+          id: "status:refresh",
+          label: "Back",
+          fallbackText: "back",
+          style: "secondary" as const,
+          priority: 1,
+        },
+      ],
+      params.capabilityProfile,
+    ),
+  };
+}
+
+export function buildStatusResponseModePickerIntent(params: {
+  binding: MessagingBindingRecord;
+  capabilityProfile?: MessagingCapabilityProfile;
+  createdAt: number;
+  defaultMode: MessagingResponseMode;
+  id: string;
+}): MessagingSingleSelectIntent {
+  const selected = params.binding.preferences?.responseMode ?? "inherit";
+  const choices: Array<{
+    label: string;
+    mode: "inherit" | MessagingResponseMode;
+  }> = [
+    {
+      label: `Channel default (${formatMessagingResponseModeLabel(
+        params.defaultMode,
+      )})`,
+      mode: "inherit",
+    },
+    {
+      label: "@mentions only",
+      mode: "mention_only",
+    },
+    {
+      label: "Every message",
+      mode: "every_message",
+    },
+  ];
+  return {
+    id: params.id,
+    kind: "single_select",
+    bindingId: params.binding.id,
+    createdAt: params.createdAt,
+    delivery: {
+      mode: params.binding.statusSurface ? "update" : "present",
+      fallback: "present_new",
+    },
+    targetSurface: params.binding.statusSurface,
+    fallbackText: "Reply with a response mode option number, Back, or Cancel.",
+    prompt:
+      "Responses — choose which messages in this shared conversation reach this bound thread. DMs and explicit commands are unaffected.",
+    choices: applyActionCapabilityLimits(
+      [
+        ...choices.map((choice, index) => ({
+          id: "status:set-response-mode",
+          label: `${choice.label}${choice.mode === selected ? " (current)" : ""}`,
+          fallbackText: String(index + 1),
+          style: "secondary" as const,
+          priority: 10 + index,
+          value: {
+            responseMode: choice.mode,
           },
         })),
         {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -940,16 +940,14 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       return false;
     }
     const binding = await params.store.findActiveBindingForChannel(event.channel);
-    if (binding?.targetKind === "thread") {
-      return false;
-    }
-    if (
+    const responseMode =
+      binding?.preferences?.responseMode ??
       responseModeForChannel(
         await this.loadConfig(),
         params.channel,
         event.channel,
-      ) !== "mention_only"
-    ) {
+      );
+    if (responseMode !== "mention_only") {
       return false;
     }
     // @mention-only mode suppresses the bot's NORMAL replies, but it must not

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -930,6 +930,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private async shouldDropAmbientSharedMessage(params: {
     channel: MessagingChannelKind;
     event: MessagingInboundEvent;
+    reportsBotMention: boolean;
     store: MessagingStoreLike;
   }): Promise<boolean> {
     const { event } = params;
@@ -937,6 +938,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       return false;
     }
     if (event.botMention || event.channel.conversation.kind === "dm") {
+      return false;
+    }
+    if (!params.reportsBotMention) {
       return false;
     }
     const binding = await params.store.findActiveBindingForChannel(event.channel);
@@ -948,6 +952,19 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         event.channel,
       );
     if (responseMode !== "mention_only") {
+      return false;
+    }
+    const [pendingIntent, browseSession] = await Promise.all([
+      params.store.findActivePendingIntentForChannel({
+        actorId: event.actor.platformUserId,
+        channel: event.channel,
+      }),
+      params.store.findActiveBrowseSessionForChannel({
+        actorId: event.actor.platformUserId,
+        channel: event.channel,
+      }),
+    ]);
+    if (pendingIntent || browseSession) {
       return false;
     }
     // @mention-only mode suppresses the bot's NORMAL replies, but it must not
@@ -1075,6 +1092,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           await this.shouldDropAmbientSharedMessage({
             channel: adapter.channel,
             event,
+            reportsBotMention:
+              adapter.capabilityProfile.conversationInput?.reportsBotMention ===
+              true,
             store,
           })
         ) {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1578,6 +1578,12 @@ export type MessagingOutboundAttachmentCapabilities = {
 
 export type MessagingConversationInputCapabilities = {
   /**
+   * The adapter sets `botMention: true` on inbound text/media events that
+   * explicitly mention the bot. Response-mode filtering may only offer or
+   * enforce `mention_only` when this capability is true.
+   */
+  reportsBotMention?: boolean;
+  /**
    * Shared conversations require an explicit bot mention before the platform
    * delivers messages to the adapter.
    */

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1238,6 +1238,12 @@ export type MessagingBindingPreferences = {
   model?: string;
   permissionsMode?: MessagingPermissionsMode;
   reasoningEffort?: string;
+  /**
+   * Per-binding override for shared-conversation input. When omitted, the
+   * binding inherits the provider conversation's configured response mode.
+   * DMs always accept ordinary text regardless of this preference.
+   */
+  responseMode?: MessagingResponseMode;
   serviceTier?: string;
   streamingResponses?: MessagingStreamingResponseMode;
   /**

--- a/packages/messaging/interface/src/testing.ts
+++ b/packages/messaging/interface/src/testing.ts
@@ -34,6 +34,9 @@ export const PERMISSIVE_CAPABILITY_PROFILE: MessagingCapabilityProfile = {
     supportsInlineCode: true,
     supportsMessageEdit: true,
   },
+  conversationInput: {
+    reportsBotMention: true,
+  },
   outboundAttachments: {
     maxUploadBytes: 100 * 1024 * 1024,
     supportsFileUpload: true,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -270,6 +270,9 @@ export class SlackAdapter implements SlackProviderAdapter {
   readonly channel = "slack" as const;
   readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "externalized";
   readonly capabilityProfile: MessagingCapabilityProfile = {
+    conversationInput: {
+      reportsBotMention: true,
+    },
     actions: {
       // Slack Block Kit actions blocks allow at most 25 elements.
       // Source: https://docs.slack.dev/reference/block-kit/blocks/actions-block/

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -453,6 +453,9 @@ export class TelegramAdapter implements TelegramProviderAdapter {
   readonly channel = "telegram" as const;
   readonly clientRateLimitStrategy: MessagingClientRateLimitStrategy = "direct";
   readonly capabilityProfile: MessagingCapabilityProfile = {
+    conversationInput: {
+      reportsBotMention: true,
+    },
     actions: {
       maxActions: 100,
       maxActionsPerRow: 8,


### PR DESCRIPTION
## Summary

Fixes shared Slack and Telegram thread bindings that could respond to ordinary channel chatter even when the channel was configured for `@ mention only`. All shared binding kinds now inherit the channel response mode unless the binding has an explicit override; DMs and explicit commands remain unaffected.

## Changes

- Apply the same effective response-mode resolution in the runtime prefilter and messaging controller, removing the hidden strict-thread bypass.
- Add a binding-level response preference that can inherit the channel default or override it with `@mentions only` / `Every message`.
- Show the effective mode and its source on shared-conversation status cards, with a `Responses` control for changing the binding override in chat.
- Preserve replies to active selections, questionnaires, skill searches, and new-thread workflows before applying ambient mention-only filtering.
- Advertise mention detection as an adapter capability and only offer or enforce mention-only mode for providers that emit the required marker.
- Cover strict bindings, inherited policy, persisted overrides, workflow replies, unsupported-provider behavior, reset-to-default behavior, runtime filtering, and status-card rendering.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-status-card.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts packages/messaging/providers/telegram/src/__tests__/telegram-adapter-security.test.ts` (415 tests)
- `pnpm lint`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (extended reasoning) via [Codex](https://openai.com/codex/)