### PR TITLE
test(desktop): await pairing subscription in editor test

### DIFF
--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -494,8 +494,9 @@ describe("AutomationEditor", () => {
     // The code is copyable (the app root sets user-select: none).
     expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
 
+    await waitFor(() => expect(pairingListener).toBeDefined());
     act(() => {
-      pairingListener?.({
+      pairingListener!({
         at: 1,
         entry: {
           id: "pair-1",


### PR DESCRIPTION
## Summary

- wait for the Telegram pairing-change subscription before emitting the simulated capture event
- invoke the installed listener non-optionally so a missing subscription fails at the synchronization point instead of silently dropping the event

## Root cause

The generated pairing code can render before React runs the passive effect that installs `onMessagingPairingChanged`. Under CI load, the test could invoke the optional listener during that gap, discard the simulated event, and time out waiting for the captured-topic confirmation.

## Impact

This stabilizes the automation editor test without changing production behavior or the review-completion aggregation implementation.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx` (22 tests passed)
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `git diff --check`