### PR TITLE
feat(messaging): show inbound message attribution

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -7,6 +7,54 @@ import type { DesktopBackendRegistry } from "../app-server/backend-registry";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
 
 describe("DesktopMessagingBackendBridge", () => {
+  it("preserves enriched messaging provenance when starting a turn", async () => {
+    const submitTurn = vi.fn(async (request) => ({
+      status: "started" as const,
+      entry: {
+        ...request,
+        id: "queue-entry-1",
+        createdAt: 1_000,
+      },
+      turnId: "turn-1",
+    }));
+    const bridge = new DesktopMessagingBackendBridge({
+      submitTurn,
+    } as unknown as DesktopBackendRegistry);
+    const messageOrigin = {
+      kind: "messaging" as const,
+      messaging: {
+        platform: "slack" as const,
+        surface: {
+          id: "thread-1",
+          kind: "thread" as const,
+          title: "api-search circuit breaker timeout",
+          parentTitle: "signals-chat",
+          ancestorTitle: "PwrAgent",
+        },
+        actor: {
+          platformUserId: "U012345",
+          displayName: "Hunter",
+          username: "huntharo",
+        },
+      },
+    };
+
+    await bridge.startTurn({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Go for it." }],
+      messageOrigin,
+    });
+
+    expect(submitTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      input: [{ type: "text", text: "Go for it." }],
+      messageOrigin,
+      origin: "messaging",
+    });
+  });
+
   it("reads active turns from the registry", async () => {
     const bridge = createBridge({
       entries: [],

--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -1046,7 +1046,7 @@ describe("DiscordAdapter", () => {
       t: "MESSAGE_CREATE",
     });
 
-    expect(harness.startTurn).toHaveBeenCalledWith({
+    expect(harness.startTurn).toHaveBeenCalledWith(expect.objectContaining({
       backend: "codex",
       input: [
         {
@@ -1054,8 +1054,23 @@ describe("DiscordAdapter", () => {
           type: "text",
         },
       ],
+      messageOrigin: {
+        kind: "messaging",
+        messaging: {
+          actor: {
+            displayName: "Ada New",
+            platformUserId: DISCORD_USER_ID,
+            username: "ada_new",
+          },
+          platform: "discord",
+          surface: {
+            id: DISCORD_CHANNEL_ID,
+            kind: "channel",
+          },
+        },
+      },
       threadId: "thread-1",
-    });
+    }));
   });
 
   it("drops matching display names with different Discord ids before controller dispatch", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -8810,6 +8810,19 @@ describe("MessagingController", () => {
           text: "second turn",
         },
       ],
+      messageOrigin: {
+        kind: "messaging",
+        messaging: {
+          platform: "telegram",
+          surface: {
+            id: "chat-1",
+            kind: "dm",
+          },
+          actor: {
+            platformUserId: "user-1",
+          },
+        },
+      },
     });
   });
 
@@ -8976,6 +8989,19 @@ describe("MessagingController", () => {
           text: "also check the logs",
         },
       ],
+      messageOrigin: {
+        kind: "messaging",
+        messaging: {
+          platform: "telegram",
+          surface: {
+            id: "chat-1",
+            kind: "dm",
+          },
+          actor: {
+            platformUserId: "user-1",
+          },
+        },
+      },
     });
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",

--- a/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
@@ -44,6 +44,50 @@ describe("MessagingTurnAdmission", () => {
     admission.dispose();
   });
 
+  it("keeps different actors in separate debounce bundles", async () => {
+    vi.useFakeTimers();
+    const binding = buildBinding();
+    const onBundleReady = vi.fn();
+    const admission = new MessagingTurnAdmission({
+      debounceMs: 500,
+      now: () => 1000,
+      onBundleReady,
+    });
+
+    await admission.append({
+      binding,
+      event: buildTextEvent("first", "user-1"),
+    });
+    await admission.append({
+      binding,
+      event: buildTextEvent("second", "user-2"),
+    });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(onBundleReady).toHaveBeenCalledTimes(2);
+    expect(onBundleReady.mock.calls.map(([bundle]) => bundle)).toEqual([
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            actor: expect.objectContaining({ platformUserId: "user-1" }),
+            text: "first",
+          }),
+        ],
+        threadKey: "codex:thread-1",
+      }),
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            actor: expect.objectContaining({ platformUserId: "user-2" }),
+            text: "second",
+          }),
+        ],
+        threadKey: "codex:thread-1",
+      }),
+    ]);
+    admission.dispose();
+  });
+
   it("tracks queued entries and skips cancelled entries when flushing", () => {
     const binding = buildBinding();
     const admission = new MessagingTurnAdmission({
@@ -94,12 +138,15 @@ function buildBinding(): MessagingBindingRecord {
   };
 }
 
-function buildTextEvent(text: string): MessagingInboundTextEvent {
+function buildTextEvent(
+  text: string,
+  platformUserId = "user-1",
+): MessagingInboundTextEvent {
   return {
     id: `event:${text}`,
     kind: "text",
     actor: {
-      platformUserId: "user-1",
+      platformUserId,
     },
     channel: {
       channel: "telegram",

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2436,7 +2436,7 @@ describe("TelegramAdapter", () => {
       },
     });
 
-    expect(harness.startTurn).toHaveBeenCalledWith({
+    expect(harness.startTurn).toHaveBeenCalledWith(expect.objectContaining({
       backend: "codex",
       input: [
         {
@@ -2444,8 +2444,22 @@ describe("TelegramAdapter", () => {
           type: "text",
         },
       ],
+      messageOrigin: {
+        kind: "messaging",
+        messaging: {
+          actor: {
+            platformUserId: "42",
+            username: "new_username",
+          },
+          platform: "telegram",
+          surface: {
+            id: "777",
+            kind: "dm",
+          },
+        },
+      },
       threadId: "thread-1",
-    });
+    }));
   });
 
   it("drops matching usernames with different Telegram numeric ids before controller dispatch", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12580,6 +12580,7 @@ export class DesktopBackendRegistry {
           backend: launchpad.backend,
           threadId: startThreadResponse.threadId,
           input,
+          messageOrigin: options?.messageOrigin,
           model: launchpad.model,
           reasoningEffort: launchpad.reasoningEffort,
           serviceTier: launchpad.serviceTier,

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -3,6 +3,7 @@ import type {
   AppServerBackendKind,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
+  AppServerThreadMessageOrigin,
   AppServerThreadStatus,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
@@ -172,8 +173,12 @@ export type MessagingBackendBridge = {
         invokingTurnId: string;
       }
   >;
-  startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
-  steerTurn?(request: SteerTurnRequest): Promise<SteerTurnResponse>;
+  startTurn(
+    request: StartTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
+  ): Promise<StartTurnResponse>;
+  steerTurn?(
+    request: SteerTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
+  ): Promise<SteerTurnResponse>;
   compactThread?(request: CompactThreadRequest): Promise<CompactThreadResponse>;
   interruptTurn?(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
   listSkills?(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -26,6 +26,7 @@ import type {
   BackendModelOption,
   BackendSummary,
   AppServerPendingRequestNotification,
+  AppServerThreadMessageOrigin,
   AppServerToolRequestUserInputNotification,
   DesktopAuthorizedContact,
   DesktopMessagingFullAccessWarningGlobalPolicy,
@@ -2506,6 +2507,7 @@ export class MessagingController {
         backend: params.binding.backend,
         threadId: params.binding.threadId,
         input: params.input,
+        messageOrigin: messageOriginForInboundEvent(params.event),
         ...turnSettings,
       });
       if (started.queueStatus === "queued") {
@@ -2785,6 +2787,7 @@ export class MessagingController {
         threadId: entry.binding.threadId,
         expectedTurnId: activeTurn.turnId,
         input: entry.input,
+        messageOrigin: messageOriginForInboundEvent(entry.event),
       });
     } catch (error) {
       await this.deliver(
@@ -6890,6 +6893,7 @@ export class MessagingController {
                 : { input: prepared.input }),
             },
             {
+              messageOrigin: messageOriginForInboundEvent(event),
               ...(environmentSetupReporter
                 ? {
                     onCodexEnvironmentSetupProgress: (
@@ -15989,6 +15993,43 @@ function messagingAdapterStateEqual(
   right: MessagingAdapterState | undefined,
 ): boolean {
   return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function messageOriginForInboundEvent(
+  event: MessagingInboundEvent | undefined,
+): AppServerThreadMessageOrigin {
+  if (!event) {
+    return { kind: "messaging" };
+  }
+
+  const conversation = event.channel.conversation;
+  return {
+    kind: "messaging",
+    messaging: {
+      platform: event.channel.channel,
+      surface: {
+        id: conversation.id,
+        kind: conversation.kind,
+        ...(conversation.title ? { title: conversation.title } : {}),
+        ...(conversation.parentTitle
+          ? { parentTitle: conversation.parentTitle }
+          : {}),
+        ...(conversation.ancestorTitle
+          ? { ancestorTitle: conversation.ancestorTitle }
+          : {}),
+      },
+      actor: {
+        platformUserId: event.actor.platformUserId,
+        ...(event.actor.displayName
+          ? { displayName: event.actor.displayName }
+          : {}),
+        ...(event.actor.phoneNumber
+          ? { phoneNumber: event.actor.phoneNumber }
+          : {}),
+        ...(event.actor.username ? { username: event.actor.username } : {}),
+      },
+    },
+  };
 }
 
 function describeConversation(

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -37,11 +37,12 @@ export type MessagingQueuedTurnEntry = {
 type PendingWindow = {
   binding: MessagingBindingRecord;
   events: MessagingTurnInputEvent[];
+  threadKey: string;
   timer?: ReturnType<typeof setTimeout>;
 };
 
 export class MessagingTurnAdmission {
-  private readonly pendingByThreadKey = new Map<string, PendingWindow>();
+  private readonly pendingByThreadActorKey = new Map<string, PendingWindow>();
   private readonly queuedByThreadKey = new Map<string, MessagingQueuedTurnEntry[]>();
   private readonly startingThreadKeys = new Set<string>();
   private sequence = 0;
@@ -59,37 +60,42 @@ export class MessagingTurnAdmission {
     event: MessagingTurnInputEvent;
   }): Promise<void> {
     const threadKey = threadKeyForBinding(params.binding);
-    const existing = this.pendingByThreadKey.get(threadKey);
+    const pendingKey = pendingKeyForActor(
+      threadKey,
+      params.event.actor.platformUserId,
+    );
+    const existing = this.pendingByThreadActorKey.get(pendingKey);
     if (existing) {
       existing.events.push(params.event);
       if (this.options.debounceMs <= 0) {
-        await this.flush(threadKey);
+        await this.flush(pendingKey);
         return;
       }
       if (existing.timer) {
         clearTimeout(existing.timer);
       }
-      existing.timer = this.schedule(threadKey);
+      existing.timer = this.schedule(pendingKey);
       return;
     }
 
-    this.pendingByThreadKey.set(threadKey, {
+    this.pendingByThreadActorKey.set(pendingKey, {
       binding: params.binding,
       events: [params.event],
-      timer: this.options.debounceMs > 0 ? this.schedule(threadKey) : undefined,
+      threadKey,
+      timer: this.options.debounceMs > 0 ? this.schedule(pendingKey) : undefined,
     });
     if (this.options.debounceMs <= 0) {
-      await this.flush(threadKey);
+      await this.flush(pendingKey);
     }
   }
 
   dispose(): void {
-    for (const pending of this.pendingByThreadKey.values()) {
+    for (const pending of this.pendingByThreadActorKey.values()) {
       if (pending.timer) {
         clearTimeout(pending.timer);
       }
     }
-    this.pendingByThreadKey.clear();
+    this.pendingByThreadActorKey.clear();
   }
 
   isStarting(threadKey: string): boolean {
@@ -203,28 +209,32 @@ export class MessagingTurnAdmission {
     return undefined;
   }
 
-  private schedule(threadKey: string): ReturnType<typeof setTimeout> {
+  private schedule(pendingKey: string): ReturnType<typeof setTimeout> {
     return setTimeout(() => {
-      void this.flush(threadKey);
+      void this.flush(pendingKey);
     }, this.options.debounceMs);
   }
 
-  private async flush(threadKey: string): Promise<void> {
-    const pending = this.pendingByThreadKey.get(threadKey);
+  private async flush(pendingKey: string): Promise<void> {
+    const pending = this.pendingByThreadActorKey.get(pendingKey);
     if (!pending) {
       return;
     }
     if (pending.timer) {
       clearTimeout(pending.timer);
     }
-    this.pendingByThreadKey.delete(threadKey);
+    this.pendingByThreadActorKey.delete(pendingKey);
     await this.options.onBundleReady({
       binding: pending.binding,
       events: pending.events,
       id: `bundle:${++this.sequence}`,
-      threadKey,
+      threadKey: pending.threadKey,
     });
   }
+}
+
+function pendingKeyForActor(threadKey: string, platformUserId: string): string {
+  return JSON.stringify([threadKey, platformUserId]);
 }
 
 export function threadKeyForBinding(binding: MessagingBindingRecord): string {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,6 +1,7 @@
 import type {
   AgentEvent,
   AppServerBackendKind,
+  AppServerThreadMessageOrigin,
   AppServerThreadReplay,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
@@ -189,7 +190,9 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     return await this.registry.updateDirectoryLaunchpad(request);
   }
 
-  async startTurn(request: StartTurnRequest): Promise<StartTurnResponse> {
+  async startTurn(
+    request: StartTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
+  ): Promise<StartTurnResponse> {
     const submitted = await this.registry.submitTurn({
       ...request,
       origin: "messaging",
@@ -225,8 +228,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     return await this.registry.submitReview(request);
   }
 
-  async steerTurn(request: SteerTurnRequest): Promise<SteerTurnResponse> {
-    return await this.registry.steerTurn(request, { kind: "messaging" });
+  async steerTurn(
+    request: SteerTurnRequest & { messageOrigin?: AppServerThreadMessageOrigin },
+  ): Promise<SteerTurnResponse> {
+    return await this.registry.steerTurn(
+      request,
+      request.messageOrigin ?? { kind: "messaging" },
+    );
   }
 
   async startThread(request: StartThreadRequest): Promise<StartThreadResponse> {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -9,6 +9,10 @@ import type {
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  formatMessagingPlatformName,
+  MESSAGING_PLATFORM_ICONS,
+} from "../../lib/messaging-platform-branding";
 import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
 import { ThreadChip } from "./ThreadChip";
 import { TranscriptImage } from "./TranscriptImage";
@@ -479,6 +483,10 @@ function renderMessageHeader(params: {
             {params.message.origin.sourceThread.title}
           </span>
         ) : null}
+        {params.message.origin?.kind === "messaging"
+          && params.message.origin.messaging ? (
+            <MessagingOriginChip origin={params.message.origin.messaging} />
+          ) : null}
       </span>
       <span className="transcript-message__header-actions">
         {params.text ? (
@@ -503,6 +511,78 @@ function renderMessageHeader(params: {
       </span>
     </header>
   );
+}
+
+function MessagingOriginChip(props: {
+  origin: NonNullable<AppServerThreadMessageOrigin["messaging"]>;
+}) {
+  const Icon = MESSAGING_PLATFORM_ICONS[props.origin.platform];
+  const platform = formatMessagingPlatformName(props.origin.platform);
+  const surface = formatMessagingOriginSurface(props.origin);
+  const actor =
+    props.origin.actor.displayName?.trim()
+    || (props.origin.actor.username?.trim()
+      ? `@${props.origin.actor.username.trim().replace(/^@/, "")}`
+      : props.origin.actor.phoneNumber?.trim()
+        || props.origin.actor.platformUserId);
+  const description = `${platform}: ${surface} · ${actor}`;
+
+  return (
+    <span
+      aria-label={description}
+      className="chip transcript-message__messaging-origin"
+      title={description}
+    >
+      <span
+        aria-hidden="true"
+        className="transcript-message__messaging-platform"
+      >
+        {Icon ? (
+          <Icon size={12} />
+        ) : (
+          <span className="transcript-message__messaging-platform-fallback">
+            {props.origin.platform.slice(0, 2)}
+          </span>
+        )}
+      </span>
+      <span className="transcript-message__messaging-surface">
+        {surface}
+      </span>
+      <span
+        aria-hidden="true"
+        className="transcript-message__messaging-separator"
+      >
+        ·
+      </span>
+      <span className="transcript-message__messaging-actor">{actor}</span>
+    </span>
+  );
+}
+
+function formatMessagingOriginSurface(
+  origin: NonNullable<AppServerThreadMessageOrigin["messaging"]>,
+): string {
+  const title = origin.surface.title?.trim();
+  const parent = origin.surface.parentTitle?.trim();
+  const ancestor = origin.surface.ancestorTitle?.trim();
+
+  switch (origin.surface.kind) {
+    case "dm":
+      return title || "Direct message";
+    case "topic":
+      return [parent, title].filter(Boolean).join(" / ") || "Topic";
+    case "thread":
+      return [ancestor, parent ? `#${parent}` : undefined, title]
+        .filter(Boolean)
+        .join(" / ") || "Thread";
+    case "channel":
+      if (origin.platform === "telegram") {
+        return title || parent || "Group";
+      }
+      return [ancestor || parent, title ? `#${title}` : undefined]
+        .filter(Boolean)
+        .join(" / ") || "Channel";
+  }
 }
 
 function messageToneClass(message: AppServerThreadMessageEntry): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -579,6 +579,11 @@ function formatMessagingOriginSurface(
       if (origin.platform === "telegram") {
         return title || parent || "Group";
       }
+      if (ancestor && parent) {
+        return [ancestor, `#${parent}`, title]
+          .filter(Boolean)
+          .join(" / ");
+      }
       return [ancestor || parent, title ? `#${title}` : undefined]
         .filter(Boolean)
         .join(" / ") || "Channel";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -208,16 +208,16 @@ describe("TranscriptList", () => {
         entries={[
           {
             type: "message",
-            id: "message-from-slack",
+            id: "message-from-discord",
             role: "user",
             text: "Go for it. Do what is necessary.",
             origin: {
               kind: "messaging",
               messaging: {
-                platform: "slack",
+                platform: "discord",
                 surface: {
                   id: "thread-1",
-                  kind: "thread",
+                  kind: "channel",
                   title: "api-search circuit breaker timeout",
                   parentTitle: "signals-chat",
                   ancestorTitle: "PwrAgent",
@@ -239,7 +239,7 @@ describe("TranscriptList", () => {
 
     expect(screen.getByText("Messaging")).toBeInTheDocument();
     const origin = screen.getByLabelText(
-      "Slack: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter",
+      "Discord: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter",
     );
     expect(origin).toHaveTextContent(
       "PwrAgent / #signals-chat / api-search circuit breaker timeout",

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -202,6 +202,53 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("shows the messaging platform, surface, and actor for an inbound message", () => {
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-from-slack",
+            role: "user",
+            text: "Go for it. Do what is necessary.",
+            origin: {
+              kind: "messaging",
+              messaging: {
+                platform: "slack",
+                surface: {
+                  id: "thread-1",
+                  kind: "thread",
+                  title: "api-search circuit breaker timeout",
+                  parentTitle: "signals-chat",
+                  ancestorTitle: "PwrAgent",
+                },
+                actor: {
+                  platformUserId: "U012345",
+                  displayName: "Hunter",
+                  username: "huntharo",
+                },
+              },
+            },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Messaging")).toBeInTheDocument();
+    const origin = screen.getByLabelText(
+      "Slack: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter",
+    );
+    expect(origin).toHaveTextContent(
+      "PwrAgent / #signals-chat / api-search circuit breaker timeout",
+    );
+    expect(origin).toHaveTextContent("Hunter");
+    expect(origin.querySelector("img")).toBeInTheDocument();
+    expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
+  });
+
   it("renders transcript history and exposes incremental history loading when available", () => {
     const loadOlder = vi.fn(async () => undefined);
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -723,6 +723,74 @@ describe("useThreadSessionState", () => {
         },
       }),
     ]);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "user-message-2",
+              type: "userMessage",
+              origin: {
+                kind: "messaging",
+                messaging: {
+                  platform: "slack",
+                  surface: {
+                    id: "message-thread-1",
+                    kind: "thread",
+                    title: "api-search circuit breaker timeout",
+                    parentTitle: "signals-chat",
+                    ancestorTitle: "PwrAgent",
+                  },
+                  actor: {
+                    platformUserId: "U012345",
+                    displayName: "Hunter",
+                    username: "huntharo",
+                  },
+                },
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Go for it.",
+                },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.response?.replay.messages.find(
+        (message) => message.id === "user-message-2",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        origin: {
+          kind: "messaging",
+          messaging: {
+            platform: "slack",
+            surface: {
+              id: "message-thread-1",
+              kind: "thread",
+              title: "api-search circuit breaker timeout",
+              parentTitle: "signals-chat",
+              ancestorTitle: "PwrAgent",
+            },
+            actor: {
+              platformUserId: "U012345",
+              displayName: "Hunter",
+              username: "huntharo",
+            },
+          },
+        },
+      }),
+    );
   });
 
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -18,6 +18,8 @@ import type {
   AppServerThreadReviewEntry,
   AppServerThreadTurnMetadata,
   AppServerThreadImagePart,
+  MessagingChannelKind,
+  MessagingConversationKind,
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
@@ -2823,16 +2825,23 @@ function threadMessageOriginFromUnknown(
   ) {
     return undefined;
   }
+  const messaging = threadMessageMessagingOriginFromUnknown(record.messaging);
   const source = record.sourceThread;
   if (!source || typeof source !== "object" || Array.isArray(source)) {
-    return { kind: record.kind };
+    return {
+      kind: record.kind,
+      ...(messaging ? { messaging } : {}),
+    };
   }
   const sourceRecord = source as Record<string, unknown>;
   if (
     typeof sourceRecord.backend !== "string"
     || typeof sourceRecord.threadId !== "string"
   ) {
-    return { kind: record.kind };
+    return {
+      kind: record.kind,
+      ...(messaging ? { messaging } : {}),
+    };
   }
   return {
     kind: record.kind,
@@ -2843,7 +2852,103 @@ function threadMessageOriginFromUnknown(
         ? { title: sourceRecord.title }
         : {}),
     },
+    ...(messaging ? { messaging } : {}),
   };
+}
+
+function threadMessageMessagingOriginFromUnknown(
+  value: unknown,
+): AppServerThreadMessageOrigin["messaging"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const surface = record.surface;
+  const actor = record.actor;
+  if (
+    typeof record.platform !== "string"
+    || !isMessagingChannelKind(record.platform)
+    || !surface
+    || typeof surface !== "object"
+    || Array.isArray(surface)
+    || !actor
+    || typeof actor !== "object"
+    || Array.isArray(actor)
+  ) {
+    return undefined;
+  }
+  const surfaceRecord = surface as Record<string, unknown>;
+  const actorRecord = actor as Record<string, unknown>;
+  if (
+    typeof surfaceRecord.id !== "string"
+    || typeof surfaceRecord.kind !== "string"
+    || !isMessagingConversationKind(surfaceRecord.kind)
+    || typeof actorRecord.platformUserId !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    platform: record.platform,
+    surface: {
+      id: surfaceRecord.id,
+      kind: surfaceRecord.kind,
+      ...(typeof surfaceRecord.title === "string"
+        ? { title: surfaceRecord.title }
+        : {}),
+      ...(typeof surfaceRecord.parentTitle === "string"
+        ? { parentTitle: surfaceRecord.parentTitle }
+        : {}),
+      ...(typeof surfaceRecord.ancestorTitle === "string"
+        ? { ancestorTitle: surfaceRecord.ancestorTitle }
+        : {}),
+    },
+    actor: {
+      platformUserId: actorRecord.platformUserId,
+      ...(typeof actorRecord.displayName === "string"
+        ? { displayName: actorRecord.displayName }
+        : {}),
+      ...(typeof actorRecord.phoneNumber === "string"
+        ? { phoneNumber: actorRecord.phoneNumber }
+        : {}),
+      ...(typeof actorRecord.username === "string"
+        ? { username: actorRecord.username }
+        : {}),
+    },
+  };
+}
+
+function isMessagingChannelKind(value: string): value is MessagingChannelKind {
+  return [
+    "telegram",
+    "discord",
+    "slack",
+    "mattermost",
+    "feishu",
+    "googlechat",
+    "msteams",
+    "matrix",
+    "irc",
+    "imessage",
+    "signal",
+    "whatsapp",
+    "line",
+    "zalo",
+    "nextcloud-talk",
+    "synology-chat",
+    "twitch",
+    "nostr",
+    "qqbot",
+    "bluebubbles",
+    "tlon",
+    "voice-call",
+    "custom",
+  ].includes(value);
+}
+
+function isMessagingConversationKind(
+  value: string,
+): value is MessagingConversationKind {
+  return ["dm", "channel", "thread", "topic"].includes(value);
 }
 
 function assistantMessageEntryFromCompletedItem(params: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8653,6 +8653,46 @@ textarea,
   height: 20px;
 }
 
+.transcript-message__messaging-origin {
+  height: 20px;
+  border: 1px solid var(--accent-border);
+}
+
+.transcript-message__messaging-platform {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+
+.transcript-message__messaging-platform-fallback {
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.transcript-message__messaging-surface,
+.transcript-message__messaging-actor {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.transcript-message__messaging-surface {
+  min-width: 0;
+}
+
+.transcript-message__messaging-separator {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.transcript-message__messaging-actor {
+  flex: 0 1 auto;
+  color: var(--text-secondary);
+}
+
 .transcript-message__source {
   overflow: hidden;
   color: var(--text-muted);

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -3,6 +3,7 @@ import type {
   AppServerMcpElicitationResponse,
   AppServerNotification,
   AppServerThreadActivityEntry,
+  AppServerThreadMessageOrigin,
   LinkedDirectorySummary,
   ThreadExecutionMode,
   AppServerReviewDelivery,
@@ -527,6 +528,7 @@ export type MaterializedDirectoryLaunchpadThread = {
 };
 
 export type MaterializeDirectoryLaunchpadOptions = {
+  messageOrigin?: AppServerThreadMessageOrigin;
   onCodexEnvironmentSetupProgress?: (
     event: CodexEnvironmentSetupProgressEvent,
   ) => void;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1,4 +1,8 @@
 import type { AutomationRunOutputDecision } from "./automations";
+import type {
+  MessagingChannelKind,
+  MessagingConversationKind,
+} from "./messaging";
 import type { PrSummary } from "./navigation";
 import type { ThreadPricingSummary, ThreadUsageLineRecord } from "../token-usage-pricing";
 
@@ -337,6 +341,22 @@ export type AppServerThreadMessageOrigin = {
     backend: AppServerBackendKind;
     threadId: ThreadIdentifier;
     title?: string;
+  };
+  messaging?: {
+    platform: MessagingChannelKind;
+    surface: {
+      id: string;
+      kind: MessagingConversationKind;
+      title?: string;
+      parentTitle?: string;
+      ancestorTitle?: string;
+    };
+    actor: {
+      platformUserId: string;
+      displayName?: string;
+      phoneNumber?: string;
+      username?: string;
+    };
   };
 };
 


### PR DESCRIPTION
## Summary

- preserve the messaging platform, conversation breadcrumb, and actor identity when an inbound platform message starts or steers a turn
- render that provenance beside the `MESSAGING` label as a compact platform-branded chip
- carry provenance through live transcript hydration, queued turns, and newly materialized threads
- retain the existing generic `MESSAGING` label for historical messages that predate the richer metadata

## Why

Messaging-originated messages were previously persisted only as `{ kind: "messaging" }`. The inbound event already contained the platform, surface, and actor, but the desktop bridge discarded those fields before transcript provenance was stored. This made the transcript distinguish the transport without identifying where the message came from or who sent it.

## User impact

New inbound transcript messages now show the messaging platform icon, the surface breadcrumb, and the actor name in the same attribution area used for Agent-sent thread chips. When a display name is unavailable, the chip falls back through username, phone number, and platform user ID.

The chip is informational: messaging providers do not currently expose a provider-neutral deep-link target through the inbound contract.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts` — 435 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — zero errors (existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
