### PR TITLE
fix(messaging): authorize Slack file shares

### DIFF
--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -881,6 +881,81 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("uses the Socket Mode envelope team ID to authorize file shares", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedConversationIds: [{ id: "C012ABCDEF0", displayName: "dev" }],
+        channelAuthorizationMode: "approved_only",
+        teamAuthorizationMode: "approved_only",
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      body: {
+        type: "event_callback",
+        team_id: "T012ABCDEF0",
+        event: {
+          type: "message",
+          subtype: "file_share",
+          channel: "C012ABCDEF0",
+          channel_type: "channel",
+          thread_ts: "1712023031.123456",
+          ts: "1712023032.123456",
+          user: "U012ABCDEF0",
+          text: "Please inspect this screenshot",
+          files: [{
+            id: "F012ABCDEF0",
+            mimetype: "image/png",
+            name: "screenshot.png",
+          }],
+        },
+      },
+    });
+
+    expect(rejected).toEqual([]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "media",
+        text: "Please inspect this screenshot",
+        attachments: [
+          expect.objectContaining({
+            id: "F012ABCDEF0",
+            kind: "image",
+            name: "screenshot.png",
+          }),
+        ],
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "C012ABCDEF0",
+            kind: "thread",
+            parentId: "1712023031.123456",
+          }),
+        }),
+        routingState: expect.objectContaining({
+          opaque: expect.objectContaining({
+            channelId: "C012ABCDEF0",
+            teamId: "T012ABCDEF0",
+          }),
+        }),
+      }),
+    ]);
+  });
+
   it("routes authorized non-self bot message events for automation triggers", async () => {
     const socket = fakeSocket();
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -229,6 +229,11 @@ type SlackSocketEnvelope = {
   event?: unknown;
 };
 
+type SlackEventsApiBody = {
+  event?: unknown;
+  team_id?: unknown;
+};
+
 type SlackMessageEvent = {
   bot_id?: string;
   channel?: string;
@@ -742,13 +747,14 @@ export class SlackAdapter implements SlackProviderAdapter {
   private readonly handleSlackEvent = async (payload: unknown): Promise<void> => {
     const envelope = payload as SlackSocketEnvelope;
     await envelope.ack?.();
-    const event = (envelope.event ?? (envelope.body as { event?: unknown })?.event) as
+    const body = envelope.body as SlackEventsApiBody | undefined;
+    const event = (envelope.event ?? body?.event) as
       | SlackMessageEvent
       | undefined;
     if (!event || (event.type !== "message" && event.type !== "app_mention")) {
       return;
     }
-    await this.handleMessageEvent(event);
+    await this.handleMessageEvent(event, body?.team_id ?? event.team);
   };
 
   private readonly handleInteractive = async (payload: unknown): Promise<void> => {
@@ -763,7 +769,10 @@ export class SlackAdapter implements SlackProviderAdapter {
     await this.handleSlashPayload(envelope.body as SlackSlashCommandPayload);
   };
 
-  private async handleMessageEvent(event: SlackMessageEvent): Promise<void> {
+  private async handleMessageEvent(
+    event: SlackMessageEvent,
+    teamId?: unknown,
+  ): Promise<void> {
     if (!this.listener) return;
     if (
       (this.botId && event.bot_id === this.botId) ||
@@ -776,7 +785,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     const ids = this.validateInboundMessageIds({
       botId: event.bot_id,
       channelId: event.channel,
-      teamId: event.team,
+      teamId,
       userId: event.user,
       ts: event.ts ?? event.event_ts,
     });


### PR DESCRIPTION
## What changed

- Preserve the Slack Events API envelope `team_id` when normalizing Socket Mode message events.
- Use that validated workspace ID for channel authorization and opaque routing state.
- Add a regression test covering an authorized `file_share` event in a restricted workspace and channel.

## Why

Slack `file_share` message events do not include `event.team`; the workspace ID is provided on the outer Events API payload as `body.team_id`. PwrAgent previously discarded the outer value, so workspace authorization failed closed and rejected screenshots or other uploads from otherwise authorized users and channels. Text messages and interactive callbacks continued to route, which made the Activity log show conflicting routed and rejected entries for the same Slack thread.

## Impact

Authorized Slack file uploads now follow the same workspace and channel authorization rules as text messages. Events that do not provide a valid workspace ID remain denied when approved-workspace mode is enabled.

## Validation

- `pnpm test packages/messaging/providers/slack/src` — 63 tests passed
- `pnpm --filter @pwragent/messaging-provider-slack typecheck`
- Targeted ESLint for the changed adapter and test
- `pnpm lint:boundaries`
- `git diff --check`
