### PR TITLE
feat(messaging): add review command routing

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1231,6 +1231,7 @@ class MockBackendClient {
         reviewThreadId: string;
         turnId: string;
       };
+      startReviewError?: Error;
     }
   ) {}
 
@@ -1447,6 +1448,9 @@ class MockBackendClient {
     cwd?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    if (this.options.startReviewError) {
+      throw this.options.startReviewError;
+    }
     this.lastStartReviewParams = params;
     return this.options.startReviewResult ?? {
       threadId: params.threadId,
@@ -21049,6 +21053,124 @@ script = "printf setup"
       target: { type: "baseBranch", branch: "main" },
       delivery: "inline",
       cwd: "/repo/pwragent",
+    });
+
+    await registry.close();
+  });
+
+  it("queues review submission while the invoking turn start is pending", async () => {
+    const startTurnDelay = createDeferred<void>();
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["turn/start", "review/start", "thread/resume"],
+      },
+      startTurnDelay: startTurnDelay.promise,
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+
+    const turnPromise = registry.startTurn({
+      backend: "codex",
+      threadId: "parent-thread",
+      input: [{ type: "text", text: "Keep working" }],
+    });
+    await flushAsync();
+
+    await expect(
+      registry.submitReview({
+        backend: "codex",
+        threadId: "parent-thread",
+        target: { type: "uncommittedChanges" },
+        delivery: "inline",
+      }),
+    ).resolves.toMatchObject({
+      status: "scheduled",
+      invokingTurnId: "pending:parent-thread",
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    startTurnDelay.resolve();
+    await turnPromise;
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+    });
+
+    expect(codexClient.lastStartReviewParams).toEqual({
+      threadId: "parent-thread",
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+    });
+
+    await registry.close();
+  });
+
+  it("emits a terminal outcome when a deferred review cannot start", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["turn/start", "review/start", "thread/resume"],
+      },
+      startReviewError: new Error("Codex disconnected"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await registry.submitReview({
+      backend: "codex",
+      threadId: "parent-thread",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+    });
+
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/reviewStart/updated",
+        params: expect.objectContaining({
+          threadId: "parent-thread",
+          status: "failed",
+          error: "Codex disconnected",
+        }),
+      },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6466,6 +6466,7 @@ script = "echo setup"
       "get_current_messaging_surface",
       "handoff_task",
       "send_message_to_thread",
+      "start_review",
       "create_monitor_delegation",
     ]);
 
@@ -6511,6 +6512,7 @@ script = "echo setup"
       "attach_thread_here",
       "handoff_task",
       "send_message_to_thread",
+      "start_review",
     ]);
     const getThreadStatusTool = pwragentDynamicTools(dynamicTools)
       .find((tool) => tool.name === "get_thread_status");
@@ -20983,6 +20985,124 @@ script = "printf setup"
 
     await registry.close();
     await rm(root, { recursive: true, force: true });
+  });
+
+  it("schedules a dynamic-tool review until the invoking turn completes", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["turn/start", "review/start", "thread/resume"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        callId: "call-review-1",
+        requestId: "call-review-1",
+        namespace: "pwragent",
+        tool: "start_review",
+        arguments: {
+          target: {
+            type: "baseBranch",
+            branch: "main",
+          },
+          cwd: "/repo/pwragent",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed", output: [] },
+      },
+    });
+
+    expect(codexClient.lastStartReviewParams).toEqual({
+      threadId: "parent-thread",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+      cwd: "/repo/pwragent",
+    });
+
+    await registry.close();
+  });
+
+  it("exposes start_review through the MCP tool catalog", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["turn/start", "review/start", "thread/resume"],
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "parent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await callRegistryMcpTool({
+      registry,
+      backend: "codex",
+      threadId: "parent-thread",
+      turnId: "turn-1",
+      tool: "start_review",
+      args: {
+        target: { type: "uncommittedChanges" },
+      },
+    });
+
+    expect(response).toMatchObject({
+      structuredContent: {
+        backend: "codex",
+        threadId: "parent-thread",
+        status: "scheduled",
+        target: { type: "uncommittedChanges" },
+        invokingTurnId: "turn-1",
+      },
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+
+    await registry.close();
   });
 
   it("sends a follow-up prompt to another thread from an active turn", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -184,6 +184,150 @@ describe("MessagingController", () => {
     });
   });
 
+  it("rejects review before opening a picker for unsupported backends", async () => {
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildAcpRuntimeBackendSummary({
+            capabilities: {
+              ...buildAcpRuntimeBackendSummary().capabilities,
+              startReview: false,
+            },
+          }),
+        ],
+      }),
+    });
+    await bindThreadToBackend(harness, "acp:gemini");
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+
+    expect(harness.submitReview).not.toHaveBeenCalled();
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "error",
+      title: "Review unavailable",
+    });
+  });
+
+  it("rejects review when Codex does not advertise review/start", async () => {
+    const harness = await createHarness({
+      listBackends: async (): Promise<ListBackendsResponse> => ({
+        fetchedAt: 1000,
+        backends: [
+          buildBackendSummary({
+            methods: ["turn/start"],
+            capabilities: {
+              ...buildBackendSummary().capabilities,
+              startReview: false,
+            },
+          }),
+        ],
+      }),
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+
+    expect(harness.submitReview).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Review unavailable",
+    });
+  });
+
+  it("uses repository metadata for review pickers on worktree threads", async () => {
+    const navigation = buildWorktreeHandoffNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        currentBranch: "feature/handoff",
+        defaultBranch: "main",
+        baseBranches: ["release"],
+        branches: ["main", "feature/handoff"],
+        recentCommits: [
+          {
+            sha: "1234567890abcdef",
+            shortSha: "1234567",
+            subject: "Fix review routing",
+          },
+        ],
+      },
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      review: {
+        cwd: "/repo/pwragent/.worktrees/pwragent-feature-handoff",
+        repositoryPath: "/repo/pwragent",
+      },
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:target:base-branch" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          label: "release",
+          value: { branch: "release" },
+        }),
+      ]),
+    });
+
+    const commitHarness = await createHarness({ navigation });
+    await bindThread(commitHarness);
+    commitHarness.delivered.length = 0;
+    await commitHarness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await commitHarness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:target:commit" }),
+    );
+    expect(commitHarness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          label: "1234567 Fix review routing",
+          value: {
+            sha: "1234567890abcdef",
+            title: "Fix review routing",
+          },
+        }),
+      ]),
+    });
+  });
+
+  it("delivers deferred review start failures to the bound conversation", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/reviewStart/updated",
+        params: {
+          threadId: "thread-1",
+          pendingReviewId: "pending-review:1",
+          status: "failed",
+          error: "Codex disconnected",
+        },
+      },
+    });
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "error",
+      title: "Queued review could not start",
+      body: "Codex disconnected",
+    });
+  });
+
   it("presents a channel-neutral thread picker for authorized /resume commands", async () => {
     const harness = await createHarness();
 
@@ -5140,6 +5284,29 @@ describe("MessagingController", () => {
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "PwrAgent commands",
+    });
+  });
+
+  it("includes review in help only for a bound review-capable thread", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+    expect((harness.delivered.at(-1) as { body?: string }).body)
+      .not.toContain("/review");
+
+    await bindThread(harness);
+    harness.delivered.length = 0;
+    await harness.controller.handleInboundEvent(buildCommandEvent("/help"));
+
+    expect((harness.delivered.at(-1) as { body?: string }).body)
+      .toContain("/review - start a code review for the bound thread");
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "command:review",
+          label: "Review",
+        }),
+      ]),
     });
   });
 
@@ -15960,6 +16127,7 @@ function buildBackendSummary(overrides: Partial<BackendSummary> = {}): BackendSu
       renameThread: true,
       readThread: true,
       startTurn: true,
+      startReview: true,
       interruptTurn: true,
       steerTurn: false,
       transcriptPagination: false,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -20,6 +20,7 @@ import type {
   SetAcpSessionRuntimeOptionRequest,
   SetThreadExecutionModeRequest,
   SetThreadModelSettingsRequest,
+  StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
   SteerTurnRequest,
@@ -83,6 +84,106 @@ afterEach(async () => {
 });
 
 describe("MessagingController", () => {
+  it("opens the review picker for a mentioned /review command", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("/review", { botMention: true }),
+    );
+
+    expect(harness.delivered).toHaveLength(1);
+    expect(harness.delivered[0]).toMatchObject({
+      kind: "review",
+      title: "Review target",
+      review: {
+        backend: "codex",
+        threadId: "thread-1",
+        phase: "target",
+        cwd: "/repo/pwragent",
+      },
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "review:target:current-changes",
+          label: "Current changes",
+        }),
+      ]),
+    });
+  });
+
+  it("submits the selected messaging review target", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "review:target:current-changes",
+      }),
+    );
+
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+      cwd: "/repo/pwragent",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Review started",
+    });
+  });
+
+  it("routes non-control slash commands to the bound thread", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("/compact preserve the summary", { botMention: true }),
+    );
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          {
+            type: "text",
+            text: "/compact preserve the summary",
+          },
+        ],
+      }),
+    );
+    expect(harness.delivered).not.toContainEqual(
+      expect.objectContaining({
+        title: expect.stringContaining("PwrAgent commands"),
+      }),
+    );
+  });
+
+  it("submits direct review command arguments without opening the picker", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review main"));
+
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Review started",
+    });
+  });
+
   it("presents a channel-neutral thread picker for authorized /resume commands", async () => {
     const harness = await createHarness();
 
@@ -5018,7 +5119,7 @@ describe("MessagingController", () => {
     });
   });
 
-  it("does not treat legacy /threads as a resume alias — falls through to the help surface", async () => {
+  it("does not treat legacy /threads as a control alias and asks for a binding", async () => {
     const harness = await createHarness();
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/threads"));
@@ -5026,7 +5127,7 @@ describe("MessagingController", () => {
     expect(harness.getNavigationSnapshot).not.toHaveBeenCalled();
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
-      title: "PwrAgent commands",
+      title: "Choose a thread",
     });
   });
 
@@ -15361,6 +15462,7 @@ async function createHarness(options?: {
   >;
   setConversationTitle?: MessagingAdapter["setConversationTitle"];
   startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
+  submitReview?: NonNullable<MessagingBackendBridge["submitReview"]>;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
   showStreamingOption?: boolean;
 }): Promise<{
@@ -15385,6 +15487,7 @@ async function createHarness(options?: {
   setThreadExecutionMode: ReturnType<typeof vi.fn>;
   setThreadModelSettings: ReturnType<typeof vi.fn>;
   startThread: ReturnType<typeof vi.fn>;
+  submitReview: ReturnType<typeof vi.fn>;
   startTurn: ReturnType<typeof vi.fn>;
   steerTurn: ReturnType<typeof vi.fn>;
   submitServerRequest: ReturnType<typeof vi.fn>;
@@ -15483,6 +15586,18 @@ async function createHarness(options?: {
         backend: request.backend,
         threadId: "new-thread-1",
         executionMode: request.executionMode ?? "default",
+      })),
+  );
+  const submitReview = vi.fn(
+    options?.submitReview ??
+      (async (request: StartReviewRequest) => ({
+        status: "started" as const,
+        response: {
+          backend: request.backend,
+          threadId: request.threadId,
+          reviewThreadId: "review-thread-1",
+          turnId: "review-turn-1",
+        },
       })),
   );
   const materializeDirectoryLaunchpad = vi.fn(
@@ -15737,6 +15852,7 @@ async function createHarness(options?: {
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
+    submitReview,
     startTurn,
     steerTurn,
     submitServerRequest,
@@ -15800,6 +15916,7 @@ async function createHarness(options?: {
     setThreadExecutionMode,
     setThreadModelSettings,
     startThread,
+    submitReview,
     startTurn,
     steerTurn,
     submitServerRequest,

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -25,10 +25,12 @@ describe("PwrAgent task monitor agent tools", () => {
       .flatMap((catalog) => catalog.router.buildMcpTools())
       .sort((left, right) => left.name.localeCompare(right.name));
 
-    expect(dynamicTools).toHaveLength(20);
+    expect(dynamicTools).toHaveLength(21);
     expect(mcpTools).toEqual(dynamicTools);
     expect(mcpTools.map((tool) => tool.name))
       .toContain("create_monitor_delegation");
+    expect(mcpTools.map((tool) => tool.name))
+      .toContain("start_review");
   });
 
   it("dispatches dynamic and MCP monitor creation with matching ACP context", async () => {

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -103,6 +103,30 @@ describe("pwragent thread orchestration agent tools", () => {
               required: ["backend", "threadId", "prompt"],
             }),
           }),
+          expect.objectContaining({
+            type: "function",
+            name: "start_review",
+            description: expect.stringContaining("after the current turn completes successfully"),
+            deferLoading: false,
+            inputSchema: expect.objectContaining({
+              required: ["target"],
+              properties: expect.objectContaining({
+                target: expect.objectContaining({
+                  required: ["type"],
+                  properties: expect.objectContaining({
+                    type: expect.objectContaining({
+                      enum: [
+                        "uncommittedChanges",
+                        "baseBranch",
+                        "commit",
+                        "custom",
+                      ],
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
         ]),
       }),
     ]);
@@ -218,6 +242,83 @@ describe("pwragent thread orchestration agent tools", () => {
           tool: "move_thread_workspace",
           arguments: {
             sourcePath: "  ",
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ success: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("validates and dispatches structured start_review args", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      data: {
+        backend: "codex" as const,
+        threadId: "thread-1",
+        pendingReviewId: "pending-review:1",
+        status: "scheduled" as const,
+        target: {
+          type: "baseBranch" as const,
+          branch: "main",
+        },
+        cwd: "/repo/app",
+        invokingTurnId: "turn-1",
+        createdAt: 1_773_000_000_000,
+        message: "Review scheduled.",
+      },
+    }));
+    const router = buildPwrAgentThreadOrchestrationToolRouter(handler);
+
+    await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: "pwragent",
+        tool: "start_review",
+        arguments: {
+          target: {
+            type: "baseBranch",
+            branch: " main ",
+          },
+          cwd: " /repo/app ",
+        },
+      },
+    });
+
+    expect(handler).toHaveBeenCalledWith({
+      operation: "start_review",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        callId: "call-1",
+        turnId: "turn-1",
+      },
+      args: {
+        target: {
+          type: "baseBranch",
+          branch: "main",
+        },
+        cwd: "/repo/app",
+      },
+    });
+
+    handler.mockClear();
+    await expect(
+      router.handleDynamicToolCall({
+        backend: "codex",
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-2",
+          namespace: "pwragent",
+          tool: "start_review",
+          arguments: {
+            target: {
+              type: "commit",
+              sha: " ",
+            },
           },
         },
       }),

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -13,6 +13,7 @@ import type {
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
   SendMessageToThreadToolArgs,
+  StartReviewToolArgs,
 } from "@pwragent/shared";
 import {
   ATTACH_THREAD_DIRECTORY_WORKSPACE_MODES,
@@ -114,6 +115,8 @@ function descriptionForOperation(
       return "Move the current PwrAgent thread runtime workspace after the invoking turn reaches a terminal boundary. Use this when the user asks to continue this same thread from an isolated worktree instead of creating a child handoff thread. The operation is path-keyed: pass sourcePath when the thread has multiple linked directories or when the intended workspace is not obvious. The tool returns a pending workspaceMoveId and stop-and-wait guidance; after the current turn ends, PwrAgent performs the move, updates future-turn cwd metadata, rebinds an ACP session when required, and starts a same-thread continuation with the result. Do not keep editing after a successful call in the invoking turn; wait for the continuation or inspect get_thread_status pendingWorkspaceMoves.";
     case "send_message_to_thread":
       return "Send a follow-up prompt to another existing PwrAgent thread. Use search_threads or read_thread first when the target threadId is unknown. Do not use this for the current thread; reply normally instead. The result includes threadLink, a ready-made markdown link to the target thread. When you mention that thread to the user, include threadLink verbatim instead of the raw threadId so it renders as a clickable chip.";
+    case "start_review":
+      return "Schedule a code review of the invoking PwrAgent thread after the current turn completes successfully. Use this only when the operator explicitly asks for a review. Choose one structured target: uncommittedChanges, baseBranch, commit, or custom. The tool returns a pendingReviewId; after a successful call, stop work and let the current turn finish so PwrAgent can start the review. Do not poll or call the tool again for the same request.";
   }
 }
 
@@ -318,6 +321,41 @@ function inputSchemaForOperation(
           sandbox: { type: "string" },
         },
       };
+    case "start_review":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["target"],
+        properties: {
+          cwd: {
+            type: "string",
+            description:
+              "Optional linked workspace to review when the thread has multiple directories.",
+          },
+          target: {
+            type: "object",
+            additionalProperties: false,
+            required: ["type"],
+            properties: {
+              type: {
+                type: "string",
+                enum: [
+                  "uncommittedChanges",
+                  "baseBranch",
+                  "commit",
+                  "custom",
+                ],
+              },
+              branch: { type: "string" },
+              sha: { type: "string" },
+              title: {
+                anyOf: [{ type: "string" }, { type: "null" }],
+              },
+              instructions: { type: "string" },
+            },
+          },
+        },
+      };
   }
 }
 
@@ -330,6 +368,7 @@ function normalizeArgsForOperation(
   | HandoffTaskToolArgs
   | MoveThreadWorkspaceToolArgs
   | SendMessageToThreadToolArgs
+  | StartReviewToolArgs
   | undefined {
   switch (operation) {
     case "attach_thread_directory":
@@ -342,6 +381,8 @@ function normalizeArgsForOperation(
       return normalizeMoveThreadWorkspaceArgs(args);
     case "send_message_to_thread":
       return normalizeSendMessageToThreadArgs(args);
+    case "start_review":
+      return normalizeStartReviewArgs(args);
   }
 }
 
@@ -359,6 +400,8 @@ function invalidArgumentsMessageForOperation(
       return "move_thread_workspace accepts only known direction/strategy values and non-empty string fields.";
     case "send_message_to_thread":
       return "send_message_to_thread requires non-empty backend, threadId, and prompt strings.";
+    case "start_review":
+      return "start_review requires a valid structured target and non-empty target-specific fields.";
   }
 }
 
@@ -566,6 +609,54 @@ function normalizeSendMessageToThreadArgs(
     ...(readTrimmedString(args.sandbox)
       ? { sandbox: readTrimmedString(args.sandbox) }
       : {}),
+  };
+}
+
+function normalizeStartReviewArgs(
+  args: Record<string, unknown>,
+): StartReviewToolArgs | undefined {
+  const targetRecord =
+    args.target && typeof args.target === "object" && !Array.isArray(args.target)
+      ? args.target as Record<string, unknown>
+      : undefined;
+  if (!targetRecord) {
+    return undefined;
+  }
+
+  let target: StartReviewToolArgs["target"] | undefined;
+  if (targetRecord.type === "uncommittedChanges") {
+    target = { type: "uncommittedChanges" };
+  } else if (targetRecord.type === "baseBranch") {
+    const branch = readTrimmedString(targetRecord.branch);
+    if (branch) {
+      target = { type: "baseBranch", branch };
+    }
+  } else if (targetRecord.type === "commit") {
+    const sha = readTrimmedString(targetRecord.sha);
+    if (sha) {
+      target = {
+        type: "commit",
+        sha,
+        title: readTrimmedString(targetRecord.title) ?? null,
+      };
+    }
+  } else if (targetRecord.type === "custom") {
+    const instructions = readTrimmedString(targetRecord.instructions);
+    if (instructions) {
+      target = { type: "custom", instructions };
+    }
+  }
+  if (!target) {
+    return undefined;
+  }
+
+  const cwd = readTrimmedString(args.cwd);
+  if (Object.hasOwn(args, "cwd") && !cwd) {
+    return undefined;
+  }
+  return {
+    target,
+    ...(cwd ? { cwd } : {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -156,6 +156,7 @@ import {
   type SteerTurnResponse,
   type StartReviewRequest,
   type StartReviewResponse,
+  type StartReviewToolResult,
   type StartThreadRequest,
   type StartThreadResponse,
   type SubmitServerRequestRequest,
@@ -2275,6 +2276,21 @@ type ReviewSubAgentRecord = {
   reviewThreadId: string;
   task: string;
   turnId: string;
+};
+
+type PendingReviewStartRecord = {
+  pendingReviewId: string;
+  backend: AppServerBackendKind;
+  threadId: string;
+  invokingTurnId: string;
+  request: StartReviewRequest;
+  createdAt: number;
+  updatedAt: number;
+  idempotencyKey?: string;
+  status: "scheduled" | "started" | "cancelled" | "failed";
+  reviewThreadId?: string;
+  reviewTurnId?: string;
+  error?: string;
 };
 
 type CodexNativeSubAgentTool =
@@ -5435,6 +5451,7 @@ export class DesktopBackendRegistry {
     string,
     PendingThreadWorkspaceMoveSummary
   >();
+  private readonly pendingReviewStarts = new Map<string, PendingReviewStartRecord>();
   private readonly captureStores: ProtocolCaptureStore[] = [];
   private readonly eventListeners = new Set<
     (event: AgentEvent) => void | Promise<void>
@@ -9662,6 +9679,132 @@ export class DesktopBackendRegistry {
       reviewThreadId: result.reviewThreadId,
       turnId: result.turnId,
     };
+  }
+
+  async submitReview(params: StartReviewRequest): Promise<
+    | {
+        status: "started";
+        response: StartReviewResponse;
+      }
+    | {
+        status: "scheduled";
+        pendingReviewId: string;
+        invokingTurnId: string;
+      }
+  > {
+    const activeTurn = this.getActiveTurnForThread({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    if (!activeTurn) {
+      return {
+        status: "started",
+        response: await this.startReview(params),
+      };
+    }
+    const pending = this.scheduleReviewStart({
+      invokingTurnId: activeTurn.turnId,
+      request: params,
+    });
+    return {
+      status: "scheduled",
+      pendingReviewId: pending.pendingReviewId,
+      invokingTurnId: pending.invokingTurnId,
+    };
+  }
+
+  private scheduleReviewStart(params: {
+    invokingTurnId: string;
+    request: StartReviewRequest;
+    idempotencyKey?: string;
+  }): PendingReviewStartRecord {
+    if (params.idempotencyKey) {
+      const existing = [...this.pendingReviewStarts.values()].find(
+        (candidate) =>
+          candidate.backend === params.request.backend &&
+          candidate.threadId === params.request.threadId &&
+          candidate.idempotencyKey === params.idempotencyKey,
+      );
+      if (existing) {
+        return existing;
+      }
+    }
+    const duplicate = [...this.pendingReviewStarts.values()].find(
+      (candidate) =>
+        candidate.backend === params.request.backend &&
+        candidate.threadId === params.request.threadId &&
+        candidate.invokingTurnId === params.invokingTurnId &&
+        candidate.status === "scheduled",
+    );
+    if (duplicate) {
+      return duplicate;
+    }
+
+    const now = Date.now();
+    const pending: PendingReviewStartRecord = {
+      pendingReviewId: `pending-review:${randomUUID()}`,
+      backend: params.request.backend,
+      threadId: params.request.threadId,
+      invokingTurnId: params.invokingTurnId,
+      request: params.request,
+      createdAt: now,
+      updatedAt: now,
+      ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+      status: "scheduled",
+    };
+    this.pendingReviewStarts.set(pending.pendingReviewId, pending);
+    return pending;
+  }
+
+  private async drainPendingReviewStartsForTerminalTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    turnId?: string;
+    method: "turn/completed" | "turn/failed" | "turn/cancelled";
+  }): Promise<void> {
+    if (!params.turnId) {
+      return;
+    }
+    const pending = [...this.pendingReviewStarts.values()].filter(
+      (candidate) =>
+        candidate.backend === params.backend &&
+        candidate.threadId === params.threadId &&
+        candidate.invokingTurnId === params.turnId &&
+        candidate.status === "scheduled",
+    );
+    for (const candidate of pending) {
+      if (params.method !== "turn/completed") {
+        this.pendingReviewStarts.set(candidate.pendingReviewId, {
+          ...candidate,
+          status: "cancelled",
+          updatedAt: Date.now(),
+        });
+        continue;
+      }
+      try {
+        const response = await this.startReview(candidate.request);
+        this.pendingReviewStarts.set(candidate.pendingReviewId, {
+          ...candidate,
+          status: "started",
+          reviewThreadId: response.reviewThreadId,
+          reviewTurnId: response.turnId,
+          updatedAt: Date.now(),
+        });
+      } catch (error) {
+        this.pendingReviewStarts.set(candidate.pendingReviewId, {
+          ...candidate,
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+          updatedAt: Date.now(),
+        });
+        backendRegistryLog.warn("scheduled review start failed", {
+          backend: candidate.backend,
+          pendingReviewId: candidate.pendingReviewId,
+          threadId: candidate.threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
   }
 
   async interruptTurn(params: {
@@ -16978,10 +17121,71 @@ export class DesktopBackendRegistry {
     if (request.operation === "send_message_to_thread") {
       return await this.sendMessageToThread(request);
     }
+    if (request.operation === "start_review") {
+      return await this.startReviewFromAgentTool(request);
+    }
     return threadOrchestrationFailure(
       "unsupported_operation",
       "Unsupported PwrAgent thread orchestration operation.",
     );
+  }
+
+  private async startReviewFromAgentTool(
+    request: PwrAgentThreadOrchestrationRequest<"start_review">,
+  ): Promise<PwrAgentThreadOrchestrationResponse> {
+    const invokingTurnId = request.context.turnId?.trim();
+    if (
+      !invokingTurnId ||
+      !this.isLiveDynamicToolCall(request.context.backend, {
+        threadId: request.context.threadId,
+        turnId: invokingTurnId,
+      })
+    ) {
+      return threadOrchestrationFailure(
+        "forbidden",
+        "start_review must be invoked from a live turn on the thread being reviewed.",
+      );
+    }
+    if (isAcpBackendId(request.context.backend)) {
+      return threadOrchestrationFailure(
+        "unsupported_backend",
+        "Selected backend does not support review/start.",
+      );
+    }
+
+    try {
+      const pending = this.scheduleReviewStart({
+        invokingTurnId,
+        idempotencyKey: request.context.callId,
+        request: {
+          backend: request.context.backend,
+          threadId: request.context.threadId,
+          target: request.args.target,
+          delivery: "inline",
+          ...(request.args.cwd ? { cwd: request.args.cwd } : {}),
+        },
+      });
+      return {
+        ok: true,
+        data: {
+          backend: pending.backend,
+          threadId: pending.threadId,
+          pendingReviewId: pending.pendingReviewId,
+          status: "scheduled",
+          target: pending.request.target,
+          ...(pending.request.cwd ? { cwd: pending.request.cwd } : {}),
+          invokingTurnId: pending.invokingTurnId,
+          createdAt: pending.createdAt,
+          message:
+            "Review scheduled. Stop work and let this turn complete; PwrAgent will start the review automatically.",
+        } satisfies StartReviewToolResult,
+      };
+    } catch (error) {
+      return threadOrchestrationFailure(
+        "internal_error",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   private startPendingThreadHandoff(
@@ -21300,6 +21504,12 @@ export class DesktopBackendRegistry {
           });
         }
       }
+      await this.drainPendingReviewStartsForTerminalTurn({
+        backend: event.backend,
+        threadId: notification.params.threadId,
+        turnId,
+        method: event.notification.method,
+      });
       this.drainPendingThreadWorkspaceMovesForTerminalTurn({
         backend: event.backend,
         threadId: notification.params.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8973,6 +8973,40 @@ export class DesktopBackendRegistry {
     return undefined;
   }
 
+  private getPendingTurnForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): { backend: AppServerBackendKind; threadId: string; turnId: string } | undefined {
+    if (params.backend === "codex") {
+      for (const key of this.activeCodexTurnModes.keys()) {
+        const parsed = parseThreadTurnKeyBody(key);
+        if (
+          parsed?.threadId === params.threadId
+          && parsed.turnId.startsWith("pending:")
+        ) {
+          return {
+            backend: params.backend,
+            threadId: parsed.threadId,
+            turnId: parsed.turnId,
+          };
+        }
+      }
+      return undefined;
+    }
+
+    for (const key of this.activeTurnKeys) {
+      const parsed = parseActiveTurnKey(key);
+      if (
+        parsed?.backend === params.backend
+        && parsed.threadId === params.threadId
+        && parsed.turnId.startsWith("pending:")
+      ) {
+        return parsed;
+      }
+    }
+    return undefined;
+  }
+
   getInProgressThreadSnapshotForQuit(): {
     count: number;
     threadIds: string[];
@@ -9175,6 +9209,12 @@ export class DesktopBackendRegistry {
         },
       });
     } catch (error) {
+      await this.drainPendingReviewStartsForTerminalTurn({
+        backend: params.backend,
+        threadId: params.threadId,
+        turnId: syntheticStartedTurnId,
+        method: "turn/failed",
+      });
       this.activeCodexTurnModes.delete(
         buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
       );
@@ -9257,6 +9297,12 @@ export class DesktopBackendRegistry {
       throw error;
     }
     this.bindPendingThreadMessageOrigin(pendingMessageOriginId, result.turnId);
+    this.rebindPendingReviewStartsForStartedTurn({
+      backend: params.backend,
+      threadId: params.threadId,
+      pendingTurnId: syntheticStartedTurnId,
+      turnId: result.turnId,
+    });
     this.activeCodexTurnModes.delete(
       buildActiveTurnModeKey(params.threadId, syntheticStartedTurnId),
     );
@@ -9696,14 +9742,26 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: params.threadId,
     });
-    if (!activeTurn) {
+    const invokingTurnId =
+      activeTurn?.turnId
+      ?? this.getPendingTurnForThread({
+        backend: params.backend,
+        threadId: params.threadId,
+      })?.turnId
+      ?? (
+        params.backend === "codex"
+        && this.reservedCodexStartThreadIds.has(params.threadId)
+          ? `pending:${params.threadId}`
+          : undefined
+      );
+    if (!invokingTurnId) {
       return {
         status: "started",
         response: await this.startReview(params),
       };
     }
     const pending = this.scheduleReviewStart({
-      invokingTurnId: activeTurn.turnId,
+      invokingTurnId,
       request: params,
     });
     return {
@@ -9756,6 +9814,29 @@ export class DesktopBackendRegistry {
     return pending;
   }
 
+  private rebindPendingReviewStartsForStartedTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    pendingTurnId: string;
+    turnId: string;
+  }): void {
+    for (const candidate of this.pendingReviewStarts.values()) {
+      if (
+        candidate.backend !== params.backend
+        || candidate.threadId !== params.threadId
+        || candidate.invokingTurnId !== params.pendingTurnId
+        || candidate.status !== "scheduled"
+      ) {
+        continue;
+      }
+      this.pendingReviewStarts.set(candidate.pendingReviewId, {
+        ...candidate,
+        invokingTurnId: params.turnId,
+        updatedAt: Date.now(),
+      });
+    }
+  }
+
   private async drainPendingReviewStartsForTerminalTurn(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -9774,10 +9855,25 @@ export class DesktopBackendRegistry {
     );
     for (const candidate of pending) {
       if (params.method !== "turn/completed") {
+        const error =
+          "The active turn did not complete successfully, so the queued review was cancelled.";
         this.pendingReviewStarts.set(candidate.pendingReviewId, {
           ...candidate,
           status: "cancelled",
+          error,
           updatedAt: Date.now(),
+        });
+        await this.emit({
+          backend: candidate.backend,
+          notification: {
+            method: "thread/reviewStart/updated",
+            params: {
+              threadId: candidate.threadId,
+              pendingReviewId: candidate.pendingReviewId,
+              status: "cancelled",
+              error,
+            },
+          },
         });
         continue;
       }
@@ -9790,18 +9886,44 @@ export class DesktopBackendRegistry {
           reviewTurnId: response.turnId,
           updatedAt: Date.now(),
         });
+        await this.emit({
+          backend: candidate.backend,
+          notification: {
+            method: "thread/reviewStart/updated",
+            params: {
+              threadId: candidate.threadId,
+              pendingReviewId: candidate.pendingReviewId,
+              status: "started",
+              reviewThreadId: response.reviewThreadId,
+              reviewTurnId: response.turnId,
+            },
+          },
+        });
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
         this.pendingReviewStarts.set(candidate.pendingReviewId, {
           ...candidate,
           status: "failed",
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
           updatedAt: Date.now(),
         });
         backendRegistryLog.warn("scheduled review start failed", {
           backend: candidate.backend,
           pendingReviewId: candidate.pendingReviewId,
           threadId: candidate.threadId,
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
+        });
+        await this.emit({
+          backend: candidate.backend,
+          notification: {
+            method: "thread/reviewStart/updated",
+            params: {
+              threadId: candidate.threadId,
+              pendingReviewId: candidate.pendingReviewId,
+              status: "failed",
+              error: message,
+            },
+          },
         });
       }
     }

--- a/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
+++ b/apps/desktop/src/main/messaging/core/deterministic-interaction-mapper.ts
@@ -85,6 +85,8 @@ export function actionsForIntent(intent: MessagingSurfaceIntent): MessagingSurfa
       return intent.choices;
     case "questionnaire":
       return questionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -29,6 +29,8 @@ import type {
   SetThreadModelSettingsResponse,
   StartThreadRequest,
   StartThreadResponse,
+  StartReviewRequest,
+  StartReviewResponse,
   StartTurnRequest,
   StartTurnResponse,
   SteerTurnRequest,
@@ -159,6 +161,17 @@ export type MessagingBackendBridge = {
     request: UpdateDirectoryLaunchpadRequest,
   ): Promise<UpdateDirectoryLaunchpadResponse>;
   startThread?(request: StartThreadRequest): Promise<StartThreadResponse>;
+  submitReview?(request: StartReviewRequest): Promise<
+    | {
+        status: "started";
+        response: StartReviewResponse;
+      }
+    | {
+        status: "scheduled";
+        pendingReviewId: string;
+        invokingTurnId: string;
+      }
+  >;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
   steerTurn?(request: SteerTurnRequest): Promise<SteerTurnResponse>;
   compactThread?(request: CompactThreadRequest): Promise<CompactThreadResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
@@ -65,6 +65,21 @@ export type MessagingCommandSpec = {
   description: string;
 };
 
+export type MessagingCommandHelpSpec = {
+  verb: string;
+  description: string;
+};
+
+/**
+ * Help-only entry for the agent-facing review command. It is deliberately
+ * excluded from `MESSAGING_COMMAND_CATALOG` so `/review` does not become a
+ * messaging control command and continues to follow backend capability checks.
+ */
+export const MESSAGING_REVIEW_HELP_SPEC: MessagingCommandHelpSpec = {
+  verb: "review",
+  description: "start a code review for the bound thread",
+};
+
 /**
  * Canonical command set, in the order they should appear in the
  * `/help` body. Order is intentional — `resume` first because it's
@@ -122,7 +137,7 @@ export const MESSAGING_COMMAND_CATALOG: readonly MessagingCommandSpec[] = [
  *   <invocation footer>
  */
 export function formatMessagingCommandHelpBody(options?: {
-  catalog?: readonly MessagingCommandSpec[];
+  catalog?: readonly MessagingCommandHelpSpec[];
   invocationFooter?: string;
 }): string {
   const catalog = options?.catalog ?? MESSAGING_COMMAND_CATALOG;
@@ -206,7 +221,7 @@ export type MessagingCommandHelpPage = {
    * Subset of `MESSAGING_COMMAND_CATALOG` for this page, in catalog
    * order. Empty when `pageSize === 0`.
    */
-  commands: readonly MessagingCommandSpec[];
+  commands: readonly MessagingCommandHelpSpec[];
 };
 
 /**
@@ -239,7 +254,7 @@ export function helpPageSize(
  * `buildHelpActions` for the canonical pattern.
  */
 export function paginateHelpCatalog(params: {
-  catalog?: readonly MessagingCommandSpec[];
+  catalog?: readonly MessagingCommandHelpSpec[];
   profile?: MessagingCapabilityProfile;
   pageIndex?: number;
 }): MessagingCommandHelpPage {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -95,6 +95,8 @@ import {
   buildHelpActions,
   formatMessagingCommandHelpBody,
   matchMessagingCommandVerb,
+  MESSAGING_COMMAND_CATALOG,
+  MESSAGING_REVIEW_HELP_SPEC,
   paginateHelpCatalog,
 } from "./messaging-command-catalog.js";
 import {
@@ -1040,6 +1042,36 @@ export class MessagingController {
         threadId,
       }),
     );
+    const reviewStartOutcome = reviewStartOutcomeForBackendEvent(event);
+    if (reviewStartOutcome) {
+      if (
+        reviewStartOutcome.status === "failed"
+        || reviewStartOutcome.status === "cancelled"
+      ) {
+        for (const binding of bindings) {
+          await this.deliver(
+            buildErrorIntent({
+              id: this.newIntentId("queued-review-terminal"),
+              createdAt: this.now(),
+              title:
+                reviewStartOutcome.status === "failed"
+                  ? "Queued review could not start"
+                  : "Queued review cancelled",
+              body:
+                reviewStartOutcome.error
+                ?? (
+                  reviewStartOutcome.status === "failed"
+                    ? "The queued review failed to start."
+                    : "The active turn did not complete successfully, so the queued review was cancelled."
+                ),
+              recoverable: reviewStartOutcome.status === "failed",
+            }),
+            binding,
+          );
+        }
+      }
+      return;
+    }
     const automationRunUpdate = automationRunUpdateForBackendEvent(event);
     if (automationRunUpdate) {
       await this.handleAutomationRunUpdated({
@@ -1598,7 +1630,7 @@ export class MessagingController {
       await this.presentThreadCommandNeedsBinding(event);
       return;
     }
-    if (!this.options.backend.submitReview) {
+    if (!await this.reviewSupportedForBinding(binding)) {
       await this.deliverReviewUnsupported(binding, event);
       return;
     }
@@ -1645,9 +1677,14 @@ export class MessagingController {
       .map((directory) => ({
         cwd: directory.worktreePath ?? directory.path,
         label: directory.label,
+        repositoryPath: directory.path,
       }))
       .filter(
-        (workspace): workspace is { cwd: string; label: string } =>
+        (workspace): workspace is {
+          cwd: string;
+          label: string;
+          repositoryPath: string;
+        } =>
           Boolean(workspace.cwd),
       );
     const phase = workspaces.length > 1 ? "workspace" : "target";
@@ -1655,7 +1692,12 @@ export class MessagingController {
       binding,
       navigation,
       phase,
-      ...(workspaces.length === 1 ? { cwd: workspaces[0]!.cwd } : {}),
+      ...(workspaces.length === 1
+        ? {
+            cwd: workspaces[0]!.cwd,
+            repositoryPath: workspaces[0]!.repositoryPath,
+          }
+        : {}),
     });
     const pending = await this.storePendingIntent(intent, binding, event);
     const result = await this.deliver(intent, binding, event);
@@ -1670,6 +1712,7 @@ export class MessagingController {
     navigation: NavigationSnapshot;
     phase: MessagingReviewIntent["review"]["phase"];
     cwd?: string;
+    repositoryPath?: string;
     id?: string;
     createdAt?: number;
     targetSurface?: MessagingSurfaceRef;
@@ -1677,10 +1720,19 @@ export class MessagingController {
     const thread = findThreadForBinding(params.navigation, params.binding);
     const linkedWorkspaces = (thread?.linkedDirectories ?? []).flatMap((directory) => {
       const cwd = directory.worktreePath ?? directory.path;
-      return cwd ? [{ cwd, label: directory.label }] : [];
+      return cwd
+        ? [{
+            cwd,
+            label: directory.label,
+            repositoryPath: directory.path,
+          }]
+        : [];
     });
     const directory = params.navigation.directories.find((candidate) =>
-      reviewWorkspaceMatches(candidate.path, params.cwd),
+      reviewWorkspaceMatches(
+        candidate.path,
+        params.repositoryPath ?? params.cwd,
+      ),
     );
     let title = "Review target";
     let body = "What should PwrAgent review?";
@@ -1695,7 +1747,10 @@ export class MessagingController {
         id: `review:workspace:${index}`,
         label: workspace.label,
         fallbackText: workspace.cwd,
-        value: { cwd: workspace.cwd },
+        value: {
+          cwd: workspace.cwd,
+          repositoryPath: workspace.repositoryPath,
+        },
       }));
     } else if (params.phase === "target") {
       actions = [
@@ -1792,6 +1847,9 @@ export class MessagingController {
         threadId: params.binding.threadId,
         phase: params.phase,
         ...(params.cwd ? { cwd: params.cwd } : {}),
+        ...(params.repositoryPath
+          ? { repositoryPath: params.repositoryPath }
+          : {}),
         ...(targetType ? { targetType } : {}),
       },
       ...(params.targetSurface
@@ -1830,7 +1888,13 @@ export class MessagingController {
     event: MessagingInboundEvent,
     options?: { pageIndex?: number; targetSurface?: MessagingSurfaceRef },
   ): Promise<void> {
+    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    const catalog =
+      binding && await this.reviewSupportedForBinding(binding)
+        ? [...MESSAGING_COMMAND_CATALOG, MESSAGING_REVIEW_HELP_SPEC]
+        : MESSAGING_COMMAND_CATALOG;
     const page = paginateHelpCatalog({
+      catalog,
       profile: this.capabilityProfile,
       pageIndex: options?.pageIndex,
     });
@@ -1845,7 +1909,7 @@ export class MessagingController {
         capabilityProfile: this.capabilityProfile,
         createdAt: this.now(),
         title: `PwrAgent commands${titleSuffix}`,
-        body: formatMessagingCommandHelpBody(),
+        body: formatMessagingCommandHelpBody({ catalog }),
         actions,
         ...(options?.targetSurface
           ? {
@@ -3061,10 +3125,15 @@ export class MessagingController {
     const phase = pendingIntent.intent.review.phase;
     if (phase === "workspace") {
       const cwd = typeof value?.cwd === "string" ? value.cwd.trim() : "";
+      const repositoryPath =
+        typeof value?.repositoryPath === "string"
+          ? value.repositoryPath.trim()
+          : "";
       if (cwd) {
         await this.updateReviewPendingIntent(pendingIntent, event, {
           phase: "target",
           cwd,
+          ...(repositoryPath ? { repositoryPath } : {}),
         });
       }
       return;
@@ -3126,6 +3195,7 @@ export class MessagingController {
     review: {
       phase: MessagingReviewIntent["review"]["phase"];
       cwd?: string;
+      repositoryPath?: string;
     },
   ): Promise<void> {
     if (pendingIntent.intent.kind !== "review") {
@@ -3150,6 +3220,9 @@ export class MessagingController {
       navigation,
       phase: review.phase,
       cwd: review.cwd ?? pendingIntent.intent.review.cwd,
+      repositoryPath:
+        review.repositoryPath
+        ?? pendingIntent.intent.review.repositoryPath,
       id: pendingIntent.intent.id,
       createdAt: pendingIntent.intent.createdAt,
       targetSurface,
@@ -3196,7 +3269,8 @@ export class MessagingController {
     targetSurface?: MessagingSurfaceRef;
     pendingIntentId?: string;
   }): Promise<void> {
-    if (!this.options.backend.submitReview) {
+    const submitReview = this.options.backend.submitReview;
+    if (!submitReview || !await this.reviewSupportedForBinding(params.binding)) {
       await this.deliverReviewUnsupported(params.binding, params.event);
       return;
     }
@@ -3206,7 +3280,7 @@ export class MessagingController {
         backend: params.binding.backend,
       });
       const settings = turnSettingsForBinding(params.binding, navigation);
-      const result = await this.options.backend.submitReview({
+      const result = await submitReview({
         backend: params.binding.backend,
         threadId: params.binding.threadId,
         target: params.target,
@@ -10432,6 +10506,24 @@ export class MessagingController {
     return response?.backends.find((candidate) => candidate.kind === backend);
   }
 
+  private async reviewSupportedForBinding(
+    binding: MessagingBindingRecord,
+  ): Promise<boolean> {
+    if (!this.options.backend.submitReview || isAcpBackendId(binding.backend)) {
+      return false;
+    }
+    try {
+      const summary = await this.getBackendSummary(binding.backend);
+      return Boolean(summary?.available && summary.capabilities.startReview);
+    } catch (error) {
+      this.logger.debug?.("messaging review capability lookup failed", {
+        backend: binding.backend,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
   private rememberContextUsageSummary(event: AgentEvent): void {
     const params = event.notification.params as {
       threadId?: unknown;
@@ -14234,6 +14326,36 @@ function threadIdForBackendEvent(event: AgentEvent): ThreadIdentifier | undefine
     return params.threadId;
   }
   return typeof params.parentThreadId === "string" ? params.parentThreadId : undefined;
+}
+
+function reviewStartOutcomeForBackendEvent(
+  event: AgentEvent,
+):
+  | {
+      status: "started" | "cancelled" | "failed";
+      error?: string;
+    }
+  | undefined {
+  if (event.notification.method !== "thread/reviewStart/updated") {
+    return undefined;
+  }
+  const params = event.notification.params as {
+    status?: unknown;
+    error?: unknown;
+  };
+  if (
+    params.status !== "started"
+    && params.status !== "cancelled"
+    && params.status !== "failed"
+  ) {
+    return undefined;
+  }
+  return {
+    status: params.status,
+    ...(typeof params.error === "string"
+      ? { error: params.error }
+      : {}),
+  };
 }
 
 function contextUsageSummaryFromValue(value: unknown): string | undefined {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15,6 +15,7 @@ import type {
   AppServerBackendKind,
   AppServerThreadPlanEntry,
   AppServerThreadReviewEntry,
+  AppServerReviewTarget,
   AutomationMessagingConversationSnapshot,
   AutomationRunSourceMetadata,
   AutomationRunOutputDecision,
@@ -74,6 +75,7 @@ import type {
   MessagingPendingIntentRecord,
   MessagingQuestionnaireAnswer,
   MessagingQuestionnaireIntent,
+  MessagingReviewIntent,
   MessagingResponseMode,
   MessagingStreamUpdateIntent,
   MessagingSurfaceAction,
@@ -83,6 +85,7 @@ import type {
   MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
 import {
+  applyActionCapabilityLimits,
   evictStaleStreamAnchors,
   MESSAGING_CALLBACK_HANDLE_TTL_MS,
   messagingQuestionnaireAnswerComplete,
@@ -141,6 +144,7 @@ import { buildMessagingAuditContext } from "./messaging-audit.js";
 import { getMainLogger } from "../../log.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
 import { actionsForIntent } from "./deterministic-interaction-mapper.js";
+import { parseReviewCommand } from "../../../shared/review-command.js";
 import type { MessagingInteractionMapper } from "./interaction-mapper.js";
 import {
   buildResumeIntent,
@@ -1516,10 +1520,291 @@ export class MessagingController {
       });
       return;
     }
-    // `verb === "help"` and any unrecognized command both fall
-    // through to the help surface. For unknown commands this serves
-    // as a "did you mean?" prompt with the canonical list.
-    await this.presentHelp(event);
+    if (verb === "help") {
+      await this.presentHelp(event);
+      return;
+    }
+    if (event.command.trim().replace(/^\/+/, "").toLowerCase() === "review") {
+      await this.handleReviewCommand(event);
+      return;
+    }
+    await this.routeUnknownCommandToBoundThread(event);
+  }
+
+  private async routeUnknownCommandToBoundThread(
+    event: MessagingInboundCommandEvent,
+  ): Promise<void> {
+    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    if (!binding) {
+      await this.presentThreadCommandNeedsBinding(event);
+      return;
+    }
+    if (
+      binding.targetKind === "agent_thread" &&
+      !await this.shouldHandleAmbientSharedMessage(
+        {
+          ...event,
+          kind: "text",
+          text: event.rawText,
+        },
+        binding,
+      )
+    ) {
+      return;
+    }
+    const text = `/${[event.command.replace(/^\/+/, ""), ...event.args]
+      .filter(Boolean)
+      .join(" ")}`;
+    await this.turnAdmission.append({
+      binding,
+      event: {
+        ...event,
+        kind: "text",
+        text,
+      },
+    });
+  }
+
+  private async presentThreadCommandNeedsBinding(
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("thread-command-needs-binding"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: "Choose a thread",
+        body: "Bind this conversation to a PwrAgent thread before sending thread commands.",
+        fallbackText: "Reply /resume to choose a thread.",
+        actions: [
+          {
+            id: "command:resume",
+            label: "Resume",
+            style: "primary",
+            fallbackText: "/resume",
+          },
+        ],
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async handleReviewCommand(
+    event: MessagingInboundCommandEvent,
+  ): Promise<void> {
+    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    if (!binding) {
+      await this.presentThreadCommandNeedsBinding(event);
+      return;
+    }
+    if (!this.options.backend.submitReview) {
+      await this.deliverReviewUnsupported(binding, event);
+      return;
+    }
+
+    if (event.args.length > 0) {
+      const parsed = parseReviewCommand(
+        `/${["review", ...event.args].join(" ")}`,
+      );
+      if (!parsed) {
+        await this.deliver(
+          buildErrorIntent({
+            id: this.newIntentId("invalid-review-command"),
+            createdAt: this.now(),
+            title: "Invalid review command",
+            body:
+              "Use /review, /review <base branch>, /review --commit <sha>, or /review --custom <instructions>.",
+            recoverable: true,
+          }),
+          binding,
+          event,
+        );
+        return;
+      }
+      await this.submitMessagingReview({
+        binding,
+        event,
+        target: parsed.target,
+      });
+      return;
+    }
+
+    await this.presentReviewPicker(binding, event);
+  }
+
+  private async presentReviewPicker(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: binding.backend,
+    });
+    const thread = findThreadForBinding(navigation, binding);
+    const workspaces = (thread?.linkedDirectories ?? [])
+      .map((directory) => ({
+        cwd: directory.worktreePath ?? directory.path,
+        label: directory.label,
+      }))
+      .filter(
+        (workspace): workspace is { cwd: string; label: string } =>
+          Boolean(workspace.cwd),
+      );
+    const phase = workspaces.length > 1 ? "workspace" : "target";
+    const intent = this.buildReviewIntent({
+      binding,
+      navigation,
+      phase,
+      ...(workspaces.length === 1 ? { cwd: workspaces[0]!.cwd } : {}),
+    });
+    const pending = await this.storePendingIntent(intent, binding, event);
+    const result = await this.deliver(intent, binding, event);
+    await this.options.store.upsertPendingIntent({
+      ...pending,
+      surface: result.surface ?? pending.surface,
+    });
+  }
+
+  private buildReviewIntent(params: {
+    binding: MessagingBindingRecord;
+    navigation: NavigationSnapshot;
+    phase: MessagingReviewIntent["review"]["phase"];
+    cwd?: string;
+    id?: string;
+    createdAt?: number;
+    targetSurface?: MessagingSurfaceRef;
+  }): MessagingReviewIntent {
+    const thread = findThreadForBinding(params.navigation, params.binding);
+    const linkedWorkspaces = (thread?.linkedDirectories ?? []).flatMap((directory) => {
+      const cwd = directory.worktreePath ?? directory.path;
+      return cwd ? [{ cwd, label: directory.label }] : [];
+    });
+    const directory = params.navigation.directories.find((candidate) =>
+      reviewWorkspaceMatches(candidate.path, params.cwd),
+    );
+    let title = "Review target";
+    let body = "What should PwrAgent review?";
+    let allowFreeform = false;
+    let targetType: AppServerReviewTarget["type"] | undefined;
+    let actions: MessagingSurfaceAction[] = [];
+
+    if (params.phase === "workspace") {
+      title = "Review project";
+      body = "Choose the linked project to review.";
+      actions = linkedWorkspaces.map((workspace, index) => ({
+        id: `review:workspace:${index}`,
+        label: workspace.label,
+        fallbackText: workspace.cwd,
+        value: { cwd: workspace.cwd },
+      }));
+    } else if (params.phase === "target") {
+      actions = [
+        {
+          id: "review:target:base-branch",
+          label: "Base branch",
+          description: "Compare this branch with a base branch",
+          fallbackText: "base branch",
+          value: { targetType: "baseBranch" },
+        },
+        {
+          id: "review:target:current-changes",
+          label: "Current changes",
+          description: "Review staged, unstaged, and untracked files",
+          fallbackText: "current changes",
+          value: { targetType: "uncommittedChanges" },
+        },
+        {
+          id: "review:target:commit",
+          label: "Commit",
+          description: "Review one commit by SHA",
+          fallbackText: "commit",
+          value: { targetType: "commit" },
+        },
+        {
+          id: "review:target:custom",
+          label: "Custom",
+          description: "Review using custom instructions",
+          fallbackText: "custom",
+          value: { targetType: "custom" },
+        },
+      ];
+    } else if (params.phase === "base_branch") {
+      title = "Base branch";
+      body = "Choose a base branch or reply with a branch name.";
+      allowFreeform = true;
+      targetType = "baseBranch";
+      const branches = [
+        ...(directory?.gitStatus?.baseBranches ?? []),
+        ...(directory?.gitStatus?.branches ?? []),
+        directory?.gitStatus?.defaultBranch,
+        "main",
+      ]
+        .map((branch) => branch?.trim())
+        .filter(
+          (branch, index, candidates): branch is string =>
+            Boolean(branch) && candidates.indexOf(branch) === index,
+        );
+      actions = branches.map((branch, index) => ({
+        id: `review:base-branch:${index}`,
+        label: branch,
+        fallbackText: branch,
+        value: { branch },
+      }));
+    } else if (params.phase === "commit") {
+      title = "Commit";
+      body = "Choose a recent commit or reply with a commit SHA.";
+      allowFreeform = true;
+      targetType = "commit";
+      actions = (directory?.gitStatus?.recentCommits ?? []).map((commit, index) => ({
+        id: `review:commit:${index}`,
+        label: `${commit.shortSha} ${commit.subject}`,
+        fallbackText: commit.sha,
+        value: {
+          sha: commit.sha,
+          title: commit.subject,
+        },
+      }));
+    } else if (params.phase === "custom") {
+      title = "Custom review";
+      body = "Reply with the review instructions.";
+      allowFreeform = true;
+      targetType = "custom";
+    } else {
+      title = "Review submitted";
+      body = "The review request was submitted.";
+    }
+
+    actions = applyActionCapabilityLimits(actions, this.capabilityProfile);
+    return {
+      id: params.id ?? this.newIntentId("review"),
+      kind: "review",
+      bindingId: params.binding.id,
+      createdAt: params.createdAt ?? this.now(),
+      title,
+      body,
+      actions,
+      allowFreeform,
+      fallbackText: allowFreeform
+        ? `${body} Reply with text or tap an option.`
+        : body,
+      review: {
+        backend: params.binding.backend,
+        threadId: params.binding.threadId,
+        phase: params.phase,
+        ...(params.cwd ? { cwd: params.cwd } : {}),
+        ...(targetType ? { targetType } : {}),
+      },
+      ...(params.targetSurface
+        ? {
+            targetSurface: params.targetSurface,
+            delivery: {
+              mode: "update",
+              replaceMarkup: true,
+              fallback: "present_new",
+            },
+          }
+        : {}),
+    };
   }
 
   /**
@@ -1655,6 +1940,12 @@ export class MessagingController {
             actionId: mapped.action.id,
             value: mapped.action.value,
           });
+          return;
+        }
+        if (
+          pendingIntent.intent.kind === "review" &&
+          await this.handleReviewTextAnswer(pendingIntent, event)
+        ) {
           return;
         }
         if (
@@ -2624,6 +2915,10 @@ export class MessagingController {
         await this.handleQuestionnaireAction(pendingIntent, event, action);
         return;
       }
+      if (action && pendingIntent.intent.kind === "review") {
+        await this.handleReviewAction(pendingIntent, event, action);
+        return;
+      }
     }
 
     if ((event.actionId ?? event.interaction.id).startsWith("approval:")) {
@@ -2648,6 +2943,21 @@ export class MessagingController {
           createdAt: this.now(),
           title: "Input request expired",
           body: "That input request is no longer available. Retry the command or request that needed input.",
+          recoverable: true,
+        }),
+        undefined,
+        event,
+      );
+      return;
+    }
+
+    if ((event.actionId ?? event.interaction.id).startsWith("review:")) {
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("expired-review"),
+          createdAt: this.now(),
+          title: "Review picker expired",
+          body: "That review picker is no longer available. Send /review to open a new one.",
           recoverable: true,
         }),
         undefined,
@@ -2695,6 +3005,286 @@ export class MessagingController {
 
     await this.updateQuestionnairePendingIntent(pendingIntent, updated, event);
     return true;
+  }
+
+  private async handleReviewTextAnswer(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundTextEvent,
+  ): Promise<boolean> {
+    if (pendingIntent.intent.kind !== "review") {
+      return false;
+    }
+
+    const value = event.text.trim();
+    if (!pendingIntent.intent.allowFreeform || !value) {
+      return false;
+    }
+
+    let target: AppServerReviewTarget | undefined;
+    if (pendingIntent.intent.review.phase === "base_branch") {
+      target = { type: "baseBranch", branch: value };
+    } else if (pendingIntent.intent.review.phase === "commit") {
+      const [sha, ...titleParts] = value.split(/\s+/);
+      if (sha) {
+        target = {
+          type: "commit",
+          sha,
+          title: titleParts.length > 0 ? titleParts.join(" ") : null,
+        };
+      }
+    } else if (pendingIntent.intent.review.phase === "custom") {
+      target = { type: "custom", instructions: value };
+    }
+
+    if (!target) {
+      return false;
+    }
+
+    await this.submitMessagingReviewFromPending(
+      pendingIntent,
+      event,
+      target,
+    );
+    return true;
+  }
+
+  private async handleReviewAction(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent,
+    action: MessagingSurfaceAction,
+  ): Promise<void> {
+    if (pendingIntent.intent.kind !== "review") {
+      return;
+    }
+
+    const value = asPlainRecord(action.value);
+    const phase = pendingIntent.intent.review.phase;
+    if (phase === "workspace") {
+      const cwd = typeof value?.cwd === "string" ? value.cwd.trim() : "";
+      if (cwd) {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "target",
+          cwd,
+        });
+      }
+      return;
+    }
+
+    if (phase === "target") {
+      const targetType =
+        typeof value?.targetType === "string" ? value.targetType : undefined;
+      if (targetType === "uncommittedChanges") {
+        await this.submitMessagingReviewFromPending(
+          pendingIntent,
+          event,
+          { type: "uncommittedChanges" },
+        );
+      } else if (targetType === "baseBranch") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "base_branch",
+        });
+      } else if (targetType === "commit") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "commit",
+        });
+      } else if (targetType === "custom") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "custom",
+        });
+      }
+      return;
+    }
+
+    if (phase === "base_branch") {
+      const branch = typeof value?.branch === "string" ? value.branch.trim() : "";
+      if (branch) {
+        await this.submitMessagingReviewFromPending(
+          pendingIntent,
+          event,
+          { type: "baseBranch", branch },
+        );
+      }
+      return;
+    }
+
+    if (phase === "commit") {
+      const sha = typeof value?.sha === "string" ? value.sha.trim() : "";
+      const title = typeof value?.title === "string" ? value.title : null;
+      if (sha) {
+        await this.submitMessagingReviewFromPending(
+          pendingIntent,
+          event,
+          { type: "commit", sha, title },
+        );
+      }
+    }
+  }
+
+  private async updateReviewPendingIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent | MessagingInboundTextEvent,
+    review: {
+      phase: MessagingReviewIntent["review"]["phase"];
+      cwd?: string;
+    },
+  ): Promise<void> {
+    if (pendingIntent.intent.kind !== "review") {
+      return;
+    }
+    const binding = pendingIntent.bindingId
+      ? await this.options.store.getBinding(pendingIntent.bindingId)
+      : undefined;
+    if (!binding || binding.revokedAt) {
+      await this.options.store.deletePendingIntent(pendingIntent.id);
+      return;
+    }
+
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: binding.backend,
+    });
+    const targetSurface = pendingIntent.surface ?? (
+      event.kind === "callback" ? event.interaction : undefined
+    );
+    const intent = this.buildReviewIntent({
+      binding,
+      navigation,
+      phase: review.phase,
+      cwd: review.cwd ?? pendingIntent.intent.review.cwd,
+      id: pendingIntent.intent.id,
+      createdAt: pendingIntent.intent.createdAt,
+      targetSurface,
+    });
+    const result = await this.deliver(intent, binding, event);
+    await this.options.store.upsertPendingIntent({
+      ...pendingIntent,
+      intent,
+      surface: result.surface ?? pendingIntent.surface,
+    });
+  }
+
+  private async submitMessagingReviewFromPending(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent | MessagingInboundTextEvent,
+    target: AppServerReviewTarget,
+  ): Promise<void> {
+    if (pendingIntent.intent.kind !== "review") {
+      return;
+    }
+    const binding = pendingIntent.bindingId
+      ? await this.options.store.getBinding(pendingIntent.bindingId)
+      : undefined;
+    if (!binding || binding.revokedAt) {
+      await this.options.store.deletePendingIntent(pendingIntent.id);
+      return;
+    }
+
+    await this.submitMessagingReview({
+      binding,
+      event,
+      target,
+      cwd: pendingIntent.intent.review.cwd,
+      targetSurface: pendingIntent.surface,
+      pendingIntentId: pendingIntent.id,
+    });
+  }
+
+  private async submitMessagingReview(params: {
+    binding: MessagingBindingRecord;
+    event: MessagingInboundEvent;
+    target: AppServerReviewTarget;
+    cwd?: string;
+    targetSurface?: MessagingSurfaceRef;
+    pendingIntentId?: string;
+  }): Promise<void> {
+    if (!this.options.backend.submitReview) {
+      await this.deliverReviewUnsupported(params.binding, params.event);
+      return;
+    }
+
+    try {
+      const navigation = await this.options.backend.getNavigationSnapshot({
+        backend: params.binding.backend,
+      });
+      const settings = turnSettingsForBinding(params.binding, navigation);
+      const result = await this.options.backend.submitReview({
+        backend: params.binding.backend,
+        threadId: params.binding.threadId,
+        target: params.target,
+        delivery: "inline",
+        ...(params.cwd ? { cwd: params.cwd } : {}),
+        ...(settings.model ? { model: settings.model } : {}),
+        ...(settings.reasoningEffort
+          ? { reasoningEffort: settings.reasoningEffort }
+          : {}),
+        ...(settings.serviceTier ? { serviceTier: settings.serviceTier } : {}),
+        ...(settings.fastMode !== undefined ? { fastMode: settings.fastMode } : {}),
+      });
+      if (params.pendingIntentId) {
+        await this.options.store.deletePendingIntent(params.pendingIntentId);
+      }
+      await this.deliver(
+        buildConfirmationIntent({
+          id: this.newIntentId("review-submitted"),
+          capabilityProfile: this.capabilityProfile,
+          createdAt: this.now(),
+          title: result.status === "scheduled" ? "Review queued" : "Review started",
+          body:
+            result.status === "scheduled"
+              ? `${formatReviewTarget(params.target)} will start after the active turn completes successfully.`
+              : `${formatReviewTarget(params.target)} is now running.`,
+          fallbackText:
+            result.status === "scheduled"
+              ? "Review queued until the active turn completes."
+              : "Review started.",
+          ...(params.targetSurface
+            ? {
+                targetSurface: params.targetSurface,
+                delivery: {
+                  mode: "update" as const,
+                  replaceMarkup: true,
+                  fallback: "present_new" as const,
+                },
+              }
+            : {}),
+        }),
+        params.binding,
+        params.event,
+      );
+    } catch (error) {
+      this.logger.warn?.("messaging review submission failed", {
+        backend: params.binding.backend,
+        threadId: params.binding.threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await this.deliver(
+        buildErrorIntent({
+          id: this.newIntentId("review-submit-failed"),
+          createdAt: this.now(),
+          title: "Review could not start",
+          body: error instanceof Error ? error.message : String(error),
+          recoverable: true,
+        }),
+        params.binding,
+        params.event,
+      );
+    }
+  }
+
+  private async deliverReviewUnsupported(
+    binding: MessagingBindingRecord,
+    event: MessagingInboundEvent,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("review-unsupported"),
+        createdAt: this.now(),
+        title: "Review unavailable",
+        body: "This thread backend does not support code review.",
+        recoverable: false,
+      }),
+      binding,
+      event,
+    );
   }
 
   private async handleQuestionnaireAction(
@@ -13000,6 +13590,30 @@ function findNavigationDirectory(
   );
 }
 
+function reviewWorkspaceMatches(
+  directoryPath: string | undefined,
+  cwd: string | undefined,
+): boolean {
+  if (!directoryPath || !cwd) {
+    return false;
+  }
+  const normalize = (value: string) => value.replace(/\/+$/, "");
+  return normalize(directoryPath) === normalize(cwd);
+}
+
+function formatReviewTarget(target: AppServerReviewTarget): string {
+  switch (target.type) {
+    case "uncommittedChanges":
+      return "Current changes review";
+    case "baseBranch":
+      return `Review against ${target.branch}`;
+    case "commit":
+      return `Review of commit ${target.sha}`;
+    case "custom":
+      return "Custom review";
+  }
+}
+
 function validateHandoffRequest(
   request: HandoffThreadWorkspaceRequest,
   context: MessagingWorkspaceHandoffContext,
@@ -14262,6 +14876,7 @@ export function messagingDeliveryPriority(
       }
       return "critical_interactive";
     case "questionnaire":
+    case "review":
       return "critical_interactive";
     case "stream_update":
       return intent.stream.isFinal ? "final_turn" : "stream_partial";

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -34,6 +34,7 @@ import type {
   SteerTurnResponse,
   StartThreadRequest,
   StartThreadResponse,
+  StartReviewRequest,
   SubmitServerRequestRequest,
   SubmitServerRequestResponse,
   ThreadMessagingBindingTransition,
@@ -208,6 +209,20 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
           queueStatus: "queued",
           queueEntryId: submitted.entry.id,
         };
+  }
+
+  async submitReview(request: StartReviewRequest): Promise<
+    | {
+        status: "started";
+        response: Awaited<ReturnType<DesktopBackendRegistry["startReview"]>>;
+      }
+    | {
+        status: "scheduled";
+        pendingReviewId: string;
+        invokingTurnId: string;
+      }
+  > {
+    return await this.registry.submitReview(request);
   }
 
   async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {

--- a/docs/brainstorms/2026-07-30-messaging-review-command-and-tool-requirements.md
+++ b/docs/brainstorms/2026-07-30-messaging-review-command-and-tool-requirements.md
@@ -1,0 +1,216 @@
+---
+date: 2026-07-30
+topic: messaging-review-command-and-tool
+---
+
+# Messaging Review Command and Tool
+
+## Problem Frame
+
+PwrAgent currently treats every slash-prefixed messaging event as a messaging
+control command. Known controls such as `/resume` work, but an unrecognized
+command such as `/review` falls through to the PwrAgent help menu instead of
+reaching the bound coding thread.
+
+Review is already a first-class desktop capability with structured targets and
+review-result rendering. It should be one capability exposed consistently
+through the desktop composer, messaging conversations, Codex dynamic tools, and
+the PwrAgent MCP server.
+
+## User Flow
+
+```text
+@PwrAgent /review
+        |
+        v
+Review target picker
+  | Base branch ------> choose project if needed -> choose branch
+  | Current changes --> ready
+  | Commit -----------> choose or enter SHA
+  | Custom -----------> enter review instructions
+        |
+        v
+Thread idle? ---- yes --> start review
+        |
+        no
+        |
+        v
+Queue review after the active turn
+        |
+        v
+Deliver progress and review result to the originating conversation
+```
+
+An Agent can reach the same operation by calling `start_review`. Because tools
+are invoked during an active turn, the tool records the request and PwrAgent
+starts it after the invoking turn completes successfully.
+
+## Requirements
+
+**Command routing**
+
+- R1. Messaging control commands remain owned by the messaging controller:
+  `/resume`, `/agent`, `/new`, `/status`, `/detach`, `/monitor`, and `/help`.
+- R2. A slash-prefixed message that is not a messaging control command must be
+  routed to the bound coding thread instead of producing the PwrAgent command
+  menu. The routed text must preserve the command and its arguments.
+- R3. R2 applies to addressed text on shared surfaces, including text remaining
+  after an `@bot` mention is removed, and to direct messages where normal bound
+  thread routing applies.
+- R4. An unbound conversation cannot execute thread commands. It must receive a
+  concise bind-first response with a Resume action rather than an unrelated
+  generic command menu.
+- R5. Provider-native slash commands remain subject to provider registration
+  and namespace constraints. Textual `@bot /review` is the universal path and
+  must not depend on native slash-command registration.
+- R6. The help surface distinguishes messaging controls from thread commands.
+  It shows `/review` when the bound backend supports review without classifying
+  it as a messaging control command.
+
+**Messaging review interaction**
+
+- R7. Bare `/review` on a review-capable bound thread opens a channel-neutral
+  review target picker rather than starting a default review immediately.
+- R8. The picker exposes the same four targets as the desktop composer:
+  Base branch, Current changes, Commit, and Custom.
+- R9. If the thread has multiple linked Git workspaces, the interaction asks
+  which workspace to review before collecting target-specific details.
+- R10. Base branch offers known branch choices plus a text fallback. Commit
+  offers known recent commits when available plus SHA entry. Custom accepts the
+  operator's text verbatim as review instructions.
+- R11. Providers render the interaction according to their capability profile:
+  native choices/buttons where supported and numbered or free-form text
+  fallbacks elsewhere.
+- R12. Existing explicit desktop syntax also works from messaging without
+  opening the picker:
+  `/review <branch>`, `/review --commit <sha> [title]`, and
+  `/review --custom <instructions>`.
+- R13. If the thread is idle, a completed picker starts the review immediately.
+  If a turn is active, PwrAgent queues the structured review request and starts
+  it after earlier work reaches a successful terminal boundary.
+- R14. The originating conversation receives an acknowledgement that names the
+  selected target and says whether the review started or was queued.
+- R15. Review progress and the final review artifact are delivered back to the
+  originating conversation using the existing messaging review-artifact
+  rendering and provider attachment fallbacks.
+- R16. Unsupported backends receive a specific "Review is not supported by
+  this Agent" response; `/review` must not silently become ordinary prompt text
+  on those backends.
+
+**Dynamic tool and MCP parity**
+
+- R17. PwrAgent exposes a `start_review` Agent tool from the shared Agent-tool
+  catalog. Adding it to that catalog makes the same contract available as a
+  Codex dynamic tool and through PwrAgent's MCP server.
+- R18. `start_review` targets the invoking PwrAgent thread. It accepts a
+  structured review target equivalent to the existing review target contract:
+  current changes, base branch, commit, or custom instructions. It may also
+  identify one linked workspace when the thread has more than one.
+- R19. The tool is intended for an explicit operator request to review work.
+  Its description must not encourage an Agent to launch unsolicited reviews.
+- R20. Since the tool is called during an active Agent turn, it records an
+  idempotent pending review and starts that review only after the invoking turn
+  completes successfully. A cancelled or failed invoking turn cancels the
+  pending review.
+- R21. The tool returns a stable pending-review identifier, normalized target
+  summary, source thread identity, and status indicating that execution is
+  scheduled. It tells the Agent to stop and let the turn finish rather than
+  polling or issuing duplicate calls.
+- R22. Repeating the same tool call ID must not schedule duplicate reviews.
+- R23. Once started, the review uses the invoking thread's effective model,
+  reasoning, service-tier, fast-mode, execution-mode, and workspace context
+  unless an existing review policy requires a narrower setting.
+- R24. Pending review state and its eventual review thread/result must be
+  visible through existing thread inspection surfaces so the operator and
+  Agent can determine what happened without relying on transient chat text.
+
+**Free-form requests**
+
+- R25. The initial messaging picker remains deterministic. Choosing Custom
+  sends the supplied instructions directly as the review target; it does not
+  create an additional interpretation subagent.
+- R26. With `start_review` available, an operator may also ask the bound Agent
+  for a review in ordinary language. The active Agent can interpret that
+  request and call the structured tool, which schedules the review after the
+  interpreting turn.
+- R27. A future picker option may explicitly hand ambiguous free-form text and
+  the available target choices to the bound Agent for interpretation. That is
+  not required for the first implementation because R25 and R26 already cover
+  exact custom instructions and natural-language orchestration.
+
+## Success Criteria
+
+- `@PwrAgent /review` in a bound Slack conversation displays the review picker
+  instead of the PwrAgent command menu.
+- Unknown non-control slash text in a bound conversation reaches the coding
+  thread unchanged.
+- An operator can configure and submit all four review target types from both
+  interactive and text-only messaging providers.
+- A review selected during active work starts once that work completes, without
+  duplicate review starts.
+- `start_review` appears with the same schema and behavior in both the Codex
+  dynamic-tool catalog and the PwrAgent MCP tool list.
+- Review results return to the conversation that initiated the review.
+
+## Scope Boundaries
+
+- Do not create a second interpretation subagent for the first version.
+- Do not make `/review` a messaging-control verb.
+- Do not register unnamespaced provider-native slash commands where doing so
+  would collide with provider or workspace commands.
+- Do not add provider-specific review workflow logic; provider differences are
+  expressed through the generic messaging capability profile.
+- Do not change the existing desktop review target meanings.
+- Do not start a tool-requested review before the invoking turn has terminated.
+
+## Key Decisions
+
+- **Unknown slash fallthrough:** Messaging only owns its explicit control
+  catalog. Other slash text belongs to the bound coding thread.
+- **Bare review opens a picker:** This matches the desktop interaction and
+  avoids silently choosing Current changes when the operator may mean a base
+  branch, commit, or custom review.
+- **One Agent-tool catalog entry:** Dynamic-tool and MCP exposure share the
+  existing catalog rather than maintaining separate review contracts.
+- **Terminal-boundary execution:** `start_review` schedules after the invoking
+  turn completes because `review/start` cannot safely run concurrently with
+  that turn.
+- **No extra interpreter for v1:** Custom instructions can be passed directly,
+  while ordinary natural-language requests can already be interpreted by the
+  bound Agent using `start_review`.
+
+## Dependencies / Assumptions
+
+- The existing structured review target and `review/start` behavior remain the
+  canonical execution contract.
+- Existing messaging questionnaire primitives can express option selection and
+  free-form answers, though planning must decide whether review warrants its own
+  pending-intent kind.
+- Existing review artifact rendering remains the output path and may need
+  routing metadata so a review subthread's result returns to the initiating
+  binding.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(none)
+
+### Deferred to Planning
+
+- [Affects R2-R5][Technical] Preserve the universal unknown-command fallthrough
+  while correctly normalizing provider-native prefixes and mention-stripped
+  text.
+- [Affects R9-R12][Technical] Identify the channel-neutral navigation data
+  needed for workspace, branch, and commit choices without importing
+  provider-specific or renderer-only code.
+- [Affects R13, R20-R24][Technical] Choose a durable pending-review record and
+  terminal-event release mechanism shared by messaging and Agent-tool callers.
+- [Affects R15][Technical] Confirm how review subthread events map back to the
+  initiating source-thread binding and persist that association across restart.
+- [Affects R17][Technical] Place `start_review` in the appropriate existing
+  Agent-tool catalog without changing established tool compatibility contracts.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning.

--- a/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+++ b/packages/messaging/interface/src/__tests__/messaging-contract.test.ts
@@ -34,6 +34,7 @@ describe("messaging surface contract", () => {
       "single_select",
       "multi_select",
       "questionnaire",
+      "review",
       "approval",
       "confirmation",
       "error",

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -866,6 +866,7 @@ export type MessagingReviewIntent = MessagingBaseSurfaceIntent & {
     threadId: ThreadIdentifier;
     phase: MessagingReviewPhase;
     cwd?: string;
+    repositoryPath?: string;
     targetType?: AppServerReviewTarget["type"];
     target?: AppServerReviewTarget;
   };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  AppServerReviewTarget,
   BackendAcpSessionRuntimeState,
   CodexEnvironmentExecutionTarget,
   LaunchpadWorkMode,
@@ -62,6 +63,7 @@ export const MESSAGING_SURFACE_INTENT_KINDS = [
   "single_select",
   "multi_select",
   "questionnaire",
+  "review",
   "approval",
   "confirmation",
   "error",
@@ -845,6 +847,30 @@ export type MessagingQuestionnaireIntent = MessagingBaseSurfaceIntent & {
   questions: MessagingQuestionnaireQuestion[];
 };
 
+export type MessagingReviewPhase =
+  | "workspace"
+  | "target"
+  | "base_branch"
+  | "commit"
+  | "custom"
+  | "submitted";
+
+export type MessagingReviewIntent = MessagingBaseSurfaceIntent & {
+  kind: "review";
+  title: string;
+  body: string;
+  actions: MessagingSurfaceAction[];
+  allowFreeform?: boolean;
+  review: {
+    backend: AppServerBackendKind;
+    threadId: ThreadIdentifier;
+    phase: MessagingReviewPhase;
+    cwd?: string;
+    targetType?: AppServerReviewTarget["type"];
+    target?: AppServerReviewTarget;
+  };
+};
+
 export function normalizeMessagingQuestionnaireIntent(
   intent: MessagingQuestionnaireIntent,
 ): MessagingQuestionnaireIntent {
@@ -1068,6 +1094,7 @@ export type MessagingSurfaceIntent =
   | MessagingSingleSelectIntent
   | MessagingMultiSelectIntent
   | MessagingQuestionnaireIntent
+  | MessagingReviewIntent
   | MessagingApprovalIntent
   | MessagingConfirmationIntent
   | MessagingErrorIntent

--- a/packages/messaging/providers/discord/src/discord-formatting.ts
+++ b/packages/messaging/providers/discord/src/discord-formatting.ts
@@ -93,6 +93,8 @@ export function textForDiscordIntent(intent: MessagingSurfaceIntent): string {
       return intent.prompt;
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
+    case "review":
+      return [intent.title, intent.body].join("\n\n");
     case "approval":
       return [intent.title, intent.body].join("\n\n");
     case "confirmation":
@@ -117,6 +119,8 @@ export function actionsForDiscordIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":

--- a/packages/messaging/providers/feishu/src/feishu-formatting.ts
+++ b/packages/messaging/providers/feishu/src/feishu-formatting.ts
@@ -63,6 +63,8 @@ export function actionsForFeishuIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -179,6 +181,8 @@ export function textForFeishuIntent(intent: MessagingSurfaceIntent): string {
         .join("\n\n");
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
+    case "review":
+      return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "approval":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/line/src/line-adapter.ts
+++ b/packages/messaging/providers/line/src/line-adapter.ts
@@ -1210,6 +1210,7 @@ function titleForLineActionBubble(
       return intent.prompt;
     case "approval":
     case "confirmation":
+    case "review":
       return intent.title;
     case "status":
       return "Thread status";

--- a/packages/messaging/providers/line/src/line-formatting.ts
+++ b/packages/messaging/providers/line/src/line-formatting.ts
@@ -81,6 +81,8 @@ export function actionsForLineIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -197,6 +199,8 @@ export function textForLineIntent(intent: MessagingSurfaceIntent): string {
         .join("\n\n");
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
+    case "review":
+      return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "approval":
     case "confirmation":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -639,6 +639,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
         case "single_select":
         case "multi_select":
         case "questionnaire":
+        case "review":
         case "approval":
         case "confirmation":
         case "error":

--- a/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
@@ -134,6 +134,8 @@ export function actionsForMattermostIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -256,6 +258,8 @@ export function textForMattermostIntent(intent: MessagingSurfaceIntent): string 
         .join("\n\n");
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
+    case "review":
+      return [intent.title, intent.body].join("\n\n");
     case "approval":
       return [intent.title, intent.body].join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -86,6 +86,8 @@ export function actionsForSlackIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":
@@ -206,6 +208,8 @@ export function textForSlackIntent(intent: MessagingSurfaceIntent): string {
         .join("\n\n");
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
+    case "review":
+      return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "approval":
       return [intent.title, intent.body].filter(Boolean).join("\n\n");
     case "confirmation":

--- a/packages/messaging/providers/telegram/src/telegram-formatting.ts
+++ b/packages/messaging/providers/telegram/src/telegram-formatting.ts
@@ -102,6 +102,8 @@ export function textForTelegramIntent(intent: MessagingSurfaceIntent): string {
       return renderTelegramHtml(intent.prompt, "plain");
     case "questionnaire":
       return renderTelegramHtml(formatMessagingQuestionnaireText(intent), "plain");
+    case "review":
+      return renderTelegramHtml([intent.title, intent.body].join("\n\n"), "plain");
     case "approval":
       return renderTelegramHtml([intent.title, intent.body].join("\n\n"), "markdown");
     case "confirmation":
@@ -126,6 +128,8 @@ export function actionsForTelegramIntent(
       return intent.choices;
     case "questionnaire":
       return messagingQuestionnaireActions(intent);
+    case "review":
+      return intent.actions;
     case "approval":
       return intent.decisions;
     case "confirmation":

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -24,6 +24,7 @@ describe("thread orchestration tool contracts", () => {
       "handoff_task",
       "move_thread_workspace",
       "send_message_to_thread",
+      "start_review",
     ]);
   });
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1219,6 +1219,17 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/reviewStart/updated";
+      params: {
+        threadId: string;
+        pendingReviewId: string;
+        status: "started" | "cancelled" | "failed";
+        reviewThreadId?: string;
+        reviewTurnId?: string;
+        error?: string;
+      };
+    }
+  | {
       method: "thread/modelSettings/updated";
       params: {
         threadId: string;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  AppServerReviewTarget,
   CodexThreadEnvironmentRuntime,
   LinkedDirectorySummary,
   ThreadExecutionMode,
@@ -16,6 +17,7 @@ export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
   "handoff_task",
   "move_thread_workspace",
   "send_message_to_thread",
+  "start_review",
 ] as const;
 
 export type PwrAgentThreadOrchestrationOperationName =
@@ -119,6 +121,15 @@ export type SendMessageToThreadToolArgs = {
   executionMode?: ThreadExecutionMode;
   approvalPolicy?: string;
   sandbox?: string;
+};
+
+export type StartReviewToolArgs = {
+  target: AppServerReviewTarget;
+  /**
+   * Optional linked workspace to review when the invoking thread has more than
+   * one directory. Omit it to use the thread's primary runtime workspace.
+   */
+  cwd?: string;
 };
 
 export type MoveThreadWorkspaceToolArgs = {
@@ -366,12 +377,25 @@ export type SendMessageToThreadResult = {
   };
 };
 
+export type StartReviewToolResult = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  pendingReviewId: string;
+  status: "scheduled";
+  target: AppServerReviewTarget;
+  cwd?: string;
+  invokingTurnId: string;
+  createdAt: number;
+  message: string;
+};
+
 export type PwrAgentThreadOrchestrationToolArgsByOperation = {
   attach_thread_directory: AttachThreadDirectoryToolArgs;
   detach_thread_directory: DetachThreadDirectoryToolArgs;
   handoff_task: HandoffTaskToolArgs;
   move_thread_workspace: MoveThreadWorkspaceToolArgs;
   send_message_to_thread: SendMessageToThreadToolArgs;
+  start_review: StartReviewToolArgs;
 };
 
 export type PwrAgentThreadOrchestrationToolArgs<
@@ -398,7 +422,8 @@ export type PwrAgentThreadOrchestrationResponse =
         | DetachThreadDirectoryResult
         | HandoffTaskResult
         | MoveThreadWorkspaceResult
-        | SendMessageToThreadResult;
+        | SendMessageToThreadResult
+        | StartReviewToolResult;
     }
   | {
       ok: false;


### PR DESCRIPTION
## What changed

- Route slash commands that are not recognized messaging-control commands to the currently bound thread instead of displaying the control-command menu.
- Add a native messaging `/review` workflow with workspace, target, base-branch, commit, and custom-instruction pickers.
- Support direct review forms such as `/review main`, `/review --commit <sha>`, and `/review --custom <instructions>`.
- Render the review intent across Slack, Discord, Telegram, Mattermost, Feishu, and LINE.
- Expose `start_review` through the shared dynamic-tool and MCP catalogs.
- Schedule tool-requested reviews after the invoking turn completes successfully, avoiding a concurrent review/start on an active thread.

## Why

An @mentioned `/review` message was classified as a messaging control command. Because `/review` was not in that control catalog, the controller displayed the generic command menu instead of letting the bound agent handle the request. Review also lacked a messaging-native target picker and a callable agent-tool surface.

## Impact

Messaging users can start code reviews without returning to the desktop UI. Other provider slash commands continue into the bound PwrAgent thread, while PwrAgent-owned control commands remain handled locally. Agents can request the same review operation through dynamic or MCP tools with turn-boundary safety.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing warnings remain)
- `pnpm lint:boundaries`
- 314 focused messaging/interface/tool tests
- 5 focused backend-registry tests
- 56 provider-formatting tests
- `git diff --check`
