### PR TITLE
fix(deps): patch parser dependency alerts

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -217,7 +217,7 @@ MIT
 - is-plain-obj@4.1.0 | sindresorhus/is-plain-obj
 - is-promise@4.0.0 | https://github.com/then/is-promise
 - jose@6.2.3 | panva/jose
-- js-yaml@4.2.0 | nodeca/js-yaml
+- js-yaml@4.3.0 | nodeca/js-yaml
 - json-schema-traverse@1.0.0 | https://github.com/epoberezkin/json-schema-traverse
 - json-with-bigint@3.5.8 | https://github.com/Ivan-Korolenko/json-with-bigint
 - jsonfile@6.2.1 | https://github.com/jprichardson/node-jsonfile
@@ -3803,13 +3803,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-js-yaml@4.2.0 (MIT)
+js-yaml@4.3.0 (MIT)
 -------------------
 
 Applies to:
-- js-yaml@4.2.0 (MIT)
+- js-yaml@4.3.0 (MIT)
 
-Representative file: js-yaml@4.2.0/LICENSE
+Representative file: js-yaml@4.3.0/LICENSE
 
 (The MIT License)
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
       "axios": "^1.16.0",
       "esbuild": "0.28.1",
       "form-data": "4.0.6",
+      "js-yaml": "4.3.0",
+      "postcss": "8.5.20",
       "prosemirror-model": "1.25.9",
       "prosemirror-view": "1.41.9",
       "protobufjs": "7.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,8 @@ overrides:
   axios: ^1.16.0
   esbuild: 0.28.1
   form-data: 4.0.6
+  js-yaml: 4.3.0
+  postcss: 8.5.20
   prosemirror-model: 1.25.9
   prosemirror-view: 1.41.9
   protobufjs: 7.6.3
@@ -1898,9 +1900,9 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -2872,8 +2874,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3335,11 +3337,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3552,10 +3549,6 @@ packages:
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
-
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
@@ -6029,7 +6022,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -6135,7 +6128,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6175,7 +6168,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -6461,7 +6454,7 @@ snapshots:
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -6550,7 +6543,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.5.1
       fs-extra: 10.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -7277,7 +7270,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -7855,7 +7848,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
@@ -7912,8 +7905,6 @@ snapshots:
       minimist: 1.2.8
 
   ms@2.1.3: {}
-
-  nanoid@3.3.15: {}
 
   nanoid@3.3.16: {}
 
@@ -8116,12 +8107,6 @@ snapshots:
       '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  postcss@8.5.16:
-    dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.20:
     dependencies:
@@ -8966,7 +8951,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.20
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

- pin PostCSS to the already-resolved patched `8.5.20`, consolidating Vite 7 and Vite 8 on one safe version
- pin `js-yaml` to patched `4.3.0` for Electron Builder and Electron Updater
- advance the compatible `brace-expansion` 5.x path from `5.0.7` to `5.0.8`
- refresh the generated third-party license inventory

## Dependency trace and alert outcome

- **Dependabot #51 — PostCSS: resolved.** Desktop Vite 7 (directly and through `@vitejs/plugin-react` / `electron-vite`) retained `8.5.16`, while Vitest's Vite 8 chain had independently resolved `8.5.20`. The root pnpm override consolidates both on patched `8.5.20`; no vulnerable PostCSS remains.
- **Dependabot #45 — js-yaml: resolved.** `app-builder-lib`, `builder-util`, `dmg-builder`, and `electron-updater` all request `^4.1.0` through the desktop package. The root pnpm override resolves every path to patched `4.3.0`; no vulnerable js-yaml remains.
- **Dependabot #53 — brace-expansion: upstream-blocked, not dismissed.** The compatible minimatch 10 paths now use patched `5.0.8`, but Electron Builder's legacy graph still requires `brace-expansion@1.1.16` and `2.1.2` through `@electron/asar@3.4.1`, `@electron/universal@2.0.3`, Electron Rebuild/glob, and EJS/Jake. The advisory marks every version through 5.0.7 vulnerable and provides no 1.x/2.x backports. Latest stable Electron Builder still pins those legacy packages; even its 27 alpha line retains an EJS/Jake legacy path. A blanket pnpm override to 5.0.8 was tested and rejected because `minimatch@3.1.5` fails at runtime with `TypeError: expand is not a function` due the changed CommonJS export shape.

No alerts were dismissed and no unsafe cross-major override is included.

## Validation

- `pnpm install`
- `pnpm install --frozen-lockfile`
- `pnpm lint` (passes: license checks, ESLint with existing warnings only, typecheck, and dependency boundaries)
- `pnpm build`
- targeted `pnpm audit --json`: no PostCSS or js-yaml finding; only brace-expansion 1.1.16/2.1.2 remains
- full `pnpm test`: 5,198 passed; 77 timeout/output failures while the build ran concurrently
- serial rerun of all nine failed files with `--maxWorkers=1`: 574 passed; five unrelated `codex-environment-runtime` assertions remain because npm prefixes child-process output with warnings about inherited pnpm config variables
