### PR TITLE
fix(release): normalize Windows ASAR verification paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
             apps/desktop/release-stage \
             apps/desktop/scripts/release.mjs \
             apps/desktop/scripts/verify-asar-contents.mjs \
+            apps/desktop/scripts/asar-entry-paths.mjs \
             apps/desktop/node_modules \
             node_modules
           sha256="$(shasum -a 256 "$tarball" | awk '{print $1}')"

--- a/apps/desktop/scripts/asar-entry-paths.mjs
+++ b/apps/desktop/scripts/asar-entry-paths.mjs
@@ -1,0 +1,3 @@
+export function normalizeAsarListing(listing) {
+  return listing.map((entry) => entry.replaceAll("\\", "/"));
+}

--- a/apps/desktop/scripts/asar-entry-paths.test.mjs
+++ b/apps/desktop/scripts/asar-entry-paths.test.mjs
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAsarListing } from "./asar-entry-paths.mjs";
+
+describe("ASAR entry paths", () => {
+  it("normalizes Windows separators for platform-independent checks", () => {
+    const listing = normalizeAsarListing([
+      "\\out\\grok-app-server\\index.mjs",
+      "\\node_modules\\example\\src\\index.ts",
+    ]);
+
+    expect(listing).toEqual([
+      "/out/grok-app-server/index.mjs",
+      "/node_modules/example/src/index.ts",
+    ]);
+  });
+
+  it("preserves POSIX entry paths", () => {
+    const listing = normalizeAsarListing([
+      "/out/grok-app-server/index.mjs",
+    ]);
+
+    expect(listing).toEqual([
+      "/out/grok-app-server/index.mjs",
+    ]);
+  });
+});

--- a/apps/desktop/scripts/verify-asar-contents.mjs
+++ b/apps/desktop/scripts/verify-asar-contents.mjs
@@ -7,6 +7,7 @@
 import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
+import { normalizeAsarListing } from "./asar-entry-paths.mjs";
 
 const args = process.argv.slice(2);
 const appPath = args[0]
@@ -41,7 +42,9 @@ if (!existsSync(asarPath)) {
 // from the desktop package's node_modules without an extra install step.
 const require = createRequire(import.meta.url);
 const asar = require("@electron/asar");
-const listing = asar.listPackage(asarPath, { isPack: false });
+const listing = normalizeAsarListing(
+  asar.listPackage(asarPath, { isPack: false }),
+);
 const required = [
   "/out/grok-app-server/index.mjs",
 ];


### PR DESCRIPTION
## Summary

- I normalize `@electron/asar` package listings to POSIX separators before validating required and forbidden paths.
- I added regression coverage for Windows backslash listings and preserved POSIX listings.
- I include the normalization helper in the macOS signing-input archive consumed by the no-checkout signing job.

## Verification

- `pnpm test apps/desktop/scripts/asar-entry-paths.test.mjs`
- `pnpm lint:eslint` (0 errors; existing warning baseline remains)
- `pnpm lint:boundaries`
- `node --check apps/desktop/scripts/verify-asar-contents.mjs`
- `node --check apps/desktop/scripts/asar-entry-paths.mjs`
- `node --check apps/desktop/scripts/asar-entry-paths.test.mjs`
- `git diff --check`
- Isolated signing-handoff archive/extract check: verifier imports resolve without a repository checkout.

## Notes

- The Windows installer and block map were built successfully in release run 30607324581, but the post-package ASAR verifier compared `/out/grok-app-server/index.mjs` with the Windows listing `\out\grok-app-server\index.mjs` and reported a false missing-file failure.
- Normalizing once before validation also makes the verifier's slash-based forbidden-file rules effective on Windows.
- The signing handoff explicitly archives the helper because the signing job does not check out the repository.
