### PR TITLE
fix(messaging): stabilize status card interactions

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5582,6 +5582,8 @@ describe("MessagingController", () => {
       },
     } satisfies AgentEvent);
 
+    expect(harness.delivered).toEqual([]);
+
     await harness.controller.handleInboundEvent(buildCommandEvent("/status"));
 
     const statusText = readDeliveredStatusText(harness.delivered.at(-1));
@@ -15913,6 +15915,79 @@ describe("MessagingController", () => {
       kind: "status",
       text: expect.stringContaining(
         "Responses: @mentions only (channel default)",
+      ),
+    });
+  });
+
+  it("preserves an active status child menu during automatic thread refreshes", async () => {
+    const harness = await createHarness({
+      responseModeForConversation: () => "mention_only",
+    });
+    const channel = buildTopicChannel("510");
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "bind:codex:thread-1",
+        channel,
+        value: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:response-mode",
+        channel,
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "single_select",
+      prompt: expect.stringContaining("Responses"),
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: "thread-1",
+          executionMode: "full-access",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([]);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "running",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "status"),
+    ).toEqual([]);
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "status:set-response-mode",
+        channel,
+        value: { responseMode: "every_message" },
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "status",
+      text: expect.stringContaining(
+        "Responses: every message (binding override)",
       ),
     });
   });

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5540,6 +5540,97 @@ describe("MessagingController", () => {
     });
   });
 
+  it("clears an active status child interaction when /status recreates the card", async () => {
+    const harness = await createHarness();
+    const statusEvent = buildCommandEvent("/status");
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:tool-updates" }),
+    );
+    await expect(
+      harness.store.findActivePendingIntentForChannel({
+        actorId: statusEvent.actor.platformUserId,
+        channel: statusEvent.channel,
+        now: 1000,
+      }),
+    ).resolves.toMatchObject({
+      bindingId: expect.any(String),
+      intent: { kind: "single_select" },
+    });
+
+    await harness.controller.handleInboundEvent(statusEvent);
+
+    await expect(
+      harness.store.findActivePendingIntentForChannel({
+        actorId: statusEvent.actor.platformUserId,
+        channel: statusEvent.channel,
+        now: 1000,
+      }),
+    ).resolves.toBeUndefined();
+    const recreatedBinding = await harness.store.findActiveBindingForChannel(
+      statusEvent.channel,
+    );
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: "thread-1",
+          executionMode: "full-access",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        targetSurface: recreatedBinding?.statusSurface,
+      }),
+    ]);
+  });
+
+  it("ignores a pending status interaction that no longer owns the current surface", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "status:tool-updates" }),
+    );
+    const binding = await harness.store.findActiveBindingForChannel(
+      buildCommandEvent("/status").channel,
+    );
+    expect(binding).toBeDefined();
+    const replacementSurface = {
+      channel: "telegram" as const,
+      id: "surface:replacement-status",
+    };
+    await harness.store.upsertBinding({
+      ...binding!,
+      statusSurface: replacementSurface,
+      updatedAt: 1001,
+    });
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/executionMode/updated",
+        params: {
+          threadId: "thread-1",
+          executionMode: "full-access",
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        kind: "status",
+        targetSurface: replacementSurface,
+      }),
+    ]);
+  });
+
   it("passes Codex backend metadata through to rendered status cards", async () => {
     const harness = await createHarness({
       listBackends: async () => ({

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -998,6 +998,7 @@ export class MessagingController {
     }
     if (event.notification.method === "thread/tokenUsage/updated") {
       this.rememberContextUsageSummary(event);
+      return;
     }
     if (event.notification.method === "serverRequest/resolved") {
       await this.handleBackendRequestResolved(event);
@@ -1027,7 +1028,6 @@ export class MessagingController {
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
       event.notification.method === "thread/codexEnvironment/updated" ||
-      event.notification.method === "thread/tokenUsage/updated" ||
       event.notification.method === "thread/parent/set" ||
       event.notification.method === "thread/parent/cleared" ||
       event.notification.method === "thread/subthreadOrder/updated" ||
@@ -8826,18 +8826,42 @@ export class MessagingController {
     event: MessagingInboundEvent,
     binding: MessagingBindingRecord,
   ): Promise<void> {
-    const pendingIntent = await this.options.store.findActivePendingIntentForChannel({
-      actorId: event.actor.platformUserId,
-      channel: event.channel,
-      now: this.now(),
-    });
-    if (
-      pendingIntent &&
-      pendingIntent.bindingId === binding.id &&
-      !pendingIntent.intent.requestContext
-    ) {
+    while (true) {
+      const pendingIntent =
+        await this.options.store.findActivePendingIntentForChannel({
+          actorId: event.actor.platformUserId,
+          channel: event.channel,
+          now: this.now(),
+        });
+      if (
+        !pendingIntent ||
+        pendingIntent.bindingId !== binding.id ||
+        pendingIntent.intent.requestContext
+      ) {
+        return;
+      }
       await this.options.store.deletePendingIntent(pendingIntent.id);
     }
+  }
+
+  private async hasActiveBindingSubmodeIntent(
+    binding: MessagingBindingRecord,
+  ): Promise<boolean> {
+    for (const actorId of binding.authorizedActorIds) {
+      const pendingIntent =
+        await this.options.store.findActivePendingIntentForChannel({
+          actorId,
+          channel: binding.channel,
+          now: this.now(),
+        });
+      if (
+        pendingIntent?.bindingId === binding.id &&
+        !pendingIntent.intent.requestContext
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async dismissActiveSkillsWorkflow(
@@ -10130,6 +10154,7 @@ export class MessagingController {
         return;
       }
       if (binding.statusSurface || binding.pinnedStatusSurface) {
+        await this.clearActiveBindingSubmodeIntent(event, binding);
         await this.renderBindingStatus(binding, event);
         return;
       }
@@ -10263,6 +10288,7 @@ export class MessagingController {
       executionMode: "full-access",
       permissionsMode: "full-access",
     });
+    await this.clearActiveBindingSubmodeIntent(event, binding);
     await this.options.backend.setThreadExecutionMode?.({
       backend: binding.backend,
       threadId: escalationContext.threadId,
@@ -11245,6 +11271,13 @@ export class MessagingController {
     event?: MessagingInboundEvent,
     navigation?: NavigationSnapshot,
   ): Promise<MessagingBindingRecord> {
+    if (!event && await this.hasActiveBindingSubmodeIntent(binding)) {
+      this.logger.debug?.("messaging deferred automatic status refresh during active interaction", {
+        bindingId: binding.id,
+        threadId: binding.threadId,
+      });
+      return await this.options.store.getBinding(binding.id) ?? binding;
+    }
     const snapshot =
       navigation ??
       (await this.options.backend.getNavigationSnapshot({

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -8847,6 +8847,10 @@ export class MessagingController {
   private async hasActiveBindingSubmodeIntent(
     binding: MessagingBindingRecord,
   ): Promise<boolean> {
+    const statusSurface = binding.statusSurface ?? binding.pinnedStatusSurface;
+    if (!statusSurface) {
+      return false;
+    }
     for (const actorId of binding.authorizedActorIds) {
       const pendingIntent =
         await this.options.store.findActivePendingIntentForChannel({
@@ -8856,7 +8860,9 @@ export class MessagingController {
         });
       if (
         pendingIntent?.bindingId === binding.id &&
-        !pendingIntent.intent.requestContext
+        !pendingIntent.intent.requestContext &&
+        pendingIntent.surface?.channel === statusSurface.channel &&
+        pendingIntent.surface.id === statusSurface.id
       ) {
         return true;
       }
@@ -11142,6 +11148,7 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     event: MessagingInboundEvent,
   ): Promise<MessagingBindingRecord> {
+    await this.clearActiveBindingSubmodeIntent(event, binding);
     const snapshot = await this.options.backend.getNavigationSnapshot({
       backend: "all",
     });


### PR DESCRIPTION
## What changed

- remember `thread/tokenUsage/updated` context data without editing bound status cards for every token event
- defer automatic status-card renders while a persisted binding child interaction still owns the current card surface
- clear stacked status submode intents when an interaction completes or `/status` recreates the parent card
- preserve the existing Full Access accept/cancel restoration behavior under the new interaction guard

## Root cause

Token-usage notifications were routed through the same status-surface refresh path as durable thread-setting changes. Separately, automatic backend renders did not consult the pending child-menu state that the controller had already persisted, so token, lifecycle, or cross-surface events could replace the menu while the operator was choosing an option.

The first interaction guard also trusted any unexpired binding submode record. A `/status` card recreation could therefore replace the menu while leaving its 30-day pending record behind. The guard now requires the pending intent's delivered surface to match the binding's current status surface, and `/status` explicitly retires the replaced interaction.

## Impact

Bound messaging status cards now follow the intended low-churn cadence: token updates do not edit the card, while turn lifecycle and durable setting changes still refresh it when no operator interaction is in progress. An open child menu remains stable until the operator completes, cancels, or explicitly refreshes it, and replaced menus cannot leave the parent card stale.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` (303 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
