### PR TITLE
fix(messaging): repaint Slack command pickers

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7376,12 +7376,67 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: "command:new",
+        interactionId: "help-surface",
+        routingState: {
+          opaque: {
+            chatId: 777,
+            messageId: 42,
+          },
+        },
       }),
     );
 
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "project_picker",
+      delivery: {
+        fallback: "present_new",
+        mode: "update",
+      },
       fallbackText: expect.stringContaining("new PwrAgent thread"),
+      targetSurface: {
+        channel: "telegram",
+        id: "help-surface",
+        state: {
+          opaque: {
+            chatId: 777,
+            messageId: 42,
+          },
+        },
+      },
+    });
+  });
+
+  it("restores the help surface when a command-button browser is cancelled", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "command:new",
+        interactionId: "help-surface",
+        routingState: {
+          opaque: {
+            chatId: 777,
+            messageId: 42,
+          },
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:cancel",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent commands",
+      delivery: {
+        mode: "update",
+        replaceMarkup: true,
+      },
+      targetSurface: expect.objectContaining({
+        channel: "telegram",
+      }),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7376,11 +7376,25 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: "command:new",
-        interactionId: "help-surface",
+        interactionId: "callback-handle",
+        interactionState: {
+          opaque: {
+            callbackData: "tg:callback-handle",
+          },
+        },
         routingState: {
           opaque: {
             chatId: 777,
-            messageId: 42,
+          },
+        },
+        sourceSurface: {
+          channel: "telegram",
+          id: "42",
+          state: {
+            opaque: {
+              chatId: 777,
+              messageId: 42,
+            },
           },
         },
       }),
@@ -7395,7 +7409,7 @@ describe("MessagingController", () => {
       fallbackText: expect.stringContaining("new PwrAgent thread"),
       targetSurface: {
         channel: "telegram",
-        id: "help-surface",
+        id: "42",
         state: {
           opaque: {
             chatId: 777,
@@ -7412,11 +7426,15 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
         actionId: "command:new",
-        interactionId: "help-surface",
-        routingState: {
-          opaque: {
-            chatId: 777,
-            messageId: 42,
+        interactionId: "callback-handle",
+        sourceSurface: {
+          channel: "telegram",
+          id: "42",
+          state: {
+            opaque: {
+              chatId: 777,
+              messageId: 42,
+            },
           },
         },
       }),
@@ -7437,6 +7455,44 @@ describe("MessagingController", () => {
       targetSurface: expect.objectContaining({
         channel: "telegram",
       }),
+    });
+  });
+
+  it("does not mistake callback identity or routing state for an editable surface", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "command:new",
+        interactionId: "callback-handle",
+        interactionState: {
+          opaque: {
+            callbackData: "tg:callback-handle",
+          },
+        },
+        routingState: {
+          opaque: {
+            chatId: 777,
+          },
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "project_picker",
+      delivery: {
+        fallback: "present_new",
+        mode: "present",
+      },
+      targetSurface: {
+        channel: "telegram",
+        id: "event-callback",
+        state: {
+          opaque: {
+            chatId: 777,
+          },
+        },
+      },
     });
   });
 
@@ -16806,7 +16862,9 @@ function buildCallbackEvent(params: {
   actionId: string;
   channel?: MessagingInboundCallbackEvent["channel"];
   interactionId?: string;
+  interactionState?: MessagingInboundCallbackEvent["interaction"]["state"];
   routingState?: MessagingInboundCallbackEvent["routingState"];
+  sourceSurface?: MessagingInboundCallbackEvent["sourceSurface"];
   value?: MessagingInboundCallbackEvent["value"];
 }): MessagingInboundCallbackEvent {
   return {
@@ -16827,7 +16885,9 @@ function buildCallbackEvent(params: {
     interaction: {
       channel: "telegram",
       id: params.interactionId ?? params.actionId,
+      state: params.interactionState,
     },
+    sourceSurface: params.sourceSurface,
     actionId: params.actionId,
     value: params.value,
   };

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1523,7 +1523,12 @@ export class MessagingController {
     this.notifyBindingChanged("refresh-from-inbound");
   }
 
-  private async handleCommand(event: MessagingInboundCommandEvent): Promise<void> {
+  private async handleCommand(
+    event: MessagingInboundCommandEvent,
+    options?: {
+      targetSurface?: MessagingSurfaceRef;
+    },
+  ): Promise<void> {
     const verb = matchMessagingCommandVerb(event.command);
     if (verb === "status") {
       await this.presentStatus(event);
@@ -1538,24 +1543,38 @@ export class MessagingController {
       return;
     }
     if (verb === "resume") {
-      await this.presentResumeBrowser(event);
-      return;
-    }
-    if (verb === "agent") {
-      await this.presentAgentBrowser(event);
-      return;
-    }
-    if (verb === "new") {
-      await this.presentResumeBrowser({
-        ...event,
-        command: "resume",
-        args: ["--new", ...event.args],
-        rawText: ["/resume", "--new", ...event.args].join(" "),
+      await this.presentResumeBrowser(event, {
+        cancelDestination: options?.targetSurface ? "help" : undefined,
+        targetSurface: options?.targetSurface,
       });
       return;
     }
+    if (verb === "agent") {
+      await this.presentAgentBrowser(event, {
+        cancelDestination: options?.targetSurface ? "help" : undefined,
+        targetSurface: options?.targetSurface,
+      });
+      return;
+    }
+    if (verb === "new") {
+      await this.presentResumeBrowser(
+        {
+          ...event,
+          command: "resume",
+          args: ["--new", ...event.args],
+          rawText: ["/resume", "--new", ...event.args].join(" "),
+        },
+        {
+          cancelDestination: options?.targetSurface ? "help" : undefined,
+          targetSurface: options?.targetSurface,
+        },
+      );
+      return;
+    }
     if (verb === "help") {
-      await this.presentHelp(event);
+      await this.presentHelp(event, {
+        targetSurface: options?.targetSurface,
+      });
       return;
     }
     if (event.command.trim().replace(/^\/+/, "").toLowerCase() === "review") {
@@ -2848,13 +2867,18 @@ export class MessagingController {
   private async handleCallback(event: MessagingInboundCallbackEvent): Promise<void> {
     const command = readCommandAction(event);
     if (command) {
-      await this.handleCommand({
-        ...event,
-        kind: "command",
-        args: [],
-        command,
-        rawText: `/${command}`,
-      });
+      await this.handleCommand(
+        {
+          ...event,
+          kind: "command",
+          args: [],
+          command,
+          rawText: `/${command}`,
+        },
+        {
+          targetSurface: surfaceForCallback(event),
+        },
+      );
       return;
     }
 
@@ -4463,7 +4487,13 @@ export class MessagingController {
     });
   }
 
-  private async presentResumeBrowser(event: MessagingInboundCommandEvent): Promise<void> {
+  private async presentResumeBrowser(
+    event: MessagingInboundCommandEvent,
+    options?: {
+      cancelDestination?: MessagingBrowseSessionRecord["cancelDestination"];
+      targetSurface?: MessagingSurfaceRef;
+    },
+  ): Promise<void> {
     const parsed = parseResumeCommandArgs(event.args);
     if (parsed.error) {
       await this.deliver(
@@ -4505,6 +4535,7 @@ export class MessagingController {
       id: this.newIntentId("browse"),
       allowedActorIds: [event.actor.platformUserId],
       backend: selectedBackend?.kind,
+      cancelDestination: options?.cancelDestination,
       channel: event.channel,
       createdAt: this.now(),
       updatedAt: this.now(),
@@ -4527,11 +4558,18 @@ export class MessagingController {
             path: selectedDirectory.path,
           }
         : undefined,
+      surface: options?.targetSurface,
     };
     await this.renderResumeBrowser(session, navigation, event);
   }
 
-  private async presentAgentBrowser(event: MessagingInboundCommandEvent): Promise<void> {
+  private async presentAgentBrowser(
+    event: MessagingInboundCommandEvent,
+    options?: {
+      cancelDestination?: MessagingBrowseSessionRecord["cancelDestination"];
+      targetSurface?: MessagingSurfaceRef;
+    },
+  ): Promise<void> {
     const parsed = parseResumeCommandArgs(event.args);
     if (parsed.error) {
       await this.deliver(
@@ -4573,6 +4611,7 @@ export class MessagingController {
       id: this.newIntentId("browse"),
       allowedActorIds: [event.actor.platformUserId],
       backend: selectedBackend?.kind,
+      cancelDestination: options?.cancelDestination,
       channel: event.channel,
       createdAt: this.now(),
       updatedAt: this.now(),
@@ -4597,6 +4636,7 @@ export class MessagingController {
             path: selectedDirectory.path,
           }
         : undefined,
+      surface: options?.targetSurface,
     };
     await this.renderResumeBrowser(session, navigation, event);
   }
@@ -4744,6 +4784,12 @@ export class MessagingController {
     }
     if (actionId === "browse:cancel") {
       await this.retireBrowseSession(session);
+      if (session.cancelDestination === "help" && session.surface) {
+        await this.presentHelp(event, {
+          targetSurface: session.surface,
+        });
+        return;
+      }
       await this.deliver(
         buildConfirmationIntent({
           id: this.newIntentId("browse-cancelled"),
@@ -12991,6 +13037,20 @@ function readCommandAction(event: MessagingInboundCallbackEvent): string | undef
   const actionId = event.actionId ?? event.interaction.id;
   const match = /^command:([a-z0-9_-]+)$/i.exec(actionId);
   return match?.[1]?.toLowerCase();
+}
+
+function surfaceForCallback(
+  event: MessagingInboundCallbackEvent,
+): MessagingSurfaceRef {
+  return {
+    channel: event.interaction.channel,
+    id: event.interaction.id,
+    ...(event.interaction.state
+      ? { state: event.interaction.state }
+      : event.routingState
+        ? { state: event.routingState }
+        : {}),
+  };
 }
 
 /**

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1991,6 +1991,7 @@ export class MessagingController {
               channel: event.channel.channel,
               id: mapped.action.id,
             },
+            sourceSurface: pendingIntent.surface,
             actionId: mapped.action.id,
             value: mapped.action.value,
           });
@@ -2022,6 +2023,7 @@ export class MessagingController {
               channel: event.channel.channel,
               id: mapped.action.id,
             },
+            sourceSurface: pendingIntent.surface,
             actionId: mapped.action.id,
             value: mapped.action.value,
           });
@@ -2876,7 +2878,7 @@ export class MessagingController {
           rawText: `/${command}`,
         },
         {
-          targetSurface: surfaceForCallback(event),
+          targetSurface: event.sourceSurface,
         },
       );
       return;
@@ -13037,20 +13039,6 @@ function readCommandAction(event: MessagingInboundCallbackEvent): string | undef
   const actionId = event.actionId ?? event.interaction.id;
   const match = /^command:([a-z0-9_-]+)$/i.exec(actionId);
   return match?.[1]?.toLowerCase();
-}
-
-function surfaceForCallback(
-  event: MessagingInboundCallbackEvent,
-): MessagingSurfaceRef {
-  return {
-    channel: event.interaction.channel,
-    id: event.interaction.id,
-    ...(event.interaction.state
-      ? { state: event.interaction.state }
-      : event.routingState
-        ? { state: event.routingState }
-        : {}),
-  };
 }
 
 /**

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -78,6 +78,10 @@ branching on platform names.
 Interactive callbacks should use compact opaque platform handles backed by
 long-lived sqlite records:
 
+- When the callback payload identifies the message containing the clicked
+  control, adapters should set `MessagingInboundCallbackEvent.sourceSurface`
+  to that editable message. Keep it separate from `interaction`, which
+  identifies the callback handle or interaction rather than the message.
 - Telegram `callback_data` is byte-limited, so never embed semantic action data.
 - Discord component `custom_id` should likewise carry only a compact handle.
 - Slack button `value` and Mattermost `integration.context` should carry or wrap

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1196,6 +1196,12 @@ export type MessagingInboundCommandEvent = MessagingInboundBaseEvent & {
 export type MessagingInboundCallbackEvent = MessagingInboundBaseEvent & {
   kind: "callback";
   interaction: MessagingInteractionRef;
+  /**
+   * The message surface that contained the clicked control, when the provider
+   * supplies an editable message reference. This is distinct from
+   * `interaction`, whose id/state identify the callback itself.
+   */
+  sourceSurface?: MessagingSurfaceRef;
   actionId?: string;
   value?: MessagingJsonValue;
 };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1486,6 +1486,7 @@ export type MessagingBrowseSessionRecord = {
   allowedActorIds: string[];
   backend?: AppServerBackendKind;
   bindingId?: string;
+  cancelDestination?: "help";
   channel: MessagingChannelRef;
   createdAt: number;
   expiresAt: number;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -26,6 +26,7 @@ const unknownChannelError = new Error("DiscordAPIError[10003]: Unknown Channel")
 const TEST_CHANNEL_ID = "1480556454498009352";
 const TEST_GUILD_ID = "1480556454498009353";
 const TEST_MESSAGE_ID = "1480556454498009354";
+const TEST_SURFACE_MESSAGE_ID = "1480556454498009357";
 const TEST_USER_ID = "1480556454498009355";
 const TEST_OTHER_USER_ID = "1480556454498009356";
 const TEST_AUTHORIZED_GUILD_IDS = [{ id: TEST_GUILD_ID, displayName: "" }];
@@ -509,6 +510,9 @@ describe("discord adapter", () => {
         },
         guild_id: TEST_GUILD_ID,
         id: TEST_MESSAGE_ID,
+        message: {
+          id: TEST_SURFACE_MESSAGE_ID,
+        },
         token: "token_ABC.123",
         type: 3,
         user: {
@@ -525,6 +529,17 @@ describe("discord adapter", () => {
       expect.objectContaining({
         actionId: "permissions",
         kind: "callback",
+        sourceSurface: {
+          channel: "discord",
+          id: TEST_SURFACE_MESSAGE_ID,
+          state: {
+            opaque: {
+              channelId: TEST_CHANNEL_ID,
+              guildId: TEST_GUILD_ID,
+              messageId: TEST_SURFACE_MESSAGE_ID,
+            },
+          },
+        },
         value: { mode: "review" },
       }),
     ]);

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -985,6 +985,14 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           now: this.now(),
         })
       : undefined;
+    const routingState = this.routingStateFromDiscord(
+      interaction.channel_id,
+      interaction.guild_id,
+      {
+        channelType: interaction.channel_type,
+        isThread: interaction.is_thread,
+      },
+    );
     await listener({
       id: `discord:interaction:${interaction.id}`,
       kind: "callback",
@@ -1000,17 +1008,25 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           },
         },
       },
+      ...(interaction.message?.id
+        ? {
+            sourceSurface: {
+              channel: this.channel,
+              id: interaction.message.id,
+              state: {
+                opaque: {
+                  channelId: interaction.channel_id,
+                  guildId: interaction.guild_id ?? null,
+                  messageId: interaction.message.id,
+                },
+              },
+            },
+          }
+        : {}),
       actionId: persistedBinding?.actionId,
       value: persistedBinding?.value,
       receivedAt: this.now(),
-      routingState: this.routingStateFromDiscord(
-        interaction.channel_id,
-        interaction.guild_id,
-        {
-          channelType: interaction.channel_type,
-          isThread: interaction.is_thread,
-        },
-      ),
+      routingState,
     });
   }
 

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -1407,6 +1407,18 @@ describe("FeishuAdapter", () => {
       expect.objectContaining({
         kind: "callback",
         actionId: "approve",
+        sourceSurface: {
+          channel: "feishu",
+          id: "om_sent",
+          state: {
+            opaque: {
+              messageId: "om_sent",
+              receiveId: "oc_chat",
+              receiveIdType: "chat_id",
+              tenantKey: "tenant_1",
+            },
+          },
+        },
         channel: {
           channel: "feishu",
           conversation: { id: "oc_chat", kind: "channel", parentId: "tenant_1" },

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -1153,6 +1153,27 @@ export class FeishuAdapter implements FeishuProviderAdapter {
         id: signed.handle,
         ...(record.surface?.state ? { state: record.surface.state } : {}),
       },
+      ...(messageId
+        ? {
+            sourceSurface: {
+              channel: this.channel,
+              id: messageId,
+              state: {
+                opaque: {
+                  messageId,
+                  receiveId: record.channel.conversation.id,
+                  receiveIdType:
+                    record.channel.conversation.kind === "dm"
+                      ? "open_id"
+                      : "chat_id",
+                  ...(record.channel.conversation.parentId
+                    ? { tenantKey: record.channel.conversation.parentId }
+                    : {}),
+                },
+              },
+            },
+          }
+        : {}),
       actionId: record.actionId,
       ...(record.value !== undefined ? { value: record.value } : {}),
       receivedAt: this.now(),

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -1237,6 +1237,15 @@ export class MattermostAdapter implements MattermostProviderAdapter {
           },
         },
       },
+      ...(body.post_id
+        ? {
+            sourceSurface: surfaceRefForPost(
+              body.post_id,
+              body.channel_id,
+              contextRootId,
+            ),
+          }
+        : {}),
     });
 
     // Channel-neutral principle: the producer (controller) is the

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -2152,6 +2152,16 @@ describe("SlackAdapter", () => {
       expect.objectContaining({
         kind: "callback",
         actionId: "resume",
+        sourceSurface: {
+          channel: "slack",
+          id: "1712023032.123456",
+          state: {
+            opaque: expect.objectContaining({
+              channelId: "D012ABCDEF0",
+              ts: "1712023032.123456",
+            }),
+          },
+        },
         channel: expect.objectContaining({
           conversation: expect.objectContaining({
             id: "D012ABCDEF0",

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -641,6 +641,92 @@ describe("SlackAdapter", () => {
     });
   });
 
+  it("updates a project picker in place without repeating its prompt", async () => {
+    const posted: unknown[] = [];
+    const updated: Array<{
+      blocks?: Array<{ text?: { text?: string } }>;
+      channel: string;
+      text?: string;
+      ts: string;
+    }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ posted, updated }),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const prompt =
+      "Choose a project for the new PwrAgent thread. Page 1/2.\n"
+      + "Tap a project to start a fresh thread there.";
+    const fallbackText =
+      `${prompt}\n1. pwragent (11)\nReply with a number, or reply next or cancel.`;
+
+    await expect(
+      adapter.deliver({
+        id: "project-picker-1",
+        kind: "project_picker",
+        browseSessionId: "browse-1",
+        createdAt: 1,
+        delivery: {
+          mode: "update",
+          fallback: "present_new",
+        },
+        fallbackText,
+        navigation: {
+          backend: "all",
+          fetchedAt: 1,
+          unchanged: false,
+        },
+        page: {
+          actions: [
+            {
+              id: "browse:select-project",
+              label: "1. pwragent (11)",
+              value: { directoryKey: "directory:pwragent", label: "pwragent" },
+            },
+          ],
+          items: [],
+          pageIndex: 0,
+          pageSize: 8,
+          totalItems: 11,
+        },
+        prompt,
+        targetSurface: {
+          channel: "slack",
+          id: "1712023032.123456",
+          state: {
+            opaque: {
+              channelId: "C012ABCDEF0",
+              ts: "1712023032.123456",
+            },
+          },
+        },
+      } satisfies MessagingSurfaceIntent),
+    ).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "updated",
+    });
+
+    expect(posted).toEqual([]);
+    expect(updated).toHaveLength(1);
+    expect(updated[0]).toMatchObject({
+      channel: "C012ABCDEF0",
+      text: fallbackText,
+      ts: "1712023032.123456",
+      blocks: [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: prompt,
+          },
+        },
+        expect.objectContaining({ type: "actions" }),
+      ],
+    });
+  });
+
   it("maps source-relative thread broadcast delivery to Slack post fields", async () => {
     const spies: { posted: unknown[] } = { posted: [] };
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
@@ -84,4 +84,27 @@ describe("Slack formatting", () => {
     };
     expect(textForSlackIntent(intent)).toBe("Working");
   });
+
+  it("keeps picker fallback copy out of the visible Block Kit section", () => {
+    const intent: MessagingSurfaceIntent = {
+      id: "picker-1",
+      kind: "project_picker",
+      createdAt: 1,
+      fallbackText: "Choose a project.\n1. PwrAgent\nReply with a number.",
+      navigation: {
+        backend: "all",
+        fetchedAt: 1,
+        unchanged: false,
+      },
+      page: {
+        actions: [],
+        items: [],
+        pageIndex: 0,
+        pageSize: 8,
+      },
+      prompt: "Choose a project.",
+    };
+
+    expect(textForSlackIntent(intent)).toBe("Choose a project.");
+  });
 });

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -567,9 +567,23 @@ export class SlackAdapter implements SlackProviderAdapter {
       intent,
       text: rawText,
     });
+    const pickerFallbackText =
+      (
+        intent.kind === "thread_picker"
+        || intent.kind === "project_picker"
+        || intent.kind === "single_select"
+        || intent.kind === "multi_select"
+      )
+        ? intent.fallbackText
+        : undefined;
     const body: SlackPostBody = {
       channel: target.channelId,
-      text: text || intent.fallbackText || "PwrAgent",
+      text:
+        (pickerFallbackText
+          ? clampSlackMessage(markdownToSlackMrkdwn(pickerFallbackText))
+          : text)
+        || intent.fallbackText
+        || "PwrAgent",
       ...(blocks.length > 0 ? { blocks } : {}),
       ...(target.threadTs ? { thread_ts: target.threadTs } : {}),
       ...(target.threadTs && intent.delivery?.broadcastThreadReply

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -983,6 +983,11 @@ export class SlackAdapter implements SlackProviderAdapter {
         id: `${ids.channelId}:${ids.ts}:${action.action_id ?? "action"}`,
         state: routingState,
       },
+      sourceSurface: {
+        channel: this.channel,
+        id: ids.ts,
+        state: routingState,
+      },
       actionId: record.actionId,
       ...(record.value !== undefined ? { value: record.value } : {}),
     });

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -198,14 +198,10 @@ export function textForSlackIntent(intent: MessagingSurfaceIntent): string {
         .join("\n");
     case "thread_picker":
     case "project_picker":
-      return [intent.prompt, intent.fallbackText]
-        .filter((value): value is string => Boolean(value))
-        .join("\n\n");
+      return intent.prompt;
     case "single_select":
     case "multi_select":
-      return [intent.prompt, intent.fallbackText]
-        .filter((value): value is string => Boolean(value))
-        .join("\n\n");
+      return intent.prompt;
     case "questionnaire":
       return formatMessagingQuestionnaireText(intent);
     case "review":

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -425,6 +425,17 @@ describe("TelegramAdapter callback persistence", () => {
       expect.objectContaining({
         actionId: undefined,
         kind: "callback",
+        sourceSurface: {
+          channel: "telegram",
+          id: "200",
+          state: {
+            opaque: {
+              chatId: 42,
+              messageId: 200,
+              messageThreadId: null,
+            },
+          },
+        },
         value: undefined,
       }),
     ]);

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1633,6 +1633,8 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     this.options.logger?.debug(
       `telegram inbound callback update=${updateId} callback=${callbackQuery.id} chat=${message.chat.id} actor=${callbackQuery.from.id} action=${persistedBinding?.actionId ?? "unresolved"}`,
     );
+    const routingState = this.routingStateFromMessage(message);
+    const messageThreadId = this.messageThreadIdFromMessage(message);
     await listener({
       id: `telegram:update:${updateId}:callback:${callbackQuery.id}`,
       kind: "callback",
@@ -1647,10 +1649,21 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           },
         },
       },
+      sourceSurface: {
+        channel: this.channel,
+        id: String(message.message_id),
+        state: {
+          opaque: {
+            chatId: message.chat.id,
+            messageId: message.message_id,
+            messageThreadId: messageThreadId ?? null,
+          },
+        },
+      },
       actionId: persistedBinding?.actionId,
       value: persistedBinding?.value,
       receivedAt: this.now(),
-      routingState: this.routingStateFromMessage(message),
+      routingState,
     });
   }
 


### PR DESCRIPTION
## Summary

- update the original Slack command surface when New, Resume, or Agent is selected
- preserve provider-supplied callback message surfaces across Telegram, Discord, Slack, Mattermost, and Feishu
- keep picker pagination and new-thread configuration on the same message when the provider supports edits
- restore the command menu when a picker launched from it is cancelled
- render Slack project-picker prompts once while retaining the complete notification/accessibility fallback

## Root cause

The controller originally discarded the callback's originating message surface when converting a command button action into a command. The first fix reconstructed that surface from generic interaction identity, but callback handles and interactions are not message identifiers on providers such as Telegram and Discord.

Callbacks now carry an explicit optional `sourceSurface` populated by adapters from their native callback message payload. The controller uses only that real editable surface for repainting. Providers without message edits can omit it and retain normal fallback posting.

Separately, Slack rendered both the picker prompt and a fallback string that already contained the prompt, duplicating the visible copy.

## User impact

Slack command flows now behave as a single control surface instead of stacking stale interactive messages in the thread. Telegram, Discord, Mattermost, and Feishu receive the same safe in-place behavior where supported, without confusing callback identity with message identity. The Slack project picker no longer repeats "Choose a project..." text.

## Validation

- 443 focused controller and provider tests passed across Telegram, Discord, Slack, Mattermost, and Feishu
- `pnpm typecheck`
- targeted ESLint (no errors; existing warning baseline only)
- `pnpm lint:boundaries`
