### PR TITLE
fix(desktop): preserve GitHub comment permalinks

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -368,7 +368,7 @@ describe("pull request links in transcript markdown", () => {
   });
 
   it("preserves an authored PR deep link while hydrating its live status", () => {
-    const deepLink = `${PR_URL}/files?diff=split#discussion_r1`;
+    const deepLink = `${PR_URL}/files?diff=split`;
     const open = vi.spyOn(window, "open").mockImplementation(() => null);
     renderWithPullRequests(`Review [the changed files](${deepLink})`, [
       prSummary(),
@@ -440,6 +440,22 @@ describe("pull request links in transcript markdown", () => {
       .toBeInTheDocument();
   });
 
+  it("leaves GitHub review comment permalinks as distinct transcript links", () => {
+    const commentUrls = [
+      `${PR_URL}#discussion_r3549020872`,
+      `${PR_URL}#discussion_r3549020877`,
+      `${PR_URL}#discussion_r3549138295`,
+    ];
+    renderWithPullRequests(commentUrls.join("\n\n"), [prSummary()]);
+
+    expect(screen.queryByRole("button", {
+      name: /Open Giphy\/giphy-services#13290/,
+    })).not.toBeInTheDocument();
+    for (const url of commentUrls) {
+      expect(screen.getByRole("link", { name: url })).toHaveAttribute("href", url);
+    }
+  });
+
   it("leaves PR links as normal links on surfaces without navigation metadata", () => {
     render(<ThreadMarkdown text={`Draft PR: [#13290](${PR_URL})`} />);
 
@@ -458,7 +474,7 @@ describe("pull request links in transcript markdown", () => {
 
 describe("parseGitHubPullRequestUrl", () => {
   it("accepts PR subpaths and query strings while preserving the target URL", () => {
-    const href = `${PR_URL}/files?diff=split#discussion_r1`;
+    const href = `${PR_URL}/files?diff=split`;
     expect(parseGitHubPullRequestUrl(href)).toMatchObject({
       provider: "github.com",
       org: "Giphy",
@@ -467,6 +483,18 @@ describe("parseGitHubPullRequestUrl", () => {
       state: "unknown",
       url: href,
     });
+  });
+
+  it("rejects GitHub pull request comment permalinks", () => {
+    expect(parseGitHubPullRequestUrl(
+      `${PR_URL}#discussion_r3549020872`,
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      `${PR_URL}#issuecomment-3549020872`,
+    )).toBeUndefined();
+    expect(parseGitHubPullRequestUrl(
+      `${PR_URL}#pullrequestreview-3549020872`,
+    )).toBeUndefined();
   });
 
   it("rejects issues, invalid numbers, non-GitHub hosts, and insecure URLs", () => {

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -385,6 +385,10 @@ export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
     return undefined;
   }
 
+  if (isGitHubPullRequestCommentHash(parsed.hash)) {
+    return undefined;
+  }
+
   const segments = parsed.pathname.split("/").filter(Boolean);
   if (segments.length < 4 || segments[2] !== "pull") {
     return undefined;
@@ -408,6 +412,10 @@ export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
     state: "unknown",
     url: href,
   };
+}
+
+function isGitHubPullRequestCommentHash(hash: string): boolean {
+  return /^#(?:discussion_r|issuecomment-|pullrequestreview-)\d+$/i.test(hash);
 }
 
 function decodeUrlSegment(value: string): string | undefined {


### PR DESCRIPTION
## What changed

- keep GitHub PR review-comment permalinks as ordinary transcript links
- continue hydrating root PR and PR subpage URLs as live status chips
- add regression coverage for the three-comment message shape observed in the affected thread
- cover GitHub review-thread, issue-comment, and review-summary fragment formats

## Why

PwrAgent classified every `https://github.com/.../pull/<number>#discussion_r...` URL as the pull request itself. Rendering then replaced three distinct comment destinations with three identical PR chips, hiding which review comment each link targeted.

## User impact

Review-comment permalinks now retain their authored text and unique destinations. Normal pull request links still render with live PR status.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx` (20 tests)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
