### PR TITLE
feat(desktop): add managed review experiment

### DIFF
--- a/apps/desktop/e2e/managed-review.spec.ts
+++ b/apps/desktop/e2e/managed-review.spec.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { applyDesktopSettingsPatch } from "../src/main/settings/desktop-config";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+async function createManagedReviewFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-managed-review-"));
+  const fixturePath = path.join(rootDir, "managed-review.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify({
+      metadata: {
+        backend: "codex",
+        scenario: "managed-review-terminal-gating",
+      },
+      steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: { name: "Replay Codex", version: "1.0.0" },
+            methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+          },
+        },
+        {
+          id: "thread-list-1",
+          kind: "response",
+          method: "thread/list",
+          result: [{
+            id: "thread-parent",
+            title: "Managed review failure",
+            titleSource: "explicit",
+            summary: "Managed review terminal gating",
+            source: "codex",
+            executionMode: "default",
+            linkedDirectories: [],
+            updatedAt: 2_000,
+          }],
+        },
+        {
+          id: "thread-read-1",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [],
+            messages: [],
+            threadStatus: "idle",
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        },
+        {
+          id: "managed-review-thread-start",
+          kind: "response",
+          method: "thread/start",
+          result: { threadId: "managed-review-child" },
+        },
+        {
+          id: "managed-review-turn-start",
+          kind: "response",
+          method: "turn/start",
+          result: {
+            threadId: "managed-review-child",
+            turnId: "managed-review-turn",
+          },
+        },
+        {
+          id: "managed-review-child-failed",
+          kind: "notification",
+          notification: {
+            method: "turn/failed",
+            params: {
+              threadId: "managed-review-child",
+              turnId: "managed-review-turn",
+              turn: {
+                id: "managed-review-turn",
+                status: "failed",
+                error: { message: "You have 8147 weighted tokens left" },
+              },
+            },
+          },
+        },
+      ],
+    }, null, 2),
+    "utf8",
+  );
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function launchManagedReviewFixture() {
+  const fixture = await createManagedReviewFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    preLaunchHook: (homeRoot) => {
+      applyDesktopSettingsPatch(
+        path.join(homeRoot, ".pwragent/profiles/default/config.toml"),
+        { experimental: { managedReview: true } },
+      );
+    },
+  });
+  return {
+    app,
+    close: async () => {
+      await app.close();
+      await fixture.cleanup();
+    },
+  };
+}
+
+test("managed review failure leaves one start marker and clears Stop state", async () => {
+  const fixture = await launchManagedReviewFixture();
+  try {
+    await fixture.app.window
+      .getByRole("button", { name: /Managed review failure/i })
+      .first()
+      .click();
+    await fixture.app.window.getByLabel("Reply").fill("/review main");
+    await fixture.app.window.getByRole("button", { name: "Send" }).click();
+
+    const transcript = fixture.app.window.getByRole("region", { name: "Transcript" });
+    await expect(transcript.getByText("Review changes against main")).toHaveCount(1);
+    await expect(fixture.app.window.getByRole("button", { name: "Stop" })).toBeVisible();
+    await expect.poll(async () => await fixture.app.getLastStartTurn()).toMatchObject({
+      threadId: "managed-review-child",
+      input: [{ type: "text", text: expect.stringContaining("Perform a code review") }],
+    });
+
+    await fixture.app.advance({ stepId: "managed-review-child-failed" });
+
+    await expect(
+      fixture.app.window.getByRole("button", { name: "Stop" }),
+    ).toHaveCount(0);
+    await expect(transcript).toContainText("Turn failed");
+    await expect(transcript).not.toContainText("Code review completed");
+    await expect(transcript.getByText("Review changes against main")).toHaveCount(1);
+  } finally {
+    await fixture.close();
+  }
+});

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -131,6 +131,19 @@ function pwragentDynamicTools(dynamicTools: unknown): DynamicToolTestSpec[] {
   return namespace?.tools as DynamicToolTestSpec[] ?? [];
 }
 
+function isCompletedItemType(event: AgentEvent, itemType: string): boolean {
+  if (event.notification.method !== "item/completed") {
+    return false;
+  }
+  const item = event.notification.params.item;
+  return Boolean(
+    item
+    && typeof item === "object"
+    && "type" in item
+    && item.type === itemType,
+  );
+}
+
 function expectPwragentDynamicTools(dynamicTools: unknown, names: string[]): void {
   expect(pwragentDynamicTools(dynamicTools)).toEqual(
     expect.arrayContaining(
@@ -14546,6 +14559,256 @@ command = "pnpm dev"
       reasoningEffort: "high",
       serviceTier: "priority",
       fastMode: true,
+    });
+
+    await registry.close();
+  });
+
+  it("runs the managed review experiment as one child turn and attributes usage to it", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "turn/start"] },
+      models: [
+        {
+          id: "gpt-5.5",
+          label: "GPT-5.5",
+          current: true,
+          supportsFast: true,
+          supportsReasoning: true,
+        },
+      ],
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-parent": {
+          backend: "codex",
+          threadId: "thread-parent",
+          executionMode: "full-access",
+          model: "gpt-5.5",
+          reasoningEffort: "high",
+          serviceTier: "priority",
+          fastMode: true,
+          extraLinkedDirectories: [
+            {
+              id: "/repo/worktree",
+              kind: "worktree",
+              label: "worktree",
+              path: "/repo",
+              worktreePath: "/repo/worktree",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      resolveManagedReviewEnabled: () => true,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const codexBackend = (await registry.listBackends({ includeUnavailable: true }))
+      .backends.find((backend) => backend.kind === "codex");
+    expect(codexBackend?.methods).not.toContain("review/start");
+    expect(codexBackend?.capabilities.startReview).toBe(true);
+
+    const response = await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "baseBranch", branch: "main" },
+      delivery: "inline",
+    });
+
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-parent",
+      reviewThreadId: "managed-review-child",
+      turnId: "turn-1",
+    });
+    expect(codexClient.lastStartReviewParams).toBeUndefined();
+    expect(codexClient.lastStartThreadParams).toMatchObject({
+      approvalPolicy: "never",
+      cwd: "/repo/worktree",
+      ephemeral: true,
+      fastMode: true,
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      sandbox: "danger-full-access",
+      serviceTier: "priority",
+    });
+    expect(codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "managed-review-child",
+      cwd: "/repo/worktree",
+      fastMode: true,
+      model: "gpt-5.5",
+      reasoningEffort: "high",
+      serviceTier: "priority",
+    });
+    expect(codexClient.lastStartTurnParams?.input[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("against base branch 'main'"),
+    });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "managed-review-child",
+        turnId: "turn-1",
+        model: "gpt-5.5",
+        tokenUsage: {
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 250,
+            outputTokens: 100,
+            reasoningOutputTokens: 25,
+            fastMode: true,
+            serviceTier: "priority",
+          },
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "managed-review-child",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [{
+            type: "text",
+            text: JSON.stringify({
+              findings: [],
+              overall_correctness: "patch is correct",
+              overall_explanation: "No blocking findings.",
+              overall_confidence_score: 0.96,
+            }),
+          }],
+        },
+      },
+    });
+
+    const parentEvents = events.filter(
+      (event) => "threadId" in event.notification.params
+        && event.notification.params.threadId === "thread-parent",
+    );
+    expect(parentEvents.filter((event) =>
+      isCompletedItemType(event, "enteredReviewMode")
+    )).toHaveLength(1);
+    expect(parentEvents.filter((event) =>
+      isCompletedItemType(event, "exitedReviewMode")
+    )).toHaveLength(1);
+    expect(parentEvents.filter((event) =>
+      event.notification.method === "turn/completed"
+    )).toHaveLength(1);
+
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      monitorId: "review:turn-1",
+      monitorThreadId: "managed-review-child",
+      monitorTurnId: "turn-1",
+      outcome: "success",
+      status: "success",
+    });
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(pricing.lines[0]).toMatchObject({
+      parentThreadId: "thread-parent",
+      scope: "monitor",
+      threadId: "managed-review-child",
+      turnId: "turn-1",
+    });
+
+    await expect(registry.startTurn({
+      backend: "codex",
+      threadId: "thread-parent",
+      input: [{ type: "text", text: "Continue after review" }],
+    })).resolves.toMatchObject({ threadId: "thread-parent" });
+
+    await registry.close();
+  });
+
+  it("terminal-gates failed managed reviews and releases the parent thread", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startThreadResult: { threadId: "managed-review-child" },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore,
+      resolveManagedReviewEnabled: () => true,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-parent",
+      target: { type: "uncommittedChanges" },
+      delivery: "inline",
+    });
+    const queuedTurn = await registry.submitTurn({
+      backend: "codex",
+      threadId: "thread-parent",
+      input: [{ type: "text", text: "Continue after failure" }],
+      origin: "messaging",
+    });
+    expect(queuedTurn.status).toBe("queued");
+    await codexClient.emit({
+      method: "turn/failed",
+      params: {
+        threadId: "managed-review-child",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "failed",
+          error: { message: "You have 8147 weighted tokens left" },
+        },
+      },
+    });
+
+    const parentEvents = events.filter(
+      (event) => "threadId" in event.notification.params
+        && event.notification.params.threadId === "thread-parent",
+    );
+    expect(parentEvents.some((event) =>
+      isCompletedItemType(event, "exitedReviewMode")
+    )).toBe(false);
+    expect(parentEvents.filter((event) =>
+      event.notification.method === "turn/completed"
+    )).toHaveLength(0);
+    expect(parentEvents.filter((event) =>
+      event.notification.method === "turn/failed"
+    )).toHaveLength(1);
+    const overlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(overlay?.subAgents?.[0]).toMatchObject({
+      outcome: "failure",
+      status: "failed",
+    });
+
+    await expect.poll(() => codexClient.lastStartTurnParams).toMatchObject({
+      threadId: "thread-parent",
+      input: [{ type: "text", text: "Continue after failure" }],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -440,6 +440,39 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return { overlay: next, persisted: true };
     },
+    upsertManagedReviewEntry: async ({
+      backend,
+      threadId,
+      entry,
+    }: {
+      backend: "codex" | "grok";
+      threadId: string;
+      entry: NonNullable<ThreadOverlayState["managedReviewEntries"]>[number];
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const existingEntries = current.managedReviewEntries ?? [];
+      const existingIndex = existingEntries.findIndex(
+        (candidate) => candidate.id === entry.id,
+      );
+      const nextEntries = [...existingEntries];
+      if (existingIndex === -1) {
+        nextEntries.push(entry);
+      } else {
+        nextEntries[existingIndex] = entry;
+      }
+      const next = {
+        ...current,
+        managedReviewEntries: nextEntries,
+      } as ThreadOverlayState;
+      overlays.set(key, next);
+      return next;
+    },
     upsertThreadSubAgent: async ({
       backend,
       threadId,
@@ -14655,6 +14688,40 @@ command = "pnpm dev"
       text: expect.stringContaining("against base branch 'main'"),
     });
 
+    const approvalResponse = codexClient.emitRequest({
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "managed-review-child",
+        turnId: "turn-1",
+        itemId: "review-command",
+        requestId: "review-approval",
+        command: "git diff main...HEAD",
+      },
+    } as AppServerPendingRequestNotification);
+    await waitForCondition(() => events.some((event) =>
+      event.notification.method === "item/commandExecution/requestApproval"
+    ));
+    expect(events.find((event) =>
+      event.notification.method === "item/commandExecution/requestApproval"
+    )).toMatchObject({
+      backend: "codex",
+      notification: {
+        params: {
+          threadId: "thread-parent",
+          turnId: "turn-1",
+          requestId: "review-approval",
+        },
+      },
+    });
+    await registry.submitServerRequest({
+      backend: "codex",
+      threadId: "thread-parent",
+      turnId: "turn-1",
+      requestId: "review-approval",
+      response: { decision: "accept" },
+    });
+    await expect(approvalResponse).resolves.toEqual({ decision: "accept" });
+
     await codexClient.emit({
       method: "thread/tokenUsage/updated",
       params: {
@@ -14719,6 +14786,34 @@ command = "pnpm dev"
       outcome: "success",
       status: "success",
     });
+    expect(overlay?.managedReviewEntries).toEqual([
+      expect.objectContaining({
+        id: "managed-review:turn-1:started",
+        displayText: "Review changes against main",
+        turn: expect.objectContaining({
+          id: "turn-1",
+          status: "in_progress",
+        }),
+      }),
+      expect.objectContaining({
+        id: "managed-review:turn-1:result",
+        output: expect.objectContaining({
+          overall_correctness: "patch is correct",
+          overall_explanation: "No blocking findings.",
+        }),
+        turn: expect.objectContaining({
+          id: "turn-1",
+          status: "completed",
+        }),
+      }),
+    ]);
+    const hydratedParent = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(hydratedParent.replay.entries.filter(
+      (entry) => entry.type === "review",
+    )).toEqual(overlay?.managedReviewEntries);
     const pricing = await overlayStore.readThreadPricing({
       backend: "codex",
       threadId: "thread-parent",
@@ -14805,6 +14900,11 @@ command = "pnpm dev"
       outcome: "failure",
       status: "failed",
     });
+    expect(overlay?.managedReviewEntries).toEqual([
+      expect.objectContaining({
+        id: "managed-review:turn-1:started",
+      }),
+    ]);
 
     await expect.poll(() => codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-parent",

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -206,6 +206,18 @@ describe("desktopSettingsPatchToEdits — experimental", () => {
       },
     ]);
   });
+
+  it("writes the managed review experiment flag", () => {
+    const edits = desktopSettingsPatchToEdits({
+      experimental: { managedReview: true },
+    });
+
+    expect(edits).toEqual([{
+      op: "set",
+      path: ["experimental", "managed_review"],
+      value: true,
+    }]);
+  });
 });
 
 describe("desktopSettingsPatchToEdits — image uploads", () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1951,6 +1951,42 @@ describe("DesktopSettingsService", () => {
     );
   });
 
+  it("defaults managed review to false and persists the additive flag", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(configPath, [
+      "# keep this operator comment",
+      "[experimental]",
+      "thread_tool_accounting = true",
+      "",
+    ].join("\n"));
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect((await service.readSettings()).experimental.managedReview).toEqual({
+      value: false,
+      source: "default",
+    });
+    expect(service.resolveManagedReviewEnabled()).toBe(false);
+
+    await service.writeConfigPatch({
+      experimental: { managedReview: true },
+    });
+
+    expect((await service.readSettings()).experimental.managedReview).toEqual({
+      value: true,
+      source: "config",
+    });
+    expect(service.resolveManagedReviewEnabled()).toBe(true);
+    const written = fs.readFileSync(configPath, "utf8");
+    expect(written).toContain("# keep this operator comment");
+    expect(written).toContain("thread_tool_accounting = true");
+    expect(written).toContain("managed_review = true");
+  });
+
   it("preserves unknown sections written by other builds when saving a patch", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildManagedReviewPrompt,
+  parseManagedReviewOutput,
+} from "../app-server/managed-review";
+
+describe("managed review", () => {
+  it.each([
+    [
+      { type: "uncommittedChanges" as const },
+      "all staged, unstaged, and untracked changes",
+    ],
+    [
+      { type: "baseBranch" as const, branch: "release/main" },
+      "against base branch 'release/main'",
+    ],
+    [
+      { type: "commit" as const, sha: "abc123", title: "Fix race" },
+      "commit abc123 (Fix race)",
+    ],
+    [
+      { type: "custom" as const, instructions: "Review the retry contract." },
+      "Review the retry contract.",
+    ],
+  ])("preserves the %s review target", (target, expected) => {
+    const prompt = buildManagedReviewPrompt(target);
+
+    expect(prompt).toContain(expected);
+    expect(prompt).toContain("Return only one JSON object");
+    expect(prompt).toContain("Do not modify files");
+  });
+
+  it("parses the structured review artifact shape", () => {
+    expect(parseManagedReviewOutput(JSON.stringify({
+      findings: [{
+        title: "[P1] Release the queue",
+        body: "The terminal path leaves queued work blocked.",
+        confidence_score: 0.98,
+        priority: 1,
+        code_location: {
+          absolute_file_path: "/repo/review.ts",
+          line_range: { start: 42, end: 44 },
+        },
+      }],
+      overall_correctness: "patch is incorrect",
+      overall_explanation: "The failure path does not release queued work.",
+      overall_confidence_score: 0.97,
+    }))).toMatchObject({
+      findings: [{
+        priority: 1,
+        code_location: {
+          absolute_file_path: "/repo/review.ts",
+          line_range: { start: 42, end: 44 },
+        },
+      }],
+      overall_correctness: "patch is incorrect",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5023,6 +5023,21 @@ describe("MessagingController", () => {
         },
       },
     } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
 
     expect(
       harness.delivered.find(
@@ -5085,6 +5100,21 @@ describe("MessagingController", () => {
         },
       },
     } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    } satisfies AgentEvent);
 
     const artifactIntent = harness.delivered.find(
       (intent): intent is MessagingSurfaceIntent & {
@@ -5113,6 +5143,53 @@ describe("MessagingController", () => {
     expect(
       textPart.text.split("The patch has one validation issue."),
     ).toHaveLength(2);
+  });
+
+  it("discards review artifacts when the review turn fails", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-capacity",
+          item: {
+            id: "review-capacity",
+            type: "exited_review_mode",
+            review: "This output must not be published.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/failed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-capacity",
+          turn: {
+            id: "turn-capacity",
+            status: "failed",
+            error: { message: "You have 8147 weighted tokens left" },
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.some(
+      (intent) => intent.kind === "message" && "artifactDelivery" in intent,
+    )).toBe(false);
+    expect(JSON.stringify(harness.delivered)).not.toContain("Code review completed");
+    expect(harness.delivered).toContainEqual(expect.objectContaining({
+      kind: "error",
+      title: "Turn failed",
+      body: "You have 8147 weighted tokens left",
+    }));
   });
 
   it("delivers a single added markdown file as attachment plus bounded preview", async () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-managed-reviews.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-managed-reviews.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppServerThreadReviewEntry } from "@pwragent/shared";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+import {
+  createTempStateDb,
+  openInMemoryStateDb,
+  removeTempStateDbDir,
+} from "./sqlite-test-utils";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+
+function buildReviewEntry(
+  overrides: Partial<AppServerThreadReviewEntry>,
+): AppServerThreadReviewEntry {
+  return {
+    type: "review",
+    id: "managed-review:turn-1:started",
+    review: "Review current changes",
+    createdAt: 1000,
+    turn: {
+      id: "turn-1",
+      status: "in_progress",
+      startedAt: 1000,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  stateDb = openInMemoryStateDb();
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+});
+
+describe("SqliteOverlayStore — managed review entries", () => {
+  it("upserts entries by id", async () => {
+    await store.upsertManagedReviewEntry({
+      backend: "codex",
+      threadId: "thread-1",
+      entry: buildReviewEntry({}),
+    });
+    await store.upsertManagedReviewEntry({
+      backend: "codex",
+      threadId: "thread-1",
+      entry: buildReviewEntry({ review: "Updated review label" }),
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.managedReviewEntries).toEqual([
+      expect.objectContaining({ review: "Updated review label" }),
+    ]);
+  });
+
+  it("persists structured results across a database reopen", async () => {
+    const { dbPath, tempDir } = createTempStateDb(
+      "pwragent-managed-reviews-test-",
+    );
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+
+    try {
+      const result = buildReviewEntry({
+        id: "managed-review:turn-1:result",
+        review: "No blocking findings.",
+        createdAt: 2000,
+        output: {
+          findings: [],
+          overall_correctness: "patch is correct",
+          overall_explanation: "No blocking findings.",
+          overall_confidence_score: 0.96,
+        },
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          completedAt: 2000,
+        },
+      });
+      await store.upsertManagedReviewEntry({
+        backend: "codex",
+        threadId: "thread-1",
+        entry: result,
+      });
+      stateDb.close();
+
+      const reopened = StateDb.open(dbPath);
+      const reopenedStore = new SqliteOverlayStore(reopened);
+      try {
+        const overlay = await reopenedStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        });
+        expect(overlay?.managedReviewEntries).toEqual([result]);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      stateDb.close();
+      removeTempStateDbDir(tempDir);
+      stateDb = openInMemoryStateDb();
+      store = new SqliteOverlayStore(stateDb);
+    }
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -46,6 +46,7 @@ import {
   type AppServerThreadEntry,
   type AppServerThreadMessage,
   type AppServerThreadMessageOrigin,
+  type AppServerThreadReviewEntry,
   type AppServerToolRequestUserInputResponse,
   type AppServerThreadReplay,
   type AppServerThreadStatus,
@@ -4567,32 +4568,53 @@ function usageActivityScope(
 
 function insertTranscriptEntry(
   entries: AppServerThreadEntry[],
-  activity: AppServerThreadActivityEntry,
+  entry: AppServerThreadEntry,
 ): AppServerThreadEntry[] {
   const nextEntries = [...entries];
-  const turnId = activity.turn?.id;
+  const turnId = entry.turn?.id;
   if (turnId) {
     const sameTurnIndex = nextEntries.findLastIndex((entry) => entry.turn?.id === turnId);
     if (sameTurnIndex !== -1) {
-      nextEntries.splice(sameTurnIndex + 1, 0, activity);
+      nextEntries.splice(sameTurnIndex + 1, 0, entry);
       return nextEntries;
     }
   }
 
-  if (typeof activity.createdAt === "number") {
+  if (typeof entry.createdAt === "number") {
     const timedIndex = nextEntries.findIndex(
-      (entry) =>
-        typeof entry.createdAt === "number" &&
-        entry.createdAt > (activity.createdAt as number),
+      (candidate) =>
+        typeof candidate.createdAt === "number" &&
+        candidate.createdAt > (entry.createdAt as number),
     );
     if (timedIndex !== -1) {
-      nextEntries.splice(timedIndex, 0, activity);
+      nextEntries.splice(timedIndex, 0, entry);
       return nextEntries;
     }
   }
 
-  nextEntries.push(activity);
+  nextEntries.push(entry);
   return nextEntries;
+}
+
+function mergeManagedReviewEntries(params: {
+  replay: AppServerThreadReplay;
+  entries?: AppServerThreadReviewEntry[];
+}): AppServerThreadReplay {
+  if (!params.entries?.length) {
+    return params.replay;
+  }
+
+  let entries = params.replay.entries;
+  for (const reviewEntry of params.entries) {
+    entries = insertTranscriptEntry(
+      entries.filter((entry) => entry.id !== reviewEntry.id),
+      reviewEntry,
+    );
+  }
+  return {
+    ...params.replay,
+    entries,
+  };
 }
 
 function mergeImmutableUsageActivities(params: {
@@ -8254,11 +8276,18 @@ export class DesktopBackendRegistry {
           runtime: overlay?.codexEnvironmentRuntime,
         })
       : replay;
-    const replayWithImmutableUsage =
+    const replayWithManagedReviews =
       request.before || !shouldAppendTranscriptOverlays
         ? replayWithEnvironment
-        : mergeImmutableUsageActivities({
+        : mergeManagedReviewEntries({
             replay: replayWithEnvironment,
+            entries: overlay?.managedReviewEntries,
+          });
+    const replayWithImmutableUsage =
+      request.before || !shouldAppendTranscriptOverlays
+        ? replayWithManagedReviews
+        : mergeImmutableUsageActivities({
+            replay: replayWithManagedReviews,
             activities: overlay?.immutableUsageActivities,
           });
     const messageIds = [
@@ -9921,6 +9950,23 @@ export class DesktopBackendRegistry {
     record: ReviewSubAgentRecord,
   ): Promise<void> {
     const startedAt = Date.now();
+    const entry: AppServerThreadReviewEntry = {
+      type: "review",
+      id: `managed-review:${record.turnId}:started`,
+      review: record.displayText,
+      displayText: record.displayText,
+      createdAt: startedAt,
+      turn: {
+        id: record.turnId,
+        status: "in_progress",
+        startedAt,
+      },
+    };
+    await this.overlayStore.upsertManagedReviewEntry({
+      backend: record.backend,
+      threadId: record.parentThreadId,
+      entry,
+    });
     await this.emit({
       backend: record.backend,
       notification: {
@@ -9944,7 +9990,7 @@ export class DesktopBackendRegistry {
           threadId: record.parentThreadId,
           turnId: record.turnId,
           item: {
-            id: `managed-review:${record.turnId}:started`,
+            id: entry.id,
             type: "enteredReviewMode",
             review: record.displayText,
             createdAt: startedAt,
@@ -16055,6 +16101,20 @@ export class DesktopBackendRegistry {
     );
   }
 
+  private findManagedReviewForChildRequest(params: {
+    backend: AppServerBackendKind;
+    reviewThreadId: string;
+    turnId?: string;
+  }): ReviewSubAgentRecord | undefined {
+    return Array.from(this.activeReviewSubAgents.values()).find(
+      (record) =>
+        record.mode === "managed"
+        && record.backend === params.backend
+        && record.reviewThreadId === params.reviewThreadId
+        && (!params.turnId || record.turnId === params.turnId),
+    );
+  }
+
   private async publishManagedReviewTerminal(params: {
     method: "turn/completed" | "turn/failed" | "turn/cancelled";
     notification: Extract<
@@ -16077,6 +16137,23 @@ export class DesktopBackendRegistry {
       const review = parsed
         ? formatManagedReviewOutput(parsed)
         : output?.trim() || "Review completed without output.";
+      const entry: AppServerThreadReviewEntry = {
+        type: "review",
+        id: `managed-review:${params.record.turnId}:result`,
+        review,
+        createdAt: completedAt,
+        ...(parsed ? { output: parsed } : {}),
+        turn: {
+          id: params.record.turnId,
+          status: "completed",
+          completedAt,
+        },
+      };
+      await this.overlayStore.upsertManagedReviewEntry({
+        backend: params.record.backend,
+        threadId: params.record.parentThreadId,
+        entry,
+      });
       await this.emit({
         backend: params.record.backend,
         notification: {
@@ -16085,7 +16162,7 @@ export class DesktopBackendRegistry {
             threadId: params.record.parentThreadId,
             turnId: params.record.turnId,
             item: {
-              id: `managed-review:${params.record.turnId}:result`,
+              id: entry.id,
               type: "exitedReviewMode",
               review,
               createdAt: completedAt,
@@ -17903,10 +17980,35 @@ export class DesktopBackendRegistry {
       return buildHeadlessAutomationRequestCancelResponse(request);
     }
 
+    const managedReview = this.findManagedReviewForChildRequest({
+      backend,
+      reviewThreadId: request.params.threadId,
+      turnId: request.params.turnId ?? undefined,
+    });
+    const routedRequest = managedReview
+      ? {
+          ...request,
+          params: {
+            ...request.params,
+            threadId: managedReview.parentThreadId,
+            turnId: managedReview.turnId,
+          },
+        } as AppServerPendingRequestNotification
+      : request;
+    if (managedReview) {
+      backendRegistryLog.info("managed review request routed to parent", {
+        method: request.method,
+        parentThreadId: managedReview.parentThreadId,
+        requestId: request.params.requestId,
+        reviewThreadId: managedReview.reviewThreadId,
+        turnId: managedReview.turnId,
+      });
+    }
+
     const key = buildPendingRequestKey({
       backend,
-      threadId: request.params.threadId,
-      requestId: request.params.requestId,
+      threadId: routedRequest.params.threadId,
+      requestId: routedRequest.params.requestId,
     });
 
     return await new Promise<SubmitServerRequestRequest["response"]>((resolve, reject) => {
@@ -17914,16 +18016,16 @@ export class DesktopBackendRegistry {
 
       void this.emit({
         backend,
-        notification: request as AppServerNotification,
+        notification: routedRequest as AppServerNotification,
       }).catch((error) => {
         backendRegistryLog.error(
           "failed to publish pending server request; keeping request pending",
           {
             backend,
             error: error instanceof Error ? error.message : String(error),
-            requestId: request.params.requestId,
-            threadId: request.params.threadId,
-            turnId: request.params.turnId,
+            requestId: routedRequest.params.requestId,
+            threadId: routedRequest.params.threadId,
+            turnId: routedRequest.params.turnId,
           },
         );
       });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -18,6 +18,11 @@ import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
+  buildManagedReviewPrompt,
+  formatManagedReviewOutput,
+  parseManagedReviewOutput,
+} from "./managed-review";
+import {
   type AcpBackendId,
   buildThreadMarkdownLink,
   buildThreadUrl,
@@ -2273,8 +2278,10 @@ type TaskMonitorDelegationRecord = {
 type ReviewSubAgentRecord = {
   backend: Exclude<AppServerBackendKind, AcpBackendId>;
   createdAt: number;
+  displayText: string;
   fastMode?: boolean;
   latestUsage?: TaskMonitorUsageSnapshot;
+  mode: "managed" | "native";
   model?: string;
   parentThreadId: string;
   serviceTier?: string;
@@ -5640,6 +5647,7 @@ export class DesktopBackendRegistry {
    */
   private readonly isCodexBootstrapDeferredFn: () => boolean;
   private readonly resolveCodexDefaultModeRequestUserInputFn: () => boolean;
+  private readonly resolveManagedReviewEnabledFn: () => boolean;
   private readonly resolveProviderModelDefaultsFn: () => Record<
     string,
     DesktopProviderModelDefaults
@@ -5688,6 +5696,7 @@ export class DesktopBackendRegistry {
     isCodexBootstrapDeferred?: () => boolean;
     isBootstrapMode?: () => boolean;
     resolveCodexDefaultModeRequestUserInput?: () => boolean;
+    resolveManagedReviewEnabled?: () => boolean;
     resolveProviderModelDefaults?: () => Record<
       string,
       DesktopProviderModelDefaults
@@ -5750,6 +5759,23 @@ export class DesktopBackendRegistry {
         } catch (error) {
           backendRegistryLog.warn(
             "failed to resolve Codex default-mode request_user_input setting",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return false;
+        }
+      });
+    this.resolveManagedReviewEnabledFn =
+      options?.resolveManagedReviewEnabled ??
+      (() => {
+        try {
+          return (
+            settingsService ?? getDesktopSettingsService()
+          ).resolveManagedReviewEnabled();
+        } catch (error) {
+          backendRegistryLog.warn(
+            "failed to resolve managed review experiment setting",
             {
               error: error instanceof Error ? error.message : String(error),
             },
@@ -9680,6 +9706,8 @@ export class DesktopBackendRegistry {
     if (isAcpBackendId(params.backend)) {
       throw new Error("Selected backend does not support review/start");
     }
+    const managedMode =
+      params.backend === "codex" && this.resolveManagedReviewEnabledFn();
     const reserveCodexReviewStart = params.backend === "codex";
     if (reserveCodexReviewStart) {
       if (this.threadHasActiveTurn(params.threadId)) {
@@ -9689,21 +9717,19 @@ export class DesktopBackendRegistry {
     }
     let modelSettings: ModelSettings = {};
     let result: { threadId: string; reviewThreadId: string; turnId: string };
+    let overlay: ThreadOverlayState | undefined;
+    let cwd: string | undefined;
     try {
-      modelSettings = hasExplicitModelSettings(params)
-        ? await this.resolveReviewModelSettings(params.backend, params)
-        : {};
       if (params.backend === "codex") {
         await this.flushQueuedExecutionModeIfPresent(params.threadId);
       }
-      const overlay =
+      overlay =
         params.backend === "codex"
           ? await this.overlayStore.getThreadOverlayState({
               backend: params.backend,
               threadId: params.threadId,
             })
           : undefined;
-      let cwd: string | undefined;
       if (params.backend === "codex") {
         cwd =
           params.cwd?.trim()
@@ -9713,6 +9739,20 @@ export class DesktopBackendRegistry {
             overlay,
           );
       }
+      const requestedModelSettings: ModelSettings = managedMode
+        ? {
+            model: params.model ?? overlay?.model,
+            reasoningEffort: params.reasoningEffort ?? overlay?.reasoningEffort,
+            serviceTier: params.serviceTier ?? overlay?.serviceTier ?? undefined,
+            fastMode: params.fastMode ?? overlay?.fastMode,
+          }
+        : params;
+      modelSettings = hasExplicitModelSettings(requestedModelSettings)
+        ? await this.resolveReviewModelSettings(
+            params.backend,
+            requestedModelSettings,
+          )
+        : {};
 
       const startWithClient = async (
         client: BackendClient,
@@ -9732,8 +9772,15 @@ export class DesktopBackendRegistry {
         });
       };
 
-      result =
-        params.backend === "codex"
+      result = managedMode
+        ? await this.startManagedReviewChild({
+            cwd,
+            modelSettings,
+            overlay,
+            parentThreadId: params.threadId,
+            target: params.target,
+          })
+        : params.backend === "codex"
           ? await this.withCodexThreadClient(params.threadId, startWithClient)
           : await startWithClient(this.getClient(params.backend));
     } catch (error) {
@@ -9745,7 +9792,9 @@ export class DesktopBackendRegistry {
 
     if (params.backend === "codex") {
       try {
-        const reviewThreadId = result.reviewThreadId || result.threadId;
+        const reviewThreadId = managedMode
+          ? result.threadId
+          : result.reviewThreadId || result.threadId;
         // Codex review/start returns the real review turn id, but current
         // Codex builds can also emit a lone, mismatched turn/started for the
         // same thread. Treat the returned review turn as active so queued
@@ -9771,8 +9820,10 @@ export class DesktopBackendRegistry {
     const reviewSubAgentRecord: ReviewSubAgentRecord = {
       backend: params.backend as Exclude<AppServerBackendKind, AcpBackendId>,
       createdAt: Date.now(),
+      displayText: reviewTaskLabel(params.target),
       ...(modelSettings.fastMode !== undefined ? { fastMode: modelSettings.fastMode } : {}),
       ...(modelSettings.model ? { model: modelSettings.model } : {}),
+      mode: managedMode ? "managed" : "native",
       parentThreadId: result.threadId,
       reviewThreadId: result.reviewThreadId || result.threadId,
       ...(modelSettings.serviceTier ? { serviceTier: modelSettings.serviceTier } : {}),
@@ -9787,6 +9838,15 @@ export class DesktopBackendRegistry {
     this.activeReviewSubAgents.set(reviewSubAgentKey, reviewSubAgentRecord);
     this.reviewSubAgentsByReviewTurn.set(reviewSubAgentKey, reviewSubAgentRecord);
     await this.persistReviewSubAgent(reviewSubAgentRecord);
+    backendRegistryLog.info("code review started", {
+      mode: reviewSubAgentRecord.mode,
+      parentThreadId: reviewSubAgentRecord.parentThreadId,
+      reviewThreadId: reviewSubAgentRecord.reviewThreadId,
+      turnId: reviewSubAgentRecord.turnId,
+    });
+    if (managedMode) {
+      await this.emitManagedReviewStarted(reviewSubAgentRecord);
+    }
     if (hasExplicitModelSettings(modelSettings)) {
       await this.overlayStore.setThreadModelSettings({
         backend: params.backend,
@@ -9801,6 +9861,97 @@ export class DesktopBackendRegistry {
       reviewThreadId: result.reviewThreadId,
       turnId: result.turnId,
     };
+  }
+
+  private async startManagedReviewChild(params: {
+    cwd?: string;
+    modelSettings: ModelSettings;
+    overlay?: ThreadOverlayState;
+    parentThreadId: string;
+    target: StartReviewRequest["target"];
+  }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
+    const executionMode =
+      params.overlay?.executionMode
+      ?? await this.resolveCodexThreadExecutionModeForActiveTurn(
+        params.parentThreadId,
+      );
+    const modeSettings = EXECUTION_MODE_SUMMARIES[executionMode];
+    const client = this.getClient("codex", executionMode);
+    const thread = await client.startThread({
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      approvalPolicy: modeSettings.approvalPolicy,
+      ephemeral: true,
+      sandbox: modeSettings.sandbox,
+      ...params.modelSettings,
+      ...(params.overlay?.codexEnvironmentRuntime
+        ? { codexEnvironmentRuntime: params.overlay.codexEnvironmentRuntime }
+        : {}),
+    });
+    this.reservedCodexStartThreadIds.add(thread.threadId);
+    try {
+      const turn = await client.startTurn({
+        threadId: thread.threadId,
+        input: [{ type: "text", text: buildManagedReviewPrompt(params.target) }],
+        ...(params.cwd ? { cwd: params.cwd } : {}),
+        approvalPolicy: modeSettings.approvalPolicy,
+        sandbox: modeSettings.sandbox,
+        ...params.modelSettings,
+        ...(params.overlay?.codexEnvironmentRuntime
+          ? { codexEnvironmentRuntime: params.overlay.codexEnvironmentRuntime }
+          : {}),
+      });
+      this.activeTurnKeys.add(
+        buildActiveTurnKey("codex", turn.threadId, turn.turnId),
+      );
+      this.activeCodexTurnModes.set(
+        buildActiveTurnModeKey(turn.threadId, turn.turnId),
+        executionMode,
+      );
+      return {
+        threadId: params.parentThreadId,
+        reviewThreadId: turn.threadId,
+        turnId: turn.turnId,
+      };
+    } finally {
+      this.reservedCodexStartThreadIds.delete(thread.threadId);
+    }
+  }
+
+  private async emitManagedReviewStarted(
+    record: ReviewSubAgentRecord,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    await this.emit({
+      backend: record.backend,
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: record.parentThreadId,
+          turnId: record.turnId,
+          turn: {
+            id: record.turnId,
+            status: "inProgress",
+            startedAt,
+          },
+        },
+      },
+    });
+    await this.emit({
+      backend: record.backend,
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: record.parentThreadId,
+          turnId: record.turnId,
+          item: {
+            id: `managed-review:${record.turnId}:started`,
+            type: "enteredReviewMode",
+            review: record.displayText,
+            createdAt: startedAt,
+          },
+        },
+      },
+    });
   }
 
   async submitReview(params: StartReviewRequest): Promise<
@@ -10027,6 +10178,33 @@ export class DesktopBackendRegistry {
             },
           },
         },
+      });
+      return params;
+    }
+
+    const managedReview = this.findManagedReviewForParentTurn({
+      backend: params.backend,
+      parentThreadId: params.threadId,
+      turnId: params.turnId,
+    });
+    if (managedReview) {
+      const activeMode = this.activeCodexTurnModes.get(
+        buildActiveTurnModeKey(
+          managedReview.reviewThreadId,
+          managedReview.turnId,
+        ),
+      );
+      const client = activeMode
+        ? this.getClient("codex", activeMode)
+        : this.codexClient;
+      await client.interruptTurn({
+        threadId: managedReview.reviewThreadId,
+        turnId: managedReview.turnId,
+      });
+      backendRegistryLog.info("managed review interrupt requested", {
+        parentThreadId: managedReview.parentThreadId,
+        reviewThreadId: managedReview.reviewThreadId,
+        turnId: managedReview.turnId,
       });
       return params;
     }
@@ -14356,6 +14534,14 @@ export class DesktopBackendRegistry {
           ? initializeResult.reason.message
           : String(initializeResult.reason)
         : "";
+    const capabilities = buildCapabilities(methods, "codex");
+    if (
+      this.resolveManagedReviewEnabledFn()
+      && capabilities.createThread
+      && capabilities.startTurn
+    ) {
+      capabilities.startReview = true;
+    }
 
     return {
       kind: "codex",
@@ -14373,7 +14559,7 @@ export class DesktopBackendRegistry {
       serverName: successful[0]?.serverInfo?.name,
       serverVersion: successful[0]?.serverInfo?.version,
       methods,
-      capabilities: buildCapabilities(methods, "codex"),
+      capabilities,
       launchpadOptions: buildLaunchpadOptions("codex", discoveredModels),
       executionModes: [
         {
@@ -15853,6 +16039,169 @@ export class DesktopBackendRegistry {
       status: "failed",
       updatedAt: completedAt,
     });
+  }
+
+  private findManagedReviewForParentTurn(params: {
+    backend: AppServerBackendKind;
+    parentThreadId: string;
+    turnId: string;
+  }): ReviewSubAgentRecord | undefined {
+    return Array.from(this.activeReviewSubAgents.values()).find(
+      (record) =>
+        record.mode === "managed"
+        && record.backend === params.backend
+        && record.parentThreadId === params.parentThreadId
+        && record.turnId === params.turnId,
+    );
+  }
+
+  private async publishManagedReviewTerminal(params: {
+    method: "turn/completed" | "turn/failed" | "turn/cancelled";
+    notification: Extract<
+      AppServerNotification,
+      { method: "turn/completed" | "turn/failed" | "turn/cancelled" }
+    >;
+    record: ReviewSubAgentRecord;
+  }): Promise<void> {
+    const completedAt =
+      completedAtFromTerminalNotification(params.notification) ?? Date.now();
+    if (params.method === "turn/completed") {
+      const output = await this.readManagedReviewOutput(
+        params.record,
+        params.notification as Extract<
+          AppServerNotification,
+          { method: "turn/completed" }
+        >,
+      );
+      const parsed = parseManagedReviewOutput(output);
+      const review = parsed
+        ? formatManagedReviewOutput(parsed)
+        : output?.trim() || "Review completed without output.";
+      await this.emit({
+        backend: params.record.backend,
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: params.record.parentThreadId,
+            turnId: params.record.turnId,
+            item: {
+              id: `managed-review:${params.record.turnId}:result`,
+              type: "exitedReviewMode",
+              review,
+              createdAt: completedAt,
+              ...(parsed ? { data: { reviewOutput: parsed } } : {}),
+            },
+          },
+        },
+      });
+      backendRegistryLog.info("managed review artifact published", {
+        parentThreadId: params.record.parentThreadId,
+        reviewThreadId: params.record.reviewThreadId,
+        structured: Boolean(parsed),
+        turnId: params.record.turnId,
+      });
+      await this.emit({
+        backend: params.record.backend,
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: params.record.parentThreadId,
+            turnId: params.record.turnId,
+            turn: {
+              id: params.record.turnId,
+              status: "completed",
+              completedAt,
+              output: [{ type: "text", text: review }],
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    backendRegistryLog.info("managed review artifact discarded", {
+      method: params.method,
+      parentThreadId: params.record.parentThreadId,
+      reviewThreadId: params.record.reviewThreadId,
+      turnId: params.record.turnId,
+    });
+    if (params.method === "turn/cancelled") {
+      await this.emit({
+        backend: params.record.backend,
+        notification: {
+          method: "turn/cancelled",
+          params: {
+            threadId: params.record.parentThreadId,
+            turnId: params.record.turnId,
+            turn: {
+              id: params.record.turnId,
+              status: "cancelled",
+              completedAt,
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    const failure = (
+      params.notification as Extract<
+        AppServerNotification,
+        { method: "turn/failed" }
+      >
+    ).params.turn?.error?.message;
+    await this.emit({
+      backend: params.record.backend,
+      notification: {
+        method: "turn/failed",
+        params: {
+          threadId: params.record.parentThreadId,
+          turnId: params.record.turnId,
+          turn: {
+            id: params.record.turnId,
+            status: "failed",
+            completedAt,
+            error: {
+              message:
+                typeof failure === "string" && failure.trim()
+                  ? failure
+                  : "Managed review failed.",
+            },
+          },
+        },
+      },
+    });
+  }
+
+  private async readManagedReviewOutput(
+    record: ReviewSubAgentRecord,
+    notification: Extract<AppServerNotification, { method: "turn/completed" }>,
+  ): Promise<string | undefined> {
+    const terminalOutput = notification.params.turn?.output
+      ?.map((item) => item.text)
+      .filter((text): text is string => typeof text === "string" && Boolean(text.trim()))
+      .join("\n\n")
+      .trim();
+    if (terminalOutput) {
+      return terminalOutput;
+    }
+    try {
+      const replay = await this.readThread({
+        backend: record.backend,
+        threadId: record.reviewThreadId,
+      });
+      return assistantOutputForTurn(replay.replay, record.turnId)
+        .map((item) => item.text)
+        .join("\n\n")
+        .trim() || undefined;
+    } catch (error) {
+      backendRegistryLog.warn("managed review output read failed", {
+        error: error instanceof Error ? error.message : String(error),
+        reviewThreadId: record.reviewThreadId,
+        turnId: record.turnId,
+      });
+      return undefined;
+    }
   }
 
   private findActiveReviewSubAgentForTerminal(params: {
@@ -21950,6 +22299,13 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromTerminalNotification(notification);
+      const managedReview = turnId
+        ? this.findActiveReviewSubAgentForTerminal({
+            backend: event.backend,
+            threadId: notification.params.threadId,
+            turnId,
+          })?.record
+        : undefined;
       if (turnId) {
         await this.completeReviewSubAgent({
           backend: event.backend,
@@ -21957,6 +22313,16 @@ export class DesktopBackendRegistry {
           method: event.notification.method,
           threadId: notification.params.threadId,
           turnId,
+        });
+      }
+      if (managedReview?.mode === "managed") {
+        await this.publishManagedReviewTerminal({
+          method: event.notification.method,
+          notification: event.notification as Extract<
+            AppServerNotification,
+            { method: "turn/completed" | "turn/failed" | "turn/cancelled" }
+          >,
+          record: managedReview,
         });
       }
       if (turnId) {

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -1,0 +1,141 @@
+import type {
+  AppServerReviewOutput,
+  AppServerReviewTarget,
+} from "@pwragent/shared";
+
+const REVIEW_OUTPUT_INSTRUCTIONS = [
+  "Return only one JSON object with this exact top-level shape:",
+  '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"...","overall_confidence_score":0.0}',
+  "Each finding must contain title, body, confidence_score, optional priority (0-3), and code_location with absolute_file_path plus line_range.start/end.",
+  "Do not wrap the JSON in Markdown fences and do not include prose outside it.",
+].join("\n");
+
+export function buildManagedReviewPrompt(
+  target: AppServerReviewTarget,
+): string {
+  return [
+    "Perform a code review. Focus on concrete correctness regressions introduced by the requested changes. Do not modify files.",
+    reviewTargetInstructions(target),
+    REVIEW_OUTPUT_INSTRUCTIONS,
+  ].join("\n\n");
+}
+
+function reviewTargetInstructions(target: AppServerReviewTarget): string {
+  switch (target.type) {
+    case "baseBranch":
+      return `Review the current checkout against base branch '${target.branch}'. Find the merge base and inspect the resulting diff.`;
+    case "commit":
+      return `Review commit ${target.sha}${target.title ? ` (${target.title})` : ""}.`;
+    case "custom":
+      return target.instructions.trim() || "Review the current code changes.";
+    case "uncommittedChanges":
+      return "Review all staged, unstaged, and untracked changes in the current checkout.";
+  }
+}
+
+export function parseManagedReviewOutput(
+  text: string | undefined,
+): AppServerReviewOutput | undefined {
+  if (!text?.trim()) {
+    return undefined;
+  }
+  const source = unwrapJsonFence(text.trim());
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    !Array.isArray(record.findings)
+    || (
+      record.overall_correctness !== "patch is correct"
+      && record.overall_correctness !== "patch is incorrect"
+    )
+    || typeof record.overall_explanation !== "string"
+    || typeof record.overall_confidence_score !== "number"
+  ) {
+    return undefined;
+  }
+
+  const findings = record.findings.flatMap(
+    (value): AppServerReviewOutput["findings"] => {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return [];
+      }
+      const finding = value as Record<string, unknown>;
+      const location = asRecord(finding.code_location);
+      const lineRange = asRecord(location?.line_range);
+      if (
+        typeof finding.title !== "string"
+        || typeof finding.body !== "string"
+        || typeof finding.confidence_score !== "number"
+        || typeof location?.absolute_file_path !== "string"
+        || typeof lineRange?.start !== "number"
+        || typeof lineRange?.end !== "number"
+      ) {
+        return [];
+      }
+      return [{
+        title: finding.title,
+        body: finding.body,
+        confidence_score: finding.confidence_score,
+        ...(typeof finding.priority === "number"
+          ? { priority: finding.priority }
+          : {}),
+        code_location: {
+          absolute_file_path: location.absolute_file_path,
+          line_range: {
+            start: lineRange.start,
+            end: lineRange.end,
+          },
+        },
+      }];
+    },
+  );
+
+  return {
+    findings,
+    overall_correctness: record.overall_correctness,
+    overall_explanation: record.overall_explanation,
+    overall_confidence_score: record.overall_confidence_score,
+  };
+}
+
+export function formatManagedReviewOutput(
+  output: AppServerReviewOutput,
+): string {
+  const lines = [
+    output.overall_explanation.trim() || output.overall_correctness,
+  ];
+  if (output.findings.length === 0) {
+    return [...lines, "", "No findings."].join("\n");
+  }
+  lines.push("");
+  for (const finding of output.findings) {
+    const priority = finding.priority === undefined
+      ? "P?"
+      : `P${finding.priority}`;
+    const range = finding.code_location.line_range;
+    lines.push(
+      `- [${priority}] ${finding.title} (${finding.code_location.absolute_file_path}:${range.start}-${range.end})`,
+      `  ${finding.body}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function unwrapJsonFence(value: string): string {
+  const match = value.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return match?.[1]?.trim() ?? value;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -661,6 +661,10 @@ export class MessagingController {
   private readonly activeTurnsByThreadKey = new Map<string, MessagingActiveTurnSummary>();
   private readonly contextUsageSummariesByThreadKey = new Map<string, string>();
   private readonly planArtifactsByTurnKey = new Map<string, AppServerThreadPlanEntry>();
+  private readonly reviewArtifactsByTurnKey = new Map<
+    string,
+    AppServerThreadReviewEntry
+  >();
   private readonly markdownFileAttachmentSelector =
     new MessagingMarkdownFileAttachmentSelector();
   private readonly typingActivityLastSignaledAt = new Map<string, number>();
@@ -1154,11 +1158,26 @@ export class MessagingController {
       );
     }
     const reviewArtifact = reviewArtifactForBackendEvent(event, this.now());
+    if (reviewArtifact) {
+      this.reviewArtifactsByTurnKey.set(
+        artifactTurnKey(
+          event.backend,
+          threadId,
+          reviewArtifact.turn?.id ?? reviewArtifact.id,
+        ),
+        reviewArtifact,
+      );
+    }
     const markdownFileArtifactSelection =
       this.markdownFileAttachmentSelector.selectFromBackendEvent(event);
     const lifecycle = turnLifecycleForBackendEvent(event, this.now());
     const completedPlan = lifecycle && isTerminalTurnLifecycle(lifecycle)
       ? this.planArtifactsByTurnKey.get(artifactTurnKey(event.backend, threadId, lifecycle.turnId))
+      : undefined;
+    const completedReview = lifecycle?.status === "completed"
+      ? this.reviewArtifactsByTurnKey.get(
+          artifactTurnKey(event.backend, threadId, lifecycle.turnId),
+        )
       : undefined;
     for (const binding of bindings) {
       let activeTurn = this.getActiveTurn(binding);
@@ -1247,6 +1266,7 @@ export class MessagingController {
         if (
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
+          && !completedReview
         ) {
           const deliveredFinalStream = await this.flushAssistantStreamForEvent(
             event,
@@ -1302,11 +1322,11 @@ export class MessagingController {
         });
       }
 
-      if (reviewArtifact && !automationTurnEvent) {
+      if (completedReview && !automationTurnEvent) {
         await this.deliverArtifactForBinding({
-          artifact: artifactFromReviewEntry(reviewArtifact),
+          artifact: artifactFromReviewEntry(completedReview),
           binding,
-          intentId: `artifact:review:${reviewArtifact.id}:${binding.id}`,
+          intentId: `artifact:review:${completedReview.id}:${binding.id}`,
         });
       }
 
@@ -1372,6 +1392,9 @@ export class MessagingController {
       this.forgetAutomationTurn(event.backend, threadId, lifecycle.turnId);
       this.forgetAgentMessagingOrigin(event.backend, threadId, lifecycle.turnId);
       this.planArtifactsByTurnKey.delete(artifactTurnKey(event.backend, threadId, lifecycle.turnId));
+      this.reviewArtifactsByTurnKey.delete(
+        artifactTurnKey(event.backend, threadId, lifecycle.turnId),
+      );
     }
   }
 

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -111,6 +111,7 @@ export type DesktopSettingsConfig = {
     threadPricingDisplayCodexCredits?: boolean;
     threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
+    managedReview?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       model?: string;
@@ -699,6 +700,12 @@ export function desktopSettingsPatchToEdits(
     set(
       ["experimental", "codex_default_mode_request_user_input"],
       patch.experimental.codexDefaultModeRequestUserInput,
+    );
+  }
+  if (patch.experimental?.managedReview !== undefined) {
+    set(
+      ["experimental", "managed_review"],
+      patch.experimental.managedReview,
     );
   }
   if (patch.experimental?.diffCondensation?.model !== undefined) {
@@ -1412,6 +1419,7 @@ function normalizeDesktopConfig(
       codexDefaultModeRequestUserInput: readBoolean(
         experimental?.codex_default_mode_request_user_input,
       ),
+      managedReview: readBoolean(experimental?.managed_review),
       diffCondensation: {
         enabled: readBoolean(diffCondensation?.enabled),
         model: readString(diffCondensation?.model),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -617,6 +617,10 @@ export class DesktopSettingsService {
           config.experimental?.codexDefaultModeRequestUserInput,
           false,
         ),
+        managedReview: this.resolveConfigBoolean(
+          config.experimental?.managedReview,
+          false,
+        ),
         diffCondensation: {
           enabled: this.resolveDiffCondensationEnabled(
             config.experimental?.diffCondensation?.enabled,
@@ -1128,6 +1132,13 @@ export class DesktopSettingsService {
   resolveCodexDefaultModeRequestUserInput(): boolean {
     return this.resolveConfigBoolean(
       this.readConfig().config.experimental?.codexDefaultModeRequestUserInput,
+      false,
+    ).value;
+  }
+
+  resolveManagedReviewEnabled(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.experimental?.managedReview,
       false,
     ).value;
   }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -35,6 +35,7 @@ import {
   AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   MAX_MESSAGING_BINDING_TRANSITION_LOG_ENTRIES,
   MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES,
+  MAX_MANAGED_REVIEW_ENTRIES,
   MAX_PERMISSION_TRANSITION_LOG_ENTRIES,
   MAX_TURN_FAILURE_LOG_ENTRIES,
   buildPullRequestStatusKey,
@@ -371,6 +372,7 @@ export class SqliteOverlayStore {
             current?.codexEnvironmentRuntime ?? thread.codexEnvironmentRuntime,
           retainedBranchDriftPairs: current?.retainedBranchDriftPairs,
           immutableUsageActivities: current?.immutableUsageActivities,
+          managedReviewEntries: current?.managedReviewEntries,
           subAgents: current?.subAgents,
           handoffOrigin: current?.handoffOrigin,
           lastSeenAt: params.fetchedAt,
@@ -669,6 +671,36 @@ export class SqliteOverlayStore {
     };
     this.putThread(threadKey, nextState);
     return { overlay: nextState, persisted: true };
+  }
+
+  async upsertManagedReviewEntry(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    entry: NonNullable<ThreadOverlayState["managedReviewEntries"]>[number];
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const existingEntries = current.managedReviewEntries ?? [];
+    const existingIndex = existingEntries.findIndex(
+      (entry) => entry.id === params.entry.id,
+    );
+    const nextEntries = [...existingEntries];
+    if (existingIndex === -1) {
+      nextEntries.push(params.entry);
+    } else {
+      nextEntries[existingIndex] = params.entry;
+    }
+    const nextState: ThreadOverlayState = {
+      ...current,
+      managedReviewEntries: nextEntries.slice(-MAX_MANAGED_REVIEW_ENTRIES),
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
   }
 
   async upsertThreadUsageLine(params: {
@@ -3758,6 +3790,7 @@ export type OverlayStoreLike = Pick<
   | "getThreadOverlayStates"
   | "setAcpWorktreeDirectory"
   | "persistThreadUsageActivity"
+  | "upsertManagedReviewEntry"
   | "upsertThreadUsageLine"
   | "readThreadPricing"
   | "upsertThreadToolInvocation"

--- a/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ExperimentalSettings.tsx
@@ -48,6 +48,11 @@ const DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT = {
   source: "default" as const,
 };
 
+const DEFAULT_MANAGED_REVIEW = {
+  value: false,
+  source: "default" as const,
+};
+
 const DEFAULT_AGENT_CORE_GROK = {
   value: false,
   source: "default" as const,
@@ -88,6 +93,7 @@ export function ExperimentalSettings(props: {
   onCodexDefaultModeRequestUserInputChange: (
     enabled: boolean,
   ) => Promise<void>;
+  onManagedReviewChange: (enabled: boolean) => Promise<void>;
   onAgentCoreGrokChange: (enabled: boolean) => Promise<void>;
 }) {
   const condensation = props.snapshot.experimental.diffCondensation;
@@ -115,6 +121,8 @@ export function ExperimentalSettings(props: {
   const codexDefaultModeRequestUserInput =
     props.snapshot.experimental.codexDefaultModeRequestUserInput ??
     DEFAULT_CODEX_DEFAULT_MODE_REQUEST_USER_INPUT;
+  const managedReview =
+    props.snapshot.experimental.managedReview ?? DEFAULT_MANAGED_REVIEW;
   const agentCoreGrok =
     props.snapshot.experimental.agentCoreGrok ?? DEFAULT_AGENT_CORE_GROK;
   const knownCondensationModel = DIFF_CONDENSATION_MODEL_OPTIONS.some(
@@ -253,6 +261,33 @@ export function ExperimentalSettings(props: {
                 label="Enable background pull request status"
                 onChange={(enabled) => {
                   void props.onBackgroundPrPollingChange(enabled);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Experimental"
+        title="PwrAgent-managed Code Review"
+        description="Run code reviews in a PwrAgent-managed child turn instead of Codex's native review lifecycle. Disabled by default while failure handling and usage attribution are validated."
+        chip={managedReview.value ? "On" : "Off"}
+        chipKind={managedReview.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Enable managed code review"
+            sub="Route desktop and messaging /review requests through a managed child turn."
+            help="Existing threads are not migrated; turning this off restores native Codex review/start for the next review."
+            source={sourceBadge(managedReview)}
+            control={
+              <SettingsSwitch
+                checked={managedReview.value}
+                disabled={props.saving}
+                label="Enable managed code review"
+                onChange={(enabled) => {
+                  void props.onManagedReviewChange(enabled);
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -448,6 +448,11 @@ function SettingsSectionBody(props: {
             experimental: { codexDefaultModeRequestUserInput: enabled },
           });
         }}
+        onManagedReviewChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            experimental: { managedReview: enabled },
+          });
+        }}
         onAgentCoreGrokChange={async (enabled: boolean) => {
           await props.settings.writeConfig({
             experimental: { agentCoreGrok: enabled },

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -783,6 +783,17 @@ describe("SettingsScreen", () => {
       });
     });
 
+    const managedReviewSwitch = screen.getByRole("switch", {
+      name: "Enable managed code review",
+    });
+    expect(managedReviewSwitch).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(managedReviewSwitch);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        experimental: { managedReview: true },
+      });
+    });
+
     fireEvent.click(within(sections).getByRole("button", { name: "Messaging" }));
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "Medium" })).toHaveAttribute(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7961,6 +7961,166 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("deduplicates Slack-started review markers by authoritative turn id", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "idle",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-start-live",
+              type: "enteredReviewMode",
+              review: "Review current changes",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-start-hydrated",
+              type: "enteredReviewMode",
+              review: "Code review started",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries.filter((entry) =>
+        entry.type === "review" && entry.turn?.status === "in_progress"
+      )).toHaveLength(1);
+    });
+  });
+
+  it("does not clear a just-started review from a racing idle hydration", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let resolveRead:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    const readThread = vi.fn(() => new Promise<AppServerReadThreadResponse>((resolve) => {
+      resolveRead = resolve;
+    }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-start",
+              type: "enteredReviewMode",
+              review: "Review current changes",
+            },
+          },
+        },
+      });
+      resolveRead?.({
+        backend: "codex",
+        fetchedAt: Date.now(),
+        threadId: "thread-1",
+        threadStatus: "idle",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.threadBusy).toBe(true);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/failed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "failed",
+              error: { message: "capacity exhausted" },
+            },
+          },
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("clears stale review thinking when idle hydration also contains a terminal review entry", async () => {
     const readThread = vi.fn(async ({ backend, threadId }) => ({
       backend: backend ?? "codex",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8121,6 +8121,86 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("rechecks an idle review after the own-update grace period", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let resolveFirstRead:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    let readCount = 0;
+    const idleResponse = (): AppServerReadThreadResponse => ({
+      backend: "codex",
+      fetchedAt: Date.now(),
+      threadId: "thread-1",
+      threadStatus: "idle",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const readThread = vi.fn(() => {
+      readCount += 1;
+      if (readCount === 1) {
+        return new Promise<AppServerReadThreadResponse>((resolve) => {
+          resolveFirstRead = resolve;
+        });
+      }
+      return Promise.resolve(idleResponse());
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-start",
+              type: "enteredReviewMode",
+              review: "Review current changes",
+            },
+          },
+        },
+      });
+      resolveFirstRead?.(idleResponse());
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.threadBusy).toBe(true);
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    }, { timeout: 2_500 });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("clears stale review thinking when idle hydration also contains a terminal review entry", async () => {
     const readThread = vi.fn(async ({ backend, threadId }) => ({
       backend: backend ?? "codex",

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -53,6 +53,7 @@ import {
 import { THREAD_HISTORY_PAGE_LIMIT } from "./thread-history-limits";
 
 const MAX_VIEW_ONLY_THREADS = 10;
+const OWN_UPDATE_IDLE_GRACE_MS = 1_500;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
   "turn/requestApproval",
   "review/requestApproval",
@@ -376,6 +377,18 @@ function mergeTranscriptEntries(
     if (existingIndex !== -1) {
       merged[existingIndex] = optimisticEntry;
       continue;
+    }
+
+    if (optimisticEntry.type === "review") {
+      const matchingReviewIndex = merged.findIndex(
+        (entry) =>
+          entry.type === "review"
+          && reviewEntriesMatch(entry, optimisticEntry)
+      );
+      if (matchingReviewIndex !== -1) {
+        merged[matchingReviewIndex] = optimisticEntry;
+        continue;
+      }
     }
 
     const optimisticTurnId = optimisticEntry.turn?.id;
@@ -1081,6 +1094,14 @@ function reviewEntriesMatch(
 ): boolean {
   if (isReviewStartEntry(candidate) !== isReviewStartEntry(optimisticEntry)) {
     return false;
+  }
+
+  if (
+    isReviewStartEntry(candidate)
+    && candidate.turn?.id
+    && candidate.turn.id === optimisticEntry.turn?.id
+  ) {
+    return true;
   }
 
   const candidateLabels = reviewEntryLabels(candidate);
@@ -2598,7 +2619,7 @@ function appendThreadEntries(
     fetchedAt: Date.now(),
     replay: {
       ...baseResponse.replay,
-      entries: mergeItems(baseResponse.replay.entries, entries),
+      entries: mergeTranscriptEntries(baseResponse.replay.entries, entries),
     },
   };
 }
@@ -3342,10 +3363,21 @@ export function useThreadSessionState(params: {
             ? current.completionHydrationRetries + 1
             : 0;
           const thinkingReasons = describeThinkingState(current);
+          const ownUpdateStillSettling =
+            current.expectOwnUpdate
+            && !targetThread.optimisticActiveTurn
+            && responseHasInProgressTurn(current.response ?? response, current.activeTurnId)
+            && !response.replay.entries.some(
+              (entry) =>
+                entry.turn?.id === current.activeTurnId
+                && isCompletedTurnMetadata(entry.turn)
+            )
+            && Date.now() - current.lastTouchedAt < OWN_UPDATE_IDLE_GRACE_MS;
           const shouldClearStaleThinking =
             readResponseThreadStatus(response) === "idle" &&
             thinkingReasons.length > 0 &&
             !hasPendingInteraction(current) &&
+            !ownUpdateStillSettling &&
             !responseHasInProgressTurn(responseWithLoadedHistory, current.activeTurnId);
 
           if (shouldClearStaleThinking) {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -152,6 +152,7 @@ type ThreadSessionEntry = {
   pendingStatusText?: string;
   pendingTurnUsage?: TurnUsageAccumulator;
   response?: AppServerReadThreadResponse;
+  staleThinkingRecheckAt?: number;
   thinkingSinceAt?: number;
   viewport?: ThreadViewportState;
 };
@@ -3363,6 +3364,9 @@ export function useThreadSessionState(params: {
             ? current.completionHydrationRetries + 1
             : 0;
           const thinkingReasons = describeThinkingState(current);
+          const now = Date.now();
+          const ownUpdateSettlesAt =
+            current.lastTouchedAt + OWN_UPDATE_IDLE_GRACE_MS;
           const ownUpdateStillSettling =
             current.expectOwnUpdate
             && !targetThread.optimisticActiveTurn
@@ -3372,7 +3376,7 @@ export function useThreadSessionState(params: {
                 entry.turn?.id === current.activeTurnId
                 && isCompletedTurnMetadata(entry.turn)
             )
-            && Date.now() - current.lastTouchedAt < OWN_UPDATE_IDLE_GRACE_MS;
+            && now < ownUpdateSettlesAt;
           const shouldClearStaleThinking =
             readResponseThreadStatus(response) === "idle" &&
             thinkingReasons.length > 0 &&
@@ -3425,6 +3429,9 @@ export function useThreadSessionState(params: {
               ? undefined
               : current.pendingStatusText,
             response: responseWithLoadedHistory,
+            staleThinkingRecheckAt: ownUpdateStillSettling
+              ? ownUpdateSettlesAt
+              : undefined,
           };
         });
       } catch (error) {
@@ -3669,6 +3676,28 @@ export function useThreadSessionState(params: {
 
     void loadLatest(thread);
   }, [initialHistoryLimit, loadLatest, sessions, thread, threadKey, updateSession]);
+
+  useEffect(() => {
+    if (!thread || !threadKey) {
+      return;
+    }
+    const recheckAt = sessions[threadKey]?.staleThinkingRecheckAt;
+    if (typeof recheckAt !== "number") {
+      return;
+    }
+    const timer = setTimeout(() => {
+      updateSession(threadKey, (current) => ({
+        ...current,
+        hydratedUpdatedAt: undefined,
+        lastTouchedAt: Date.now(),
+        staleThinkingRecheckAt: undefined,
+      }));
+      void loadLatest(thread);
+    }, Math.max(0, recheckAt - Date.now()) + 1);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [loadLatest, sessions, thread, threadKey, updateSession]);
 
   useEffect(() => {
     if (!desktopApi?.onAgentEvent) {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadImagePart,
+  AppServerThreadReviewEntry,
   AppServerThreadSummary,
   CodexEnvironmentAction,
   CodexEnvironmentExecutionTarget,
@@ -1345,6 +1346,12 @@ export type ThreadOverlayState = {
    * narrower per-request usage payload for the same completed turn.
    */
   immutableUsageActivities?: AppServerThreadActivityEntry[];
+  /**
+   * PwrAgent-managed review markers and successful result artifacts. These
+   * supplement the parent provider transcript because managed review child
+   * threads are intentionally ephemeral.
+   */
+  managedReviewEntries?: AppServerThreadReviewEntry[];
   /** Durable delegated sub-agent/task-monitor summaries for this thread. */
   subAgents?: ThreadSubAgentSummary[];
   /** Durable origin metadata for threads created by an Agent handoff tool. */
@@ -1388,6 +1395,8 @@ export type ThreadOverlayState = {
 export const MAX_PERMISSION_TRANSITION_LOG_ENTRIES = 100;
 
 export const MAX_IMMUTABLE_USAGE_ACTIVITY_ENTRIES = 100;
+
+export const MAX_MANAGED_REVIEW_ENTRIES = 100;
 
 export type ThreadPermissionTransitionStatus =
   | "queued"

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -550,6 +550,11 @@ export type DesktopSettingsSnapshot = {
      */
     codexDefaultModeRequestUserInput: DesktopSettingsValue<boolean>;
     /**
+     * Runs reviews as PwrAgent-managed Codex child turns instead of calling
+     * Codex App Server review/start. Disabled by default.
+     */
+    managedReview?: DesktopSettingsValue<boolean>;
+    /**
      * Diff condensation (a.k.a. "diff eliding") gates whether we send
      * focused-diff requests to xAI. When enabled, less-relevant diff
      * hunks are hidden via an xAI judgment call. When disabled, every
@@ -794,6 +799,7 @@ export type DesktopSettingsConfigPatch = {
     threadPricingDisplayCodexCredits?: boolean;
     threadToolAccounting?: boolean;
     codexDefaultModeRequestUserInput?: boolean;
+    managedReview?: boolean;
     diffCondensation?: {
       enabled?: boolean;
       /** "auto" or a specific model id. Empty string is coerced to "auto". */


### PR DESCRIPTION
## Summary

- add an off-by-default `experimental.managed_review` switch that routes desktop and messaging `/review` requests through a PwrAgent-managed Codex child turn
- keep native Codex `review/start` as the default and preserve review targets, workspace selection, execution mode, model, reasoning, service tier, and fast-mode settings
- use one child turn identity for lifecycle, sub-agent state, token usage, and pricing attribution
- terminal-gate review artifacts so success publishes the existing structured review shape while failure/cancellation discards pending output
- deduplicate Slack-started review markers and protect just-started reviews from stale idle hydration
- clear parent active state and release queued turns after managed-review failure or cancellation

## Why

The native Codex review lifecycle can expose an authoritative outer review turn plus a stray inner task turn. In the reported Slack-started incident, an idle hydration response arrived roughly 100 ms after review start, cleared the authoritative turn, and allowed the stray turn to become active indefinitely. Messaging also published any `exitedReviewMode` item immediately with a hard-coded completion message, even when the turn subsequently failed.

This experiment provides a PwrAgent-owned lifecycle for several days of testing while retaining the existing native path when disabled.

## Configuration

Enable in Settings → Experimental → PwrAgent-managed Code Review, or set:

```toml
[experimental]
managed_review = true
```

Turning the setting off restores native `review/start` for subsequent reviews. Existing threads and unrelated configuration are unchanged.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/managed-review.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts`
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm test:desktop-e2e apps/desktop/e2e/managed-review.spec.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (zero errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
