### PR TITLE
fix(desktop): clarify completed thread migration

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1058,32 +1058,38 @@ function ThreadMigrationDialog(props: {
           Click or ⌘-click to toggle a model. Shift-click selects a range.
         </p>
         <div className="settings-confirm-dialog__actions">
-          <button
-            className="button button--secondary"
-            disabled={props.applying}
-            type="button"
-            onClick={props.onCancel}
-          >
-            Cancel
-          </button>
-          <button
-            className="button button--primary"
-            disabled={
-              props.applying
-              || selectedThreadCount === 0
-              || alreadyScheduled
-            }
-            type="button"
-            onClick={props.onConfirm}
-          >
-            {props.applying
-              ? "Creating migration…"
-              : alreadyScheduled
-                ? "Already scheduled"
-                : `Schedule ${selectedThreadCount} thread${
-                    selectedThreadCount === 1 ? "" : "s"
-                  }`}
-          </button>
+          {alreadyScheduled ? (
+            <button
+              className="button button--primary"
+              type="button"
+              onClick={props.onCancel}
+            >
+              Done
+            </button>
+          ) : (
+            <>
+              <button
+                className="button button--secondary"
+                disabled={props.applying}
+                type="button"
+                onClick={props.onCancel}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button--primary"
+                disabled={props.applying || selectedThreadCount === 0}
+                type="button"
+                onClick={props.onConfirm}
+              >
+                {props.applying
+                  ? "Creating migration…"
+                  : `Schedule ${selectedThreadCount} thread${
+                      selectedThreadCount === 1 ? "" : "s"
+                    }`}
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1914,12 +1914,16 @@ describe("SettingsScreen", () => {
     );
     expect(
       within(migrationDialog).getByRole("button", {
-        name: "Already scheduled",
+        name: "Done",
       }),
-    ).toBeDisabled();
+    ).toBeEnabled();
+    expect(
+      within(migrationDialog).queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(
-      within(migrationDialog).getByRole("button", { name: "Cancel" }),
+      within(migrationDialog).getByRole("button", { name: "Done" }),
     );
+    expect(migrationDialog).not.toBeInTheDocument();
 
     snapshot.models.providerThreadMigrations = {
       codex: {
@@ -1950,12 +1954,16 @@ describe("SettingsScreen", () => {
     );
     expect(
       within(scheduledDialog).getByRole("button", {
-        name: "Already scheduled",
+        name: "Done",
       }),
-    ).toBeDisabled();
+    ).toBeEnabled();
+    expect(
+      within(scheduledDialog).queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(
-      within(scheduledDialog).getByRole("button", { name: "Cancel" }),
+      within(scheduledDialog).getByRole("button", { name: "Done" }),
     );
+    expect(scheduledDialog).not.toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole("button", { name: "Turn Fast off everywhere" }),


### PR DESCRIPTION
## Summary

- I replace the misleading post-scheduling `Cancel` plus disabled `Already scheduled` actions with one primary `Done` action that dismisses the dialog.
- I preserve the normal `Cancel` and `Schedule` actions whenever the selected source models do not match the scheduled migration.
- I add regression coverage for both the first successful scheduling transition and reopening an existing scheduled migration.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (58 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)

## Notes

- I created this branch from a freshly fetched `origin/main` after the squash merge of #1044.
