### PR TITLE
test(desktop): stabilize PR cache timing assertion

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2440,7 +2440,7 @@ describe("app server ipc", () => {
       state: "passing",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/922",
     });
-    const fetchedAt = 1_000_000;
+    const fetchedAt = Date.now();
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2440,13 +2440,14 @@ describe("app server ipc", () => {
       state: "passing",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/922",
     });
+    const fetchedAt = 1_000_000;
     readPrLookupCache.mockResolvedValueOnce({
       [lookupKey]: {
         lookupKey,
         provider: "github.com",
         branch: "feat/cached-detached-pr",
         directoryPaths: ["/repo"],
-        fetchedAt: Date.now(),
+        fetchedAt,
         prs: [detachedPr, cachedPr],
       },
     });
@@ -2457,7 +2458,7 @@ describe("app server ipc", () => {
       extraLinkedDirectories: [],
       detachedPrKeys: ["github.com/pwrdrvr/pwragent#921"],
       prs: [previousPr],
-      prsFetchedAt: Date.now() - 120_000,
+      prsFetchedAt: fetchedAt - 120_000,
       prsRefreshKey: "old-refresh-key",
     });
     setThreadPullRequests.mockResolvedValueOnce({
@@ -2466,7 +2467,7 @@ describe("app server ipc", () => {
       executionMode: "default",
       extraLinkedDirectories: [],
       prs: [previousPr, cachedPr],
-      prsFetchedAt: Date.now(),
+      prsFetchedAt: fetchedAt,
       prsRefreshKey: requestKey,
     });
 


### PR DESCRIPTION
## Summary

- use one fixed fetchedAt value across the lookup-cache fixture and mocked persisted store result
- keep the prior store observation deterministically two minutes older
- preserve production behavior where a genuinely newer store observation suppresses a stale publish

## Root cause

The test independently called Date.now() for the lookup-cache observation and the mocked setThreadPullRequests result. On Windows, the latter could advance to a newer millisecond, so production correctly treated the mocked store state as newer and suppressed publishLocalEvent, contradicting the test's expectation.

Failing run: https://github.com/pwrdrvr/PwrAgent/actions/runs/30651615698

## Impact

Test-only change. This removes a Windows timing flake without changing production behavior.

## Validation

- affected test passed 20 consecutive focused runs
- pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts (65 tests passed)
- pnpm exec eslint apps/desktop/src/main/__tests__/app-server-ipc.test.ts
- pnpm typecheck
- git diff --check
