### PR TITLE
fix(deps): resolve Hono and protobuf alerts

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -66,8 +66,8 @@ MIT
 - @floating-ui/core@1.8.0 | https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 | https://github.com/floating-ui/floating-ui
 - @floating-ui/utils@0.2.12 | https://github.com/floating-ui/floating-ui
-- @hono/node-server@1.19.14 | https://github.com/honojs/node-server
-- @modelcontextprotocol/sdk@1.29.0 | https://github.com/modelcontextprotocol/typescript-sdk
+- @hono/node-server@2.0.5 | https://github.com/honojs/node-server
+- @modelcontextprotocol/sdk@1.30.0 | https://github.com/modelcontextprotocol/typescript-sdk
 - @octokit/endpoint@11.0.3 | github:octokit/endpoint.js
 - @octokit/graphql@9.0.3 | github:octokit/graphql.js
 - @octokit/openapi-types@27.0.0 | https://github.com/octokit/openapi-types.ts
@@ -411,13 +411,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@hono/node-server@1.19.14 (MIT)
--------------------------------
+@hono/node-server@2.0.5 (MIT)
+-----------------------------
 
 Applies to:
-- @hono/node-server@1.19.14 (MIT)
+- @hono/node-server@2.0.5 (MIT)
 
-Representative file: @hono/node-server@1.19.14/LICENSE
+Representative file: @hono/node-server@2.0.5/LICENSE
 
 MIT License
 
@@ -441,13 +441,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-@modelcontextprotocol/sdk@1.29.0 (MIT)
+@modelcontextprotocol/sdk@1.30.0 (MIT)
 --------------------------------------
 
 Applies to:
-- @modelcontextprotocol/sdk@1.29.0 (MIT)
+- @modelcontextprotocol/sdk@1.30.0 (MIT)
 
-Representative file: @modelcontextprotocol/sdk@1.29.0/LICENSE
+Representative file: @modelcontextprotocol/sdk@1.30.0/LICENSE
 
 MIT License
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -49,7 +49,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@octokit/graphql": "^9.0.3",
     "@pwragent/messaging-interface": "workspace:*",
     "@pwragent/messaging-provider-discord": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -51,13 +51,14 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
+      "@hono/node-server": "2.0.5",
       "@types/node": "^24.12.4",
       "axios": "^1.16.0",
       "esbuild": "0.28.1",
       "form-data": "4.0.6",
       "prosemirror-model": "1.25.9",
       "prosemirror-view": "1.41.9",
-      "protobufjs": "7.6.3",
+      "protobufjs": "7.6.5",
       "qs": "6.15.2",
       "rollup": "4.61.1",
       "tmp": "0.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,14 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
+  '@hono/node-server': 2.0.5
   '@types/node': ^24.12.4
   axios: ^1.16.0
   esbuild: 0.28.1
   form-data: 4.0.6
   prosemirror-model: 1.25.9
   prosemirror-view: 1.41.9
-  protobufjs: 7.6.3
+  protobufjs: 7.6.5
   qs: 6.15.2
   rollup: 4.61.1
   tmp: 0.2.7
@@ -60,8 +61,8 @@ importers:
   apps/desktop:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.3.6)
       '@octokit/graphql':
         specifier: ^9.0.3
         version: 9.0.3
@@ -815,9 +816,9 @@ packages:
   '@grammyjs/types@4.0.0':
     resolution: {integrity: sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.5':
+    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -897,8 +898,8 @@ packages:
       typescript:
         optional: true
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -976,9 +977,6 @@ packages:
 
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -3641,8 +3639,8 @@ packages:
   prosemirror-view@1.41.9:
     resolution: {integrity: sha512-clTunTX+eaLbr87L1V1QPheRlEQJyTlL3gXe9x3jQIk3rL0RVWxviDGz8tFaydwIVm+hKhYCyr+R/zBtWr9s6A==}
 
-  protobufjs@7.6.3:
-    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -5001,7 +4999,7 @@ snapshots:
 
   '@grammyjs/types@4.0.0': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.5(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -5059,7 +5057,7 @@ snapshots:
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       qs: 6.15.2
       ws: 8.21.0
     transitivePeerDependencies:
@@ -5095,9 +5093,9 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.5(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5193,8 +5191,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -8253,7 +8249,7 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  protobufjs@7.6.3:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -8261,7 +8257,6 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@pwrdrvr/codex-app-server-protocol@0.133.0'
+  - '@modelcontextprotocol/sdk@1.30.0'
   - '@pwrdrvr/agent-core'
   - '@pwrdrvr/agent-transport'
   - '@pwrdrvr/codex-discovery'
@@ -40,7 +41,7 @@ minimumReleaseAgeExclude:
   - '@esbuild/win32-x64@0.28.1'
   - esbuild@0.28.1
   - form-data@4.0.6
-  - protobufjs@7.6.3
+  - protobufjs@7.6.5
   - tmp@0.2.7
   - ws@8.21.0
 globalPnpmfile: ''


### PR DESCRIPTION
## Summary

- resolves Dependabot alert #54 / GHSA-frvp-7c67-39w9 by moving `@hono/node-server` from 1.19.14 to patched 2.0.5
- resolves Dependabot alert #42 / CVE-2026-59877 (GHSA-j3f2-48v5-ccww) by moving `protobufjs` from 7.6.3 to patched 7.6.5
- refreshes the generated third-party license notice

## Dependency ownership and compatibility

`@hono/node-server` is a runtime transitive dependency of the desktop app's direct `@modelcontextprotocol/sdk` dependency. SDK 1.29.0 constrained Hono's Node adapter to 1.x, so forcing Hono 2 under that version would have violated the upstream range. SDK 1.30.0 explicitly widens its dependency to `^1.19.9 || ^2.0.5` for GHSA-frvp-7c67-39w9, so this PR upgrades the direct owner first and pins the patched adapter through the existing root override mechanism.

Hono 2 retains the public server API. Its documented breaking changes are dropping Node 18 and removing the Vercel adapter. PwrAgent CI uses Node 24, the desktop app does not import the Vercel adapter or `@hono/node-server` directly, and its MCP endpoint uses the SDK's Web Standard transport over PwrAgent's own Node HTTP server. The focused MCP client/server tests and production desktop build pass with SDK 1.30.0 and Hono 2.0.5.

`protobufjs` is a runtime transitive dependency of `@larksuiteoapi/node-sdk`, owned by the Feishu messaging provider. The repo already controlled it through a root security override; this PR advances that override within the same 7.x line to the first patched release. Feishu's focused suite passes.

Exact resolved graph:

- `@modelcontextprotocol/sdk@1.30.0`
- `@hono/node-server@2.0.5`
- `protobufjs@7.6.5`

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test apps/desktop/src/main/agent-tools/__tests__/agent-tool-mcp-server.test.ts packages/messaging/providers/feishu/src` (5 files, 42 tests)
- `pnpm --filter @pwragent/desktop build`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `pnpm lint:colors`
- `pnpm licenses:check`
