### PR TITLE
fix(desktop): auto-pin externally created hidden threads

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -164,6 +164,7 @@ const reconcileNavigationSnapshot = vi.fn(async (params: unknown) => ({
     executionMode: "default" as const,
   },
 }));
+const rememberCompleteNavigationSnapshot = vi.fn();
 const readDirectoryStatuses = vi.fn(async () => ({
   "directory:/repo/app": {
     currentBranch: "main",
@@ -504,6 +505,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setThreadPullRequestStatusToolHandler,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
+    rememberCompleteNavigationSnapshot,
   }),
 }));
 
@@ -533,6 +535,7 @@ describe("app server ipc", () => {
     listThreads.mockClear();
     readThread.mockClear();
     reconcileNavigationSnapshot.mockClear();
+    rememberCompleteNavigationSnapshot.mockClear();
     readDirectoryStatuses.mockClear();
     readDirectoryStatusEntries.mockClear();
     readDirectoryGitStatusCache.mockClear();
@@ -619,6 +622,7 @@ describe("app server ipc", () => {
         path.join(os.homedir(), ".pwragnt", "projects"),
       ],
     });
+    expect(rememberCompleteNavigationSnapshot).toHaveBeenCalledWith(response);
     expect(response).toEqual({
       backend: "all",
       fetchedAt: 1234,
@@ -669,6 +673,7 @@ describe("app server ipc", () => {
       maxPages: 1,
       skipArchivedMetadataRefresh: true,
     });
+    expect(rememberCompleteNavigationSnapshot).not.toHaveBeenCalled();
   });
 
   it("merges lightweight navigation refreshes into the last full thread list", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -31,7 +31,6 @@ import type {
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
   DesktopProviderThreadModelMigration,
-  DirectoryOverlayState,
   LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -265,7 +264,6 @@ async function expectEventually<T>(
 }
 
 function createOverlayStoreMock(params?: {
-  directoryOverlays?: Record<string, DirectoryOverlayState>;
   executionMode?: "default" | "full-access";
   launchpadDefaults?: NavigationLaunchpadDefaults;
   overlays?: Record<string, ThreadOverlayState>;
@@ -280,9 +278,6 @@ function createOverlayStoreMock(params?: {
     : undefined;
   const overlays = new Map<string, ThreadOverlayState>(
     Object.entries(params?.overlays ?? {})
-  );
-  const directoryOverlays = new Map<string, DirectoryOverlayState>(
-    Object.entries(params?.directoryOverlays ?? {}),
   );
   const usageLines = new Map<string, ThreadUsageLineRecord>();
   const messageOrigins = new Map<string, AppServerThreadMessageOrigin>();
@@ -596,41 +591,6 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
-    getDirectoryOverlayState: async ({
-      directoryKey,
-    }: {
-      directoryKey: string;
-    }) => directoryOverlays.get(directoryKey),
-    readAllDirectoryOverlays: async () =>
-      Object.fromEntries(directoryOverlays),
-    reconcileNavigationSnapshot: async ({
-      backend,
-      fetchedAt,
-      threads,
-      workspaceRoots,
-    }: {
-      backend: "all" | AppServerBackendKind;
-      fetchedAt: number;
-      threads: AppServerThreadSummary[];
-      workspaceRoots?: string[];
-    }) => buildNavigationSnapshot({
-      backend,
-      fetchedAt,
-      firstSnapshot: false,
-      directoryOverlayByKey: Object.fromEntries(directoryOverlays),
-      overlayByThreadKey: Object.fromEntries(
-        threads.map((thread) => [
-          buildThreadIdentityKey(thread.source, thread.id),
-          overlays.get(buildThreadIdentityKey(thread.source, thread.id)),
-        ]),
-      ),
-      previousKnownThreadKeys: threads.map((thread) =>
-        buildThreadIdentityKey(thread.source, thread.id),
-      ),
-      threads,
-      unchanged: false,
-      workspaceRoots,
-    }),
     updateSubthreadOrder: async ({
       backend,
       parentThreadId,
@@ -1989,6 +1949,54 @@ async function emitCompletedTurn(
       },
     },
   });
+}
+
+function rememberCollapsedDirectoryWithPinnedThread(params: {
+  directoryKey: string;
+  directoryPath: string;
+  registry: DesktopBackendRegistry;
+  threadId?: string;
+}): void {
+  const threadId = params.threadId ?? "thread-pinned";
+  params.registry.rememberCompleteNavigationSnapshot(buildNavigationSnapshot({
+    backend: "all",
+    fetchedAt: 1_000,
+    firstSnapshot: false,
+    directoryOverlayByKey: {
+      [params.directoryKey]: {
+        directoryKey: params.directoryKey,
+        directoryThreadsCollapsed: true,
+      },
+    },
+    overlayByThreadKey: {
+      [`codex:${threadId}`]: {
+        backend: "codex",
+        threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        pinnedRank: "1024",
+      },
+    },
+    previousKnownThreadKeys: [`codex:${threadId}`],
+    threads: [
+      {
+        id: threadId,
+        title: "Pinned thread",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [
+          {
+            id: params.directoryKey,
+            kind: "local",
+            label: "project",
+            path: params.directoryPath,
+          },
+        ],
+        updatedAt: 1_000,
+      },
+    ],
+    unchanged: false,
+  }));
 }
 
 describe("DesktopBackendRegistry", () => {
@@ -4649,7 +4657,9 @@ describe("DesktopBackendRegistry", () => {
   });
 
   it("auto-pins a top-level thread created through the shared launchpad materialization path", async () => {
-    const directoryPath = "/repo/project";
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-project"),
+    );
     const directoryKey = `directory:${directoryPath}`;
     const linkedDirectory = {
       id: directoryKey,
@@ -4658,12 +4668,6 @@ describe("DesktopBackendRegistry", () => {
       path: directoryPath,
     };
     const overlayStore = createOverlayStoreMock({
-      directoryOverlays: {
-        [directoryKey]: {
-          directoryKey,
-          directoryThreadsCollapsed: true,
-        },
-      },
       overlays: {
         "codex:thread-pinned": {
           backend: "codex",
@@ -4674,19 +4678,21 @@ describe("DesktopBackendRegistry", () => {
         },
       },
     });
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-pinned",
+          title: "Pinned thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+      ],
+    });
+    const listThreads = vi.spyOn(codexClient, "listThreads");
     const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({
-        threads: [
-          {
-            id: "thread-pinned",
-            title: "Pinned thread",
-            titleSource: "explicit",
-            source: "codex",
-            linkedDirectories: [linkedDirectory],
-            updatedAt: 1_000,
-          },
-        ],
-      }),
+      codexClient,
       grokClient: new MockBackendClient({ threads: [] }),
       overlayStore,
       gitDirectoryService: {
@@ -4695,6 +4701,11 @@ describe("DesktopBackendRegistry", () => {
           workMode: "local" as const,
         })),
       } as never,
+    });
+    rememberCollapsedDirectoryWithPinnedThread({
+      directoryKey,
+      directoryPath,
+      registry,
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {
@@ -4738,12 +4749,70 @@ describe("DesktopBackendRegistry", () => {
         },
       },
     });
+    expect(listThreads).not.toHaveBeenCalled();
+
+    await registry.close();
+  });
+
+  it("reports an automatic visibility pin failure to the creation caller", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-failure-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const overlayStore = createOverlayStoreMock();
+    overlayStore.setThreadPin = vi.fn(async () => {
+      throw new Error("state database is unavailable");
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: directoryPath,
+          workMode: "local" as const,
+        })),
+      } as never,
+    });
+    rememberCollapsedDirectoryWithPinnedThread({
+      directoryKey,
+      directoryPath,
+      registry,
+    });
+
+    const response = await registry.materializeDirectoryLaunchpad({
+      directoryKey,
+      launchpad: {
+        directoryKey,
+        directoryKind: "directory",
+        directoryLabel: "project",
+        directoryPath,
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      autoPinFailure: {
+        message:
+          "The new thread was created, but it could not be pinned automatically: state database is unavailable",
+      },
+    });
+    expect(response).not.toHaveProperty("pinnedRank");
 
     await registry.close();
   });
 
   it("does not redundantly auto-pin a child of a pinned parent", async () => {
-    const directoryPath = "/repo/project";
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-child-project"),
+    );
     const directoryKey = `directory:${directoryPath}`;
     const linkedDirectory = {
       id: directoryKey,
@@ -4752,12 +4821,6 @@ describe("DesktopBackendRegistry", () => {
       path: directoryPath,
     };
     const overlayStore = createOverlayStoreMock({
-      directoryOverlays: {
-        [directoryKey]: {
-          directoryKey,
-          directoryThreadsCollapsed: true,
-        },
-      },
       overlays: {
         "codex:thread-pinned": {
           backend: "codex",
@@ -4783,6 +4846,11 @@ describe("DesktopBackendRegistry", () => {
       }),
       grokClient: new MockBackendClient({ threads: [] }),
       overlayStore,
+    });
+    rememberCollapsedDirectoryWithPinnedThread({
+      directoryKey,
+      directoryPath,
+      registry,
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -31,6 +31,7 @@ import type {
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
   DesktopProviderThreadModelMigration,
+  DirectoryOverlayState,
   LinkedDirectorySummary,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -264,6 +265,7 @@ async function expectEventually<T>(
 }
 
 function createOverlayStoreMock(params?: {
+  directoryOverlays?: Record<string, DirectoryOverlayState>;
   executionMode?: "default" | "full-access";
   launchpadDefaults?: NavigationLaunchpadDefaults;
   overlays?: Record<string, ThreadOverlayState>;
@@ -278,6 +280,9 @@ function createOverlayStoreMock(params?: {
     : undefined;
   const overlays = new Map<string, ThreadOverlayState>(
     Object.entries(params?.overlays ?? {})
+  );
+  const directoryOverlays = new Map<string, DirectoryOverlayState>(
+    Object.entries(params?.directoryOverlays ?? {}),
   );
   const usageLines = new Map<string, ThreadUsageLineRecord>();
   const messageOrigins = new Map<string, AppServerThreadMessageOrigin>();
@@ -568,6 +573,64 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadPin: async ({
+      backend,
+      threadId,
+      pinnedRank,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      pinnedRank?: string | null;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = {
+        ...current,
+        pinnedRank: pinnedRank?.trim() || undefined,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
+    getDirectoryOverlayState: async ({
+      directoryKey,
+    }: {
+      directoryKey: string;
+    }) => directoryOverlays.get(directoryKey),
+    readAllDirectoryOverlays: async () =>
+      Object.fromEntries(directoryOverlays),
+    reconcileNavigationSnapshot: async ({
+      backend,
+      fetchedAt,
+      threads,
+      workspaceRoots,
+    }: {
+      backend: "all" | AppServerBackendKind;
+      fetchedAt: number;
+      threads: AppServerThreadSummary[];
+      workspaceRoots?: string[];
+    }) => buildNavigationSnapshot({
+      backend,
+      fetchedAt,
+      firstSnapshot: false,
+      directoryOverlayByKey: Object.fromEntries(directoryOverlays),
+      overlayByThreadKey: Object.fromEntries(
+        threads.map((thread) => [
+          buildThreadIdentityKey(thread.source, thread.id),
+          overlays.get(buildThreadIdentityKey(thread.source, thread.id)),
+        ]),
+      ),
+      previousKnownThreadKeys: threads.map((thread) =>
+        buildThreadIdentityKey(thread.source, thread.id),
+      ),
+      threads,
+      unchanged: false,
+      workspaceRoots,
+    }),
     updateSubthreadOrder: async ({
       backend,
       parentThreadId,
@@ -4579,6 +4642,182 @@ describe("DesktopBackendRegistry", () => {
       executionMode: "default",
       acpRuntime: expect.objectContaining({
         configValues: expect.objectContaining({ mode: "auto" }),
+      }),
+    });
+
+    await registry.close();
+  });
+
+  it("auto-pins a top-level thread created through the shared launchpad materialization path", async () => {
+    const directoryPath = "/repo/project";
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const overlayStore = createOverlayStoreMock({
+      directoryOverlays: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+      gitDirectoryService: {
+        prepareLaunchpadWorkspace: vi.fn(async () => ({
+          cwd: directoryPath,
+          workMode: "local" as const,
+        })),
+      } as never,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const response = await registry.materializeDirectoryLaunchpad({
+      directoryKey,
+      launchpad: {
+        directoryKey,
+        directoryKind: "directory",
+        directoryLabel: "project",
+        directoryPath,
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        createdAt: 1_000,
+        updatedAt: 2_000,
+      },
+    });
+
+    expect(response).toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      pinnedRank: "2048",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({ pinnedRank: "2048" });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/pin/added",
+        params: {
+          threadId: "thread-1",
+          pinnedRank: "2048",
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("does not redundantly auto-pin a child of a pinned parent", async () => {
+    const directoryPath = "/repo/project";
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const overlayStore = createOverlayStoreMock({
+      directoryOverlays: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned parent",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-pinned",
+    });
+
+    expect(response).not.toHaveProperty("pinnedRank");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "thread-pinned",
+    });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/parent/set",
+        params: {
+          threadId: "thread-1",
+          parentThreadId: "thread-pinned",
+        },
+      },
+    });
+    expect(events).not.toContainEqual({
+      backend: "codex",
+      notification: expect.objectContaining({
+        method: "thread/pin/added",
       }),
     });
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -19,6 +19,7 @@ import { requestShowThread } from "../window-show-thread";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
   type AcpBackendId,
+  buildAppendPinRank,
   buildThreadMarkdownLink,
   buildThreadUrl,
   estimateTokenUsageCost,
@@ -298,7 +299,10 @@ import {
   type AgentToolMcpServerLike,
   type ResolvedAgentToolMcpCallContext,
 } from "../agent-tools/agent-tool-mcp-server";
-import { createScratchProjectDirectory } from "./scratch-projects";
+import {
+  createScratchProjectDirectory,
+  resolveScratchProjectsRoots,
+} from "./scratch-projects";
 import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
@@ -8366,6 +8370,90 @@ export class DesktopBackendRegistry {
     });
   }
 
+  /**
+   * Keep a newly created top-level thread visible when its directory's
+   * unpinned section is collapsed. This runs after parent and directory
+   * relationships are persisted so every creation surface shares the same
+   * policy and a child of an already-visible parent is never pinned itself.
+   */
+  private async finalizeCreatedThreadVisibility(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<string | undefined> {
+    try {
+      const threads = await this.listThreads({
+        callerReason: "thread-visibility-finalization",
+      });
+      const snapshot = await this.overlayStore.reconcileNavigationSnapshot({
+        backend: "all",
+        fetchedAt: Date.now(),
+        threads,
+        workspaceRoots: resolveScratchProjectsRoots(),
+      });
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const thread = snapshot.threads.find(
+        (candidate) =>
+          candidate.source === params.backend &&
+          candidate.id === params.threadId,
+      );
+      if (!thread || thread.pinnedRank || thread.parentThreadId) {
+        return thread?.pinnedRank;
+      }
+
+      const directory = snapshot.directories.find((candidate) =>
+        candidate.threadKeys.includes(threadKey),
+      );
+      if (directory?.directoryThreadsCollapsed !== true) {
+        return undefined;
+      }
+
+      const threadsByKey = new Map(
+        snapshot.threads.map((candidate) => [
+          buildThreadIdentityKey(candidate.source, candidate.id),
+          candidate,
+        ]),
+      );
+      const hasPinnedTopLevelThread = directory.threadKeys.some(
+        (candidateKey) => {
+          const candidate = threadsByKey.get(candidateKey);
+          return Boolean(
+            candidate && !candidate.parentThreadId && candidate.pinnedRank,
+          );
+        },
+      );
+      if (!hasPinnedTopLevelThread) {
+        return undefined;
+      }
+
+      const pinnedRank = buildAppendPinRank(
+        snapshot.threads.map((candidate) => candidate.pinnedRank),
+      );
+      await this.overlayStore.setThreadPin({
+        backend: params.backend,
+        threadId: params.threadId,
+        pinnedRank,
+      });
+      await this.emit({
+        backend: params.backend,
+        notification: {
+          method: "thread/pin/added",
+          params: {
+            threadId: params.threadId,
+            pinnedRank,
+          },
+        },
+      });
+      return pinnedRank;
+    } catch (error) {
+      backendRegistryLog.warn("created thread visibility finalization failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+      return undefined;
+    }
+  }
+
   async startThread(params: {
     backend: AppServerBackendKind;
     executionMode?: ThreadExecutionMode;
@@ -8381,6 +8469,7 @@ export class DesktopBackendRegistry {
     workMode?: NavigationLaunchpadDraft["workMode"];
     branchName?: string;
     requiredWorkMode?: NavigationLaunchpadDraft["workMode"];
+    parentThreadId?: string;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
@@ -8392,6 +8481,7 @@ export class DesktopBackendRegistry {
       workMode,
       branchName,
       requiredWorkMode,
+      parentThreadId,
       ...request
     } = params;
     const modelSettings = await this.resolveModelSettings(backend, request);
@@ -8667,10 +8757,33 @@ export class DesktopBackendRegistry {
       });
     }
 
+    if (parentThreadId?.trim()) {
+      await this.overlayStore.setThreadParent?.({
+        backend,
+        threadId: result.threadId,
+        parentThreadId,
+      });
+      await this.emit({
+        backend,
+        notification: {
+          method: "thread/parent/set",
+          params: {
+            threadId: result.threadId,
+            parentThreadId,
+          },
+        },
+      });
+    }
+    const pinnedRank = await this.finalizeCreatedThreadVisibility({
+      backend,
+      threadId: result.threadId,
+    });
+
     return {
       backend,
       threadId: result.threadId,
       executionMode: effectiveExecutionMode,
+      ...(pinnedRank ? { pinnedRank } : {}),
       codexEnvironmentRuntime,
       codexEnvironmentStartupFailure,
     };
@@ -8947,12 +9060,17 @@ export class DesktopBackendRegistry {
       request.onPreparedWorkspaceRollback?.(undefined);
       throw error;
     }
+    const pinnedRank = await this.finalizeCreatedThreadVisibility({
+      backend,
+      threadId: result.threadId,
+    });
 
     return {
       backend,
       sourceThreadId: request.sourceThreadId,
       threadId: result.threadId,
       executionMode,
+      ...(pinnedRank ? { pinnedRank } : {}),
       linkedDirectory: linkedDirectories[0],
       workMode: preparedWorkspace.workMode,
       ...(gitBranch ? { gitBranch, observedGitBranch: gitBranch } : {}),
@@ -12775,29 +12893,13 @@ export class DesktopBackendRegistry {
       fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
       acpRuntime: launchpad.acpRuntime,
       codexEnvironmentRuntime,
+      parentThreadId: request.parentThreadId,
     });
     pendingActionThreadId = startThreadResponse.threadId;
     // The auto-started environment action spawned before this thread existed;
     // give its detached-process record an owner now so the quit dialog can name
     // it and link back here.
     attachDetachedCommandThreadId(autoActionRunId, startThreadResponse.threadId);
-    if (request.parentThreadId?.trim()) {
-      await this.overlayStore.setThreadParent?.({
-        backend: startThreadResponse.backend,
-        threadId: startThreadResponse.threadId,
-        parentThreadId: request.parentThreadId,
-      });
-      await this.emit({
-        backend: startThreadResponse.backend,
-        notification: {
-          method: "thread/parent/set",
-          params: {
-            threadId: startThreadResponse.threadId,
-            parentThreadId: request.parentThreadId,
-          },
-        },
-      });
-    }
     if (codexEnvironmentSelection?.action?.id) {
       for (const event of queuedActionDetachedOutputs) {
         void this.handleCodexEnvironmentActionDetachedOutput({
@@ -12829,6 +12931,9 @@ export class DesktopBackendRegistry {
       backend: startThreadResponse.backend,
       threadId: startThreadResponse.threadId,
       executionMode: startThreadResponse.executionMode,
+      ...(startThreadResponse.pinnedRank
+        ? { pinnedRank: startThreadResponse.pinnedRank }
+        : {}),
       ...(linkedDirectories?.[0] ? { linkedDirectory: linkedDirectories[0] } : {}),
       workMode: workspace.workMode,
       codexEnvironmentRuntime,
@@ -19174,18 +19279,12 @@ export class DesktopBackendRegistry {
           approvalPolicy: inheritedSettings.approvalPolicy,
           sandbox: inheritedSettings.sandbox,
           codexEnvironmentRuntime: inheritedSettings.codexEnvironmentRuntime,
+          parentThreadId: groupedParentThreadId,
         });
         threadId = started.threadId;
         this.updatePendingThreadHandoff(handoffId, { threadId });
         inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
-        if (groupedParentThreadId) {
-          await this.overlayStore.setThreadParent?.({
-            backend,
-            threadId,
-            parentThreadId: groupedParentThreadId,
-          });
-        }
       }
       if (groupedParentThreadId && this.overlayStore.updateSubthreadOrder) {
         const parentOverlay = await this.overlayStore.getThreadOverlayState({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -89,6 +89,7 @@ import {
   type NavigationDirectorySummary,
   type NavigationLaunchpadDraft,
   type NavigationLaunchpadDefaults,
+  type NavigationSnapshot,
   type ResetDirectoryLaunchpadRequest,
   type ResetDirectoryLaunchpadResponse,
   type RetainThreadBranchDriftRequest,
@@ -299,10 +300,7 @@ import {
   type AgentToolMcpServerLike,
   type ResolvedAgentToolMcpCallContext,
 } from "../agent-tools/agent-tool-mcp-server";
-import {
-  createScratchProjectDirectory,
-  resolveScratchProjectsRoots,
-} from "./scratch-projects";
+import { createScratchProjectDirectory } from "./scratch-projects";
 import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
@@ -4225,6 +4223,14 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
+type CreatedThreadDirectoryVisibility = Pick<
+  NavigationDirectorySummary,
+  "key" | "kind" | "path"
+> & {
+  directoryThreadsCollapsed: boolean;
+  hasPinnedTopLevelThread: boolean;
+};
+
 let threadListCacheSequence = 0;
 
 function shouldEnrichThreadDirectories(
@@ -5460,6 +5466,12 @@ export class DesktopBackendRegistry {
   private readonly codexEnvironmentHydrationStore?: CodexEnvironmentHydrationStoreLike;
   private readonly threadListCacheOwnerId = `backend-thread-list-cache-${++threadListCacheSequence}`;
   private readonly threadListCache = new Map<string, ThreadListCacheState>();
+  private createdThreadDirectoryVisibility = new Map<
+    string,
+    CreatedThreadDirectoryVisibility
+  >();
+  private createdThreadVisibilityPinnedRanks: string[] = [];
+  private readonly createdThreadVisibilityLock = new PerKeyAsyncLock();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
   private readonly pendingStartedThreads = new Map<string, AppServerThreadSummary>();
   private readonly pendingThreadHandoffs = new Map<string, PendingThreadHandoffSummary>();
@@ -6164,6 +6176,41 @@ export class DesktopBackendRegistry {
     handler: ThreadPullRequestStatusToolHandler | null | undefined,
   ): void {
     this.threadPullRequestStatusToolHandler = handler ?? undefined;
+  }
+
+  /**
+   * Remember only the visibility facts needed when a later creation finishes.
+   * Callers provide a complete, unfiltered snapshot; this intentionally does
+   * not advance overlay reconciliation state or retain the thread history.
+   */
+  rememberCompleteNavigationSnapshot(snapshot: NavigationSnapshot): void {
+    const threadsByKey = new Map(
+      snapshot.threads.map((thread) => [
+        buildThreadIdentityKey(thread.source, thread.id),
+        thread,
+      ]),
+    );
+    this.createdThreadVisibilityPinnedRanks = snapshot.threads
+      .map((thread) => thread.pinnedRank)
+      .filter((rank): rank is string => Boolean(rank));
+    this.createdThreadDirectoryVisibility = new Map(
+      snapshot.directories.map((directory) => [
+        directory.key,
+        {
+          key: directory.key,
+          kind: directory.kind,
+          path: directory.path,
+          directoryThreadsCollapsed:
+            directory.directoryThreadsCollapsed === true,
+          hasPinnedTopLevelThread: directory.threadKeys.some((threadKey) => {
+            const thread = threadsByKey.get(threadKey);
+            return Boolean(
+              thread && !thread.parentThreadId && thread.pinnedRank,
+            );
+          }),
+        },
+      ]),
+    );
   }
 
   async publishLocalEvent(event: AgentEvent): Promise<void> {
@@ -8376,88 +8423,119 @@ export class DesktopBackendRegistry {
    * relationships are persisted so every creation surface shares the same
    * policy and a child of an already-visible parent is never pinned itself.
    */
+  private resolveCreatedThreadDirectoryVisibility(params: {
+    directoryKey?: string;
+    cwd?: string;
+    linkedDirectories?: LinkedDirectorySummary[];
+  }): CreatedThreadDirectoryVisibility | undefined {
+    const explicitDirectory = params.directoryKey
+      ? this.createdThreadDirectoryVisibility.get(params.directoryKey)
+      : undefined;
+    if (explicitDirectory) {
+      return explicitDirectory;
+    }
+
+    const normalizePath = (value?: string): string | undefined => {
+      const normalized = value?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+      return normalized || undefined;
+    };
+    const candidatePaths = new Set(
+      [
+        ...(params.linkedDirectories ?? []).map((directory) => directory.path),
+        params.cwd,
+      ]
+        .map(normalizePath)
+        .filter((value): value is string => Boolean(value)),
+    );
+    const directories = [...this.createdThreadDirectoryVisibility.values()];
+    for (const candidatePath of candidatePaths) {
+      const exact = directories.find(
+        (directory) => normalizePath(directory.path) === candidatePath,
+      );
+      if (exact) {
+        return exact;
+      }
+    }
+
+    return directories
+      .filter((directory) => directory.kind === "workspace")
+      .sort(
+        (left, right) =>
+          (normalizePath(right.path)?.length ?? 0)
+          - (normalizePath(left.path)?.length ?? 0),
+      )
+      .find((directory) => {
+        const directoryPath = normalizePath(directory.path);
+        return Boolean(
+          directoryPath
+          && [...candidatePaths].some((candidatePath) =>
+            candidatePath.startsWith(`${directoryPath}/`),
+          ),
+        );
+      });
+  }
+
   private async finalizeCreatedThreadVisibility(params: {
     backend: AppServerBackendKind;
+    directoryKey?: string;
+    cwd?: string;
+    linkedDirectories?: LinkedDirectorySummary[];
+    parentThreadId?: string;
     threadId: string;
-  }): Promise<string | undefined> {
-    try {
-      const threads = await this.listThreads({
-        callerReason: "thread-visibility-finalization",
-      });
-      const snapshot = await this.overlayStore.reconcileNavigationSnapshot({
-        backend: "all",
-        fetchedAt: Date.now(),
-        threads,
-        workspaceRoots: resolveScratchProjectsRoots(),
-      });
-      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
-      const thread = snapshot.threads.find(
-        (candidate) =>
-          candidate.source === params.backend &&
-          candidate.id === params.threadId,
-      );
-      if (!thread || thread.pinnedRank || thread.parentThreadId) {
-        return thread?.pinnedRank;
-      }
-
-      const directory = snapshot.directories.find((candidate) =>
-        candidate.threadKeys.includes(threadKey),
-      );
-      if (directory?.directoryThreadsCollapsed !== true) {
-        return undefined;
-      }
-
-      const threadsByKey = new Map(
-        snapshot.threads.map((candidate) => [
-          buildThreadIdentityKey(candidate.source, candidate.id),
-          candidate,
-        ]),
-      );
-      const hasPinnedTopLevelThread = directory.threadKeys.some(
-        (candidateKey) => {
-          const candidate = threadsByKey.get(candidateKey);
-          return Boolean(
-            candidate && !candidate.parentThreadId && candidate.pinnedRank,
-          );
-        },
-      );
-      if (!hasPinnedTopLevelThread) {
-        return undefined;
-      }
-
-      const pinnedRank = buildAppendPinRank(
-        snapshot.threads.map((candidate) => candidate.pinnedRank),
-      );
-      await this.overlayStore.setThreadPin({
-        backend: params.backend,
-        threadId: params.threadId,
-        pinnedRank,
-      });
-      await this.emit({
-        backend: params.backend,
-        notification: {
-          method: "thread/pin/added",
-          params: {
-            threadId: params.threadId,
-            pinnedRank,
-          },
-        },
-      });
-      return pinnedRank;
-    } catch (error) {
-      backendRegistryLog.warn("created thread visibility finalization failed", {
-        backend: params.backend,
-        error: error instanceof Error ? error.message : String(error),
-        threadId: params.threadId,
-      });
-      return undefined;
+  }): Promise<Pick<StartThreadResponse, "pinnedRank" | "autoPinFailure">> {
+    if (params.parentThreadId?.trim()) {
+      return {};
     }
+
+    const directory = this.resolveCreatedThreadDirectoryVisibility(params);
+    if (
+      !directory?.directoryThreadsCollapsed
+      || !directory.hasPinnedTopLevelThread
+    ) {
+      return {};
+    }
+
+    return await this.createdThreadVisibilityLock.run("global-pin-order", async () => {
+      const pinnedRank = buildAppendPinRank(
+        this.createdThreadVisibilityPinnedRanks,
+      );
+      try {
+        await this.overlayStore.setThreadPin({
+          backend: params.backend,
+          threadId: params.threadId,
+          pinnedRank,
+        });
+        await this.emit({
+          backend: params.backend,
+          notification: {
+            method: "thread/pin/added",
+            params: {
+              threadId: params.threadId,
+              pinnedRank,
+            },
+          },
+        });
+        this.createdThreadVisibilityPinnedRanks.push(pinnedRank);
+        return { pinnedRank };
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        const message =
+          `The new thread was created, but it could not be pinned automatically: ${detail}`;
+        backendRegistryLog.warn("created thread visibility finalization failed", {
+          backend: params.backend,
+          error: detail,
+          threadId: params.threadId,
+        });
+        return { autoPinFailure: { message } };
+      }
+    });
   }
 
   async startThread(params: {
     backend: AppServerBackendKind;
     executionMode?: ThreadExecutionMode;
     cwd?: string;
+    directoryKey?: string;
     model?: string;
     approvalPolicy?: string;
     sandbox?: string;
@@ -8477,6 +8555,7 @@ export class DesktopBackendRegistry {
     const {
       backend,
       executionMode = "default",
+      directoryKey,
       linkedDirectories,
       workMode,
       branchName,
@@ -8774,8 +8853,15 @@ export class DesktopBackendRegistry {
         },
       });
     }
-    const pinnedRank = await this.finalizeCreatedThreadVisibility({
+    const visibilityFinalization = await this.finalizeCreatedThreadVisibility({
       backend,
+      directoryKey,
+      cwd,
+      linkedDirectories:
+        resolvedLinkedDirectories?.length
+          ? resolvedLinkedDirectories
+          : buildLocalLinkedDirectory(cwd),
+      parentThreadId,
       threadId: result.threadId,
     });
 
@@ -8783,7 +8869,7 @@ export class DesktopBackendRegistry {
       backend,
       threadId: result.threadId,
       executionMode: effectiveExecutionMode,
-      ...(pinnedRank ? { pinnedRank } : {}),
+      ...visibilityFinalization,
       codexEnvironmentRuntime,
       codexEnvironmentStartupFailure,
     };
@@ -9060,8 +9146,11 @@ export class DesktopBackendRegistry {
       request.onPreparedWorkspaceRollback?.(undefined);
       throw error;
     }
-    const pinnedRank = await this.finalizeCreatedThreadVisibility({
+    const visibilityFinalization = await this.finalizeCreatedThreadVisibility({
       backend,
+      cwd,
+      linkedDirectories,
+      parentThreadId: request.parentThreadId,
       threadId: result.threadId,
     });
 
@@ -9070,7 +9159,7 @@ export class DesktopBackendRegistry {
       sourceThreadId: request.sourceThreadId,
       threadId: result.threadId,
       executionMode,
-      ...(pinnedRank ? { pinnedRank } : {}),
+      ...visibilityFinalization,
       linkedDirectory: linkedDirectories[0],
       workMode: preparedWorkspace.workMode,
       ...(gitBranch ? { gitBranch, observedGitBranch: gitBranch } : {}),
@@ -12893,6 +12982,7 @@ export class DesktopBackendRegistry {
       fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
       acpRuntime: launchpad.acpRuntime,
       codexEnvironmentRuntime,
+      directoryKey: launchpad.directoryKey,
       parentThreadId: request.parentThreadId,
     });
     pendingActionThreadId = startThreadResponse.threadId;
@@ -12933,6 +13023,9 @@ export class DesktopBackendRegistry {
       executionMode: startThreadResponse.executionMode,
       ...(startThreadResponse.pinnedRank
         ? { pinnedRank: startThreadResponse.pinnedRank }
+        : {}),
+      ...(startThreadResponse.autoPinFailure
+        ? { autoPinFailure: startThreadResponse.autoPinFailure }
         : {}),
       ...(linkedDirectories?.[0] ? { linkedDirectory: linkedDirectories[0] } : {}),
       workMode: workspace.workMode,
@@ -19218,6 +19311,7 @@ export class DesktopBackendRegistry {
     let codexEnvironmentStartupFailure:
       | HandoffTaskResult["codexEnvironmentStartupFailure"]
       | undefined;
+    let autoPinFailure: HandoffTaskResult["autoPinFailure"];
     try {
       this.updatePendingThreadHandoff(handoffId, {
         phase: "preparing_workspace",
@@ -19257,6 +19351,7 @@ export class DesktopBackendRegistry {
         createdLinkedDirectory = forked.linkedDirectory;
         inheritedSettings.codexEnvironmentRuntime = forked.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = forked.codexEnvironmentStartupFailure;
+        autoPinFailure = forked.autoPinFailure;
         createdWorkspaceMode =
           forked.workMode === "worktree" ? "new_worktree" : workspaceMode;
       } else {
@@ -19285,6 +19380,7 @@ export class DesktopBackendRegistry {
         this.updatePendingThreadHandoff(handoffId, { threadId });
         inheritedSettings.codexEnvironmentRuntime = started.codexEnvironmentRuntime;
         codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
+        autoPinFailure = started.autoPinFailure;
       }
       if (groupedParentThreadId && this.overlayStore.updateSubthreadOrder) {
         const parentOverlay = await this.overlayStore.getThreadOverlayState({
@@ -19454,6 +19550,7 @@ export class DesktopBackendRegistry {
         ...(codexEnvironmentStartupFailure
           ? { codexEnvironmentStartupFailure }
           : {}),
+        ...(autoPinFailure ? { autoPinFailure } : {}),
         ...(turnStartFailure ? { turnStartFailure } : {}),
       },
     };

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1270,6 +1270,13 @@ class DesktopAppServerService {
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    if (
+      backend === "all"
+      && !request.filter?.trim()
+      && !activeRecentRefresh
+    ) {
+      getDesktopBackendRegistry().rememberCompleteNavigationSnapshot(snapshot);
+    }
     await this.loadPrStatusRegistry();
     await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -7720,6 +7720,7 @@ export class MessagingController {
     const started = materialized ?? (await this.options.backend.startThread!({
       backend: selectedBackend.kind,
       cwd: directory?.path ?? project.path,
+      directoryKey: directory?.key,
       executionMode: options.executionMode,
       fastMode: options.supportsFast ? options.fastMode : undefined,
       model: options.supportsModel ? options.model : undefined,

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -81,6 +81,13 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       threads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    if (
+      backend === "all"
+      && !request.filter?.trim()
+      && request.refreshMode !== "active-recent"
+    ) {
+      this.registry.rememberCompleteNavigationSnapshot(snapshot);
+    }
     const directoryStatuses = await this.registry.readDirectoryStatuses(
       snapshot.directories,
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2348,7 +2348,7 @@ describe("useThreadNavigation", () => {
     expect(setThreadPin).not.toHaveBeenCalled();
   });
 
-  it("auto-pins a new top-level thread when Directory threads are collapsed", async () => {
+  it("projects a centrally auto-pinned materialized thread without another pin write", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const existingPinnedThread = {
       id: "thread-pinned",
@@ -2401,6 +2401,7 @@ describe("useThreadNavigation", () => {
       threadId: "thread-new",
       executionMode: "default" as const,
       workMode: "worktree" as const,
+      pinnedRank: "2048",
     }));
     const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
       async (request) => ({
@@ -2425,149 +2426,11 @@ describe("useThreadNavigation", () => {
       await result.current.materializeDirectoryLaunchpad(directoryKey);
     });
 
-    expect(setThreadPin).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-new",
-      pinnedRank: "2048",
-    });
+    expect(setThreadPin).not.toHaveBeenCalled();
     expect(result.current.selectedThread).toMatchObject({
       id: "thread-new",
       pinnedRank: "2048",
     });
-  });
-
-  it("auto-pins a new top-level thread created outside the renderer when Directory threads are collapsed", async () => {
-    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
-    const listeners = new Set<
-      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
-    >();
-    let threadStarted = false;
-    let childThreadStarted = false;
-    const existingPinnedThread = {
-      id: "thread-pinned",
-      title: "Pinned thread",
-      titleSource: "explicit" as const,
-      source: "codex" as const,
-      linkedDirectories: [],
-      inbox: { inInbox: true },
-      executionMode: "default" as const,
-      updatedAt: 1,
-      pinnedRank: "1024",
-    };
-    const newThread = {
-      id: "thread-new",
-      title: "Thread created by handoff",
-      titleSource: "explicit" as const,
-      source: "codex" as const,
-      linkedDirectories: [],
-      inbox: { inInbox: true, reason: "new-thread" as const },
-      executionMode: "default" as const,
-      updatedAt: 2,
-    };
-    const newChildThread = {
-      ...newThread,
-      id: "thread-child",
-      title: "Child thread created by handoff",
-      parentThreadId: "thread-pinned",
-      updatedAt: 3,
-    };
-    const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({
-      backend: "all",
-      fetchedAt: Date.now(),
-      unchanged: false,
-      inboxThreadKeys: childThreadStarted
-        ? ["codex:thread-child", "codex:thread-new", "codex:thread-pinned"]
-        : threadStarted
-          ? ["codex:thread-new", "codex:thread-pinned"]
-          : ["codex:thread-pinned"],
-      threads: threadStarted
-        ? [
-            ...(childThreadStarted ? [newChildThread] : []),
-            newThread,
-            existingPinnedThread,
-          ]
-        : [existingPinnedThread],
-      directories: [
-        {
-          key: directoryKey,
-          kind: "directory",
-          label: "PwrAgent",
-          path: "/Users/huntharo/github/PwrAgent",
-          threadKeys: threadStarted
-            ? [
-                "codex:thread-pinned",
-                "codex:thread-new",
-                ...(childThreadStarted ? ["codex:thread-child"] : []),
-              ]
-            : ["codex:thread-pinned"],
-          needsAttentionCount: childThreadStarted ? 2 : threadStarted ? 1 : 0,
-          directoryThreadsCollapsed: true,
-        },
-      ],
-      launchpadDefaults: {
-        backend: "codex",
-        executionMode: "default",
-      },
-    }));
-    const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
-      async (request) => ({
-        backend: request.backend ?? "codex",
-        threadId: request.threadId,
-        pinnedRank: request.pinnedRank ?? undefined,
-      }),
-    );
-    const desktopApi: DesktopApi = {
-      getNavigationSnapshot,
-      onAgentEvent: (listener) => {
-        listeners.add(listener);
-        return () => listeners.delete(listener);
-      },
-      setThreadPin,
-    };
-    renderHook(() => useThreadNavigation(desktopApi));
-
-    await waitFor(() => {
-      expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
-    });
-
-    threadStarted = true;
-    act(() => {
-      for (const listener of listeners) {
-        listener({
-          backend: "codex",
-          notification: {
-            method: "thread/started",
-            params: { threadId: "thread-new" },
-          },
-        });
-      }
-    });
-
-    await waitFor(() => {
-      expect(setThreadPin).toHaveBeenCalledWith({
-        backend: "codex",
-        threadId: "thread-new",
-        pinnedRank: "2048",
-      });
-    });
-
-    childThreadStarted = true;
-    act(() => {
-      for (const listener of listeners) {
-        listener({
-          backend: "codex",
-          notification: {
-            method: "thread/started",
-            params: { threadId: "thread-child" },
-          },
-        });
-      }
-    });
-
-    await waitFor(() => {
-      expect(getNavigationSnapshot).toHaveBeenCalledTimes(3);
-    });
-    expect(setThreadPin).toHaveBeenCalledTimes(1);
   });
 
   it("carries the started review turn from launchpad materialization", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2436,6 +2436,140 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("auto-pins a new top-level thread created outside the renderer when Directory threads are collapsed", async () => {
+    const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    let threadStarted = false;
+    let childThreadStarted = false;
+    const existingPinnedThread = {
+      id: "thread-pinned",
+      title: "Pinned thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true },
+      executionMode: "default" as const,
+      updatedAt: 1,
+      pinnedRank: "1024",
+    };
+    const newThread = {
+      id: "thread-new",
+      title: "Thread created by handoff",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: { inInbox: true, reason: "new-thread" as const },
+      executionMode: "default" as const,
+      updatedAt: 2,
+    };
+    const newChildThread = {
+      ...newThread,
+      id: "thread-child",
+      title: "Child thread created by handoff",
+      parentThreadId: "thread-pinned",
+      updatedAt: 3,
+    };
+    const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({
+      backend: "all",
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: childThreadStarted
+        ? ["codex:thread-child", "codex:thread-new", "codex:thread-pinned"]
+        : threadStarted
+          ? ["codex:thread-new", "codex:thread-pinned"]
+          : ["codex:thread-pinned"],
+      threads: threadStarted
+        ? [
+            ...(childThreadStarted ? [newChildThread] : []),
+            newThread,
+            existingPinnedThread,
+          ]
+        : [existingPinnedThread],
+      directories: [
+        {
+          key: directoryKey,
+          kind: "directory",
+          label: "PwrAgent",
+          path: "/Users/huntharo/github/PwrAgent",
+          threadKeys: threadStarted
+            ? [
+                "codex:thread-pinned",
+                "codex:thread-new",
+                ...(childThreadStarted ? ["codex:thread-child"] : []),
+              ]
+            : ["codex:thread-pinned"],
+          needsAttentionCount: childThreadStarted ? 2 : threadStarted ? 1 : 0,
+          directoryThreadsCollapsed: true,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    }));
+    const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
+      async (request) => ({
+        backend: request.backend ?? "codex",
+        threadId: request.threadId,
+        pinnedRank: request.pinnedRank ?? undefined,
+      }),
+    );
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      setThreadPin,
+    };
+    renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    threadStarted = true;
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/started",
+            params: { threadId: "thread-new" },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(setThreadPin).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-new",
+        pinnedRank: "2048",
+      });
+    });
+
+    childThreadStarted = true;
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/started",
+            params: { threadId: "thread-child" },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(3);
+    });
+    expect(setThreadPin).toHaveBeenCalledTimes(1);
+  });
+
   it("carries the started review turn from launchpad materialization", async () => {
     const directoryKey = "directory:/Users/huntharo/github/PwrAgent";
     const getNavigationSnapshot = vi.fn(async (): Promise<NavigationSnapshot> => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4922,6 +4922,8 @@ export function useThreadNavigation(
       }
       if (response.turnStartFailure) {
         setLaunchpadError(response.turnStartFailure.message);
+      } else if (response.autoPinFailure) {
+        setLaunchpadError(response.autoPinFailure.message);
       }
       // Link composer `@`-referenced directories to the just-created
       // thread before the refresh below so the snapshot comes back with

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2056,7 +2056,7 @@ function buildOptimisticThreadFromLaunchpad(params: {
   };
 }
 
-function shouldAutoPinMaterializedThread(params: {
+function shouldAutoPinThreadForVisibility(params: {
   directory: NavigationDirectorySummary | undefined;
   threads: NavigationThreadSummary[];
   parentThreadId: string | undefined;
@@ -2468,6 +2468,9 @@ export function useThreadNavigation(
   const pendingDirectoryGitStatusRef = useRef(
     new Map<string, NavigationDirectoryGitStatus | null>(),
   );
+  const autoPinRequestsRef = useRef(
+    new Map<string, Promise<string | undefined>>(),
+  );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
 
@@ -2519,6 +2522,56 @@ export function useThreadNavigation(
     }));
     setRetainedUnreadThread(undefined);
   }, []);
+
+  const autoPinThreadForVisibility = useCallback(
+    async (params: {
+      backend: AppServerBackendKind;
+      directory: NavigationDirectorySummary | undefined;
+      parentThreadId: string | undefined;
+      threadId: string;
+      threads: NavigationThreadSummary[];
+    }): Promise<string | undefined> => {
+      if (!shouldAutoPinThreadForVisibility(params)) {
+        return undefined;
+      }
+
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const existingRequest = autoPinRequestsRef.current.get(threadKey);
+      if (existingRequest) {
+        return await existingRequest;
+      }
+
+      const request = (async (): Promise<string | undefined> => {
+        if (!desktopApi?.setThreadPin) {
+          throw new Error(
+            "The new thread was created, but it could not be pinned automatically.",
+          );
+        }
+        const pinResult = await desktopApi.setThreadPin({
+          backend: params.backend,
+          threadId: params.threadId,
+          pinnedRank: buildAppendPinRank(
+            params.threads.map((thread) => thread.pinnedRank),
+          ),
+        });
+        if (!pinResult.pinnedRank) {
+          throw new Error(
+            "The new thread was created, but it could not be pinned automatically.",
+          );
+        }
+        return pinResult.pinnedRank;
+      })();
+      autoPinRequestsRef.current.set(threadKey, request);
+
+      try {
+        return await request;
+      } catch (error) {
+        autoPinRequestsRef.current.delete(threadKey);
+        throw error;
+      }
+    },
+    [desktopApi],
+  );
 
   const performRefresh = useCallback(
     async (
@@ -2578,10 +2631,52 @@ export function useThreadNavigation(
           threadCount: snapshot.threads.length,
           unchanged: Boolean(snapshot.unchanged),
         });
-        const response = removeThreadKeysFromSnapshot(
+        let response = removeThreadKeysFromSnapshot(
           snapshot,
           suppressedArchivedThreadKeysRef.current
         );
+        const previousResponse = stateRef.current.response;
+        // Handoffs, messaging, and other main-process paths can create a
+        // thread without materializing a renderer launchpad. Apply the same
+        // collapsed-directory visibility rule whenever a refresh discovers a
+        // new thread so creation path does not determine whether it is shown.
+        if (previousResponse) {
+          const previousThreadKeys = new Set(
+            previousResponse.threads.map((thread) =>
+              buildThreadIdentityKey(thread.source, thread.id),
+            ),
+          );
+          for (const thread of response.threads) {
+            const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+            if (previousThreadKeys.has(threadKey) || thread.pinnedRank) {
+              continue;
+            }
+            const directory = response.directories.find((candidate) =>
+              candidate.threadKeys.includes(threadKey),
+            );
+            try {
+              const pinnedRank = await autoPinThreadForVisibility({
+                backend: thread.source,
+                directory,
+                parentThreadId: thread.parentThreadId,
+                threadId: thread.id,
+                threads: response.threads,
+              });
+              if (pinnedRank) {
+                response = updateThreadPinInSnapshot(response, {
+                  backend: thread.source,
+                  threadId: thread.id,
+                  pinnedRank,
+                })!;
+              }
+            } catch (error) {
+              console.warn(
+                `Could not auto-pin newly discovered thread ${threadKey}:`,
+                error,
+              );
+            }
+          }
+        }
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
         const optimisticThreadKey = optimisticSelection
           ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
@@ -2655,7 +2750,7 @@ export function useThreadNavigation(
         }));
       }
     },
-    [desktopApi, enabled]
+    [autoPinThreadForVisibility, desktopApi, enabled]
   );
 
   const refresh = useCallback(
@@ -4883,39 +4978,16 @@ export function useThreadNavigation(
       }
       let autoPinnedRank: string | undefined;
       let autoPinFailure: string | undefined;
-      if (
-        shouldAutoPinMaterializedThread({
+      try {
+        autoPinnedRank = await autoPinThreadForVisibility({
+          backend: response.backend,
           directory,
-          threads: stateRef.current.response?.threads ?? [],
           parentThreadId: materializeParentThreadId,
-        })
-      ) {
-        const requestedPinnedRank = buildAppendPinRank(
-          (stateRef.current.response?.threads ?? []).map(
-            (thread) => thread.pinnedRank,
-          ),
-        );
-        if (!desktopApi.setThreadPin) {
-          autoPinFailure =
-            "The new thread was created, but it could not be pinned automatically.";
-        } else {
-          try {
-            const pinResult = await desktopApi.setThreadPin({
-              backend: response.backend,
-              threadId: response.threadId,
-              pinnedRank: requestedPinnedRank,
-            });
-            autoPinnedRank = pinResult.pinnedRank;
-            if (!autoPinnedRank) {
-              autoPinFailure =
-                "The new thread was created, but it could not be pinned automatically.";
-            }
-          } catch (error) {
-            autoPinFailure = `The new thread was created, but it could not be pinned automatically: ${
-              error instanceof Error ? error.message : String(error)
-            }`;
-          }
-        }
+          threadId: response.threadId,
+          threads: stateRef.current.response?.threads ?? [],
+        });
+      } catch (error) {
+        autoPinFailure = error instanceof Error ? error.message : String(error);
       }
       const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
         directory,
@@ -5026,7 +5098,13 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [desktopApi, directories, insertSubthreadBelowSource, refresh]
+    [
+      autoPinThreadForVisibility,
+      desktopApi,
+      directories,
+      insertSubthreadBelowSource,
+      refresh,
+    ]
   );
 
   /**

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2056,29 +2056,6 @@ function buildOptimisticThreadFromLaunchpad(params: {
   };
 }
 
-function shouldAutoPinThreadForVisibility(params: {
-  directory: NavigationDirectorySummary | undefined;
-  threads: NavigationThreadSummary[];
-  parentThreadId: string | undefined;
-}): boolean {
-  if (
-    params.parentThreadId
-    || params.directory?.directoryThreadsCollapsed !== true
-  ) {
-    return false;
-  }
-
-  const directoryThreadKeys = new Set(params.directory.threadKeys);
-  return params.threads.some(
-    (thread) =>
-      !thread.parentThreadId
-      && Boolean(thread.pinnedRank)
-      && directoryThreadKeys.has(
-        buildThreadIdentityKey(thread.source, thread.id),
-      ),
-  );
-}
-
 function mergeHydratedThreadWithOptimisticTitle(
   thread: NavigationThreadSummary,
   optimisticThread: NavigationThreadSummary,
@@ -2468,9 +2445,6 @@ export function useThreadNavigation(
   const pendingDirectoryGitStatusRef = useRef(
     new Map<string, NavigationDirectoryGitStatus | null>(),
   );
-  const autoPinRequestsRef = useRef(
-    new Map<string, Promise<string | undefined>>(),
-  );
   const setNavigationBrowseModeRequestRef = useRef(setNavigationBrowseModeRequest);
   const stateRef = useRef(state);
 
@@ -2522,56 +2496,6 @@ export function useThreadNavigation(
     }));
     setRetainedUnreadThread(undefined);
   }, []);
-
-  const autoPinThreadForVisibility = useCallback(
-    async (params: {
-      backend: AppServerBackendKind;
-      directory: NavigationDirectorySummary | undefined;
-      parentThreadId: string | undefined;
-      threadId: string;
-      threads: NavigationThreadSummary[];
-    }): Promise<string | undefined> => {
-      if (!shouldAutoPinThreadForVisibility(params)) {
-        return undefined;
-      }
-
-      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
-      const existingRequest = autoPinRequestsRef.current.get(threadKey);
-      if (existingRequest) {
-        return await existingRequest;
-      }
-
-      const request = (async (): Promise<string | undefined> => {
-        if (!desktopApi?.setThreadPin) {
-          throw new Error(
-            "The new thread was created, but it could not be pinned automatically.",
-          );
-        }
-        const pinResult = await desktopApi.setThreadPin({
-          backend: params.backend,
-          threadId: params.threadId,
-          pinnedRank: buildAppendPinRank(
-            params.threads.map((thread) => thread.pinnedRank),
-          ),
-        });
-        if (!pinResult.pinnedRank) {
-          throw new Error(
-            "The new thread was created, but it could not be pinned automatically.",
-          );
-        }
-        return pinResult.pinnedRank;
-      })();
-      autoPinRequestsRef.current.set(threadKey, request);
-
-      try {
-        return await request;
-      } catch (error) {
-        autoPinRequestsRef.current.delete(threadKey);
-        throw error;
-      }
-    },
-    [desktopApi],
-  );
 
   const performRefresh = useCallback(
     async (
@@ -2631,52 +2555,10 @@ export function useThreadNavigation(
           threadCount: snapshot.threads.length,
           unchanged: Boolean(snapshot.unchanged),
         });
-        let response = removeThreadKeysFromSnapshot(
+        const response = removeThreadKeysFromSnapshot(
           snapshot,
           suppressedArchivedThreadKeysRef.current
         );
-        const previousResponse = stateRef.current.response;
-        // Handoffs, messaging, and other main-process paths can create a
-        // thread without materializing a renderer launchpad. Apply the same
-        // collapsed-directory visibility rule whenever a refresh discovers a
-        // new thread so creation path does not determine whether it is shown.
-        if (previousResponse) {
-          const previousThreadKeys = new Set(
-            previousResponse.threads.map((thread) =>
-              buildThreadIdentityKey(thread.source, thread.id),
-            ),
-          );
-          for (const thread of response.threads) {
-            const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-            if (previousThreadKeys.has(threadKey) || thread.pinnedRank) {
-              continue;
-            }
-            const directory = response.directories.find((candidate) =>
-              candidate.threadKeys.includes(threadKey),
-            );
-            try {
-              const pinnedRank = await autoPinThreadForVisibility({
-                backend: thread.source,
-                directory,
-                parentThreadId: thread.parentThreadId,
-                threadId: thread.id,
-                threads: response.threads,
-              });
-              if (pinnedRank) {
-                response = updateThreadPinInSnapshot(response, {
-                  backend: thread.source,
-                  threadId: thread.id,
-                  pinnedRank,
-                })!;
-              }
-            } catch (error) {
-              console.warn(
-                `Could not auto-pin newly discovered thread ${threadKey}:`,
-                error,
-              );
-            }
-          }
-        }
         const optimisticSelection = preferredOptimisticThread ?? optimisticThreadRef.current;
         const optimisticThreadKey = optimisticSelection
           ? buildThreadIdentityKey(optimisticSelection.source, optimisticSelection.id)
@@ -2750,7 +2632,7 @@ export function useThreadNavigation(
         }));
       }
     },
-    [autoPinThreadForVisibility, desktopApi, enabled]
+    [desktopApi, enabled]
   );
 
   const refresh = useCallback(
@@ -4976,19 +4858,6 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
         throw error;
       }
-      let autoPinnedRank: string | undefined;
-      let autoPinFailure: string | undefined;
-      try {
-        autoPinnedRank = await autoPinThreadForVisibility({
-          backend: response.backend,
-          directory,
-          parentThreadId: materializeParentThreadId,
-          threadId: response.threadId,
-          threads: stateRef.current.response?.threads ?? [],
-        });
-      } catch (error) {
-        autoPinFailure = error instanceof Error ? error.message : String(error);
-      }
       const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
         directory,
         launchpad,
@@ -5015,7 +4884,7 @@ export function useThreadNavigation(
             }
           : undefined,
         parentThreadId: materializeParentThreadId,
-        pinnedRank: autoPinnedRank,
+        pinnedRank: response.pinnedRank,
       });
       const nextThreadKey = buildThreadIdentityKey(response.backend, response.threadId);
       // Sub-thread launchpads drop the new child directly below their source
@@ -5053,8 +4922,6 @@ export function useThreadNavigation(
       }
       if (response.turnStartFailure) {
         setLaunchpadError(response.turnStartFailure.message);
-      } else if (autoPinFailure) {
-        setLaunchpadError(autoPinFailure);
       }
       // Link composer `@`-referenced directories to the just-created
       // thread before the refresh below so the snapshot comes back with
@@ -5098,13 +4965,7 @@ export function useThreadNavigation(
         setLaunchpadError(error instanceof Error ? error.message : String(error));
       }
     },
-    [
-      autoPinThreadForVisibility,
-      desktopApi,
-      directories,
-      insertSubthreadBelowSource,
-      refresh,
-    ]
+    [desktopApi, directories, insertSubthreadBelowSource, refresh]
   );
 
   /**

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -35,6 +35,7 @@ export type StartThreadRequest = {
   };
   executionMode?: ThreadExecutionMode;
   cwd?: string;
+  directoryKey?: string;
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
@@ -53,6 +54,7 @@ export type StartThreadResponse = {
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
   pinnedRank?: string;
+  autoPinFailure?: ThreadAutoPinFailure;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 };
@@ -61,6 +63,10 @@ export type CodexEnvironmentStartupFailure = {
   message: string;
   phase: "setup" | "action";
   worktreeCleanupAvailable: boolean;
+};
+
+export type ThreadAutoPinFailure = {
+  message: string;
 };
 
 export type ForkThreadRequest = {
@@ -94,6 +100,7 @@ export type ForkThreadResponse = {
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
   pinnedRank?: string;
+  autoPinFailure?: ThreadAutoPinFailure;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   gitBranch?: string;
@@ -556,6 +563,7 @@ export type MaterializedDirectoryLaunchpadThread = {
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
   pinnedRank?: string;
+  autoPinFailure?: ThreadAutoPinFailure;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -45,12 +45,14 @@ export type StartThreadRequest = {
   branchName?: string;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   acpRuntime?: BackendAcpSessionRuntimeState;
+  parentThreadId?: ThreadIdentifier;
 };
 
 export type StartThreadResponse = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
+  pinnedRank?: string;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
 };
@@ -91,6 +93,7 @@ export type ForkThreadResponse = {
   sourceThreadId: ThreadIdentifier;
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
+  pinnedRank?: string;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   gitBranch?: string;
@@ -552,6 +555,7 @@ export type MaterializedDirectoryLaunchpadThread = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
   executionMode: ThreadExecutionMode;
+  pinnedRank?: string;
   linkedDirectory?: LinkedDirectorySummary;
   workMode: LaunchpadWorkMode;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -8,7 +8,10 @@ import type {
   ThreadWorkspaceHandoffDirection,
   ThreadWorkspaceHandoffStrategy,
 } from "./normalized-app-server";
-import type { CodexEnvironmentStartupFailure } from "./agent";
+import type {
+  CodexEnvironmentStartupFailure,
+  ThreadAutoPinFailure,
+} from "./agent";
 import type { MessagingChannelKind, MessagingConversationKind } from "./messaging";
 
 export const PWRAGENT_THREAD_ORCHESTRATION_OPERATION_NAMES = [
@@ -351,6 +354,7 @@ export type HandoffTaskResult = {
   workspace: ThreadHandoffOriginWorkspace;
   messagingAttachment: HandoffTaskMessagingAttachment;
   codexEnvironmentStartupFailure?: CodexEnvironmentStartupFailure;
+  autoPinFailure?: ThreadAutoPinFailure;
   turnStartFailure?: {
     message: string;
     phase: "turn";


### PR DESCRIPTION
## Summary

- Finalize collapsed-directory visibility in `DesktopBackendRegistry` after every thread creation path, including messaging, handoffs, forks, and GUI launchpad materialization.
- Base the decision on a small read-only projection of the latest complete navigation snapshot, without advancing reconciliation state or scanning provider history during creation.
- Persist parent linkage before visibility finalization, return assigned pin ranks to callers, and surface automatic pin failures instead of silently hiding the created thread.

## Root cause

The visibility policy lived in renderer-only post-processing after GUI launchpad materialization. Messaging and other non-GUI callers reached the same main-process registry to create threads but bypassed that post-processing, so a new top-level thread could remain unpinned inside a collapsed directory and be invisible on returning to desktop.

The first centralized revision rebuilt navigation during every creation. That introduced three problems caught in review and CI: it consumed the shared reconciliation hash before the renderer refreshed, swallowed pin failures, and added an all-backend history scan to every thread start. The Windows regression fixture also used a POSIX-only directory path, while the history scan caused two launchpad E2E timeouts.

## Fix

Creation now converges on a main-process visibility finalizer. Complete, unfiltered GUI or messaging navigation reads feed it only the directory collapse/pin facts and global pin ranks it needs. It performs no reconciliation or provider listing. Top-level threads are auto-pinned when required, while children remain grouped under their already-visible pinned parent. The normal pin event is published, the rank is returned for optimistic renderer projection, and failures are returned as `autoPinFailure` for user-visible handling.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts` — 562 passed
- `pnpm --filter @pwragent/desktop test:e2e e2e/directory-launchpad-workspace.spec.ts --grep "new-thread picker starts a newly added directory|keeps new worktree as the sticky default"` — 2 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; warning baseline only
- `pnpm lint:boundaries`
- `git diff --check`

## Scope

This PR does not change messaging status cards or menus.