### PR TITLE
fix(messaging): surface MCP prompts when updates are hidden

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -96,6 +96,50 @@ describe("buildApprovalIntent", () => {
     );
   });
 
+  it.each([
+    {
+      label: "URL mode without an elicitation id",
+      params: {
+        serverName: "github",
+        mode: "url" as const,
+        _meta: null,
+        message: "Reconnect GitHub to restore access.",
+        url: "https://example.test/oauth/start?state=opaque",
+      },
+    },
+    {
+      label: "form mode without a requested schema",
+      params: {
+        serverName: "example",
+        mode: "form" as const,
+        _meta: null,
+        message: "Provide deployment details.",
+      },
+    },
+  ])("does not offer Allow for malformed MCP requests: $label", ({ params }) => {
+    const intent = buildApprovalIntent({
+      id: "mcp-malformed-1",
+      createdAt: 1000,
+      request: {
+        method: "mcpServer/elicitation/request",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "request-mcp-malformed-1",
+          ...params,
+        },
+      },
+    });
+
+    expect(intent.decisions.map((decision) => decision.decision)).toEqual([
+      "decline",
+      "cancel",
+    ]);
+    expect(intent.body).toContain(
+      "must be completed in PwrAgent desktop",
+    );
+  });
+
   it("renders command approvals with prompt, command code block, and conservative choices", () => {
     const intent = buildApprovalIntent({
       id: "approval-1",

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -2,6 +2,100 @@ import { describe, expect, it } from "vitest";
 import { buildApprovalIntent } from "../messaging/core/messaging-approval-renderer";
 
 describe("buildApprovalIntent", () => {
+  it("renders URL-mode MCP login requests with MCP-shaped responses", () => {
+    const intent = buildApprovalIntent({
+      id: "mcp-login-1",
+      createdAt: 1000,
+      request: {
+        method: "mcpServer/elicitation/request",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "request-mcp-1",
+          serverName: "github",
+          mode: "url",
+          _meta: null,
+          message: "Reconnect GitHub to restore access.",
+          url: "https://example.test/oauth/start?state=opaque",
+          elicitationId: "elicitation-1",
+        },
+      },
+    });
+
+    expect(intent).toMatchObject({
+      kind: "approval",
+      title: "MCP Login",
+      decisions: [
+        {
+          id: "approval:mcp:accept",
+          label: "Allow",
+          decision: "accept",
+          response: {
+            action: "accept",
+            content: {},
+            _meta: null,
+          },
+        },
+        {
+          id: "approval:mcp:decline",
+          decision: "decline",
+          response: {
+            action: "decline",
+            content: null,
+            _meta: null,
+          },
+        },
+        {
+          id: "approval:mcp:cancel",
+          decision: "cancel",
+          response: {
+            action: "cancel",
+            content: null,
+            _meta: null,
+          },
+        },
+      ],
+    });
+    expect(intent.body).toContain("Reconnect GitHub to restore access.");
+    expect(intent.body).toContain(
+      "Open login: https://example.test/oauth/start?state=opaque",
+    );
+  });
+
+  it("keeps required MCP forms visible without offering an invalid empty approval", () => {
+    const intent = buildApprovalIntent({
+      id: "mcp-form-1",
+      createdAt: 1000,
+      request: {
+        method: "mcpServer/elicitation/request",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "request-mcp-form-1",
+          serverName: "example",
+          mode: "form",
+          _meta: null,
+          message: "Provide the deployment region.",
+          requestedSchema: {
+            type: "object",
+            properties: {
+              region: { type: "string" },
+            },
+            required: ["region"],
+          },
+        },
+      },
+    });
+
+    expect(intent.decisions.map((decision) => decision.decision)).toEqual([
+      "decline",
+      "cancel",
+    ]);
+    expect(intent.body).toContain(
+      "must be completed in PwrAgent desktop",
+    );
+  });
+
   it("renders command approvals with prompt, command code block, and conservative choices", () => {
     const intent = buildApprovalIntent({
       id: "approval-1",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11106,6 +11106,78 @@ describe("MessagingController", () => {
     });
   });
 
+  it("presents and submits MCP login requests even when Working Updates is None", async () => {
+    const harness = await createHarness({ toolUpdateDefaultMode: "show_none" });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "mcpServer/elicitation/request",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "mcp-login-1",
+        serverName: "github",
+        mode: "url",
+        _meta: null,
+        message: "Reconnect GitHub to restore access.",
+        url: "https://example.test/oauth/start?state=opaque",
+        elicitationId: "elicitation-1",
+      },
+    });
+
+    expect(harness.delivered.find((intent) => intent.kind === "approval"))
+      .toMatchObject({
+        kind: "approval",
+        title: "MCP Login",
+        decisions: expect.arrayContaining([
+          expect.objectContaining({
+            id: "approval:mcp:accept",
+            label: "Allow",
+          }),
+        ]),
+      });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "approval:mcp:accept" }),
+    );
+
+    expect(harness.submitServerRequest).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      requestId: "mcp-login-1",
+      response: {
+        action: "accept",
+        content: {},
+        _meta: null,
+      },
+    });
+  });
+
+  it("presents command approvals even when Working Updates is None", async () => {
+    const harness = await createHarness({ toolUpdateDefaultMode: "show_none" });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendPendingRequest("codex", {
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        requestId: "approval-none-1",
+        prompt: "Run tests?",
+        command: "pnpm test",
+      },
+    });
+
+    expect(harness.delivered.find((intent) => intent.kind === "approval"))
+      .toMatchObject({
+        kind: "approval",
+        title: "Command Approval",
+      });
+  });
+
   it("keeps Plan questionnaires active for the durable callback lifetime", async () => {
     let now = 1000;
     const harness = await createHarness({ now: () => now });

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -752,6 +752,51 @@ describe("DesktopMessagingRuntime", () => {
     });
   });
 
+  it("routes MCP login requests to bound channel adapters", async () => {
+    const { runtime, adapter, emitBackendEvent } = await createRuntimeHarness();
+
+    await runtime.start();
+    await adapter.listener?.(
+      buildCallbackEvent("bind:codex:thread-1", {
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    );
+    adapter.delivered.length = 0;
+
+    await emitBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "mcpServer/elicitation/request",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          requestId: "mcp-login-1",
+          serverName: "github",
+          mode: "url",
+          _meta: null,
+          message: "Reconnect GitHub to restore access.",
+          url: "https://example.test/oauth/start?state=opaque",
+          elicitationId: "elicitation-1",
+        },
+      },
+    });
+
+    expect(adapter.delivered.find((intent) => intent.kind === "approval"))
+      .toMatchObject({
+        kind: "approval",
+        title: "MCP Login",
+        body: expect.stringContaining("https://example.test/oauth/start?state=opaque"),
+        requestContext: {
+          backend: "codex",
+          method: "mcpServer/elicitation/request",
+          requestId: "mcp-login-1",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      });
+  });
+
   it("logs rejected inbound actor ids before returning the authorization error", async () => {
     const { runtime, adapter } = await createRuntimeHarness();
 

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -142,11 +142,13 @@ function mcpElicitationContext(
   if (!isMcpElicitationRequest(request)) {
     return undefined;
   }
-  if (request.params.mode === "url" && request.params.url) {
-    return `Open login: ${request.params.url}`;
-  }
   if (!mcpElicitationCanAcceptWithoutFormInput(request)) {
-    return "This request includes fields that must be completed in PwrAgent desktop. You can still decline or cancel it here.";
+    return request.params.mode === "url"
+      ? "This MCP login request is incomplete and must be completed in PwrAgent desktop. You can still decline or cancel it here."
+      : "This request includes fields that must be completed in PwrAgent desktop. You can still decline or cancel it here.";
+  }
+  if (request.params.mode === "url") {
+    return `Open login: ${request.params.url}`;
   }
   return request.params.serverName
     ? `MCP server: ${request.params.serverName}`
@@ -157,9 +159,26 @@ function mcpElicitationCanAcceptWithoutFormInput(
   request: AppServerMcpElicitationRequestNotification,
 ): boolean {
   if (request.params.mode === "url") {
-    return Boolean(request.params.url);
+    return (
+      hasNonEmptyString(request.params.url)
+      && hasNonEmptyString(request.params.elicitationId)
+    );
   }
-  return (request.params.requestedSchema?.required?.length ?? 0) === 0;
+  const schema = request.params.requestedSchema;
+  if (
+    !schema
+    || typeof schema !== "object"
+    || Array.isArray(schema)
+    || schema.type !== "object"
+  ) {
+    return false;
+  }
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  return required.length === 0;
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function messagingDecisionFromPendingAction(

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -1,6 +1,7 @@
 import {
   buildPendingRequestActions,
   buildPendingRequestApprovalContext,
+  type AppServerMcpElicitationRequestNotification,
   type AppServerPendingRequestNotification,
   type PendingRequestAction,
 } from "@pwragent/shared";
@@ -20,12 +21,16 @@ export function buildApprovalIntent(params: {
   id: string;
   request: AppServerPendingRequestNotification;
 }): MessagingApprovalIntent {
-  const prompt = stringField(params.request.params.prompt) ?? "Approve this action?";
+  const prompt =
+    stringField(params.request.params.prompt)
+    ?? stringField(params.request.params.message)
+    ?? "Approve this action?";
   const command = extractCommand(params.request.params);
   const context = buildPendingRequestApprovalContext(params.request, {
     directoryPaths: params.directoryPaths,
   });
   const fileContext = approvalContextMarkdown(context);
+  const mcpContext = mcpElicitationContext(params.request);
   const decisions = applyActionCapabilityLimits(
     buildDecisions(params.request),
     params.capabilityProfile,
@@ -44,6 +49,7 @@ export function buildApprovalIntent(params: {
         ? ["Command:", "```shell", stripDisplayShellWrapper(command), "```"].join("\n")
         : undefined,
       fileContext ? ["Context:", fileContext].join("\n") : undefined,
+      mcpContext,
       replyInstruction.body,
     ]
       .filter((part): part is string => Boolean(part))
@@ -54,6 +60,9 @@ export function buildApprovalIntent(params: {
 }
 
 function titleForRequest(request: AppServerPendingRequestNotification): string {
+  if (isMcpElicitationRequest(request)) {
+    return request.params.mode === "url" ? "MCP Login" : "MCP Approval";
+  }
   if (request.method.toLowerCase().includes("command")) {
     return "Command Approval";
   }
@@ -66,6 +75,51 @@ function titleForRequest(request: AppServerPendingRequestNotification): string {
 function buildDecisions(
   request: AppServerPendingRequestNotification,
 ): MessagingApprovalIntent["decisions"] {
+  if (isMcpElicitationRequest(request)) {
+    const canAccept = mcpElicitationCanAcceptWithoutFormInput(request);
+    return [
+      ...(canAccept
+        ? [
+            {
+              id: "approval:mcp:accept",
+              label: "Allow",
+              decision: "accept" as const,
+              style: "primary" as const,
+              fallbackText: "yes",
+              response: {
+                action: "accept",
+                content: {},
+                _meta: null,
+              },
+            },
+          ]
+        : []),
+      {
+        id: "approval:mcp:decline",
+        label: "Decline",
+        decision: "decline" as const,
+        style: "danger" as const,
+        fallbackText: "no",
+        response: {
+          action: "decline",
+          content: null,
+          _meta: null,
+        },
+      },
+      {
+        id: "approval:mcp:cancel",
+        label: "Cancel Turn",
+        decision: "cancel" as const,
+        style: "secondary" as const,
+        fallbackText: "cancel",
+        response: {
+          action: "cancel",
+          content: null,
+          _meta: null,
+        },
+      },
+    ];
+  }
   return buildPendingRequestActions(request).map((action) => ({
     id: action.id,
     label: action.label,
@@ -74,6 +128,38 @@ function buildDecisions(
     fallbackText: action.fallbackText,
     response: action.response,
   }));
+}
+
+function isMcpElicitationRequest(
+  request: AppServerPendingRequestNotification,
+): request is AppServerMcpElicitationRequestNotification {
+  return request.method === "mcpServer/elicitation/request";
+}
+
+function mcpElicitationContext(
+  request: AppServerPendingRequestNotification,
+): string | undefined {
+  if (!isMcpElicitationRequest(request)) {
+    return undefined;
+  }
+  if (request.params.mode === "url" && request.params.url) {
+    return `Open login: ${request.params.url}`;
+  }
+  if (!mcpElicitationCanAcceptWithoutFormInput(request)) {
+    return "This request includes fields that must be completed in PwrAgent desktop. You can still decline or cancel it here.";
+  }
+  return request.params.serverName
+    ? `MCP server: ${request.params.serverName}`
+    : undefined;
+}
+
+function mcpElicitationCanAcceptWithoutFormInput(
+  request: AppServerMcpElicitationRequestNotification,
+): boolean {
+  if (request.params.mode === "url") {
+    return Boolean(request.params.url);
+  }
+  return (request.params.requestedSchema?.required?.length ?? 0) === 0;
 }
 
 function messagingDecisionFromPendingAction(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -11233,7 +11233,7 @@ export class MessagingController {
       });
     }
 
-    if (request.method.toLowerCase().includes("requestapproval")) {
+    if (isMessagingInteractivePendingRequest(request)) {
       return buildApprovalIntent({
         id: this.newIntentId("approval"),
         capabilityProfile: this.capabilityProfile,
@@ -12241,6 +12241,18 @@ export class MessagingController {
   private newIntentId(prefix: string): string {
     return `${prefix}:${randomUUID()}`;
   }
+}
+
+export function isMessagingInteractivePendingRequest(
+  notification: AgentEvent["notification"],
+): notification is AppServerPendingRequestNotification {
+  return (
+    notification.method === "item/tool/requestUserInput"
+    || notification.method === "mcpServer/elicitation/request"
+    || notification.method === "applyPatchApproval"
+    || notification.method === "execCommandApproval"
+    || notification.method.toLowerCase().includes("requestapproval")
+  );
 }
 
 function readCommandAction(event: MessagingInboundCallbackEvent): string | undefined {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1,5 +1,6 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import {
+  isMessagingInteractivePendingRequest,
   MessagingController,
   type MessagingControllerDeliveryBudgetEvent,
 } from "./core/messaging-controller";
@@ -13,7 +14,6 @@ import type {
 } from "./core/messaging-adapter";
 import type {
   AgentEvent,
-  AppServerPendingRequestNotification,
   GenerateMessagingPairingTokenRequest,
   GenerateMessagingPairingTokenResponse,
   InboundPreviewMessage,
@@ -1304,7 +1304,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       await Promise.all(
         this.controllers.map(async (controller) => {
           try {
-            if (isMessagingPendingRequest(event.notification)) {
+            if (isMessagingInteractivePendingRequest(event.notification)) {
               await controller.handleBackendPendingRequest(
                 event.backend,
                 event.notification,
@@ -2506,14 +2506,4 @@ function formatDurationForStatus(durationMs: number): string {
   }
   const minutes = Math.ceil(seconds / 60);
   return `${minutes}m`;
-}
-
-function isMessagingPendingRequest(
-  notification: AgentEvent["notification"],
-): notification is AppServerPendingRequestNotification {
-  if (notification.method === "item/tool/requestUserInput") {
-    return true;
-  }
-
-  return notification.method.toLowerCase().includes("requestapproval");
 }

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1031,7 +1031,7 @@ export type MessagingApprovalIntent = MessagingBaseSurfaceIntent & {
   decisions: Array<
     MessagingSurfaceAction & {
       decision: MessagingApprovalDecision;
-      response?: { decision: unknown };
+      response?: Record<string, unknown>;
     }
   >;
 };


### PR DESCRIPTION
## Summary

- route MCP elicitations through the durable interactive messaging path
- render URL-mode MCP login prompts with the authorization URL and Allow, Decline, and Cancel actions
- keep required-field MCP forms visible while directing field entry to the desktop UI
- centralize interactive-request classification across approvals, questionnaires, MCP requests, and legacy approval methods
- add regression coverage for Working Updates set to None

## Root cause

`mcpServer/elicitation/request` was not included in messaging's pending interactive-request classifier. The desktop renderer correctly showed the MCP login request, but messaging treated the event like an ordinary backend update and never presented it to the bound conversation. Working Updates set to None exposed the gap, but the prompt was not intentionally subject to the working-update filter.

## Impact

Response-required prompts now bypass working-update verbosity as intended. Operators can complete URL-based MCP authentication from the bound messaging conversation, and MCP forms that require structured field entry remain visible with safe remote decline/cancel controls.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts apps/desktop/src/main/__tests__/messaging-runtime.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts` (336 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
