### PR TITLE
feat(messaging): add review configuration summary

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -542,6 +542,113 @@ describe("MessagingController", () => {
     });
   });
 
+  it("pages linked review projects within the provider action limit", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      linkedDirectories: Array.from({ length: 12 }, (_, index) => ({
+        id: `directory:project-${index + 1}`,
+        kind: "worktree" as const,
+        label: `Project ${index + 1}`,
+        path: `/repo/project-${index + 1}`,
+        worktreePath: `/worktrees/project-${index + 1}`,
+      })),
+    };
+    navigation.directories = Array.from({ length: 12 }, (_, index) => ({
+      key: `directory:project-${index + 1}`,
+      kind: "directory" as const,
+      label: `Project ${index + 1}`,
+      path: `/repo/project-${index + 1}`,
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        defaultBranch: "main",
+        branches: ["main"],
+        baseBranches: ["origin/main", "main"],
+      },
+    }));
+    const harness = await createHarness({
+      capabilityProfile: {
+        ...PERMISSIVE_CAPABILITY_PROFILE,
+        actions: {
+          ...PERMISSIVE_CAPABILITY_PROFILE.actions!,
+          maxActions: 13,
+        },
+      },
+      navigation,
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:workspace" }),
+    );
+
+    const firstPage = harness.delivered.at(-1);
+    expect(firstPage).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Page 1/2."),
+    });
+    if (!firstPage || firstPage.kind !== "review") {
+      throw new Error("Expected the first review project page");
+    }
+    expect(firstPage.actions).toHaveLength(12);
+    expect(firstPage.actions).toContainEqual(
+      expect.objectContaining({
+        id: "review:workspace:next",
+        value: { pageIndex: 1 },
+      }),
+    );
+    expect(firstPage.actions).not.toContainEqual(
+      expect.objectContaining({ id: "review:workspace:11" }),
+    );
+
+    const next = findAction(firstPage, "review:workspace:next");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: next.id,
+        value: next.value,
+      }),
+    );
+
+    const secondPage = harness.delivered.at(-1);
+    expect(secondPage).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Page 2/2."),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "review:workspace:11",
+          label: "Project 12",
+        }),
+        expect.objectContaining({
+          id: "review:workspace:previous",
+          value: { pageIndex: 0 },
+        }),
+      ]),
+    });
+    if (!secondPage || secondPage.kind !== "review") {
+      throw new Error("Expected the second review project page");
+    }
+    expect(secondPage.actions.length).toBeLessThanOrEqual(13);
+
+    const projectTwelve = findAction(secondPage, "review:workspace:11");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: projectTwelve.id,
+        value: projectTwelve.value,
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Project: Project 12"),
+      review: {
+        cwd: "/worktrees/project-12",
+        repositoryPath: "/repo/project-12",
+      },
+    });
+  });
+
   it("cancels the review summary without starting a review", async () => {
     const harness = await createHarness();
     await bindThread(harness);
@@ -16782,7 +16889,7 @@ function buildMultiProjectReviewNavigationSnapshot(): NavigationSnapshot {
   const snapshot = buildNavigationSnapshot();
   snapshot.threads[0] = {
     ...snapshot.threads[0]!,
-    projectKey: "/worktrees/app",
+    projectKey: "/worktrees/app/packages/service",
     gitWorkingState: {
       dirtyFiles: 0,
       dirtyAdditions: 0,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -396,56 +396,7 @@ describe("MessagingController", () => {
   });
 
   it("returns to the summary with the selected project and its default base branch", async () => {
-    const navigation = buildNavigationSnapshot();
-    navigation.threads[0] = {
-      ...navigation.threads[0]!,
-      linkedDirectories: [
-        {
-          id: "directory:app",
-          kind: "worktree",
-          label: "App",
-          path: "/repo/app",
-          worktreePath: "/worktrees/app",
-        },
-        {
-          id: "directory:infra",
-          kind: "worktree",
-          label: "Infra",
-          path: "/repo/infra",
-          worktreePath: "/worktrees/infra",
-        },
-      ],
-    };
-    navigation.directories = [
-      {
-        key: "directory:app",
-        kind: "directory",
-        label: "App",
-        path: "/repo/app",
-        threadKeys: ["codex:thread-1"],
-        needsAttentionCount: 0,
-        gitStatus: {
-          currentBranch: "feature/app",
-          defaultBranch: "main",
-          branches: ["feature/app", "main"],
-          baseBranches: ["origin/main", "main"],
-        },
-      },
-      {
-        key: "directory:infra",
-        kind: "directory",
-        label: "Infra",
-        path: "/repo/infra",
-        threadKeys: ["codex:thread-1"],
-        needsAttentionCount: 0,
-        gitStatus: {
-          currentBranch: "deploy/search",
-          defaultBranch: "develop",
-          branches: ["deploy/search", "develop"],
-          baseBranches: ["origin/develop", "develop"],
-        },
-      },
-    ];
+    const navigation = buildMultiProjectReviewNavigationSnapshot();
     const harness = await createHarness({ navigation });
     await bindThread(harness);
     harness.delivered.length = 0;
@@ -506,6 +457,79 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "review:back" }),
     );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:start" }),
+    );
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "origin/develop" },
+      delivery: "inline",
+      cwd: "/worktrees/infra",
+    });
+  });
+
+  it("resets a selected commit when changing review projects", async () => {
+    const harness = await createHarness({
+      navigation: buildMultiProjectReviewNavigationSnapshot(),
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:workspace" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:workspace:0" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Base Branch: release"),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:target" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:target:commit" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:commit:0" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Commit: Fix app review"),
+      review: {
+        target: {
+          type: "commit",
+          sha: "aaaaaaaaaaaaaaaa",
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:workspace" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:workspace:1" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: [
+        "Project: Infra",
+        "Review: Base Branch",
+        "Base Branch: origin/develop",
+      ].join("\n"),
+      review: {
+        cwd: "/worktrees/infra",
+        target: {
+          type: "baseBranch",
+          branch: "origin/develop",
+        },
+      },
+    });
+
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "review:summary:start" }),
     );
@@ -16752,6 +16776,83 @@ function buildNavigationSnapshot(): NavigationSnapshot {
       executionMode: "default",
     },
   };
+}
+
+function buildMultiProjectReviewNavigationSnapshot(): NavigationSnapshot {
+  const snapshot = buildNavigationSnapshot();
+  snapshot.threads[0] = {
+    ...snapshot.threads[0]!,
+    projectKey: "/worktrees/app",
+    gitWorkingState: {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 1,
+      baseBranch: "release",
+    },
+    linkedDirectories: [
+      {
+        id: "directory:app",
+        kind: "worktree",
+        label: "App",
+        path: "/repo/app",
+        worktreePath: "/worktrees/app",
+      },
+      {
+        id: "directory:infra",
+        kind: "worktree",
+        label: "Infra",
+        path: "/repo/infra",
+        worktreePath: "/worktrees/infra",
+      },
+    ],
+  };
+  snapshot.directories = [
+    {
+      key: "directory:app",
+      kind: "directory",
+      label: "App",
+      path: "/repo/app",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "feature/app",
+        defaultBranch: "main",
+        branches: ["feature/app", "main"],
+        baseBranches: ["origin/main", "main"],
+        recentCommits: [
+          {
+            sha: "aaaaaaaaaaaaaaaa",
+            shortSha: "aaaaaaa",
+            subject: "Fix app review",
+          },
+        ],
+      },
+    },
+    {
+      key: "directory:infra",
+      kind: "directory",
+      label: "Infra",
+      path: "/repo/infra",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "deploy/search",
+        defaultBranch: "develop",
+        branches: ["deploy/search", "develop"],
+        baseBranches: ["origin/develop", "develop"],
+        recentCommits: [
+          {
+            sha: "bbbbbbbbbbbbbbbb",
+            shortSha: "bbbbbbb",
+            subject: "Fix infra review",
+          },
+        ],
+      },
+    },
+  ];
+  return snapshot;
 }
 
 function buildWorktreeLaunchpadNavigationSnapshot(): NavigationSnapshot {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -96,17 +96,27 @@ describe("MessagingController", () => {
     expect(harness.delivered).toHaveLength(1);
     expect(harness.delivered[0]).toMatchObject({
       kind: "review",
-      title: "Review target",
+      title: "Review",
+      body: [
+        "Project: PwrAgent",
+        "Review: Base Branch",
+        "Base Branch: main",
+      ].join("\n"),
       review: {
         backend: "codex",
         threadId: "thread-1",
-        phase: "target",
+        phase: "summary",
         cwd: "/repo/pwragent",
+        target: { type: "baseBranch", branch: "main" },
       },
       actions: expect.arrayContaining([
         expect.objectContaining({
-          id: "review:target:current-changes",
-          label: "Current changes",
+          id: "review:summary:start",
+          label: "Start Review",
+        }),
+        expect.objectContaining({
+          id: "review:cancel",
+          label: "Cancel",
         }),
       ]),
     });
@@ -120,7 +130,22 @@ describe("MessagingController", () => {
 
     await harness.controller.handleInboundEvent(
       buildCallbackEvent({
+        actionId: "review:summary:target",
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
         actionId: "review:target:current-changes",
+      }),
+    );
+    expect(harness.submitReview).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Review: Current Changes"),
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "review:summary:start",
       }),
     );
 
@@ -131,6 +156,37 @@ describe("MessagingController", () => {
       delivery: "inline",
       cwd: "/repo/pwragent",
     });
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Review started",
+    });
+  });
+
+  it("preserves the backend bridge receiver when submitting a review", async () => {
+    let receiver: MessagingBackendBridge | undefined;
+    const harness = await createHarness({
+      submitReview: async function (request) {
+        receiver = this as MessagingBackendBridge;
+        if (typeof receiver.getNavigationSnapshot !== "function") {
+          throw new Error("backend receiver was lost");
+        }
+        return {
+          status: "started" as const,
+          response: {
+            backend: request.backend,
+            threadId: request.threadId,
+            reviewThreadId: request.threadId,
+            turnId: "review-turn-1",
+          },
+        };
+      },
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review main"));
+
+    expect(receiver).toBeDefined();
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "confirmation",
       title: "Review started",
@@ -256,6 +312,17 @@ describe("MessagingController", () => {
         ],
       },
     };
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      gitWorkingState: {
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 1,
+        baseBranch: "release",
+      },
+    };
     const harness = await createHarness({ navigation });
     await bindThread(harness);
     harness.delivered.length = 0;
@@ -263,13 +330,14 @@ describe("MessagingController", () => {
     await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "review",
+      body: expect.stringContaining("Base Branch: release"),
       review: {
         cwd: "/repo/pwragent/.worktrees/pwragent-feature-handoff",
         repositoryPath: "/repo/pwragent",
       },
     });
     await harness.controller.handleInboundEvent(
-      buildCallbackEvent({ actionId: "review:target:base-branch" }),
+      buildCallbackEvent({ actionId: "review:summary:base-branch" }),
     );
     expect(harness.delivered.at(-1)).toMatchObject({
       kind: "review",
@@ -280,11 +348,36 @@ describe("MessagingController", () => {
         }),
       ]),
     });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:base-branch:0" }),
+    );
+    expect(harness.submitReview).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: expect.stringContaining("Base Branch: release"),
+      review: {
+        phase: "summary",
+        target: { type: "baseBranch", branch: "release" },
+      },
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:start" }),
+    );
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "release" },
+      delivery: "inline",
+      cwd: "/repo/pwragent/.worktrees/pwragent-feature-handoff",
+    });
 
     const commitHarness = await createHarness({ navigation });
     await bindThread(commitHarness);
     commitHarness.delivered.length = 0;
     await commitHarness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await commitHarness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:target" }),
+    );
     await commitHarness.controller.handleInboundEvent(
       buildCallbackEvent({ actionId: "review:target:commit" }),
     );
@@ -300,6 +393,155 @@ describe("MessagingController", () => {
         }),
       ]),
     });
+  });
+
+  it("returns to the summary with the selected project and its default base branch", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      linkedDirectories: [
+        {
+          id: "directory:app",
+          kind: "worktree",
+          label: "App",
+          path: "/repo/app",
+          worktreePath: "/worktrees/app",
+        },
+        {
+          id: "directory:infra",
+          kind: "worktree",
+          label: "Infra",
+          path: "/repo/infra",
+          worktreePath: "/worktrees/infra",
+        },
+      ],
+    };
+    navigation.directories = [
+      {
+        key: "directory:app",
+        kind: "directory",
+        label: "App",
+        path: "/repo/app",
+        threadKeys: ["codex:thread-1"],
+        needsAttentionCount: 0,
+        gitStatus: {
+          currentBranch: "feature/app",
+          defaultBranch: "main",
+          branches: ["feature/app", "main"],
+          baseBranches: ["origin/main", "main"],
+        },
+      },
+      {
+        key: "directory:infra",
+        kind: "directory",
+        label: "Infra",
+        path: "/repo/infra",
+        threadKeys: ["codex:thread-1"],
+        needsAttentionCount: 0,
+        gitStatus: {
+          currentBranch: "deploy/search",
+          defaultBranch: "develop",
+          branches: ["deploy/search", "develop"],
+          baseBranches: ["origin/develop", "develop"],
+        },
+      },
+    ];
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: [
+        "Project: [needs selection]",
+        "Review: Base Branch",
+        "Base Branch: origin/main",
+      ].join("\n"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "review:summary:workspace" }),
+        expect.objectContaining({ id: "review:summary:start" }),
+        expect.objectContaining({ id: "review:cancel" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:workspace" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:workspace:1" }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: [
+        "Project: Infra",
+        "Review: Base Branch",
+        "Base Branch: origin/develop",
+      ].join("\n"),
+      review: {
+        phase: "summary",
+        cwd: "/worktrees/infra",
+        repositoryPath: "/repo/infra",
+        target: {
+          type: "baseBranch",
+          branch: "origin/develop",
+        },
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:base-branch" }),
+    );
+    const baseBranchIntent = harness.delivered.at(-1);
+    expect(baseBranchIntent).toMatchObject({ kind: "review" });
+    expect(
+      baseBranchIntent && "actions" in baseBranchIntent
+        ? baseBranchIntent.actions?.[0]
+        : undefined,
+    ).toMatchObject({
+      label: "origin/develop",
+      value: { branch: "origin/develop" },
+    });
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:back" }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:start" }),
+    );
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "origin/develop" },
+      delivery: "inline",
+      cwd: "/worktrees/infra",
+    });
+  });
+
+  it("cancels the review summary without starting a review", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:cancel" }),
+    );
+
+    expect(harness.submitReview).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Review cancelled",
+      body: "No review was started.",
+      delivery: expect.objectContaining({ mode: "update" }),
+    });
+    await expect(
+      harness.store.findActivePendingIntentForChannel({
+        actorId: "user-1",
+        channel: buildCommandEvent("/review").channel,
+        now: 1000,
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it("delivers deferred review start failures to the bound conversation", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
+  buildReviewBranchOptions,
   buildThreadIdentityKey,
   isAcpBackendId,
   isAppServerBackendKind,
@@ -1689,15 +1690,30 @@ export class MessagingController {
         } =>
           Boolean(workspace.cwd),
       );
-    const phase = workspaces.length > 1 ? "workspace" : "target";
+    const selectedWorkspace = workspaces.length === 1
+      ? workspaces[0]
+      : undefined;
+    const defaultRepositoryPath =
+      selectedWorkspace?.repositoryPath
+      ?? workspaces[0]?.repositoryPath;
+    const directory = navigation.directories.find((candidate) =>
+      reviewWorkspaceMatches(candidate.path, defaultRepositoryPath),
+    );
+    const target: AppServerReviewTarget = {
+      type: "baseBranch",
+      branch:
+        buildReviewBranchOptions({ directory, thread })[0]
+        ?? "main",
+    };
     const intent = this.buildReviewIntent({
       binding,
       navigation,
-      phase,
-      ...(workspaces.length === 1
+      phase: "summary",
+      target,
+      ...(selectedWorkspace
         ? {
-            cwd: workspaces[0]!.cwd,
-            repositoryPath: workspaces[0]!.repositoryPath,
+            cwd: selectedWorkspace.cwd,
+            repositoryPath: selectedWorkspace.repositoryPath,
           }
         : {}),
     });
@@ -1715,6 +1731,7 @@ export class MessagingController {
     phase: MessagingReviewIntent["review"]["phase"];
     cwd?: string;
     repositoryPath?: string;
+    target?: AppServerReviewTarget;
     id?: string;
     createdAt?: number;
     targetSurface?: MessagingSurfaceRef;
@@ -1733,28 +1750,129 @@ export class MessagingController {
     const directory = params.navigation.directories.find((candidate) =>
       reviewWorkspaceMatches(
         candidate.path,
-        params.repositoryPath ?? params.cwd,
+        params.repositoryPath
+        ?? params.cwd
+        ?? linkedWorkspaces[0]?.repositoryPath,
       ),
     );
-    let title = "Review target";
-    let body = "What should PwrAgent review?";
+    const selectedWorkspace = linkedWorkspaces.find(
+      (workspace) => workspace.cwd === params.cwd,
+    );
+    const defaultBaseBranch =
+      buildReviewBranchOptions({ directory, thread })[0]
+      ?? "main";
+    const target =
+      params.target
+      ?? {
+        type: "baseBranch" as const,
+        branch: defaultBaseBranch,
+      };
+    let title = "Review";
+    let body: string;
     let allowFreeform = false;
-    let targetType: AppServerReviewTarget["type"] | undefined;
     let actions: MessagingSurfaceAction[] = [];
+    const backAction: MessagingSurfaceAction = {
+      id: "review:back",
+      label: "Back",
+      fallbackText: "back",
+      priority: 1,
+    };
+    const cancelAction: MessagingSurfaceAction = {
+      id: "review:cancel",
+      label: "Cancel",
+      style: "danger",
+      fallbackText: "cancel",
+      priority: 2,
+    };
 
-    if (params.phase === "workspace") {
+    if (params.phase === "summary") {
+      const projectLabel =
+        selectedWorkspace?.label
+        ?? (
+          linkedWorkspaces.length > 1
+            ? "[needs selection]"
+            : linkedWorkspaces[0]?.label ?? "Thread workspace"
+        );
+      const summaryLines = [
+        `Project: ${projectLabel}`,
+        `Review: ${formatMessagingReviewScope(target)}`,
+      ];
+      if (target.type === "baseBranch") {
+        summaryLines.push(`Base Branch: ${target.branch}`);
+      } else if (target.type === "commit") {
+        summaryLines.push(
+          `Commit: ${target.title?.trim() || target.sha || "[needs selection]"}`,
+        );
+      } else if (target.type === "custom") {
+        summaryLines.push(`Instructions: ${target.instructions}`);
+      }
+      body = summaryLines.join("\n");
+      actions = [
+        ...(linkedWorkspaces.length > 1
+          ? [{
+              id: "review:summary:workspace",
+              label: "Project",
+              fallbackText: "project",
+              priority: 10,
+            }]
+          : []),
+        {
+          id: "review:summary:target",
+          label: "Review Scope",
+          fallbackText: "review scope",
+          priority: 11,
+        },
+        ...(target.type === "baseBranch"
+          ? [{
+              id: "review:summary:base-branch",
+              label: "Base Branch",
+              fallbackText: "base branch",
+              priority: 12,
+            }]
+          : target.type === "commit"
+            ? [{
+                id: "review:summary:commit",
+                label: "Commit",
+                fallbackText: "commit",
+                priority: 12,
+              }]
+            : target.type === "custom"
+              ? [{
+                  id: "review:summary:custom",
+                  label: "Instructions",
+                  fallbackText: "instructions",
+                  priority: 12,
+                }]
+              : []),
+        {
+          id: "review:summary:start",
+          label: "Start Review",
+          style: "primary",
+          fallbackText: "start review",
+          priority: 0,
+        },
+        cancelAction,
+      ];
+    } else if (params.phase === "workspace") {
       title = "Review project";
       body = "Choose the linked project to review.";
-      actions = linkedWorkspaces.map((workspace, index) => ({
-        id: `review:workspace:${index}`,
-        label: workspace.label,
-        fallbackText: workspace.cwd,
-        value: {
-          cwd: workspace.cwd,
-          repositoryPath: workspace.repositoryPath,
-        },
-      }));
+      actions = [
+        ...linkedWorkspaces.map((workspace, index) => ({
+          id: `review:workspace:${index}`,
+          label: workspace.label,
+          fallbackText: workspace.cwd,
+          priority: 10 + index,
+          value: {
+            cwd: workspace.cwd,
+            repositoryPath: workspace.repositoryPath,
+          },
+        })),
+        backAction,
+        cancelAction,
+      ];
     } else if (params.phase === "target") {
+      title = "Review scope";
+      body = "Choose what PwrAgent should review.";
       actions = [
         {
           id: "review:target:base-branch",
@@ -1784,48 +1902,47 @@ export class MessagingController {
           fallbackText: "custom",
           value: { targetType: "custom" },
         },
+        backAction,
+        cancelAction,
       ];
     } else if (params.phase === "base_branch") {
       title = "Base branch";
       body = "Choose a base branch or reply with a branch name.";
       allowFreeform = true;
-      targetType = "baseBranch";
-      const branches = [
-        ...(directory?.gitStatus?.baseBranches ?? []),
-        ...(directory?.gitStatus?.branches ?? []),
-        directory?.gitStatus?.defaultBranch,
-        "main",
-      ]
-        .map((branch) => branch?.trim())
-        .filter(
-          (branch, index, candidates): branch is string =>
-            Boolean(branch) && candidates.indexOf(branch) === index,
-        );
-      actions = branches.map((branch, index) => ({
-        id: `review:base-branch:${index}`,
-        label: branch,
-        fallbackText: branch,
-        value: { branch },
-      }));
+      actions = [
+        ...buildReviewBranchOptions({ directory, thread }).map((branch, index) => ({
+          id: `review:base-branch:${index}`,
+          label: branch,
+          fallbackText: branch,
+          priority: 10 + index,
+          value: { branch },
+        })),
+        backAction,
+        cancelAction,
+      ];
     } else if (params.phase === "commit") {
       title = "Commit";
       body = "Choose a recent commit or reply with a commit SHA.";
       allowFreeform = true;
-      targetType = "commit";
-      actions = (directory?.gitStatus?.recentCommits ?? []).map((commit, index) => ({
-        id: `review:commit:${index}`,
-        label: `${commit.shortSha} ${commit.subject}`,
-        fallbackText: commit.sha,
-        value: {
-          sha: commit.sha,
-          title: commit.subject,
-        },
-      }));
+      actions = [
+        ...(directory?.gitStatus?.recentCommits ?? []).map((commit, index) => ({
+          id: `review:commit:${index}`,
+          label: `${commit.shortSha} ${commit.subject}`,
+          fallbackText: commit.sha,
+          priority: 10 + index,
+          value: {
+            sha: commit.sha,
+            title: commit.subject,
+          },
+        })),
+        backAction,
+        cancelAction,
+      ];
     } else if (params.phase === "custom") {
       title = "Custom review";
       body = "Reply with the review instructions.";
       allowFreeform = true;
-      targetType = "custom";
+      actions = [backAction, cancelAction];
     } else {
       title = "Review submitted";
       body = "The review request was submitted.";
@@ -1852,7 +1969,9 @@ export class MessagingController {
         ...(params.repositoryPath
           ? { repositoryPath: params.repositoryPath }
           : {}),
-        ...(targetType ? { targetType } : {}),
+        workspaceSelectionRequired: linkedWorkspaces.length > 1,
+        targetType: target.type,
+        target,
       },
       ...(params.targetSurface
         ? {
@@ -3105,11 +3224,10 @@ export class MessagingController {
       return false;
     }
 
-    await this.submitMessagingReviewFromPending(
-      pendingIntent,
-      event,
+    await this.updateReviewPendingIntent(pendingIntent, event, {
+      phase: "summary",
       target,
-    );
+    });
     return true;
   }
 
@@ -3124,6 +3242,64 @@ export class MessagingController {
 
     const value = asPlainRecord(action.value);
     const phase = pendingIntent.intent.review.phase;
+    if (action.id === "review:cancel") {
+      await this.cancelReviewPendingIntent(pendingIntent, event);
+      return;
+    }
+    if (action.id === "review:back") {
+      await this.updateReviewPendingIntent(pendingIntent, event, {
+        phase: "summary",
+      });
+      return;
+    }
+
+    if (phase === "summary") {
+      if (action.id === "review:summary:workspace") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "workspace",
+        });
+      } else if (action.id === "review:summary:target") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "target",
+        });
+      } else if (action.id === "review:summary:base-branch") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "base_branch",
+        });
+      } else if (action.id === "review:summary:commit") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "commit",
+        });
+      } else if (action.id === "review:summary:custom") {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "custom",
+        });
+      } else if (action.id === "review:summary:start") {
+        if (
+          pendingIntent.intent.review.workspaceSelectionRequired
+          && !pendingIntent.intent.review.cwd
+        ) {
+          await this.updateReviewPendingIntent(pendingIntent, event, {
+            phase: "workspace",
+          });
+          return;
+        }
+        const target = pendingIntent.intent.review.target;
+        if (!target) {
+          await this.updateReviewPendingIntent(pendingIntent, event, {
+            phase: "target",
+          });
+          return;
+        }
+        await this.submitMessagingReviewFromPending(
+          pendingIntent,
+          event,
+          target,
+        );
+      }
+      return;
+    }
+
     if (phase === "workspace") {
       const cwd = typeof value?.cwd === "string" ? value.cwd.trim() : "";
       const repositoryPath =
@@ -3132,9 +3308,10 @@ export class MessagingController {
           : "";
       if (cwd) {
         await this.updateReviewPendingIntent(pendingIntent, event, {
-          phase: "target",
+          phase: "summary",
           cwd,
           ...(repositoryPath ? { repositoryPath } : {}),
+          resetBaseBranch: true,
         });
       }
       return;
@@ -3144,14 +3321,15 @@ export class MessagingController {
       const targetType =
         typeof value?.targetType === "string" ? value.targetType : undefined;
       if (targetType === "uncommittedChanges") {
-        await this.submitMessagingReviewFromPending(
-          pendingIntent,
-          event,
-          { type: "uncommittedChanges" },
-        );
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "summary",
+          target: { type: "uncommittedChanges" },
+        });
       } else if (targetType === "baseBranch") {
         await this.updateReviewPendingIntent(pendingIntent, event, {
-          phase: "base_branch",
+          phase: "summary",
+          forceBaseBranch: true,
+          resetBaseBranch: true,
         });
       } else if (targetType === "commit") {
         await this.updateReviewPendingIntent(pendingIntent, event, {
@@ -3168,11 +3346,10 @@ export class MessagingController {
     if (phase === "base_branch") {
       const branch = typeof value?.branch === "string" ? value.branch.trim() : "";
       if (branch) {
-        await this.submitMessagingReviewFromPending(
-          pendingIntent,
-          event,
-          { type: "baseBranch", branch },
-        );
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "summary",
+          target: { type: "baseBranch", branch },
+        });
       }
       return;
     }
@@ -3181,11 +3358,10 @@ export class MessagingController {
       const sha = typeof value?.sha === "string" ? value.sha.trim() : "";
       const title = typeof value?.title === "string" ? value.title : null;
       if (sha) {
-        await this.submitMessagingReviewFromPending(
-          pendingIntent,
-          event,
-          { type: "commit", sha, title },
-        );
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "summary",
+          target: { type: "commit", sha, title },
+        });
       }
     }
   }
@@ -3197,6 +3373,9 @@ export class MessagingController {
       phase: MessagingReviewIntent["review"]["phase"];
       cwd?: string;
       repositoryPath?: string;
+      target?: AppServerReviewTarget;
+      forceBaseBranch?: boolean;
+      resetBaseBranch?: boolean;
     },
   ): Promise<void> {
     if (pendingIntent.intent.kind !== "review") {
@@ -3216,14 +3395,40 @@ export class MessagingController {
     const targetSurface = pendingIntent.surface ?? (
       event.kind === "callback" ? event.interaction : undefined
     );
+    const cwd = review.cwd ?? pendingIntent.intent.review.cwd;
+    const repositoryPath =
+      review.repositoryPath
+      ?? pendingIntent.intent.review.repositoryPath;
+    let target = review.target ?? pendingIntent.intent.review.target;
+    if (
+      review.resetBaseBranch
+      && (
+        review.forceBaseBranch
+        || !target
+        || target.type === "baseBranch"
+      )
+    ) {
+      const thread = findThreadForBinding(navigation, binding);
+      const directory = navigation.directories.find((candidate) =>
+        reviewWorkspaceMatches(
+          candidate.path,
+          repositoryPath ?? cwd,
+        ),
+      );
+      target = {
+        type: "baseBranch",
+        branch:
+          buildReviewBranchOptions({ directory, thread })[0]
+          ?? "main",
+      };
+    }
     const intent = this.buildReviewIntent({
       binding,
       navigation,
       phase: review.phase,
-      cwd: review.cwd ?? pendingIntent.intent.review.cwd,
-      repositoryPath:
-        review.repositoryPath
-        ?? pendingIntent.intent.review.repositoryPath,
+      cwd,
+      repositoryPath,
+      target,
       id: pendingIntent.intent.id,
       createdAt: pendingIntent.intent.createdAt,
       targetSurface,
@@ -3234,6 +3439,33 @@ export class MessagingController {
       intent,
       surface: result.surface ?? pendingIntent.surface,
     });
+  }
+
+  private async cancelReviewPendingIntent(
+    pendingIntent: MessagingPendingIntentRecord,
+    event: MessagingInboundCallbackEvent,
+  ): Promise<void> {
+    const binding = pendingIntent.bindingId
+      ? await this.options.store.getBinding(pendingIntent.bindingId)
+      : undefined;
+    await this.options.store.deletePendingIntent(pendingIntent.id);
+    await this.deliver(
+      buildConfirmationIntent({
+        id: this.newIntentId("review-cancelled"),
+        capabilityProfile: this.capabilityProfile,
+        createdAt: this.now(),
+        title: "Review cancelled",
+        body: "No review was started.",
+        targetSurface: pendingIntent.surface ?? event.interaction,
+        delivery: {
+          mode: "update",
+          replaceMarkup: true,
+          fallback: "present_new",
+        },
+      }),
+      binding && !binding.revokedAt ? binding : undefined,
+      event,
+    );
   }
 
   private async submitMessagingReviewFromPending(
@@ -3281,7 +3513,7 @@ export class MessagingController {
         backend: params.binding.backend,
       });
       const settings = turnSettingsForBinding(params.binding, navigation);
-      const result = await submitReview({
+      const result = await submitReview.call(this.options.backend, {
         backend: params.binding.backend,
         threadId: params.binding.threadId,
         target: params.target,
@@ -9141,7 +9373,6 @@ export class MessagingController {
     const navigation = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });
-    const thread = findThreadForBinding(navigation, binding);
     const models = summary?.launchpadOptions?.models ?? [];
     const modelOption = models.find((candidate) => candidate.id === model);
     if (summary && !modelOption) {
@@ -13753,6 +13984,19 @@ function reviewWorkspaceMatches(
   }
   const normalize = (value: string) => value.replace(/\/+$/, "");
   return normalize(directoryPath) === normalize(cwd);
+}
+
+function formatMessagingReviewScope(target: AppServerReviewTarget): string {
+  switch (target.type) {
+    case "uncommittedChanges":
+      return "Current Changes";
+    case "baseBranch":
+      return "Base Branch";
+    case "commit":
+      return "Commit";
+    case "custom":
+      return "Custom";
+  }
 }
 
 function formatReviewTarget(target: AppServerReviewTarget): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildReviewBranchOptions,
@@ -1735,6 +1736,7 @@ export class MessagingController {
     phase: MessagingReviewIntent["review"]["phase"];
     cwd?: string;
     repositoryPath?: string;
+    workspacePageIndex?: number;
     target?: AppServerReviewTarget;
     id?: string;
     createdAt?: number;
@@ -1859,19 +1861,51 @@ export class MessagingController {
         cancelAction,
       ];
     } else if (params.phase === "workspace") {
+      const page = paginateReviewWorkspaces({
+        itemCount: linkedWorkspaces.length,
+        maxActions: this.capabilityProfile.actions?.maxActions,
+        pageIndex: params.workspacePageIndex,
+      });
       title = "Review project";
-      body = "Choose the linked project to review.";
+      body = [
+        "Choose the linked project to review.",
+        page.totalPages > 1
+          ? `Page ${page.pageIndex + 1}/${page.totalPages}.`
+          : undefined,
+      ]
+        .filter((line): line is string => Boolean(line))
+        .join("\n");
       actions = [
-        ...linkedWorkspaces.map((workspace, index) => ({
-          id: `review:workspace:${index}`,
-          label: workspace.label,
-          fallbackText: workspace.cwd,
-          priority: 10 + index,
-          value: {
-            cwd: workspace.cwd,
-            repositoryPath: workspace.repositoryPath,
-          },
-        })),
+        ...linkedWorkspaces
+          .slice(page.startIndex, page.endIndex)
+          .map((workspace, index) => ({
+            id: `review:workspace:${page.startIndex + index}`,
+            label: workspace.label,
+            fallbackText: workspace.cwd,
+            priority: 10 + index,
+            value: {
+              cwd: workspace.cwd,
+              repositoryPath: workspace.repositoryPath,
+            },
+          })),
+        ...(page.pageIndex > 0
+          ? [{
+              id: "review:workspace:previous",
+              label: "Previous",
+              fallbackText: "previous",
+              priority: 3,
+              value: { pageIndex: page.pageIndex - 1 },
+            }]
+          : []),
+        ...(page.pageIndex < page.totalPages - 1
+          ? [{
+              id: "review:workspace:next",
+              label: "Next",
+              fallbackText: "next",
+              priority: 4,
+              value: { pageIndex: page.pageIndex + 1 },
+            }]
+          : []),
         backAction,
         cancelAction,
       ];
@@ -1978,6 +2012,9 @@ export class MessagingController {
           ? { repositoryPath: params.repositoryPath }
           : {}),
         workspaceSelectionRequired: linkedWorkspaces.length > 1,
+        ...(params.workspacePageIndex !== undefined
+          ? { workspacePageIndex: params.workspacePageIndex }
+          : {}),
         targetType: target.type,
         target,
       },
@@ -3265,6 +3302,7 @@ export class MessagingController {
       if (action.id === "review:summary:workspace") {
         await this.updateReviewPendingIntent(pendingIntent, event, {
           phase: "workspace",
+          workspacePageIndex: 0,
         });
       } else if (action.id === "review:summary:target") {
         await this.updateReviewPendingIntent(pendingIntent, event, {
@@ -3289,6 +3327,7 @@ export class MessagingController {
         ) {
           await this.updateReviewPendingIntent(pendingIntent, event, {
             phase: "workspace",
+            workspacePageIndex: 0,
           });
           return;
         }
@@ -3309,6 +3348,23 @@ export class MessagingController {
     }
 
     if (phase === "workspace") {
+      const workspacePageIndex =
+        typeof value?.pageIndex === "number" && Number.isFinite(value.pageIndex)
+          ? Math.max(0, Math.trunc(value.pageIndex))
+          : undefined;
+      if (
+        (
+          action.id === "review:workspace:previous"
+          || action.id === "review:workspace:next"
+        )
+        && workspacePageIndex !== undefined
+      ) {
+        await this.updateReviewPendingIntent(pendingIntent, event, {
+          phase: "workspace",
+          workspacePageIndex,
+        });
+        return;
+      }
       const cwd = typeof value?.cwd === "string" ? value.cwd.trim() : "";
       const repositoryPath =
         typeof value?.repositoryPath === "string"
@@ -3382,6 +3438,7 @@ export class MessagingController {
       phase: MessagingReviewIntent["review"]["phase"];
       cwd?: string;
       repositoryPath?: string;
+      workspacePageIndex?: number;
       target?: AppServerReviewTarget;
       forceBaseBranch?: boolean;
       resetRepositoryTarget?: boolean;
@@ -3442,6 +3499,7 @@ export class MessagingController {
       phase: review.phase,
       cwd,
       repositoryPath,
+      workspacePageIndex: review.workspacePageIndex,
       target,
       id: pendingIntent.intent.id,
       createdAt: pendingIntent.intent.createdAt,
@@ -14000,6 +14058,23 @@ function reviewWorkspaceMatches(
   return normalize(directoryPath) === normalize(cwd);
 }
 
+function reviewWorkspaceContains(
+  workspacePath: string | undefined,
+  cwd: string | undefined,
+): boolean {
+  if (!workspacePath || !cwd) {
+    return false;
+  }
+  const relative = path.relative(
+    path.resolve(workspacePath),
+    path.resolve(cwd),
+  );
+  return (
+    relative === ""
+    || (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
 function reviewThreadForWorkspace(
   thread: NavigationThreadSummary | undefined,
   cwd: string | undefined,
@@ -14007,9 +14082,40 @@ function reviewThreadForWorkspace(
   if (!thread || thread.linkedDirectories.length <= 1) {
     return thread;
   }
-  return reviewWorkspaceMatches(thread.projectKey, cwd)
+  return reviewWorkspaceContains(cwd, thread.projectKey)
     ? thread
     : undefined;
+}
+
+function paginateReviewWorkspaces(params: {
+  itemCount: number;
+  maxActions: number | undefined;
+  pageIndex: number | undefined;
+}): {
+  endIndex: number;
+  pageIndex: number;
+  startIndex: number;
+  totalPages: number;
+} {
+  const maxActions =
+    params.maxActions === undefined
+      ? Number.MAX_SAFE_INTEGER
+      : Math.max(1, Math.trunc(params.maxActions));
+  const singlePageSize = Math.max(1, maxActions - 2);
+  const pageSize =
+    params.itemCount > singlePageSize
+      ? Math.max(1, maxActions - 4)
+      : singlePageSize;
+  const totalPages = Math.max(1, Math.ceil(params.itemCount / pageSize));
+  const requestedPage = Math.max(0, Math.trunc(params.pageIndex ?? 0));
+  const pageIndex = Math.min(requestedPage, totalPages - 1);
+  const startIndex = pageIndex * pageSize;
+  return {
+    endIndex: Math.min(params.itemCount, startIndex + pageSize),
+    pageIndex,
+    startIndex,
+    totalPages,
+  };
 }
 
 function formatMessagingReviewScope(target: AppServerReviewTarget): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1699,10 +1699,14 @@ export class MessagingController {
     const directory = navigation.directories.find((candidate) =>
       reviewWorkspaceMatches(candidate.path, defaultRepositoryPath),
     );
+    const workspaceThread = reviewThreadForWorkspace(
+      thread,
+      selectedWorkspace?.cwd,
+    );
     const target: AppServerReviewTarget = {
       type: "baseBranch",
       branch:
-        buildReviewBranchOptions({ directory, thread })[0]
+        buildReviewBranchOptions({ directory, thread: workspaceThread })[0]
         ?? "main",
     };
     const intent = this.buildReviewIntent({
@@ -1758,8 +1762,9 @@ export class MessagingController {
     const selectedWorkspace = linkedWorkspaces.find(
       (workspace) => workspace.cwd === params.cwd,
     );
+    const workspaceThread = reviewThreadForWorkspace(thread, params.cwd);
     const defaultBaseBranch =
-      buildReviewBranchOptions({ directory, thread })[0]
+      buildReviewBranchOptions({ directory, thread: workspaceThread })[0]
       ?? "main";
     const target =
       params.target
@@ -1910,7 +1915,10 @@ export class MessagingController {
       body = "Choose a base branch or reply with a branch name.";
       allowFreeform = true;
       actions = [
-        ...buildReviewBranchOptions({ directory, thread }).map((branch, index) => ({
+        ...buildReviewBranchOptions({
+          directory,
+          thread: workspaceThread,
+        }).map((branch, index) => ({
           id: `review:base-branch:${index}`,
           label: branch,
           fallbackText: branch,
@@ -3311,6 +3319,7 @@ export class MessagingController {
           phase: "summary",
           cwd,
           ...(repositoryPath ? { repositoryPath } : {}),
+          resetRepositoryTarget: true,
           resetBaseBranch: true,
         });
       }
@@ -3375,6 +3384,7 @@ export class MessagingController {
       repositoryPath?: string;
       target?: AppServerReviewTarget;
       forceBaseBranch?: boolean;
+      resetRepositoryTarget?: boolean;
       resetBaseBranch?: boolean;
     },
   ): Promise<void> {
@@ -3400,6 +3410,9 @@ export class MessagingController {
       review.repositoryPath
       ?? pendingIntent.intent.review.repositoryPath;
     let target = review.target ?? pendingIntent.intent.review.target;
+    if (review.resetRepositoryTarget && target?.type === "commit") {
+      target = undefined;
+    }
     if (
       review.resetBaseBranch
       && (
@@ -3409,6 +3422,7 @@ export class MessagingController {
       )
     ) {
       const thread = findThreadForBinding(navigation, binding);
+      const workspaceThread = reviewThreadForWorkspace(thread, cwd);
       const directory = navigation.directories.find((candidate) =>
         reviewWorkspaceMatches(
           candidate.path,
@@ -3418,7 +3432,7 @@ export class MessagingController {
       target = {
         type: "baseBranch",
         branch:
-          buildReviewBranchOptions({ directory, thread })[0]
+          buildReviewBranchOptions({ directory, thread: workspaceThread })[0]
           ?? "main",
       };
     }
@@ -13984,6 +13998,18 @@ function reviewWorkspaceMatches(
   }
   const normalize = (value: string) => value.replace(/\/+$/, "");
   return normalize(directoryPath) === normalize(cwd);
+}
+
+function reviewThreadForWorkspace(
+  thread: NavigationThreadSummary | undefined,
+  cwd: string | undefined,
+): NavigationThreadSummary | undefined {
+  if (!thread || thread.linkedDirectories.length <= 1) {
+    return thread;
+  }
+  return reviewWorkspaceMatches(thread.projectKey, cwd)
+    ? thread
+    : undefined;
 }
 
 function formatMessagingReviewScope(target: AppServerReviewTarget): string {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -37,7 +37,10 @@ import type {
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
-import { readCodexEnvironmentActionRuns } from "@pwragent/shared";
+import {
+  buildReviewBranchOptions,
+  readCodexEnvironmentActionRuns,
+} from "@pwragent/shared";
 import {
   BranchIcon,
   CheckIcon,
@@ -579,10 +582,6 @@ const REVIEW_TARGET_OPTIONS: Array<{
   },
 ];
 
-const REVIEW_PREFERRED_BASE_BRANCHES = ["main", "master", "develop", "trunk"];
-const REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN =
-  /^(main|master|develop|development|trunk)$|^(release|releases|stable|support|maintenance)\//;
-
 function getDefaultModelOption(backend?: BackendSummary): ModelOption | undefined {
   const models = backend?.launchpadOptions?.models ?? [];
   return (
@@ -624,141 +623,6 @@ function getReasoningEffortValue(
   return reasoningEfforts.includes(currentValue ?? "")
     ? currentValue
     : getDefaultReasoningEffort(backend, model);
-}
-
-function buildReviewBranchOptions(params: {
-  directory?: NavigationDirectorySummary;
-  thread?: NavigationThreadSummary;
-}): string[] {
-  const threadCurrentBranches = [
-    params.thread?.gitBranch,
-    params.thread?.observedGitBranch,
-  ]
-    .map((branch) => branch?.trim())
-    .filter((branch): branch is string => Boolean(branch));
-  const currentBranches = new Set(
-    [
-      ...threadCurrentBranches,
-      ...(threadCurrentBranches.length === 0
-        ? [params.directory?.gitStatus?.currentBranch]
-        : []),
-    ]
-      .map((branch) => branch?.trim())
-      .filter((branch): branch is string => Boolean(branch)),
-  );
-  const isCurrentBranch = (candidate?: string): boolean => {
-    const value = candidate?.trim();
-    if (!value) {
-      return false;
-    }
-    if (currentBranches.has(value)) {
-      return true;
-    }
-    return (
-      value.startsWith("origin/") &&
-      currentBranches.has(value.slice("origin/".length))
-    );
-  };
-  const upstreamBranch = params.directory?.gitStatus?.upstreamBranch?.replace(
-    /^origin\//,
-    "",
-  );
-  const directoryCurrentBranch = params.directory?.gitStatus?.currentBranch
-    ?.trim()
-    .replace(/^origin\//, "");
-  const directoryDefaultBranch = params.directory?.gitStatus?.defaultBranch
-    ?.trim()
-    .replace(/^origin\//, "");
-  const baseBranches = params.directory?.gitStatus?.baseBranches ?? [];
-  const knownBranches = new Set(
-    [
-      ...baseBranches,
-      ...(params.directory?.gitStatus?.branches ?? []),
-      params.directory?.gitStatus?.defaultBranch,
-      upstreamBranch,
-    ]
-      .map((branch) => branch?.trim())
-      .filter((branch): branch is string => Boolean(branch)),
-  );
-  const options = new Set<string>();
-  const push = (
-    candidate?: string,
-    optionsForCandidate?: { allowCurrent?: boolean },
-  ): void => {
-    const value = candidate?.trim();
-    if (
-      value &&
-      (optionsForCandidate?.allowCurrent || !isCurrentBranch(value))
-    ) {
-      options.add(value);
-    }
-  };
-  const pushIfKnown = (candidate?: string): void => {
-    const value = candidate?.trim();
-    if (value && knownBranches.has(value)) {
-      push(value);
-    }
-  };
-  const pushPreferredDefault = (candidate?: string): void => {
-    const value = candidate?.trim().replace(/^origin\//, "");
-    if (!value) {
-      return;
-    }
-    pushIfKnown(`origin/${value}`);
-    pushIfKnown(value);
-  };
-  const pushDirectoryDefault = (): void => {
-    if (!directoryDefaultBranch) {
-      return;
-    }
-    if (
-      threadCurrentBranches.length > 0 &&
-      directoryDefaultBranch === directoryCurrentBranch &&
-      !REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(directoryDefaultBranch)
-    ) {
-      return;
-    }
-    pushPreferredDefault(directoryDefaultBranch);
-  };
-  const pushInferredBaseBranch = (candidate?: string): void => {
-    const value = candidate?.trim();
-    if (!value) {
-      return;
-    }
-
-    const optionCount = options.size;
-    if (value.startsWith("origin/")) {
-      pushIfKnown(value);
-      pushIfKnown(value.slice("origin/".length));
-    } else if (REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(value)) {
-      pushIfKnown(`origin/${value}`);
-      pushIfKnown(value);
-    } else {
-      pushIfKnown(value);
-    }
-
-    if (options.size === optionCount) {
-      push(value);
-    }
-  };
-
-  pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
-  pushDirectoryDefault();
-  for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
-    pushPreferredDefault(branch);
-  }
-  push("main", { allowCurrent: true });
-  pushIfKnown(upstreamBranch);
-  for (const candidate of baseBranches) {
-    push(candidate);
-  }
-  push(params.thread?.gitBranch);
-  push(params.thread?.observedGitBranch);
-  push(params.directory?.gitStatus?.currentBranch);
-  for (const candidate of params.directory?.gitStatus?.branches ?? []) {
-    push(candidate);
-  }
-  return [...options];
 }
 
 function buildReviewBranchPickerOptions(params: {

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -869,6 +869,7 @@ export type MessagingReviewIntent = MessagingBaseSurfaceIntent & {
     cwd?: string;
     repositoryPath?: string;
     workspaceSelectionRequired?: boolean;
+    workspacePageIndex?: number;
     targetType?: AppServerReviewTarget["type"];
     target?: AppServerReviewTarget;
   };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -848,6 +848,7 @@ export type MessagingQuestionnaireIntent = MessagingBaseSurfaceIntent & {
 };
 
 export type MessagingReviewPhase =
+  | "summary"
   | "workspace"
   | "target"
   | "base_branch"
@@ -867,6 +868,7 @@ export type MessagingReviewIntent = MessagingBaseSurfaceIntent & {
     phase: MessagingReviewPhase;
     cwd?: string;
     repositoryPath?: string;
+    workspaceSelectionRequired?: boolean;
     targetType?: AppServerReviewTarget["type"];
     target?: AppServerReviewTarget;
   };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from "./inbox";
 export * from "./navigation-state";
 export * from "./pending-request-response";
 export * from "./renderer-payload-boundary";
+export * from "./review-branches";
 export * from "./subthreads";
 export * from "./thread-pins";
 export * from "./thread-titles";

--- a/packages/shared/src/review-branches.ts
+++ b/packages/shared/src/review-branches.ts
@@ -1,0 +1,143 @@
+import type {
+  NavigationDirectorySummary,
+  NavigationThreadSummary,
+} from "./contracts/navigation";
+
+const REVIEW_PREFERRED_BASE_BRANCHES = ["main", "master", "develop", "trunk"];
+const REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN =
+  /^(main|master|develop|development|trunk)$|^(release|releases|stable|support|maintenance)\//;
+
+export function buildReviewBranchOptions(params: {
+  directory?: NavigationDirectorySummary;
+  thread?: NavigationThreadSummary;
+}): string[] {
+  const threadCurrentBranches = [
+    params.thread?.gitBranch,
+    params.thread?.observedGitBranch,
+  ]
+    .map((branch) => branch?.trim())
+    .filter((branch): branch is string => Boolean(branch));
+  const currentBranches = new Set(
+    [
+      ...threadCurrentBranches,
+      ...(threadCurrentBranches.length === 0
+        ? [params.directory?.gitStatus?.currentBranch]
+        : []),
+    ]
+      .map((branch) => branch?.trim())
+      .filter((branch): branch is string => Boolean(branch)),
+  );
+  const isCurrentBranch = (candidate?: string): boolean => {
+    const value = candidate?.trim();
+    if (!value) {
+      return false;
+    }
+    if (currentBranches.has(value)) {
+      return true;
+    }
+    return (
+      value.startsWith("origin/")
+      && currentBranches.has(value.slice("origin/".length))
+    );
+  };
+  const upstreamBranch = params.directory?.gitStatus?.upstreamBranch?.replace(
+    /^origin\//,
+    "",
+  );
+  const directoryCurrentBranch = params.directory?.gitStatus?.currentBranch
+    ?.trim()
+    .replace(/^origin\//, "");
+  const directoryDefaultBranch = params.directory?.gitStatus?.defaultBranch
+    ?.trim()
+    .replace(/^origin\//, "");
+  const baseBranches = params.directory?.gitStatus?.baseBranches ?? [];
+  const knownBranches = new Set(
+    [
+      ...baseBranches,
+      ...(params.directory?.gitStatus?.branches ?? []),
+      params.directory?.gitStatus?.defaultBranch,
+      upstreamBranch,
+    ]
+      .map((branch) => branch?.trim())
+      .filter((branch): branch is string => Boolean(branch)),
+  );
+  const options = new Set<string>();
+  const push = (
+    candidate?: string,
+    optionsForCandidate?: { allowCurrent?: boolean },
+  ): void => {
+    const value = candidate?.trim();
+    if (
+      value
+      && (optionsForCandidate?.allowCurrent || !isCurrentBranch(value))
+    ) {
+      options.add(value);
+    }
+  };
+  const pushIfKnown = (candidate?: string): void => {
+    const value = candidate?.trim();
+    if (value && knownBranches.has(value)) {
+      push(value);
+    }
+  };
+  const pushPreferredDefault = (candidate?: string): void => {
+    const value = candidate?.trim().replace(/^origin\//, "");
+    if (!value) {
+      return;
+    }
+    pushIfKnown(`origin/${value}`);
+    pushIfKnown(value);
+  };
+  const pushDirectoryDefault = (): void => {
+    if (!directoryDefaultBranch) {
+      return;
+    }
+    if (
+      threadCurrentBranches.length > 0
+      && directoryDefaultBranch === directoryCurrentBranch
+      && !REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(directoryDefaultBranch)
+    ) {
+      return;
+    }
+    pushPreferredDefault(directoryDefaultBranch);
+  };
+  const pushInferredBaseBranch = (candidate?: string): void => {
+    const value = candidate?.trim();
+    if (!value) {
+      return;
+    }
+
+    const optionCount = options.size;
+    if (value.startsWith("origin/")) {
+      pushIfKnown(value);
+      pushIfKnown(value.slice("origin/".length));
+    } else if (REVIEW_REMOTE_AGNOSTIC_BASE_BRANCH_PATTERN.test(value)) {
+      pushIfKnown(`origin/${value}`);
+      pushIfKnown(value);
+    } else {
+      pushIfKnown(value);
+    }
+
+    if (options.size === optionCount) {
+      push(value);
+    }
+  };
+
+  pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
+  pushDirectoryDefault();
+  for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {
+    pushPreferredDefault(branch);
+  }
+  push("main", { allowCurrent: true });
+  pushIfKnown(upstreamBranch);
+  for (const candidate of baseBranches) {
+    push(candidate);
+  }
+  push(params.thread?.gitBranch);
+  push(params.thread?.observedGitBranch);
+  push(params.directory?.gitStatus?.currentBranch);
+  for (const candidate of params.directory?.gitStatus?.branches ?? []) {
+    push(candidate);
+  }
+  return [...options];
+}


### PR DESCRIPTION
## Summary

- replace the sequential bare `/review` questionnaire with a summary-first configuration card
- add Project, Review Scope, Base Branch/Commit/Instructions, Start Review, Back, and Cancel actions
- share the desktop GUI's base-branch ranking logic with messaging so inferred PR roots such as `origin/develop` are selected by default
- return picker selections to the summary before submission
- preserve direct argument forms such as `/review main`

## Root cause and impact

The previous messaging flow required several one-at-a-time selections and did not use the same base-branch inference as the desktop GUI. It also detached `DesktopMessagingBackendBridge.submitReview` from its receiver before calling it. In production this made `this.registry` undefined and caused Slack review submission to fail with `Cannot read properties of undefined (reading 'registry')`.

The new flow makes the common path a single Start Review click after any required project choice, and calls the bridge method with its receiver intact.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts` — 499 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warnings only
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `pnpm licenses:check`
- `pnpm lint:boundaries`
- `pnpm build`

A full workspace test run reached 5,093 passing tests; 43 unrelated git/environment tests timed out under parallel load. Representative failures were rerun in isolation and passed 17/17.
