### PR TITLE
fix(messaging): clean up review lifecycle and choices

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-artifact-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-artifact-renderer.test.ts
@@ -4,6 +4,7 @@ import { PERMISSIVE_CAPABILITY_PROFILE } from "@pwragent/messaging-interface/tes
 import {
   buildArtifactDeliveryIntent,
   buildPlanArtifactIntent,
+  buildReviewArtifactIntent,
 } from "../messaging/core/messaging-artifact-renderer";
 
 describe("messaging artifact renderer", () => {
@@ -28,6 +29,41 @@ describe("messaging artifact renderer", () => {
       type: "text",
       text: expect.stringContaining("Write the test"),
     });
+  });
+
+  it("renders a structured review explanation only once", () => {
+    const explanation =
+      "The forced fetch refspec correctly permits updating the shallow remote-tracking ref.";
+    const intent = buildReviewArtifactIntent({
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
+      createdAt: 1000,
+      id: "review-structured",
+      review: {
+        type: "review",
+        id: "review-1",
+        createdAt: 1000,
+        displayText: "Code review completed",
+        review: explanation,
+        output: {
+          findings: [],
+          overall_correctness: "patch is correct",
+          overall_confidence_score: 0.97,
+          overall_explanation: explanation,
+        },
+      },
+    });
+
+    expect(intent.artifactDelivery).toEqual({
+      kind: "review",
+      mode: "inline_only",
+    });
+    const text = intent.parts[0]?.type === "text"
+      ? intent.parts[0].text
+      : "";
+    expect(text).toContain("# Review");
+    expect(text).toContain("Code review completed");
+    expect(text).toContain("- Correctness: patch is correct");
+    expect(text.split(explanation)).toHaveLength(2);
   });
 
   it("adds a markdown attachment and bounded preview for long artifacts when upload is supported", () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -395,6 +395,66 @@ describe("MessagingController", () => {
     });
   });
 
+  it("shows only plausible review base branches as buttons", async () => {
+    const navigation = buildWorktreeHandoffNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        currentBranch: "feature/handoff",
+        defaultBranch: "develop",
+        baseBranches: [
+          "origin/develop",
+          "develop",
+          ...Array.from(
+            { length: 50 },
+            (_, index) => `origin/feature/old-${index + 1}`,
+          ),
+        ],
+        branches: [
+          "develop",
+          "feature/handoff",
+          ...Array.from(
+            { length: 50 },
+            (_, index) => `feature/old-${index + 1}`,
+          ),
+        ],
+      },
+    };
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      gitWorkingState: {
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 1,
+        baseBranch: "develop",
+      },
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:base-branch" }),
+    );
+
+    const branchPicker = harness.delivered.at(-1);
+    expect(branchPicker).toMatchObject({
+      kind: "review",
+      body: "Choose a suggested base branch or reply with any branch name.",
+    });
+    if (!branchPicker || branchPicker.kind !== "review") {
+      throw new Error("Expected review base branch picker");
+    }
+    expect(
+      branchPicker.actions
+        .filter((action) => action.id.startsWith("review:base-branch:"))
+        .map((action) => action.label),
+    ).toEqual(["origin/develop", "develop"]);
+  });
+
   it("returns to the summary with the selected project and its default base branch", async () => {
     const navigation = buildMultiProjectReviewNavigationSnapshot();
     const harness = await createHarness({ navigation });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -4393,6 +4393,12 @@ describe("MessagingController", () => {
     expect(textPart).toEqual(expect.objectContaining({
       text: expect.stringContaining("Missing validation"),
     }));
+    if (!textPart || textPart.type !== "text") {
+      throw new Error("Expected structured review artifact text");
+    }
+    expect(
+      textPart.text.split("The patch has one validation issue."),
+    ).toHaveLength(2);
   });
 
   it("delivers a single added markdown file as attachment plus bounded preview", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -455,6 +455,47 @@ describe("MessagingController", () => {
     ).toEqual(["origin/develop", "develop"]);
   });
 
+  it("offers conventional base branches from remotes not named origin", async () => {
+    const navigation = buildWorktreeHandoffNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        currentBranch: "feature/handoff",
+        upstreamBranch: "upstream/feature/handoff",
+        baseBranches: ["upstream/main"],
+        branches: ["feature/handoff"],
+      },
+    };
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      gitWorkingState: {
+        dirtyFiles: 0,
+        dirtyAdditions: 0,
+        dirtyDeletions: 0,
+        untrackedFiles: 0,
+        unpushedCommits: 1,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:base-branch" }),
+    );
+
+    const branchPicker = harness.delivered.at(-1);
+    if (!branchPicker || branchPicker.kind !== "review") {
+      throw new Error("Expected review base branch picker");
+    }
+    expect(
+      branchPicker.actions
+        .filter((action) => action.id.startsWith("review:base-branch:"))
+        .map((action) => action.label),
+    ).toEqual(["upstream/main"]);
+  });
+
   it("returns to the summary with the selected project and its default base branch", async () => {
     const navigation = buildMultiProjectReviewNavigationSnapshot();
     const harness = await createHarness({ navigation });

--- a/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
@@ -261,17 +261,25 @@ function renderPlanMarkdown(plan: AppServerThreadPlanEntry): string {
 
 function renderReviewMarkdown(review: AppServerThreadReviewEntry): string {
   const lines = ["# Review"];
+  const reviewText = review.review.trim();
   if (review.displayText?.trim()) {
     lines.push("", review.displayText.trim());
   }
-  if (review.review.trim()) {
-    lines.push("", review.review.trim());
+  if (reviewText) {
+    lines.push("", reviewText);
   }
   if (review.output) {
     lines.push("", "## Summary");
     lines.push(`- Correctness: ${review.output.overall_correctness}`);
     lines.push(`- Confidence: ${review.output.overall_confidence_score}`);
-    lines.push(`- Explanation: ${review.output.overall_explanation}`);
+    if (
+      !reviewTextContainsExplanation(
+        reviewText,
+        review.output.overall_explanation,
+      )
+    ) {
+      lines.push(`- Explanation: ${review.output.overall_explanation}`);
+    }
     if (review.output.findings.length > 0) {
       lines.push("", "## Findings");
       for (const finding of review.output.findings) {
@@ -280,6 +288,18 @@ function renderReviewMarkdown(review: AppServerThreadReviewEntry): string {
     }
   }
   return lines.join("\n").trim();
+}
+
+function reviewTextContainsExplanation(
+  reviewText: string,
+  explanation: string,
+): boolean {
+  const normalize = (value: string) => value.replace(/\s+/g, " ").trim();
+  const normalizedExplanation = normalize(explanation);
+  return (
+    normalizedExplanation.length > 0
+    && normalize(reviewText).includes(normalizedExplanation)
+  );
 }
 
 function formatAttachmentSummary(params: {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -14187,15 +14187,22 @@ function messagingReviewBranchOptions(params: {
   thread: NavigationThreadSummary | undefined;
 }): string[] {
   const options = buildReviewBranchOptions(params);
-  const primaryBranch = normalizeReviewBranchName(options[0]);
-  const knownBranchNames = new Set(
+  const primaryBranch = options[0]?.trim();
+  const localBranchNames = new Set(
     [
-      ...(params.directory?.gitStatus?.baseBranches ?? []),
       ...(params.directory?.gitStatus?.branches ?? []),
       params.directory?.gitStatus?.defaultBranch,
     ]
-      .map(normalizeReviewBranchName)
+      .map((branch) => branch?.trim())
       .filter((branch): branch is string => Boolean(branch)),
+  );
+  const baseBranchNames = new Set(
+    (params.directory?.gitStatus?.baseBranches ?? [])
+      .map((branch) => branch.trim())
+      .filter(Boolean),
+  );
+  const knownBranchNames = new Set(
+    [...localBranchNames, ...baseBranchNames],
   );
   const conventionalBaseBranches = new Set([
     "main",
@@ -14203,26 +14210,39 @@ function messagingReviewBranchOptions(params: {
     "develop",
     "trunk",
   ]);
-  return options
-    .filter((branch) => {
-      const normalized = normalizeReviewBranchName(branch);
-      if (!normalized) {
-        return false;
-      }
-      return (
-        normalized === primaryBranch
-        || (
-          conventionalBaseBranches.has(normalized)
-          && knownBranchNames.has(normalized)
-        )
-      );
-    })
+  const conventionalName = (branch: string): string | undefined => {
+    const value = branch.trim();
+    if (conventionalBaseBranches.has(value)) {
+      return value;
+    }
+    if (!baseBranchNames.has(value) || localBranchNames.has(value)) {
+      return undefined;
+    }
+    const remoteSeparator = value.indexOf("/");
+    const remoteBranch =
+      remoteSeparator >= 0 ? value.slice(remoteSeparator + 1) : "";
+    return conventionalBaseBranches.has(remoteBranch)
+      ? remoteBranch
+      : undefined;
+  };
+  const knownConventionalOptions = options.filter(
+    (branch) =>
+      knownBranchNames.has(branch.trim())
+      && Boolean(conventionalName(branch)),
+  );
+  const keepPrimary =
+    primaryBranch !== undefined
+    && (
+      knownBranchNames.has(primaryBranch)
+      || primaryBranch !== "main"
+      || knownConventionalOptions.length === 0
+    );
+  return [
+    ...(keepPrimary && primaryBranch ? [primaryBranch] : []),
+    ...knownConventionalOptions,
+  ]
+    .filter((branch, index, branches) => branches.indexOf(branch) === index)
     .slice(0, 8);
-}
-
-function normalizeReviewBranchName(branch: string | undefined): string | undefined {
-  const normalized = branch?.trim().replace(/^origin\//, "");
-  return normalized || undefined;
 }
 
 function formatMessagingReviewScope(target: AppServerReviewTarget): string {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1966,10 +1966,10 @@ export class MessagingController {
       ];
     } else if (params.phase === "base_branch") {
       title = "Base branch";
-      body = "Choose a base branch or reply with a branch name.";
+      body = "Choose a suggested base branch or reply with any branch name.";
       allowFreeform = true;
       actions = [
-        ...buildReviewBranchOptions({
+        ...messagingReviewBranchOptions({
           directory,
           thread: workspaceThread,
         }).map((branch, index) => ({
@@ -14180,6 +14180,49 @@ function paginateReviewWorkspaces(params: {
     startIndex,
     totalPages,
   };
+}
+
+function messagingReviewBranchOptions(params: {
+  directory: NavigationDirectorySummary | undefined;
+  thread: NavigationThreadSummary | undefined;
+}): string[] {
+  const options = buildReviewBranchOptions(params);
+  const primaryBranch = normalizeReviewBranchName(options[0]);
+  const knownBranchNames = new Set(
+    [
+      ...(params.directory?.gitStatus?.baseBranches ?? []),
+      ...(params.directory?.gitStatus?.branches ?? []),
+      params.directory?.gitStatus?.defaultBranch,
+    ]
+      .map(normalizeReviewBranchName)
+      .filter((branch): branch is string => Boolean(branch)),
+  );
+  const conventionalBaseBranches = new Set([
+    "main",
+    "master",
+    "develop",
+    "trunk",
+  ]);
+  return options
+    .filter((branch) => {
+      const normalized = normalizeReviewBranchName(branch);
+      if (!normalized) {
+        return false;
+      }
+      return (
+        normalized === primaryBranch
+        || (
+          conventionalBaseBranches.has(normalized)
+          && knownBranchNames.has(normalized)
+        )
+      );
+    })
+    .slice(0, 8);
+}
+
+function normalizeReviewBranchName(branch: string | undefined): string | undefined {
+  const normalized = branch?.trim().replace(/^origin\//, "");
+  return normalized || undefined;
 }
 
 function formatMessagingReviewScope(target: AppServerReviewTarget): string {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3949,6 +3949,32 @@ export function Composer(props: ComposerProps) {
         return;
       }
 
+      const completedItemRecord =
+        event.notification.method === "item/completed" &&
+        typeof event.notification.params.item === "object" &&
+        event.notification.params.item !== null
+          ? (event.notification.params.item as { type?: unknown })
+          : undefined;
+      const completedItemTurnId =
+        event.notification.method === "item/completed" &&
+        typeof event.notification.params.turnId === "string"
+          ? event.notification.params.turnId
+          : undefined;
+      if (
+        completedItemRecord?.type === "enteredReviewMode" &&
+        completedItemTurnId
+      ) {
+        // Reviews started outside this Composer (for example from a bound
+        // messaging conversation) do not pass through submitReviewCommand,
+        // so claim their review turn from the first review-mode item. Codex
+        // can follow it with a mismatched turn/started id that never receives
+        // a terminal event; retaining the review id keeps Stop and completion
+        // handling wired to the lifecycle that actually finishes.
+        updateActiveTurnId(completedItemTurnId, { review: true });
+        props.onActiveTurnIdChange?.(completedItemTurnId);
+        props.onPendingStatusChange?.("Reviewing");
+      }
+
       if (
         pendingSteer?.status === "steering" &&
         event.notification.method === "item/completed" &&

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -13479,6 +13479,108 @@ describe("Composer", () => {
     });
   });
 
+  it("keeps messaging-started reviews on the turn that actually completes", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const interruptTurn = vi.fn(async (request) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: request.turnId,
+    }));
+    const onActiveTurnIdChange = vi.fn();
+    const onPendingStatusChange = vi.fn();
+    render(
+      <Composer
+        desktopApi={{
+          interruptTurn,
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback;
+            return () => undefined;
+          },
+        }}
+        disabled={false}
+        onActiveTurnIdChange={onActiveTurnIdChange}
+        onPendingStatusChange={onPendingStatusChange}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-entered",
+              type: "enteredReviewMode",
+              review: "Review changes against main",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-stray",
+            turn: {
+              id: "turn-stray",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(await screen.findByRole("button", { name: "Stop" })).toBeInTheDocument();
+    await clickButton("Stop");
+    expect(interruptTurn).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-review",
+    });
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    });
+    expect(onActiveTurnIdChange).not.toHaveBeenCalledWith("turn-stray");
+    expect(onActiveTurnIdChange).toHaveBeenLastCalledWith(undefined);
+    expect(onPendingStatusChange).toHaveBeenCalledWith("Reviewing");
+    expect(onPendingStatusChange).toHaveBeenLastCalledWith(undefined);
+  });
+
   it("clears stale thinking when Stop finds no active backend turn", async () => {
     const interruptTurn = vi.fn(async () => {
       throw new Error("json-rpc error (-32600): no active turn to interrupt");


### PR DESCRIPTION
## Summary

- stop rendering a structured review overall explanation twice in messaging artifacts
- retain structured correctness, confidence, and findings while suppressing only repeated explanation prose
- curate the messaging Base Branch picker instead of rendering dozens of stale feature branches
- preserve conventional base branches from remotes not named origin, such as upstream/main
- keep free-form branch entry available for unusual review bases
- keep messaging-started reviews bound to the review turn that actually emits their terminal event, so the desktop clears Reviewing and Stop

## Root cause and impact

Structured review events use overall_explanation as their review prose when no separate review text is present. The artifact renderer then emitted that same value again in its structured Summary, so Slack displayed duplicate prose.

The shared desktop branch selector is intentionally comprehensive because the GUI provides a searchable picker. Messaging converted that full inventory directly into buttons. The messaging picker now consumes the shared ranking while exposing only the inferred/default and known conventional base branches. It distinguishes remote-tracking refs from local slash-named branches, so upstream/main remains selectable without restoring the noisy inventory.

Codex review/start can emit review items and the terminal event on the returned review turn while also emitting a lone mismatched turn/started ID. Reviews submitted inside the desktop already claimed the returned review turn, but messaging submissions bypassed that path. The Composer now claims externally started reviews from enteredReviewMode before processing the stray start, allowing the real terminal event to clear desktop state.

## Validation

- 504 focused tests across messaging controller and Composer
- pnpm typecheck
- targeted ESLint: 0 errors; existing warnings only
- pnpm lint:boundaries
- pnpm build
