### PR TITLE
fix(desktop): reveal hidden selected threads

### DIFF
--- a/apps/desktop/e2e/thread-title-reveal.spec.ts
+++ b/apps/desktop/e2e/thread-title-reveal.spec.ts
@@ -197,7 +197,7 @@ async function createThreadTitleRevealFixture(): Promise<{
   };
 }
 
-test("thread title reveals a linked child hidden by collapsed directory sections", async () => {
+async function launchThreadTitleRevealApp() {
   const fixture = await createThreadTitleRevealFixture();
   const app = await launchElectronApp({
     fixturePath: fixture.fixturePath,
@@ -226,6 +226,11 @@ test("thread title reveals a linked child hidden by collapsed directory sections
       }
     },
   });
+  return { app, fixture };
+}
+
+test("thread title reveals a linked child hidden by collapsed directory sections", async () => {
+  const { app, fixture } = await launchThreadTitleRevealApp();
 
   try {
     const threadBrowser = app.window.getByRole("region", {
@@ -306,6 +311,101 @@ test("thread title reveals a linked child hidden by collapsed directory sections
       .filter({ hasText: "Hidden linked child thread" });
     await expect(selectedChild).toBeVisible();
 
+    const scrollRegion = threadBrowser.locator(".sidebar__scroll-region");
+    const [childBox, scrollBox] = await Promise.all([
+      selectedChild.boundingBox(),
+      scrollRegion.boundingBox(),
+    ]);
+    expect(childBox).not.toBeNull();
+    expect(scrollBox).not.toBeNull();
+    expect(childBox!.y).toBeGreaterThanOrEqual(scrollBox!.y);
+    expect(childBox!.y + childBox!.height).toBeLessThanOrEqual(
+      scrollBox!.y + scrollBox!.height + GEOMETRY_TOLERANCE_PX,
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});
+
+test("quick jump reveals a hidden child before restoring a hidden sidebar", async () => {
+  const { app, fixture } = await launchThreadTitleRevealApp();
+
+  try {
+    const sidebar = app.window.getByRole("complementary", { name: "Threads" });
+    const threadBrowser = app.window.getByRole("region", {
+      name: "Thread browser",
+    });
+    const anchorShell = threadBrowser
+      .locator(".thread-row-shell")
+      .filter({ hasText: "Pinned anchor thread" });
+    await anchorShell.hover();
+    await anchorShell.getByRole("button", { name: "Open thread actions" }).click();
+    await app.window.getByRole("menuitem", { name: "Pin Thread" }).click();
+
+    await threadBrowser
+      .getByRole("button", {
+        name: "Parent thread with child link",
+        exact: true,
+      })
+      .click();
+    await threadBrowser.getByRole("tab", { name: "Directories" }).click();
+
+    const directorySummary = threadBrowser
+      .locator(".directory-row__summary")
+      .filter({ hasText: "RevealFixture" });
+    const hideDirectoryThreads = threadBrowser.getByRole("button", {
+      name: "Hide directory threads for RevealFixture",
+    });
+    const collapseSubthreads = threadBrowser.getByRole("button", {
+      name: "Collapse sub-threads for Parent thread with child link",
+    });
+    await collapseSubthreads.click();
+    await hideDirectoryThreads.click();
+    await directorySummary.click();
+    await expect(directorySummary).toHaveAttribute("aria-expanded", "false");
+
+    await app.window.getByRole("button", { name: "Hide sidebar" }).click();
+    await expect(sidebar).toBeHidden();
+    await app.window.keyboard.press(
+      process.platform === "darwin" ? "Meta+K" : "Control+K",
+    );
+
+    const jumpDialog = app.window.getByRole("dialog", { name: "Jump to thread" });
+    await expect(jumpDialog).toBeVisible();
+    await jumpDialog
+      .getByRole("textbox", { name: "Jump to thread" })
+      .fill("Hidden linked child thread");
+    await jumpDialog
+      .getByRole("button", { name: /Hidden linked child thread/ })
+      .click();
+
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Hidden linked child thread",
+      }),
+    ).toBeVisible();
+    await expect(sidebar).toBeHidden();
+
+    await app.window.getByRole("button", { name: "Show sidebar" }).click();
+    await expect(sidebar).toBeVisible();
+    await expect(directorySummary).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Hide directory threads for RevealFixture",
+      }),
+    ).toBeVisible();
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Collapse sub-threads for Parent thread with child link",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    const selectedChild = threadBrowser
+      .locator(".thread-row.is-selected")
+      .filter({ hasText: "Hidden linked child thread" });
+    await expect(selectedChild).toBeVisible();
     const scrollRegion = threadBrowser.locator(".sidebar__scroll-region");
     const [childBox, scrollBox] = await Promise.all([
       selectedChild.boundingBox(),

--- a/apps/desktop/e2e/thread-title-reveal.spec.ts
+++ b/apps/desktop/e2e/thread-title-reveal.spec.ts
@@ -6,6 +6,8 @@ import { launchElectronApp } from "./fixtures/electron-app";
 import { SqliteOverlayStore } from "../src/main/state/overlay-store-sqlite";
 import { StateDb } from "../src/main/state/state-db";
 
+const GEOMETRY_TOLERANCE_PX = 1;
+
 async function createThreadTitleRevealFixture(): Promise<{
   cleanup: () => Promise<void>;
   fixturePath: string;
@@ -313,7 +315,7 @@ test("thread title reveals a linked child hidden by collapsed directory sections
     expect(scrollBox).not.toBeNull();
     expect(childBox!.y).toBeGreaterThanOrEqual(scrollBox!.y);
     expect(childBox!.y + childBox!.height).toBeLessThanOrEqual(
-      scrollBox!.y + scrollBox!.height,
+      scrollBox!.y + scrollBox!.height + GEOMETRY_TOLERANCE_PX,
     );
   } finally {
     await app.close();

--- a/apps/desktop/e2e/thread-title-reveal.spec.ts
+++ b/apps/desktop/e2e/thread-title-reveal.spec.ts
@@ -1,0 +1,322 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+import { SqliteOverlayStore } from "../src/main/state/overlay-store-sqlite";
+import { StateDb } from "../src/main/state/state-db";
+
+async function createThreadTitleRevealFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-reveal-"));
+  const repoDir = path.join(rootDir, "RevealFixture");
+  const fixturePath = path.join(rootDir, "thread-title-reveal.fixture.json");
+  await mkdir(repoDir, { recursive: true });
+
+  const linkedDirectories = [
+    {
+      id: "reveal-fixture-repo",
+      kind: "local",
+      label: "RevealFixture",
+      path: repoDir,
+    },
+  ];
+  const fillerThreads = Array.from({ length: 8 }, (_, index) => ({
+    id: `thread-filler-${index + 1}`,
+    title: `Filler thread ${index + 1}`,
+    titleSource: "explicit",
+    summary: "Makes the selected child require a real sidebar scroll.",
+    source: "codex",
+    executionMode: "default",
+    linkedDirectories,
+    createdAt: 1_800 - index,
+    updatedAt: 1_800 - index,
+  }));
+
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "thread-title-reveal",
+          threadId: "thread-parent",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: {
+                name: "Replay Codex",
+                version: "1.0.0",
+              },
+              methods: ["thread/list", "thread/read"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-anchor",
+                title: "Pinned anchor thread",
+                titleSource: "explicit",
+                summary: "Keeps the directory disclosure available.",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories,
+                createdAt: 2_000,
+                updatedAt: 2_000,
+              },
+              ...fillerThreads,
+              {
+                id: "thread-parent",
+                title: "Parent thread with child link",
+                titleSource: "explicit",
+                summary: "Links to a child hidden in the directory list.",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories,
+                createdAt: 1_000,
+                updatedAt: 1_000,
+              },
+              {
+                id: "thread-child",
+                title: "Hidden linked child thread",
+                titleSource: "explicit",
+                summary: "The row the title reveal must restore.",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories,
+                createdAt: 900,
+                updatedAt: 900,
+              },
+            ],
+          },
+          {
+            id: "thread-read-anchor",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "anchor-message-1",
+                  role: "assistant",
+                  text: "Pin this thread before exercising the reveal.",
+                },
+              ],
+              messages: [
+                {
+                  id: "anchor-message-1",
+                  role: "assistant",
+                  text: "Pin this thread before exercising the reveal.",
+                },
+              ],
+              lastAssistantMessage: "Pin this thread before exercising the reveal.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-read-parent",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "parent-message-1",
+                  role: "assistant",
+                  text: "Open the [linked child](pwragent://thread/thread-child?backend=codex).",
+                },
+              ],
+              messages: [
+                {
+                  id: "parent-message-1",
+                  role: "assistant",
+                  text: "Open the [linked child](pwragent://thread/thread-child?backend=codex).",
+                },
+              ],
+              lastAssistantMessage: "Open the linked child.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+          {
+            id: "thread-read-child",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "child-message-1",
+                  role: "assistant",
+                  text: "The hidden child is focused.",
+                },
+              ],
+              messages: [
+                {
+                  id: "child-message-1",
+                  role: "assistant",
+                  text: "The hidden child is focused.",
+                },
+              ],
+              lastAssistantMessage: "The hidden child is focused.",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
+test("thread title reveals a linked child hidden by collapsed directory sections", async () => {
+  const fixture = await createThreadTitleRevealFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: { width: 1280, height: 760 },
+    preLaunchHook: async (homeRoot) => {
+      const stateDb = StateDb.open(
+        path.join(
+          homeRoot,
+          ".pwragent",
+          "profiles",
+          "default",
+          "state",
+          "state.db",
+        ),
+        { profileName: "default" },
+      );
+      try {
+        const overlayStore = new SqliteOverlayStore(stateDb);
+        await overlayStore.setThreadParent({
+          backend: "codex",
+          threadId: "thread-child",
+          parentThreadId: "thread-parent",
+        });
+      } finally {
+        stateDb.close();
+      }
+    },
+  });
+
+  try {
+    const threadBrowser = app.window.getByRole("region", {
+      name: "Thread browser",
+    });
+    const anchorShell = threadBrowser
+      .locator(".thread-row-shell")
+      .filter({ hasText: "Pinned anchor thread" });
+    await anchorShell.hover();
+    await anchorShell.getByRole("button", { name: "Open thread actions" }).click();
+    await app.window.getByRole("menuitem", { name: "Pin Thread" }).click();
+
+    await threadBrowser
+      .getByRole("button", {
+        name: "Parent thread with child link",
+        exact: true,
+      })
+      .click();
+    const childChip = app.window.getByRole("button", {
+      name: "Open thread Hidden linked child thread",
+    });
+    await expect(childChip).toBeVisible();
+
+    await threadBrowser.getByRole("tab", { name: "Directories" }).click();
+    const directorySummary = threadBrowser
+      .locator(".directory-row__summary")
+      .filter({ hasText: "RevealFixture" });
+    await expect(directorySummary).toHaveAttribute("aria-expanded", "true");
+
+    const hideDirectoryThreads = threadBrowser.getByRole("button", {
+      name: "Hide directory threads for RevealFixture",
+    });
+    await expect(hideDirectoryThreads).toBeVisible();
+    const collapseSubthreads = threadBrowser.getByRole("button", {
+      name: "Collapse sub-threads for Parent thread with child link",
+    });
+    await collapseSubthreads.click();
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Expand sub-threads for Parent thread with child link",
+      }),
+    ).toBeVisible();
+    await hideDirectoryThreads.click();
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Show directory threads for RevealFixture",
+      }),
+    ).toBeVisible();
+
+    await childChip.click();
+    await expect(
+      app.window.getByRole("heading", {
+        level: 2,
+        name: "Hidden linked child thread",
+      }),
+    ).toBeVisible();
+
+    await directorySummary.click();
+    await expect(directorySummary).toHaveAttribute("aria-expanded", "false");
+
+    await app.window
+      .getByRole("button", { name: "Show selected thread in thread list" })
+      .click();
+
+    await expect(directorySummary).toHaveAttribute("aria-expanded", "true");
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Hide directory threads for RevealFixture",
+      }),
+    ).toBeVisible();
+    await expect(
+      threadBrowser.getByRole("button", {
+        name: "Collapse sub-threads for Parent thread with child link",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+    const selectedChild = threadBrowser
+      .locator(".thread-row.is-selected")
+      .filter({ hasText: "Hidden linked child thread" });
+    await expect(selectedChild).toBeVisible();
+
+    const scrollRegion = threadBrowser.locator(".sidebar__scroll-region");
+    const [childBox, scrollBox] = await Promise.all([
+      selectedChild.boundingBox(),
+      scrollRegion.boundingBox(),
+    ]);
+    expect(childBox).not.toBeNull();
+    expect(scrollBox).not.toBeNull();
+    expect(childBox!.y).toBeGreaterThanOrEqual(scrollBox!.y);
+    expect(childBox!.y + childBox!.height).toBeLessThanOrEqual(
+      scrollBox!.y + scrollBox!.height,
+    );
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1303,6 +1303,7 @@ function DesktopAppShell(props: {
           queuedMessageThreadKeys={queuedMessageThreadKeys}
           composerSourceThreadKey={navigation.composerSourceThreadKey}
           revealSelectedThreadRequest={revealSelectedThreadRequest}
+          onRevealSelectedThreadComplete={threadJump.completePeekRestore}
           selectedItemKey={navigation.selectedItemKey}
           thinkingThreadKeys={session.thinkingThreadKeys}
           threads={navigation.threads}
@@ -1363,12 +1364,15 @@ function DesktopAppShell(props: {
             navigation.selectThread(thread);
             // Reveal on the next frame, once the new selection has rendered.
             // Do it even when the sidebar is only peeked open (⌘K over a hidden
-            // sidebar) — the popup is closing and taking the sidebar with it,
-            // but the scroll offset survives, so bringing the sidebar back later
-            // shows the thread we jumped to instead of stranding it off-screen.
-            // That reveal must be instant: an animated scroll wouldn't finish
-            // before the sidebar hides.
+            // sidebar). Hidden rows reveal asynchronously as their collapsed
+            // containers reopen, so keep a peek laid out until ThreadRow reports
+            // that the selected row mounted and scrolled. The offset survives
+            // restoring the hidden preference, and an instant scroll avoids
+            // dismissing the peek partway through an animation.
             const instant = threadJump.isPeeking();
+            if (instant) {
+              threadJump.deferPeekRestore();
+            }
             requestAnimationFrame(() => revealSelectedThreadInList({ instant }));
           }}
           onArchiveThread={navigation.archiveThread}

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -203,6 +203,8 @@ function DesktopAppShell(props: {
   // The rail defaults to pinned-open (matches the persisted default) so a
   // fresh user discovers it without a collapse→expand flash on first paint.
   const [sidebarHidden, setSidebarHidden] = useState(false);
+  const [revealSelectedThreadRequest, setRevealSelectedThreadRequest] =
+    useState(0);
   const [contextRailPinned, setContextRailPinned] = useState(true);
   const [activeContextTab, setActiveContextTab] =
     useState<ContextTabId>(DEFAULT_CONTEXT_TAB);
@@ -469,6 +471,13 @@ function DesktopAppShell(props: {
   // the first argument) still gets the default.
   const revealSelectedThreadInList = useCallback(
     (options?: { instant?: boolean }) => {
+      // A selected row can be unmounted behind a collapsed directory,
+      // Directory threads divider, overflow cap, or parent-thread group. The
+      // request nonce lets the active sidebar lens open those containers
+      // before ThreadRow's mount effect performs the final nearest-edge
+      // scroll. Keep the direct query for the common already-visible case so
+      // title clicks retain their centered smooth-scroll behavior.
+      setRevealSelectedThreadRequest((current) => current + 1);
       const selectedRow = document.querySelector<HTMLElement>(
         ".sidebar .thread-row.is-selected",
       );
@@ -1293,6 +1302,7 @@ function DesktopAppShell(props: {
           terminalThreadKeys={terminalThreadKeys}
           queuedMessageThreadKeys={queuedMessageThreadKeys}
           composerSourceThreadKey={navigation.composerSourceThreadKey}
+          revealSelectedThreadRequest={revealSelectedThreadRequest}
           selectedItemKey={navigation.selectedItemKey}
           thinkingThreadKeys={session.thinkingThreadKeys}
           threads={navigation.threads}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -47,6 +47,7 @@ type DirectoriesListProps = {
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   composerSourceThreadKey?: string;
   directories: NavigationDirectorySummary[];
+  revealSelectedThreadRequest?: number;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -213,6 +214,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const [directoriesPinnedDividerDropTarget, setDirectoriesPinnedDividerDropTarget] =
     useState(false);
   const previousSelectedItemKeyRef = useRef<string | undefined>(undefined);
+  const handledRevealRequestRef = useRef(0);
   /**
    * Suppress the directory summary button's expand/collapse click
    * when the click is the trailing edge of a drag gesture. Browsers
@@ -300,6 +302,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
     () => new Map(visibleDirectories.map((directory) => [directory.key, directory])),
     [visibleDirectories],
   );
+  const revealSelectedThreadRequest = props.revealSelectedThreadRequest;
+  const selectedItemKeyForReveal = props.selectedItemKey;
+  const setDirectoryThreadsCollapsed = props.onSetDirectoryThreadsCollapsed;
 
   const reorderDirectoryPins = (nextKeys: string[]): void => {
     void props.onReorderDirectoryPins?.(nextKeys);
@@ -446,6 +451,102 @@ export function DirectoriesList(props: DirectoriesListProps) {
       };
     });
   }, [visibleDirectories, props.selectedItemKey]);
+
+  useEffect(() => {
+    const request = revealSelectedThreadRequest ?? 0;
+    const selectedItemKey = selectedItemKeyForReveal;
+    if (request <= handledRevealRequestRef.current || !selectedItemKey) {
+      return;
+    }
+
+    const matchingDirectory = visibleDirectories.find(
+      (directory) =>
+        selectedItemKey === buildLaunchpadSelectionKey(directory.key) ||
+        directory.threadKeys.includes(selectedItemKey),
+    );
+    if (!matchingDirectory) {
+      // showThread() can select before a refreshed navigation snapshot adds
+      // the thread to its directory. Leave the request pending until the
+      // matching directory exists instead of consuming it as a no-op.
+      return;
+    }
+    handledRevealRequestRef.current = request;
+    setExpandedByKey((current) => ({
+      ...current,
+      [matchingDirectory.key]: true,
+    }));
+
+    const selectedThread = threadsByKey.get(selectedItemKey);
+    if (!selectedThread) {
+      return;
+    }
+
+    const directoryThreadKeys = new Set(matchingDirectory.threadKeys);
+    let topLevelThread = selectedThread;
+    const visited = new Set<string>();
+    while (topLevelThread.parentThreadId) {
+      const parentKey = buildThreadIdentityKey(
+        topLevelThread.source,
+        topLevelThread.parentThreadId,
+      );
+      if (visited.has(parentKey) || !directoryThreadKeys.has(parentKey)) {
+        break;
+      }
+      visited.add(parentKey);
+      const parent = threadsByKey.get(parentKey);
+      if (!parent) {
+        break;
+      }
+      topLevelThread = parent;
+    }
+
+    if (isPinnedThread(topLevelThread)) {
+      return;
+    }
+
+    // The selected child is rendered with its top-level ancestor. Reveal that
+    // ancestor through both directory-only layers: the sticky pinned/unpinned
+    // disclosure and the ten-row overflow cap. ThreadRow scrolls the selected
+    // child into view when these state changes mount it.
+    if (matchingDirectory.directoryThreadsCollapsed === true) {
+      void setDirectoryThreadsCollapsed?.(matchingDirectory, false);
+    }
+
+    const topLevelUnpinnedThreads = matchingDirectory.threadKeys
+      .map((threadKey) => threadsByKey.get(threadKey))
+      .filter((thread): thread is NavigationThreadSummary => Boolean(thread))
+      .filter((thread) => {
+        if (!thread.parentThreadId) {
+          return true;
+        }
+        return !directoryThreadKeys.has(
+          buildThreadIdentityKey(thread.source, thread.parentThreadId),
+        );
+      })
+      .filter((thread) => !isPinnedThread(thread));
+    const topLevelThreadKey = buildThreadIdentityKey(
+      topLevelThread.source,
+      topLevelThread.id,
+    );
+    if (
+      topLevelUnpinnedThreads.findIndex(
+        (thread) =>
+          buildThreadIdentityKey(thread.source, thread.id) ===
+          topLevelThreadKey,
+      ) >= UNPINNED_THREAD_CAP
+    ) {
+      setUnpinnedExpandedByKey((current) => ({
+        ...current,
+        [matchingDirectory.key]: true,
+      }));
+    }
+  }, [
+    revealSelectedThreadRequest,
+    selectedItemKeyForReveal,
+    setDirectoryThreadsCollapsed,
+    threadsByKey,
+    visibleDirectories,
+  ]);
 
   if (visibleDirectories.length === 0) {
     return <p className="sidebar-empty">No directory-linked threads.</p>;

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -64,6 +64,7 @@ type DirectoriesListProps = {
     directory: NavigationDirectorySummary,
     preferredBackend?: AppServerBackendKind
   ) => Promise<void>;
+  onRevealSelectedThreadComplete?: (request: number) => void;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onPrefetchPullRequests?: (thread: NavigationThreadSummary) => void;
   onDetachPullRequest?: (
@@ -640,6 +641,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               includeLinkedDirectories
               linkedDirectoryMode="kind"
               nested
+              revealSelectedThreadRequest={props.revealSelectedThreadRequest}
               selectedThreadKey={props.selectedItemKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
               thread={child}
@@ -708,6 +710,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onRevealSelectedThreadComplete={
+                props.onRevealSelectedThreadComplete
+              }
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
@@ -770,6 +775,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             draggable={Boolean(props.onReorderThreadPins)}
             includeLinkedDirectories
             linkedDirectoryMode="kind"
+            revealSelectedThreadRequest={props.revealSelectedThreadRequest}
             selectedThreadKey={props.selectedItemKey}
             subthreadCount={subthreadCount}
             subthreadsCollapsed={thread.subthreadsCollapsed === true}
@@ -798,6 +804,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
             onDetachPullRequest={props.onDetachPullRequest}
             onPrefetchPullRequests={props.onPrefetchPullRequests}
+            onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
             onUnbindMessagingBinding={props.onUnbindMessagingBinding}
@@ -1082,6 +1089,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
                           linkedDirectoryMode="kind"
+                          revealSelectedThreadRequest={
+                            props.revealSelectedThreadRequest
+                          }
 	                          selectedThreadKey={props.selectedItemKey}
                               subthreadCount={subthreadCount}
                               subthreadsCollapsed={thread.subthreadsCollapsed === true}
@@ -1159,6 +1169,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
                           onDetachPullRequest={props.onDetachPullRequest}
                           onPrefetchPullRequests={props.onPrefetchPullRequests}
+                          onRevealSelectedThreadComplete={
+                            props.onRevealSelectedThreadComplete
+                          }
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
 	                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -27,6 +27,7 @@ type RecentsListProps = {
   inputRequestThreadKeys?: Record<string, boolean>;
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   composerSourceThreadKey?: string;
+  revealSelectedThreadRequest?: number;
   selectedThreadKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -54,6 +55,7 @@ type RecentsListProps = {
     collapsed: boolean,
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
+  onRevealSelectedThreadComplete?: (request: number) => void;
   onSetReaction?: (
     thread: NavigationThreadSummary,
     emoji: string,
@@ -157,6 +159,7 @@ export function RecentsList(props: RecentsListProps) {
               draggable={children.length > 1 && Boolean(props.onUpdateSubthreadOrder)}
               includeLinkedDirectories
               nested
+              revealSelectedThreadRequest={props.revealSelectedThreadRequest}
               selectedThreadKey={props.selectedThreadKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
               thread={child}
@@ -220,6 +223,9 @@ export function RecentsList(props: RecentsListProps) {
               onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
               onDetachPullRequest={props.onDetachPullRequest}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onRevealSelectedThreadComplete={
+                props.onRevealSelectedThreadComplete
+              }
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
@@ -249,6 +255,7 @@ export function RecentsList(props: RecentsListProps) {
           }
           draggable={pinned || pinnedThreads.length > 0}
           includeLinkedDirectories
+          revealSelectedThreadRequest={props.revealSelectedThreadRequest}
           selectedThreadKey={props.selectedThreadKey}
           subthreadCount={children.length}
           subthreadsCollapsed={thread.subthreadsCollapsed === true}
@@ -333,6 +340,7 @@ export function RecentsList(props: RecentsListProps) {
           onOpenPullRequestContextMenu={props.onOpenPullRequestContextMenu}
           onDetachPullRequest={props.onDetachPullRequest}
           onPrefetchPullRequests={props.onPrefetchPullRequests}
+          onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
           onSelectThread={props.onSelectThread}
           onSetReaction={props.onSetReaction}
           onUnbindMessagingBinding={props.onUnbindMessagingBinding}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -93,6 +93,8 @@ type SidebarProps = {
   queuedMessageThreadKeys?: Record<string, ThreadQueuedMessageState>;
   /** Identity key of the card to highlight as the open composer's source. */
   composerSourceThreadKey?: string;
+  /** Incremented when the thread title asks the active lens to reveal its row. */
+  revealSelectedThreadRequest?: number;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -224,6 +226,8 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const directoryContextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const handledRevealRequestRef = useRef(0);
+  const [directoryRevealRequest, setDirectoryRevealRequest] = useState(0);
   const [contextMenu, setContextMenu] = useState<
     | {
         requestedPosition: ThreadContextMenuPosition;
@@ -296,6 +300,72 @@ export function Sidebar(props: SidebarProps) {
     props.browseMode === "recents"
       ? props.recentThreads ?? props.threads
       : props.inboxThreads ?? props.threads;
+  const revealSelectedThreadRequest = props.revealSelectedThreadRequest;
+  const selectedItemKey = props.selectedItemKey;
+  const navigationThreads = props.threads;
+  const setSubthreadsCollapsed = props.onSetSubthreadsCollapsed;
+  const browseMode = props.browseMode;
+
+  useEffect(() => {
+    const request = revealSelectedThreadRequest ?? 0;
+    if (request <= handledRevealRequestRef.current || !selectedItemKey) {
+      return;
+    }
+
+    const threadByKey = new Map(
+      navigationThreads.map((thread) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread,
+      ]),
+    );
+    const selectedThread = threadByKey.get(selectedItemKey);
+    if (!selectedThread) {
+      return;
+    }
+    handledRevealRequestRef.current = request;
+    if (browseMode === "directories") {
+      setDirectoryRevealRequest(request);
+    }
+
+    // Child rows are shared by every thread lens. Open each collapsed parent
+    // in the selected thread's ancestry here, while DirectoriesList handles
+    // its additional directory-only disclosures below.
+    const visited = new Set<string>();
+    let current = selectedThread;
+    while (current.parentThreadId) {
+      const parentKey = buildThreadIdentityKey(
+        current.source,
+        current.parentThreadId,
+      );
+      if (visited.has(parentKey)) {
+        break;
+      }
+      visited.add(parentKey);
+      const parent = threadByKey.get(parentKey);
+      if (!parent) {
+        break;
+      }
+      if (parent.subthreadsCollapsed === true) {
+        void setSubthreadsCollapsed?.(parent, false);
+      }
+      current = parent;
+    }
+  }, [
+    browseMode,
+    navigationThreads,
+    revealSelectedThreadRequest,
+    selectedItemKey,
+    setSubthreadsCollapsed,
+  ]);
+
+  useEffect(() => {
+    // DirectoriesList unmounts when another lens is active. Clear its event
+    // nonce on the way out so remounting the lens later cannot replay a title
+    // click that was already handled in an earlier view.
+    if (browseMode !== "directories" && directoryRevealRequest !== 0) {
+      setDirectoryRevealRequest(0);
+    }
+  }, [browseMode, directoryRevealRequest]);
 
   useEffect(() => {
     if (!copiedRuntimeValue) {
@@ -946,6 +1016,7 @@ export function Sidebar(props: SidebarProps) {
               queuedMessageThreadKeys={props.queuedMessageThreadKeys}
               composerSourceThreadKey={props.composerSourceThreadKey}
               directories={props.directories}
+              revealSelectedThreadRequest={directoryRevealRequest}
               selectedItemKey={props.selectedItemKey}
               thinkingThreadKeys={props.thinkingThreadKeys}
               threads={props.threads}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -95,6 +95,7 @@ type SidebarProps = {
   composerSourceThreadKey?: string;
   /** Incremented when the thread title asks the active lens to reveal its row. */
   revealSelectedThreadRequest?: number;
+  onRevealSelectedThreadComplete?: (request: number) => void;
   selectedItemKey?: string;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -1023,6 +1024,9 @@ export function Sidebar(props: SidebarProps) {
               onOpenThreadContextMenu={openThreadContextMenu}
               onOpenLaunchpad={props.onOpenLaunchpad}
               onPrefetchPullRequests={props.onPrefetchPullRequests}
+              onRevealSelectedThreadComplete={
+                props.onRevealSelectedThreadComplete
+              }
               onDetachPullRequest={detachPullRequest}
               onReorderThreadPins={props.onReorderThreadPins}
               onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}
@@ -1050,12 +1054,16 @@ export function Sidebar(props: SidebarProps) {
                 inputRequestThreadKeys={props.inputRequestThreadKeys}
                 queuedMessageThreadKeys={props.queuedMessageThreadKeys}
                 composerSourceThreadKey={props.composerSourceThreadKey}
+                revealSelectedThreadRequest={revealSelectedThreadRequest}
                 selectedThreadKey={props.selectedItemKey}
                 thinkingThreadKeys={props.thinkingThreadKeys}
                 threads={visibleThreads}
                 onOpenThreadContextMenu={openThreadContextMenu}
                 onOpenPullRequestContextMenu={openPullRequestContextMenu}
                 onPrefetchPullRequests={props.onPrefetchPullRequests}
+                onRevealSelectedThreadComplete={
+                  props.onRevealSelectedThreadComplete
+                }
                 onDetachPullRequest={detachPullRequest}
                 onReorderThreadPins={props.onReorderThreadPins}
                 onUpdateSubthreadOrder={props.onUpdateSubthreadOrder}

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -52,6 +52,7 @@ type ThreadRowProps = {
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   nested?: boolean;
+  revealSelectedThreadRequest?: number;
   selectedThreadKey?: string;
   subthreadCount?: number;
   subthreadsCollapsed?: boolean;
@@ -86,6 +87,7 @@ type ThreadRowProps = {
     binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
+  onRevealSelectedThreadComplete?: (request: number) => void;
   onToggleSubthreads?: () => void;
   onDragStartThread?: (event: DragEvent<HTMLDivElement>) => void;
   onDragOverThread?: (event: DragEvent<HTMLDivElement>) => void;
@@ -112,6 +114,10 @@ export function ThreadRow(props: ThreadRowProps) {
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
   const [pickerOpen, setPickerOpen] = useState(false);
   const rowButtonRef = useRef<HTMLButtonElement>(null);
+  const completedRevealRequestRef = useRef(0);
+  const revealSelectedThreadRequest = props.revealSelectedThreadRequest ?? 0;
+  const onRevealSelectedThreadComplete =
+    props.onRevealSelectedThreadComplete;
   const addReactionRef = useRef<HTMLSpanElement>(null);
   const reactions = props.thread.reactions ?? [];
   const canReact = Boolean(props.onSetReaction);
@@ -146,6 +152,23 @@ export function ThreadRow(props: ThreadRowProps) {
       block: "nearest",
     });
   }, [selected, threadKey]);
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+
+    if (
+      revealSelectedThreadRequest > completedRevealRequestRef.current
+      && onRevealSelectedThreadComplete
+    ) {
+      completedRevealRequestRef.current = revealSelectedThreadRequest;
+      onRevealSelectedThreadComplete(revealSelectedThreadRequest);
+    }
+  }, [
+    onRevealSelectedThreadComplete,
+    revealSelectedThreadRequest,
+    selected,
+  ]);
   const armHoverPrefetch = (): void => {
     if (!props.onPrefetchPullRequests) return;
     if (hoverTimerRef.current !== undefined) return;

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -367,6 +367,118 @@ describe("Sidebar", () => {
     }
   });
 
+  it("reveals a selected child through collapsed directory and parent disclosures", async () => {
+    const { scrollIntoView, restore } = withMockScrollIntoView();
+    const onSetDirectoryThreadsCollapsed = vi.fn(async () => undefined);
+    const onSetSubthreadsCollapsed = vi.fn(async () => undefined);
+    const pinnedThread: NavigationThreadSummary = {
+      ...updatedSinceSeenThread,
+      pinnedRank: "1024",
+    };
+    const parentThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-parent",
+      title: "Collapsed parent thread",
+      subthreadsCollapsed: true,
+    };
+    const childThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "thread-child",
+      title: "Hidden selected child",
+      parentThreadId: parentThread.id,
+    };
+    const collapsedDirectory: NavigationDirectorySummary = {
+      ...directories[0]!,
+      directoryThreadsCollapsed: true,
+      threadKeys: [
+        "codex:thread-updated",
+        "codex:thread-parent",
+        "codex:thread-child",
+      ],
+    };
+    const renderSidebar = (params: {
+      directoryThreadsCollapsed: boolean;
+      subthreadsCollapsed: boolean;
+    }) => (
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[
+          {
+            ...collapsedDirectory,
+            directoryThreadsCollapsed: params.directoryThreadsCollapsed,
+          },
+        ]}
+        inboxThreads={[pinnedThread, parentThread, childThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        revealSelectedThreadRequest={1}
+        selectedItemKey="codex:thread-child"
+        threads={[
+          pinnedThread,
+          {
+            ...parentThread,
+            subthreadsCollapsed: params.subthreadsCollapsed,
+          },
+          childThread,
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetDirectoryThreadsCollapsed={onSetDirectoryThreadsCollapsed}
+        onSetSubthreadsCollapsed={onSetSubthreadsCollapsed}
+      />
+    );
+
+    try {
+      const { rerender } = render(
+        renderSidebar({
+          directoryThreadsCollapsed: true,
+          subthreadsCollapsed: true,
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: "Show directory threads for PwrAgent",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Hidden selected child" }),
+      ).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(onSetDirectoryThreadsCollapsed).toHaveBeenCalledWith(
+          expect.objectContaining({ key: collapsedDirectory.key }),
+          false,
+        );
+        expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(
+          expect.objectContaining({ id: parentThread.id }),
+          false,
+        );
+      });
+
+      scrollIntoView.mockClear();
+      rerender(
+        renderSidebar({
+          directoryThreadsCollapsed: false,
+          subthreadsCollapsed: false,
+        }),
+      );
+
+      expect(
+        await screen.findByRole("button", { name: "Hidden selected child" }),
+      ).toBeInTheDocument();
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("reveals a selected thread after its directory membership refreshes", async () => {
     const { scrollIntoView, restore } = withMockScrollIntoView();
     const refreshedThread: NavigationThreadSummary = {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/useThreadJump.test.ts
@@ -94,6 +94,25 @@ describe("useThreadJump", () => {
     expect(setSidebarHidden).toHaveBeenCalledWith(true);
   });
 
+  it("keeps a peek open until an asynchronous selected-row reveal completes", () => {
+    const { hook, setSidebarHidden, sidebarHidden } = renderThreadJump(true);
+    act(() => hook.result.current.openJump());
+    setSidebarHidden.mockClear();
+
+    act(() => hook.result.current.deferPeekRestore());
+    act(() => hook.result.current.closeJump());
+    flushFrame();
+
+    expect(hook.result.current.open).toBe(false);
+    expect(sidebarHidden()).toBe(false);
+    expect(setSidebarHidden).not.toHaveBeenCalled();
+
+    act(() => hook.result.current.completePeekRestore());
+
+    expect(setSidebarHidden).toHaveBeenCalledWith(true);
+    expect(sidebarHidden()).toBe(true);
+  });
+
   it("reports the peek to callers before the popup's close clears it", () => {
     // App reads isPeeking() inside onJumpToThread to choose an instant scroll —
     // and the popup calls onJumpToThread BEFORE onClose, so the peek must still

--- a/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/useThreadJump.ts
@@ -19,6 +19,10 @@ export function useThreadJump(options: {
   open: boolean;
   openJump: () => void;
   closeJump: () => void;
+  /** Keep a peek laid out until an asynchronous selected-row reveal completes. */
+  deferPeekRestore: () => void;
+  /** Restore a deferred peek after the selected row has mounted and scrolled. */
+  completePeekRestore: () => void;
   /**
    * Whether the sidebar on screen right now is a peek — i.e. it's about to be
    * hidden again when the search closes. Callers that scroll the thread list on
@@ -41,6 +45,7 @@ export function useThreadJump(options: {
   const { sidebarHidden, setSidebarHidden } = options;
   const [open, setOpen] = useState(false);
   const peekedRef = useRef(false);
+  const peekRestoreDeferredRef = useRef(false);
 
   const openJump = useCallback(() => {
     if (sidebarHidden) {
@@ -55,6 +60,9 @@ export function useThreadJump(options: {
     if (!peekedRef.current) {
       return;
     }
+    if (peekRestoreDeferredRef.current) {
+      return;
+    }
     peekedRef.current = false;
     // Restore on the NEXT frame, not in this commit. Picking a thread closes the
     // popup and schedules a scroll-the-selected-row-into-view for that same
@@ -67,6 +75,21 @@ export function useThreadJump(options: {
     requestAnimationFrame(() => setSidebarHidden(true));
   }, [setSidebarHidden]);
 
+  const deferPeekRestore = useCallback(() => {
+    if (peekedRef.current) {
+      peekRestoreDeferredRef.current = true;
+    }
+  }, []);
+
+  const completePeekRestore = useCallback(() => {
+    if (!peekedRef.current || !peekRestoreDeferredRef.current) {
+      return;
+    }
+    peekRestoreDeferredRef.current = false;
+    peekedRef.current = false;
+    setSidebarHidden(true);
+  }, [setSidebarHidden]);
+
   const toggleJump = useCallback(() => {
     if (open) {
       closeJump();
@@ -77,9 +100,19 @@ export function useThreadJump(options: {
 
   const endPeek = useCallback(() => {
     peekedRef.current = false;
+    peekRestoreDeferredRef.current = false;
   }, []);
 
   const isPeeking = useCallback(() => peekedRef.current, []);
 
-  return { open, openJump, closeJump, isPeeking, toggleJump, endPeek };
+  return {
+    open,
+    openJump,
+    closeJump,
+    deferPeekRestore,
+    completePeekRestore,
+    isPeeking,
+    toggleJump,
+    endPeek,
+  };
 }


### PR DESCRIPTION
## Summary

- turn thread-title reveal into an explicit request that the active sidebar lens can handle
- expand collapsed parent sub-thread trays in every lens
- expand the outer directory, Directory threads disclosure, and overflow cap in the Directories lens before scrolling
- avoid replaying a handled reveal request after switching away from and back to Directories
- add unit coverage and a replay-backed Electron E2E regression

## Root cause

The title click queried for `.thread-row.is-selected` and called `scrollIntoView` directly. When a selected thread was hidden behind a collapsed directory section, its row was not mounted, so the query returned nothing and the click became a no-op.

## User impact

A thread focused from a transcript chip, history, search, notification, or another non-row navigation path can now be located from its title even when its sidebar row starts behind collapsed ancestors. PwrAgent opens every required disclosure and scrolls the selected row into the sidebar viewport.

## E2E regression

The new Playwright scenario was added and run before the production fix. It failed after the linked child was focused because `Hide directory threads for RevealFixture` never appeared: the persisted Directory threads disclosure stayed collapsed and the selected row never mounted.

The final scenario collapses all three relevant layers before the title click:

- the parent thread's sub-thread tray
- the Directory threads divider
- the outer directory row

It then verifies all layers reopen, the child row becomes selected and visible, and its bounding box is inside the sidebar scroll region.

## Validation

- `pnpm --filter @pwragent/desktop test:e2e e2e/thread-title-reveal.spec.ts`
- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (107 tests passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- headed Electron functional and visual QA at 1280×760, including a dense directory list and viewport-fit check
