### PR TITLE
fix(desktop): streamline paginated transcript navigation

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -946,6 +946,14 @@ type BranchDriftDialogState = {
   threadKey: string;
 };
 
+type PendingTranscriptTurnTarget = {
+  threadKey: string;
+  turnId: string;
+  turnTimeMs?: number;
+};
+
+const MAX_TRANSCRIPT_TARGET_PAGE_LOADS = 60;
+
 function scrollRenderedTranscriptToTurn(
   container: HTMLElement,
   turnId: string,
@@ -1001,6 +1009,11 @@ function findTranscriptTurnEntryIndex(
         return index;
       }
     }
+    // A supplied turn id is authoritative. Do not let a nearby timestamp
+    // masquerade as the target while the exact turn may still live in an
+    // older server page; the caller can choose a rendered-time fallback only
+    // after history is exhausted.
+    return -1;
   }
   if (typeof turnTimeMs !== "number") {
     return -1;
@@ -1063,6 +1076,10 @@ export function ThreadView(props: ThreadViewProps) {
   const [transcriptEntryLimits, setTranscriptEntryLimits] = useState(
     () => new Map<string, number>(),
   );
+  const [pendingTranscriptTurnTarget, setPendingTranscriptTurnTarget] =
+    useState<PendingTranscriptTurnTarget>();
+  const transcriptTurnPageLoadsRef = useRef(0);
+  const transcriptTurnPageRequestPendingRef = useRef(false);
   const [contextRailWidth, setContextRailWidth] = useState(380);
   const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
   // Terminal state is owned by `useIntegratedTerminals` up in App, mirroring
@@ -1116,6 +1133,9 @@ export function ThreadView(props: ThreadViewProps) {
     setSetupFailureArchiving(false);
     setContextRailResizing(false);
     setExpandedImage(undefined);
+    setPendingTranscriptTurnTarget(undefined);
+    transcriptTurnPageLoadsRef.current = 0;
+    transcriptTurnPageRequestPendingRef.current = false;
     setLaunchpadMaterializing(false);
     setLaunchpadMaterializeError(undefined);
     setLaunchpadSetupProgress(undefined);
@@ -1279,6 +1299,88 @@ export function ThreadView(props: ThreadViewProps) {
     onLoadOlder,
     transcriptEntryCount,
     transcriptEntryLimit,
+  ]);
+  useEffect(() => {
+    const target = pendingTranscriptTurnTarget;
+    if (!target) {
+      return;
+    }
+    if (target.threadKey !== selectedThreadKey) {
+      setPendingTranscriptTurnTarget(undefined);
+      transcriptTurnPageLoadsRef.current = 0;
+      return;
+    }
+
+    const targetIndex = findTranscriptTurnEntryIndex(
+      props.transcriptEntries,
+      target.turnId,
+      target.turnTimeMs,
+    );
+    if (targetIndex >= 0) {
+      expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
+      setPendingTranscriptTurnTarget(undefined);
+      transcriptTurnPageLoadsRef.current = 0;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          const container = transcriptPanelRef.current;
+          if (container) {
+            scrollRenderedTranscriptToTurn(
+              container,
+              target.turnId,
+              target.turnTimeMs,
+            );
+          }
+        });
+      });
+      return;
+    }
+
+    const finishAtNearestRenderedTurn = (): void => {
+      const container = transcriptPanelRef.current;
+      if (container) {
+        scrollRenderedTranscriptToTurn(
+          container,
+          target.turnId,
+          target.turnTimeMs,
+        );
+      }
+      setPendingTranscriptTurnTarget(undefined);
+      transcriptTurnPageLoadsRef.current = 0;
+    };
+    if (
+      !canLoadServerTranscriptHistory
+      || transcriptTurnPageLoadsRef.current >= MAX_TRANSCRIPT_TARGET_PAGE_LOADS
+    ) {
+      finishAtNearestRenderedTurn();
+      return;
+    }
+    if (props.loadingMore || transcriptTurnPageRequestPendingRef.current) {
+      return;
+    }
+
+    transcriptTurnPageRequestPendingRef.current = true;
+    transcriptTurnPageLoadsRef.current += 1;
+    void onLoadOlder()
+      .catch(() => {
+        setPendingTranscriptTurnTarget((current) =>
+          current?.threadKey === target.threadKey
+          && current.turnId === target.turnId
+            ? undefined
+            : current,
+        );
+      })
+      .finally(() => {
+        transcriptTurnPageRequestPendingRef.current = false;
+      });
+  }, [
+    canLoadServerTranscriptHistory,
+    expandTranscriptEntryLimit,
+    onLoadOlder,
+    pendingTranscriptTurnTarget,
+    props.loadingMore,
+    props.transcriptEntries,
+    props.transcriptPagination?.previousCursor,
+    selectedThreadKey,
   ]);
   const fileViewerContext = useMemo<MarkdownFileViewerContext | undefined>(() => {
     if (!selectedThread || !selectedThreadKey) {
@@ -1854,29 +1956,41 @@ export function ThreadView(props: ThreadViewProps) {
       if (!container) {
         return;
       }
-      if (scrollRenderedTranscriptToTurn(container, turnId, turnTimeMs)) {
-        return;
-      }
       const targetIndex = findTranscriptTurnEntryIndex(
         props.transcriptEntries,
         turnId,
         turnTimeMs,
       );
-      if (targetIndex < 0) {
+      if (targetIndex >= 0) {
+        expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const liveContainer = transcriptPanelRef.current;
+            if (liveContainer) {
+              scrollRenderedTranscriptToTurn(liveContainer, turnId, turnTimeMs);
+            }
+          });
+        });
+        return;
+      }
+      if (canLoadServerTranscriptHistory && selectedThreadKey) {
+        transcriptTurnPageLoadsRef.current = 0;
+        setPendingTranscriptTurnTarget({
+          threadKey: selectedThreadKey,
+          turnId,
+          turnTimeMs,
+        });
         return;
       }
 
-      expandTranscriptEntryLimit(props.transcriptEntries.length - targetIndex);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          const liveContainer = transcriptPanelRef.current;
-          if (liveContainer) {
-            scrollRenderedTranscriptToTurn(liveContainer, turnId, turnTimeMs);
-          }
-        });
-      });
+      scrollRenderedTranscriptToTurn(container, turnId, turnTimeMs);
     },
-    [expandTranscriptEntryLimit, props.transcriptEntries],
+    [
+      canLoadServerTranscriptHistory,
+      expandTranscriptEntryLimit,
+      props.transcriptEntries,
+      selectedThreadKey,
+    ],
   );
 
   const moveEditedFilesToSidebar = useCallback(() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1079,7 +1079,9 @@ export function ThreadView(props: ThreadViewProps) {
   const [pendingTranscriptTurnTarget, setPendingTranscriptTurnTarget] =
     useState<PendingTranscriptTurnTarget>();
   const transcriptTurnPageLoadsRef = useRef(0);
-  const transcriptTurnPageRequestPendingRef = useRef(false);
+  const transcriptTurnPageRequestGenerationRef = useRef(0);
+  const [transcriptTurnPageRequestPending, setTranscriptTurnPageRequestPending] =
+    useState(false);
   const [contextRailWidth, setContextRailWidth] = useState(380);
   const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
   // Terminal state is owned by `useIntegratedTerminals` up in App, mirroring
@@ -1135,7 +1137,8 @@ export function ThreadView(props: ThreadViewProps) {
     setExpandedImage(undefined);
     setPendingTranscriptTurnTarget(undefined);
     transcriptTurnPageLoadsRef.current = 0;
-    transcriptTurnPageRequestPendingRef.current = false;
+    transcriptTurnPageRequestGenerationRef.current += 1;
+    setTranscriptTurnPageRequestPending(false);
     setLaunchpadMaterializing(false);
     setLaunchpadMaterializeError(undefined);
     setLaunchpadSetupProgress(undefined);
@@ -1354,11 +1357,12 @@ export function ThreadView(props: ThreadViewProps) {
       finishAtNearestRenderedTurn();
       return;
     }
-    if (props.loadingMore || transcriptTurnPageRequestPendingRef.current) {
+    if (props.loadingMore || transcriptTurnPageRequestPending) {
       return;
     }
 
-    transcriptTurnPageRequestPendingRef.current = true;
+    setTranscriptTurnPageRequestPending(true);
+    const requestGeneration = transcriptTurnPageRequestGenerationRef.current;
     transcriptTurnPageLoadsRef.current += 1;
     void onLoadOlder()
       .catch(() => {
@@ -1370,7 +1374,11 @@ export function ThreadView(props: ThreadViewProps) {
         );
       })
       .finally(() => {
-        transcriptTurnPageRequestPendingRef.current = false;
+        if (
+          transcriptTurnPageRequestGenerationRef.current === requestGeneration
+        ) {
+          setTranscriptTurnPageRequestPending(false);
+        }
       });
   }, [
     canLoadServerTranscriptHistory,
@@ -1381,6 +1389,7 @@ export function ThreadView(props: ThreadViewProps) {
     props.transcriptEntries,
     props.transcriptPagination?.previousCursor,
     selectedThreadKey,
+    transcriptTurnPageRequestPending,
   ]);
   const fileViewerContext = useMemo<MarkdownFileViewerContext | undefined>(() => {
     if (!selectedThread || !selectedThreadKey) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -567,6 +567,8 @@ export function TranscriptList(props: TranscriptListProps) {
   const appliedReglueRequestKeyRef = useRef(0);
   const olderPageRequestPendingRef = useRef(false);
   const olderPageRequestGenerationRef = useRef(0);
+  const lastUnderflowHistoryRequestRef = useRef<string | undefined>(undefined);
+  const [olderPageRequestSettledKey, setOlderPageRequestSettledKey] = useState(0);
   const shouldScrollToBottomRef = useRef(true);
   const isGluedToBottomRef = useRef(true);
   const [hasContentBelow, setHasContentBelow] = useState(false);
@@ -590,14 +592,15 @@ export function TranscriptList(props: TranscriptListProps) {
   useEffect(() => {
     olderPageRequestGenerationRef.current += 1;
     olderPageRequestPendingRef.current = false;
+    lastUnderflowHistoryRequestRef.current = undefined;
   }, [props.threadId]);
-  const requestOlderPage = useCallback(() => {
+  const requestOlderPage = useCallback((): boolean => {
     if (
       !canLoadOlder
       || loadingMore
       || olderPageRequestPendingRef.current
     ) {
-      return;
+      return false;
     }
 
     olderPageRequestPendingRef.current = true;
@@ -605,6 +608,7 @@ export function TranscriptList(props: TranscriptListProps) {
     const releaseRequestLock = (): void => {
       if (olderPageRequestGenerationRef.current === requestGeneration) {
         olderPageRequestPendingRef.current = false;
+        setOlderPageRequestSettledKey((current) => current + 1);
       }
     };
     try {
@@ -616,7 +620,35 @@ export function TranscriptList(props: TranscriptListProps) {
       releaseRequestLock();
       throw error;
     }
+    return true;
   }, [canLoadOlder, loadingMore, onLoadOlder]);
+  const requestOlderPageIfUnderflowing = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (
+      !container
+      || container.clientHeight <= 0
+      || container.scrollHeight > container.clientHeight
+    ) {
+      return;
+    }
+    const historySignature = [
+      props.threadId ?? "",
+      props.pagination?.previousCursor ?? "",
+      props.entries[0]?.id ?? "",
+      props.entries.length,
+    ].join(":");
+    if (lastUnderflowHistoryRequestRef.current === historySignature) {
+      return;
+    }
+    if (requestOlderPage()) {
+      lastUnderflowHistoryRequestRef.current = historySignature;
+    }
+  }, [
+    props.pagination?.previousCursor,
+    props.entries,
+    props.threadId,
+    requestOlderPage,
+  ]);
   const hasPendingContent = Boolean(
     props.pendingActivityEntry ||
       props.pendingProtocolActivityEntry ||
@@ -1060,6 +1092,14 @@ export function TranscriptList(props: TranscriptListProps) {
   ]);
 
   useEffect(() => {
+    requestOlderPageIfUnderflowing();
+  }, [
+    olderPageRequestSettledKey,
+    requestOlderPageIfUnderflowing,
+    transcriptEntries,
+  ]);
+
+  useEffect(() => {
     const content = scrollContentRef.current;
     const container = scrollContainerRef.current;
     if (!content || !container || typeof ResizeObserver === "undefined") {
@@ -1079,13 +1119,14 @@ export function TranscriptList(props: TranscriptListProps) {
       } else {
         syncScrollState({ preserveGlueOnResize: true });
       }
+      requestOlderPageIfUnderflowing();
     });
     observer.observe(content);
     observer.observe(container);
     return () => {
       observer.disconnect();
     };
-  }, [scrollToBottom, syncScrollState]);
+  }, [requestOlderPageIfUnderflowing, scrollToBottom, syncScrollState]);
 
   // When a sidebar drag ends, the pane has settled at its final width but the
   // ResizeObserver/onScroll handlers were paused throughout — re-sync the
@@ -1138,6 +1179,9 @@ export function TranscriptList(props: TranscriptListProps) {
         onWheel={(event) => {
           if (event.deltaY < 0) {
             disableBottomGlue();
+            if (event.currentTarget.scrollTop <= LOAD_OLDER_THRESHOLD_PX) {
+              requestOlderPage();
+            }
           }
         }}
         onScroll={(event) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1128,22 +1128,13 @@ export function TranscriptList(props: TranscriptListProps) {
       data-fade-top={isAtTop ? "hidden" : "visible"}
       data-fade-bottom={hasContentBelow ? "visible" : "hidden"}
     >
-      {canLoadOlder ? (
-        <button
-          className="button button--ghost transcript-list__load-older"
-          type="button"
-          onClick={requestOlderPage}
-        >
-          {props.loadingMore ? "Loading older messages" : "Load older messages"}
-        </button>
-      ) : null}
-
       {props.error ? <p className="transcript-error">{props.error}</p> : null}
 
       <div
         ref={scrollContainerRef}
         className="transcript-list__items"
         role="list"
+        tabIndex={0}
         onWheel={(event) => {
           if (event.deltaY < 0) {
             disableBottomGlue();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -749,6 +749,7 @@ describe("ThreadView", () => {
   it("loads older server pages to reach a pricing timestamp target", async () => {
     const targetTime = 1_800_000_000_000;
     const loadOlder = vi.fn();
+    let loadedPageCount = 0;
     const recentEntries = Array.from({ length: 40 }, (_, index) => ({
       type: "message" as const,
       id: `message-${index}`,
@@ -782,6 +783,24 @@ describe("ThreadView", () => {
           messageCount={entries.length}
           onLoadOlder={async () => {
             loadOlder();
+            loadedPageCount += 1;
+            if (loadedPageCount === 1) {
+              setEntries((current) => [
+                {
+                  type: "message",
+                  id: "message-intermediate",
+                  role: "assistant",
+                  text: "Intermediate older page",
+                  turn: {
+                    id: "turn-intermediate",
+                    status: "completed",
+                    completedAt: targetTime - 1,
+                  },
+                },
+                ...current,
+              ]);
+              return;
+            }
             setEntries((current) => [
               {
                 type: "message",
@@ -829,7 +848,7 @@ describe("ThreadView", () => {
     );
 
     await waitFor(() => {
-      expect(loadOlder).toHaveBeenCalledTimes(1);
+      expect(loadOlder).toHaveBeenCalledTimes(2);
     });
     expect(await screen.findByText("Server-loaded exact target")).toBeInTheDocument();
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -12,6 +12,7 @@ import type {
   NavigationLaunchpadDraft,
   NavigationThreadSummary,
   StartReviewRequest,
+  ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import type { PendingMcpInteractionState } from "../mcp-elicitation";
@@ -58,6 +59,54 @@ import {
 function ThreadView(props: Omit<ThreadViewProps, "terminals">): ReactElement {
   const terminals = useIntegratedTerminals(props.desktopApi);
   return <ThreadViewWithTerminals {...props} terminals={terminals} />;
+}
+
+function buildTimestampPricingLine(params: {
+  createdAt: number;
+  threadId: string;
+  turnId: string;
+}): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: params.createdAt,
+    currency: "USD",
+    inputTokens: 100,
+    outputCostMicros: 0,
+    outputTokens: 10,
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "turn",
+    source: "hydration",
+    status: "finalized",
+    threadId: params.threadId,
+    totalCostMicros: 1_000,
+    totalTokens: 110,
+    turnId: params.turnId,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 100,
+    usageLineId: `line-${params.turnId}`,
+  };
+}
+
+function buildTimestampTargetThread(
+  id: string,
+  title: string,
+): NavigationThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "explicit",
+    source: "codex",
+    executionMode: "default",
+    updatedAt: Date.now(),
+    linkedDirectories: [],
+    inbox: {
+      inInbox: true,
+    },
+  };
 }
 
 function buildRendererLiveDiffEvent(params: {
@@ -632,6 +681,160 @@ describe("ThreadView", () => {
 
     expect(container.querySelectorAll(".transcript-message")).toHaveLength(90);
     expect(loadOlder).not.toHaveBeenCalled();
+  });
+
+  it("reveals an exact hidden turn when its pricing timestamp is clicked", async () => {
+    const targetTime = 1_800_000_000_000;
+    const entries = Array.from({ length: 95 }, (_, index) => ({
+      type: "message" as const,
+      id: `message-${index}`,
+      role: "assistant" as const,
+      text: index === 0 ? "Exact hidden target" : `History ${index}`,
+      turn: {
+        id: `turn-${index}`,
+        status: "completed" as const,
+        completedAt: targetTime + index,
+      },
+    }));
+    const selectedThread = buildTimestampTargetThread(
+      "thread-hidden-turn",
+      "Hidden timestamp target",
+    );
+    const { container } = render(
+      <ThreadView
+        activeContextTab="pricing"
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        contextRailPinned
+        desktopApi={{}}
+        loading={false}
+        loadingMore={false}
+        messageCount={entries.length}
+        onLoadOlder={async () => undefined}
+        pricing={{
+          lines: [buildTimestampPricingLine({
+            createdAt: targetTime,
+            threadId: selectedThread.id,
+            turnId: "turn-0",
+          })],
+          summaries: [],
+        }}
+        removeOptimisticMessage={(_id) => undefined}
+        selectedThread={selectedThread}
+        skills={[]}
+        threadPricingSummaryEnabled
+        transcriptEntries={entries}
+      />,
+    );
+
+    expect(container.querySelectorAll(".transcript-message")).toHaveLength(40);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".transcript-message")).toHaveLength(95);
+    });
+    expect(screen.getByText("Exact hidden target")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
+  });
+
+  it("loads older server pages to reach a pricing timestamp target", async () => {
+    const targetTime = 1_800_000_000_000;
+    const loadOlder = vi.fn();
+    const recentEntries = Array.from({ length: 40 }, (_, index) => ({
+      type: "message" as const,
+      id: `message-${index}`,
+      role: "assistant" as const,
+      text: `Recent history ${index}`,
+      turn: {
+        id: `turn-recent-${index}`,
+        status: "completed" as const,
+        completedAt: targetTime + index + 1,
+      },
+    }));
+    const selectedThread = buildTimestampTargetThread(
+      "thread-server-turn",
+      "Server timestamp target",
+    );
+
+    function Harness() {
+      const [entries, setEntries] = useState(recentEntries);
+      const [hasPreviousPage, setHasPreviousPage] = useState(true);
+      return (
+        <ThreadView
+          activeContextTab="pricing"
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          clearPendingRequest={() => undefined}
+          composerDisabled={false}
+          contextRailPinned
+          desktopApi={{}}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          onLoadOlder={async () => {
+            loadOlder();
+            setEntries((current) => [
+              {
+                type: "message",
+                id: "message-target",
+                role: "assistant",
+                text: "Server-loaded exact target",
+                turn: {
+                  id: "turn-target",
+                  status: "completed",
+                  completedAt: targetTime,
+                },
+              },
+              ...current,
+            ]);
+            setHasPreviousPage(false);
+          }}
+          pricing={{
+            lines: [buildTimestampPricingLine({
+              createdAt: targetTime,
+              threadId: selectedThread.id,
+              turnId: "turn-target",
+            })],
+            summaries: [],
+          }}
+          removeOptimisticMessage={(_id) => undefined}
+          selectedThread={selectedThread}
+          skills={[]}
+          threadPricingSummaryEnabled
+          transcriptEntries={entries}
+          transcriptPagination={{
+            supportsPagination: true,
+            hasPreviousPage,
+            previousCursor: hasPreviousPage ? "cursor-1" : undefined,
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Scroll the transcript to this turn/,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(loadOlder).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText("Server-loaded exact target")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    });
   });
 
   it("pages manual find through hidden in-memory transcript history", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -626,7 +626,9 @@ describe("ThreadView", () => {
 
     expect(container.querySelectorAll(".transcript-message")).toHaveLength(40);
 
-    fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
+    const transcriptList = screen.getByRole("list");
+    transcriptList.scrollTop = 120;
+    fireEvent.scroll(transcriptList);
 
     expect(container.querySelectorAll(".transcript-message")).toHaveLength(90);
     expect(loadOlder).not.toHaveBeenCalled();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -396,6 +396,44 @@ describe("TranscriptList", () => {
     expect(loadOlder).toHaveBeenCalledTimes(1);
   });
 
+  it("loads older history when the transcript is too short to scroll", async () => {
+    scrollHeight = 200;
+    clientHeight = 240;
+    const loadOlder = vi.fn(async () => undefined);
+
+    render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "message-1",
+            role: "assistant",
+            text: "Short recent history",
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        pagination={{
+          supportsPagination: true,
+          hasPreviousPage: true,
+          previousCursor: "cursor-1",
+        }}
+        threadId="thread-underflow"
+        onLoadOlder={loadOlder}
+      />,
+    );
+
+    expect(loadOlder).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Load older messages" }),
+    ).not.toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(loadOlder).toHaveBeenCalledTimes(1);
+  });
+
   it("does not carry an in-flight older-page lock into another thread", () => {
     let resolveFirstLoad: (() => void) | undefined;
     const firstLoad = vi.fn(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -269,7 +269,7 @@ describe("TranscriptList", () => {
     expect(container.querySelector(".transcript-message--injected")).toBeInTheDocument();
   });
 
-  it("renders transcript history and exposes incremental history loading when available", () => {
+  it("renders transcript history without a persistent older-history button", () => {
     const loadOlder = vi.fn(async () => undefined);
 
     render(
@@ -348,9 +348,14 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Read ThreadView.tsx")).toBeInTheDocument();
     expect(screen.getByText("pwd && rg --files")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
-
-    expect(loadOlder).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Load older messages" })
+    ).not.toBeInTheDocument();
+    expect(document.querySelector(".transcript-list__items")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+    expect(loadOlder).not.toHaveBeenCalled();
     expect(
       screen.queryByRole("button", { name: "Jump to latest message" })
     ).not.toBeInTheDocument();
@@ -425,7 +430,9 @@ describe("TranscriptList", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
+    const firstList = screen.getByRole("list");
+    firstList.scrollTop = 120;
+    fireEvent.scroll(firstList);
     expect(firstLoad).toHaveBeenCalledTimes(1);
 
     rerender(
@@ -435,7 +442,9 @@ describe("TranscriptList", () => {
         onLoadOlder={secondLoad}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Load older messages" }));
+    const secondList = screen.getByRole("list");
+    secondList.scrollTop = 120;
+    fireEvent.scroll(secondList);
 
     expect(secondLoad).toHaveBeenCalledTimes(1);
     resolveFirstLoad?.();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8640,10 +8640,9 @@ textarea,
   overflow: hidden;
 }
 
-.transcript-list__load-older,
 .transcript-list > .transcript-error {
   /* Restore the lateral / top breathing room the wrapper used to
-     provide for these sibling rows above the items. */
+     provide for error rows above the items. */
   align-self: flex-start;
   margin: 12px 16px 0;
 }


### PR DESCRIPTION
## What changed

- remove the persistent “Load older messages” button above paginated transcripts
- keep near-top automatic history pagination and request deduplication
- automatically load older history when transcript content is too short to overflow, with upward-wheel loading as an explicit retry path
- make the transcript scroll region keyboard-focusable so keyboard scrolling reaches older history without a separate control
- treat search-result and timestamp turn IDs as authoritative navigation targets
- reveal renderer-hidden targets and page older backend history until exact timestamp targets render
- resume timestamp and underflow pagination after each request settles, even when entries render before the promise resolves
- retain a 60-page safety cap before falling back to the nearest available rendered timestamp
- add regression coverage for hidden in-memory, multi-page server timestamp targets, and non-overflowing transcripts

## Why

The explicit control duplicated automatic scroll-to-load behavior, consumed transcript height, and appeared persistently at the top of every thread with additional history. Removing it restores the full transcript viewport. Direct navigation and short transcripts must remain reliable without the button: search and timestamp links page to their exact targets, while underflowing transcripts automatically fetch enough older history to become scrollable.

## Validation

- 122 focused renderer tests
- 5 thread scroll-stability Electron E2E tests
- 5 WCAG accessibility Electron E2E tests
- full workspace typecheck for the button removal; desktop typecheck after pagination fixes
- ESLint (0 errors; existing warnings only)