### PR TITLE
fix(desktop): align directory autocomplete with reference picker

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7965,7 +7965,7 @@ export function Composer(props: ComposerProps) {
           </div>
         ) : autocompleteKind === "directories" ? (
           <div
-            className={`composer__autocomplete composer__autocomplete--${autocompleteLayout.placement}`}
+            className={`composer__autocomplete composer__autocomplete--directories composer__autocomplete--${autocompleteLayout.placement}`}
             ref={autocompleteListRef}
             role="listbox"
             aria-label="Directories"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -10429,6 +10429,7 @@ describe("Composer", () => {
       });
 
       const listbox = screen.getByRole("listbox", { name: "Directories" });
+      expect(listbox).toHaveClass("composer__autocomplete--directories");
       fireEvent.click(
         within(listbox).getByRole("button", { name: /search-product/ })
       );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -592,6 +592,14 @@ describe("Tangerine Terminal theme contract", () => {
       css,
       ".composer__autocomplete--directories",
     );
+    const directoryOptionRule = extractRuleBody(
+      css,
+      ".composer__autocomplete--directories .composer__autocomplete-option:not(.composer__autocomplete-option--action)",
+    );
+    const directoryMetaRule = extractRuleBody(
+      css,
+      ".composer__autocomplete--directories .composer__autocomplete-meta",
+    );
 
     expect(autocompleteRule).toContain("border: 1px solid var(--border-strong);");
     expect(autocompleteRule).toContain("background: var(--bg-panel-elevated);");
@@ -600,7 +608,19 @@ describe("Tangerine Terminal theme contract", () => {
     );
     expect(autocompleteRule).not.toContain("background: rgba(10, 10, 10, 0.98);");
     expect(directoryAutocompleteRule).toContain("right: auto;");
-    expect(directoryAutocompleteRule).toContain("width: min(100%, 560px);");
+    expect(directoryAutocompleteRule).toContain("width: min(100%, 440px);");
+    expect(directoryAutocompleteRule).toContain(
+      "border-color: var(--border-subtle);",
+    );
+    expect(directoryAutocompleteRule).toContain(
+      "box-shadow: var(--shadow-popover);",
+    );
+    expect(directoryOptionRule).toContain(
+      "grid-template-columns: minmax(0, 160px) minmax(0, 1fr);",
+    );
+    expect(directoryOptionRule).toContain("min-height: 38px;");
+    expect(directoryMetaRule).toContain("text-align: right;");
+    expect(directoryMetaRule).toContain("white-space: nowrap;");
   });
 
   it("locks composer height contract — compact when empty, grows, capped at 280px", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -588,6 +588,10 @@ describe("Tangerine Terminal theme contract", () => {
 
   it("keeps composer autocomplete visually separated from transcript surfaces", () => {
     const autocompleteRule = extractRuleBody(css, ".composer__autocomplete");
+    const directoryAutocompleteRule = extractRuleBody(
+      css,
+      ".composer__autocomplete--directories",
+    );
 
     expect(autocompleteRule).toContain("border: 1px solid var(--border-strong);");
     expect(autocompleteRule).toContain("background: var(--bg-panel-elevated);");
@@ -595,6 +599,8 @@ describe("Tangerine Terminal theme contract", () => {
       "inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent)",
     );
     expect(autocompleteRule).not.toContain("background: rgba(10, 10, 10, 0.98);");
+    expect(directoryAutocompleteRule).toContain("right: auto;");
+    expect(directoryAutocompleteRule).toContain("width: min(100%, 560px);");
   });
 
   it("locks composer height contract — compact when empty, grows, capped at 280px", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16257,11 +16257,72 @@ a.transcript-message__messaging-origin:focus-visible {
   top: calc(100% + 10px);
 }
 
-/* Directory names and paths need room to scan, but stretching this picker
-   across the entire 940px chat column leaves excessive empty space. */
+/* The typed "@" picker mirrors the compact scan pattern of the "+" reference
+   picker: folder + name on the left, path on the same row at right. Keep the
+   autocomplete's keyboard/type-to-filter behavior, but share the reference
+   picker's panel width, density, and accent-focused row treatment. */
 .composer__autocomplete--directories {
   right: auto;
-  width: min(100%, 560px);
+  width: min(100%, 440px);
+  gap: 0;
+  padding: 6px;
+  border-color: var(--border-subtle);
+  box-shadow: var(--shadow-popover);
+}
+
+.composer__autocomplete--directories .composer__autocomplete-option:not(.composer__autocomplete-option--action) {
+  display: grid;
+  grid-template-columns: minmax(0, 160px) minmax(0, 1fr);
+  min-height: 38px;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+}
+
+.composer__autocomplete--directories
+  .composer__autocomplete-option:not(.composer__autocomplete-option--action):hover,
+.composer__autocomplete--directories
+  .composer__autocomplete-option:not(.composer__autocomplete-option--action).is-active {
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.composer__autocomplete--directories
+  .composer__autocomplete-option.is-active::before {
+  display: none;
+}
+
+.composer__autocomplete--directories .composer__autocomplete-title {
+  overflow: hidden;
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.composer__autocomplete--directories .composer__autocomplete-title > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.composer__autocomplete--directories .composer__autocomplete-meta {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer__autocomplete--directories
+  .composer__autocomplete-option--action {
+  min-height: 38px;
+  justify-content: center;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
 }
 
 .composer__autocomplete-option {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16257,6 +16257,13 @@ a.transcript-message__messaging-origin:focus-visible {
   top: calc(100% + 10px);
 }
 
+/* Directory names and paths need room to scan, but stretching this picker
+   across the entire 940px chat column leaves excessive empty space. */
+.composer__autocomplete--directories {
+  right: auto;
+  width: min(100%, 560px);
+}
+
 .composer__autocomplete-option {
   display: flex;
   position: relative;


### PR DESCRIPTION
## Summary

- align the composer `@` autocomplete with the compact `+` reference picker
- place the directory name and path on one row, with the path right-aligned
- use the reference picker's 440px panel width and 38px row density
- preserve full available width on windows narrower than the cap
- leave the `$` skill and `/` command autocomplete widths unchanged
- preserve `@` type-to-filter and keyboard navigation behavior
- lock the scoped layout and sizing behavior with regression coverage

## Why

The shared composer autocomplete uses `left: 0` and `right: 0`, so the `@`
picker stretched across the entire 940px chat column even when its directory
rows needed far less space. It also inherited the generic autocomplete's
stacked title/path layout, which made each directory consume substantially
more vertical space than the purpose-built `+` reference picker.

The `@` picker now gets scoped reference-picker styling instead of changing
every composer autocomplete surface.

## User impact

The directory picker is easier to scan, shows roughly eight directories in the
space that previously showed about five, and no longer presents a large empty
panel across the composer. Long names and paths truncate independently, and
the panel remains responsive on narrow windows.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (254 tests passed)
- targeted ESLint (0 errors)
- `git diff --check`
- visual verification in the branch-bound PwrAgent `dev` profile
