### PR TITLE
fix(messaging): avoid rejecting approved pairings on dismiss

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -413,47 +413,50 @@ describe("messaging status ipc", () => {
     );
   });
 
-  it("dismisses a partially approved Slack pairing without reporting rejection", async () => {
-    const { registerMessagingStatusIpcHandlers } = await import(
-      "../ipc/messaging-status"
-    );
-    const { MESSAGING_REJECT_PAIRING_CHANNEL } = await import("../../shared/ipc");
-    const entry = {
-      id: "pairing-slack-partial",
-      platform: "slack",
-      instanceId: "default",
-      scope: "observed",
-      status: "observed",
-      generatedAt: 1_000,
-      expiresAt: 2_000,
-      observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
-      observedChat: {
-        id: "C012ABCDEF0",
-        kind: "channel",
-        title: "p-search-signals-projects",
-        bucketId: "T025C2NKT",
-      },
-      approvedTargets: ["conversation"],
-    };
-    const consumed = { ...entry, status: "consumed" };
-    runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
-    pairingStoreMock.markStatus.mockReturnValue(consumed);
+  it.each(["observed", "expired"] as const)(
+    "dismisses a %s partially approved Slack pairing without reporting rejection",
+    async (status) => {
+      const { registerMessagingStatusIpcHandlers } = await import(
+        "../ipc/messaging-status"
+      );
+      const { MESSAGING_REJECT_PAIRING_CHANNEL } = await import("../../shared/ipc");
+      const entry = {
+        id: "pairing-slack-partial",
+        platform: "slack",
+        instanceId: "default",
+        scope: "observed",
+        status,
+        generatedAt: 1_000,
+        expiresAt: 2_000,
+        observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
+        observedChat: {
+          id: "C012ABCDEF0",
+          kind: "channel",
+          title: "p-search-signals-projects",
+          bucketId: "T025C2NKT",
+        },
+        approvedTargets: ["conversation"],
+      };
+      const consumed = { ...entry, status: "consumed" };
+      runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
+      pairingStoreMock.markStatus.mockReturnValue(consumed);
 
-    registerMessagingStatusIpcHandlers();
+      registerMessagingStatusIpcHandlers();
 
-    await expect(
-      handlers.get(MESSAGING_REJECT_PAIRING_CHANNEL)?.(
-        {},
-        { entryId: entry.id },
-      ),
-    ).resolves.toEqual({ entry: consumed });
+      await expect(
+        handlers.get(MESSAGING_REJECT_PAIRING_CHANNEL)?.(
+          {},
+          { entryId: entry.id },
+        ),
+      ).resolves.toEqual({ entry: consumed });
 
-    expect(pairingStoreMock.markStatus).toHaveBeenCalledWith({
-      entryId: entry.id,
-      status: "consumed",
-    });
-    expect(runtimeMock.deliverPairingOutcome).not.toHaveBeenCalled();
-  });
+      expect(pairingStoreMock.markStatus).toHaveBeenCalledWith({
+        entryId: entry.id,
+        status: "consumed",
+      });
+      expect(runtimeMock.deliverPairingOutcome).not.toHaveBeenCalled();
+    },
+  );
 
   it("reports rejection when dismissing a Slack pairing with no approvals", async () => {
     const { registerMessagingStatusIpcHandlers } = await import(

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -413,6 +413,92 @@ describe("messaging status ipc", () => {
     );
   });
 
+  it("dismisses a partially approved Slack pairing without reporting rejection", async () => {
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_REJECT_PAIRING_CHANNEL } = await import("../../shared/ipc");
+    const entry = {
+      id: "pairing-slack-partial",
+      platform: "slack",
+      instanceId: "default",
+      scope: "observed",
+      status: "observed",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+      observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
+      observedChat: {
+        id: "C012ABCDEF0",
+        kind: "channel",
+        title: "p-search-signals-projects",
+        bucketId: "T025C2NKT",
+      },
+      approvedTargets: ["conversation"],
+    };
+    const consumed = { ...entry, status: "consumed" };
+    runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
+    pairingStoreMock.markStatus.mockReturnValue(consumed);
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_REJECT_PAIRING_CHANNEL)?.(
+        {},
+        { entryId: entry.id },
+      ),
+    ).resolves.toEqual({ entry: consumed });
+
+    expect(pairingStoreMock.markStatus).toHaveBeenCalledWith({
+      entryId: entry.id,
+      status: "consumed",
+    });
+    expect(runtimeMock.deliverPairingOutcome).not.toHaveBeenCalled();
+  });
+
+  it("reports rejection when dismissing a Slack pairing with no approvals", async () => {
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_REJECT_PAIRING_CHANNEL } = await import("../../shared/ipc");
+    const entry = {
+      id: "pairing-slack-unapproved",
+      platform: "slack",
+      instanceId: "default",
+      scope: "observed",
+      status: "observed",
+      generatedAt: 1_000,
+      expiresAt: 2_000,
+      observedActor: { id: "U012ABCDEF0", displayName: "Harold" },
+      observedChat: {
+        id: "C012ABCDEF0",
+        kind: "channel",
+        title: "p-search-signals-projects",
+        bucketId: "T025C2NKT",
+      },
+    };
+    const rejected = { ...entry, status: "rejected" };
+    runtimeMock.listPairingRequests.mockReturnValue({ entries: [entry] });
+    pairingStoreMock.markStatus.mockReturnValue(rejected);
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_REJECT_PAIRING_CHANNEL)?.(
+        {},
+        { entryId: entry.id },
+      ),
+    ).resolves.toEqual({ entry: rejected });
+
+    expect(pairingStoreMock.markStatus).toHaveBeenCalledWith({
+      entryId: entry.id,
+      status: "rejected",
+    });
+    expect(runtimeMock.deliverPairingOutcome).toHaveBeenCalledWith(
+      rejected,
+      "rejected",
+    );
+  });
+
   it("confirms a user-only approval and notes the channel is still gated", async () => {
     const { registerMessagingStatusIpcHandlers } = await import(
       "../ipc/messaging-status"

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -701,10 +701,24 @@ export function registerMessagingStatusIpcHandlers(): void {
       _event,
       request: RejectMessagingPairingRequest,
     ): Promise<RejectMessagingPairingResponse> => {
-      const entry = markPairingRejected(request.entryId);
+      const pairing = runtime.listPairingRequests({ includeResolved: true }).entries
+        .find((entry) => entry.id === request.entryId);
+      const dismissAfterApproval =
+        pairing?.status === "observed"
+        && (pairing.approvedTargets?.length ?? 0) > 0;
+      const entry = dismissAfterApproval
+        ? markPairingConsumed(request.entryId)
+        : markPairingRejected(request.entryId);
       if (!entry) throw new Error("Pairing request not found.");
-      recordPairingActivity(entry, "Rejected pairing request");
-      await runtime.deliverPairingOutcome(entry, "rejected");
+      recordPairingActivity(
+        entry,
+        dismissAfterApproval
+          ? "Dismissed pairing request after partial approval"
+          : "Rejected pairing request",
+      );
+      if (!dismissAfterApproval) {
+        await runtime.deliverPairingOutcome(entry, "rejected");
+      }
       broadcastPairingChanged({ at: Date.now(), entry });
       return { entry };
     },

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -704,8 +704,7 @@ export function registerMessagingStatusIpcHandlers(): void {
       const pairing = runtime.listPairingRequests({ includeResolved: true }).entries
         .find((entry) => entry.id === request.entryId);
       const dismissAfterApproval =
-        pairing?.status === "observed"
-        && (pairing.approvedTargets?.length ?? 0) > 0;
+        (pairing?.approvedTargets?.length ?? 0) > 0;
       const entry = dismissAfterApproval
         ? markPairingConsumed(request.entryId)
         : markPairingRejected(request.entryId);


### PR DESCRIPTION
## Summary

- close partially approved Slack pairing requests as consumed when the operator clicks Dismiss
- preserve previously approved user, channel, or workspace targets
- suppress the contradictory `PwrAgent pairing rejected.` message after any target was approved
- retain the existing rejection behavior when no pairing target has been approved

## Root cause

Slack multi-target pairing intentionally keeps a request in the `observed` state after an individual target is approved so the remaining targets can still be approved. The Dismiss control called the generic rejection handler, which unconditionally marked that still-observed request as rejected and delivered a rejection outcome even though an approval had already succeeded.

## User impact

Operators can dismiss the remaining pairing choices after approving the target they need without PwrAgent posting a false rejection message to the paired Slack channel.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm lint:boundaries`
- `git diff --check`
