### PR TITLE
fix(messaging): honor Working Updates for monitor progress

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25564,11 +25564,14 @@ script = "printf setup"
         item.text?.includes("lint is running") === true
       );
     });
-    expect(
+    const progressText =
       progressEvent?.notification.method === "item/completed"
         ? (progressEvent.notification.params.item as { text?: string }).text
-        : undefined,
-    ).not.toContain("Monitor usage");
+        : undefined;
+    expect(progressText).toBe(
+      "Monitor · Watch PR #123 checks until they finish\nlint is running",
+    );
+    expect(progressText).not.toContain("Monitor usage");
     expect(progressEvent).toMatchObject({
       backend: "codex",
       notification: {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11405,15 +11405,59 @@ describe("MessagingController", () => {
     );
   });
 
-  it("discards a coalesced monitor heartbeat when the monitor completes", async () => {
+  it("cancels a released monitor heartbeat when the monitor completes", async () => {
     vi.useFakeTimers();
+    let now = 0;
+    let finishFirstAttempt:
+      | ((result: MessagingDeliveryResult) => void)
+      | undefined;
+    let signalFirstAttemptStarted: (() => void) | undefined;
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      signalFirstAttemptStarted = resolve;
+    });
+    const scope: MessagingDeliveryScope = {
+      platform: "telegram",
+      id: "telegram:dm:chat-1",
+      kind: "dm",
+      budget: { limit: 10, intervalMs: 60_000, reserved: 1 },
+    };
+    const attempts: MessagingSurfaceIntent[] = [];
+    let holdNextAttempt = false;
+    const deliveryBudget = new MessagingDeliveryBudget({ now: () => now });
     let harness: Awaited<ReturnType<typeof createHarness>> | undefined;
     try {
       harness = await createHarness({
+        deliveryBudget,
+        now: () => now,
+        resolveDeliveryScope: () => scope,
+        deliver: async (intent) => {
+          attempts.push(intent);
+          if (holdNextAttempt) {
+            holdNextAttempt = false;
+            signalFirstAttemptStarted?.();
+            return await new Promise<MessagingDeliveryResult>((resolve) => {
+              finishFirstAttempt = resolve;
+            });
+          }
+          return {
+            channel: "telegram",
+            deliveredAt: now,
+            outcome: "presented",
+            surface: {
+              channel: "telegram",
+              id: `surface:${intent.id}`,
+            },
+          };
+        },
+        sleepUntil: async () => {
+          throw new Error("Completed monitor delivery should not retry");
+        },
         toolUpdateDefaultMode: "show_less",
       });
       await bindThread(harness);
-      harness.delivered.length = 0;
+      attempts.length = 0;
+      holdNextAttempt = true;
+      now = 2000;
 
       await harness.controller.handleBackendEvent({
         backend: "codex",
@@ -11435,7 +11479,9 @@ describe("MessagingController", () => {
           },
         },
       } satisfies AgentEvent);
-      expect(harness.delivered).toEqual([]);
+      expect(attempts).toEqual([]);
+      vi.advanceTimersByTime(60_000);
+      await firstAttemptStarted;
 
       await harness.controller.handleBackendEvent({
         backend: "codex",
@@ -11457,9 +11503,29 @@ describe("MessagingController", () => {
           },
         },
       } satisfies AgentEvent);
-      await vi.advanceTimersByTimeAsync(60_000);
+      finishFirstAttempt?.({
+        channel: "telegram",
+        deliveredAt: now,
+        errorMessage: "Too Many Requests",
+        outcome: "failed",
+        rateLimit: {
+          scope,
+          retryAfterMs: 5_000,
+          observedAt: now,
+          message: "Too Many Requests",
+          retryable: true,
+        },
+      });
+      await vi.waitFor(() => {
+        expect(attempts).toHaveLength(1);
+      });
+      await Promise.resolve();
 
-      expect(harness.delivered).toEqual([]);
+      expect(attempts).toHaveLength(1);
+      expect(attempts[0]).toMatchObject({
+        kind: "message",
+        role: "assistant",
+      });
     } finally {
       harness?.controller.dispose();
       vi.useRealTimers();

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11287,6 +11287,185 @@ describe("MessagingController", () => {
     expect(assistantTexts).toContain("Pulling current conditions now.");
   });
 
+  it("suppresses transient monitor progress at None and keeps the parent terminal result", async () => {
+    const harness = await createHarness({
+      toolUpdateDefaultMode: "show_none",
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "monitor:monitor-1",
+          item: {
+            id: "monitor-1:progress:1000",
+            type: "agentMessage",
+            text: "Monitor · PR checks\nLint is still running.",
+            data: {
+              source: "pwragent_task_monitor",
+              monitorId: "monitor-1",
+              transient: true,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "monitor:monitor-1",
+          item: {
+            id: "monitor-1:completion:2000",
+            type: "taskMonitorCompletion",
+            data: {
+              source: "pwragent_task_monitor",
+              monitorId: "monitor-1",
+              outcome: "success",
+              transient: false,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "parent-turn-2",
+          item: {
+            id: "parent-final",
+            type: "agentMessage",
+            phase: "final",
+            text: "PR #315 is green and ready for review.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    const assistantTexts = harness.delivered
+      .filter(
+        (intent): intent is Extract<MessagingSurfaceIntent, { kind: "message" }> =>
+          intent.kind === "message" && intent.role === "assistant",
+      )
+      .flatMap((intent) =>
+        intent.parts.map((part) => ("text" in part ? part.text : "")),
+      );
+    expect(assistantTexts).toEqual([
+      "PR #315 is green and ready for review.",
+    ]);
+  });
+
+  it("posts transient monitor progress through Working Updates at Show All", async () => {
+    const harness = await createHarness({
+      toolUpdateDefaultMode: "show_all",
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "monitor:monitor-1",
+          item: {
+            id: "monitor-1:progress:1000",
+            type: "agentMessage",
+            text: "Monitor · PR checks\nLint is still running.",
+            data: {
+              source: "pwragent_task_monitor",
+              monitorId: "monitor-1",
+              transient: true,
+            },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          expect.objectContaining({
+            text: "Monitor · PR checks\nLint is still running.",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("discards a coalesced monitor heartbeat when the monitor completes", async () => {
+    vi.useFakeTimers();
+    let harness: Awaited<ReturnType<typeof createHarness>> | undefined;
+    try {
+      harness = await createHarness({
+        toolUpdateDefaultMode: "show_less",
+      });
+      await bindThread(harness);
+      harness.delivered.length = 0;
+
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-1:progress:1000",
+              type: "agentMessage",
+              text: "Monitor · PR checks\nTests are still running.",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                transient: true,
+              },
+            },
+          },
+        },
+      } satisfies AgentEvent);
+      expect(harness.delivered).toEqual([]);
+
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-1:completion:2000",
+              type: "taskMonitorCompletion",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                outcome: "success",
+                transient: false,
+              },
+            },
+          },
+        },
+      } satisfies AgentEvent);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(harness.delivered).toEqual([]);
+    } finally {
+      harness?.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not re-post buffered text when deltas arrive after the turn is terminal", async () => {
     let now = 1000;
     const delivered: MessagingSurfaceIntent[] = [];

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11405,6 +11405,67 @@ describe("MessagingController", () => {
     );
   });
 
+  it("discards a coalesced monitor heartbeat when the monitor completes", async () => {
+    vi.useFakeTimers();
+    let harness: Awaited<ReturnType<typeof createHarness>> | undefined;
+    try {
+      harness = await createHarness({
+        toolUpdateDefaultMode: "show_less",
+      });
+      await bindThread(harness);
+      harness.delivered.length = 0;
+
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-1:progress:1000",
+              type: "agentMessage",
+              text: "Monitor · PR checks\nTests are still running.",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                transient: true,
+              },
+            },
+          },
+        },
+      } satisfies AgentEvent);
+      expect(harness.delivered).toEqual([]);
+
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "monitor:monitor-1",
+            item: {
+              id: "monitor-1:completion:2000",
+              type: "taskMonitorCompletion",
+              data: {
+                source: "pwragent_task_monitor",
+                monitorId: "monitor-1",
+                outcome: "success",
+                transient: false,
+              },
+            },
+          },
+        },
+      } satisfies AgentEvent);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(harness.delivered).toEqual([]);
+    } finally {
+      harness?.controller.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("cancels a released monitor heartbeat when the monitor completes", async () => {
     vi.useFakeTimers();
     let now = 0;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2822,14 +2822,17 @@ function formatTaskMonitorProgressMessage(params: {
   status?: InjectMonitorProgressToolArgs["status"];
   task: string;
 }): string {
+  const taskTitle =
+    shortenDerivedThreadTitle(params.task)
+    ?? truncateSubAgentText(params.task, 80);
+  const status =
+    params.status && params.status !== "running"
+      ? ` · ${params.status}`
+      : "";
   return [
-    "PwrAgent monitor update",
-    `Task: ${params.task}`,
-    params.status ? `Status: ${params.status}` : undefined,
-    params.message,
-  ]
-    .filter(Boolean)
-    .join("\n");
+    `Monitor · ${truncateSubAgentText(taskTitle, 80)}${status}`,
+    truncateSubAgentText(params.message, 360),
+  ].join("\n");
 }
 
 function formatTaskMonitorCompletionMessage(params: {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -571,6 +571,10 @@ type PendingNewThreadPromptBundle = {
   session: MessagingBrowseSessionRecord;
 };
 
+type MessagingDeliveryGuard = {
+  isCancelled: () => boolean;
+};
+
 export type MessagingControllerOptions = {
   adapter: MessagingAdapter;
   authorizedActorIds: string[];
@@ -668,6 +672,7 @@ export class MessagingController {
   // Bounded so a turn that ends without a clean terminal event to clear it
   // cannot grow the map without limit.
   private readonly turnProse = new Map<string, MessagingTurnProseState>();
+  private readonly completedTaskMonitorTurns = new Set<string>();
   private readonly turnAdmission: MessagingTurnAdmission;
   private readonly pendingNewThreadPrompts = new Map<string, PendingNewThreadPromptWindow>();
   private readonly pendingFullAccessNewThreadPrompts = new Map<
@@ -1187,9 +1192,11 @@ export class MessagingController {
       );
       if (eventTurnId && isTaskMonitorCompletionEvent(event)) {
         // A monitor's terminal result wakes the parent agent, whose final
-        // response is the one user-facing completion notification. Discard
-        // any coalesced heartbeat that has not fired yet so stale progress
-        // cannot arrive after that terminal response.
+        // response is the one user-facing completion notification. Tombstone
+        // the monitor turn before clearing its batch so a heartbeat already
+        // released into budget/retry handling is also cancelled before the
+        // adapter sees it.
+        this.rememberCompletedTaskMonitorTurn(binding.id, eventTurnId);
         this.toolUpdatePolicy.flush({
           bindingId: binding.id,
           clear: true,
@@ -4762,6 +4769,7 @@ export class MessagingController {
     this.pendingNewThreadPrompts.clear();
     this.pendingFullAccessNewThreadPrompts.clear();
     this.toolUpdatePolicy.dispose();
+    this.completedTaskMonitorTurns.clear();
   }
 
   /**
@@ -12444,6 +12452,7 @@ export class MessagingController {
     intent: MessagingSurfaceIntent,
     binding?: MessagingBindingRecord,
     event?: MessagingInboundEvent,
+    guard?: MessagingDeliveryGuard,
   ): Promise<MessagingDeliveryResult> {
     if (binding && shouldFlushToolUpdatesBeforeIntent(intent)) {
       await this.flushToolUpdatesForBinding(binding, { clear: false });
@@ -12457,7 +12466,15 @@ export class MessagingController {
     const channel = binding?.channel.channel ??
       routedIntent.audit?.channel.channel ??
       this.options.channel;
+    const cancelledResult = (): MessagingDeliveryResult => ({
+      channel: channel ?? "telegram",
+      deliveredAt: this.now(),
+      outcome: "discarded",
+    });
     while (true) {
+      if (guard?.isCancelled()) {
+        return cancelledResult();
+      }
       if (this.deliveryBudget) {
         const budgetChannel = channel ?? scope?.platform ?? "telegram";
         let admission = this.deliveryBudget.admit({
@@ -12494,6 +12511,9 @@ export class MessagingController {
           });
           this.notifyDeliveryBudgetEvent(budgetEvent);
           await (this.options.sleepUntil ?? sleepUntil)(admission.retryAt, this.now);
+          if (guard?.isCancelled()) {
+            return cancelledResult();
+          }
           admission = this.deliveryBudget.admit({
             consumeCapacity: consumeDeliveryBudget,
             priority,
@@ -12533,6 +12553,9 @@ export class MessagingController {
             outcome: "discarded",
           };
         }
+      }
+      if (guard?.isCancelled()) {
+        return cancelledResult();
       }
       const result = await this.options.adapter.deliver(routedIntent);
       this.logDeliveryResult(routedIntent, binding, result);
@@ -12791,6 +12814,29 @@ export class MessagingController {
     this.turnProse.delete(this.turnProseKey(bindingId, turnId));
   }
 
+  private rememberCompletedTaskMonitorTurn(
+    bindingId: string,
+    turnId: string,
+  ): void {
+    this.completedTaskMonitorTurns.add(this.turnProseKey(bindingId, turnId));
+    while (this.completedTaskMonitorTurns.size > MAX_TRACKED_TURN_PROSE) {
+      const oldest = this.completedTaskMonitorTurns.values().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.completedTaskMonitorTurns.delete(oldest);
+    }
+  }
+
+  private isTaskMonitorTurnComplete(
+    bindingId: string,
+    turnId: string,
+  ): boolean {
+    return this.completedTaskMonitorTurns.has(
+      this.turnProseKey(bindingId, turnId),
+    );
+  }
+
   private async flushToolUpdatesForBinding(
     binding: MessagingBindingRecord,
     options: { clear: boolean; turnId?: string },
@@ -12809,6 +12855,11 @@ export class MessagingController {
     delivery: MessagingToolUpdatePolicyDelivery,
     knownBinding?: MessagingBindingRecord,
   ): Promise<void> {
+    const isCancelled = () =>
+      this.isTaskMonitorTurnComplete(delivery.bindingId, delivery.turnId);
+    if (isCancelled()) {
+      return;
+    }
     const binding =
       knownBinding?.id === delivery.bindingId
         ? knownBinding
@@ -12839,7 +12890,7 @@ export class MessagingController {
             id: this.newIntentId("tool-update-batch"),
           });
     this.markProseActivitiesDelivered({ ...delivery, activities });
-    await this.deliver(intent, binding);
+    await this.deliver(intent, binding, undefined, { isCancelled });
   }
 
   private filterUndeliveredProseActivities(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1185,6 +1185,18 @@ export class MessagingController {
         binding,
         activeTurn?.turnId,
       );
+      if (eventTurnId && isTaskMonitorCompletionEvent(event)) {
+        // A monitor's terminal result wakes the parent agent, whose final
+        // response is the one user-facing completion notification. Discard
+        // any coalesced heartbeat that has not fired yet so stale progress
+        // cannot arrive after that terminal response.
+        this.toolUpdatePolicy.flush({
+          bindingId: binding.id,
+          clear: true,
+          turnId: eventTurnId,
+        });
+        this.clearTurnProse(binding.id, eventTurnId);
+      }
       if (
         turnStateChanged &&
         (isTerminalTurnLifecycle(lifecycle) ||
@@ -1209,7 +1221,10 @@ export class MessagingController {
 
       const assistantText = assistantTextForBackendEvent(event);
       if (assistantText) {
-        if (!isNonFinalAssistantTextForBackendEvent(event)) {
+        if (
+          !isNonFinalAssistantTextForBackendEvent(event)
+          && !isTaskMonitorProgressEvent(event)
+        ) {
           const deliveredFinalStream = await this.flushAssistantStreamForEvent(
             event,
             binding,
@@ -15424,6 +15439,41 @@ function isNonFinalAssistantTextForBackendEvent(event: AgentEvent): boolean {
   }
   const phase = typeof params.item.phase === "string" ? params.item.phase : undefined;
   return Boolean(phase && phase !== "final" && phase !== "final_answer");
+}
+
+function isTaskMonitorProgressEvent(event: AgentEvent): boolean {
+  if (event.notification.method !== "item/completed") {
+    return false;
+  }
+  const item = (event.notification.params as {
+    item?: {
+      data?: unknown;
+      type?: unknown;
+    };
+  }).item;
+  const data = asPlainRecord(item?.data);
+  return (
+    item?.type === "agentMessage"
+    && data?.source === "pwragent_task_monitor"
+    && data.transient === true
+  );
+}
+
+function isTaskMonitorCompletionEvent(event: AgentEvent): boolean {
+  if (event.notification.method !== "item/completed") {
+    return false;
+  }
+  const item = (event.notification.params as {
+    item?: {
+      data?: unknown;
+      type?: unknown;
+    };
+  }).item;
+  const data = asPlainRecord(item?.data);
+  return (
+    item?.type === "taskMonitorCompletion"
+    && data?.source === "pwragent_task_monitor"
+  );
 }
 
 /**

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1194,8 +1194,8 @@ export class MessagingController {
         // A monitor's terminal result wakes the parent agent, whose final
         // response is the one user-facing completion notification. Tombstone
         // the monitor turn before clearing its batch so a heartbeat already
-        // released into budget/retry handling is also cancelled before the
-        // adapter sees it.
+        // released into budget/retry handling is also cancelled before a
+        // pending or replayed adapter attempt.
         this.rememberCompletedTaskMonitorTurn(binding.id, eventTurnId);
         this.toolUpdatePolicy.flush({
           bindingId: binding.id,


### PR DESCRIPTION
## Summary

- route transient PwrAgent monitor heartbeats through the existing Working Updates policy
- suppress monitor progress when a binding is set to Working Updates: None
- discard delayed/coalesced heartbeats when a monitor completes so stale progress cannot arrive after the terminal result
- keep the parent agent's terminal monitor response user-visible
- compact monitor heartbeat text and bound task/message lengths

## Root cause

Task monitor progress was emitted as a phase-less `agentMessage`. Messaging treated phase-less assistant messages as final answers, so every monitor heartbeat bypassed the Working Updates policy and posted immediately to attached channels such as Telegram.

## User impact

Telegram and other messaging bindings now honor their configured Working Updates level for monitor progress. Bindings set to None receive no heartbeat pings, while the final monitor result still arrives normally.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` — 303 passed
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 398 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors
- `pnpm lint:boundaries`
- `git diff --check origin/main...HEAD`
