### PR TITLE
fix(desktop): improve command prefix approval actions

### DIFF
--- a/apps/desktop/e2e/approval-pending.spec.ts
+++ b/apps/desktop/e2e/approval-pending.spec.ts
@@ -4,6 +4,9 @@ import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
 
 const approvalPendingSpecDir = path.dirname(fileURLToPath(import.meta.url));
+const approvalCommand =
+  "/opt/homebrew/bin/python3.13 -m unittest scripts.github_actions.tests.test_spin_scala_environments scripts.github_actions.tests.test_spin_scala_metadata scripts.github_actions.tests.test_ci_config_contract scripts.github_actions.tests.test_classify_changes";
+const approvalPrefix = approvalCommand;
 
 async function openApprovalPendingReplay() {
   const app = await launchElectronApp({
@@ -49,13 +52,45 @@ async function openApprovalPendingReplay() {
   await expect(pendingApproval.getByText("Command:")).toBeVisible();
   await expect(
     pendingApproval.locator("pre code")
-  ).toHaveText("npm view dive");
+  ).toHaveText(approvalCommand);
   await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
   await expect(
     app.window.getByText("Waiting for approval before this turn can continue.")
   ).toBeVisible();
   await expect(
     app.window.getByRole("button", { name: "Approve Once" })
+  ).toBeVisible();
+  const allowPrefix = app.window.getByRole("button", {
+    name: `Always Allow Prefix: ${approvalPrefix}`,
+  });
+  await expect(allowPrefix).toBeVisible();
+  await expect(allowPrefix).toHaveClass(/button--ghost/);
+  await expect(allowPrefix).toHaveClass(/transcript-request__action--detailed/);
+  await expect(allowPrefix).toHaveAttribute(
+    "title",
+    `Always Allow Prefix: ${approvalPrefix}`
+  );
+  await expect(
+    allowPrefix.locator(".transcript-request__action-detail")
+  ).toHaveText(approvalPrefix);
+  const prefixLayout = await allowPrefix.evaluate((element) => {
+    const detail = element.querySelector("code");
+    const style = detail ? window.getComputedStyle(detail) : undefined;
+    return {
+      actionHeight: element.getBoundingClientRect().height,
+      overflow: style?.overflow,
+      textOverflow: style?.textOverflow,
+      whiteSpace: style?.whiteSpace,
+    };
+  });
+  expect(prefixLayout).toMatchObject({
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  });
+  expect(prefixLayout.actionHeight).toBeLessThan(60);
+  await expect(
+    app.window.getByRole("button", { name: "Cancel Turn" })
   ).toBeVisible();
 
   return app;
@@ -73,7 +108,7 @@ test("shows pending approval UI without duplicating the turn elsewhere", async (
     await expect(pendingApproval.getByText("Command:")).toBeVisible();
     await expect(
       pendingApproval.locator("pre code")
-    ).toHaveText("npm view dive");
+    ).toHaveText(approvalCommand);
     await expect(app.window.getByText(/\/bin\/zsh -lc/)).toHaveCount(0);
     await expect(
       app.window.getByText("Waiting for approval before this turn can continue.")

--- a/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
+++ b/apps/desktop/e2e/fixtures/approval-pending/replay.fixture.json
@@ -129,10 +129,27 @@
         "params": {
           "threadId": "thread-approval-pending",
           "turnId": "turn-approval-2",
-          "itemId": "call-npm-view-dive",
+          "itemId": "call-read-only-validation",
           "requestId": "approval-request-1",
-          "reason": "Do you want to allow network access so I can query npm metadata for the `dive` package?",
-          "command": "/bin/zsh -lc 'npm view dive'"
+          "reason": "Do you want to allow a read-only validation command outside the sandbox?",
+          "command": "/opt/homebrew/bin/python3.13 -m unittest scripts.github_actions.tests.test_spin_scala_environments scripts.github_actions.tests.test_spin_scala_metadata scripts.github_actions.tests.test_ci_config_contract scripts.github_actions.tests.test_classify_changes",
+          "availableDecisions": [
+            "accept",
+            {
+              "acceptWithExecpolicyAmendment": {
+                "execpolicy_amendment": [
+                  "/opt/homebrew/bin/python3.13",
+                  "-m",
+                  "unittest",
+                  "scripts.github_actions.tests.test_spin_scala_environments",
+                  "scripts.github_actions.tests.test_spin_scala_metadata",
+                  "scripts.github_actions.tests.test_ci_config_contract",
+                  "scripts.github_actions.tests.test_classify_changes"
+                ]
+              }
+            },
+            "cancel"
+          ]
         }
       }
     },

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -241,10 +241,20 @@ test("keeps workflow states and narrow desktop layout readable", async ({}, test
     await expect(composer).toBeVisible();
     await expect(approval).toContainText("Approval needed");
     await expect(approval).toContainText(
-      "Do you want to allow network access so I can query npm metadata for the dive package?"
+      "Do you want to allow a read-only validation command outside the sandbox?"
     );
     await expect(approval.getByText("Command:")).toBeVisible();
-    await expect(approval.locator("pre code")).toHaveText("npm view dive");
+    await expect(approval.locator("pre code")).toContainText(
+      "/opt/homebrew/bin/python3.13 -m unittest"
+    );
+    const allowPrefix = approval.getByRole("button", {
+      name: /Always Allow Prefix: \/opt\/homebrew\/bin\/python3\.13 -m unittest/,
+    });
+    await expect(allowPrefix).toBeVisible();
+    await expect(allowPrefix).toHaveClass(/button--ghost/);
+    await expect(allowPrefix.locator("code")).toContainText(
+      "scripts.github_actions.tests.test_classify_changes"
+    );
     await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
     await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();
 

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -364,6 +364,39 @@ describe("buildApprovalIntent", () => {
     );
   });
 
+  it("preserves a free-form ACP persistent label when its scope cannot be extracted", () => {
+    const intent = buildApprovalIntent({
+      id: "approval-acp-prefix",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-acp-prefix",
+          prompt: "Run npm metadata lookup?",
+          acpPermissionOptions: [
+            {
+              optionId: "allow-always-command",
+              name: "Always allow npm view",
+              kind: "allow_always",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(intent.decisions).toEqual([
+      expect.objectContaining({
+        decision: "accept_with_execpolicy_amendment",
+        label: "Always allow npm view",
+        response: { decision: "allow-always-command" },
+      }),
+      expect.objectContaining({ decision: "cancel" }),
+    ]);
+    expect(intent.decisions[0]).not.toHaveProperty("description");
+    expect(intent.body).not.toContain("Persistent prefix:");
+  });
+
   it("renders file-change approval context without a shell command", () => {
     const intent = buildApprovalIntent({
       id: "approval-3",

--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -302,13 +302,66 @@ describe("buildApprovalIntent", () => {
       expect.objectContaining({
         id: "approval:accept_with_execpolicy_amendment:1",
         decision: "accept_with_execpolicy_amendment",
-        label: "Always Allow Prefix: pnpm test",
+        label: "Always Allow Prefix",
+        description: "pnpm test",
+        style: "secondary",
         response: { decision: structuredDecision },
       }),
       expect.objectContaining({
         decision: "cancel",
       }),
     ]);
+    expect(intent.body).toContain(
+      ["Persistent prefix:", "```shell", "pnpm test", "```"].join("\n"),
+    );
+  });
+
+  it("numbers multiple persistent prefixes while preserving their exact scope", () => {
+    const firstDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "test"],
+      },
+    };
+    const secondDecision = {
+      acceptWithExecpolicyAmendment: {
+        execpolicy_amendment: ["pnpm", "lint"],
+      },
+    };
+    const intent = buildApprovalIntent({
+      id: "approval-prefixes",
+      createdAt: 1000,
+      request: {
+        method: "item/commandExecution/requestApproval",
+        params: {
+          threadId: "thread-1",
+          requestId: "request-prefixes",
+          prompt: "Run checks?",
+          availableDecisions: ["accept", firstDecision, secondDecision, "cancel"],
+        },
+      },
+    });
+
+    expect(intent.decisions).toEqual([
+      expect.objectContaining({ decision: "accept" }),
+      expect.objectContaining({
+        label: "Always Allow Prefix 1",
+        description: "pnpm test",
+        response: { decision: firstDecision },
+      }),
+      expect.objectContaining({
+        label: "Always Allow Prefix 2",
+        description: "pnpm lint",
+        response: { decision: secondDecision },
+      }),
+      expect.objectContaining({ decision: "cancel" }),
+    ]);
+    expect(intent.body).toContain("Persistent prefixes:");
+    expect(intent.body).toContain(
+      ["Always Allow Prefix 1:", "```shell", "pnpm test", "```"].join("\n"),
+    );
+    expect(intent.body).toContain(
+      ["Always Allow Prefix 2:", "```shell", "pnpm lint", "```"].join("\n"),
+    );
   });
 
   it("renders file-change approval context without a shell command", () => {

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -123,21 +123,27 @@ function buildDecisions(
     ];
   }
   const actions = buildPendingRequestActions(request);
-  const persistentActions = actions.filter(
-    (action) => action.decision === "accept_with_execpolicy_amendment",
-  );
+  const presentedActions = actions.map((action) => ({
+    action,
+    description:
+      action.decision === "accept_with_execpolicy_amendment"
+        ? execpolicyPrefix(action)
+        : undefined,
+  }));
+  const describedPersistentCount = presentedActions.filter(
+    ({ description }) => Boolean(description),
+  ).length;
   let persistentIndex = 0;
 
-  return actions.map((action) => {
+  return presentedActions.map(({ action, description }) => {
     const isPersistent = action.decision === "accept_with_execpolicy_amendment";
-    const description = isPersistent ? execpolicyPrefix(action) : undefined;
-    if (isPersistent) {
+    if (description) {
       persistentIndex += 1;
     }
     return {
       id: action.id,
-      label: isPersistent
-        ? `Always Allow Prefix${persistentActions.length > 1 ? ` ${persistentIndex}` : ""}`
+      label: isPersistent && description
+        ? `Always Allow Prefix${describedPersistentCount > 1 ? ` ${persistentIndex}` : ""}`
         : action.label,
       ...(description ? { description } : {}),
       decision: messagingDecisionFromPendingAction(action),

--- a/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-approval-renderer.ts
@@ -35,6 +35,7 @@ export function buildApprovalIntent(params: {
     buildDecisions(params.request),
     params.capabilityProfile,
   );
+  const persistentPrefixContext = persistentPrefixMarkdown(decisions);
   const replyInstruction = approvalReplyInstruction(decisions);
 
   return {
@@ -48,6 +49,7 @@ export function buildApprovalIntent(params: {
       command
         ? ["Command:", "```shell", stripDisplayShellWrapper(command), "```"].join("\n")
         : undefined,
+      persistentPrefixContext,
       fileContext ? ["Context:", fileContext].join("\n") : undefined,
       mcpContext,
       replyInstruction.body,
@@ -120,14 +122,85 @@ function buildDecisions(
       },
     ];
   }
-  return buildPendingRequestActions(request).map((action) => ({
-    id: action.id,
-    label: action.label,
-    decision: messagingDecisionFromPendingAction(action),
-    style: action.style,
-    fallbackText: action.fallbackText,
-    response: action.response,
-  }));
+  const actions = buildPendingRequestActions(request);
+  const persistentActions = actions.filter(
+    (action) => action.decision === "accept_with_execpolicy_amendment",
+  );
+  let persistentIndex = 0;
+
+  return actions.map((action) => {
+    const isPersistent = action.decision === "accept_with_execpolicy_amendment";
+    const description = isPersistent ? execpolicyPrefix(action) : undefined;
+    if (isPersistent) {
+      persistentIndex += 1;
+    }
+    return {
+      id: action.id,
+      label: isPersistent
+        ? `Always Allow Prefix${persistentActions.length > 1 ? ` ${persistentIndex}` : ""}`
+        : action.label,
+      ...(description ? { description } : {}),
+      decision: messagingDecisionFromPendingAction(action),
+      style: action.style,
+      fallbackText: action.fallbackText,
+      response: action.response,
+    };
+  });
+}
+
+function execpolicyPrefix(action: PendingRequestAction): string | undefined {
+  const responseDecision = objectField(action.response.decision);
+  const amendment = objectField(
+    responseDecision?.acceptWithExecpolicyAmendment
+    ?? responseDecision?.accept_with_execpolicy_amendment,
+  );
+  const rawPrefix =
+    amendment?.execpolicy_amendment
+    ?? amendment?.proposed_execpolicy_amendment;
+  if (Array.isArray(rawPrefix)) {
+    const rendered = rawPrefix
+      .filter((part): part is string => typeof part === "string" && Boolean(part.trim()))
+      .join(" ");
+    if (rendered) {
+      return rendered;
+    }
+  }
+
+  const separatorIndex = action.label.indexOf(": ");
+  return separatorIndex > 0
+    ? action.label.slice(separatorIndex + 2).trim() || undefined
+    : undefined;
+}
+
+function persistentPrefixMarkdown(
+  decisions: MessagingApprovalIntent["decisions"],
+): string | undefined {
+  const persistent = decisions.filter(
+    (decision) =>
+      decision.decision === "accept_with_execpolicy_amendment"
+      && Boolean(decision.description),
+  );
+  if (persistent.length === 0) {
+    return undefined;
+  }
+  if (persistent.length === 1) {
+    return [
+      "Persistent prefix:",
+      "```shell",
+      persistent[0]!.description!,
+      "```",
+    ].join("\n");
+  }
+
+  return [
+    "Persistent prefixes:",
+    ...persistent.flatMap((decision) => [
+      `${decision.label}:`,
+      "```shell",
+      decision.description!,
+      "```",
+    ]),
+  ].join("\n");
 }
 
 function isMcpElicitationRequest(
@@ -179,6 +252,12 @@ function mcpElicitationCanAcceptWithoutFormInput(
 
 function hasNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function objectField(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 function messagingDecisionFromPendingAction(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -336,6 +336,45 @@ function isGenericShellToolTitle(command: string): boolean {
   return /^(?:bash|shell|sh|zsh|terminal|tool)$/i.test(command.trim());
 }
 
+function pendingRequestActionPresentation(action: PendingRequestAction): {
+  detail?: string;
+  label: string;
+} {
+  if (action.decision !== "accept_with_execpolicy_amendment") {
+    return { label: action.label };
+  }
+
+  const responseDecision = asRecord(action.response.decision);
+  const amendment = asRecord(
+    responseDecision?.acceptWithExecpolicyAmendment
+    ?? responseDecision?.accept_with_execpolicy_amendment,
+  );
+  const rawPrefix =
+    amendment?.execpolicy_amendment
+    ?? amendment?.proposed_execpolicy_amendment;
+  const structuredDetail = Array.isArray(rawPrefix)
+    ? rawPrefix
+        .filter((part): part is string => typeof part === "string" && Boolean(part.trim()))
+        .join(" ")
+    : "";
+  if (structuredDetail) {
+    return {
+      detail: structuredDetail,
+      label: "Always Allow Prefix",
+    };
+  }
+
+  const separatorIndex = action.label.indexOf(": ");
+  if (separatorIndex > 0) {
+    return {
+      detail: action.label.slice(separatorIndex + 2),
+      label: action.label.slice(0, separatorIndex),
+    };
+  }
+
+  return { label: action.label };
+}
+
 function pendingRequestPrompt(
   request: AppServerPendingRequestNotification,
   context: PendingRequestApprovalContext | undefined,
@@ -1306,23 +1345,37 @@ export function TranscriptList(props: TranscriptListProps) {
               />
               <ApprovalDiffDisclosures context={pendingApprovalContext} />
               <div className="transcript-request__actions">
-                {pendingRequestActions.map((action) => (
-                  <button
-                    className={
-                      action.style === "primary"
-                        ? "button button--primary"
-                        : "button button--ghost"
-                    }
-                    disabled={props.pendingRequestBusy}
-                    key={action.id}
-                    type="button"
-                    onClick={() => {
-                      void props.onRespondToPendingRequest?.(action);
-                    }}
-                  >
-                    {action.label}
-                  </button>
-                ))}
+                {pendingRequestActions.map((action) => {
+                  const presentation = pendingRequestActionPresentation(action);
+                  return (
+                    <button
+                      aria-label={presentation.detail ? action.label : undefined}
+                      className={[
+                        "button",
+                        action.style === "primary" ? "button--primary" : "button--ghost",
+                        presentation.detail
+                          ? "transcript-request__action--detailed"
+                          : "",
+                      ].filter(Boolean).join(" ")}
+                      disabled={props.pendingRequestBusy}
+                      key={action.id}
+                      title={presentation.detail ? action.label : undefined}
+                      type="button"
+                      onClick={() => {
+                        void props.onRespondToPendingRequest?.(action);
+                      }}
+                    >
+                      <span className="transcript-request__action-label">
+                        {presentation.label}
+                      </span>
+                      {presentation.detail ? (
+                        <code className="transcript-request__action-detail">
+                          {presentation.detail}
+                        </code>
+                      ) : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
           ) : null}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3243,6 +3243,53 @@ describe("TranscriptList", () => {
     );
   });
 
+  it("renders a durable command prefix as a secondary, structured action", () => {
+    render(
+      <TranscriptList
+        entries={[]}
+        loading={false}
+        loadingMore={false}
+        pendingRequest={{
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId: "thread-1",
+            requestId: "approval-1",
+            command: "python -m unittest package.tests.test_first package.tests.test_second",
+            availableDecisions: [
+              "accept",
+              {
+                acceptWithExecpolicyAmendment: {
+                  execpolicy_amendment: [
+                    "python",
+                    "-m",
+                    "unittest",
+                    "package.tests.test_first",
+                    "package.tests.test_second",
+                  ],
+                },
+              },
+              "cancel",
+            ],
+          },
+        }}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const action = screen.getByRole("button", {
+      name: "Always Allow Prefix: python -m unittest package.tests.test_first package.tests.test_second",
+    });
+    expect(action).toHaveClass("button--ghost", "transcript-request__action--detailed");
+    expect(action).not.toHaveClass("button--primary");
+    expect(action.querySelector(".transcript-request__action-label")).toHaveTextContent(
+      "Always Allow Prefix"
+    );
+    expect(action.querySelector(".transcript-request__action-detail")).toHaveTextContent(
+      "python -m unittest package.tests.test_first package.tests.test_second"
+    );
+  });
+
   it("derives Kimi approval commands from prompt text when command is a shell title", () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11077,6 +11077,39 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: normal;
 }
 
+.transcript-request__action--detailed {
+  flex: 0 0 100%;
+  width: 100%;
+  height: auto;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  padding: 7px 10px;
+  text-align: left;
+}
+
+.transcript-request__action-label {
+  line-height: 1.2;
+}
+
+.transcript-request__action-detail {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcript-request__action--detailed:hover:not([disabled])
+  .transcript-request__action-detail {
+  color: var(--text-primary);
+}
+
 .transcript-questionnaire__prompt,
 .transcript-mcp__prompt {
   display: flex;

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -198,6 +198,7 @@ describe("buildPendingRequestResponse", () => {
         decision: "accept_with_execpolicy_amendment",
         label: "Always allow: npm view",
         response: { decision: "allow-always-command" },
+        style: "secondary",
       }),
       expect.objectContaining({
         decision: "decline",
@@ -255,6 +256,7 @@ describe("buildPendingRequestResponse", () => {
         decision: "accept_with_execpolicy_amendment",
         label: "Always Allow Prefix: pnpm test",
         response: { decision: structuredDecision },
+        style: "secondary",
       }),
       expect.objectContaining({
         decision: "cancel",

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -566,7 +566,7 @@ function actionFromEntry(
       id: `approval:accept_with_execpolicy_amendment:${index}`,
       label: label ?? execpolicyLabel(execpolicyPayload),
       responseDecision: entry,
-      style: "primary",
+      style: "secondary",
     });
   }
 
@@ -814,12 +814,12 @@ function defaultLabel(
 function defaultStyle(decision: PendingRequestActionDecision): PendingRequestActionStyle {
   switch (decision) {
     case "accept":
-    case "accept_with_execpolicy_amendment":
     case "apply_network_policy_amendment":
       return "primary";
     case "decline":
       return "danger";
     case "accept_for_session":
+    case "accept_with_execpolicy_amendment":
     case "cancel":
       return "secondary";
   }


### PR DESCRIPTION
## Summary

- render desktop durable command-prefix approvals as a structured title plus monospace preview
- keep the durable grant secondary so “Approve Once” remains the single primary action
- constrain long desktop prefixes to a compact ellipsis preview while preserving the exact value in the accessible label and hover title
- use a short `Always Allow Prefix` button on every messaging provider and show the exact persistent scope in the approval message body
- number multiple persistent-prefix choices so each button maps clearly to its full body block
- extend unit and replay-backed Electron coverage for long prefixes at narrow desktop widths

## Root cause

The desktop renderer flattened Codex’s structured exec-policy amendment into one centered button label. Long dotted command prefixes wrapped across many lines, and the durable grant was styled as a second primary action, producing a large orange block on hover.

Messaging already capped native button labels, which avoided the oversized layout but truncated the permission scope—completely on providers with 20-character limits. The message showed the full command, but not the exact boundary that would be persisted.

## Impact

Desktop approval cards stay compact and scannable, retain the full permission scope for accessibility and hover inspection, and keep Cancel Turn visible within the approval card.

Messaging platforms now show a compact neutral action while the approval body carries the exact persistent prefix in a shell code block. Opaque callback responses remain unchanged.

## Validation

- `pnpm test packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts packages/shared/src/__tests__/pending-request-response.test.ts`
- provider formatting tests for Discord, Feishu, LINE, Mattermost, Slack, and Telegram
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/approval-pending.spec.ts`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/tangerine-terminal-theme.spec.ts -g 'keeps workflow states and narrow desktop layout readable'`
- `pnpm lint:eslint` (existing warnings only)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
