### PR TITLE
fix(tests): remove Windows cleanup races

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,10 @@ import { AcpRolloutStore } from "../acp/acp-rollout-store";
 import { AcpSessionStore } from "../acp/acp-session-store";
 import { FakeAcpAgentTransport } from "../acp/testing/fake-acp-agent";
 import { StateDb } from "../state/state-db";
+import {
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
 
 let tempDir: string;
 let stateDb: StateDb;
@@ -18,14 +22,14 @@ let store: AcpSessionStore;
 
 beforeEach(() => {
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-acp-client-"));
-  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  stateDb = openInMemoryStateDb();
   store = new AcpSessionStore(stateDb);
 });
 
 afterEach(() => {
   vi.useRealTimers();
   stateDb.close();
-  rmSync(tempDir, { recursive: true, force: true });
+  removeTempStateDbDir(tempDir);
 });
 
 function createDeferred<T>(): {
@@ -163,6 +167,9 @@ describe("AcpAgentClient", () => {
     await vi.waitFor(() => {
       expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
         "Kimi says hi.",
+      );
+      expect(store.getSession("acp:kimi", session.sessionId)?.status).toBe(
+        "idle",
       );
     });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -9613,8 +9613,7 @@ command = "pnpm test"
 
   it("refreshes stale thread environment actions before running a command", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-env-run-"));
-    const outputPath = path.join(root, "action.txt");
-    const shellOutputPath = outputPath.replace(/\\/g, "/");
+    const expectedActionCommand = `node -e "process.stdout.write('action-ran')"`;
     await mkdir(path.join(root, ".codex", "environments"), { recursive: true });
     await writeFile(
       path.join(root, ".codex", "environments", "environment.toml"),
@@ -9624,7 +9623,7 @@ name = "PwrAgnt"
 
 [[actions]]
 name = "Dev - Messaging"
-command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-ran')" ${JSON.stringify(shellOutputPath)}'''
+command = '''${expectedActionCommand}'''
 `,
       "utf8",
     );
@@ -9646,6 +9645,7 @@ command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-
         },
       },
     });
+    let commandParams: Parameters<CodexEnvironmentCommandRunner>[0] | undefined;
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
         initializeResult: { methods: ["thread/list"] },
@@ -9655,6 +9655,10 @@ command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
       overlayStore,
+      codexEnvironmentCommandRunner: vi.fn(async (params) => {
+        commandParams = params;
+        return { pid: 12345 };
+      }),
     });
 
     try {
@@ -9675,13 +9679,10 @@ command = '''node -e "require('node:fs').writeFileSync(process.argv[1], 'action-
           ],
         },
       });
-      await expectEventually(async () => await readFile(outputPath, "utf8"), "action-ran");
-      // Gate cleanup on the detached child fully exiting (see helper) so the
-      // temp dir it spawned into is no longer locked when we remove it.
-      await waitForDetachedActionRunToExit(overlayStore, {
-        backend: "codex",
-        threadId: "thread-1",
-        actionId: "dev-messaging",
+      expect(commandParams).toMatchObject({
+        command: expectedActionCommand,
+        cwd: root,
+        mode: "detach",
       });
     } finally {
       await registry.close();

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 // bash.exe), so git/worktree-heavy desktop tests can exceed the 5s default.
 // Give Windows more headroom; POSIX keeps the standard timeout.
 const TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000;
+const HOOK_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 10_000;
 
 export default defineConfig({
   test: {
@@ -49,6 +50,7 @@ export default defineConfig({
           name: "desktop-main",
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
+          hookTimeout: HOOK_TIMEOUT_MS,
           environment: "node",
           include: [
             "scripts/**/*.test.mjs",


### PR DESCRIPTION
## Summary

- use an in-memory state database in the ACP client unit suite while retaining temporary directories for rollout-file coverage
- wait for the Kimi prompt turn to become idle before test teardown
- verify refreshed Codex environment actions at the command-runner boundary instead of spawning a detached process
- give Windows desktop-main hooks the same 30-second allowance as Windows tests

## Verification

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` — 439 tests passed
- `pnpm typecheck`
- `pnpm exec eslint apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts vitest.workspace.ts` — no errors; one pre-existing `prefer-const` warning
- `git diff --check`

## Notes

- The Windows flakes were cleanup races under runner load: file-backed WAL SQLite teardown could exceed Vitest's default 10-second hook timeout, and the detached environment-action test could encounter `EBUSY` while removing the child process's working directory.
- This keeps subprocess lifecycle coverage in the dedicated environment-runtime tests while making the backend-registry test deterministic.
