### PR TITLE
feat(messaging): add default Agent surfaces

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -919,12 +919,73 @@ describe("MessagingController", () => {
       threadId: "thread-1",
       targetKind: "agent_thread",
     });
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(agentEvent.channel),
+    ).resolves.toBeUndefined();
     const confirmation = harness.delivered.find(
       (intent) => intent.kind === "confirmation" && intent.title === "Thread bound",
     );
     expect(confirmation).toMatchObject({
       body: expect.stringContaining("selected Agent thread"),
       fallbackText: "Send a message to continue with the Agent thread.",
+    });
+  });
+
+  it("explicitly sets, inspects, and clears a conversation default Agent", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      title: "Default Agent",
+      agent: {
+        name: "Inbox Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    const event = buildCommandEvent("/agent default set");
+
+    await harness.controller.handleInboundEvent(event);
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "thread_picker",
+      prompt: expect.stringContaining("Choose the default Agent"),
+      page: {
+        items: [expect.objectContaining({ id: "thread-1", source: "codex" })],
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        value: { backend: "codex", threadId: "thread-1" },
+      }),
+    );
+
+    await expect(
+      harness.store.findActiveBindingForChannel(event.channel),
+    ).resolves.toBeUndefined();
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(event.channel),
+    ).resolves.toMatchObject({
+      scope: { kind: "conversation" },
+      target: { backend: "codex", threadId: "thread-1" },
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Default Agent",
+      body: expect.stringContaining("Effective default: Default Agent (conversation)."),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCommandEvent("/agent default clear"),
+    );
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(event.channel),
+    ).resolves.toBeUndefined();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("conversation default cleared"),
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -989,6 +989,158 @@ describe("MessagingController", () => {
     });
   });
 
+  it("assigns and bootstraps ACP Agents with PwrAgent HTTP MCP tools", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads = [
+      {
+        ...navigation.threads[0]!,
+        id: "codex-agent",
+        title: "Codex Agent",
+        agent: {
+          name: "Codex Agent",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1500,
+        },
+      },
+      {
+        ...navigation.threads[0]!,
+        id: "kimi-agent",
+        source: "acp:kimi",
+        title: "Kimi Agent",
+        updatedAt: 2000,
+        agent: {
+          name: "Kimi Agent",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1500,
+        },
+      },
+      {
+        ...navigation.threads[0]!,
+        id: "gemini-agent",
+        source: "acp:gemini",
+        title: "Gemini Agent",
+        agent: {
+          name: "Gemini Agent",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1500,
+        },
+      },
+      {
+        ...navigation.threads[0]!,
+        id: "grok-agent",
+        source: "grok",
+        title: "Grok Agent",
+        agent: {
+          name: "Grok Agent",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1500,
+        },
+      },
+    ];
+    const listBackends = async (): Promise<ListBackendsResponse> => ({
+      fetchedAt: 1000,
+      backends: [
+        buildBackendSummary(),
+        buildAcpHttpMcpBackendSummary(),
+        buildAcpRuntimeBackendSummary(),
+        buildBackendSummary({ kind: "grok" }),
+      ],
+    });
+    const harness = await createHarness({ listBackends, navigation });
+    const command = buildTopicCommandEvent("/agent default set", "13056");
+
+    await harness.controller.handleInboundEvent(command);
+
+    const picker = harness.delivered.at(-1);
+    expect(picker?.kind).toBe("thread_picker");
+    if (picker?.kind !== "thread_picker") {
+      throw new Error("Expected default Agent thread picker");
+    }
+    expect(picker.page.items.map((thread) => thread.source)).toEqual([
+      "acp:kimi",
+      "codex",
+    ]);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-thread",
+        channel: command.channel,
+        value: { backend: "acp:kimi", threadId: "kimi-agent" },
+      }),
+    );
+
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(command.channel),
+    ).resolves.toMatchObject({
+      target: { backend: "acp:kimi", threadId: "kimi-agent" },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("summarize this topic", {
+        botMention: true,
+        channel: command.channel,
+      }),
+    );
+
+    await expect(
+      harness.store.findActiveBindingForChannel(command.channel),
+    ).resolves.toMatchObject({
+      backend: "acp:kimi",
+      targetKind: "agent_thread",
+      threadId: "kimi-agent",
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "acp:kimi",
+        input: [{ type: "text", text: "summarize this topic" }],
+        threadId: "kimi-agent",
+      }),
+    );
+  });
+
+  it("preserves an ACP default when tool-capability discovery is unavailable", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      source: "acp:kimi",
+      title: "Kimi Agent",
+      agent: {
+        name: "Kimi Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({
+      listBackends: async () => {
+        throw new Error("backend discovery unavailable");
+      },
+      navigation,
+    });
+    const channel = buildTopicChannel("13056");
+    await seedConversationDefaultAgent(harness.store, channel, "acp:kimi");
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("keep this default", { botMention: true, channel }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(channel),
+    ).resolves.toMatchObject({
+      target: { backend: "acp:kimi", threadId: "thread-1" },
+    });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Default Agent unavailable",
+      body: expect.stringContaining("assignment was preserved"),
+    });
+  });
+
   it("binds an addressed unbound topic to its default Agent and admits the turn there", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
@@ -17924,6 +18076,24 @@ function buildKimiRuntimeBackendSummary(
   });
 }
 
+function buildAcpHttpMcpBackendSummary(): BackendSummary {
+  const summary = buildKimiRuntimeBackendSummary();
+  return {
+    ...summary,
+    acp: {
+      ...summary.acp!,
+      runtime: {
+        ...summary.acp!.runtime!,
+        agentCapabilities: {
+          mcp: {
+            http: true,
+          },
+        },
+      },
+    },
+  };
+}
+
 function buildNavigationSnapshot(): NavigationSnapshot {
   return {
     backend: "all",
@@ -18237,6 +18407,7 @@ function buildTopicChannel(topicId: string): MessagingInboundEvent["channel"] {
 async function seedConversationDefaultAgent(
   store: MessagingStore,
   channel: MessagingInboundEvent["channel"],
+  backend: AppServerBackendKind = "codex",
 ): Promise<void> {
   await store.upsertDefaultAgentAssignment({
     id: `default-agent:${channel.channel}:${channel.conversation.id}`,
@@ -18246,7 +18417,7 @@ async function seedConversationDefaultAgent(
     },
     target: {
       kind: "agent",
-      backend: "codex",
+      backend,
       threadId: "thread-1",
     },
     createdAt: 1000,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -989,6 +989,342 @@ describe("MessagingController", () => {
     });
   });
 
+  it("binds an addressed unbound topic to its default Agent and admits the turn there", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      title: "Topic Agent",
+      agent: {
+        name: "Topic Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const createManagedConversation = vi.fn(async () => ({
+      channel: "telegram" as const,
+      outcome: "unsupported" as const,
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({
+      createManagedConversation,
+      navigation,
+    });
+    const channel = buildTopicChannel("13056");
+    const event = buildTextEvent("find the thread for 13056", {
+      botMention: true,
+      channel,
+      routingState: {
+        opaque: {
+          chatId: -1001,
+          messageThreadId: 13056,
+        },
+      },
+    });
+    await seedConversationDefaultAgent(harness.store, channel);
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(createManagedConversation).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      channel,
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        input: [{ type: "text", text: "find the thread for 13056" }],
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("creates a child for an addressed unbound root and admits the default Agent turn there", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      title: "Search Signals Agent",
+      agent: {
+        name: "Search Signals Agent",
+        instructionLineCount: 2,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const rootChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SIGNALS",
+        kind: "channel" as const,
+        title: "p-search-signals-project",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const childChannel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SIGNALS",
+        kind: "thread" as const,
+        parentId: "1712023030.000000",
+        parentConversationId: "C012SIGNALS",
+        parentTitle: "p-search-signals-project",
+        title: "Search Signals Agent",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const getManagedConversationRights = vi.fn(async () => ({
+      channel: "slack" as const,
+      conversation: rootChannel.conversation,
+      operations: [
+        {
+          operation: "create_child" as const,
+          supported: true,
+        },
+      ],
+      outcome: "ok" as const,
+      updatedAt: 1000,
+    }));
+    const createManagedConversation = vi.fn(async () => ({
+      channel: "slack" as const,
+      conversation: childChannel.conversation,
+      outcome: "created" as const,
+      routingState: {
+        opaque: {
+          channelId: "C012SIGNALS",
+          teamId: "T012WORKSPACE",
+          threadTs: "1712023030.000000",
+        },
+      },
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({
+      channel: "slack",
+      createManagedConversation,
+      getManagedConversationRights,
+      navigation,
+    });
+    const event = buildTextEvent(
+      "find the thread for 13056 and attach it as a reply",
+      {
+        botMention: true,
+        channel: rootChannel,
+        routingState: {
+          opaque: {
+            channelId: "C012SIGNALS",
+            teamId: "T012WORKSPACE",
+            ts: "1712023030.000000",
+          },
+        },
+      },
+    );
+    await seedConversationDefaultAgent(harness.store, rootChannel);
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(getManagedConversationRights).toHaveBeenCalledWith({
+      actor: event.actor,
+      channel: rootChannel,
+      routingState: event.routingState,
+    });
+    expect(createManagedConversation).toHaveBeenCalledWith({
+      actor: event.actor,
+      parent: rootChannel,
+      routingState: event.routingState,
+      title: "Search Signals Agent",
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(childChannel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      channel: childChannel,
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+    });
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "find the thread for 13056 and attach it as a reply",
+          },
+        ],
+        threadId: "thread-1",
+      }),
+    );
+  });
+
+  it("reports a capability error when an addressed root cannot create a child", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Default Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    const channel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "channel-1",
+        kind: "channel" as const,
+        workspaceId: "guild-1",
+      },
+    };
+    const event = buildTextEvent("handle this", {
+      botMention: true,
+      channel,
+    });
+    await seedConversationDefaultAgent(harness.store, channel);
+
+    await harness.controller.handleInboundEvent(event);
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    await expect(
+      harness.store.findActiveBindingForChannel(channel),
+    ).resolves.toBeUndefined();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "error",
+      title: "Default Agent cannot start here",
+      body: expect.stringContaining("cannot safely create a child conversation"),
+    });
+  });
+
+  it("does not bootstrap a default for an unaddressed ambient root message", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Default Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const createManagedConversation = vi.fn(async () => ({
+      channel: "slack" as const,
+      outcome: "unsupported" as const,
+      updatedAt: 1000,
+    }));
+    const harness = await createHarness({
+      channel: "slack",
+      createManagedConversation,
+      navigation,
+    });
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SIGNALS",
+        kind: "channel" as const,
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    await seedConversationDefaultAgent(harness.store, channel);
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("ambient channel conversation", { channel }),
+    );
+
+    expect(createManagedConversation).not.toHaveBeenCalled();
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "PwrAgent commands",
+    });
+  });
+
+  it("revokes a stale specific default and continues to a valid broader default", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Provider Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1500,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    const channel = buildTopicChannel("13056");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:stale-conversation",
+      scope: {
+        kind: "conversation",
+        channel,
+      },
+      target: {
+        kind: "agent",
+        backend: "codex",
+        threadId: "archived-agent",
+      },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:telegram-provider",
+      scope: {
+        kind: "provider",
+        channel: "telegram",
+      },
+      target: {
+        kind: "agent",
+        backend: "codex",
+        threadId: "thread-1",
+      },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", {
+        botMention: true,
+        channel,
+      }),
+    );
+
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:stale-conversation"),
+    ).resolves.toMatchObject({
+      revokedAt: 1000,
+    });
+    await expect(
+      harness.store.findActiveBindingForChannel(channel),
+    ).resolves.toMatchObject({
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+    });
+  });
+
+  it("revokes default assignments when their Agent thread is archived", async () => {
+    const harness = await createHarness();
+    await seedConversationDefaultAgent(
+      harness.store,
+      buildTextEvent("request").channel,
+    );
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/archived",
+        params: {
+          threadId: "thread-1",
+        },
+      },
+    });
+
+    await expect(
+      harness.store.findActiveDefaultAgentAssignmentForChannel(
+        buildTextEvent("request").channel,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it("starts a new Agent thread from /agent --new and binds it as an Agent target", async () => {
     const harness = await createHarness();
 
@@ -1193,6 +1529,70 @@ describe("MessagingController", () => {
         routingState: event.routingState,
       }),
     );
+  });
+
+  it("preserves a concrete live messaging origin for ordinary Codex turns only", async () => {
+    const harness = await createHarness();
+    const event = buildTextEvent(
+      "Hand that off to a new thread in project XYZ",
+    );
+    await harness.store.upsertBinding({
+      id: "binding:telegram:dm::chat-1:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1000,
+      routingState: event.routingState,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(event);
+
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "get_current_messaging_surface",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+        args: {},
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: {
+        location: {
+          actor: {
+            platformUserId: "user-1",
+          },
+          binding: {
+            targetKind: "thread",
+            threadId: "thread-1",
+          },
+          conversation: {
+            id: "chat-1",
+            kind: "dm",
+          },
+        },
+      },
+    });
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "get_current_messaging_surface",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        args: {},
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "not_found",
+      },
+    });
   });
 
   it("preserves the messaging location for queued Agent-thread turns", async () => {
@@ -17827,10 +18227,31 @@ function buildTopicChannel(topicId: string): MessagingInboundEvent["channel"] {
       id: topicId,
       kind: "topic",
       parentId: "-1001",
+      parentConversationId: "-1001",
       parentTitle: "Ops",
       title: topicId === "100" ? "PwrAgent" : `Topic ${topicId}`,
     },
   };
+}
+
+async function seedConversationDefaultAgent(
+  store: MessagingStore,
+  channel: MessagingInboundEvent["channel"],
+): Promise<void> {
+  await store.upsertDefaultAgentAssignment({
+    id: `default-agent:${channel.channel}:${channel.conversation.id}`,
+    scope: {
+      kind: "conversation",
+      channel,
+    },
+    target: {
+      kind: "agent",
+      backend: "codex",
+      threadId: "thread-1",
+    },
+    createdAt: 1000,
+    updatedAt: 1000,
+  });
 }
 
 function buildTextEvent(

--- a/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
@@ -188,6 +188,49 @@ describe("messaging resume browser", () => {
     expect(intent.fallbackText).not.toContain("Ordinary thread");
   });
 
+  it("preserves pagination without browse-mode actions in default-Agent assignment", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot({
+        threads: Array.from({ length: 8 }, (_, index) =>
+          buildThread({
+            id: `agent-thread-${index + 1}`,
+            title: `Agent thread ${index + 1}`,
+            updatedAt: 2000 - index,
+            agent: {
+              name: `Agent ${index + 1}`,
+              instructionLineCount: 1,
+              instructionsTooLong: false,
+              updatedAt: 1500,
+            },
+          }),
+        ),
+      }),
+      session: buildBrowseSession({
+        launchAction: "assign_default_agent",
+        mode: "agents",
+        pageIndex: 1,
+        pageSize: 3,
+      }),
+    });
+
+    expect(intent.kind).toBe("thread_picker");
+    expect(intent.page.actions.map((action) => action.id)).toEqual([
+      "browse:select-thread",
+      "browse:select-thread",
+      "browse:select-thread",
+      "browse:page:prev",
+      "browse:page:next",
+      "browse:cancel",
+    ]);
+    expect(intent.fallbackText).toContain(
+      "Reply with a number, or reply previous, next, or cancel.",
+    );
+    expect(intent.fallbackText).not.toContain("recent");
+    expect(intent.fallbackText).not.toContain("new");
+  });
+
   it("renders Grok worktree threads with the primary project label", () => {
     const intent = buildResumeIntent({
       id: "intent-1",

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type {
   MessagingBindingRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
@@ -40,6 +41,26 @@ function buildBinding(
     backend: "codex",
     threadId: "thread-1",
     authorizedActorIds: ["user-1"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildDefaultAgentAssignment(
+  overrides: Partial<MessagingDefaultAgentAssignmentRecord> = {},
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    id: "default-agent-1",
+    scope: {
+      kind: "conversation",
+      channel: buildBinding().channel,
+    },
+    target: {
+      kind: "agent",
+      backend: "codex",
+      threadId: "agent-thread-1",
+    },
     createdAt: 1000,
     updatedAt: 1000,
     ...overrides,
@@ -194,6 +215,155 @@ describe("SqliteMessagingStore", () => {
       id: "binding-1",
       targetKind: "agent_thread",
     });
+  });
+
+  it("keeps default Agent assignments separate from active bindings", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding({ threadId: "work-thread-1" }));
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+
+    await expect(store.findActiveBindingForChannel(buildBinding().channel)).resolves
+      .toMatchObject({
+        id: "binding-1",
+        threadId: "work-thread-1",
+      });
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-1",
+      target: { threadId: "agent-thread-1" },
+    });
+  });
+
+  it("resolves the most specific active default Agent assignment", async () => {
+    const store = await createStore();
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "profile-default",
+        scope: { kind: "profile" },
+        target: { kind: "agent", backend: "codex", threadId: "profile-agent" },
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "provider-default",
+        scope: { kind: "provider", channel: "telegram" },
+        target: { kind: "agent", backend: "codex", threadId: "provider-agent" },
+        createdAt: 1100,
+        updatedAt: 1100,
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "conversation-default",
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "conversation-agent",
+        },
+        createdAt: 1200,
+        updatedAt: 1200,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "conversation-default",
+      target: { threadId: "conversation-agent" },
+    });
+
+    await store.revokeDefaultAgentAssignment({
+      assignmentId: "conversation-default",
+      revokedAt: 1300,
+    });
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "provider-default",
+      target: { threadId: "provider-agent" },
+    });
+  });
+
+  it("replaces active default Agent assignments within the same scope", async () => {
+    const store = await createStore();
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "default-agent-2",
+        target: { kind: "agent", backend: "codex", threadId: "agent-thread-2" },
+        createdAt: 2000,
+        updatedAt: 2000,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-2",
+      target: { threadId: "agent-thread-2" },
+    });
+    await expect(store.getDefaultAgentAssignment("default-agent-1")).resolves
+      .toMatchObject({
+        revokedAt: 2000,
+      });
+  });
+
+  it("resolves parent and workspace defaults in specificity order", async () => {
+    const store = await createStore();
+    const channel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "thread-1",
+        kind: "thread" as const,
+        parentId: "legacy-thread-parent",
+        parentConversationId: "channel-1",
+        workspaceId: "guild-1",
+      },
+    };
+    for (const assignment of [
+      buildDefaultAgentAssignment({
+        id: "workspace-default",
+        scope: { kind: "workspace", channel: "discord", workspaceId: "guild-1" },
+        target: { kind: "agent", backend: "codex", threadId: "workspace-agent" },
+      }),
+      buildDefaultAgentAssignment({
+        id: "parent-default",
+        scope: { kind: "parent", channel: "discord", conversationId: "channel-1" },
+        target: { kind: "agent", backend: "codex", threadId: "parent-agent" },
+      }),
+      buildDefaultAgentAssignment({
+        id: "exact-default",
+        scope: { kind: "conversation", channel },
+        target: { kind: "agent", backend: "codex", threadId: "exact-agent" },
+      }),
+    ]) {
+      await store.upsertDefaultAgentAssignment(assignment);
+    }
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(channel))
+      .resolves.toMatchObject([
+        { id: "exact-default" },
+        { id: "parent-default" },
+        { id: "workspace-default" },
+      ]);
+  });
+
+  it("enforces one active assignment per scope in the database", async () => {
+    const store = await createStore();
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+    const db = stateDbs.at(-1)!.raw;
+
+    expect(() =>
+      db.prepare(
+        `INSERT INTO messaging_default_agent_assignments
+         (assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, payload)
+         SELECT 'duplicate', scope_kind, scope_key, channel_kind, backend, 'other-agent', 'active', 2000, 2000, '{}'
+         FROM messaging_default_agent_assignments
+         WHERE assignment_id = 'default-agent-1'`,
+      ).run()
+    ).toThrow(/UNIQUE constraint failed/);
   });
 
   it("persists pending skill selections on bindings", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
@@ -217,6 +217,36 @@ describe("SqliteMessagingStore", () => {
     });
   });
 
+  it("finds a legacy channel-shaped binding from its normalized thread surface", async () => {
+    const store = await createStore();
+    await store.upsertBinding(buildBinding({
+      channel: {
+        channel: "discord",
+        conversation: {
+          id: "thread-channel-1",
+          kind: "channel",
+          parentId: "guild-1",
+        },
+      },
+    }));
+
+    await expect(
+      store.findActiveBindingForChannel({
+        channel: "discord",
+        conversation: {
+          id: "thread-channel-1",
+          kind: "thread",
+          parentConversationId: "parent-channel-1",
+          parentId: "guild-1",
+          workspaceId: "guild-1",
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: "binding-1",
+      threadId: "thread-1",
+    });
+  });
+
   it("keeps default Agent assignments separate from active bindings", async () => {
     const store = await createStore();
     await store.upsertBinding(buildBinding({ threadId: "work-thread-1" }));

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -6,11 +6,13 @@ import type {
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingManagedTopicRecord,
   MessagingPendingIntentRecord,
   MessagingThreadTopicLinkRecord,
   MessagingTopicCleanupProposalRecord,
 } from "@pwragent/messaging-interface";
+import { migrateMessagingStoreData } from "../messaging/core/messaging-migrations";
 import { MessagingStore } from "../messaging/core/messaging-store";
 
 const tempDirs: string[] = [];
@@ -40,6 +42,26 @@ function buildBinding(
     backend: "codex",
     threadId: "thread-1",
     authorizedActorIds: ["user-1"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function buildDefaultAgentAssignment(
+  overrides: Partial<MessagingDefaultAgentAssignmentRecord> = {},
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    id: "default-agent-1",
+    scope: {
+      kind: "conversation",
+      channel: buildBinding().channel,
+    },
+    target: {
+      kind: "agent",
+      backend: "codex",
+      threadId: "agent-thread-1",
+    },
     createdAt: 1000,
     updatedAt: 1000,
     ...overrides,
@@ -405,6 +427,158 @@ describe("MessagingStore", () => {
     });
   });
 
+  it("keeps default Agent assignments separate from active bindings", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({ threadId: "work-thread-1" }));
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+
+    await expect(store.findActiveBindingForChannel(buildBinding().channel)).resolves
+      .toMatchObject({
+        id: "binding-1",
+        threadId: "work-thread-1",
+      });
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-1",
+      target: { threadId: "agent-thread-1" },
+    });
+  });
+
+  it("resolves the most specific active default Agent assignment", async () => {
+    const { store } = await createStore();
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "profile-default",
+        scope: { kind: "profile" },
+        target: { kind: "agent", backend: "codex", threadId: "profile-agent" },
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "provider-default",
+        scope: { kind: "provider", channel: "telegram" },
+        target: { kind: "agent", backend: "codex", threadId: "provider-agent" },
+        createdAt: 1100,
+        updatedAt: 1100,
+      }),
+    );
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "conversation-default",
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "conversation-agent",
+        },
+        createdAt: 1200,
+        updatedAt: 1200,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "conversation-default",
+      target: { threadId: "conversation-agent" },
+    });
+
+    await store.revokeDefaultAgentAssignment({
+      assignmentId: "conversation-default",
+      revokedAt: 1300,
+    });
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "provider-default",
+      target: { threadId: "provider-agent" },
+    });
+  });
+
+  it("replaces active default Agent assignments within the same scope", async () => {
+    const { store } = await createStore();
+    await store.upsertDefaultAgentAssignment(buildDefaultAgentAssignment());
+    await store.upsertDefaultAgentAssignment(
+      buildDefaultAgentAssignment({
+        id: "default-agent-2",
+        target: { kind: "agent", backend: "codex", threadId: "agent-thread-2" },
+        createdAt: 2000,
+        updatedAt: 2000,
+      }),
+    );
+
+    await expect(
+      store.findActiveDefaultAgentAssignmentForChannel(buildBinding().channel),
+    ).resolves.toMatchObject({
+      id: "default-agent-2",
+      target: { threadId: "agent-thread-2" },
+    });
+    await expect(store.getDefaultAgentAssignment("default-agent-1")).resolves
+      .toMatchObject({
+        revokedAt: 2000,
+      });
+  });
+
+  it("resolves parent and workspace defaults in specificity order", async () => {
+    const { store } = await createStore();
+    const channel = {
+      channel: "discord" as const,
+      conversation: {
+        id: "thread-1",
+        kind: "thread" as const,
+        parentId: "legacy-thread-parent",
+        parentConversationId: "channel-1",
+        workspaceId: "guild-1",
+      },
+    };
+    const records = [
+      buildDefaultAgentAssignment({
+        id: "workspace-default",
+        scope: { kind: "workspace", channel: "discord", workspaceId: "guild-1" },
+        target: { kind: "agent", backend: "codex", threadId: "workspace-agent" },
+      }),
+      buildDefaultAgentAssignment({
+        id: "parent-default",
+        scope: { kind: "parent", channel: "discord", conversationId: "channel-1" },
+        target: { kind: "agent", backend: "codex", threadId: "parent-agent" },
+      }),
+      buildDefaultAgentAssignment({
+        id: "exact-default",
+        scope: { kind: "conversation", channel },
+        target: { kind: "agent", backend: "codex", threadId: "exact-agent" },
+      }),
+    ];
+    for (const record of records) {
+      await store.upsertDefaultAgentAssignment(record);
+    }
+
+    await expect(store.findActiveDefaultAgentAssignmentsForChannel(channel))
+      .resolves.toMatchObject([
+        { id: "exact-default" },
+        { id: "parent-default" },
+        { id: "workspace-default" },
+      ]);
+  });
+
+  it("rejects malformed persisted assignment scopes instead of widening them", () => {
+    const migrated = migrateMessagingStoreData({
+      version: 2,
+      defaultAgentAssignments: {
+        malformed: {
+          id: "malformed",
+          scope: { kind: "workspace", channel: "slack" },
+          target: { kind: "agent", backend: "codex", threadId: "agent-1" },
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+      },
+    });
+
+    expect(migrated.defaultAgentAssignments).toEqual({});
+    expect(migrated.version).toBe(3);
+  });
+
   it("sweeps binding and channel state when a binding is revoked", async () => {
     const { store } = await createStore();
     await store.upsertBinding(buildBinding());
@@ -686,7 +860,7 @@ describe("MessagingStore", () => {
     const store = new MessagingStore(filePath);
 
     await expect(store.readSnapshot()).resolves.toMatchObject({
-      version: 2,
+      version: 3,
       bindings: {
         valid: {
           id: "valid",

--- a/apps/desktop/src/main/__tests__/messaging-store.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-store.test.ts
@@ -405,6 +405,36 @@ describe("MessagingStore", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("finds a legacy channel-shaped binding from its normalized thread surface", async () => {
+    const { store } = await createStore();
+    await store.upsertBinding(buildBinding({
+      channel: {
+        channel: "discord",
+        conversation: {
+          id: "thread-channel-1",
+          kind: "channel",
+          parentId: "guild-1",
+        },
+      },
+    }));
+
+    await expect(
+      store.findActiveBindingForChannel({
+        channel: "discord",
+        conversation: {
+          id: "thread-channel-1",
+          kind: "thread",
+          parentConversationId: "parent-channel-1",
+          parentId: "guild-1",
+          workspaceId: "guild-1",
+        },
+      }),
+    ).resolves.toMatchObject({
+      id: "binding-1",
+      threadId: "thread-1",
+    });
+  });
+
   it("replaces the active binding when a conversation is rebound", async () => {
     const { store } = await createStore();
     await store.upsertBinding(buildBinding({ id: "binding-old", threadId: "thread-old" }));

--- a/apps/desktop/src/main/__tests__/state-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/state-migration.test.ts
@@ -156,18 +156,20 @@ VALUES ('codex', 'thread-1', 'turn-1', 1000, '{"kind":"messaging"}');
     }
   });
 
-  it("adds default Agent assignments after the current-main v31 schema", () => {
+  it("adds default Agent assignments after the current-main v32 schema", () => {
     const root = createTempRoot();
     const dbPath = path.join(root, "state.db");
     StateDb.open(dbPath).close();
     const raw = new Database(dbPath);
     raw.exec("DROP TABLE messaging_default_agent_assignments");
-    raw.pragma("user_version = 31");
+    raw.pragma("user_version = 32");
     raw.close();
 
     const stateDb = StateDb.open(dbPath);
     try {
-      expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(32);
+      expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+        CURRENT_STATE_DB_USER_VERSION,
+      );
       const indexes = stateDb.raw
         .prepare("PRAGMA index_list(messaging_default_agent_assignments)")
         .all() as Array<{ name: string; unique: number }>;

--- a/apps/desktop/src/main/__tests__/state-migration.test.ts
+++ b/apps/desktop/src/main/__tests__/state-migration.test.ts
@@ -156,6 +156,32 @@ VALUES ('codex', 'thread-1', 'turn-1', 1000, '{"kind":"messaging"}');
     }
   });
 
+  it("adds default Agent assignments after the current-main v31 schema", () => {
+    const root = createTempRoot();
+    const dbPath = path.join(root, "state.db");
+    StateDb.open(dbPath).close();
+    const raw = new Database(dbPath);
+    raw.exec("DROP TABLE messaging_default_agent_assignments");
+    raw.pragma("user_version = 31");
+    raw.close();
+
+    const stateDb = StateDb.open(dbPath);
+    try {
+      expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(32);
+      const indexes = stateDb.raw
+        .prepare("PRAGMA index_list(messaging_default_agent_assignments)")
+        .all() as Array<{ name: string; unique: number }>;
+      expect(indexes).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          name: "idx_messaging_default_agent_assignments_active_scope",
+          unique: 1,
+        }),
+      ]));
+    } finally {
+      stateDb.close();
+    }
+  });
+
   it("does not copy legacy default settings into a new named profile", () => {
     const root = createTempRoot();
     const pwragentHome = path.join(root, "pwragent");

--- a/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-command-catalog.ts
@@ -93,7 +93,7 @@ export const MESSAGING_COMMAND_CATALOG: readonly MessagingCommandSpec[] = [
   },
   {
     verb: "agent",
-    description: "choose an Agent thread to control from this conversation",
+    description: "choose an Agent thread, or manage the default with /agent default",
   },
   {
     verb: "new",

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -63,6 +63,8 @@ import type {
   MessagingConfirmationIntent,
   MessagingDeliveryScope,
   MessagingDeliveryResult,
+  MessagingDefaultAgentAssignmentRecord,
+  MessagingDefaultAgentScope,
   MessagingInboundCallbackEvent,
   MessagingInboundCommandEvent,
   MessagingInboundEvent,
@@ -114,6 +116,10 @@ import {
   selectMonitorThreads,
 } from "./messaging-monitor-card.js";
 import { buildMessagingConversationKey } from "./messaging-store.js";
+import {
+  defaultAgentScopeForChannel,
+  type MessagingDefaultAgentScopeKind,
+} from "./messaging-default-agent.js";
 import type { MessagingStoreLike } from "../../state/messaging-store-sqlite";
 import type { MessagingCapabilityProfile } from "@pwragent/messaging-interface";
 import type {
@@ -1575,6 +1581,10 @@ export class MessagingController {
       return;
     }
     if (verb === "agent") {
+      if (event.args[0]?.toLowerCase() === "default") {
+        await this.handleDefaultAgentCommand(event);
+        return;
+      }
       await this.presentAgentBrowser(event, {
         cancelDestination: options?.targetSurface ? "help" : undefined,
         targetSurface: options?.targetSurface,
@@ -3056,6 +3066,14 @@ export class MessagingController {
   }
 
   private async handleCallback(event: MessagingInboundCallbackEvent): Promise<void> {
+    if (event.actionId === "agent-default:set") {
+      await this.presentDefaultAgentAssignmentBrowser(event, "conversation");
+      return;
+    }
+    if (event.actionId === "agent-default:clear") {
+      await this.clearDefaultAgentAssignment(event, "conversation");
+      return;
+    }
     const command = readCommandAction(event);
     if (command) {
       await this.handleCommand(
@@ -4973,6 +4991,175 @@ export class MessagingController {
     await this.renderResumeBrowser(session, navigation, event);
   }
 
+  private async handleDefaultAgentCommand(
+    event: MessagingInboundCommandEvent,
+  ): Promise<void> {
+    const action = event.args[1]?.toLowerCase() ?? "show";
+    const requestedScope = parseDefaultAgentScopeKind(event.args[2]);
+    if (event.args[2] && !requestedScope) {
+      await this.deliverDefaultAgentCommandError(
+        event,
+        "Scope must be conversation, parent, workspace, provider, or profile.",
+      );
+      return;
+    }
+    const scopeKind = requestedScope ?? "conversation";
+    if (action === "set" || action === "change") {
+      await this.presentDefaultAgentAssignmentBrowser(event, scopeKind);
+      return;
+    }
+    if (action === "clear") {
+      await this.clearDefaultAgentAssignment(event, scopeKind);
+      return;
+    }
+    if (action !== "show") {
+      await this.deliverDefaultAgentCommandError(
+        event,
+        "Use /agent default, /agent default set [scope], or /agent default clear [scope].",
+      );
+      return;
+    }
+    await this.presentDefaultAgentStatus(event);
+  }
+
+  private async presentDefaultAgentAssignmentBrowser(
+    event: MessagingInboundEvent,
+    scopeKind: MessagingDefaultAgentScopeKind,
+  ): Promise<void> {
+    const scope = defaultAgentScopeForChannel(event.channel, scopeKind);
+    if (!scope) {
+      await this.deliverDefaultAgentCommandError(
+        event,
+        `This messaging surface does not expose a normalized ${scopeKind} scope.`,
+      );
+      return;
+    }
+    const navigation = await this.options.backend.getNavigationSnapshot({
+      backend: "all",
+    });
+    const session: MessagingBrowseSessionRecord = {
+      id: this.newIntentId("default-agent-browse"),
+      allowedActorIds: [event.actor.platformUserId],
+      channel: event.channel,
+      createdAt: this.now(),
+      updatedAt: this.now(),
+      expiresAt: this.now() + this.pendingIntentTtlMs,
+      launchAction: "assign_default_agent",
+      defaultAgentScope: scope,
+      mode: "agents",
+      pageIndex: 0,
+      pageSize: resumeBrowserPageSize(this.capabilityProfile),
+    };
+    await this.renderResumeBrowser(session, navigation, event);
+  }
+
+  private async clearDefaultAgentAssignment(
+    event: MessagingInboundEvent,
+    scopeKind: MessagingDefaultAgentScopeKind,
+  ): Promise<void> {
+    const scope = defaultAgentScopeForChannel(event.channel, scopeKind);
+    if (!scope) {
+      await this.deliverDefaultAgentCommandError(
+        event,
+        `This messaging surface does not expose a normalized ${scopeKind} scope.`,
+      );
+      return;
+    }
+    const assignment =
+      await this.options.store.findActiveDefaultAgentAssignmentForScope(scope);
+    if (assignment) {
+      await this.options.store.revokeDefaultAgentAssignment({
+        assignmentId: assignment.id,
+        revokedAt: this.now(),
+      });
+    }
+    await this.presentDefaultAgentStatus(event, {
+      notice: assignment
+        ? `${formatDefaultAgentScope(scope)} default cleared.`
+        : `No ${formatDefaultAgentScope(scope)} default was configured.`,
+    });
+  }
+
+  private async presentDefaultAgentStatus(
+    event: MessagingInboundEvent,
+    options: { notice?: string } = {},
+  ): Promise<void> {
+    const exactScope = defaultAgentScopeForChannel(event.channel, "conversation")!;
+    const exact =
+      await this.options.store.findActiveDefaultAgentAssignmentForScope(exactScope);
+    const effective =
+      await this.options.store.findActiveDefaultAgentAssignmentForChannel(event.channel);
+    let targetLabel: string | undefined;
+    if (effective) {
+      try {
+        const navigation = await this.options.backend.getNavigationSnapshot({
+          backend: "all",
+        });
+        targetLabel = navigation.threads.find(
+          (thread) =>
+            thread.source === effective.target.backend
+            && thread.id === effective.target.threadId,
+        )?.title;
+      } catch {
+        targetLabel = undefined;
+      }
+    }
+    const body = [
+      options.notice,
+      effective
+        ? `Effective default: ${targetLabel ?? effective.target.threadId} (${formatDefaultAgentScope(effective.scope)}).`
+        : "Effective default: none.",
+      exact
+        ? "This conversation has an explicit default."
+        : "This conversation has no explicit default.",
+      "",
+      "Use /agent default set [scope] or /agent default clear [scope].",
+    ].filter((line): line is string => line !== undefined).join("\n");
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("default-agent-status"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: "Default Agent",
+        body,
+        actions: [
+          {
+            id: "agent-default:set",
+            label: exact ? "Change" : "Set",
+            style: "primary",
+            fallbackText: "set",
+          },
+          {
+            id: "agent-default:clear",
+            label: "Clear",
+            style: "secondary",
+            disabled: !exact,
+            fallbackText: "clear",
+          },
+        ],
+      }),
+      undefined,
+      event,
+    );
+  }
+
+  private async deliverDefaultAgentCommandError(
+    event: MessagingInboundEvent,
+    body: string,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("default-agent-error"),
+        createdAt: this.now(),
+        title: "Default Agent command error",
+        body,
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
+  }
+
   private async handleBrowseCallback(
     event: MessagingInboundCallbackEvent,
     actionId: string,
@@ -5614,6 +5801,39 @@ export class MessagingController {
       );
       if (session.mode === "agents" && !targetThread?.agent) {
         await this.deliverInvalidBrowseSelection(event);
+        return;
+      }
+      if (session.launchAction === "assign_default_agent") {
+        if (
+          !session.defaultAgentScope
+          || target.backend !== "codex"
+          || targetThread?.source !== "codex"
+          || !targetThread.agent
+        ) {
+          await this.deliverDefaultAgentCommandError(
+            event,
+            "That thread is not an eligible default Agent. Choose a Codex Agent thread.",
+          );
+          return;
+        }
+        const assignment: MessagingDefaultAgentAssignmentRecord = {
+          id: this.newIntentId("default-agent-assignment"),
+          scope: session.defaultAgentScope,
+          target: {
+            kind: "agent",
+            backend: target.backend,
+            threadId: target.threadId,
+          },
+          createdAt: this.now(),
+          updatedAt: this.now(),
+        };
+        await this.options.store.upsertDefaultAgentAssignment(assignment);
+        await this.options.store.deleteBrowseSession(session.id);
+        await this.presentDefaultAgentStatus(event, {
+          notice:
+            `${targetThread.title || target.threadId} is now the `
+            + `${formatDefaultAgentScope(assignment.scope)} default.`,
+        });
         return;
       }
       if (
@@ -15297,6 +15517,40 @@ function summarizeMessagingActor(
     username: actor.username,
     isBot: actor.isBot,
   };
+}
+
+function parseDefaultAgentScopeKind(
+  value: string | undefined,
+): MessagingDefaultAgentScopeKind | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (
+    normalized === "conversation"
+    || normalized === "parent"
+    || normalized === "workspace"
+    || normalized === "provider"
+    || normalized === "profile"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function formatDefaultAgentScope(scope: MessagingDefaultAgentScope): string {
+  switch (scope.kind) {
+    case "conversation":
+      return "conversation";
+    case "parent":
+      return "parent conversation";
+    case "workspace":
+      return "workspace";
+    case "provider":
+      return `${scope.channel} provider`;
+    case "profile":
+      return "profile";
+  }
 }
 
 function summarizeMessagingBinding(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -119,6 +119,7 @@ import {
 } from "./messaging-monitor-card.js";
 import { buildMessagingConversationKey } from "./messaging-store.js";
 import {
+  defaultAgentBackendSupport,
   defaultAgentScopeForChannel,
   type MessagingDefaultAgentScopeKind,
 } from "./messaging-default-agent.js";
@@ -2338,6 +2339,7 @@ export class MessagingController {
           thread: NavigationThreadSummary;
         }
       | undefined;
+    const backendSummaries = await this.loadDefaultAgentBackendSummaries();
     for (const assignment of assignments) {
       const thread = navigation.threads.find(
         (candidate) =>
@@ -2345,13 +2347,25 @@ export class MessagingController {
           && candidate.id === assignment.target.threadId
           && Boolean(candidate.agent),
       );
+      const backendSupport = defaultAgentBackendSupport(
+        assignment.target.backend,
+        backendSummaries,
+      );
       if (
-        assignment.target.backend === "codex"
-        && assignment.target.kind === "agent"
+        assignment.target.kind === "agent"
         && thread
+        && backendSupport === "supported"
       ) {
         selected = { assignment, thread };
         break;
+      }
+      if (thread && backendSupport === "unknown") {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent unavailable",
+          "PwrAgent could not confirm that this Agent backend currently exposes the required tools. The default assignment was preserved.",
+        );
+        return true;
       }
       await this.options.store.revokeDefaultAgentAssignment({
         assignmentId: assignment.id,
@@ -5999,15 +6013,16 @@ export class MessagingController {
         return;
       }
       if (session.launchAction === "assign_default_agent") {
+        const backendSummaries = await this.loadDefaultAgentBackendSummaries();
         if (
           !session.defaultAgentScope
-          || target.backend !== "codex"
-          || targetThread?.source !== "codex"
-          || !targetThread.agent
+          || !targetThread?.agent
+          || defaultAgentBackendSupport(target.backend, backendSummaries)
+            !== "supported"
         ) {
           await this.deliverDefaultAgentCommandError(
             event,
-            "That thread is not an eligible default Agent. Choose a Codex Agent thread.",
+            "That thread is not an eligible default Agent. Choose a Codex Agent or an ACP Agent with PwrAgent HTTP MCP tools.",
           );
           return;
         }
@@ -7908,6 +7923,16 @@ export class MessagingController {
     session: MessagingBrowseSessionRecord,
     navigation: NavigationSnapshot,
   ): Promise<NavigationSnapshot> {
+    if (session.launchAction === "assign_default_agent") {
+      const backendSummaries = await this.loadDefaultAgentBackendSummaries();
+      const threads = navigation.threads.filter(
+        (thread) =>
+          Boolean(thread.agent)
+          && defaultAgentBackendSupport(thread.source, backendSummaries)
+            === "supported",
+      );
+      return filterNavigationToThreads(navigation, threads);
+    }
     if (session.launchAction !== "resume_thread") {
       return navigation;
     }
@@ -7917,22 +7942,25 @@ export class MessagingController {
     const threads = navigation.threads.filter(
       (thread) => thread.executionMode !== "full-access",
     );
-    const allowedThreadKeys = new Set(
-      threads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
-    );
-    return {
-      ...navigation,
-      threads,
-      directories: navigation.directories.map((directory) => ({
-        ...directory,
-        threadKeys: directory.threadKeys.filter((threadKey) =>
-          allowedThreadKeys.has(threadKey)
-        ),
-      })),
-      inboxThreadKeys: navigation.inboxThreadKeys.filter((threadKey) =>
-        allowedThreadKeys.has(threadKey)
-      ),
-    };
+    return filterNavigationToThreads(navigation, threads);
+  }
+
+  private async loadDefaultAgentBackendSummaries(): Promise<
+    BackendSummary[] | undefined
+  > {
+    if (!this.options.backend.listBackends) {
+      return undefined;
+    }
+    try {
+      return (await this.options.backend.listBackends({
+        includeUnavailable: true,
+      })).backends;
+    } catch (error) {
+      this.logger.debug?.("default Agent backend capability lookup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
   }
 
   private async presentStatus(event: MessagingInboundEvent): Promise<void> {
@@ -14824,6 +14852,28 @@ function handoffSuccessText(result: HandoffThreadWorkspaceResponse): string {
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n");
+}
+
+function filterNavigationToThreads(
+  navigation: NavigationSnapshot,
+  threads: NavigationThreadSummary[],
+): NavigationSnapshot {
+  const allowedThreadKeys = new Set(
+    threads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
+  );
+  return {
+    ...navigation,
+    threads,
+    directories: navigation.directories.map((directory) => ({
+      ...directory,
+      threadKeys: directory.threadKeys.filter((threadKey) =>
+        allowedThreadKeys.has(threadKey)
+      ),
+    })),
+    inboxThreadKeys: navigation.inboxThreadKeys.filter((threadKey) =>
+      allowedThreadKeys.has(threadKey)
+    ),
+  };
 }
 
 function normalizeNewThreadSessionForBackend(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -73,7 +73,9 @@ import type {
   MessagingAdapterState,
   MessagingJsonValue,
   MessagingManagedConversationActionResult,
+  MessagingManagedConversationCreateResult,
   MessagingManagedConversationOperationSupport,
+  MessagingManagedConversationRightsResult,
   MessagingManagedTopicRecord,
   MessagingMonitorState,
   MessagingMonitorSubscriptionRecord,
@@ -1006,6 +1008,13 @@ export class MessagingController {
     }
     if (!threadId) {
       return;
+    }
+    if (event.notification.method === "thread/archived") {
+      await this.options.store.revokeDefaultAgentAssignmentsForTarget({
+        backend: event.backend,
+        threadId,
+        revokedAt: this.now(),
+      });
     }
     if (event.notification.method === "thread/tokenUsage/updated") {
       this.rememberContextUsageSummary(event);
@@ -2269,6 +2278,12 @@ export class MessagingController {
 
     const binding = await this.options.store.findActiveBindingForChannel(event.channel);
     if (!binding) {
+      if (
+        event.botMention &&
+        await this.bootstrapDefaultAgentForAddressedMessage(event)
+      ) {
+        return;
+      }
       if (!await this.shouldHandleAmbientSharedMessage(event)) {
         return;
       }
@@ -2290,6 +2305,186 @@ export class MessagingController {
     }
 
     await this.turnAdmission.append({ binding, event });
+  }
+
+  private async bootstrapDefaultAgentForAddressedMessage(
+    event: MessagingInboundTextEvent,
+  ): Promise<boolean> {
+    const assignments =
+      await this.options.store.findActiveDefaultAgentAssignmentsForChannel(
+        event.channel,
+      );
+    if (assignments.length === 0) {
+      return false;
+    }
+
+    let navigation: NavigationSnapshot;
+    try {
+      navigation = await this.options.backend.getNavigationSnapshot({
+        backend: "all",
+      });
+    } catch (error) {
+      await this.deliverDefaultAgentBootstrapError(
+        event,
+        "Default Agent unavailable",
+        error instanceof Error ? error.message : String(error),
+      );
+      return true;
+    }
+
+    let selected:
+      | {
+          assignment: MessagingDefaultAgentAssignmentRecord;
+          thread: NavigationThreadSummary;
+        }
+      | undefined;
+    for (const assignment of assignments) {
+      const thread = navigation.threads.find(
+        (candidate) =>
+          candidate.source === assignment.target.backend
+          && candidate.id === assignment.target.threadId
+          && Boolean(candidate.agent),
+      );
+      if (
+        assignment.target.backend === "codex"
+        && assignment.target.kind === "agent"
+        && thread
+      ) {
+        selected = { assignment, thread };
+        break;
+      }
+      await this.options.store.revokeDefaultAgentAssignment({
+        assignmentId: assignment.id,
+        revokedAt: this.now(),
+      });
+    }
+    if (!selected) {
+      return false;
+    }
+
+    let admissionEvent: MessagingInboundTextEvent = event;
+    const conversationKind = event.channel.conversation.kind;
+    if (conversationKind !== "thread" && conversationKind !== "topic") {
+      const createManagedConversation =
+        this.options.adapter.createManagedConversation;
+      if (!createManagedConversation) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent cannot start here",
+          "This messaging adapter cannot safely create a child conversation from the addressed message.",
+        );
+        return true;
+      }
+
+      let rights: MessagingManagedConversationRightsResult | undefined;
+      try {
+        rights = this.options.adapter.getManagedConversationRights
+          ? await this.options.adapter.getManagedConversationRights({
+              actor: event.actor,
+              channel: event.channel,
+              routingState: event.routingState,
+            })
+          : undefined;
+      } catch (error) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent cannot start here",
+          error instanceof Error ? error.message : String(error),
+        );
+        return true;
+      }
+      const createChild = rights?.operations.find(
+        (operation) => operation.operation === "create_child",
+      );
+      if (
+        rights
+        && (rights.outcome !== "ok" || !createChild?.supported)
+      ) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent cannot start here",
+          createChild?.reason
+            ?? (createChild?.missingPermission
+              ? `Missing adapter permission: ${createChild.missingPermission}.`
+              : rights.errorMessage
+                ?? "This messaging surface cannot create a child conversation."),
+        );
+        return true;
+      }
+
+      let created: MessagingManagedConversationCreateResult;
+      try {
+        created = await createManagedConversation({
+          actor: event.actor,
+          parent: event.channel,
+          routingState: event.routingState,
+          title: selected.thread.title,
+        });
+      } catch (error) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent cannot start here",
+          error instanceof Error ? error.message : String(error),
+        );
+        return true;
+      }
+      if (
+        created.outcome !== "created"
+        || !created.conversation
+        || created.channel !== event.channel.channel
+        || (
+          created.conversation.kind !== "thread"
+          && created.conversation.kind !== "topic"
+        )
+      ) {
+        await this.deliverDefaultAgentBootstrapError(
+          event,
+          "Default Agent cannot start here",
+          created.errorMessage
+            ?? "The adapter did not create a bindable child conversation.",
+        );
+        return true;
+      }
+      admissionEvent = {
+        ...event,
+        id: `${event.id}:default-agent-child`,
+        channel: {
+          channel: created.channel,
+          conversation: created.conversation,
+        },
+        routingState: created.routingState,
+      };
+    }
+
+    const binding = await this.bindChannelToThread(admissionEvent, {
+      backend: selected.assignment.target.backend,
+      threadId: selected.assignment.target.threadId,
+      targetKind: "agent_thread",
+    });
+    await this.renderBindingStatus(binding, admissionEvent, navigation);
+    await this.turnAdmission.append({
+      binding,
+      event: admissionEvent,
+    });
+    return true;
+  }
+
+  private async deliverDefaultAgentBootstrapError(
+    event: MessagingInboundEvent,
+    title: string,
+    body: string,
+  ): Promise<void> {
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("default-agent-bootstrap"),
+        createdAt: this.now(),
+        title,
+        body,
+        recoverable: true,
+      }),
+      undefined,
+      event,
+    );
   }
 
   private async handleMedia(event: MessagingInboundMediaEvent): Promise<void> {
@@ -12221,7 +12416,7 @@ export class MessagingController {
   }): void {
     if (
       !params.event ||
-      !isMessagingToolOriginBinding(params.binding, params.navigation)
+      !isLiveMessagingToolOriginBinding(params.binding, params.navigation)
     ) {
       return;
     }
@@ -12495,7 +12690,8 @@ export class MessagingController {
     };
     if (
       previousBinding &&
-      (previousBinding.backend !== binding.backend ||
+      (previousBinding.id !== binding.id ||
+        previousBinding.backend !== binding.backend ||
         previousBinding.threadId !== binding.threadId)
     ) {
       await this.options.store.revokeBinding({
@@ -15582,6 +15778,16 @@ function isMessagingToolOriginBinding(
       thread.source === binding.backend &&
       thread.id === binding.threadId &&
       Boolean(thread.handoffOrigin),
+  );
+}
+
+function isLiveMessagingToolOriginBinding(
+  binding: MessagingBindingRecord,
+  navigation: NavigationSnapshot | undefined,
+): boolean {
+  return (
+    binding.backend === "codex"
+    || isMessagingToolOriginBinding(binding, navigation)
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
@@ -1,0 +1,77 @@
+import type {
+  MessagingChannelRef,
+  MessagingDefaultAgentScope,
+} from "@pwragent/messaging-interface";
+
+export type MessagingDefaultAgentScopeKind = MessagingDefaultAgentScope["kind"];
+
+export function buildMessagingDefaultAgentScopeKey(
+  scope: MessagingDefaultAgentScope,
+): string {
+  switch (scope.kind) {
+    case "conversation":
+      return `conversation:${buildMessagingConversationKey(scope.channel)}`;
+    case "parent":
+      return `parent:${JSON.stringify([scope.channel, scope.conversationId])}`;
+    case "workspace":
+      return `workspace:${JSON.stringify([scope.channel, scope.workspaceId])}`;
+    case "provider":
+      return `provider:${scope.channel}`;
+    case "profile":
+      return "profile";
+  }
+}
+
+export function buildDefaultAgentScopeLookup(
+  channel: MessagingChannelRef,
+): Array<{ key: string; scope: MessagingDefaultAgentScope }> {
+  const scopes: MessagingDefaultAgentScope[] = [
+    {
+      kind: "conversation",
+      channel: {
+        ...channel,
+        conversation: { ...channel.conversation },
+      },
+    },
+  ];
+  if (channel.conversation.parentConversationId) {
+    scopes.push({
+      kind: "parent",
+      channel: channel.channel,
+      conversationId: channel.conversation.parentConversationId,
+    });
+  }
+  if (channel.conversation.workspaceId) {
+    scopes.push({
+      kind: "workspace",
+      channel: channel.channel,
+      workspaceId: channel.conversation.workspaceId,
+    });
+  }
+  scopes.push(
+    { kind: "provider", channel: channel.channel },
+    { kind: "profile" },
+  );
+  return scopes.map((scope) => ({
+    key: buildMessagingDefaultAgentScopeKey(scope),
+    scope,
+  }));
+}
+
+export function defaultAgentScopeForChannel(
+  channel: MessagingChannelRef,
+  kind: MessagingDefaultAgentScopeKind,
+): MessagingDefaultAgentScope | undefined {
+  return buildDefaultAgentScopeLookup(channel)
+    .find((candidate) => candidate.scope.kind === kind)
+    ?.scope;
+}
+
+function buildMessagingConversationKey(channel: MessagingChannelRef): string {
+  return [
+    channel.channel,
+    channel.conversation.kind,
+    channel.conversation.parentId ?? "",
+    channel.conversation.id,
+  ].join(":");
+}

--- a/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-default-agent.ts
@@ -1,9 +1,37 @@
+import {
+  isAcpBackendId,
+  type AppServerBackendKind,
+  type BackendSummary,
+} from "@pwragent/shared";
 import type {
   MessagingChannelRef,
   MessagingDefaultAgentScope,
 } from "@pwragent/messaging-interface";
 
 export type MessagingDefaultAgentScopeKind = MessagingDefaultAgentScope["kind"];
+export type MessagingDefaultAgentBackendSupport =
+  | "supported"
+  | "unsupported"
+  | "unknown";
+
+export function defaultAgentBackendSupport(
+  backend: AppServerBackendKind,
+  summaries: readonly BackendSummary[] | undefined,
+): MessagingDefaultAgentBackendSupport {
+  if (backend === "codex") {
+    return "supported";
+  }
+  if (!isAcpBackendId(backend)) {
+    return "unsupported";
+  }
+  const summary = summaries?.find((candidate) => candidate.kind === backend);
+  if (!summary) {
+    return "unknown";
+  }
+  return summary.acp?.runtime?.agentCapabilities?.mcp?.http === true
+    ? "supported"
+    : "unsupported";
+}
 
 export function buildMessagingDefaultAgentScopeKey(
   scope: MessagingDefaultAgentScope,

--- a/apps/desktop/src/main/messaging/core/messaging-migrations.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-migrations.ts
@@ -2,6 +2,7 @@ import type {
   MessagingBindingRecord,
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
+  MessagingDefaultAgentAssignmentRecord,
   MessagingDeliveryResult,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -20,7 +21,7 @@ import { normalizeMessagingBindingTargetKind } from "@pwragent/shared";
 // must also land in the seed module, or the README screenshot capture
 // (`pnpm --filter @pwragent/desktop screenshot:readme`) silently
 // produces broken UI shots.
-export const CURRENT_MESSAGING_STORE_VERSION = 2;
+export const CURRENT_MESSAGING_STORE_VERSION = 3;
 
 export type MessagingDeliveryRecord = MessagingDeliveryResult & {
   id: string;
@@ -32,6 +33,7 @@ export type MessagingStoreData = {
   version: number;
   browseSessions: Record<string, MessagingBrowseSessionRecord>;
   bindings: Record<string, MessagingBindingRecord>;
+  defaultAgentAssignments: Record<string, MessagingDefaultAgentAssignmentRecord>;
   callbackHandles: Record<string, MessagingCallbackHandleRecord>;
   monitorSubscriptions: Record<string, MessagingMonitorSubscriptionRecord>;
   topicCleanupProposals: Record<string, MessagingTopicCleanupProposalRecord>;
@@ -45,6 +47,7 @@ const EMPTY_MESSAGING_STORE_DATA: MessagingStoreData = {
   version: CURRENT_MESSAGING_STORE_VERSION,
   browseSessions: {},
   bindings: {},
+  defaultAgentAssignments: {},
   callbackHandles: {},
   monitorSubscriptions: {},
   topicCleanupProposals: {},
@@ -64,6 +67,10 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
     version: CURRENT_MESSAGING_STORE_VERSION,
     browseSessions: migrateRecord(record.browseSessions, isMessagingBrowseSessionRecord),
     bindings: migrateBindingRecords(record.bindings),
+    defaultAgentAssignments: migrateRecord(
+      record.defaultAgentAssignments,
+      isMessagingDefaultAgentAssignmentRecord,
+    ),
     callbackHandles: migrateRecord(record.callbackHandles, isMessagingCallbackHandleRecord),
     monitorSubscriptions: migrateRecord(
       record.monitorSubscriptions,
@@ -78,6 +85,60 @@ export function migrateMessagingStoreData(raw: unknown): MessagingStoreData {
     pendingIntents: migrateRecord(record.pendingIntents, isMessagingPendingIntentRecord),
     deliveries: migrateRecord(record.deliveries, isMessagingDeliveryRecord),
   };
+}
+
+function isMessagingDefaultAgentAssignmentRecord(
+  value: unknown,
+): value is MessagingDefaultAgentAssignmentRecord {
+  const record = asRecord(value);
+  const scope = asRecord(record?.scope);
+  const target = asRecord(record?.target);
+  return Boolean(
+    record &&
+      typeof record.id === "string" &&
+      isMessagingDefaultAgentScope(scope) &&
+      target?.kind === "agent" &&
+      typeof target.backend === "string" &&
+      typeof target.threadId === "string" &&
+      typeof record.createdAt === "number" &&
+      typeof record.updatedAt === "number",
+  );
+}
+
+function isMessagingDefaultAgentScope(
+  scope: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!scope || typeof scope.kind !== "string") {
+    return false;
+  }
+  if (scope.kind === "profile") {
+    return true;
+  }
+  if (scope.kind === "provider") {
+    return typeof scope.channel === "string";
+  }
+  if (scope.kind === "parent") {
+    return (
+      typeof scope.channel === "string"
+      && typeof scope.conversationId === "string"
+    );
+  }
+  if (scope.kind === "workspace") {
+    return (
+      typeof scope.channel === "string"
+      && typeof scope.workspaceId === "string"
+    );
+  }
+  if (scope.kind === "conversation") {
+    const channel = asRecord(scope.channel);
+    const conversation = asRecord(channel?.conversation);
+    return (
+      typeof channel?.channel === "string"
+      && typeof conversation?.id === "string"
+      && typeof conversation?.kind === "string"
+    );
+  }
+  return false;
 }
 
 function migrateBindingRecords(value: unknown): Record<string, MessagingBindingRecord> {

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -482,15 +482,6 @@ function navigationActions(
   pageIndex: number,
   totalPages: number,
 ): MessagingSurfaceAction[] {
-  if (session.launchAction === "assign_default_agent") {
-    return [{
-      id: "browse:cancel",
-      label: "Cancel",
-      style: "secondary",
-      fallbackText: "cancel",
-      layout: { row: FOOTER_ROW },
-    }];
-  }
   const actions: MessagingSurfaceAction[] = [];
   if (pageIndex > 0) {
     actions.push({
@@ -509,6 +500,16 @@ function navigationActions(
       fallbackText: "next",
       layout: { row: NAV_ROW },
     });
+  }
+  if (session.launchAction === "assign_default_agent") {
+    actions.push({
+      id: "browse:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+      layout: { row: FOOTER_ROW },
+    });
+    return actions;
   }
   if (session.mode === "agents") {
     actions.push({
@@ -619,14 +620,21 @@ function threadPickerFallbackText(
     totalPages: number;
   },
 ): string {
-  const controls = [
-    page.pageIndex > 0 ? "previous" : undefined,
-    page.pageIndex < page.totalPages - 1 ? "next" : undefined,
-    session.mode === "agents" ? "recent" : "projects",
-    session.mode === "agents" ? undefined : "agents",
-    "new",
-    "cancel",
-  ].filter(Boolean);
+  const controls =
+    session.launchAction === "assign_default_agent"
+      ? [
+          page.pageIndex > 0 ? "previous" : undefined,
+          page.pageIndex < page.totalPages - 1 ? "next" : undefined,
+          "cancel",
+        ].filter(Boolean)
+      : [
+          page.pageIndex > 0 ? "previous" : undefined,
+          page.pageIndex < page.totalPages - 1 ? "next" : undefined,
+          session.mode === "agents" ? "recent" : "projects",
+          session.mode === "agents" ? undefined : "agents",
+          "new",
+          "cancel",
+        ].filter(Boolean);
   return [
     threadPickerPromptText(session, page.totalPages, page.totalItems),
     ...page.items.map(

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -337,6 +337,11 @@ function threadsForSession(
   if (session.mode === "agents") {
     threads = threads.filter((thread) => Boolean(thread.agent));
   }
+  if (session.launchAction === "assign_default_agent") {
+    threads = threads.filter(
+      (thread) => thread.source === "codex" && Boolean(thread.agent),
+    );
+  }
   const selectedDirectory = session.selectedProject
     ? directoryForProjectSelection(navigation, session.selectedProject)
     : undefined;
@@ -477,6 +482,15 @@ function navigationActions(
   pageIndex: number,
   totalPages: number,
 ): MessagingSurfaceAction[] {
+  if (session.launchAction === "assign_default_agent") {
+    return [{
+      id: "browse:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+      layout: { row: FOOTER_ROW },
+    }];
+  }
   const actions: MessagingSurfaceAction[] = [];
   if (pageIndex > 0) {
     actions.push({
@@ -571,14 +585,18 @@ function threadPickerPromptText(
 ): string {
   const pageLabel = `Page ${session.pageIndex + 1}/${totalPages}`;
   const scope =
-    session.mode === "agents"
+    session.launchAction === "assign_default_agent"
+      ? "Showing eligible PwrAgent Agent threads."
+      : session.mode === "agents"
       ? "Showing PwrAgent Agent threads."
       : session.selectedProject
         ? `Showing recent PwrAgent threads for ${session.selectedProject.label}.`
         : "Showing recent PwrAgent threads.";
   return [
     `${scope} ${pageLabel}.`,
-    session.mode === "agents"
+    session.launchAction === "assign_default_agent"
+      ? "Choose the default Agent for this messaging scope, or Cancel to leave it unchanged."
+      : session.mode === "agents"
       ? "Choose an Agent thread to attach. Use Recent Threads to show every thread, or Cancel to close this picker."
       : "Choose a thread to resume. Use Projects to browse by project, New to start a thread, or Cancel to close this picker.",
     totalItems === 0

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -338,9 +338,7 @@ function threadsForSession(
     threads = threads.filter((thread) => Boolean(thread.agent));
   }
   if (session.launchAction === "assign_default_agent") {
-    threads = threads.filter(
-      (thread) => thread.source === "codex" && Boolean(thread.agent),
-    );
+    threads = threads.filter((thread) => Boolean(thread.agent));
   }
   const selectedDirectory = session.selectedProject
     ? directoryForProjectSelection(navigation, session.selectedProject)

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -193,14 +193,14 @@ export class MessagingStore {
   async findActiveBindingForChannel(
     channel: MessagingChannelRef,
   ): Promise<MessagingBindingRecord | undefined> {
-    const channelKey = buildMessagingConversationKey(channel);
+    const channelKeys = buildMessagingConversationLookupKeys(channel);
     return await this.withReadData((data) =>
       cloneOptional(
         Object.values(data.bindings)
           .filter(
             (binding) =>
               !binding.revokedAt &&
-              buildMessagingConversationKey(binding.channel) === channelKey,
+              channelKeys.has(buildMessagingConversationKey(binding.channel)),
           )
           .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)[0],
       ),
@@ -797,6 +797,22 @@ export function buildMessagingConversationKey(channel: MessagingChannelRef): str
     channel.conversation.parentId ?? "",
     channel.conversation.id,
   ].join(":");
+}
+
+function buildMessagingConversationLookupKeys(
+  channel: MessagingChannelRef,
+): Set<string> {
+  const keys = new Set([buildMessagingConversationKey(channel)]);
+  if (channel.conversation.kind === "thread") {
+    keys.add(buildMessagingConversationKey({
+      channel: channel.channel,
+      conversation: {
+        ...channel.conversation,
+        kind: "channel",
+      },
+    }));
+  }
+  return keys;
 }
 
 function sanitizeDefaultAgentAssignment(

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -7,6 +7,8 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
+  MessagingDefaultAgentAssignmentRecord,
+  MessagingDefaultAgentScope,
   MessagingJsonValue,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -21,6 +23,10 @@ import {
   type MessagingDeliveryRecord,
   type MessagingStoreData,
 } from "./messaging-migrations.js";
+import {
+  buildDefaultAgentScopeLookup,
+  buildMessagingDefaultAgentScopeKey,
+} from "./messaging-default-agent.js";
 
 const SECRET_KEY_PATTERN = /token|secret|password|authorization|api[_-]?key/i;
 
@@ -52,6 +58,136 @@ export class MessagingStore {
 
   async getBinding(id: string): Promise<MessagingBindingRecord | undefined> {
     return await this.withReadData((data) => cloneOptional(data.bindings[id]));
+  }
+
+  async upsertDefaultAgentAssignment(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+  ): Promise<MessagingDefaultAgentAssignmentRecord> {
+    const sanitized = sanitizeDefaultAgentAssignment(assignment);
+    const scopeKey = buildMessagingDefaultAgentScopeKey(sanitized.scope);
+    return await this.withData((data) => {
+      for (const existing of Object.values(data.defaultAgentAssignments)) {
+        if (
+          !sanitized.revokedAt &&
+          existing.id !== sanitized.id &&
+          !existing.revokedAt &&
+          buildMessagingDefaultAgentScopeKey(existing.scope) === scopeKey
+        ) {
+          const revoked: MessagingDefaultAgentAssignmentRecord = {
+            ...existing,
+            revokedAt: sanitized.updatedAt,
+            updatedAt: sanitized.updatedAt,
+          };
+          data.defaultAgentAssignments[existing.id] = revoked;
+        }
+      }
+
+      data.defaultAgentAssignments[sanitized.id] = sanitized;
+      return structuredClone(sanitized);
+    });
+  }
+
+  async getDefaultAgentAssignment(
+    id: string,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return await this.withReadData((data) =>
+      cloneOptional(data.defaultAgentAssignments[id]),
+    );
+  }
+
+  async findActiveDefaultAgentAssignmentForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return (await this.findActiveDefaultAgentAssignmentsForChannel(channel))[0];
+  }
+
+  async findActiveDefaultAgentAssignmentsForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord[]> {
+    const scopeKeys = buildDefaultAgentScopeLookup(channel).map(
+      (candidate) => candidate.key,
+    );
+    return await this.withReadData((data) => {
+      const active = Object.values(data.defaultAgentAssignments).filter(
+        (assignment) => !assignment.revokedAt,
+      );
+      const matches: MessagingDefaultAgentAssignmentRecord[] = [];
+      for (const scopeKey of scopeKeys) {
+        const match = active
+          .filter(
+            (assignment) =>
+              buildMessagingDefaultAgentScopeKey(assignment.scope) === scopeKey,
+          )
+          .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)[0];
+        if (match) {
+          matches.push(structuredClone(match));
+        }
+      }
+      return matches;
+    });
+  }
+
+  async findActiveDefaultAgentAssignmentForScope(
+    scope: MessagingDefaultAgentScope,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const scopeKey = buildMessagingDefaultAgentScopeKey(scope);
+    return await this.withReadData((data) =>
+      cloneOptional(
+        Object.values(data.defaultAgentAssignments)
+          .filter(
+            (assignment) =>
+              !assignment.revokedAt
+              && buildMessagingDefaultAgentScopeKey(assignment.scope) === scopeKey,
+          )
+          .sort((a, b) => b.updatedAt - a.updatedAt || b.createdAt - a.createdAt)[0],
+      ),
+    );
+  }
+
+  async revokeDefaultAgentAssignment(params: {
+    assignmentId: string;
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return await this.withData((data) => {
+      const current = data.defaultAgentAssignments[params.assignmentId];
+      if (!current) return undefined;
+      const revokedAt = params.revokedAt ?? Date.now();
+      const revoked: MessagingDefaultAgentAssignmentRecord = {
+        ...current,
+        revokedAt,
+        updatedAt: revokedAt,
+      };
+      data.defaultAgentAssignments[params.assignmentId] = revoked;
+      return structuredClone(revoked);
+    });
+  }
+
+  async revokeDefaultAgentAssignmentsForTarget(params: {
+    backend: MessagingDefaultAgentAssignmentRecord["target"]["backend"];
+    threadId: MessagingDefaultAgentAssignmentRecord["target"]["threadId"];
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord[]> {
+    return await this.withData((data) => {
+      const revokedAt = params.revokedAt ?? Date.now();
+      const revoked: MessagingDefaultAgentAssignmentRecord[] = [];
+      for (const assignment of Object.values(data.defaultAgentAssignments)) {
+        if (
+          assignment.revokedAt
+          || assignment.target.backend !== params.backend
+          || assignment.target.threadId !== params.threadId
+        ) {
+          continue;
+        }
+        const next = {
+          ...assignment,
+          revokedAt,
+          updatedAt: revokedAt,
+        };
+        data.defaultAgentAssignments[assignment.id] = next;
+        revoked.push(structuredClone(next));
+      }
+      return revoked;
+    });
   }
 
   async findActiveBindingForChannel(
@@ -638,6 +774,7 @@ export class MessagingStore {
           callbackHandles: {},
           pendingIntents: {},
           deliveries: {},
+          defaultAgentAssignments: {},
         });
       }
 
@@ -660,6 +797,24 @@ export function buildMessagingConversationKey(channel: MessagingChannelRef): str
     channel.conversation.parentId ?? "",
     channel.conversation.id,
   ].join(":");
+}
+
+function sanitizeDefaultAgentAssignment(
+  assignment: MessagingDefaultAgentAssignmentRecord,
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    ...assignment,
+    scope: assignment.scope.kind === "conversation"
+      ? {
+          ...assignment.scope,
+          channel: {
+            ...assignment.scope.channel,
+            conversation: { ...assignment.scope.channel.conversation },
+          },
+        }
+      : { ...assignment.scope },
+    target: { ...assignment.target },
+  };
 }
 
 function sanitizeBinding(binding: MessagingBindingRecord): MessagingBindingRecord {

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -254,7 +254,7 @@ export class SqliteMessagingStore {
   async findActiveBindingForChannel(
     channel: MessagingChannelRef,
   ): Promise<MessagingBindingRecord | undefined> {
-    const channelKey = buildMessagingConversationKey(channel);
+    const channelKeys = buildMessagingConversationLookupKeys(channel);
     const rows = this.stateDb.raw
       .prepare(
         "SELECT payload FROM bindings WHERE status = 'active' AND channel_kind = ?",
@@ -264,7 +264,7 @@ export class SqliteMessagingStore {
       const binding: MessagingBindingRecord = JSON.parse(row.payload);
       if (
         !binding.revokedAt &&
-        buildMessagingConversationKey(binding.channel) === channelKey
+        channelKeys.has(buildMessagingConversationKey(binding.channel))
       ) {
         return binding;
       }
@@ -1072,6 +1072,22 @@ export function buildMessagingConversationKey(
     channel.conversation.parentId ?? "",
     channel.conversation.id,
   ].join(":");
+}
+
+function buildMessagingConversationLookupKeys(
+  channel: MessagingChannelRef,
+): Set<string> {
+  const keys = new Set([buildMessagingConversationKey(channel)]);
+  if (channel.conversation.kind === "thread") {
+    keys.add(buildMessagingConversationKey({
+      channel: channel.channel,
+      conversation: {
+        ...channel.conversation,
+        kind: "channel",
+      },
+    }));
+  }
+  return keys;
 }
 
 function buildChannelId(channel: MessagingChannelRef): string {

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -4,6 +4,8 @@ import type {
   MessagingBrowseSessionRecord,
   MessagingCallbackHandleRecord,
   MessagingChannelRef,
+  MessagingDefaultAgentAssignmentRecord,
+  MessagingDefaultAgentScope,
   MessagingJsonValue,
   MessagingManagedTopicRecord,
   MessagingMonitorSubscriptionRecord,
@@ -18,6 +20,10 @@ import type {
   MessagingStoreData,
 } from "../messaging/core/messaging-migrations.js";
 import { CURRENT_MESSAGING_STORE_VERSION } from "../messaging/core/messaging-migrations.js";
+import {
+  buildDefaultAgentScopeLookup,
+  buildMessagingDefaultAgentScopeKey,
+} from "../messaging/core/messaging-default-agent.js";
 
 const SECRET_KEY_PATTERN = /token|secret|password|authorization|api[_-]?key/i;
 
@@ -53,6 +59,196 @@ export class SqliteMessagingStore {
       .prepare("SELECT payload FROM bindings WHERE binding_id = ?")
       .get(id) as { payload: string } | undefined;
     return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async upsertDefaultAgentAssignment(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+  ): Promise<MessagingDefaultAgentAssignmentRecord> {
+    const sanitized = sanitizeDefaultAgentAssignment(assignment);
+    const scopeKey = buildMessagingDefaultAgentScopeKey(sanitized.scope);
+    const now = sanitized.updatedAt;
+    const upsertAssignment = this.stateDb.raw.prepare(
+      `INSERT OR REPLACE INTO messaging_default_agent_assignments(assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, revoked_at, payload)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const upsert = this.stateDb.raw.transaction(() => {
+      const rowsToRevoke = sanitized.revokedAt
+        ? []
+        : this.stateDb.raw
+            .prepare(
+              "SELECT assignment_id, payload FROM messaging_default_agent_assignments WHERE status = 'active' AND scope_key = ? AND assignment_id != ?",
+            )
+            .all(scopeKey, sanitized.id) as {
+              assignment_id: string;
+              payload: string;
+            }[];
+      for (const row of rowsToRevoke) {
+        try {
+          const current = JSON.parse(
+            row.payload,
+          ) as MessagingDefaultAgentAssignmentRecord;
+          const revoked: MessagingDefaultAgentAssignmentRecord = {
+            ...current,
+            revokedAt: now,
+            updatedAt: now,
+          };
+          upsertAssignment.run(
+            revoked.id,
+            revoked.scope.kind,
+            buildMessagingDefaultAgentScopeKey(revoked.scope),
+            channelKindForDefaultAgentScope(revoked.scope),
+            revoked.target.backend,
+            revoked.target.threadId,
+            "revoked",
+            revoked.createdAt,
+            revoked.updatedAt,
+            revoked.revokedAt ?? null,
+            JSON.stringify(revoked),
+          );
+        } catch {
+          this.stateDb.raw
+            .prepare(
+              "UPDATE messaging_default_agent_assignments SET status = 'revoked', revoked_at = ?, updated_at = ? WHERE assignment_id = ?",
+            )
+            .run(now, now, row.assignment_id);
+        }
+      }
+
+      upsertAssignment.run(
+        sanitized.id,
+        sanitized.scope.kind,
+        scopeKey,
+        channelKindForDefaultAgentScope(sanitized.scope),
+        sanitized.target.backend,
+        sanitized.target.threadId,
+        sanitized.revokedAt ? "revoked" : "active",
+        sanitized.createdAt,
+        sanitized.updatedAt,
+        sanitized.revokedAt ?? null,
+        JSON.stringify(sanitized),
+      );
+    });
+    upsert();
+
+    return structuredClone(sanitized);
+  }
+
+  async getDefaultAgentAssignment(
+    id: string,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_default_agent_assignments WHERE assignment_id = ?",
+      )
+      .get(id) as { payload: string } | undefined;
+    return row ? JSON.parse(row.payload) : undefined;
+  }
+
+  async findActiveDefaultAgentAssignmentForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    return (await this.findActiveDefaultAgentAssignmentsForChannel(channel))[0];
+  }
+
+  async findActiveDefaultAgentAssignmentsForChannel(
+    channel: MessagingChannelRef,
+  ): Promise<MessagingDefaultAgentAssignmentRecord[]> {
+    const matches: MessagingDefaultAgentAssignmentRecord[] = [];
+    for (const { key: scopeKey } of buildDefaultAgentScopeLookup(channel)) {
+      const rows = this.stateDb.raw
+        .prepare(
+          "SELECT payload FROM messaging_default_agent_assignments WHERE status = 'active' AND scope_key = ? ORDER BY updated_at DESC, created_at DESC",
+        )
+        .all(scopeKey) as { payload: string }[];
+      const match = rows
+        .map((row) => JSON.parse(row.payload) as MessagingDefaultAgentAssignmentRecord)
+        .find((assignment) => !assignment.revokedAt);
+      if (match) matches.push(match);
+    }
+    return matches;
+  }
+
+  async findActiveDefaultAgentAssignmentForScope(
+    scope: MessagingDefaultAgentScope,
+  ): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const row = this.stateDb.raw
+      .prepare(
+        "SELECT payload FROM messaging_default_agent_assignments WHERE status = 'active' AND scope_key = ? ORDER BY updated_at DESC, created_at DESC LIMIT 1",
+      )
+      .get(buildMessagingDefaultAgentScopeKey(scope)) as
+        | { payload: string }
+        | undefined;
+    if (!row) return undefined;
+    const assignment = JSON.parse(row.payload) as MessagingDefaultAgentAssignmentRecord;
+    return assignment.revokedAt ? undefined : assignment;
+  }
+
+  async revokeDefaultAgentAssignment(params: {
+    assignmentId: string;
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord | undefined> {
+    const current = await this.getDefaultAgentAssignment(params.assignmentId);
+    if (!current) return undefined;
+    const revokedAt = params.revokedAt ?? Date.now();
+    const revoked: MessagingDefaultAgentAssignmentRecord = {
+      ...current,
+      revokedAt,
+      updatedAt: revokedAt,
+    };
+    await this.upsertDefaultAgentAssignment(revoked);
+    return structuredClone(revoked);
+  }
+
+  async revokeDefaultAgentAssignmentsForTarget(params: {
+    backend: MessagingDefaultAgentAssignmentRecord["target"]["backend"];
+    threadId: MessagingDefaultAgentAssignmentRecord["target"]["threadId"];
+    revokedAt?: number;
+  }): Promise<MessagingDefaultAgentAssignmentRecord[]> {
+    const revokedAt = params.revokedAt ?? Date.now();
+    const revoke = this.stateDb.raw.transaction(() => {
+      const rows = this.stateDb.raw
+        .prepare(
+          "SELECT payload FROM messaging_default_agent_assignments WHERE status = 'active' AND backend = ? AND thread_id = ?",
+        )
+        .all(params.backend, params.threadId) as { payload: string }[];
+      const revoked: MessagingDefaultAgentAssignmentRecord[] = [];
+      for (const row of rows) {
+        const current = JSON.parse(row.payload) as MessagingDefaultAgentAssignmentRecord;
+        const next = {
+          ...current,
+          revokedAt,
+          updatedAt: revokedAt,
+        };
+        this.writeDefaultAgentAssignment(next);
+        revoked.push(next);
+      }
+      return revoked;
+    });
+    return revoke().map((assignment) => structuredClone(assignment));
+  }
+
+  private writeDefaultAgentAssignment(
+    assignment: MessagingDefaultAgentAssignmentRecord,
+  ): void {
+    const scopeKey = buildMessagingDefaultAgentScopeKey(assignment.scope);
+    this.stateDb.raw
+      .prepare(
+        `INSERT OR REPLACE INTO messaging_default_agent_assignments(assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, revoked_at, payload)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        assignment.id,
+        assignment.scope.kind,
+        scopeKey,
+        channelKindForDefaultAgentScope(assignment.scope),
+        assignment.target.backend,
+        assignment.target.threadId,
+        assignment.revokedAt ? "revoked" : "active",
+        assignment.createdAt,
+        assignment.updatedAt,
+        assignment.revokedAt ?? null,
+        JSON.stringify(assignment),
+      );
   }
 
   async findActiveBindingForChannel(
@@ -785,6 +981,10 @@ export class SqliteMessagingStore {
 
   async readSnapshot(): Promise<MessagingStoreData> {
     const bindings: Record<string, MessagingBindingRecord> = {};
+    const defaultAgentAssignments: Record<
+      string,
+      MessagingDefaultAgentAssignmentRecord
+    > = {};
     const monitorSubscriptions: Record<string, MessagingMonitorSubscriptionRecord> = {};
     const pendingIntents: Record<string, MessagingPendingIntentRecord> = {};
     const browseSessions: Record<string, MessagingBrowseSessionRecord> = {};
@@ -798,6 +998,13 @@ export class SqliteMessagingStore {
       .prepare("SELECT binding_id, payload FROM bindings")
       .all() as { binding_id: string; payload: string }[]) {
       bindings[row.binding_id] = JSON.parse(row.payload);
+    }
+    for (const row of this.stateDb.raw
+      .prepare(
+        "SELECT assignment_id, payload FROM messaging_default_agent_assignments",
+      )
+      .all() as { assignment_id: string; payload: string }[]) {
+      defaultAgentAssignments[row.assignment_id] = JSON.parse(row.payload);
     }
     for (const row of this.stateDb.raw
       .prepare("SELECT subscription_id, payload FROM monitor_subscriptions")
@@ -843,6 +1050,7 @@ export class SqliteMessagingStore {
     return {
       version: CURRENT_MESSAGING_STORE_VERSION,
       bindings,
+      defaultAgentAssignments,
       monitorSubscriptions,
       topicCleanupProposals,
       topicLinks,
@@ -888,6 +1096,33 @@ function sanitizeBinding(
     statusSurface: sanitizeSurfaceRef(binding.statusSurface),
     targetKind: normalizeMessagingBindingTargetKind(binding.targetKind),
   };
+}
+
+function sanitizeDefaultAgentAssignment(
+  assignment: MessagingDefaultAgentAssignmentRecord,
+): MessagingDefaultAgentAssignmentRecord {
+  return {
+    ...assignment,
+    scope: assignment.scope.kind === "conversation"
+      ? {
+          ...assignment.scope,
+          channel: {
+            ...assignment.scope.channel,
+            conversation: { ...assignment.scope.channel.conversation },
+          },
+        }
+      : { ...assignment.scope },
+    target: { ...assignment.target },
+  };
+}
+
+function channelKindForDefaultAgentScope(
+  scope: MessagingDefaultAgentScope,
+): string | null {
+  if (scope.kind === "profile") {
+    return null;
+  }
+  return scope.kind === "conversation" ? scope.channel.channel : scope.channel;
 }
 
 function sanitizePendingIntent(
@@ -993,6 +1228,13 @@ export type MessagingStoreLike = Pick<
   SqliteMessagingStore,
   | "upsertBinding"
   | "getBinding"
+  | "upsertDefaultAgentAssignment"
+  | "getDefaultAgentAssignment"
+  | "findActiveDefaultAgentAssignmentForChannel"
+  | "findActiveDefaultAgentAssignmentsForChannel"
+  | "findActiveDefaultAgentAssignmentForScope"
+  | "revokeDefaultAgentAssignment"
+  | "revokeDefaultAgentAssignmentsForTarget"
   | "findActiveBindingForChannel"
   | "findActiveBindingsForBackend"
   | "findActiveBindingsForThread"

--- a/apps/desktop/src/main/state/migration.ts
+++ b/apps/desktop/src/main/state/migration.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import type BetterSqlite3 from "better-sqlite3";
 import Database from "better-sqlite3";
+import type {
+  MessagingDefaultAgentAssignmentRecord,
+} from "@pwragent/messaging-interface";
+import { buildMessagingDefaultAgentScopeKey } from "../messaging/core/messaging-default-agent.js";
 import { migrateMessagingStoreData } from "../messaging/core/messaging-migrations.js";
 import {
   resolveActiveProfileName,
@@ -156,6 +160,10 @@ export function migrateIfNeeded(options?: {
         migrated.callbackHandles,
       );
       counts.deliveries = migrateDeliveries(stateDb.raw, migrated.deliveries);
+      counts.default_agent_assignments = migrateDefaultAgentAssignments(
+        stateDb.raw,
+        migrated.defaultAgentAssignments,
+      );
     }
 
     if (overlayData) {
@@ -347,6 +355,37 @@ function migrateDeliveries(
   return count;
 }
 
+function migrateDefaultAgentAssignments(
+  db: BetterSqlite3.Database,
+  assignments: Record<string, MessagingDefaultAgentAssignmentRecord>,
+): number {
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO messaging_default_agent_assignments(assignment_id, scope_kind, scope_key, channel_kind, backend, thread_id, status, created_at, updated_at, revoked_at, payload)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  let count = 0;
+  const insert = db.transaction(() => {
+    for (const [id, assignment] of Object.entries(assignments)) {
+      const result = stmt.run(
+        id,
+        assignment.scope.kind,
+        buildMessagingDefaultAgentScopeKey(assignment.scope),
+        defaultAgentAssignmentChannelKind(assignment),
+        assignment.target.backend,
+        assignment.target.threadId,
+        assignment.revokedAt ? "revoked" : "active",
+        assignment.createdAt,
+        assignment.updatedAt,
+        assignment.revokedAt ?? null,
+        JSON.stringify(assignment),
+      );
+      count += result.changes;
+    }
+  });
+  insert();
+  return count;
+}
+
 function migrateBackends(
   db: BetterSqlite3.Database,
   backends: unknown,
@@ -486,6 +525,17 @@ function channelId(channel: Record<string, unknown> | undefined): string {
   return [conv.kind ?? "", conv.parentId ?? "", conv.id ?? ""].join(":");
 }
 
+function defaultAgentAssignmentChannelKind(
+  assignment: MessagingDefaultAgentAssignmentRecord,
+): string | null {
+  if (assignment.scope.kind === "profile") {
+    return null;
+  }
+  return assignment.scope.kind === "conversation"
+    ? assignment.scope.channel.channel
+    : assignment.scope.channel;
+}
+
 function copyConfig(
   srcPath: string | undefined,
   options?: { env?: NodeJS.ProcessEnv; homeDir?: string; cliProfile?: string },
@@ -522,6 +572,10 @@ function verifyCounts(dbPath: string): Record<string, number> {
   try {
     const tableCountQueries = [
       ["bindings", "SELECT COUNT(*) as count FROM bindings"],
+      [
+        "default_agent_assignments",
+        "SELECT COUNT(*) as count FROM messaging_default_agent_assignments",
+      ],
       ["pending_intents", "SELECT COUNT(*) as count FROM pending_intents"],
       ["browse_sessions", "SELECT COUNT(*) as count FROM browse_sessions"],
       ["callback_handles", "SELECT COUNT(*) as count FROM callback_handles"],

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 32;
+export const CURRENT_STATE_DB_USER_VERSION = 33;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -417,6 +417,29 @@ CREATE TABLE IF NOT EXISTS messaging_activity_summary (
   last_response_at INTEGER,
   updated_at       INTEGER NOT NULL
 );
+`;
+
+const MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA = `
+CREATE TABLE IF NOT EXISTS messaging_default_agent_assignments (
+  assignment_id TEXT PRIMARY KEY,
+  scope_kind    TEXT NOT NULL,
+  scope_key     TEXT NOT NULL,
+  channel_kind  TEXT,
+  backend       TEXT NOT NULL,
+  thread_id     TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  revoked_at    INTEGER,
+  payload       TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messaging_default_agent_assignments_scope
+  ON messaging_default_agent_assignments(scope_key, status, updated_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messaging_default_agent_assignments_active_scope
+  ON messaging_default_agent_assignments(scope_key)
+  WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS idx_messaging_default_agent_assignments_thread
+  ON messaging_default_agent_assignments(backend, thread_id, status);
 `;
 
 const THREAD_SEARCH_SCHEMA = `
@@ -970,6 +993,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 32) {
       db.transaction(() => {
         repairTokenUsagePricing(db);
+        db.pragma("user_version = 32");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 33) {
+      db.transaction(() => {
+        db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1118,6 +1147,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(ACP_SESSION_SCHEMA);
     db.exec(AUTOMATION_SCHEMA);
     db.exec(MESSAGING_ACTIVITY_SUMMARY_SCHEMA);
+    db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);

--- a/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
+++ b/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
@@ -106,17 +106,18 @@ where available.
 The required bootstrap prompt depends on `search_threads`, `read_thread`,
 `send_message_to_thread`, and `attach_thread_here`.
 
-The first implementation explicitly limits default assignment to Codex Agent
-threads because current main only guarantees the complete PwrAgent dynamic-tool
-set for Codex. The picker filters to:
+Default assignment is available when the backend exposes the complete PwrAgent
+tool catalog through a supported transport. Codex receives that catalog through
+dynamic tools. ACP runtimes receive the same catalog through PwrAgent's HTTP MCP
+server when their discovered runtime capabilities advertise HTTP MCP support.
+The picker filters to:
 
-- `thread.source === "codex"`
 - Agent metadata is present
+- the backend is Codex, or an ACP runtime advertising HTTP MCP support
 - the thread is present in the current navigation snapshot
 
-This is an explicit product constraint, not an assumption that every Agent
-backend has Codex tools. A future backend can become eligible through a shared
-backend capability once it supplies the same tool contract.
+Built-in Grok and ACP runtimes without HTTP MCP remain ineligible until they
+can expose the same PwrAgent search, send, handoff, and attachment contract.
 
 ### Addressed unbound bootstrap
 
@@ -193,7 +194,8 @@ without making lifecycle/no-turn tool calls guess a location.
 - Parse the `default` subcommand under `/agent`.
 - Add scope parsing and a compact status/management confirmation surface.
 - Extend browse-session continuation state for explicit default assignment.
-- Filter that picker to eligible Codex Agent threads.
+- Filter that picker to Agent threads whose backend exposes the complete
+  PwrAgent tool catalog through Codex dynamic tools or ACP HTTP MCP.
 - On selection, set the requested assignment and render confirmation without
   changing any active messaging binding.
 - Add callback actions for set/change and clear at the exact scope.
@@ -283,8 +285,8 @@ Executed verification:
 - Ephemeral control bindings, controller-local turn ownership maps, custom
   delivery filtering, and alternate backend FIFO routing.
 - Automatic default persistence from ordinary Agent browsing.
-- Non-Codex default Agents until a shared backend capability guarantees the
-  required PwrAgent tools.
+- Default Agents on built-in Grok or ACP runtimes without HTTP MCP until those
+  backends expose the required PwrAgent tools.
 - Settings-window management UI. Messaging commands/buttons/pickers are the
   first complete operator surface.
 - Automatic use of a default for unaddressed ambient shared-channel messages.

--- a/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
+++ b/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
@@ -57,7 +57,7 @@ type MessagingDefaultAgentTarget = {
 };
 
 type MessagingDefaultAgentScope =
-  | { kind: "conversation"; channel: MessagingChannelKind; conversationKey: string }
+  | { kind: "conversation"; channel: MessagingChannelRef }
   | { kind: "parent"; channel: MessagingChannelKind; conversationId: string }
   | { kind: "workspace"; channel: MessagingChannelKind; workspaceId: string }
   | { kind: "provider"; channel: MessagingChannelKind }
@@ -242,6 +242,8 @@ pnpm test apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
 pnpm test apps/desktop/src/main/__tests__/state-db.test.ts
 pnpm test packages/messaging/interface/src/__tests__/messaging-contract.test.ts
 pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+pnpm test packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+pnpm test packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
 pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts
 pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts
 pnpm lint:eslint

--- a/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
+++ b/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
@@ -13,10 +13,10 @@ ordinary messaging bindings and provider-managed child conversations.
 
 An operator explicitly assigns an eligible Agent as the default for a
 normalized messaging scope. An authorized, addressed message in an unbound
-surface resolves that assignment, asks the adapter to materialize a bindable
-child conversation, creates a normal Agent-thread binding there, and submits the
-message through normal turn admission. From then on, the child conversation is
-an ordinary bound messaging surface.
+surface resolves that assignment, chooses a bindable placement from normalized
+conversation kind and adapter capabilities, creates a normal Agent-thread
+binding there, and submits the message through normal turn admission. From then
+on, the conversation is an ordinary bound messaging surface.
 
 Ordinary bound work-thread turns also retain their live messaging origin. That
 lets existing `handoff_task` messaging attachment behavior and
@@ -127,22 +127,30 @@ The bootstrap applies only when all of these are true:
 - the normalized conversation has no active binding
 - a valid default resolves
 
-The controller then:
+The controller then resolves placement generically:
 
-1. asks `getManagedConversationRights` when available
-2. calls `createManagedConversation` with the original actor, channel, and
-   opaque routing state
-3. creates a normal `agent_thread` binding for the returned conversation
-4. delivers the initial status surface, which materializes Slack's reply thread
-5. admits the original text through the existing turn-admission path with an
-   event rewritten only to the adapter-returned normalized child conversation
+1. If the normalized inbound conversation kind is `thread` or `topic`, use
+   `current_conversation`. The existing child is already a safe bindable
+   placement; no adapter create call is needed.
+2. Otherwise, ask `getManagedConversationRights` when available and call
+   `createManagedConversation` only when `create_child` is supported for the
+   source event.
+3. If neither current-conversation placement nor safe child creation is
+   available, return a capability error without creating a binding or admitting
+   a turn.
+4. Create a normal `agent_thread` binding for the selected current or returned
+   child conversation.
+5. Deliver the initial status surface. For Slack root mentions, this reply
+   materializes the Slack thread.
+6. Admit the original text through the existing turn-admission path, rewriting
+   the event channel/routing state only when the adapter returned a new child.
 
 The original actor, text, and routing state remain intact. Mutable conversation
 labels are not interpolated into privileged Agent instructions.
 
-If child creation is unsupported, denied, or fails, the controller sends a
-clear capability error to the source surface and creates no binding. It does
-not invent an ephemeral binding or submit a side-channel turn.
+If child creation is needed but unsupported, denied, or fails, the controller
+sends a clear capability error to the source surface and creates no binding. It
+does not invent an ephemeral binding or submit a side-channel turn.
 
 Unaddressed ambient messages in unbound shared channels retain current behavior.
 Commands, callbacks, media handling, authorization, queueing, steering, and
@@ -193,7 +201,8 @@ without making lifecycle/no-turn tool calls guess a location.
 ### 3. Bootstrap and origin parity
 
 - Resolve valid defaults for addressed, unbound text.
-- Create an adapter-managed child conversation and a normal Agent binding.
+- Bind an existing normalized child conversation in place, or create an
+  adapter-managed child from a root conversation when supported.
 - Submit through existing turn admission and preserve the original actor and
   normalized origin.
 - Revoke stale targets and continue fallback resolution.
@@ -214,13 +223,16 @@ without making lifecycle/no-turn tool calls guess a location.
 4. The Agent can use existing thread search/read/send tools, then
    `attach_thread_here` with `placement=current_conversation` to replace the
    Slack reply-thread binding with the chosen work thread.
-5. An ordinary bound Codex turn can call `handoff_task` with
+5. An authorized addressed message in an unbound normalized Telegram topic or
+   Discord/Slack thread binds that existing conversation to the default Agent
+   and admits the turn without calling `createManagedConversation`.
+6. An ordinary bound Codex turn can call `handoff_task` with
    `messagingAttachment` or `attach_thread_here` using its concrete turn
    origin.
-6. Telegram topics and Discord threads resolve exact and normalized parent
+7. Telegram topics and Discord threads resolve exact and normalized parent
    fallbacks without desktop core parsing native IDs.
-7. A provider that cannot create a bindable child returns a capability error
-   and receives no Agent turn.
+8. A root-like surface whose provider cannot create a bindable child returns a
+   capability error and receives no Agent turn.
 
 ## Verification
 

--- a/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
+++ b/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
@@ -251,6 +251,32 @@ pnpm lint:boundaries
 pnpm typecheck
 ```
 
+## Implementation Status
+
+Completed on 2026-07-30:
+
+- [x] Provider-neutral assignment contract, specificity lookup, JSON/SQLite
+  parity, and state DB version 32 migration.
+- [x] Explicit `/agent default` inspect/set/change/clear workflow without
+  implicit persistence from ordinary Agent browsing.
+- [x] Existing-child and root-to-managed-child addressed bootstrap through
+  ordinary bindings and turn admission.
+- [x] Live origin parity for ordinary bound Codex turns with the conservative
+  no-turn fallback unchanged.
+- [x] Slack, Telegram, and Discord hierarchy normalization, including
+  compatibility lookup for legacy channel-shaped Discord thread bindings.
+- [x] Stale-target fallback cleanup and proactive archive cleanup.
+
+Executed verification:
+
+- Focused controller, store, migration, Slack, Telegram, and Discord suites:
+  442 tests passed.
+- Messaging interface and backend-registry suites: 397 tests passed.
+- `pnpm lint:eslint`: passed with zero errors (baseline warnings remain).
+- `pnpm lint:boundaries`: passed with no dependency violations.
+- `pnpm lint:sql`: passed.
+- `pnpm typecheck`: passed for all workspace projects.
+
 ## Deferred
 
 - `/agent <request>` side-channel routing from an already bound surface.

--- a/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
+++ b/docs/plans/2026-07-30-feat-messaging-default-agent-surfaces-plan.md
@@ -1,0 +1,251 @@
+---
+title: "feat: Add provider-neutral default Agent messaging surfaces"
+type: feat
+date: 2026-07-30
+---
+
+# Provider-neutral default Agent messaging surfaces
+
+## Summary
+
+Replace PR #861's side-channel control routing with a smaller workflow built on
+ordinary messaging bindings and provider-managed child conversations.
+
+An operator explicitly assigns an eligible Agent as the default for a
+normalized messaging scope. An authorized, addressed message in an unbound
+surface resolves that assignment, asks the adapter to materialize a bindable
+child conversation, creates a normal Agent-thread binding there, and submits the
+message through normal turn admission. From then on, the child conversation is
+an ordinary bound messaging surface.
+
+Ordinary bound work-thread turns also retain their live messaging origin. That
+lets existing `handoff_task` messaging attachment behavior and
+`attach_thread_here` understand "this channel" without a second Agent route.
+
+## Product Contract
+
+### Explicit default management
+
+- Default Agent assignment is persisted separately from
+  `MessagingBindingRecord`.
+- `/agent` keeps its current behavior: browse or create an Agent and bind the
+  current conversation.
+- `/agent default` shows the effective default, the scope that supplied it, and
+  whether an exact assignment exists for the current conversation.
+- `/agent default set [conversation|parent|workspace|provider|profile]` opens
+  the existing Agent picker in an explicit default-assignment continuation.
+- Selecting an Agent from that continuation replaces the assignment at the
+  requested scope. It does not bind the current conversation and cannot happen
+  as a side effect of ordinary `/agent` browsing.
+- `/agent default clear [conversation|parent|workspace|provider|profile]`
+  revokes only that scope's assignment and then shows the newly effective
+  fallback.
+- The no-argument `set` and `clear` operations target the exact conversation.
+  Scope options that cannot be expressed by the normalized inbound surface are
+  reported as unavailable rather than guessed from provider-native IDs.
+
+### Resolution hierarchy
+
+The generic contract uses a discriminated assignment scope and an explicit
+Agent target:
+
+```ts
+type MessagingDefaultAgentTarget = {
+  kind: "agent";
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+type MessagingDefaultAgentScope =
+  | { kind: "conversation"; channel: MessagingChannelKind; conversationKey: string }
+  | { kind: "parent"; channel: MessagingChannelKind; conversationId: string }
+  | { kind: "workspace"; channel: MessagingChannelKind; workspaceId: string }
+  | { kind: "provider"; channel: MessagingChannelKind }
+  | { kind: "profile" };
+```
+
+Resolution evaluates the normalized inbound surface from most to least
+specific:
+
+1. exact conversation identity, including thread/topic identity
+2. explicit normalized parent/channel identity
+3. explicit normalized workspace/server/team identity
+4. provider
+5. PwrAgent profile
+
+The adapter contract gains normalized hierarchy identifiers where current
+fields are insufficient. Providers populate them at their boundary. Desktop
+core only builds and compares generic scope keys; it never parses
+`routingState.opaque` or provider-native identifiers.
+
+For Slack, a root channel assignment is an exact conversation assignment. The
+adapter already normalizes app mentions and retains the source timestamp in
+opaque routing state for managed-conversation creation. It will additionally
+expose the workspace/team identifier through the normalized hierarchy contract
+where available.
+
+### Assignment integrity
+
+- Assignment records are a discriminated union; malformed scoped records are
+  rejected during JSON migration instead of being widened to profile scope.
+- A scope has at most one active assignment.
+- JSON replacement occurs under the store's existing serialized write queue.
+- SQLite replacement revokes the previous row and inserts the replacement in
+  one transaction.
+- SQLite has a partial unique index on the active scope key so multiple app
+  instances cannot create competing active assignments.
+- Clearing is a revocation, preserving audit history.
+- Resolution validates that the target is still an available eligible Agent.
+  Stale assignments are revoked and lookup continues at the next broader scope.
+- Thread archive events best-effort revoke assignments targeting the archived
+  Agent, while resolution remains the correctness backstop for missed events or
+  restarts.
+
+### Eligible Agent backends
+
+The required bootstrap prompt depends on `search_threads`, `read_thread`,
+`send_message_to_thread`, and `attach_thread_here`.
+
+The first implementation explicitly limits default assignment to Codex Agent
+threads because current main only guarantees the complete PwrAgent dynamic-tool
+set for Codex. The picker filters to:
+
+- `thread.source === "codex"`
+- Agent metadata is present
+- the thread is present in the current navigation snapshot
+
+This is an explicit product constraint, not an assumption that every Agent
+backend has Codex tools. A future backend can become eligible through a shared
+backend capability once it supplies the same tool contract.
+
+### Addressed unbound bootstrap
+
+The bootstrap applies only when all of these are true:
+
+- the inbound event is authorized by the existing actor/conversation gates
+- it is text with `botMention === true`
+- the normalized conversation has no active binding
+- a valid default resolves
+
+The controller then:
+
+1. asks `getManagedConversationRights` when available
+2. calls `createManagedConversation` with the original actor, channel, and
+   opaque routing state
+3. creates a normal `agent_thread` binding for the returned conversation
+4. delivers the initial status surface, which materializes Slack's reply thread
+5. admits the original text through the existing turn-admission path with an
+   event rewritten only to the adapter-returned normalized child conversation
+
+The original actor, text, and routing state remain intact. Mutable conversation
+labels are not interpolated into privileged Agent instructions.
+
+If child creation is unsupported, denied, or fails, the controller sends a
+clear capability error to the source surface and creates no binding. It does
+not invent an ephemeral binding or submit a side-channel turn.
+
+Unaddressed ambient messages in unbound shared channels retain current behavior.
+Commands, callbacks, media handling, authorization, queueing, steering, and
+normal bound delivery continue through their existing paths.
+
+### Ordinary bound-turn origin parity
+
+`rememberAgentMessagingOrigin` should record every live inbound messaging turn
+whose backend has the messaging tool contract, including ordinary Codex work
+threads. A concrete `turnId` plus the live inbound event makes this
+unambiguous.
+
+The no-turn fallback remains conservative:
+
+- Agent-thread bindings remain eligible.
+- Handoff-origin bindings remain eligible.
+- Ordinary work-thread bindings do not become eligible without a concrete live
+  turn.
+- Multiple fallback bindings still fail with `ambiguous_location`.
+
+This preserves the originating actor and surface for ordinary bound Codex turns
+without making lifecycle/no-turn tool calls guess a location.
+
+## Implementation Units
+
+### 1. Contract and persistence
+
+- Add normalized hierarchy fields and default-assignment types to
+  `@pwragent/messaging-interface`.
+- Bump the JSON messaging store version and migrate only structurally valid
+  assignments.
+- Add assignment CRUD, replacement, resolution candidate lookup, target revoke,
+  and snapshot parity to JSON and SQLite stores.
+- Add a SQLite table, active-scope partial unique index, and state DB migration.
+- Cover malformed records, specificity, transactional replacement, uniqueness,
+  clearing, stale-target revocation, fresh schema, and previous-version reopen.
+
+### 2. Explicit management
+
+- Parse the `default` subcommand under `/agent`.
+- Add scope parsing and a compact status/management confirmation surface.
+- Extend browse-session continuation state for explicit default assignment.
+- Filter that picker to eligible Codex Agent threads.
+- On selection, set the requested assignment and render confirmation without
+  changing any active messaging binding.
+- Add callback actions for set/change and clear at the exact scope.
+
+### 3. Bootstrap and origin parity
+
+- Resolve valid defaults for addressed, unbound text.
+- Create an adapter-managed child conversation and a normal Agent binding.
+- Submit through existing turn admission and preserve the original actor and
+  normalized origin.
+- Revoke stale targets and continue fallback resolution.
+- Record live ordinary Codex messaging origins by turn while preserving the
+  conservative no-turn fallback.
+- Cover Slack-shaped, Telegram-shaped, Discord-shaped, unsupported-capability,
+  ambient-message, authorization, stale-target, and ordinary-bound-origin
+  paths in focused controller tests.
+
+## Acceptance
+
+1. `/agent default` can inspect, explicitly set/change, and clear a Slack
+   channel's exact default without changing its current binding.
+2. Selecting an Agent in ordinary `/agent` browsing never persists a default.
+3. An authorized `@PwrAgent ...` message in an unbound Slack channel with a
+   default creates a Slack reply-thread binding to that Agent and starts the
+   normal bound turn with the real actor and origin.
+4. The Agent can use existing thread search/read/send tools, then
+   `attach_thread_here` with `placement=current_conversation` to replace the
+   Slack reply-thread binding with the chosen work thread.
+5. An ordinary bound Codex turn can call `handoff_task` with
+   `messagingAttachment` or `attach_thread_here` using its concrete turn
+   origin.
+6. Telegram topics and Discord threads resolve exact and normalized parent
+   fallbacks without desktop core parsing native IDs.
+7. A provider that cannot create a bindable child returns a capability error
+   and receives no Agent turn.
+
+## Verification
+
+```bash
+pnpm test apps/desktop/src/main/__tests__/messaging-store.test.ts
+pnpm test apps/desktop/src/main/__tests__/messaging-store-sqlite.test.ts
+pnpm test apps/desktop/src/main/__tests__/state-db.test.ts
+pnpm test packages/messaging/interface/src/__tests__/messaging-contract.test.ts
+pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts
+pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts
+pnpm lint:eslint
+pnpm lint:boundaries
+pnpm typecheck
+```
+
+## Deferred
+
+- `/agent <request>` side-channel routing from an already bound surface.
+- Ephemeral control bindings, controller-local turn ownership maps, custom
+  delivery filtering, and alternate backend FIFO routing.
+- Automatic default persistence from ordinary Agent browsing.
+- Non-Codex default Agents until a shared backend capability guarantees the
+  required PwrAgent tools.
+- Settings-window management UI. Messaging commands/buttons/pickers are the
+  first complete operator surface.
+- Automatic use of a default for unaddressed ambient shared-channel messages.
+- Provider-native scope inference in desktop core.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -293,6 +293,17 @@ export type MessagingConversationRef = {
   kind: MessagingConversationKind;
   parentId?: string;
   /**
+   * Normalized containing conversation used for scope inheritance. This is
+   * separate from `parentId`, which remains part of some providers' persisted
+   * conversation identity.
+   */
+  parentConversationId?: string;
+  /**
+   * Normalized workspace/server/team identifier. Providers populate this at
+   * their boundary; workflow code must not recover it from opaque state.
+   */
+  workspaceId?: string;
+  /**
    * Title of this conversation node (DM peer, channel, topic, thread).
    * Optional — adapters populate when the platform makes it cheap.
    */
@@ -1456,6 +1467,44 @@ export type MessagingBindingRecord = {
   threadDisplay?: MessagingThreadDisplaySummary;
 };
 
+export type MessagingDefaultAgentTarget = {
+  kind: "agent";
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+};
+
+export type MessagingDefaultAgentScope =
+  | {
+      kind: "conversation";
+      channel: MessagingChannelRef;
+    }
+  | {
+      kind: "parent";
+      channel: MessagingChannelKind;
+      conversationId: string;
+    }
+  | {
+      kind: "workspace";
+      channel: MessagingChannelKind;
+      workspaceId: string;
+    }
+  | {
+      kind: "provider";
+      channel: MessagingChannelKind;
+    }
+  | {
+      kind: "profile";
+    };
+
+export type MessagingDefaultAgentAssignmentRecord = {
+  id: string;
+  scope: MessagingDefaultAgentScope;
+  target: MessagingDefaultAgentTarget;
+  createdAt: number;
+  updatedAt: number;
+  revokedAt?: number;
+};
+
 export type MessagingPendingIntentRecord = {
   id: string;
   bindingId?: string;
@@ -1478,7 +1527,8 @@ export type MessagingBrowseMode =
 export type MessagingBrowseLaunchAction =
   | "resume_thread"
   | "start_new_thread"
-  | "start_new_agent_thread";
+  | "start_new_agent_thread"
+  | "assign_default_agent";
 
 export type MessagingBrowseSelectedProject = {
   directoryKey?: string;
@@ -1506,6 +1556,7 @@ export type MessagingBrowseSessionRecord = {
   expiresAt: number;
   fullAccessRiskAcceptedAt?: number;
   launchAction: MessagingBrowseLaunchAction;
+  defaultAgentScope?: MessagingDefaultAgentScope;
   mode: MessagingBrowseMode;
   pageIndex: number;
   pageSize: number;

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -982,16 +982,15 @@ describe("discord adapter", () => {
       expect(events).toEqual([
         expect.objectContaining({
           actor: expect.objectContaining({ platformUserId: TEST_USER_ID }),
-          args: ["123456789ABCDEFGHJKLMNPQRSTUVWXY"],
+          botMention: true,
           channel: expect.objectContaining({
             conversation: expect.objectContaining({
               id: TEST_CHANNEL_ID,
               parentId: TEST_GUILD_ID,
             }),
           }),
-          command: "pair",
-          kind: "command",
-          rawText: "/pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
+          kind: "text",
+          text: "pair 123456789ABCDEFGHJKLMNPQRSTUVWXY",
         }),
       ]);
       expect(rejectedEvents).toEqual([]);
@@ -1335,7 +1334,7 @@ describe("discord adapter", () => {
       await adapter.stop();
     });
 
-    it("dispatches `<@bot> resume` as a command event", async () => {
+    it("normalizes `<@bot> resume` as addressed text for core command matching", async () => {
       const BOT_ID = "1480556454498009352";
       const events: MessagingInboundEvent[] = [];
       const gateway = new TestDiscordGateway();
@@ -1369,14 +1368,83 @@ describe("discord adapter", () => {
       expect(events).toHaveLength(1);
       const dispatched = events[0];
       expect(dispatched).toMatchObject({
-        kind: "command",
-        command: "resume",
-        rawText: "/resume",
+        botMention: true,
+        kind: "text",
+        text: "resume",
       });
       await adapter.stop();
     });
 
-    it("dispatches `<@bot> help args` with args parsed from the remainder", async () => {
+    it("normalizes addressed Discord threads as bindable child conversations", async () => {
+      const BOT_ID = "1480556454498009352";
+      const parentChannelId = "1480556454498009357";
+      const events: MessagingInboundEvent[] = [];
+      const gateway = new TestDiscordGateway();
+      const adapter = new DiscordAdapter({
+        api: createApi({
+          getChannel: async (id) => id === TEST_CHANNEL_ID
+            ? {
+                id,
+                name: "Search signals",
+                parentId: parentChannelId,
+              }
+            : {
+                id,
+                name: "p-search-signals-project",
+              },
+          getGuild: async (id) => ({
+            id,
+            name: "PwrDrvr",
+          }),
+        }),
+        config: {
+          applicationId: BOT_ID,
+          authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+          authorizedGuildIds: TEST_AUTHORIZED_GUILD_IDS,
+          botToken: "token",
+          channel: "discord",
+        },
+        gateway,
+        now: () => 1234,
+      });
+      await adapter.start(async (event) => {
+        events.push(event);
+      });
+
+      await gateway.emit({
+        op: 0,
+        t: "MESSAGE_CREATE",
+        d: {
+          ...messageDispatch({
+            authorBot: false,
+            content: `<@${BOT_ID}> investigate this`,
+            id: "thread-msg",
+          }),
+          channel_type: 11,
+          is_thread: true,
+        },
+      });
+
+      expect(events[0]).toMatchObject({
+        botMention: true,
+        channel: {
+          channel: "discord",
+          conversation: {
+            ancestorTitle: "PwrDrvr",
+            id: TEST_CHANNEL_ID,
+            kind: "thread",
+            parentConversationId: parentChannelId,
+            parentTitle: "p-search-signals-project",
+            workspaceId: TEST_GUILD_ID,
+          },
+        },
+        kind: "text",
+        text: "investigate this",
+      });
+      await adapter.stop();
+    });
+
+    it("normalizes `<@bot> help args` as addressed text", async () => {
       const BOT_ID = "1480556454498009352";
       const events: MessagingInboundEvent[] = [];
       const gateway = new TestDiscordGateway();
@@ -1408,15 +1476,14 @@ describe("discord adapter", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0]).toMatchObject({
-        kind: "command",
-        command: "help",
-        args: ["foo", "bar"],
-        rawText: "/help foo bar",
+        botMention: true,
+        kind: "text",
+        text: "help foo bar",
       });
       await adapter.stop();
     });
 
-    it("dispatches a bare `<@bot>` mention as the help command", async () => {
+    it("normalizes a bare `<@bot>` mention to addressed help text", async () => {
       const BOT_ID = "1480556454498009352";
       const events: MessagingInboundEvent[] = [];
       const gateway = new TestDiscordGateway();
@@ -1448,15 +1515,14 @@ describe("discord adapter", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0]).toMatchObject({
-        kind: "command",
-        command: "help",
-        args: [],
-        rawText: "/help",
+        botMention: true,
+        kind: "text",
+        text: "help",
       });
       await adapter.stop();
     });
 
-    it("routes a caption like `<@bot> resume` on an attachment to a command, not media", async () => {
+    it("normalizes a caption like `<@bot> resume` for core command matching", async () => {
       const BOT_ID = "1480556454498009352";
       const events: MessagingInboundEvent[] = [];
       const gateway = new TestDiscordGateway();
@@ -1496,9 +1562,9 @@ describe("discord adapter", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0]).toMatchObject({
-        kind: "command",
-        command: "resume",
-        rawText: "/resume",
+        botMention: true,
+        kind: "media",
+        text: "resume",
       });
       await adapter.stop();
     });
@@ -1543,8 +1609,9 @@ describe("discord adapter", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0]).toMatchObject({
+        botMention: true,
         kind: "media",
-        text: `<@${BOT_ID}>`,
+        text: "",
         attachments: [
           expect.objectContaining({
             kind: "file",

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -811,6 +811,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       dmPeerName: message.guild_id
         ? undefined
         : (message.author.global_name ?? message.author.username),
+      isThread: message.is_thread,
     });
     const receivedAt = this.now();
     const routingState = this.routingStateFromDiscord(message.channel_id, message.guild_id, {
@@ -823,56 +824,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       messageId: message.id,
     });
     const hasAttachments = Boolean(message.attachments?.length);
-
-    // `<@botUserId> <verb>` text mention → command. Run BEFORE the
-    // attachment branch so captions like `@PwrAgent resume` on a
-    // file/image upload route to the command pathway too — the user
-    // typed a verb, that intent wins over the incidental attachment.
-    // Mirrors the Mattermost `@<bot> <verb>` path so users on Discord
-    // can invoke commands without remembering slash names. Discord
-    // ships raw `<@USER_ID>` (or legacy `<@!USER_ID>`) tokens in
-    // `message.content` even though the UI renders `@PwrAgent`, so we
-    // match on the id rather than the display name. The bot's user_id
-    // equals the configured applicationId for any modern Discord app
-    // (the application id and bot user id were unified for bots
-    // created since 2016).
-    if (message.content !== undefined) {
-      if (
-        mentionRemainder !== undefined &&
-        // A bare mention caption has no command verb. Let the media
-        // branch handle the upload so bound conversations can send it
-        // to the thread; unbound conversations will get the
-        // controller's normal "bind before attachments" response.
-        !(mentionRemainder.length === 0 && hasAttachments)
-      ) {
-        // Synthesize the slash form so the controller sees the same
-        // `MessagingInboundCommandEvent` shape as a `/`-prefixed
-        // message. The slash regex below extracts verb + args. If
-        // the remainder doesn't form a valid verb (e.g. `@bot @bot
-        // help` strips one mention but leaves another, or `@bot 123`
-        // leads with a non-identifier char) we deliberately fall
-        // through to the standard attachment / slash / text paths
-        // below — the original `message.content` is dispatched as
-        // media or plain text rather than a half-recognized command.
-        const synthRaw = mentionRemainder.length === 0 ? "/help" : `/${mentionRemainder}`;
-        const mentionCommandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(synthRaw);
-        if (mentionCommandMatch) {
-          await listener({
-            id: `discord:message:${message.id}`,
-            kind: "command",
-            actor: this.actorFromUser(message.author),
-            args: mentionCommandMatch[2]?.split(/\s+/).filter(Boolean) ?? [],
-            channel,
-            command: mentionCommandMatch[1]?.toLowerCase() ?? "",
-            rawText: synthRaw,
-            receivedAt,
-            routingState,
-            sourceUrl,
-          });
-          return;
-        }
-      }
-    }
+    const normalizedContent = mentionRemainder === "" && !hasAttachments
+      ? "help"
+      : mentionRemainder ?? message.content;
 
     if (message.attachments && message.attachments.length > 0) {
       const attachments = message.attachments.map((attachment) =>
@@ -896,7 +850,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         receivedAt,
         routingState,
         sourceUrl,
-        text: message.content,
+        text: normalizedContent,
+        ...(mentionRemainder !== undefined ? { botMention: true } : {}),
       });
       return;
     }
@@ -907,7 +862,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       );
     }
 
-    const commandMatch = /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(message.content);
+    const commandMatch = mentionRemainder === undefined
+      ? /^\/([A-Za-z0-9_]+)(?:\s+(.*))?$/.exec(message.content)
+      : undefined;
     await listener({
       id: `discord:message:${message.id}`,
       kind: commandMatch ? "command" : "text",
@@ -920,7 +877,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             rawText: message.content,
           }
         : {
-            text: message.content,
+            text: normalizedContent ?? "",
+            ...(mentionRemainder !== undefined ? { botMention: true } : {}),
           }),
       receivedAt,
       routingState,
@@ -984,6 +942,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const channel = await this.channelFromDiscord(
       interaction.channel_id,
       interaction.guild_id,
+      { isThread: interaction.is_thread },
     );
     const persistedBinding = this.options.store
       ? await this.options.store.resolveCallbackHandle({
@@ -1057,6 +1016,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const channel = await this.channelFromDiscord(
       interaction.channel_id,
       interaction.guild_id,
+      { isThread: interaction.is_thread },
     );
     await listener({
       id: `discord:command:${interaction.id}`,
@@ -1617,7 +1577,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private async channelFromDiscord(
     channelId: string,
     guildId: string | undefined,
-    options?: { dmPeerName?: string },
+    options?: { dmPeerName?: string; isThread?: boolean },
   ): Promise<MessagingInboundEvent["channel"]> {
     if (!guildId) {
       // DM — title from the peer's display name; no parent.
@@ -1630,25 +1590,24 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         },
       };
     }
-    // Guild-channel-or-thread. We keep kind="channel" for both
-    // regular channels and threads — kind is part of the conversation
-    // key used for binding lookup, so flipping to kind="thread" would
-    // make legacy thread bindings unfindable. Thread vs channel is
-    // distinguishable from data shape (ancestorTitle populated → it
-    // came from a thread).
     const breadcrumbs = await this.lookupChannelBreadcrumbs(
       channelId,
       guildId,
     );
+    const kind = options?.isThread ? "thread" : "channel";
     return {
       channel: this.channel,
       conversation: {
         id: channelId,
-        kind: "channel",
+        kind,
         parentId: guildId,
+        workspaceId: guildId,
+        ...(options?.isThread && breadcrumbs.parentChannelId
+          ? { parentConversationId: breadcrumbs.parentChannelId }
+          : {}),
         title: breadcrumbs.channelName,
         parentTitle: breadcrumbs.parentChannelName ?? breadcrumbs.guildName,
-        ancestorTitle: breadcrumbs.parentChannelName
+        ancestorTitle: options?.isThread && breadcrumbs.parentChannelName
           ? breadcrumbs.guildName
           : undefined,
       },
@@ -1668,6 +1627,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     guildId: string,
   ): Promise<{
     channelName?: string;
+    parentChannelId?: string;
     parentChannelName?: string;
     guildName?: string;
   }> {
@@ -1679,6 +1639,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     const guild = await this.cachedGuild(guildId);
     return {
       channelName: channel?.name,
+      parentChannelId: channel?.parentId,
       parentChannelName: parentChannel?.name,
       guildName: guild?.name,
     };
@@ -1798,7 +1759,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
   private basicChannelRef(
     channelId: string,
     guildId: string | undefined,
-    kind: "dm" | "channel",
+    kind: "dm" | "channel" | "thread",
   ): MessagingInboundEvent["channel"] {
     return {
       channel: this.channel,
@@ -1806,6 +1767,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         id: channelId,
         kind,
         ...(guildId ? { parentId: guildId } : {}),
+        ...(guildId ? { workspaceId: guildId } : {}),
       },
     };
   }

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -221,8 +221,10 @@ describe("SlackAdapter", () => {
         id: "C012ABCDEF0",
         kind: "thread",
         parentId: "1712023030.000000",
+        parentConversationId: "C012ABCDEF0",
         parentTitle: "signals-chat",
         title: "GIPHY-services PR status",
+        workspaceId: "T012ABCDEF0",
       },
       outcome: "created",
       routingState: {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -748,6 +748,10 @@ export class SlackAdapter implements SlackProviderAdapter {
         id: target.channelId,
         kind: "thread",
         parentId: target.threadTs,
+        parentConversationId: request.parent.conversation.id,
+        ...(request.parent.conversation.workspaceId
+          ? { workspaceId: request.parent.conversation.workspaceId }
+          : {}),
         ...(request.parent.conversation.title
           ? { parentTitle: request.parent.conversation.title }
           : {}),
@@ -1725,8 +1729,10 @@ export class SlackAdapter implements SlackProviderAdapter {
       conversation: {
         id: params.channelId,
         kind,
+        ...(params.teamId ? { workspaceId: params.teamId } : {}),
         ...(kind === "dm" && channelTitle ? { title: channelTitle } : {}),
         ...(isThread && params.threadTs ? { parentId: params.threadTs } : {}),
+        ...(isThread ? { parentConversationId: params.channelId } : {}),
         ...(kind === "channel" && channelTitle ? { title: channelTitle } : {}),
         ...(isThread && threadTitle ? { title: threadTitle } : {}),
         ...(isThread && channelTitle ? { parentTitle: channelTitle } : {}),

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -510,6 +510,59 @@ describe("TelegramAdapter callback persistence", () => {
     });
     expect(rejected).toEqual(["unauthorized-conversation"]);
   });
+
+  it("normalizes Telegram topics with their containing conversation", async () => {
+    const adapter = new TelegramAdapter({
+      api: fakeTelegramApi(),
+      config: {
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+        authorizedSupergroupIds: [{ id: "-100123", displayName: "Claw Dev" }],
+        botToken: "token",
+        channel: "telegram",
+      },
+      now: () => 1_700_000_000_000,
+      store: fakeCallbackStore(),
+    });
+    const events: MessagingInboundEvent[] = [];
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await adapter.handleUpdate({
+      update_id: 102,
+      message: {
+        chat: {
+          id: -100123,
+          title: "Claw Dev",
+          type: "supergroup",
+        },
+        date: 1_700_000_002,
+        from: {
+          first_name: "Harold",
+          id: 42,
+          username: "huntharo",
+        },
+        message_id: 502,
+        message_thread_id: 77,
+        text: "topic request",
+      },
+    });
+
+    expect(events[0]).toMatchObject({
+      channel: {
+        channel: "telegram",
+        conversation: {
+          id: "77",
+          kind: "topic",
+          parentConversationId: "-100123",
+          parentId: "-100123",
+          parentTitle: "Claw Dev",
+        },
+      },
+      kind: "text",
+      text: "topic request",
+    });
+  });
 });
 
 describe("TelegramAdapter source-relative delivery", () => {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1327,6 +1327,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         id: String(topic.message_thread_id),
         kind: "topic" as const,
         parentId: String(target.chatId),
+        parentConversationId: String(target.chatId),
         parentTitle: parent.kind === "topic" ? parent.parentTitle : parent.title,
         title: topic.name,
       };
@@ -2503,6 +2504,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           id: String(messageThreadId),
           kind: "topic",
           parentId: String(message.chat.id),
+          parentConversationId: String(message.chat.id),
           title: topicTitle,
           parentTitle: chatTitle,
         },


### PR DESCRIPTION
## Summary

- I added explicit, provider-neutral default Agent assignment with conversation, parent, workspace, provider, and profile fallback scopes.
- I added `/agent default` inspection plus explicit set/change/clear flows without changing ordinary `/agent` binding behavior or silently persisting picker selections.
- I route authorized addressed messages from unbound surfaces through ordinary bindings and turn admission: root Slack messages create reply threads, while existing Slack/Discord threads and Telegram topics bind in place.
- I preserve concrete messaging origins for ordinary bound turns so existing `handoff_task` and `attach_thread_here` operations can attach delegated work to the originating messaging surface.
- I allow default assignment to Codex Agents through dynamic tools and ACP Agents whose runtime advertises PwrAgent HTTP MCP support.
- I added JSON/SQLite persistence parity, transactional replacement, a unique active-scope constraint, stale-target cleanup, normalized provider hierarchy fields, and focused regression coverage.

## Verification

- I ran the combined focused controller, resume browser, store, state migration, Slack, Discord, and Telegram suites: 8 files and 470 tests passed.
- I verified the additional messaging interface/backend coverage recorded by the implementation: 397 tests passed.
- I ran `pnpm lint:eslint`: passed with zero errors; existing baseline warnings remain.
- I ran `pnpm lint:boundaries`: passed with no dependency violations.
- I ran `pnpm lint:sql`: passed.
- I ran `pnpm typecheck`: passed for all workspace projects.
- I ran `git diff --check`: passed.

## Notes

- This supersedes the side-channel approach in #861. It deliberately does not add `/agent <request>` escape-valve routing, ephemeral control bindings, or custom response/queue ownership.
- Built-in Grok and ACP runtimes without HTTP MCP remain ineligible until they expose the required PwrAgent search, send, handoff, and attachment tool contract.
- Unaddressed ambient messages retain their existing behavior. Settings-window management and automatic ambient default activation remain deferred.
