### PR TITLE
feat(desktop): persist collapsed directory threads

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-directory-pins.test.ts
@@ -65,6 +65,33 @@ describe("SqliteOverlayStore — directory pins", () => {
     ).resolves.toMatchObject({ pinnedRank: "2048" });
   });
 
+  it("persists the Directory threads disclosure without erasing pin state", async () => {
+    const directoryKey = "directory:/Users/me/code/PwrAgent";
+    await store.setDirectoryPin({
+      directoryKey,
+      pinnedRank: "2048",
+    });
+
+    await expect(
+      store.setDirectoryThreadsCollapsed({
+        directoryKey,
+        collapsed: true,
+      }),
+    ).resolves.toMatchObject({
+      pinnedRank: "2048",
+      directoryThreadsCollapsed: true,
+    });
+
+    await expect(
+      store.setDirectoryPin({
+        directoryKey,
+        pinnedRank: null,
+      }),
+    ).resolves.toMatchObject({
+      directoryThreadsCollapsed: true,
+    });
+  });
+
   it("returns undefined for a directoryKey with no overlay row", async () => {
     await expect(
       store.getDirectoryOverlayState({
@@ -130,6 +157,10 @@ describe("SqliteOverlayStore — directory pins", () => {
         directoryKey: "directory:/Users/me/code/PwrAgent",
         pinnedRank: "1024",
       });
+      await store.setDirectoryThreadsCollapsed({
+        directoryKey: "directory:/Users/me/code/PwrAgent",
+        collapsed: true,
+      });
       stateDb.close();
 
       const reopenedDb = StateDb.open(dbPath);
@@ -139,7 +170,10 @@ describe("SqliteOverlayStore — directory pins", () => {
           reopenedStore.getDirectoryOverlayState({
             directoryKey: "directory:/Users/me/code/PwrAgent",
           }),
-        ).resolves.toMatchObject({ pinnedRank: "1024" });
+        ).resolves.toMatchObject({
+          pinnedRank: "1024",
+          directoryThreadsCollapsed: true,
+        });
       } finally {
         reopenedDb.close();
       }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -77,6 +77,8 @@ import {
   type SetSubthreadsCollapsedResponse,
   type SetDirectoryPinRequest,
   type SetDirectoryPinResponse,
+  type SetDirectoryThreadsCollapsedRequest,
+  type SetDirectoryThreadsCollapsedResponse,
   type SetThreadParentRequest,
   type SetThreadParentResponse,
   type SetThreadAgentRequest,
@@ -169,6 +171,7 @@ import {
   NAVIGATION_MARK_THREAD_SEEN_CHANNEL,
   NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_DIRECTORY_PIN_CHANNEL,
+  NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_THREAD_PARENT_CHANNEL,
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
@@ -272,25 +275,20 @@ type ThreadPrRefreshContext = {
 const appServerLog = getMainLogger("pwragent:app-server");
 
 /**
- * Reject pin requests that target the synthetic catch-all bucket
- * (`unlinked`). Directory pinning is a user-curated order for
- * named entries the user actually browses — both real directories
- * (`directory:*`) and workspaces (`workspace:*`) qualify, since the
- * user picks them by name in the sidebar. The `unlinked` bucket is
- * a roll-up of threads with no linked directory and doesn't model
- * a single entry, so pinning it is meaningless. The snapshot
- * builder (`buildDirectorySummaries`) also defends against this on
- * the read side, but rejecting here keeps the overlay store free
- * of stale rows that would otherwise accumulate without any
- * read-side effect. See plan 2026-05-09-002, Unit G.
+ * Reject directory preference writes that target the synthetic
+ * catch-all bucket (`unlinked`). Both real directories
+ * (`directory:*`) and workspaces (`workspace:*`) are named entries
+ * the user actually browses. The `unlinked` bucket is a roll-up of
+ * threads with no linked directory and doesn't model a single
+ * entry, so sticky preferences there are meaningless.
  */
-function rejectNonDirectoryPinKey(directoryKey: string): void {
+function rejectNonUserDirectoryKey(directoryKey: string): void {
   if (
     !directoryKey.startsWith("directory:") &&
     !directoryKey.startsWith("workspace:")
   ) {
     throw new Error(
-      `Cannot pin synthetic directory entry: ${directoryKey} (only directory:* and workspace:* keys are pinnable)`,
+      `Cannot persist preferences for synthetic directory entry: ${directoryKey} (only directory:* and workspace:* keys are supported)`,
     );
   }
 }
@@ -3725,7 +3723,7 @@ class DesktopAppServerService {
   async setDirectoryPin(
     request: SetDirectoryPinRequest,
   ): Promise<SetDirectoryPinResponse> {
-    rejectNonDirectoryPinKey(request.directoryKey);
+    rejectNonUserDirectoryKey(request.directoryKey);
 
     const overlay = await this.getOverlayStore().setDirectoryPin({
       directoryKey: request.directoryKey,
@@ -3765,7 +3763,7 @@ class DesktopAppServerService {
     request: ReorderDirectoryPinsRequest,
   ): Promise<ReorderDirectoryPinsResponse> {
     for (const directoryKey of request.directoryKeys) {
-      rejectNonDirectoryPinKey(directoryKey);
+      rejectNonUserDirectoryKey(directoryKey);
     }
 
     const pinnedRanks = await this.getOverlayStore().reorderDirectoryPins({
@@ -3787,6 +3785,39 @@ class DesktopAppServerService {
     });
 
     return { pinnedRanks };
+  }
+
+  async setDirectoryThreadsCollapsed(
+    request: SetDirectoryThreadsCollapsedRequest,
+  ): Promise<SetDirectoryThreadsCollapsedResponse> {
+    rejectNonUserDirectoryKey(request.directoryKey);
+
+    const overlay = await this.getOverlayStore().setDirectoryThreadsCollapsed({
+      directoryKey: request.directoryKey,
+      collapsed: request.collapsed,
+    });
+    const collapsed = overlay.directoryThreadsCollapsed === true;
+
+    logDebug("setDirectoryThreadsCollapsed", {
+      directoryKey: request.directoryKey,
+      collapsed,
+    });
+
+    await getDesktopBackendRegistry().publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "directory/threadsCollapsed/updated",
+        params: {
+          directoryKey: request.directoryKey,
+          collapsed,
+        },
+      },
+    });
+
+    return {
+      directoryKey: request.directoryKey,
+      collapsed,
+    };
   }
 
   async ensureDirectoryLaunchpad(
@@ -4666,6 +4697,16 @@ export function registerAppServerIpcHandlers(): void {
       request: ReorderDirectoryPinsRequest,
     ): Promise<ReorderDirectoryPinsResponse> => {
       return await appServerService.reorderDirectoryPins(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL,
+    async (
+      _event,
+      request: SetDirectoryThreadsCollapsedRequest,
+    ): Promise<SetDirectoryThreadsCollapsedResponse> => {
+      return await appServerService.setDirectoryThreadsCollapsed(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1742,6 +1742,7 @@ export class SqliteOverlayStore {
   }): Promise<DirectoryOverlayState> {
     const pinnedRank = params.pinnedRank?.trim();
     const nextState: DirectoryOverlayState = {
+      ...this.getDirectoryOverlay(params.directoryKey),
       directoryKey: params.directoryKey,
       pinnedRank: pinnedRank || undefined,
     };
@@ -1758,6 +1759,7 @@ export class SqliteOverlayStore {
         const pinnedRank = String((index + 1) * 1024);
         pinnedRanks[directoryKey] = pinnedRank;
         this.putDirectoryOverlay(directoryKey, {
+          ...this.getDirectoryOverlay(directoryKey),
           directoryKey,
           pinnedRank,
         });
@@ -1765,6 +1767,19 @@ export class SqliteOverlayStore {
     });
     write();
     return pinnedRanks;
+  }
+
+  async setDirectoryThreadsCollapsed(params: {
+    directoryKey: string;
+    collapsed: boolean;
+  }): Promise<DirectoryOverlayState> {
+    const nextState: DirectoryOverlayState = {
+      ...this.getDirectoryOverlay(params.directoryKey),
+      directoryKey: params.directoryKey,
+      directoryThreadsCollapsed: params.collapsed,
+    };
+    this.putDirectoryOverlay(params.directoryKey, nextState);
+    return nextState;
   }
 
   async getDirectoryOverlayState(params: {
@@ -3672,6 +3687,7 @@ export type OverlayStoreLike = Pick<
   | "setSubthreadsCollapsed"
   | "setDirectoryPin"
   | "reorderDirectoryPins"
+  | "setDirectoryThreadsCollapsed"
   | "getDirectoryOverlayState"
   | "readAllDirectoryOverlays"
   | "setThreadPullRequests"

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -86,6 +86,8 @@ import type {
   SetSubthreadsCollapsedResponse,
   SetDirectoryPinRequest,
   SetDirectoryPinResponse,
+  SetDirectoryThreadsCollapsedRequest,
+  SetDirectoryThreadsCollapsedResponse,
   SetThreadParentRequest,
   SetThreadParentResponse,
   SetThreadPinRequest,
@@ -401,6 +403,7 @@ import {
   NAVIGATION_SET_BROWSE_MODE_CHANNEL,
   NAVIGATION_SET_SUBTHREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_DIRECTORY_PIN_CHANNEL,
+  NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL,
   NAVIGATION_SET_THREAD_PARENT_CHANNEL,
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
@@ -1171,6 +1174,13 @@ const desktopApi = Object.freeze({
   ): Promise<ReorderDirectoryPinsResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
+      request,
+    ),
+  setDirectoryThreadsCollapsed: async (
+    request: SetDirectoryThreadsCollapsedRequest,
+  ): Promise<SetDirectoryThreadsCollapsedResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL,
       request,
     ),
   refreshThreadPullRequests: async (

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1366,6 +1366,9 @@ function DesktopAppShell(props: {
           onSetSubthreadsCollapsed={navigation.setSubthreadsCollapsed}
           onSetDirectoryPin={navigation.setDirectoryPin}
           onReorderDirectoryPins={navigation.reorderDirectoryPins}
+          onSetDirectoryThreadsCollapsed={
+            navigation.setDirectoryThreadsCollapsed
+          }
           onRemoveDirectory={(directory) => {
             void navigation.removeDirectory(directory.key);
           }}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -89,6 +89,10 @@ type DirectoriesListProps = {
     pinned: boolean,
   ) => Promise<void>;
   onReorderDirectoryPins?: (directoryKeys: string[]) => Promise<void>;
+  onSetDirectoryThreadsCollapsed?: (
+    directory: NavigationDirectorySummary,
+    collapsed: boolean,
+  ) => Promise<void>;
   /**
    * Opens the directory context menu at the cursor position. Sidebar
    * owns the menu (so it can escape the sidebar's scroll container,
@@ -632,6 +636,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
     );
     const unpinnedExpanded =
       unpinnedExpandedByKey[directory.key] ?? selectedUnpinnedInOverflow;
+    // This preference applies only when there is a pinned section to
+    // preserve. Without pinned threads, hiding every row would make an
+    // expanded directory look empty and remove the disclosure control.
+    const directoryThreadsCollapsed =
+      directoryPinnedThreads.length > 0 &&
+      directory.directoryThreadsCollapsed === true;
     // Render one unpinned thread row. Shared by the always-shown capped
     // slice and the overflow slice so the "Show more / Show less" toggle
     // sits at a fixed pivot between them — collapsing never makes the
@@ -1055,14 +1065,24 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
                     {directoryPinnedThreads.length > 0 &&
                     directoryUnpinnedThreads.length > 0 ? (
-                      <div
+                      <button
+                        type="button"
                         className={`recents-pinned-divider directory-row__thread-divider${
                           dividerDropTarget === directory.key
                             ? " is-drop-target"
                             : ""
                         }`}
-                        role="separator"
-                        aria-label={`Directory threads for ${directory.label}`}
+                        aria-expanded={!directoryThreadsCollapsed}
+                        aria-label={`${
+                          directoryThreadsCollapsed ? "Show" : "Hide"
+                        } directory threads for ${directory.label}`}
+                        disabled={!props.onSetDirectoryThreadsCollapsed}
+                        onClick={() => {
+                          void props.onSetDirectoryThreadsCollapsed?.(
+                            directory,
+                            !directoryThreadsCollapsed,
+                          );
+                        }}
                         onDragOver={(event) => {
                           event.preventDefault();
                           if (
@@ -1093,12 +1113,27 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           );
                         }}
                       >
-                        <span>Directory threads</span>
-                      </div>
+                        <span className="directory-row__thread-divider-label">
+                          <span>Directory threads</span>
+                          {directoryThreadsCollapsed ? (
+                            <span className="directory-row__thread-divider-count">
+                              {directoryUnpinnedThreads.length}
+                            </span>
+                          ) : null}
+                          <span
+                            aria-hidden="true"
+                            className={`directory-row__thread-divider-chevron${
+                              directoryThreadsCollapsed ? "" : " is-open"
+                            }`}
+                          />
+                        </span>
+                      </button>
                     ) : null}
 
-                    {cappedUnpinnedThreads.map(renderUnpinnedRow)}
-                    {hiddenUnpinnedCount > 0 ? (
+                    {directoryThreadsCollapsed
+                      ? null
+                      : cappedUnpinnedThreads.map(renderUnpinnedRow)}
+                    {!directoryThreadsCollapsed && hiddenUnpinnedCount > 0 ? (
                       <button
                         type="button"
                         className="directory-row__show-more"
@@ -1115,7 +1150,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           : `Show ${hiddenUnpinnedCount} more`}
                       </button>
                     ) : null}
-                    {unpinnedExpanded
+                    {!directoryThreadsCollapsed && unpinnedExpanded
                       ? overflowUnpinnedThreads.map(renderUnpinnedRow)
                       : null}
                   </div>

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -229,6 +229,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
    * naturally expires. Plan 2026-05-09-002 Unit K follow-up.
    */
   const lastDirectoryDragEndedAtRef = useRef(0);
+  // The Directory threads disclosure is also a thread-pin drop target.
+  // Suppress the click browsers synthesize immediately after a drop so
+  // pinning a thread never also minimizes the section.
+  const lastDirectoryThreadDropAtRef = useRef(0);
   const threadsByKey = useMemo(
     () =>
       new Map(
@@ -1078,6 +1082,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         } directory threads for ${directory.label}`}
                         disabled={!props.onSetDirectoryThreadsCollapsed}
                         onClick={() => {
+                          if (
+                            Date.now() - lastDirectoryThreadDropAtRef.current <
+                            POST_DRAG_CLICK_SUPPRESS_MS
+                          ) {
+                            return;
+                          }
                           void props.onSetDirectoryThreadsCollapsed?.(
                             directory,
                             !directoryThreadsCollapsed,
@@ -1105,6 +1115,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         }}
                         onDrop={(event) => {
                           event.preventDefault();
+                          lastDirectoryThreadDropAtRef.current = Date.now();
                           setDraggedThreadKey(undefined);
                           setDividerDropTarget(undefined);
                           dropThreadAfterDirectoryPins(

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -161,6 +161,10 @@ type SidebarProps = {
     pinned: boolean,
   ) => Promise<void>;
   onReorderDirectoryPins?: (directoryKeys: string[]) => Promise<void>;
+  onSetDirectoryThreadsCollapsed?: (
+    directory: NavigationDirectorySummary,
+    collapsed: boolean,
+  ) => Promise<void>;
   /**
    * Remove an empty directory (no linked threads) from the Directories list.
    * Offered in the directory context menu only when the directory has no
@@ -954,6 +958,9 @@ export function Sidebar(props: SidebarProps) {
               onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
               onSetDirectoryPin={props.onSetDirectoryPin}
               onReorderDirectoryPins={props.onReorderDirectoryPins}
+              onSetDirectoryThreadsCollapsed={
+                props.onSetDirectoryThreadsCollapsed
+              }
               onOpenDirectoryContextMenu={
                 props.onSetDirectoryPin ? openDirectoryContextMenu : undefined
               }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2068,6 +2068,7 @@ describe("Sidebar", () => {
 
   it("pins a same-directory thread by dropping it on the directory divider", () => {
     const onReorderThreadPins = vi.fn(async () => undefined);
+    const onSetDirectoryThreadsCollapsed = vi.fn(async () => undefined);
     const pinnedThread = {
       ...updatedSinceSeenThread,
       pinnedRank: "1024",
@@ -2094,21 +2095,24 @@ describe("Sidebar", () => {
         onOpenLaunchpad={async () => undefined}
         onReorderThreadPins={onReorderThreadPins}
         onSelectThread={() => undefined}
-        onSetDirectoryThreadsCollapsed={async () => undefined}
+        onSetDirectoryThreadsCollapsed={onSetDirectoryThreadsCollapsed}
       />
     );
 
+    const directoryThreads = screen.getByRole("button", {
+      name: "Hide directory threads for PwrAgent",
+    });
     fireEvent.drop(
-      screen.getByRole("button", {
-        name: "Hide directory threads for PwrAgent",
-      }),
+      directoryThreads,
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
+    fireEvent.click(directoryThreads);
 
     expect(onReorderThreadPins).toHaveBeenCalledWith([
       "codex:thread-updated",
       "codex:thread-1",
     ]);
+    expect(onSetDirectoryThreadsCollapsed).not.toHaveBeenCalled();
   });
 
   it("shows recents drop targets for row edges and the pin divider", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1852,7 +1852,9 @@ describe("Sidebar", () => {
     );
 
     const directoryThreads = screen
-      .getByRole("separator", { name: "Directory threads for PwrAgent" })
+      .getByRole("button", {
+        name: "Hide directory threads for PwrAgent",
+      })
       .closest(".directory-row__threads") as HTMLElement;
     expect(
       screen.queryByRole("separator", {
@@ -1868,6 +1870,64 @@ describe("Sidebar", () => {
       within(rows[0]).getByRole("img", { name: "Pinned" }),
     ).toBeInTheDocument();
     expect(rows[1]).toHaveTextContent("Cross-project cleanup");
+  });
+
+  it("minimizes only unpinned directory threads and restores the sticky state", async () => {
+    const onSetDirectoryThreadsCollapsed = vi.fn(async () => undefined);
+    const pinnedThread = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+    const directoryWithPinnedThread = {
+      ...directories[0],
+      threadKeys: ["codex:thread-1", "codex:thread-updated"],
+    };
+    const renderSidebar = (directoryThreadsCollapsed: boolean) => (
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[
+          {
+            ...directoryWithPinnedThread,
+            directoryThreadsCollapsed,
+          },
+        ]}
+        inboxThreads={[sharedThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-updated"
+        threads={[sharedThread, pinnedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetDirectoryThreadsCollapsed={onSetDirectoryThreadsCollapsed}
+      />
+    );
+
+    const { rerender } = render(renderSidebar(false));
+
+    await clickElement(
+      screen.getByRole("button", {
+        name: "Hide directory threads for PwrAgent",
+      }),
+    );
+    expect(onSetDirectoryThreadsCollapsed).toHaveBeenCalledWith(
+      expect.objectContaining({ key: directories[0].key }),
+      true,
+    );
+
+    rerender(renderSidebar(true));
+
+    expect(screen.getByText("Updated thread")).toBeInTheDocument();
+    expect(screen.queryByText("Cross-project cleanup")).not.toBeInTheDocument();
+    const showDirectoryThreads = screen.getByRole("button", {
+      name: "Show directory threads for PwrAgent",
+    });
+    expect(showDirectoryThreads).toHaveAttribute("aria-expanded", "false");
+    expect(within(showDirectoryThreads).getByText("1")).toBeInTheDocument();
   });
 
   it("caps unpinned directory threads and toggles the overflow behind Show more / Show less", async () => {
@@ -2000,8 +2060,8 @@ describe("Sidebar", () => {
       }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("separator", {
-        name: "Directory threads for PwrAgent",
+      screen.queryByRole("button", {
+        name: "Hide directory threads for PwrAgent",
       }),
     ).not.toBeInTheDocument();
   });
@@ -2034,11 +2094,14 @@ describe("Sidebar", () => {
         onOpenLaunchpad={async () => undefined}
         onReorderThreadPins={onReorderThreadPins}
         onSelectThread={() => undefined}
+        onSetDirectoryThreadsCollapsed={async () => undefined}
       />
     );
 
     fireEvent.drop(
-      screen.getByRole("separator", { name: "Directory threads for PwrAgent" }),
+      screen.getByRole("button", {
+        name: "Hide directory threads for PwrAgent",
+      }),
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
 
@@ -2164,6 +2227,7 @@ describe("Sidebar", () => {
         onOpenLaunchpad={async () => undefined}
         onReorderThreadPins={onReorderThreadPins}
         onSelectThread={() => undefined}
+        onSetDirectoryThreadsCollapsed={async () => undefined}
       />
     );
 
@@ -2174,7 +2238,9 @@ describe("Sidebar", () => {
 
     fireEvent.click(projectBSummary!);
     fireEvent.drop(
-      screen.getByRole("separator", { name: "Directory threads for ProjectB" }),
+      screen.getByRole("button", {
+        name: "Hide directory threads for ProjectB",
+      }),
       { dataTransfer: createDataTransfer("codex:thread-1") },
     );
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7358,6 +7358,55 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("persists and optimistically applies the Directory threads disclosure", async () => {
+    const directory = {
+      key: "directory:/Users/me/repos/PwrAgent",
+      kind: "directory" as const,
+      label: "PwrAgent",
+      path: "/Users/me/repos/PwrAgent",
+      threadKeys: [],
+      needsAttentionCount: 0,
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [],
+      directories: [directory],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setDirectoryThreadsCollapsed: NonNullable<
+      DesktopApi["setDirectoryThreadsCollapsed"]
+    > = vi.fn(async (request) => ({
+      directoryKey: request.directoryKey,
+      collapsed: request.collapsed,
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+      setDirectoryThreadsCollapsed,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setDirectoryThreadsCollapsed(directory, true);
+    });
+
+    expect(setDirectoryThreadsCollapsed).toHaveBeenCalledWith({
+      directoryKey: directory.key,
+      collapsed: true,
+    });
+    expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
+  });
+
   describe("pickAndRegisterDirectory (issue #223)", () => {
     const launchpadDefaults = {
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2273,6 +2273,9 @@ describe("useThreadNavigation", () => {
           path: "/Users/huntharo/github/PwrAgent",
           threadKeys: [],
           needsAttentionCount: 0,
+          // A saved collapsed preference is latent when the directory
+          // has no pinned threads, so it must not auto-pin by itself.
+          directoryThreadsCollapsed: true,
           launchpad: {
             directoryKey: "directory:/Users/huntharo/github/PwrAgent",
             directoryKind: "directory" as const,
@@ -2299,11 +2302,19 @@ describe("useThreadNavigation", () => {
       executionMode: "default" as const,
       workMode: "worktree" as const,
     }));
+    const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
+      async (request) => ({
+        backend: request.backend ?? "codex",
+        threadId: request.threadId,
+        pinnedRank: request.pinnedRank ?? undefined,
+      }),
+    );
 
     const desktopApi: DesktopApi = {
       getNavigationSnapshot,
       materializeDirectoryLaunchpad,
       onAgentEvent: () => () => undefined,
+      setThreadPin,
     };
 
     const { result } = renderHook(() => useThreadNavigation(desktopApi));
@@ -2334,6 +2345,95 @@ describe("useThreadNavigation", () => {
     expect(result.current.selectedThread?.observedGitBranch).toBe("HEAD");
     expect(result.current.directories[0]?.threadKeys).toEqual(["codex:thread-new"]);
     expect(result.current.directories[0]?.needsAttentionCount).toBe(1);
+    expect(setThreadPin).not.toHaveBeenCalled();
+  });
+
+  it("auto-pins a new top-level thread when Directory threads are collapsed", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const existingPinnedThread = {
+      id: "thread-pinned",
+      title: "Pinned thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      executionMode: "default" as const,
+      updatedAt: 1,
+      pinnedRank: "1024",
+    };
+    const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-pinned"],
+      threads: [existingPinnedThread],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: ["codex:thread-pinned"],
+          needsAttentionCount: 0,
+          directoryThreadsCollapsed: true,
+          launchpad: {
+            directoryKey,
+            directoryKind: "directory",
+            directoryLabel: "PwrAgent",
+            directoryPath: "/Users/huntharo/github/PwrAgent",
+            backend: "codex",
+            executionMode: "default",
+            prompt: "",
+            workMode: "worktree",
+            branchName: "main",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    }));
+    const materializeDirectoryLaunchpad = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-new",
+      executionMode: "default" as const,
+      workMode: "worktree" as const,
+    }));
+    const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
+      async (request) => ({
+        backend: request.backend ?? "codex",
+        threadId: request.threadId,
+        pinnedRank: request.pinnedRank ?? undefined,
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      materializeDirectoryLaunchpad,
+      onAgentEvent: () => () => undefined,
+      setThreadPin,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.directories[0]?.directoryThreadsCollapsed).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.materializeDirectoryLaunchpad(directoryKey);
+    });
+
+    expect(setThreadPin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-new",
+      pinnedRank: "2048",
+    });
+    expect(result.current.selectedThread).toMatchObject({
+      id: "thread-new",
+      pinnedRank: "2048",
+    });
   });
 
   it("carries the started review turn from launchpad materialization", async () => {

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -93,6 +93,8 @@ import type {
   SetSubthreadsCollapsedResponse,
   SetDirectoryPinRequest,
   SetDirectoryPinResponse,
+  SetDirectoryThreadsCollapsedRequest,
+  SetDirectoryThreadsCollapsedResponse,
   SetThreadReactionRequest,
   SetThreadReactionResponse,
   SetThreadParentRequest,
@@ -642,6 +644,9 @@ export type DesktopApi = {
   reorderDirectoryPins?: (
     request: ReorderDirectoryPinsRequest
   ) => Promise<ReorderDirectoryPinsResponse>;
+  setDirectoryThreadsCollapsed?: (
+    request: SetDirectoryThreadsCollapsedRequest
+  ) => Promise<SetDirectoryThreadsCollapsedResponse>;
   refreshThreadPullRequests?: (
     request: RefreshThreadPullRequestsRequest
   ) => Promise<RefreshThreadPullRequestsResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1180,6 +1180,35 @@ function updateDirectoryPinsInSnapshot(
   return changed ? { ...snapshot, directories } : snapshot;
 }
 
+function updateDirectoryThreadsCollapsedInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    directoryKey: string;
+    collapsed: boolean;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const directories = snapshot.directories.map((directory) => {
+    if (directory.key !== params.directoryKey) {
+      return directory;
+    }
+    if (directory.directoryThreadsCollapsed === params.collapsed) {
+      return directory;
+    }
+    changed = true;
+    return {
+      ...directory,
+      directoryThreadsCollapsed: params.collapsed,
+    };
+  });
+
+  return changed ? { ...snapshot, directories } : snapshot;
+}
+
 function markThreadSeenInSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -2321,6 +2350,10 @@ export function useThreadNavigation(
     pinned: boolean,
   ) => Promise<void>;
   reorderDirectoryPins: (directoryKeys: string[]) => Promise<void>;
+  setDirectoryThreadsCollapsed: (
+    directory: NavigationDirectorySummary,
+    collapsed: boolean,
+  ) => Promise<void>;
   snapshot?: NavigationSnapshot;
   threads: NavigationThreadSummary[];
 } {
@@ -3409,6 +3442,24 @@ export function useThreadNavigation(
           response: updateDirectoryPinsInSnapshot(current.response, {
             pinnedRanks,
           }),
+        }));
+        return;
+      }
+
+      if (method === "directory/threadsCollapsed/updated") {
+        const { directoryKey, collapsed } = event.notification.params as {
+          directoryKey: string;
+          collapsed: boolean;
+        };
+        setState((current) => ({
+          ...current,
+          response: updateDirectoryThreadsCollapsedInSnapshot(
+            current.response,
+            {
+              directoryKey,
+              collapsed,
+            },
+          ),
         }));
         return;
       }
@@ -5230,6 +5281,8 @@ export function useThreadNavigation(
   const setSubthreadsCollapsedRequest = desktopApi?.setSubthreadsCollapsed;
   const setDirectoryPinRequest = desktopApi?.setDirectoryPin;
   const reorderDirectoryPinsRequest = desktopApi?.reorderDirectoryPins;
+  const setDirectoryThreadsCollapsedRequest =
+    desktopApi?.setDirectoryThreadsCollapsed;
   const setThreadReaction = useCallback(
     async (
       thread: NavigationThreadSummary,
@@ -5586,6 +5639,48 @@ export function useThreadNavigation(
     [refresh, reorderDirectoryPinsRequest],
   );
 
+  const setDirectoryThreadsCollapsed = useCallback(
+    async (
+      directory: NavigationDirectorySummary,
+      collapsed: boolean,
+    ): Promise<void> => {
+      if (!setDirectoryThreadsCollapsedRequest) {
+        return;
+      }
+
+      setState((current) => ({
+        ...current,
+        response: updateDirectoryThreadsCollapsedInSnapshot(
+          current.response,
+          {
+            directoryKey: directory.key,
+            collapsed,
+          },
+        ),
+      }));
+
+      try {
+        const result = await setDirectoryThreadsCollapsedRequest({
+          directoryKey: directory.key,
+          collapsed,
+        });
+        setState((current) => ({
+          ...current,
+          response: updateDirectoryThreadsCollapsedInSnapshot(
+            current.response,
+            {
+              directoryKey: result.directoryKey,
+              collapsed: result.collapsed,
+            },
+          ),
+        }));
+      } catch {
+        await refresh();
+      }
+    },
+    [refresh, setDirectoryThreadsCollapsedRequest],
+  );
+
   const updateThreadExecutionMode = useCallback(
     async (
       thread: NavigationThreadSummary,
@@ -5861,6 +5956,7 @@ export function useThreadNavigation(
     setSubthreadsCollapsed,
     setDirectoryPin,
     reorderDirectoryPins,
+    setDirectoryThreadsCollapsed,
     snapshot: state.response,
     threads,
   };

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2008,6 +2008,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   optimisticUserMessage?: NavigationThreadSummary["optimisticUserMessage"];
   optimisticActiveTurn?: NavigationThreadSummary["optimisticActiveTurn"];
   parentThreadId?: string;
+  pinnedRank?: string;
 }): NavigationThreadSummary {
   const titlePrompt =
     params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
@@ -2026,6 +2027,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
     serviceTier: params.launchpad.serviceTier,
     fastMode: params.launchpad.fastMode,
     parentThreadId: params.parentThreadId,
+    pinnedRank: params.pinnedRank,
     acpRuntime: params.launchpad.acpRuntime,
     codexEnvironmentRuntime: params.codexEnvironmentRuntime,
     optimisticUserMessage: params.optimisticUserMessage,
@@ -2052,6 +2054,29 @@ function buildOptimisticThreadFromLaunchpad(params: {
       reason: "new-thread",
     },
   };
+}
+
+function shouldAutoPinMaterializedThread(params: {
+  directory: NavigationDirectorySummary | undefined;
+  threads: NavigationThreadSummary[];
+  parentThreadId: string | undefined;
+}): boolean {
+  if (
+    params.parentThreadId
+    || params.directory?.directoryThreadsCollapsed !== true
+  ) {
+    return false;
+  }
+
+  const directoryThreadKeys = new Set(params.directory.threadKeys);
+  return params.threads.some(
+    (thread) =>
+      !thread.parentThreadId
+      && Boolean(thread.pinnedRank)
+      && directoryThreadKeys.has(
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+  );
 }
 
 function mergeHydratedThreadWithOptimisticTitle(
@@ -4850,6 +4875,42 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
         throw error;
       }
+      let autoPinnedRank: string | undefined;
+      let autoPinFailure: string | undefined;
+      if (
+        shouldAutoPinMaterializedThread({
+          directory,
+          threads: stateRef.current.response?.threads ?? [],
+          parentThreadId: materializeParentThreadId,
+        })
+      ) {
+        const requestedPinnedRank = buildAppendPinRank(
+          (stateRef.current.response?.threads ?? []).map(
+            (thread) => thread.pinnedRank,
+          ),
+        );
+        if (!desktopApi.setThreadPin) {
+          autoPinFailure =
+            "The new thread was created, but it could not be pinned automatically.";
+        } else {
+          try {
+            const pinResult = await desktopApi.setThreadPin({
+              backend: response.backend,
+              threadId: response.threadId,
+              pinnedRank: requestedPinnedRank,
+            });
+            autoPinnedRank = pinResult.pinnedRank;
+            if (!autoPinnedRank) {
+              autoPinFailure =
+                "The new thread was created, but it could not be pinned automatically.";
+            }
+          } catch (error) {
+            autoPinFailure = `The new thread was created, but it could not be pinned automatically: ${
+              error instanceof Error ? error.message : String(error)
+            }`;
+          }
+        }
+      }
       const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
         directory,
         launchpad,
@@ -4876,6 +4937,7 @@ export function useThreadNavigation(
             }
           : undefined,
         parentThreadId: materializeParentThreadId,
+        pinnedRank: autoPinnedRank,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source
@@ -4913,6 +4975,8 @@ export function useThreadNavigation(
       }
       if (response.turnStartFailure) {
         setLaunchpadError(response.turnStartFailure.message);
+      } else if (autoPinFailure) {
+        setLaunchpadError(autoPinFailure);
       }
       // Link composer `@`-referenced directories to the just-created
       // thread before the refresh below so the snapshot comes back with

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -781,6 +781,16 @@ describe("Tangerine Terminal theme contract", () => {
       expect(directoriesDivider).toContain(fragment);
     }
 
+    // The Directory threads disclosure reuses the divider primitive.
+    // A late `font:` shorthand would reset the inherited 11px divider
+    // size to the sidebar row size, making this label visibly oversized.
+    const directoryThreadsDivider = extractRuleBody(
+      css,
+      ".directory-row__thread-divider",
+    );
+    expect(directoryThreadsDivider).not.toMatch(/(?:^|\s)font\s*:/);
+    expect(directoryThreadsDivider).toContain("font-family: inherit;");
+
     const recentsActive = extractRuleBody(
       css,
       ".recents-pinned-divider.is-drop-target",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4265,8 +4265,53 @@ textarea,
 }
 
 .directory-row__thread-divider {
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
   margin-top: 4px;
   margin-bottom: 2px;
+}
+
+.directory-row__thread-divider:hover:not(:disabled) {
+  color: var(--text-secondary);
+}
+
+.directory-row__thread-divider:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.directory-row__thread-divider:disabled {
+  cursor: default;
+}
+
+.directory-row__thread-divider-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.directory-row__thread-divider-count {
+  color: currentColor;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.82;
+}
+
+.directory-row__thread-divider-chevron {
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  opacity: 0.82;
+  transition: transform 120ms ease;
+  transform: rotate(-45deg);
+}
+
+.directory-row__thread-divider-chevron.is-open {
+  transform: rotate(45deg);
 }
 
 .directory-row__threads .thread-row--compact {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4269,7 +4269,7 @@ textarea,
   padding: 0;
   border: 0;
   background: transparent;
-  font: inherit;
+  font-family: inherit;
   cursor: pointer;
   margin-top: 4px;
   margin-bottom: 2px;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -87,6 +87,8 @@ export const NAVIGATION_SET_DIRECTORY_PIN_CHANNEL =
   "navigation:set-directory-pin";
 export const NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL =
   "navigation:reorder-directory-pins";
+export const NAVIGATION_SET_DIRECTORY_THREADS_COLLAPSED_CHANNEL =
+  "navigation:set-directory-threads-collapsed";
 export const NAVIGATION_REFRESH_THREAD_PRS_CHANNEL =
   "navigation:refresh-thread-prs";
 export const NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL =

--- a/packages/agent-core/src/__tests__/directory-navigation.test.ts
+++ b/packages/agent-core/src/__tests__/directory-navigation.test.ts
@@ -1557,6 +1557,33 @@ describe("buildDirectorySummaries — directory pin overlay (Unit D)", () => {
     expect(directories[0]?.pinnedRank).toBeUndefined();
   });
 
+  it("attaches the sticky Directory threads disclosure preference", () => {
+    const directoryKey = "directory:/Users/me/code/PwrAgent";
+    const directories = buildDirectorySummaries({
+      threads: [
+        buildThread({
+          id: "thread-1",
+          linkedDirectories: [
+            {
+              id: "dir-1",
+              label: "PwrAgent",
+              path: "/Users/me/code/PwrAgent",
+              kind: "local",
+            },
+          ],
+        }),
+      ],
+      directoryOverlayByKey: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+    });
+
+    expect(directories[0]?.directoryThreadsCollapsed).toBe(true);
+  });
+
   it("attaches pinnedRank to workspace pseudo-directories (workspaces are pinnable)", () => {
     // Policy: both `kind: "directory"` and `kind: "workspace"`
     // entries are user-pinnable. Workspaces are named entries the
@@ -1656,6 +1683,22 @@ describe("buildNavigationSnapshotHash — directory pin invariant (Unit E, GATE)
     const pinnedHash = buildNavigationSnapshotHash(pinned);
 
     expect(pinnedHash).not.toBe(unpinnedHash);
+  });
+
+  it("changes the hash when Directory threads are minimized", () => {
+    const base = buildBaseHashInput();
+    const expandedHash = buildNavigationSnapshotHash(base);
+    const collapsedHash = buildNavigationSnapshotHash({
+      ...base,
+      directories: [
+        {
+          ...base.directories[0]!,
+          directoryThreadsCollapsed: true,
+        },
+      ],
+    });
+
+    expect(collapsedHash).not.toBe(expandedHash);
   });
 
   it("changes the hash when the pinnedRank value changes (reorder case)", () => {

--- a/packages/agent-core/src/__tests__/overlay-store.test.ts
+++ b/packages/agent-core/src/__tests__/overlay-store.test.ts
@@ -398,6 +398,29 @@ describe("OverlayStore", () => {
     });
   });
 
+  it("preserves sticky Directory threads state across JSON store reloads", async () => {
+    const store = await createStore();
+    const directoryKey = "directory:/Users/me/code/PwrAgent";
+    await store.setDirectoryPin({
+      directoryKey,
+      pinnedRank: "1024",
+    });
+    await store.setDirectoryThreadsCollapsed({
+      directoryKey,
+      collapsed: true,
+    });
+
+    const filePath = (store as unknown as { filePath: string }).filePath;
+    const reopened = new OverlayStore(filePath);
+
+    await expect(
+      reopened.getDirectoryOverlayState({ directoryKey }),
+    ).resolves.toMatchObject({
+      pinnedRank: "1024",
+      directoryThreadsCollapsed: true,
+    });
+  });
+
   it("persists thread model settings separately from launchpad defaults", async () => {
     const store = await createStore();
 

--- a/packages/agent-core/src/persistence/migrations.ts
+++ b/packages/agent-core/src/persistence/migrations.ts
@@ -271,9 +271,8 @@ function migrateRetainedBranchDriftPairs(
 /**
  * Migrate the directory overlay map (plan 2026-05-09-002). New in
  * version 6; pre-v6 stores get an empty `{}` from the parent
- * migrator. The shape is intentionally minimal — currently just
- * `pinnedRank` — so the migrator only validates the key + filters
- * malformed payloads.
+ * migrator. Validate each optional display preference so malformed
+ * payloads cannot leak into navigation snapshots.
  */
 function migrateDirectoryOverlays(
   raw: Record<string, unknown>,
@@ -288,7 +287,15 @@ function migrateDirectoryOverlays(
       typeof record.pinnedRank === "string" && record.pinnedRank.trim()
         ? record.pinnedRank
         : undefined;
-    result[directoryKey] = { directoryKey, pinnedRank };
+    const directoryThreadsCollapsed =
+      typeof record.directoryThreadsCollapsed === "boolean"
+        ? record.directoryThreadsCollapsed
+        : undefined;
+    result[directoryKey] = {
+      directoryKey,
+      pinnedRank,
+      directoryThreadsCollapsed,
+    };
   }
   return result;
 }

--- a/packages/agent-core/src/persistence/overlay-store.ts
+++ b/packages/agent-core/src/persistence/overlay-store.ts
@@ -666,6 +666,7 @@ export class OverlayStore {
     return await this.withData(async (data) => {
       const pinnedRank = params.pinnedRank?.trim();
       const nextState: DirectoryOverlayState = {
+        ...data.directoryOverlays[params.directoryKey],
         directoryKey: params.directoryKey,
         pinnedRank: pinnedRank || undefined,
       };
@@ -683,11 +684,27 @@ export class OverlayStore {
         const pinnedRank = String((index + 1) * 1024);
         pinnedRanks[directoryKey] = pinnedRank;
         data.directoryOverlays[directoryKey] = {
+          ...data.directoryOverlays[directoryKey],
           directoryKey,
           pinnedRank,
         };
       });
       return pinnedRanks;
+    });
+  }
+
+  async setDirectoryThreadsCollapsed(params: {
+    directoryKey: string;
+    collapsed: boolean;
+  }): Promise<DirectoryOverlayState> {
+    return await this.withData(async (data) => {
+      const nextState: DirectoryOverlayState = {
+        ...data.directoryOverlays[params.directoryKey],
+        directoryKey: params.directoryKey,
+        directoryThreadsCollapsed: params.collapsed,
+      };
+      data.directoryOverlays[params.directoryKey] = nextState;
+      return nextState;
     });
   }
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -643,7 +643,7 @@ export type NavigationDirectorySummary = {
    * pseudo-directories are filtered at both the snapshot builder
    * (`buildDirectorySummaries`) and the IPC handler
    * (`setDirectoryPin`) so this field stays meaningful.
-  */
+   */
   pinnedRank?: string;
   /**
    * Sticky per-directory preference for hiding the unpinned

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -643,8 +643,13 @@ export type NavigationDirectorySummary = {
    * pseudo-directories are filtered at both the snapshot builder
    * (`buildDirectorySummaries`) and the IPC handler
    * (`setDirectoryPin`) so this field stays meaningful.
-   */
+  */
   pinnedRank?: string;
+  /**
+   * Sticky per-directory preference for hiding the unpinned
+   * "Directory threads" section while keeping pinned threads visible.
+   */
+  directoryThreadsCollapsed?: boolean;
 };
 
 export type NavigationDirectoryGitStatusUpdatedNotification = {
@@ -1021,6 +1026,16 @@ export type ReorderDirectoryPinsResponse = {
   pinnedRanks: Record<string, string>;
 };
 
+export type SetDirectoryThreadsCollapsedRequest = {
+  directoryKey: string;
+  collapsed: boolean;
+};
+
+export type SetDirectoryThreadsCollapsedResponse = {
+  directoryKey: string;
+  collapsed: boolean;
+};
+
 /**
  * Tells the main-process PR poller which threads the operator is actually
  * looking at, so their PRs poll on the fast tier and everything else backs off.
@@ -1187,12 +1202,10 @@ export type GetGhStatusRequest = {
 };
 
 /**
- * Persisted per-directory overlay. Today this only carries
- * `pinnedRank` (directory pinning), but the shape is intentionally
- * extensible so future per-directory state (e.g., a user-curated
- * label, a tracked-only-when-active flag, etc.) lands here rather
- * than in scattered tables. Mirrors `ThreadOverlayState`'s "single
- * JSON payload per row, keyed by identity" pattern.
+ * Persisted per-directory overlay. Carries directory pin order and
+ * directory-specific display preferences. Mirrors
+ * `ThreadOverlayState`'s "single JSON payload per row, keyed by
+ * identity" pattern.
  */
 export type DirectoryOverlayState = {
   /**
@@ -1205,6 +1218,8 @@ export type DirectoryOverlayState = {
   directoryKey: string;
   /** User-curated position in the pinned section. Undefined = unpinned. */
   pinnedRank?: string;
+  /** Hide unpinned directory threads while leaving pinned threads visible. */
+  directoryThreadsCollapsed?: boolean;
 };
 
 export type ThreadOverlayState = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1429,4 +1429,11 @@ export type AppServerNotification =
         pinnedRanks: Record<string, string>;
       };
     }
+  | {
+      method: "directory/threadsCollapsed/updated";
+      params: {
+        directoryKey: string;
+        collapsed: boolean;
+      };
+    }
   | AppServerPendingRequestNotification;

--- a/packages/shared/src/directory-navigation.ts
+++ b/packages/shared/src/directory-navigation.ts
@@ -496,14 +496,12 @@ export function buildDirectorySummaries(params: {
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
   gitStatusByKey?: Record<string, NavigationDirectoryGitStatus | undefined>;
   /**
-   * Per-directory overlay state (currently only carries `pinnedRank`
-   * for the Directories-lens pin order). Keyed by the same directory
-   * key the snapshot exposes on `NavigationDirectorySummary.key`.
-   * Only `kind: "directory"` summaries receive `pinnedRank` from
-   * this map — workspace and unlinked pseudo-directories ignore
-   * overlay rows even if a misbehaving caller stores one (defense
-   * in depth with the IPC handler's validation).
-   * See plan: 2026-05-09-002-feat-directory-pinning-plan.md Unit D.
+   * Per-directory pin and display preferences, keyed by the same
+   * directory key exposed on `NavigationDirectorySummary.key`.
+   * `kind: "directory"` and `kind: "workspace"` summaries consume
+   * these overlays; the unlinked pseudo-directory ignores them even
+   * if a misbehaving caller stores one (defense in depth with the IPC
+   * handler's validation).
    */
   directoryOverlayByKey?: Record<string, DirectoryOverlayState | undefined>;
   workspaceRoots?: string[];
@@ -637,14 +635,15 @@ export function buildDirectorySummaries(params: {
     }
   }
 
-  // Directory pin overlay (Unit D). Attach `pinnedRank` to
-  // `kind: "directory"` AND `kind: "workspace"` summaries — both
-  // are named entries the user explicitly browses by clicking. The
-  // `unlinked` bucket is a synthetic roll-up of threads with no
-  // linked directory and isn't user-pinnable, so we skip it here
-  // even though the IPC handler also rejects pinning that key.
+  // Per-directory overlay. Attach pin order and the sticky
+  // Directory-threads disclosure preference to `kind: "directory"`
+  // AND `kind: "workspace"` summaries — both are named entries the
+  // user explicitly browses by clicking. The `unlinked` bucket is a
+  // synthetic roll-up of threads with no linked directory and isn't
+  // user-curated, so we skip it here even though the IPC handlers
+  // also reject that key.
   for (const [directoryKey, overlay] of Object.entries(params.directoryOverlayByKey ?? {})) {
-    if (!overlay?.pinnedRank) {
+    if (!overlay) {
       continue;
     }
     const summary = summaries.get(directoryKey);
@@ -652,7 +651,13 @@ export function buildDirectorySummaries(params: {
       summary &&
       (summary.kind === "directory" || summary.kind === "workspace")
     ) {
-      summary.pinnedRank = overlay.pinnedRank;
+      if (overlay.pinnedRank) {
+        summary.pinnedRank = overlay.pinnedRank;
+      }
+      if (overlay.directoryThreadsCollapsed !== undefined) {
+        summary.directoryThreadsCollapsed =
+          overlay.directoryThreadsCollapsed;
+      }
     }
   }
 

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -271,7 +271,7 @@ export function buildNavigationSnapshot(params: {
   launchpadDefaults?: NavigationLaunchpadDefaults;
   launchpadsByKey?: Record<string, DirectoryLaunchpadOverlayState | undefined>;
   /**
-   * Per-directory overlay (currently `pinnedRank` only) — see
+   * Per-directory pin and display preferences — see
    * `buildDirectorySummaries` for the contract. Plumbed through here
    * so the caller (SqliteOverlayStore.reconcileNavigationSnapshot)
    * doesn't have to call the builder twice.
@@ -573,6 +573,10 @@ export function buildNavigationSnapshotHash(params: {
       // unchanged-snapshot short-circuit. Without this, the renderer
       // never sees the new pin state.
       pinnedRank: directory.pinnedRank ?? null,
+      // Sticky Directory-threads disclosure state is persisted in
+      // the same overlay and must invalidate the snapshot cache too.
+      directoryThreadsCollapsed:
+        directory.directoryThreadsCollapsed ?? null,
       launchpad: directory.launchpad
         ? {
             backend: directory.launchpad.backend,


### PR DESCRIPTION
## Summary

- add a clickable disclosure to minimize each directory's unpinned **Directory threads** section while keeping pinned threads visible
- persist the collapsed state per project directory through the existing directory overlay, IPC bridge, and navigation snapshot
- show the hidden thread count while collapsed
- preserve the preference across pin/unpin/reorder operations and both SQLite and JSON-backed overlay reloads
- auto-pin new top-level threads created while a project's Directory Threads section is effectively collapsed
- retain the divider's compact 11px typography and prevent pin-drop gestures from also toggling the disclosure

## Behavior

When a project has an existing pinned section and its Directory Threads disclosure is collapsed, a newly materialized top-level thread is appended to the global pin order before navigation refresh. Expanded projects, projects with no pinned threads, and subthreads keep their existing behavior.

## Validation

- focused Vitest coverage for sidebar behavior, theme contracts, renderer navigation, auto-pin lifecycle, SQLite persistence, JSON persistence, and snapshot materialization (291 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warnings)
- `pnpm lint:boundaries`
