### PR TITLE
fix(desktop): reconcile review busy state

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8323,6 +8323,86 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("rechecks an idle optimistic review before clearing missed terminal state", async () => {
+    let resolveFirstRead:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    let readCount = 0;
+    const idleResponse = (): AppServerReadThreadResponse => ({
+      backend: "codex",
+      fetchedAt: Date.now(),
+      threadId: "thread-1",
+      threadStatus: "idle",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const readThread = vi.fn(() => {
+      readCount += 1;
+      if (readCount === 1) {
+        return new Promise<AppServerReadThreadResponse>((resolve) => {
+          resolveFirstRead = resolve;
+        });
+      }
+      return Promise.resolve(idleResponse());
+    });
+    const optimisticThread = {
+      ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      optimisticActiveTurn: {
+        id: "turn-review",
+        statusText: "Reviewing",
+        startedAt: Date.now(),
+        reviewDisplayText: "Review changes against main",
+      },
+    };
+    const { result, rerender } = renderHook(
+      ({ currentThread }) =>
+        useThreadSessionState({
+          desktopApi: { readThread },
+          thread: currentThread,
+        }),
+      {
+        initialProps: {
+          currentThread: optimisticThread,
+        },
+      }
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.threadBusy).toBe(true);
+    });
+
+    act(() => {
+      resolveFirstRead?.(idleResponse());
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBe("turn-review");
+      expect(result.current.threadBusy).toBe(true);
+    });
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    }, { timeout: 2_500 });
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+
+    rerender({ currentThread: { ...optimisticThread } });
+    await flushReactUpdates();
+
+    expect(result.current.activeTurnId).toBeUndefined();
+    expect(result.current.threadBusy).toBe(false);
+  });
+
   it("clears stale review thinking when idle hydration also contains a terminal review entry", async () => {
     const readThread = vi.fn(async ({ backend, threadId }) => ({
       backend: backend ?? "codex",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7552,6 +7552,128 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps a live review authoritative across a transient idle hydration", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let resolveReadThread:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async () =>
+        await new Promise<AppServerReadThreadResponse>((resolve) => {
+          resolveReadThread = resolve;
+        })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(agentEventHandler).toBeDefined();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "turn-review-entered",
+              type: "enteredReviewMode",
+              review: "Review changes against main",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-review");
+    expect(result.current.threadBusy).toBe(true);
+
+    await act(async () => {
+      resolveReadThread?.({
+        backend: "codex",
+        fetchedAt: Date.now(),
+        threadId: "thread-1",
+        threadStatus: "idle",
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-review");
+    expect(result.current.threadBusy).toBe(true);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-stray",
+            turn: {
+              id: "turn-stray",
+              status: "inProgress",
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.activeTurnId).toBe("turn-review");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/failed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            turn: {
+              id: "turn-review",
+              status: "failed",
+              error: {
+                message: "Selected model is at capacity. Please try a different model.",
+              },
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeTurnId).toBeUndefined();
+      expect(result.current.pendingStatusText).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+    });
+  });
+
   it("seeds launchpad review turns before stray turn starts arrive", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3415,18 +3415,20 @@ export function useThreadSessionState(params: {
                 && isCompletedTurnMetadata(entry.turn)
             )
             && now < ownUpdateSettlesAt;
+          const reviewUpdateStillSettling =
+            current.expectOwnUpdate
+            && sessionHasInProgressReviewTurn(current, current.activeTurnId)
+            && !responseHasCompletedTurn(
+              responseWithLoadedHistory,
+              current.activeTurnId
+            )
+            && now < ownUpdateSettlesAt;
           const shouldClearStaleThinking =
             readResponseThreadStatus(response) === "idle"
             && thinkingReasons.length > 0
             && !hasPendingInteraction(current)
             && !ownUpdateStillSettling
-            && (
-              !sessionHasInProgressReviewTurn(current, current.activeTurnId)
-              || responseHasCompletedTurn(
-                responseWithLoadedHistory,
-                current.activeTurnId
-              )
-            )
+            && !reviewUpdateStillSettling
             && !responseHasInProgressTurn(
               responseWithLoadedHistory,
               current.activeTurnId
@@ -3477,7 +3479,8 @@ export function useThreadSessionState(params: {
               ? undefined
               : current.pendingStatusText,
             response: responseWithLoadedHistory,
-            staleThinkingRecheckAt: ownUpdateStillSettling
+            staleThinkingRecheckAt:
+              ownUpdateStillSettling || reviewUpdateStillSettling
               ? ownUpdateSettlesAt
               : undefined,
           };

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1408,6 +1408,44 @@ function responseHasInProgressTurn(
   return turnEntries.some((entry) => entry.turn?.status === "in_progress");
 }
 
+function responseHasCompletedTurn(
+  response: AppServerReadThreadResponse,
+  turnId: string | undefined
+): boolean {
+  if (!turnId) {
+    return false;
+  }
+
+  return response.replay.entries.some(
+    (entry) =>
+      entry.turn?.id === turnId
+      && isCompletedTurnMetadata(entry.turn)
+  );
+}
+
+function sessionHasInProgressReviewTurn(
+  session: ThreadSessionEntry,
+  turnId: string | undefined
+): boolean {
+  if (!turnId) {
+    return false;
+  }
+
+  const reviewEntries = [
+    ...(session.response?.replay.entries ?? []),
+    ...session.optimisticEntries,
+  ].filter(
+    (entry) =>
+      entry.type === "review"
+      && entry.turn?.id === turnId
+  );
+  if (reviewEntries.some((entry) => isCompletedTurnMetadata(entry.turn))) {
+    return false;
+  }
+
+  return reviewEntries.some((entry) => entry.turn?.status === "in_progress");
+}
+
 function normalizeNotificationTimestamp(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return undefined;
@@ -3378,11 +3416,21 @@ export function useThreadSessionState(params: {
             )
             && now < ownUpdateSettlesAt;
           const shouldClearStaleThinking =
-            readResponseThreadStatus(response) === "idle" &&
-            thinkingReasons.length > 0 &&
-            !hasPendingInteraction(current) &&
-            !ownUpdateStillSettling &&
-            !responseHasInProgressTurn(responseWithLoadedHistory, current.activeTurnId);
+            readResponseThreadStatus(response) === "idle"
+            && thinkingReasons.length > 0
+            && !hasPendingInteraction(current)
+            && !ownUpdateStillSettling
+            && (
+              !sessionHasInProgressReviewTurn(current, current.activeTurnId)
+              || responseHasCompletedTurn(
+                responseWithLoadedHistory,
+                current.activeTurnId
+              )
+            )
+            && !responseHasInProgressTurn(
+              responseWithLoadedHistory,
+              current.activeTurnId
+            );
 
           if (shouldClearStaleThinking) {
             if (targetThread.optimisticActiveTurn) {


### PR DESCRIPTION
## Summary

- Preserve an authoritative live review turn across a transient stale idle hydration.
- Reject a stray inner review turn ID so the authoritative terminal event clears the shared renderer session.
- Add regression coverage for the observed split-brain sequence and retain Stop self-healing coverage.

## Root cause

A pending `thread/read` response could clear a newly entered review because its stale snapshot still reported the thread as idle. That allowed a later inner Codex turn ID to become the renderer's active turn. When the authoritative outer review failed, its terminal event no longer matched the renderer's adopted turn and was ignored.

The main-process active-turn registry had already reached idle, so the quit snapshot correctly reported no active work, while the renderer retained a phantom active turn that drove Thinking, Stop, and the sidebar animation.

## Result

A live review entry now protects its active turn from stale idle hydration. A hydrated terminal entry for that same turn can still clear it. The authoritative review failure therefore clears the shared renderer state used by Composer and thread navigation, bringing the Stop button and sidebar busy indicator back to idle together.

## Validation

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` — 86 passed
- Focused Composer review/Stop lifecycle tests — 3 passed
- `pnpm test apps/desktop/src/main/__tests__/quit-manager.test.ts` — 11 passed
- Focused backend quit-snapshot test — 1 passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors (138 existing warnings)
- `pnpm lint:boundaries`
