### PR TITLE
feat(messaging): link inbound message origins

### DIFF
--- a/apps/desktop/src/main/__tests__/discord-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/discord-adapter.test.ts
@@ -1063,6 +1063,8 @@ describe("DiscordAdapter", () => {
             username: "ada_new",
           },
           platform: "discord",
+          sourceUrl:
+            `https://discord.com/channels/${DISCORD_GUILD_ID}/${DISCORD_CHANNEL_ID}/${DISCORD_MESSAGE_ID}`,
           surface: {
             id: DISCORD_CHANNEL_ID,
             kind: "channel",

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2452,7 +2452,7 @@ describe("TelegramAdapter", () => {
             username: "new_username",
           },
           platform: "telegram",
-          sourceUrl: "https://t.me/new_username",
+          sourceUrl: "https://t.me/pwragentbot",
           surface: {
             id: "777",
             kind: "dm",
@@ -2461,6 +2461,44 @@ describe("TelegramAdapter", () => {
       },
       threadId: "thread-1",
     }));
+  });
+
+  it("links private Telegram messages to the bot when the actor has no username", async () => {
+    const events: MessagingInboundEvent[] = [];
+    const adapter = new TelegramAdapter({
+      api: createApi() as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+      },
+      pollOnStart: false,
+    });
+
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    await adapter.handleUpdate({
+      update_id: 4,
+      message: {
+        chat: {
+          id: 777,
+          type: "private",
+        },
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        message_id: 103,
+        text: "show status",
+      },
+    });
+
+    expect(events.at(-1)).toMatchObject({
+      kind: "text",
+      sourceUrl: "https://t.me/pwragentbot",
+      text: "show status",
+    });
   });
 
   it("drops matching usernames with different Telegram numeric ids before controller dispatch", async () => {

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -2452,6 +2452,7 @@ describe("TelegramAdapter", () => {
             username: "new_username",
           },
           platform: "telegram",
+          sourceUrl: "https://t.me/new_username",
           surface: {
             id: "777",
             kind: "dm",
@@ -2538,6 +2539,51 @@ describe("TelegramAdapter", () => {
       },
     });
     expect(api.getFile).not.toHaveBeenCalled();
+  });
+
+  it("links inbound Telegram forum messages to their exact private post", async () => {
+    const events: MessagingInboundEvent[] = [];
+    const adapter = new TelegramAdapter({
+      api: createApi() as unknown as TelegramBotApi,
+      config: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "42", displayName: "" }],
+        authorizedSupergroupIds: [{ id: "-100123", displayName: "Ops" }],
+      },
+      pollOnStart: false,
+    });
+
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+    await adapter.handleUpdate({
+      update_id: 6,
+      message: {
+        chat: {
+          id: -100123,
+          is_forum: true,
+          title: "Ops",
+          type: "supergroup",
+        },
+        from: {
+          id: 42,
+          is_bot: false,
+        },
+        is_topic_message: true,
+        message_id: 107,
+        message_thread_id: 77,
+        text: "Investigate the alert",
+      },
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        sourceUrl: "https://t.me/c/123/107?thread=77",
+        text: "Investigate the alert",
+      }),
+    ]);
   });
 
   it("ignores Telegram pin service messages", async () => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -16506,6 +16506,7 @@ function messageOriginForInboundEvent(
     kind: "messaging",
     messaging: {
       platform: event.channel.channel,
+      ...(event.sourceUrl ? { sourceUrl: event.sourceUrl } : {}),
       surface: {
         id: conversation.id,
         kind: conversation.kind,

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -1,4 +1,11 @@
-import { memo, useMemo, useState, type ReactNode } from "react";
+import {
+  memo,
+  useMemo,
+  useState,
+  type FocusEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import type {
   DesktopApplicationsSnapshot,
   AppServerSkillSummary,
@@ -14,6 +21,7 @@ import {
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
 import { useThreadLinks, type ResolvedThreadLink } from "../../lib/thread-links";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { ThreadChip } from "./ThreadChip";
 import { TranscriptImage } from "./TranscriptImage";
 import { ThreadMarkdown } from "./ThreadMarkdown";
@@ -516,6 +524,7 @@ function renderMessageHeader(params: {
 function MessagingOriginChip(props: {
   origin: NonNullable<AppServerThreadMessageOrigin["messaging"]>;
 }) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const Icon = MESSAGING_PLATFORM_ICONS[props.origin.platform];
   const platform = formatMessagingPlatformName(props.origin.platform);
   const surface = formatMessagingOriginSurface(props.origin);
@@ -526,13 +535,12 @@ function MessagingOriginChip(props: {
       : props.origin.actor.phoneNumber?.trim()
         || props.origin.actor.platformUserId);
   const description = `${platform}: ${surface} · ${actor}`;
-
-  return (
-    <span
-      aria-label={description}
-      className="chip transcript-message__messaging-origin"
-      title={description}
-    >
+  const sourceUrl = safeMessagingSourceUrl(props.origin.sourceUrl);
+  const tooltipText = sourceUrl
+    ? `${description}\nOpen in ${platform}`
+    : description;
+  const content = (
+    <>
       <span
         aria-hidden="true"
         className="transcript-message__messaging-platform"
@@ -555,8 +563,51 @@ function MessagingOriginChip(props: {
         ·
       </span>
       <span className="transcript-message__messaging-actor">{actor}</span>
-    </span>
+    </>
   );
+  const sharedProps = {
+    "aria-label": description,
+    className: "chip transcript-message__messaging-origin",
+    onBlur: tooltip.hide,
+    onFocus: (event: FocusEvent<HTMLElement>) =>
+      tooltip.show(event.currentTarget, tooltipText),
+    onMouseEnter: (event: MouseEvent<HTMLElement>) =>
+      tooltip.show(event.currentTarget, tooltipText),
+    onMouseLeave: tooltip.hide,
+  };
+
+  return (
+    <>
+      {sourceUrl ? (
+        <a
+          {...sharedProps}
+          href={sourceUrl}
+          onClick={tooltip.hide}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {content}
+        </a>
+      ) : (
+        <span {...sharedProps} tabIndex={0}>
+          {content}
+        </span>
+      )}
+      {tooltip.tooltipNode}
+    </>
+  );
+}
+
+function safeMessagingSourceUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function formatMessagingOriginSurface(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -527,18 +527,17 @@ function MessagingOriginChip(props: {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const Icon = MESSAGING_PLATFORM_ICONS[props.origin.platform];
   const platform = formatMessagingPlatformName(props.origin.platform);
-  const surface = formatMessagingOriginSurface(props.origin);
-  const actor =
-    props.origin.actor.displayName?.trim()
-    || (props.origin.actor.username?.trim()
-      ? `@${props.origin.actor.username.trim().replace(/^@/, "")}`
-      : props.origin.actor.phoneNumber?.trim()
-        || props.origin.actor.platformUserId);
-  const description = `${platform}: ${surface} · ${actor}`;
+  const surfaceParts = messagingOriginSurfaceParts(props.origin);
+  const surface = surfaceParts.join(" / ");
+  const actor = formatMessagingOriginActor(props.origin.actor);
+  const description = `${platform}: ${surface} · ${actor.detail}`;
   const sourceUrl = safeMessagingSourceUrl(props.origin.sourceUrl);
-  const tooltipText = sourceUrl
-    ? `${description}\nOpen in ${platform}`
-    : description;
+  const tooltipText = [
+    platform,
+    surface,
+    actor.detail,
+    sourceUrl ? `Open in ${platform}` : undefined,
+  ].filter(Boolean).join("\n");
   const content = (
     <>
       <span
@@ -554,7 +553,24 @@ function MessagingOriginChip(props: {
         )}
       </span>
       <span className="transcript-message__messaging-surface">
-        {surface}
+        {surfaceParts.map((part, index) => (
+          <span
+            className="transcript-message__messaging-surface-segment"
+            key={`${index}:${part}`}
+          >
+            {index > 0 ? (
+              <span
+                aria-hidden="true"
+                className="transcript-message__messaging-surface-divider"
+              >
+                {" / "}
+              </span>
+            ) : null}
+            <span className="transcript-message__messaging-surface-label">
+              {part}
+            </span>
+          </span>
+        ))}
       </span>
       <span
         aria-hidden="true"
@@ -562,7 +578,7 @@ function MessagingOriginChip(props: {
       >
         ·
       </span>
-      <span className="transcript-message__messaging-actor">{actor}</span>
+      <span className="transcript-message__messaging-actor">{actor.label}</span>
     </>
   );
   const sharedProps = {
@@ -610,35 +626,66 @@ function safeMessagingSourceUrl(value: string | undefined): string | undefined {
   }
 }
 
-function formatMessagingOriginSurface(
+function messagingOriginSurfaceParts(
   origin: NonNullable<AppServerThreadMessageOrigin["messaging"]>,
-): string {
+): string[] {
   const title = origin.surface.title?.trim();
   const parent = origin.surface.parentTitle?.trim();
   const ancestor = origin.surface.ancestorTitle?.trim();
 
   switch (origin.surface.kind) {
     case "dm":
-      return title || "Direct message";
+      return [title || "Direct message"];
     case "topic":
-      return [parent, title].filter(Boolean).join(" / ") || "Topic";
+      return messagingSurfaceParts([parent, title], "Topic");
     case "thread":
-      return [ancestor, parent ? `#${parent}` : undefined, title]
-        .filter(Boolean)
-        .join(" / ") || "Thread";
+      return messagingSurfaceParts([
+        ancestor,
+        parent ? `#${parent}` : undefined,
+        title,
+      ], "Thread");
     case "channel":
       if (origin.platform === "telegram") {
-        return title || parent || "Group";
+        return [title || parent || "Group"];
       }
       if (ancestor && parent) {
-        return [ancestor, `#${parent}`, title]
-          .filter(Boolean)
-          .join(" / ");
+        return messagingSurfaceParts(
+          [ancestor, `#${parent}`, title],
+          "Channel",
+        );
       }
-      return [ancestor || parent, title ? `#${title}` : undefined]
-        .filter(Boolean)
-        .join(" / ") || "Channel";
+      return messagingSurfaceParts([
+        ancestor || parent,
+        title ? `#${title}` : undefined,
+      ], "Channel");
   }
+}
+
+function messagingSurfaceParts(
+  parts: Array<string | undefined>,
+  fallback: string,
+): string[] {
+  const available = parts.filter((part): part is string => Boolean(part));
+  return available.length > 0 ? available : [fallback];
+}
+
+function formatMessagingOriginActor(
+  actor: NonNullable<AppServerThreadMessageOrigin["messaging"]>["actor"],
+): { detail: string; label: string } {
+  const displayName = actor.displayName?.trim();
+  const username = actor.username?.trim().replace(/^@/, "");
+  const usernameLabel = username ? `@${username}` : undefined;
+  const label =
+    displayName
+    || usernameLabel
+    || actor.phoneNumber?.trim()
+    || actor.platformUserId;
+  return {
+    label,
+    detail: displayName && usernameLabel
+      ? `${displayName} (${usernameLabel})`
+      : label,
+  };
 }
 
 function messageToneClass(message: AppServerThreadMessageEntry): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -241,20 +241,30 @@ describe("TranscriptList", () => {
 
     expect(screen.getByText("Messaging")).toBeInTheDocument();
     const origin = screen.getByLabelText(
-      "Discord: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter",
+      "Discord: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter (@huntharo)",
     );
     expect(origin).toHaveTextContent(
       "PwrAgent / #signals-chat / api-search circuit breaker timeout",
     );
-    expect(origin).toHaveTextContent("Hunter");
+    expect(
+      origin.querySelector(".transcript-message__messaging-actor"),
+    ).toHaveTextContent("Hunter");
+    expect(
+      origin.querySelectorAll(".transcript-message__messaging-surface-segment"),
+    ).toHaveLength(3);
     expect(origin.querySelector("img")).toBeInTheDocument();
     expect(origin).toHaveAttribute(
       "href",
       "https://discord.com/channels/1480556454498009353/1480556454498009352/1480556454498009354",
     );
     fireEvent.mouseEnter(origin);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Discord: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter Open in Discord",
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      [
+        "Discord",
+        "PwrAgent / #signals-chat / api-search circuit breaker timeout",
+        "Hunter (@huntharo)",
+        "Open in Discord",
+      ].join("\n"),
     );
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -202,7 +202,7 @@ describe("TranscriptList", () => {
     });
   });
 
-  it("shows the messaging platform, surface, and actor for an inbound message", () => {
+  it("shows a linked messaging origin with its full value in a tooltip", async () => {
     const { container } = render(
       <TranscriptList
         entries={[
@@ -215,6 +215,8 @@ describe("TranscriptList", () => {
               kind: "messaging",
               messaging: {
                 platform: "discord",
+                sourceUrl:
+                  "https://discord.com/channels/1480556454498009353/1480556454498009352/1480556454498009354",
                 surface: {
                   id: "thread-1",
                   kind: "channel",
@@ -246,6 +248,14 @@ describe("TranscriptList", () => {
     );
     expect(origin).toHaveTextContent("Hunter");
     expect(origin.querySelector("img")).toBeInTheDocument();
+    expect(origin).toHaveAttribute(
+      "href",
+      "https://discord.com/channels/1480556454498009353/1480556454498009352/1480556454498009354",
+    );
+    fireEvent.mouseEnter(origin);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Discord: PwrAgent / #signals-chat / api-search circuit breaker timeout · Hunter Open in Discord",
+    );
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -739,6 +739,8 @@ describe("useThreadSessionState", () => {
                 kind: "messaging",
                 messaging: {
                   platform: "slack",
+                  sourceUrl:
+                    "https://pwrdrvr.slack.com/archives/C012ABCDEF0/p1712023030000000",
                   surface: {
                     id: "message-thread-1",
                     kind: "thread",
@@ -775,6 +777,8 @@ describe("useThreadSessionState", () => {
           kind: "messaging",
           messaging: {
             platform: "slack",
+            sourceUrl:
+              "https://pwrdrvr.slack.com/archives/C012ABCDEF0/p1712023030000000",
             surface: {
               id: "message-thread-1",
               kind: "thread",

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -2890,6 +2890,9 @@ function threadMessageMessagingOriginFromUnknown(
   }
   return {
     platform: record.platform,
+    ...(typeof record.sourceUrl === "string"
+      ? { sourceUrl: record.sourceUrl }
+      : {}),
     surface: {
       id: surfaceRecord.id,
       kind: surfaceRecord.kind,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -223,6 +223,17 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps messaging origin actors visible when breadcrumbs are truncated", () => {
+    const actorRules = [
+      ...css.matchAll(
+        /(?:^|\n)\.transcript-message__messaging-actor\s*\{(?<body>[\s\S]*?)\n\}/g,
+      ),
+    ];
+
+    expect(actorRules).toHaveLength(1);
+    expect(actorRules[0]?.groups?.body).toContain("flex: 0 0 auto;");
+  });
+
   it("keeps unavailable thread detail surfaces draggable", () => {
     const emptyStateRule = extractRuleBody(css, ".thread-empty-state");
     const pendingMainRule = extractRuleBody(css, ".app-main--thread-detail-pending");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8703,6 +8703,21 @@ textarea,
   border: 1px solid var(--accent-border);
 }
 
+a.transcript-message__messaging-origin {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a.transcript-message__messaging-origin:hover,
+a.transcript-message__messaging-origin:focus-visible {
+  background: var(--bg-row-active);
+}
+
+.transcript-message__messaging-origin:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .transcript-message__messaging-platform {
   display: inline-flex;
   flex: 0 0 auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8760,16 +8760,12 @@ a.transcript-message__messaging-origin:focus-visible {
 .transcript-message__messaging-actor {
   flex: 0 0 auto;
   min-width: 0;
+  color: var(--text-secondary);
 }
 
 .transcript-message__messaging-separator {
   flex: 0 0 auto;
   color: var(--text-muted);
-}
-
-.transcript-message__messaging-actor {
-  flex: 0 1 auto;
-  color: var(--text-secondary);
 }
 
 .transcript-message__source {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8733,13 +8733,32 @@ a.transcript-message__messaging-origin:focus-visible {
   text-transform: uppercase;
 }
 
-.transcript-message__messaging-surface,
-.transcript-message__messaging-actor {
+.transcript-message__messaging-surface {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.transcript-message__messaging-surface-segment {
+  display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.transcript-message__messaging-surface-divider {
+  flex: 0 0 auto;
+}
+
+.transcript-message__messaging-surface-label {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.transcript-message__messaging-surface {
+.transcript-message__messaging-actor {
+  flex: 0 0 auto;
   min-width: 0;
 }
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1144,6 +1144,11 @@ export type MessagingInboundBaseEvent = {
   channel: MessagingChannelRef;
   receivedAt: number;
   /**
+   * Provider-generated HTTPS destination for the original message or, when
+   * the platform cannot expose a message permalink, its conversation.
+   */
+  sourceUrl?: string;
+  /**
    * True when the original platform message explicitly addressed the bot via
    * a textual @mention. Slash commands and button callbacks are already
    * explicit event kinds and do not need this marker.

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -817,6 +817,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       channelType: message.channel_type,
       isThread: message.is_thread,
     });
+    const sourceUrl = discordConversationUrl({
+      channelId: message.channel_id,
+      guildId: message.guild_id,
+      messageId: message.id,
+    });
     const hasAttachments = Boolean(message.attachments?.length);
 
     // `<@botUserId> <verb>` text mention → command. Run BEFORE the
@@ -862,6 +867,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
             rawText: synthRaw,
             receivedAt,
             routingState,
+            sourceUrl,
           });
           return;
         }
@@ -889,6 +895,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         },
         receivedAt,
         routingState,
+        sourceUrl,
         text: message.content,
       });
       return;
@@ -917,6 +924,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           }),
       receivedAt,
       routingState,
+      sourceUrl,
     } as MessagingInboundEvent);
   }
 
@@ -1027,6 +1035,11 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       value: persistedBinding?.value,
       receivedAt: this.now(),
       routingState,
+      sourceUrl: discordConversationUrl({
+        channelId: interaction.channel_id,
+        guildId: interaction.guild_id,
+        messageId: interaction.message?.id,
+      }),
     });
   }
 
@@ -1054,6 +1067,10 @@ export class DiscordAdapter implements DiscordProviderAdapter {
       command: commandName,
       rawText: [`/${commandName}`, ...args].join(" ").trim(),
       receivedAt: this.now(),
+      sourceUrl: discordConversationUrl({
+        channelId: interaction.channel_id,
+        guildId: interaction.guild_id,
+      }),
       routingState: this.routingStateFromDiscord(
         interaction.channel_id,
         interaction.guild_id,
@@ -2381,6 +2398,19 @@ function userToDiscordUser(user: User): DiscordUser {
     id: user.id,
     username: user.username,
   };
+}
+
+function discordConversationUrl(params: {
+  channelId: string;
+  guildId?: string;
+  messageId?: string;
+}): string {
+  return [
+    "https://discord.com/channels",
+    params.guildId ?? "@me",
+    params.channelId,
+    params.messageId,
+  ].filter(Boolean).join("/");
 }
 
 function isDiscordThreadConversation(

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -58,6 +58,7 @@ function fakeApi(spies: {
   assistantStatuses?: Array<{ channelId: string; status: string; threadTs: string }>;
   conversations?: Record<string, string>;
   mpimChannels?: string[];
+  permalinks?: Record<string, string>;
   deleted?: Array<{ channel: string; ts: string }>;
   posted?: unknown[];
   replies?: Record<string, string>;
@@ -87,6 +88,8 @@ function fakeApi(spies: {
       ts: params.ts,
       text: spies.replies?.[`${params.channel}:${params.ts}`],
     }],
+    getPermalink: async (params) =>
+      spies.permalinks?.[`${params.channel}:${params.messageTs}`],
     deleteMessage: async (params) => {
       spies.deleted?.push(params);
     },
@@ -160,6 +163,10 @@ describe("SlackAdapter", () => {
       callbackHandleStore: fakeStore(),
       api: fakeApi({
         conversations: { C012ABCDEF0: "signals-chat" },
+        permalinks: {
+          "C012ABCDEF0:1712023030.000000":
+            "https://pwrdrvr.slack.com/archives/C012ABCDEF0/p1712023030000000",
+        },
         posted,
       }),
       socketClient: socket,
@@ -184,6 +191,9 @@ describe("SlackAdapter", () => {
     });
 
     const source = events[0]!;
+    expect(source.sourceUrl).toBe(
+      "https://pwrdrvr.slack.com/archives/C012ABCDEF0/p1712023030000000",
+    );
     await expect(adapter.getManagedConversationRights({
       actor: source.actor,
       channel: source.channel,
@@ -963,6 +973,8 @@ describe("SlackAdapter", () => {
             teamId: "T012ABCDEF0",
           }),
         }),
+        sourceUrl:
+          "https://slack.com/app_redirect?channel=C012ABCDEF0&team=T012ABCDEF0",
       }),
     ]);
   });

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -98,6 +98,10 @@ export type SlackApi = {
     limit?: number;
     ts: string;
   }): Promise<SlackThreadMessageInfo[]>;
+  getPermalink?(params: {
+    channel: string;
+    messageTs: string;
+  }): Promise<string | undefined>;
   deleteMessage(params: { channel: string; ts: string }): Promise<void>;
   downloadFile(params: { url: string; maxBytes: number }): Promise<Uint8Array>;
   filesInfo(params: { file: string }): Promise<SlackFileInfo | undefined>;
@@ -858,6 +862,8 @@ export class SlackAdapter implements SlackProviderAdapter {
       teamId: ids.teamId,
     })) return;
 
+    const sourceUrl = await this.sourceUrlForSlackMessage(ids);
+
     if (event.files?.length) {
       await this.listener({
         id: this.newEventId("slack-media"),
@@ -866,6 +872,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         channel,
         receivedAt: this.now(),
         routingState,
+        sourceUrl,
         ...(isMention ? { botMention: true } : {}),
         text: text || undefined,
         disposition: "available",
@@ -882,6 +889,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         channel,
         receivedAt: this.now(),
         routingState,
+        sourceUrl,
         ...(isMention ? { botMention: true } : {}),
         command: command.command,
         args: command.args,
@@ -898,9 +906,32 @@ export class SlackAdapter implements SlackProviderAdapter {
       channel,
       receivedAt: this.now(),
       routingState,
+      sourceUrl,
       ...(isMention ? { botMention: true } : {}),
       text,
     });
+  }
+
+  private async sourceUrlForSlackMessage(ids: {
+    channelId: string;
+    teamId?: string;
+    ts: string;
+  }): Promise<string> {
+    const fallback = slackConversationUrl(ids.channelId, ids.teamId);
+    if (!this.api.getPermalink) {
+      return fallback;
+    }
+    try {
+      return (await this.api.getPermalink({
+        channel: ids.channelId,
+        messageTs: ids.ts,
+      })) ?? fallback;
+    } catch {
+      this.logger.debug?.(
+        "slack inbound permalink lookup failed; using channel link",
+      );
+      return fallback;
+    }
   }
 
   private async handleBlockAction(body: SlackBlockActionPayload): Promise<void> {
@@ -988,6 +1019,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         id: ids.ts,
         state: routingState,
       },
+      sourceUrl: await this.sourceUrlForSlackMessage(ids),
       actionId: record.actionId,
       ...(record.value !== undefined ? { value: record.value } : {}),
     });
@@ -1039,6 +1071,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       channel,
       receivedAt: this.now(),
       routingState,
+      sourceUrl: slackConversationUrl(ids.channelId, ids.teamId),
       command,
       args,
       rawText: [body.command, body.text].filter(Boolean).join(" "),
@@ -2197,6 +2230,15 @@ export function createSlackApi(botToken: string): SlackApi {
       const response = await client.files.info(params);
       return response.file as SlackFileInfo | undefined;
     },
+    async getPermalink(params) {
+      const response = await client.chat.getPermalink({
+        channel: params.channel,
+        message_ts: params.messageTs,
+      });
+      return typeof response.permalink === "string"
+        ? response.permalink
+        : undefined;
+    },
     async postMessage(params) {
       return (await client.chat.postMessage(
         params as unknown as Parameters<typeof client.chat.postMessage>[0],
@@ -2246,6 +2288,15 @@ function hostFromUrl(url: string | undefined): string | undefined {
   } catch {
     return url;
   }
+}
+
+function slackConversationUrl(channelId: string, teamId?: string): string {
+  const url = new URL("https://slack.com/app_redirect");
+  url.searchParams.set("channel", channelId);
+  if (teamId) {
+    url.searchParams.set("team", teamId);
+  }
+  return url.toString();
 }
 
 export function stripBotMention(text: string, botUserId: string | undefined): string {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -119,6 +119,7 @@ export type TelegramChat = {
   is_forum?: true;
   title?: string;
   type: "private" | "group" | "supergroup" | "channel";
+  username?: string;
 };
 
 export type TelegramMessage = {
@@ -1500,6 +1501,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       ? stripTelegramBotMention(mentionCandidate, this.botUsername)
       : undefined;
     const attachments = this.attachmentsFromMessage(message);
+    const sourceUrl = telegramMessageUrl(message);
     if (
       !isPairingMessage &&
       !this.isAuthorizedMessageSource(message, {
@@ -1535,6 +1537,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           rawText: "/help",
           receivedAt: this.messageReceivedAt(message),
           routingState: this.routingStateFromMessage(message),
+          ...(sourceUrl ? { sourceUrl } : {}),
         });
         return;
       }
@@ -1562,6 +1565,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
         },
         receivedAt: this.messageReceivedAt(message),
         routingState: this.routingStateFromMessage(message),
+        ...(sourceUrl ? { sourceUrl } : {}),
         ...(mentionRemainder !== undefined ? { botMention: true } : {}),
         text: mentionRemainder ?? message.caption,
       });
@@ -1594,6 +1598,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           }),
       receivedAt: this.messageReceivedAt(message),
       routingState: this.routingStateFromMessage(message),
+      ...(sourceUrl ? { sourceUrl } : {}),
     } as MessagingInboundEvent);
   }
 
@@ -1635,6 +1640,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     );
     const routingState = this.routingStateFromMessage(message);
     const messageThreadId = this.messageThreadIdFromMessage(message);
+    const sourceUrl = telegramMessageUrl(message);
     await listener({
       id: `telegram:update:${updateId}:callback:${callbackQuery.id}`,
       kind: "callback",
@@ -1664,6 +1670,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       value: persistedBinding?.value,
       receivedAt: this.now(),
       routingState,
+      ...(sourceUrl ? { sourceUrl } : {}),
     });
   }
 
@@ -2883,6 +2890,47 @@ function coerceTelegramSentMessage(
     },
     message_id: request.message_id,
   };
+}
+
+function telegramMessageUrl(message: TelegramMessage): string | undefined {
+  const username = message.chat.username ?? (
+    message.chat.type === "private"
+      ? message.from?.username
+      : undefined
+  );
+  if (username) {
+    const base = `https://t.me/${encodeURIComponent(username.replace(/^@/, ""))}`;
+    if (message.chat.type === "private") {
+      return base;
+    }
+    return telegramMessageUrlWithBase(base, message);
+  }
+
+  if (
+    message.chat.type !== "supergroup"
+    && message.chat.type !== "channel"
+  ) {
+    return undefined;
+  }
+  const chatId = String(message.chat.id);
+  if (!chatId.startsWith("-100") || chatId.length <= 4) {
+    return undefined;
+  }
+  return telegramMessageUrlWithBase(
+    `https://t.me/c/${chatId.slice(4)}`,
+    message,
+  );
+}
+
+function telegramMessageUrlWithBase(
+  base: string,
+  message: TelegramMessage,
+): string {
+  const url = new URL(`${base}/${message.message_id}`);
+  if (message.message_thread_id) {
+    url.searchParams.set("thread", String(message.message_thread_id));
+  }
+  return url.toString();
 }
 
 function parseTelegramIdentifier(value: string): number | string {

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -1501,7 +1501,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
       ? stripTelegramBotMention(mentionCandidate, this.botUsername)
       : undefined;
     const attachments = this.attachmentsFromMessage(message);
-    const sourceUrl = telegramMessageUrl(message);
+    const sourceUrl = telegramMessageUrl(message, this.botUsername);
     if (
       !isPairingMessage &&
       !this.isAuthorizedMessageSource(message, {
@@ -1640,7 +1640,7 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     );
     const routingState = this.routingStateFromMessage(message);
     const messageThreadId = this.messageThreadIdFromMessage(message);
-    const sourceUrl = telegramMessageUrl(message);
+    const sourceUrl = telegramMessageUrl(message, this.botUsername);
     await listener({
       id: `telegram:update:${updateId}:callback:${callbackQuery.id}`,
       kind: "callback",
@@ -2892,17 +2892,19 @@ function coerceTelegramSentMessage(
   };
 }
 
-function telegramMessageUrl(message: TelegramMessage): string | undefined {
-  const username = message.chat.username ?? (
-    message.chat.type === "private"
-      ? message.from?.username
-      : undefined
-  );
+function telegramMessageUrl(
+  message: TelegramMessage,
+  botUsername: string | undefined,
+): string | undefined {
+  if (message.chat.type === "private") {
+    return botUsername
+      ? `https://t.me/${encodeURIComponent(botUsername.replace(/^@/, ""))}`
+      : undefined;
+  }
+
+  const username = message.chat.username;
   if (username) {
     const base = `https://t.me/${encodeURIComponent(username.replace(/^@/, ""))}`;
-    if (message.chat.type === "private") {
-      return base;
-    }
     return telegramMessageUrlWithBase(base, message);
   }
 

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -344,6 +344,7 @@ export type AppServerThreadMessageOrigin = {
   };
   messaging?: {
     platform: MessagingChannelKind;
+    sourceUrl?: string;
     surface: {
       id: string;
       kind: MessagingConversationKind;


### PR DESCRIPTION
## What changed

- Show the full messaging platform, surface breadcrumb, and actor in the same viewport-safe tooltip used by thread chips.
- Keep the actor name fully visible while independently truncating Team / Channel / Thread breadcrumb segments to fit the available width.
- Show multiline tooltip context as provider, full surface path, and actor; include `@username` alongside the display name when available.
- Make provenance chips clickable when the provider can produce a safe HTTPS destination.
- Carry the provider-generated source URL through inbound events, persisted message provenance, replay normalization, and transcript rendering.

## Provider behavior

- **Slack:** prefer the exact `chat.getPermalink` message URL; fall back to Slack’s documented `app_redirect` channel URL when permalink lookup is unavailable or fails. Slash commands link to their conversation.
- **Discord:** link to the exact guild/DM message; application commands without a source message link to the conversation.
- **Telegram:** link public and private channel/supergroup posts, including forum topics; DMs with a username link to that conversation.
- **Other providers:** remain tooltip-only until their adapter can supply a reliable destination.

The renderer accepts only HTTPS provenance destinations before turning a chip into a link. Links are handed to Electron’s existing guarded external-open path.

## Why

Messaging provenance chips truncate long channel/thread breadcrumbs. Operators need the actor to remain identifiable, the full source context on hover, and, when the platform supports it, a one-click path back to the originating conversation or message.

## Validation

- 614 focused adapter, controller, replay, and transcript tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- `git diff --check`