### PR TITLE
fix(desktop): align directory thread chevron

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1125,18 +1125,18 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         }}
                       >
                         <span className="directory-row__thread-divider-label">
-                          <span>Directory threads</span>
-                          {directoryThreadsCollapsed ? (
-                            <span className="directory-row__thread-divider-count">
-                              {directoryUnpinnedThreads.length}
-                            </span>
-                          ) : null}
                           <span
                             aria-hidden="true"
                             className={`directory-row__thread-divider-chevron${
                               directoryThreadsCollapsed ? "" : " is-open"
                             }`}
                           />
+                          <span>Directory threads</span>
+                          {directoryThreadsCollapsed ? (
+                            <span className="directory-row__thread-divider-count">
+                              {directoryUnpinnedThreads.length}
+                            </span>
+                          ) : null}
                         </span>
                       </button>
                     ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1909,11 +1909,21 @@ describe("Sidebar", () => {
 
     const { rerender } = render(renderSidebar(false));
 
-    await clickElement(
-      screen.getByRole("button", {
-        name: "Hide directory threads for PwrAgent",
-      }),
+    const hideDirectoryThreads = screen.getByRole("button", {
+      name: "Hide directory threads for PwrAgent",
+    });
+    const expandedDividerLabel = hideDirectoryThreads.querySelector(
+      ".directory-row__thread-divider-label",
     );
+    expect(expandedDividerLabel?.firstElementChild).toHaveClass(
+      "directory-row__thread-divider-chevron",
+      "is-open",
+    );
+    expect(expandedDividerLabel?.children[1]).toHaveTextContent(
+      "Directory threads",
+    );
+
+    await clickElement(hideDirectoryThreads);
     expect(onSetDirectoryThreadsCollapsed).toHaveBeenCalledWith(
       expect.objectContaining({ key: directories[0].key }),
       true,
@@ -1928,6 +1938,16 @@ describe("Sidebar", () => {
     });
     expect(showDirectoryThreads).toHaveAttribute("aria-expanded", "false");
     expect(within(showDirectoryThreads).getByText("1")).toBeInTheDocument();
+    const collapsedDividerLabel = showDirectoryThreads.querySelector(
+      ".directory-row__thread-divider-label",
+    );
+    expect(collapsedDividerLabel?.firstElementChild).toHaveClass(
+      "directory-row__thread-divider-chevron",
+    );
+    expect(collapsedDividerLabel?.firstElementChild).not.toHaveClass("is-open");
+    expect(collapsedDividerLabel?.children[1]).toHaveTextContent(
+      "Directory threads",
+    );
   });
 
   it("caps unpinned directory threads and toggles the overflow behind Show more / Show less", async () => {


### PR DESCRIPTION
## Summary

- move the Directory threads disclosure chevron before its label
- keep the established collapsed-right / expanded-down orientation
- cover the chevron placement and state in the sidebar test

## Why

The newer Directory threads divider rendered its collapsed right-pointing chevron after the label, so it pointed away from the text. Existing sidebar disclosures place the chevron before the label, where the collapsed chevron points toward the content it controls.

## User impact

Directory disclosures now read consistently: the chevron sits on the left, points toward the label when collapsed, and points down when expanded.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` (85 tests passed)
- `pnpm exec eslint apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `git diff --check`
