### PR TITLE
fix(desktop): isolate thread title helper context

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13409,7 +13409,7 @@ command = "pnpm dev"
     const titleService = {
       generateTitle: vi.fn(async () => ({
         status: "invalid" as const,
-        reason: "title_too_many_words",
+        reason: "title_empty",
         helperThreadId: "invalid-title-helper-thread",
         helperTurnId: "invalid-title-helper-turn",
         model: "gpt-5.6-luna",
@@ -13468,7 +13468,7 @@ command = "pnpm dev"
         monitorTurnId: "invalid-title-helper-turn",
         preferredModel: "gpt-5.6-luna",
         preferredReasoningEffort: "low",
-        lastMessage: "Title generation failed: title_too_many_words",
+        lastMessage: "Title generation failed: title_empty",
         monitorUsage: expect.objectContaining({
           model: "gpt-5.6-luna",
           tokenUsage: {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -135,6 +135,11 @@ class MockTransport implements JsonRpcTransport {
     },
   };
   static configReadError: { code?: number; message: string } | undefined;
+  static threadMcpServerStatusResult: unknown = {
+    data: [],
+    nextCursor: null,
+  };
+  static mcpServerStatusError: { code?: number; message: string } | undefined;
   static lastConfigValueWritePayload: unknown;
   static rateLimitsResult: unknown = {
     rateLimitsByLimitId: {}
@@ -169,6 +174,7 @@ class MockTransport implements JsonRpcTransport {
     const payload = JSON.parse(message) as {
       id?: string;
       method?: string;
+      params?: Record<string, unknown>;
     };
 
     if (payload.method === "initialize") {
@@ -648,6 +654,30 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "mcpServerStatus/list") {
+      if (MockTransport.mcpServerStatusError) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            error: {
+              code: MockTransport.mcpServerStatusError.code ?? -32000,
+              message: MockTransport.mcpServerStatusError.message,
+            },
+          }),
+        );
+        return;
+      }
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.threadMcpServerStatusResult,
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "account/rateLimits/read") {
       this.messageHandler(
         JSON.stringify({
@@ -1116,6 +1146,11 @@ describe("CodexAppServerClient", () => {
       },
     };
     MockTransport.configReadError = undefined;
+    MockTransport.mcpServerStatusError = undefined;
+    MockTransport.threadMcpServerStatusResult = {
+      data: [],
+      nextCursor: null,
+    };
     MockTransport.lastConfigValueWritePayload = undefined;
     MockTransport.rateLimitsResult = {
       rateLimitsByLimitId: {}
@@ -6511,10 +6546,19 @@ describe("CodexAppServerClient", () => {
 
   it("generates thread titles through an ephemeral Codex helper turn", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const observedMessages: string[] = [];
+    MockTransport.threadMcpServerStatusResult = {
+      data: [
+        { name: "context7", tools: {} },
+        { name: "github", tools: {} },
+      ],
+      nextCursor: null,
+    };
     MockTransport.threadStartResult = {
       thread: {
         id: "thread-title-helper",
       },
+      instructionSources: [],
     };
     MockTransport.turnStartResult = {
       thread: {
@@ -6527,7 +6571,12 @@ describe("CodexAppServerClient", () => {
 
     const client = new CodexAppServerClient({
       command: "codex",
-      directoryResolver: async () => []
+      directoryResolver: async () => [],
+      connectionObserver: {
+        onMessage: (event) => {
+          observedMessages.push(event.raw);
+        },
+      },
     });
     const forwardedNotifications: string[] = [];
     client.onNotification((notification) => {
@@ -6633,11 +6682,13 @@ describe("CodexAppServerClient", () => {
           cwd: titleHelperWorkspace,
           runtimeWorkspaceRoots: [titleHelperWorkspace],
           environments: [],
+          baseInstructions: "",
           ephemeral: true,
           model: "gpt-5.6-luna",
           serviceTier: null,
           config: {
             web_search: "disabled",
+            notify: [],
             include_permissions_instructions: false,
             include_apps_instructions: false,
             include_collaboration_mode_instructions: false,
@@ -6649,11 +6700,40 @@ describe("CodexAppServerClient", () => {
             },
             features: {
               apps: false,
-              plugins: false,
-              tool_suggest: false,
-              image_generation: false,
-              multi_agent: false,
+              code_mode: false,
+              code_mode_only: false,
+              current_time_reminder: false,
+              deferred_executor: false,
+              enable_fanout: false,
               goals: false,
+              hooks: false,
+              image_generation: false,
+              memories: false,
+              multi_agent: false,
+              multi_agent_v2: false,
+              plugins: false,
+              standalone_web_search: false,
+              token_budget: false,
+              tool_suggest: false,
+            },
+            orchestrator: {
+              mcp: { enabled: false },
+              skills: { enabled: false },
+            },
+            tools: {
+              experimental_request_user_input: { enabled: false },
+            },
+            hooks: {
+              PreToolUse: [],
+              PermissionRequest: [],
+              PostToolUse: [],
+              PreCompact: [],
+              PostCompact: [],
+              SessionStart: [],
+              UserPromptSubmit: [],
+              SubagentStart: [],
+              SubagentStop: [],
+              Stop: [],
             },
             mcp_servers: {
               context7: { enabled: false },
@@ -6677,9 +6757,18 @@ describe("CodexAppServerClient", () => {
     );
     for (const request of threadStartRequests) {
       expect(request.params).not.toHaveProperty("dynamicTools");
-      expect(JSON.stringify(request.params)).not.toContain("never-forward-me");
-      expect(JSON.stringify(request.params)).not.toContain("github-mcp-server");
     }
+    expect(
+      requests
+        .filter((request) => request.method === "mcpServerStatus/list")
+        .map((request) => request.params),
+    ).toEqual([
+      {
+        threadId: "thread-title-helper",
+        detail: "toolsAndAuthOnly",
+        limit: 100,
+      },
+    ]);
     expect(requests).toContainEqual(
       expect.objectContaining({
         method: "config/read",
@@ -6689,6 +6778,10 @@ describe("CodexAppServerClient", () => {
         },
       }),
     );
+    expect(observedMessages.join("\n")).not.toContain("never-forward-me");
+    expect(observedMessages.join("\n")).not.toContain("github-mcp-server");
+    expect(observedMessages.join("\n")).toContain('"context7":{}');
+    expect(observedMessages.join("\n")).toContain('"github":{}');
     expect(requests).toContainEqual(
       expect.objectContaining({
         method: "turn/start",
@@ -6733,6 +6826,7 @@ describe("CodexAppServerClient", () => {
     const generate = async (threadId: string, turnId: string, title: string) => {
       MockTransport.threadStartResult = {
         thread: { id: threadId },
+        instructionSources: [],
       };
       MockTransport.turnStartResult = {
         thread: { id: threadId },
@@ -6780,6 +6874,15 @@ describe("CodexAppServerClient", () => {
       (message) => JSON.parse(message) as { method?: string; params?: Record<string, unknown> },
     );
     expect(
+      requests.filter((request) => request.method === "mcpServerStatus/list"),
+    ).toHaveLength(2);
+    expect(
+      requests
+        .filter((request) => request.method === "mcpServerStatus/list")
+        .map((request) => request.params?.threadId)
+        .filter(Boolean),
+    ).toEqual(["thread-title-helper-1", "thread-title-helper-2"]);
+    expect(
       requests.filter((request) => request.method === "config/read"),
     ).toHaveLength(2);
     expect(
@@ -6797,9 +6900,9 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("fails closed before starting a title helper when MCP config inspection fails", async () => {
+  it("fails closed before starting a title helper when MCP inventory inspection fails", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
-    MockTransport.configReadError = { message: "config unavailable" };
+    MockTransport.configReadError = { message: "inventory unavailable" };
     const client = new CodexAppServerClient({
       command: "codex",
       directoryResolver: async () => [],
@@ -6819,14 +6922,139 @@ describe("CodexAppServerClient", () => {
       }),
     ).resolves.toEqual({
       status: "failed",
-      reason: "json-rpc error (-32000): config unavailable",
+      reason: "json-rpc error (-32000): inventory unavailable",
     });
 
     const methods = MockTransport.instances.at(-1)!.sentMessages.map(
       (message) => (JSON.parse(message) as { method?: string }).method,
     );
     expect(methods).toContain("config/read");
+    expect(methods).not.toContain("mcpServerStatus/list");
     expect(methods).not.toContain("thread/start");
+
+    await client.close();
+  });
+
+  it("rejects global Codex instructions before starting the helper turn", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "thread-title-helper" },
+      instructionSources: ["/Users/huntharo/.codex/AGENTS.md"],
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_helper_instruction_sources_present",
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests.map((request) => request.method)).not.toContain("turn/start");
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/unsubscribe",
+        params: { threadId: "thread-title-helper" },
+      }),
+    );
+
+    await client.close();
+  });
+
+  it("rejects configured MCP tools that survive the helper thread overlay", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "thread-title-helper" },
+      instructionSources: [],
+    };
+    MockTransport.threadMcpServerStatusResult = {
+      data: [{ name: "context7", tools: { search: {} } }],
+      nextCursor: null,
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_helper_configured_mcp_tools_present",
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests.map((request) => request.method)).not.toContain("turn/start");
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/unsubscribe",
+        params: { threadId: "thread-title-helper" },
+      }),
+    );
+
+    await client.close();
+  });
+
+  it("fails closed when Codex omits the helper instruction-source signal", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "thread-title-helper" },
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_thread_start_missing_instruction_sources",
+    });
+
+    const methods = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => (JSON.parse(message) as { method?: string }).method,
+    );
+    expect(methods).not.toContain("turn/start");
+    expect(methods).toContain("thread/unsubscribe");
 
     await client.close();
   });
@@ -6837,6 +7065,7 @@ describe("CodexAppServerClient", () => {
       thread: {
         id: "thread-title-helper",
       },
+      instructionSources: [],
     };
     MockTransport.turnStartResult = {
       thread: {
@@ -6917,6 +7146,7 @@ describe("CodexAppServerClient", () => {
       thread: {
         id: "thread-title-helper",
       },
+      instructionSources: [],
     };
     MockTransport.turnStartResult = {
       thread: {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -121,6 +121,20 @@ class MockTransport implements JsonRpcTransport {
     filePath: "/Users/huntharo/.codex/config.toml",
     overriddenMetadata: null,
   };
+  static configReadResult: unknown = {
+    config: {
+      mcp_servers: {
+        context7: {
+          command: "npx",
+          env: { SECRET: "never-forward-me" },
+        },
+        github: {
+          command: "github-mcp-server",
+        },
+      },
+    },
+  };
+  static configReadError: { code?: number; message: string } | undefined;
   static lastConfigValueWritePayload: unknown;
   static rateLimitsResult: unknown = {
     rateLimitsByLimitId: {}
@@ -610,6 +624,30 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "config/read") {
+      if (MockTransport.configReadError) {
+        this.messageHandler(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: payload.id,
+            error: {
+              code: MockTransport.configReadError.code ?? -32000,
+              message: MockTransport.configReadError.message,
+            },
+          }),
+        );
+        return;
+      }
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: MockTransport.configReadResult,
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "account/rateLimits/read") {
       this.messageHandler(
         JSON.stringify({
@@ -865,6 +903,17 @@ class MockTransport implements JsonRpcTransport {
       return;
     }
 
+    if (payload.method === "thread/unsubscribe") {
+      this.messageHandler(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {},
+        }),
+      );
+      return;
+    }
+
     if (payload.method === "thread/settings/update") {
       const result: ThreadSettingsUpdateResponse = {};
       this.messageHandler(
@@ -1053,6 +1102,20 @@ describe("CodexAppServerClient", () => {
       filePath: "/Users/huntharo/.codex/config.toml",
       overriddenMetadata: null,
     };
+    MockTransport.configReadResult = {
+      config: {
+        mcp_servers: {
+          context7: {
+            command: "npx",
+            env: { SECRET: "never-forward-me" },
+          },
+          github: {
+            command: "github-mcp-server",
+          },
+        },
+      },
+    };
+    MockTransport.configReadError = undefined;
     MockTransport.lastConfigValueWritePayload = undefined;
     MockTransport.rateLimitsResult = {
       rateLimitsByLimitId: {}
@@ -6569,6 +6632,7 @@ describe("CodexAppServerClient", () => {
         params: expect.objectContaining({
           cwd: titleHelperWorkspace,
           runtimeWorkspaceRoots: [titleHelperWorkspace],
+          environments: [],
           ephemeral: true,
           model: "gpt-5.6-luna",
           serviceTier: null,
@@ -6578,9 +6642,22 @@ describe("CodexAppServerClient", () => {
             include_apps_instructions: false,
             include_collaboration_mode_instructions: false,
             include_environment_context: false,
+            project_doc_max_bytes: 0,
             skills: {
               include_instructions: false,
               bundled: { enabled: false },
+            },
+            features: {
+              apps: false,
+              plugins: false,
+              tool_suggest: false,
+              image_generation: false,
+              multi_agent: false,
+              goals: false,
+            },
+            mcp_servers: {
+              context7: { enabled: false },
+              github: { enabled: false },
             },
           },
         }),
@@ -6597,6 +6674,20 @@ describe("CodexAppServerClient", () => {
           }),
         }),
       ]),
+    );
+    for (const request of threadStartRequests) {
+      expect(request.params).not.toHaveProperty("dynamicTools");
+      expect(JSON.stringify(request.params)).not.toContain("never-forward-me");
+      expect(JSON.stringify(request.params)).not.toContain("github-mcp-server");
+    }
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "config/read",
+        params: {
+          includeLayers: false,
+          cwd: titleHelperWorkspace,
+        },
+      }),
     );
     expect(requests).toContainEqual(
       expect.objectContaining({
@@ -6620,6 +6711,122 @@ describe("CodexAppServerClient", () => {
         }),
       })
     );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/unsubscribe",
+        params: { threadId: "thread-title-helper" },
+      }),
+    );
+    expect(requests.map((request) => request.method)).not.toContain(
+      "thread/rollback",
+    );
+
+    await client.close();
+  });
+
+  it("uses a fresh helper thread for every title and unsubscribes each one", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    const generate = async (threadId: string, turnId: string, title: string) => {
+      MockTransport.threadStartResult = {
+        thread: { id: threadId },
+      };
+      MockTransport.turnStartResult = {
+        thread: { id: threadId },
+        turn: {
+          id: turnId,
+          output: [{ type: "text", text: JSON.stringify({ title }) }],
+        },
+      };
+      return await client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      });
+    };
+
+    const first = await generate(
+      "thread-title-helper-1",
+      "turn-title-helper-1",
+      "First title",
+    );
+    const second = await generate(
+      "thread-title-helper-2",
+      "turn-title-helper-2",
+      "Second title",
+    );
+
+    expect(first).toMatchObject({
+      status: "ok",
+      helperThreadId: "thread-title-helper-1",
+      helperTurnId: "turn-title-helper-1",
+    });
+    expect(second).toMatchObject({
+      status: "ok",
+      helperThreadId: "thread-title-helper-2",
+      helperTurnId: "turn-title-helper-2",
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: Record<string, unknown> },
+    );
+    expect(
+      requests.filter((request) => request.method === "config/read"),
+    ).toHaveLength(2);
+    expect(
+      requests.filter((request) => request.method === "thread/start"),
+    ).toHaveLength(2);
+    expect(
+      requests
+        .filter((request) => request.method === "thread/unsubscribe")
+        .map((request) => request.params?.threadId),
+    ).toEqual(["thread-title-helper-1", "thread-title-helper-2"]);
+    expect(requests.map((request) => request.method)).not.toContain(
+      "thread/rollback",
+    );
+
+    await client.close();
+  });
+
+  it("fails closed before starting a title helper when MCP config inspection fails", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.configReadError = { message: "config unavailable" };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "json-rpc error (-32000): config unavailable",
+    });
+
+    const methods = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => (JSON.parse(message) as { method?: string }).method,
+    );
+    expect(methods).toContain("config/read");
+    expect(methods).not.toContain("thread/start");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6935,11 +6935,18 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("rejects global Codex instructions before starting the helper turn", async () => {
+  it("runs the bounded helper turn when Codex retains global instructions", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.threadStartResult = {
       thread: { id: "thread-title-helper" },
       instructionSources: ["/Users/huntharo/.codex/AGENTS.md"],
+    };
+    MockTransport.turnStartResult = {
+      thread: { id: "thread-title-helper" },
+      turn: {
+        id: "turn-title-helper",
+        output: [{ type: "text", text: JSON.stringify({ title: "Paul Revere story" }) }],
+      },
     };
     const client = new CodexAppServerClient({
       command: "codex",
@@ -6958,33 +6965,42 @@ describe("CodexAppServerClient", () => {
         schemaName: "thread_title",
         timeoutMs: 5_000,
       }),
-    ).resolves.toEqual({
-      status: "failed",
-      reason: "codex_title_helper_instruction_sources_present",
+    ).resolves.toMatchObject({
+      status: "ok",
+      object: { title: "Paul Revere story" },
+      helperThreadId: "thread-title-helper",
+      helperTurnId: "turn-title-helper",
     });
 
     const requests = MockTransport.instances.at(-1)!.sentMessages.map(
       (message) => JSON.parse(message) as { method?: string; params?: unknown },
     );
-    expect(requests.map((request) => request.method)).not.toContain("turn/start");
+    expect(requests.map((request) => request.method)).toContain("turn/start");
     expect(requests).toContainEqual(
       expect.objectContaining({
         method: "thread/unsubscribe",
         params: { threadId: "thread-title-helper" },
       }),
     );
+    expect(codexClientLogWarn).toHaveBeenCalledWith(
+      "codex helper thread retained global instruction source",
+      {
+        threadId: "thread-title-helper",
+        instructionSourceCount: 1,
+      },
+    );
 
     await client.close();
   });
 
-  it("rejects configured MCP tools that survive the helper thread overlay", async () => {
+  it("rejects any MCP tools that survive the helper thread overlay", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.threadStartResult = {
       thread: { id: "thread-title-helper" },
       instructionSources: [],
     };
     MockTransport.threadMcpServerStatusResult = {
-      data: [{ name: "context7", tools: { search: {} } }],
+      data: [{ name: "managed-server", tools: { search: {} } }],
       nextCursor: null,
     };
     const client = new CodexAppServerClient({
@@ -7006,7 +7022,7 @@ describe("CodexAppServerClient", () => {
       }),
     ).resolves.toEqual({
       status: "failed",
-      reason: "codex_title_helper_configured_mcp_tools_present",
+      reason: "codex_title_helper_mcp_tools_present",
     });
 
     const requests = MockTransport.instances.at(-1)!.sentMessages.map(

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6900,6 +6900,88 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("skips process-wide MCP attestation before Codex 0.144", async () => {
+    MockTransport.serverVersion = "0.143.0";
+    MockTransport.threadMcpServerStatusResult = {
+      data: [
+        {
+          name: "context7",
+          tools: {
+            resolve: {
+              name: "resolve",
+              description: "Resolve documentation",
+              inputSchema: { type: "object" },
+            },
+          },
+        },
+      ],
+      nextCursor: null,
+    };
+    MockTransport.threadStartResult = {
+      thread: { id: "legacy-title-helper" },
+      instructionSources: [],
+    };
+    MockTransport.turnStartResult = {
+      thread: { id: "legacy-title-helper" },
+      turn: {
+        id: "legacy-title-turn",
+        output: [
+          {
+            type: "text",
+            text: JSON.stringify({ title: "Legacy helper title" }),
+          },
+        ],
+      },
+    };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v2",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      object: { title: "Legacy helper title" },
+      helperThreadId: "legacy-title-helper",
+      helperTurnId: "legacy-title-turn",
+    });
+
+    const requests = MockTransport.instances.at(-1)!.sentMessages.map(
+      (message) => JSON.parse(message) as {
+        method?: string;
+        params?: Record<string, unknown>;
+      },
+    );
+    expect(requests.map((request) => request.method)).not.toContain(
+      "mcpServerStatus/list",
+    );
+    expect(
+      requests.find((request) => request.method === "thread/start")?.params,
+    ).toMatchObject({
+      config: {
+        mcp_servers: {
+          context7: { enabled: false },
+          github: { enabled: false },
+        },
+      },
+    });
+    expect(requests.map((request) => request.method)).toContain("turn/start");
+
+    await client.close();
+  });
+
   it("fails closed before starting a title helper when MCP inventory inspection fails", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.configReadError = { message: "inventory unavailable" };

--- a/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
@@ -12,6 +12,7 @@ describe("Codex App Server protocol compatibility", () => {
         dynamicToolFormat: "flat",
         includePersistExtendedHistory: true,
         supportsOnFailureApprovalPolicy: true,
+        supportsThreadScopedMcpServerStatus: false,
       },
     },
     {
@@ -20,6 +21,7 @@ describe("Codex App Server protocol compatibility", () => {
         dynamicToolFormat: "flat",
         includePersistExtendedHistory: true,
         supportsOnFailureApprovalPolicy: true,
+        supportsThreadScopedMcpServerStatus: false,
       },
     },
     {
@@ -28,6 +30,7 @@ describe("Codex App Server protocol compatibility", () => {
         dynamicToolFormat: "flat",
         includePersistExtendedHistory: false,
         supportsOnFailureApprovalPolicy: true,
+        supportsThreadScopedMcpServerStatus: false,
       },
     },
     {
@@ -36,6 +39,7 @@ describe("Codex App Server protocol compatibility", () => {
         dynamicToolFormat: "namespaced",
         includePersistExtendedHistory: false,
         supportsOnFailureApprovalPolicy: true,
+        supportsThreadScopedMcpServerStatus: false,
       },
     },
     {
@@ -44,6 +48,16 @@ describe("Codex App Server protocol compatibility", () => {
         dynamicToolFormat: "namespaced",
         includePersistExtendedHistory: false,
         supportsOnFailureApprovalPolicy: false,
+        supportsThreadScopedMcpServerStatus: false,
+      },
+    },
+    {
+      version: "codex-cli 0.144.0",
+      expected: {
+        dynamicToolFormat: "namespaced",
+        includePersistExtendedHistory: false,
+        supportsOnFailureApprovalPolicy: false,
+        supportsThreadScopedMcpServerStatus: true,
       },
     },
   ])("negotiates the wire features for $version", ({ version, expected }) => {

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -35,6 +35,17 @@ describe("ThreadTitleGenerationService", () => {
       title: "PROJECT-123 checkout crash",
       cachedTokens: 12,
     });
+    expect(generator.generateTitle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schema: expect.objectContaining({
+          properties: expect.objectContaining({
+            title: expect.objectContaining({
+              maxLength: 50,
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("allows 20 seconds for title generators by default", async () => {
@@ -238,7 +249,7 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
-  it("rejects overlong and wordy generated titles", async () => {
+  it("rejects overlong titles and accepts clear titles over six words", async () => {
     const longTitleService = new ThreadTitleGenerationService({
       generators: {
         codex: makeGenerator({
@@ -248,7 +259,9 @@ describe("ThreadTitleGenerationService", () => {
     });
     const wordyTitleService = new ThreadTitleGenerationService({
       generators: {
-        codex: makeGenerator({ title: "One two three four five six seven" }),
+        codex: makeGenerator({
+          title: "Paul Revere opening by the Beastie Boys",
+        }),
       },
     });
 
@@ -268,8 +281,8 @@ describe("ThreadTitleGenerationService", () => {
         userPrompt: "Name this thread",
       })
     ).resolves.toEqual({
-      status: "invalid",
-      reason: "title_too_many_words",
+      status: "generated",
+      title: "Paul Revere opening by the Beastie Boys",
       cachedTokens: 12,
     });
   });
@@ -286,7 +299,10 @@ describe("ThreadTitleGenerationService", () => {
         codex: {
           generateTitle: vi.fn(async () => ({
             status: "ok" as const,
-            object: { title: "One two three four five six seven" },
+            object: {
+              title:
+                "This generated title is intentionally too long for the desktop title limit",
+            },
             helperThreadId: "title-helper-thread",
             helperTurnId: "title-helper-turn",
             model: "gpt-5.4-mini",
@@ -305,7 +321,7 @@ describe("ThreadTitleGenerationService", () => {
       })
     ).resolves.toEqual({
       status: "invalid",
-      reason: "title_too_many_words",
+      reason: "title_too_long",
       helperThreadId: "title-helper-thread",
       helperTurnId: "title-helper-turn",
       model: "gpt-5.4-mini",

--- a/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-generation-service.test.ts
@@ -35,17 +35,11 @@ describe("ThreadTitleGenerationService", () => {
       title: "PROJECT-123 checkout crash",
       cachedTokens: 12,
     });
-    expect(generator.generateTitle).toHaveBeenCalledWith(
-      expect.objectContaining({
-        schema: expect.objectContaining({
-          properties: expect.objectContaining({
-            title: expect.objectContaining({
-              maxLength: 50,
-            }),
-          }),
-        }),
-      }),
-    );
+    const schema = vi.mocked(generator.generateTitle).mock.calls[0]?.[0]
+      .schema as {
+        properties?: { title?: Record<string, unknown> };
+      };
+    expect(schema.properties?.title).not.toHaveProperty("maxLength");
   });
 
   it("allows 20 seconds for title generators by default", async () => {
@@ -249,11 +243,11 @@ describe("ThreadTitleGenerationService", () => {
     });
   });
 
-  it("rejects overlong titles and accepts clear titles over six words", async () => {
+  it("allows 30 percent title slack and truncates beyond it", async () => {
     const longTitleService = new ThreadTitleGenerationService({
       generators: {
         codex: makeGenerator({
-          title: "This title is intentionally much too long for the desktop thread title limit",
+          title: "x".repeat(66),
         }),
       },
     });
@@ -271,8 +265,8 @@ describe("ThreadTitleGenerationService", () => {
         userPrompt: "Name this thread",
       })
     ).resolves.toEqual({
-      status: "invalid",
-      reason: "title_too_long",
+      status: "generated",
+      title: "x".repeat(65),
       cachedTokens: 12,
     });
     await expect(
@@ -283,6 +277,24 @@ describe("ThreadTitleGenerationService", () => {
     ).resolves.toEqual({
       status: "generated",
       title: "Paul Revere opening by the Beastie Boys",
+      cachedTokens: 12,
+    });
+
+    const eightWordService = new ThreadTitleGenerationService({
+      generators: {
+        codex: makeGenerator({
+          title: "One two three four five six seven eight",
+        }),
+      },
+    });
+    await expect(
+      eightWordService.generateTitle({
+        backend: "codex",
+        userPrompt: "Name this thread",
+      })
+    ).resolves.toEqual({
+      status: "generated",
+      title: "One two three four five six seven",
       cachedTokens: 12,
     });
   });
@@ -299,10 +311,7 @@ describe("ThreadTitleGenerationService", () => {
         codex: {
           generateTitle: vi.fn(async () => ({
             status: "ok" as const,
-            object: {
-              title:
-                "This generated title is intentionally too long for the desktop title limit",
-            },
+            object: { title: 123 },
             helperThreadId: "title-helper-thread",
             helperTurnId: "title-helper-turn",
             model: "gpt-5.4-mini",
@@ -321,7 +330,7 @@ describe("ThreadTitleGenerationService", () => {
       })
     ).resolves.toEqual({
       status: "invalid",
-      reason: "title_too_long",
+      reason: "title_must_be_string",
       helperThreadId: "title-helper-thread",
       helperTurnId: "title-helper-turn",
       model: "gpt-5.4-mini",

--- a/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
@@ -9,8 +9,9 @@ describe("thread title prompt", () => {
     const prompt = readThreadTitlePrompt();
 
     expect(prompt).toContain("same language as the user's prompt");
-    expect(prompt).toContain("under 50 characters");
+    expect(prompt).toContain("Never exceed 50 characters");
     expect(prompt).toContain("6 words or fewer");
+    expect(prompt).toContain("7-word title is acceptable");
     expect(prompt).toContain("PROJECT-123");
     expect(prompt).toContain("#123");
     expect(prompt).toContain("issue 123");

--- a/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-title-prompt.test.ts
@@ -11,7 +11,6 @@ describe("thread title prompt", () => {
     expect(prompt).toContain("same language as the user's prompt");
     expect(prompt).toContain("Never exceed 50 characters");
     expect(prompt).toContain("6 words or fewer");
-    expect(prompt).toContain("7-word title is acceptable");
     expect(prompt).toContain("PROJECT-123");
     expect(prompt).toContain("#123");
     expect(prompt).toContain("issue 123");

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -5,11 +5,19 @@ import {
 } from "./ephemeral-object-call";
 import { buildThreadTitlePrompt } from "./thread-title-prompt";
 
-export const THREAD_TITLE_PROMPT_VERSION = "thread-title-v1";
+export const THREAD_TITLE_PROMPT_VERSION = "thread-title-v2";
 export const DEFAULT_GROK_THREAD_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
 
 const THREAD_TITLE_TIMEOUT_MS = 20_000;
-const MAX_TITLE_CHARACTERS = 50;
+const REQUESTED_MAX_TITLE_CHARACTERS = 50;
+const REQUESTED_MAX_TITLE_WORDS = 6;
+const TITLE_LIMIT_TOLERANCE = 0.3;
+const ACCEPTED_MAX_TITLE_CHARACTERS = Math.floor(
+  REQUESTED_MAX_TITLE_CHARACTERS * (1 + TITLE_LIMIT_TOLERANCE),
+);
+const ACCEPTED_MAX_TITLE_WORDS = Math.floor(
+  REQUESTED_MAX_TITLE_WORDS * (1 + TITLE_LIMIT_TOLERANCE),
+);
 
 const THREAD_TITLE_RESPONSE_SCHEMA = {
   type: "object",
@@ -19,8 +27,8 @@ const THREAD_TITLE_RESPONSE_SCHEMA = {
     title: {
       type: "string",
       minLength: 1,
-      maxLength: MAX_TITLE_CHARACTERS,
-      description: "A concise thread title, ideally 6 words or fewer.",
+      description:
+        "A concise thread title of 6 words or fewer and no more than 50 characters.",
     },
   },
 } as const;
@@ -226,11 +234,8 @@ function normalizeThreadTitleObject(
   if (!cleaned) {
     return { reason: "title_empty" };
   }
-  if (cleaned.length > MAX_TITLE_CHARACTERS) {
-    return { reason: "title_too_long" };
-  }
   return {
-    title: cleaned,
+    title: truncateThreadTitle(cleaned),
     reason: "ok",
   };
 }
@@ -254,6 +259,20 @@ function cleanThreadTitle(value: string): string {
   title = stripMatchingQuotes(title);
   title = title.replace(/[.!?。！？]+$/u, "").trim();
   return title;
+}
+
+function truncateThreadTitle(value: string): string {
+  const words = value.split(/\s+/u);
+  const wordTruncated = words
+    .slice(0, ACCEPTED_MAX_TITLE_WORDS)
+    .join(" ");
+  const characters = Array.from(wordTruncated);
+  if (characters.length <= ACCEPTED_MAX_TITLE_CHARACTERS) {
+    return wordTruncated;
+  }
+  return cleanThreadTitle(
+    characters.slice(0, ACCEPTED_MAX_TITLE_CHARACTERS).join(""),
+  );
 }
 
 function stripMatchingQuotes(value: string): string {

--- a/apps/desktop/src/main/app-server/thread-title-generation-service.ts
+++ b/apps/desktop/src/main/app-server/thread-title-generation-service.ts
@@ -10,7 +10,6 @@ export const DEFAULT_GROK_THREAD_TITLE_MODEL = "grok-4-1-fast-non-reasoning";
 
 const THREAD_TITLE_TIMEOUT_MS = 20_000;
 const MAX_TITLE_CHARACTERS = 50;
-const MAX_TITLE_WORDS = 6;
 
 const THREAD_TITLE_RESPONSE_SCHEMA = {
   type: "object",
@@ -20,7 +19,8 @@ const THREAD_TITLE_RESPONSE_SCHEMA = {
     title: {
       type: "string",
       minLength: 1,
-      maxLength: 80,
+      maxLength: MAX_TITLE_CHARACTERS,
+      description: "A concise thread title, ideally 6 words or fewer.",
     },
   },
 } as const;
@@ -229,10 +229,6 @@ function normalizeThreadTitleObject(
   if (cleaned.length > MAX_TITLE_CHARACTERS) {
     return { reason: "title_too_long" };
   }
-  if (countWords(cleaned) > MAX_TITLE_WORDS) {
-    return { reason: "title_too_many_words" };
-  }
-
   return {
     title: cleaned,
     reason: "ok",
@@ -274,8 +270,4 @@ function stripMatchingQuotes(value: string): string {
   }
 
   return value;
-}
-
-function countWords(value: string): number {
-  return value.split(/\s+/).filter(Boolean).length;
 }

--- a/apps/desktop/src/main/app-server/thread-title-prompt.md
+++ b/apps/desktop/src/main/app-server/thread-title-prompt.md
@@ -14,8 +14,7 @@ Requirements:
 
 - Write the title in the same language as the user's prompt.
 - Never exceed 50 characters.
-- Aim for 6 words or fewer. A clear 7-word title is acceptable when shortening
-  it would make the title incomplete or awkward.
+- Keep the title to 6 words or fewer.
 - Capture the main task, question, bug, artifact, or decision.
 - Prefer specific nouns from the prompt over generic wording.
 - Preserve code identifiers, filenames, product names, and proper nouns when they are central to the request.

--- a/apps/desktop/src/main/app-server/thread-title-prompt.md
+++ b/apps/desktop/src/main/app-server/thread-title-prompt.md
@@ -13,8 +13,9 @@ Return only valid JSON. Do not wrap the JSON in markdown fences. Use this exact 
 Requirements:
 
 - Write the title in the same language as the user's prompt.
-- Keep the title under 50 characters when possible.
-- Keep the title to 6 words or fewer when possible.
+- Never exceed 50 characters.
+- Aim for 6 words or fewer. A clear 7-word title is acceptable when shortening
+  it would make the title incomplete or awkward.
 - Capture the main task, question, bug, artifact, or decision.
 - Prefer specific nouns from the prompt over generic wording.
 - Preserve code identifiers, filenames, product names, and proper nouns when they are central to the request.

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -84,6 +84,7 @@ import {
   type JsonRpcId,
   type JsonRpcObserver,
   type JsonRpcObserverDiagnostics,
+  type JsonRpcObserverEvent,
 } from "@pwrdrvr/agent-transport";
 import {
   createThreadDirectoryEnricher,
@@ -110,6 +111,7 @@ const ARCHIVED_THREAD_METADATA_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.6-luna";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
+const CODEX_THREAD_TITLE_CONFIG_READ_REASON = "thread-title-mcp-inventory";
 const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
   tmpdir(),
   "pwragent",
@@ -117,6 +119,7 @@ const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
 );
 const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
   web_search: "disabled",
+  notify: [],
   include_permissions_instructions: false,
   include_apps_instructions: false,
   include_collaboration_mode_instructions: false,
@@ -128,11 +131,40 @@ const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> =
   },
   features: {
     apps: false,
-    plugins: false,
-    tool_suggest: false,
-    image_generation: false,
-    multi_agent: false,
+    code_mode: false,
+    code_mode_only: false,
+    current_time_reminder: false,
+    deferred_executor: false,
+    enable_fanout: false,
     goals: false,
+    hooks: false,
+    image_generation: false,
+    memories: false,
+    multi_agent: false,
+    multi_agent_v2: false,
+    plugins: false,
+    standalone_web_search: false,
+    token_budget: false,
+    tool_suggest: false,
+  },
+  orchestrator: {
+    mcp: { enabled: false },
+    skills: { enabled: false },
+  },
+  tools: {
+    experimental_request_user_input: { enabled: false },
+  },
+  hooks: {
+    PreToolUse: [],
+    PermissionRequest: [],
+    PostToolUse: [],
+    PreCompact: [],
+    PostCompact: [],
+    SessionStart: [],
+    UserPromptSubmit: [],
+    SubagentStart: [],
+    SubagentStop: [],
+    Stop: [],
   },
 };
 const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
@@ -450,29 +482,13 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 /**
  * Codex recursively merges `mcp_servers`, so an empty table does not erase
- * servers configured in lower layers. Inspect only the effective server names
- * and pin each one off in the helper-thread overlay. Never copy commands, env,
- * credentials, or any other server configuration into the request.
+ * servers configured in lower layers. Pin every inventoried server off in the
+ * helper-thread overlay.
  */
 function buildCodexHelperConfig(
   baseConfig: NonNullable<CodexThreadStartParams["config"]>,
-  configReadResponse: unknown,
+  serverNames: string[],
 ): NonNullable<CodexThreadStartParams["config"]> {
-  const effectiveConfig = asRecord(asRecord(configReadResponse)?.config);
-  if (!effectiveConfig) {
-    throw new Error("codex_title_config_read_invalid_response");
-  }
-
-  const configuredServersValue = effectiveConfig.mcp_servers;
-  const configuredServers =
-    configuredServersValue === undefined
-      ? null
-      : asRecord(configuredServersValue);
-  if (configuredServersValue !== undefined && !configuredServers) {
-    throw new Error("codex_title_config_read_invalid_mcp_servers");
-  }
-
-  const serverNames = Object.keys(configuredServers ?? {}).sort();
   if (serverNames.length === 0) {
     return baseConfig;
   }
@@ -483,6 +499,124 @@ function buildCodexHelperConfig(
       serverNames.map((name) => [name, { enabled: false }]),
     ),
   };
+}
+
+function readConfiguredMcpServerNames(value: unknown): string[] {
+  const effectiveConfig = asRecord(asRecord(value)?.config);
+  if (!effectiveConfig) {
+    throw new Error("codex_title_config_read_invalid_response");
+  }
+  const configuredServersValue = effectiveConfig.mcp_servers;
+  if (configuredServersValue === undefined) {
+    return [];
+  }
+  const configuredServers = asRecord(configuredServersValue);
+  if (!configuredServers) {
+    throw new Error("codex_title_config_read_invalid_mcp_servers");
+  }
+  return Object.keys(configuredServers).sort();
+}
+
+function createCodexObserverWithConfigReadRedaction(
+  observer: JsonRpcObserver | undefined,
+): JsonRpcObserver | undefined {
+  if (!observer) {
+    return undefined;
+  }
+  const sensitiveRequestIds = new Set<string>();
+
+  return {
+    onMessage: async (event) => {
+      const requestId = event.envelope.id;
+      const requestKey = requestId === null || requestId === undefined
+        ? undefined
+        : String(requestId);
+      if (
+        event.direction === "outbound"
+        && event.envelope.method === "config/read"
+        && event.diagnostics?.callerReason === CODEX_THREAD_TITLE_CONFIG_READ_REASON
+        && requestKey
+      ) {
+        sensitiveRequestIds.add(requestKey);
+        await observer.onMessage(event);
+        return;
+      }
+      if (
+        event.direction !== "inbound"
+        || !requestKey
+        || !sensitiveRequestIds.delete(requestKey)
+        || !Object.hasOwn(event.envelope, "result")
+      ) {
+        await observer.onMessage(event);
+        return;
+      }
+
+      const names = readConfiguredMcpServerNames(event.envelope.result);
+      const envelope: JsonRpcObserverEvent["envelope"] = {
+        ...event.envelope,
+        result: {
+          config: {
+            mcp_servers: Object.fromEntries(names.map((name) => [name, {}])),
+          },
+        },
+      };
+      await observer.onMessage({
+        ...event,
+        envelope,
+        raw: JSON.stringify(envelope),
+      });
+    },
+  };
+}
+
+function readMcpServerInventoryPage(value: unknown): {
+  names: string[];
+  namesWithTools: string[];
+  nextCursor?: string;
+} {
+  const record = asRecord(value);
+  if (!record || !Array.isArray(record.data)) {
+    throw new Error("codex_title_mcp_inventory_invalid_response");
+  }
+
+  const namesWithTools: string[] = [];
+  const names = record.data.map((item) => {
+    const name = readStringFromRecord(item, "name");
+    if (!name) {
+      throw new Error("codex_title_mcp_inventory_invalid_server");
+    }
+    const tools = asRecord(asRecord(item)?.tools);
+    if (!tools) {
+      throw new Error("codex_title_mcp_inventory_invalid_tools");
+    }
+    if (Object.keys(tools).length > 0) {
+      namesWithTools.push(name);
+    }
+    return name;
+  });
+  const nextCursorValue = record.nextCursor;
+  if (nextCursorValue === null || nextCursorValue === undefined) {
+    return { names, namesWithTools };
+  }
+  if (typeof nextCursorValue !== "string" || !nextCursorValue.trim()) {
+    throw new Error("codex_title_mcp_inventory_invalid_cursor");
+  }
+  return { names, namesWithTools, nextCursor: nextCursorValue.trim() };
+}
+
+function readThreadInstructionSources(value: unknown): string[] | null {
+  const sources = asRecord(value)?.instructionSources;
+  if (!Array.isArray(sources)) {
+    return null;
+  }
+  const normalized: string[] = [];
+  for (const source of sources) {
+    if (typeof source !== "string" || !source.trim()) {
+      return null;
+    }
+    normalized.push(source.trim());
+  }
+  return normalized;
 }
 
 function pickString(
@@ -5164,6 +5298,7 @@ function buildThreadStartPayload(params: {
   cwd?: string;
   runtimeWorkspaceRoots?: string[];
   environments?: CodexThreadStartParams["environments"];
+  baseInstructions?: CodexThreadStartParams["baseInstructions"];
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
@@ -5191,6 +5326,9 @@ function buildThreadStartPayload(params: {
   }
   if (params.environments !== undefined) {
     base.environments = params.environments;
+  }
+  if (params.baseInstructions !== undefined) {
+    base.baseInstructions = params.baseInstructions;
   }
   if (params.model?.trim()) {
     base.model = params.model.trim();
@@ -5824,7 +5962,7 @@ export class CodexAppServerClient {
         resolveEnv: options.resolveEnv,
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
-      options.connectionObserver,
+      createCodexObserverWithConfigReadRedaction(options.connectionObserver),
       { logContext: { backend: "codex" }, logger: getMainLogger("pwragent:json-rpc") },
     );
     const directoryResolver = options.directoryResolver;
@@ -6747,6 +6885,56 @@ export class CodexAppServerClient {
     return await this.runHelperStructuredTurn(params);
   }
 
+  /** Read only configured MCP names; the observer wrapper strips secret values. */
+  private async readHelperMcpServerNames(
+    cwd: string,
+    timeoutMs: number,
+  ): Promise<string[]> {
+    const result = await requestWithFallbacks({
+      client: this.connection,
+      diagnostics: { callerReason: CODEX_THREAD_TITLE_CONFIG_READ_REASON },
+      methods: ["config/read"],
+      payloads: [{ includeLayers: false, cwd }],
+      timeoutMs,
+    });
+    return readConfiguredMcpServerNames(result);
+  }
+
+  private async attestHelperHasNoConfiguredMcpTools(
+    threadId: string,
+    configuredServerNames: string[],
+    timeoutMs: number,
+  ): Promise<void> {
+    const configuredNames = new Set(configuredServerNames);
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+
+    do {
+      const result = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["mcpServerStatus/list"],
+        payloads: [{
+          threadId,
+          detail: "toolsAndAuthOnly",
+          limit: 100,
+          ...(cursor ? { cursor } : {}),
+        }],
+        timeoutMs,
+      });
+      const page = readMcpServerInventoryPage(result);
+      if (page.namesWithTools.some((name) => configuredNames.has(name))) {
+        throw new Error("codex_title_helper_configured_mcp_tools_present");
+      }
+      cursor = page.nextCursor;
+      if (cursor) {
+        if (seenCursors.has(cursor)) {
+          throw new Error("codex_title_helper_mcp_inventory_repeated_cursor");
+        }
+        seenCursors.add(cursor);
+      }
+    } while (cursor);
+  }
+
   private async runHelperStructuredTurn(params: {
     prompt: string;
     schema: Record<string, unknown>;
@@ -6761,19 +6949,17 @@ export class CodexAppServerClient {
     const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
     const helperWorkspaceDir = await ensureCodexThreadTitleWorkspace();
     try {
-      const configReadResult = await requestWithFallbacks({
-        client: this.connection,
-        methods: ["config/read"],
-        payloads: [{ includeLayers: false, cwd: helperWorkspaceDir }],
+      const mcpServerNames = await this.readHelperMcpServerNames(
+        helperWorkspaceDir,
         timeoutMs,
-      });
+      );
       const helperConfig = buildCodexHelperConfig(
         CODEX_THREAD_TITLE_CONFIG,
-        configReadResult,
+        mcpServerNames,
       );
       const legacyHelperConfig = buildCodexHelperConfig(
         LEGACY_CODEX_THREAD_TITLE_CONFIG,
-        configReadResult,
+        mcpServerNames,
       );
       const threadStartResult = await requestWithFallbacks({
         client: this.connection,
@@ -6784,6 +6970,7 @@ export class CodexAppServerClient {
               cwd: helperWorkspaceDir,
               runtimeWorkspaceRoots: [helperWorkspaceDir],
               environments: [],
+              baseInstructions: "",
               model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
               serviceTier: null,
               ephemeral: true,
@@ -6796,6 +6983,7 @@ export class CodexAppServerClient {
               cwd: helperWorkspaceDir,
               runtimeWorkspaceRoots: [helperWorkspaceDir],
               environments: [],
+              baseInstructions: "",
               model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
               serviceTier: null,
               ephemeral: true,
@@ -6813,6 +7001,28 @@ export class CodexAppServerClient {
           reason: "codex_title_thread_start_missing_thread_id",
         };
       }
+      const instructionSources = readThreadInstructionSources(threadStartResult);
+      if (!instructionSources) {
+        return {
+          status: "failed",
+          reason: "codex_title_thread_start_missing_instruction_sources",
+        };
+      }
+      if (instructionSources.length > 0) {
+        codexClientLog.warn("codex helper thread rejected instruction sources", {
+          threadId: helperThreadId,
+          instructionSourceCount: instructionSources.length,
+        });
+        return {
+          status: "failed",
+          reason: "codex_title_helper_instruction_sources_present",
+        };
+      }
+      await this.attestHelperHasNoConfiguredMcpTools(
+        helperThreadId,
+        mcpServerNames,
+        timeoutMs,
+      );
       this.helperThreadIds.add(helperThreadId);
       this.helperThreadPredicates.set(helperThreadId, params.isMatch);
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6946,6 +6946,7 @@ export class CodexAppServerClient {
     let helperTurnCompleted = false;
     const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
     const helperWorkspaceDir = await ensureCodexThreadTitleWorkspace();
+    const protocolCompatibility = this.getProtocolCompatibility();
     try {
       const mcpServerNames = await this.readHelperMcpServerNames(
         helperWorkspaceDir,
@@ -6974,7 +6975,7 @@ export class CodexAppServerClient {
               ephemeral: true,
               config: helperConfig,
             },
-            this.getProtocolCompatibility(),
+            protocolCompatibility,
           ),
           buildThreadStartPayload(
             {
@@ -6987,7 +6988,7 @@ export class CodexAppServerClient {
               ephemeral: true,
               config: legacyHelperConfig,
             },
-            this.getProtocolCompatibility(),
+            protocolCompatibility,
           ),
         ],
         timeoutMs,
@@ -7016,10 +7017,20 @@ export class CodexAppServerClient {
           instructionSourceCount: instructionSources.length,
         });
       }
-      await this.attestHelperHasNoMcpTools(
-        helperThreadId,
-        timeoutMs,
-      );
+      if (protocolCompatibility.supportsThreadScopedMcpServerStatus) {
+        await this.attestHelperHasNoMcpTools(
+          helperThreadId,
+          timeoutMs,
+        );
+      } else {
+        // Before 0.144, mcpServerStatus/list is process-wide even when a
+        // threadId is supplied. Configured servers are still disabled in the
+        // helper overlay, but that legacy inventory cannot attest the helper
+        // without falsely rejecting tools active on interactive threads.
+        logCodexClientDebug("codex helper skipped unavailable thread-scoped MCP attestation", {
+          threadId: helperThreadId,
+        });
+      }
       this.helperThreadIds.add(helperThreadId);
       this.helperThreadPredicates.set(helperThreadId, params.isMatch);
 
@@ -7036,7 +7047,7 @@ export class CodexAppServerClient {
               reasoningEffort: "low",
               outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
             },
-            this.getProtocolCompatibility(),
+            protocolCompatibility,
           ),
         ],
         timeoutMs,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -121,9 +121,18 @@ const CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> =
   include_apps_instructions: false,
   include_collaboration_mode_instructions: false,
   include_environment_context: false,
+  project_doc_max_bytes: 0,
   skills: {
     include_instructions: false,
     bundled: { enabled: false },
+  },
+  features: {
+    apps: false,
+    plugins: false,
+    tool_suggest: false,
+    image_generation: false,
+    multi_agent: false,
+    goals: false,
   },
 };
 const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["config"]> = {
@@ -132,8 +141,17 @@ const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["conf
   include_apps_instructions: false,
   include_collaboration_mode_instructions: false,
   include_environment_context: false,
+  project_doc_max_bytes: 0,
   skills: {
     include_instructions: false,
+  },
+  features: {
+    apps: false,
+    plugins: false,
+    tool_suggest: false,
+    image_generation: false,
+    multi_agent: false,
+    goals: false,
   },
 };
 const CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY =
@@ -428,6 +446,43 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+/**
+ * Codex recursively merges `mcp_servers`, so an empty table does not erase
+ * servers configured in lower layers. Inspect only the effective server names
+ * and pin each one off in the helper-thread overlay. Never copy commands, env,
+ * credentials, or any other server configuration into the request.
+ */
+function buildCodexHelperConfig(
+  baseConfig: NonNullable<CodexThreadStartParams["config"]>,
+  configReadResponse: unknown,
+): NonNullable<CodexThreadStartParams["config"]> {
+  const effectiveConfig = asRecord(asRecord(configReadResponse)?.config);
+  if (!effectiveConfig) {
+    throw new Error("codex_title_config_read_invalid_response");
+  }
+
+  const configuredServersValue = effectiveConfig.mcp_servers;
+  const configuredServers =
+    configuredServersValue === undefined
+      ? null
+      : asRecord(configuredServersValue);
+  if (configuredServersValue !== undefined && !configuredServers) {
+    throw new Error("codex_title_config_read_invalid_mcp_servers");
+  }
+
+  const serverNames = Object.keys(configuredServers ?? {}).sort();
+  if (serverNames.length === 0) {
+    return baseConfig;
+  }
+
+  return {
+    ...baseConfig,
+    mcp_servers: Object.fromEntries(
+      serverNames.map((name) => [name, { enabled: false }]),
+    ),
+  };
 }
 
 function pickString(
@@ -5108,6 +5163,7 @@ function normalizeCodexReasoningEffort(
 function buildThreadStartPayload(params: {
   cwd?: string;
   runtimeWorkspaceRoots?: string[];
+  environments?: CodexThreadStartParams["environments"];
   model?: string;
   approvalPolicy?: string;
   sandbox?: string;
@@ -5132,6 +5188,9 @@ function buildThreadStartPayload(params: {
   }
   if (params.runtimeWorkspaceRoots !== undefined) {
     base.runtimeWorkspaceRoots = params.runtimeWorkspaceRoots;
+  }
+  if (params.environments !== undefined) {
+    base.environments = params.environments;
   }
   if (params.model?.trim()) {
     base.model = params.model.trim();
@@ -5177,6 +5236,7 @@ function buildThreadStartPayload(params: {
     );
   }
   if (
+    params.environments === undefined &&
     params.codexEnvironmentRuntime?.executionTarget === "remote" &&
     params.codexEnvironmentRuntime.environmentId &&
     params.cwd?.trim()
@@ -6696,9 +6756,25 @@ export class CodexAppServerClient {
     await this.ensureInitialized();
 
     let helperThreadId: string | undefined;
+    let helperTurnId: string | undefined;
+    let helperTurnCompleted = false;
     const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
     const helperWorkspaceDir = await ensureCodexThreadTitleWorkspace();
     try {
+      const configReadResult = await requestWithFallbacks({
+        client: this.connection,
+        methods: ["config/read"],
+        payloads: [{ includeLayers: false, cwd: helperWorkspaceDir }],
+        timeoutMs,
+      });
+      const helperConfig = buildCodexHelperConfig(
+        CODEX_THREAD_TITLE_CONFIG,
+        configReadResult,
+      );
+      const legacyHelperConfig = buildCodexHelperConfig(
+        LEGACY_CODEX_THREAD_TITLE_CONFIG,
+        configReadResult,
+      );
       const threadStartResult = await requestWithFallbacks({
         client: this.connection,
         methods: ["thread/start"],
@@ -6707,10 +6783,11 @@ export class CodexAppServerClient {
             {
               cwd: helperWorkspaceDir,
               runtimeWorkspaceRoots: [helperWorkspaceDir],
+              environments: [],
               model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
               serviceTier: null,
               ephemeral: true,
-              config: CODEX_THREAD_TITLE_CONFIG,
+              config: helperConfig,
             },
             this.getProtocolCompatibility(),
           ),
@@ -6718,10 +6795,11 @@ export class CodexAppServerClient {
             {
               cwd: helperWorkspaceDir,
               runtimeWorkspaceRoots: [helperWorkspaceDir],
+              environments: [],
               model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
               serviceTier: null,
               ephemeral: true,
-              config: LEGACY_CODEX_THREAD_TITLE_CONFIG,
+              config: legacyHelperConfig,
             },
             this.getProtocolCompatibility(),
           ),
@@ -6756,23 +6834,23 @@ export class CodexAppServerClient {
         ],
         timeoutMs,
       });
+      helperTurnId = extractTurnIdFromValue(turnStartResult);
       const immediateObject = findStructuredRecord(turnStartResult, params.isMatch);
       if (immediateObject) {
-        const immediateTurnId = extractTurnIdFromValue(turnStartResult);
+        helperTurnCompleted = true;
         const tokenUsage = readHelperTokenUsage(turnStartResult);
         return {
           status: "ok",
           object: immediateObject,
           helperThreadId,
-          ...(immediateTurnId ? { helperTurnId: immediateTurnId } : {}),
+          ...(helperTurnId ? { helperTurnId } : {}),
           model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
           reasoningEffort: "low",
           ...(tokenUsage !== undefined ? { tokenUsage } : {}),
         };
       }
 
-      const turnId = extractTurnIdFromValue(turnStartResult);
-      if (!turnId) {
+      if (!helperTurnId) {
         return {
           status: "failed",
           reason: "codex_title_turn_start_missing_turn_id",
@@ -6781,14 +6859,15 @@ export class CodexAppServerClient {
 
       const helperResult = await this.waitForHelperTurnTitle({
         threadId: helperThreadId,
-        turnId,
+        turnId: helperTurnId,
         timeoutMs,
       });
+      helperTurnCompleted = true;
       return {
         status: "ok",
         object: helperResult.object,
         helperThreadId,
-        helperTurnId: turnId,
+        helperTurnId,
         model: DEFAULT_CODEX_THREAD_TITLE_MODEL,
         reasoningEffort: "low",
         ...(helperResult.tokenUsage !== undefined
@@ -6802,6 +6881,38 @@ export class CodexAppServerClient {
       };
     } finally {
       if (helperThreadId) {
+        if (helperTurnId && !helperTurnCompleted) {
+          await requestWithFallbacks({
+            client: this.connection,
+            methods: ["turn/interrupt"],
+            payloads: [{ threadId: helperThreadId, turnId: helperTurnId }],
+            timeoutMs,
+          }).catch((error: unknown) => {
+            codexClientLog.warn("codex helper turn cleanup interrupt failed", {
+              threadId: helperThreadId,
+              turnId: helperTurnId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
+        }
+        await requestWithFallbacks({
+          client: this.connection,
+          methods: ["thread/unsubscribe"],
+          payloads: [{ threadId: helperThreadId }],
+          timeoutMs,
+        }).catch((error: unknown) => {
+          codexClientLog.warn("codex helper thread unsubscribe failed", {
+            threadId: helperThreadId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+        if (helperTurnId) {
+          const helperTurnKey = buildHelperTurnKey(helperThreadId, helperTurnId);
+          this.completedHelperTurnResults.delete(helperTurnKey);
+          this.helperTurnTitleObjects.delete(helperTurnKey);
+          this.helperTurnTokenUsage.delete(helperTurnKey);
+        }
+        this.helperThreadIds.delete(helperThreadId);
         this.helperThreadPredicates.delete(helperThreadId);
       }
     }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6900,12 +6900,10 @@ export class CodexAppServerClient {
     return readConfiguredMcpServerNames(result);
   }
 
-  private async attestHelperHasNoConfiguredMcpTools(
+  private async attestHelperHasNoMcpTools(
     threadId: string,
-    configuredServerNames: string[],
     timeoutMs: number,
   ): Promise<void> {
-    const configuredNames = new Set(configuredServerNames);
     const seenCursors = new Set<string>();
     let cursor: string | undefined;
 
@@ -6922,8 +6920,8 @@ export class CodexAppServerClient {
         timeoutMs,
       });
       const page = readMcpServerInventoryPage(result);
-      if (page.namesWithTools.some((name) => configuredNames.has(name))) {
-        throw new Error("codex_title_helper_configured_mcp_tools_present");
+      if (page.namesWithTools.length > 0) {
+        throw new Error("codex_title_helper_mcp_tools_present");
       }
       cursor = page.nextCursor;
       if (cursor) {
@@ -7009,18 +7007,17 @@ export class CodexAppServerClient {
         };
       }
       if (instructionSources.length > 0) {
-        codexClientLog.warn("codex helper thread rejected instruction sources", {
+        // Current Codex has no thread-level switch for process-owned global
+        // AGENTS.md. The helper cwd and project-doc budget still exclude
+        // project instructions, while the remaining global source is bounded
+        // to one fresh copy because every helper uses a new ephemeral thread.
+        codexClientLog.warn("codex helper thread retained global instruction source", {
           threadId: helperThreadId,
           instructionSourceCount: instructionSources.length,
         });
-        return {
-          status: "failed",
-          reason: "codex_title_helper_instruction_sources_present",
-        };
       }
-      await this.attestHelperHasNoConfiguredMcpTools(
+      await this.attestHelperHasNoMcpTools(
         helperThreadId,
-        mcpServerNames,
         timeoutMs,
       );
       this.helperThreadIds.add(helperThreadId);

--- a/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
+++ b/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
@@ -4,11 +4,13 @@ const PERSIST_EXTENDED_HISTORY_REMOVED_VERSION = [0, 137, 0] as const;
 const NAMESPACED_DYNAMIC_TOOLS_MIN_VERSION = [0, 141, 0] as const;
 const ON_FAILURE_APPROVAL_REMOVED_VERSION = [0, 143, 0] as const;
 const GENERATED_MODEL_LIST_MIN_VERSION = [0, 144, 0] as const;
+const THREAD_SCOPED_MCP_STATUS_MIN_VERSION = [0, 144, 0] as const;
 
 export type CodexProtocolCompatibility = {
   dynamicToolFormat: "flat" | "namespaced";
   includePersistExtendedHistory: boolean;
   supportsOnFailureApprovalPolicy: boolean;
+  supportsThreadScopedMcpServerStatus: boolean;
 };
 
 type ModernDynamicToolFunction = Extract<
@@ -39,6 +41,7 @@ export type CompatibleApprovalPolicy =
  * - 0.137.0 removed the deprecated `persistExtendedHistory` thread parameter.
  * - 0.141.0 changed dynamic tools to function/namespace discriminated specs.
  * - 0.143.0 removed the `on-failure` approval policy.
+ * - 0.144.0 made MCP status inventory thread-scoped.
  *
  * Missing or unparseable versions stay on the legacy shape. That preserves
  * the contract PwrAgent used before this migration instead of assuming that
@@ -59,6 +62,8 @@ export function resolveCodexProtocolCompatibility(
       !isAtLeast(PERSIST_EXTENDED_HISTORY_REMOVED_VERSION),
     supportsOnFailureApprovalPolicy:
       !isAtLeast(ON_FAILURE_APPROVAL_REMOVED_VERSION),
+    supportsThreadScopedMcpServerStatus:
+      isAtLeast(THREAD_SCOPED_MCP_STATUS_MIN_VERSION),
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1877,7 +1877,7 @@ describe("ThreadContextPanel", () => {
     expect(times?.textContent).toContain("· 1m 5s");
   });
 
-  for (const status of ["success", "failure", "failed", "blocked", "cancelled"] as const) {
+  for (const status of ["success", "failure", "cancelled"] as const) {
     it(`shows a ${status} sub-agent's name but no Live chip`, () => {
       const { container } = renderPanel({
         activeTab: "pricing",
@@ -1905,6 +1905,73 @@ describe("ThreadContextPanel", () => {
       expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
       expect(screen.queryByText("Live")).not.toBeInTheDocument();
       expect(screen.getByText("Reviewer")).toBeInTheDocument();
+    });
+  }
+
+  for (const status of ["failed", "blocked"] as const) {
+    it(`settles a completed ${status} sub-agent in pricing`, () => {
+      const { container } = renderPanel({
+        activeTab: "pricing",
+        pinned: true,
+        thread: {
+          ...baseThread,
+          subAgents: [
+            {
+              monitorId: "mon-1",
+              task: "Review the diff",
+              status,
+              agentName: "Reviewer",
+              completedAt: 1_800_000_001_000,
+              createdAt: 1_800_000_000_000,
+              updatedAt: 1_800_000_001_000,
+            },
+          ],
+        },
+        pricing: {
+          lines: [buildMonitorLine({})],
+          summaries: [],
+        },
+        threadPricingSummaryEnabled: true,
+      });
+
+      expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
+      expect(screen.queryByText("Live")).not.toBeInTheDocument();
+    });
+
+    it(`keeps a progress-only ${status} monitor live`, () => {
+      const startedAt = 1_800_000_000_000;
+      vi.useFakeTimers();
+      vi.setSystemTime(startedAt + 65_000);
+
+      const { container } = renderPanel({
+        activeTab: "pricing",
+        pinned: true,
+        thread: {
+          ...baseThread,
+          subAgents: [
+            {
+              monitorId: "mon-1",
+              task: "Review the diff",
+              status,
+              agentName: "Reviewer",
+              createdAt: startedAt,
+              updatedAt: startedAt + 1_000,
+            },
+          ],
+        },
+        pricing: {
+          lines: [buildMonitorLine({ createdAt: startedAt })],
+          summaries: [],
+        },
+        threadPricingSummaryEnabled: true,
+      });
+
+      const activeRow = container.querySelector(".pricing-usage-row--active");
+      expect(activeRow).not.toBeNull();
+      expect(within(activeRow as HTMLElement).getByText("Live")).toBeInTheDocument();
+      expect(activeRow?.querySelector(".rail-card__times")?.textContent).toContain(
+        "· 1m 5s",
+      );
     });
   }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1908,6 +1908,65 @@ describe("ThreadContextPanel", () => {
     });
   }
 
+  it("labels known sub-agent pricing rows by purpose", () => {
+    const subAgents = [
+      {
+        monitorId: "system:title-helper:codex:thread-1",
+        task: "Name this thread",
+        status: "success" as const,
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_000,
+      },
+      {
+        monitorId: "monitor-1",
+        task: "Watch CI",
+        status: "success" as const,
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_000,
+      },
+      {
+        monitorId: "review:turn-1",
+        task: "Review changes",
+        status: "success" as const,
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_000,
+      },
+      {
+        monitorId: "codex-native:thread-2",
+        task: "Inspect implementation",
+        status: "success" as const,
+        createdAt: 1_800_000_000_000,
+        updatedAt: 1_800_000_000_000,
+      },
+    ];
+    const pricingLines = subAgents.map((subAgent, index) =>
+      buildMonitorLine({
+        sourceItemId: subAgent.monitorId,
+        usageLineId: `monitor-line-${index}`,
+      })
+    );
+
+    renderPanel({
+      activeTab: "pricing",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents,
+      },
+      pricing: {
+        lines: pricingLines,
+        summaries: [],
+      },
+      threadPricingSummaryEnabled: true,
+    });
+
+    expect(screen.getByText("Thread naming")).toBeInTheDocument();
+    expect(screen.getByText("Monitor usage")).toBeInTheDocument();
+    expect(screen.getByText("Review usage")).toBeInTheDocument();
+    expect(screen.getByText("Codex sub-agent usage")).toBeInTheDocument();
+    expect(screen.queryByText("Sub-agent usage")).not.toBeInTheDocument();
+  });
+
   it("marks multiple concurrently-running sub-agents live", () => {
     const startedAt = 1_800_000_000_000;
     vi.useFakeTimers();

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1877,34 +1877,36 @@ describe("ThreadContextPanel", () => {
     expect(times?.textContent).toContain("· 1m 5s");
   });
 
-  it("shows a terminal sub-agent's name but no Live chip", () => {
-    const { container } = renderPanel({
-      activeTab: "pricing",
-      pinned: true,
-      thread: {
-        ...baseThread,
-        subAgents: [
-          {
-            monitorId: "mon-1",
-            task: "Review the diff",
-            status: "success",
-            agentName: "Reviewer",
-            createdAt: 1_800_000_000_000,
-            updatedAt: 1_800_000_000_000,
-          },
-        ],
-      },
-      pricing: {
-        lines: [buildMonitorLine({})],
-        summaries: [],
-      },
-      threadPricingSummaryEnabled: true,
-    });
+  for (const status of ["success", "failure", "failed", "blocked", "cancelled"] as const) {
+    it(`shows a ${status} sub-agent's name but no Live chip`, () => {
+      const { container } = renderPanel({
+        activeTab: "pricing",
+        pinned: true,
+        thread: {
+          ...baseThread,
+          subAgents: [
+            {
+              monitorId: "mon-1",
+              task: "Review the diff",
+              status,
+              agentName: "Reviewer",
+              createdAt: 1_800_000_000_000,
+              updatedAt: 1_800_000_000_000,
+            },
+          ],
+        },
+        pricing: {
+          lines: [buildMonitorLine({})],
+          summaries: [],
+        },
+        threadPricingSummaryEnabled: true,
+      });
 
-    expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
-    expect(screen.queryByText("Live")).not.toBeInTheDocument();
-    expect(screen.getByText("Reviewer")).toBeInTheDocument();
-  });
+      expect(container.querySelector(".pricing-usage-row--active")).toBeNull();
+      expect(screen.queryByText("Live")).not.toBeInTheDocument();
+      expect(screen.getByText("Reviewer")).toBeInTheDocument();
+    });
+  }
 
   it("marks multiple concurrently-running sub-agents live", () => {
     const startedAt = 1_800_000_000_000;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -42,12 +42,19 @@ type PricingPanelProps = {
 // running, so its usage row reads as live. Mirrors the main process
 // `codexNativeSubAgentIsTerminal`.
 const SUBAGENT_TERMINAL_STATUSES: ReadonlySet<ThreadSubAgentStatus> = new Set([
-  "blocked",
-  "failed",
   "success",
   "failure",
   "cancelled",
 ]);
+
+function isTerminalSubAgent(subAgent: ThreadSubAgentSummary): boolean {
+  return (
+    SUBAGENT_TERMINAL_STATUSES.has(subAgent.status)
+    || subAgent.completedAt !== undefined
+    || subAgent.outcome !== undefined
+    || subAgent.completionSource !== undefined
+  );
+}
 
 type PricingDisplayOptions = {
   codexCredits: boolean;
@@ -1261,7 +1268,7 @@ function isActiveUsageLine(params: {
     return false;
   }
   const subAgent = params.subAgentsById.get(params.line.sourceItemId);
-  return Boolean(subAgent && !SUBAGENT_TERMINAL_STATUSES.has(subAgent.status));
+  return Boolean(subAgent && !isTerminalSubAgent(subAgent));
 }
 
 function PricingUsageTimestamp(props: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -41,6 +41,8 @@ type PricingPanelProps = {
 // running, so its usage row reads as live. Mirrors the main process
 // `codexNativeSubAgentIsTerminal`.
 const SUBAGENT_TERMINAL_STATUSES: ReadonlySet<ThreadSubAgentStatus> = new Set([
+  "blocked",
+  "failed",
   "success",
   "failure",
   "cancelled",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../../lib/format-duration";
 import { formatTimestamp } from "./context-rail-shared";
 import { formatTokenCount } from "./subagent-format";
+import { subAgentPricingUsageTitle } from "./subagent-kind";
 
 type PricingPanelProps = {
   activeTurnId?: string;
@@ -317,7 +318,7 @@ export function PricingPanel(props: PricingPanelProps) {
               >
                 <div className="pricing-usage-row__header">
                   <p className="rail-card__title">
-                    {formatUsageLineTitle(line)}
+                    {formatUsageLineTitle(line, subAgent)}
                   </p>
                   {isActive ? (
                     <span className="rail-chip pricing-usage-row__live">
@@ -1155,9 +1156,14 @@ function hasSelectedEstimateUnit(displayOptions: PricingDisplayOptions): boolean
   return displayOptions.usd || displayOptions.codexCredits;
 }
 
-function formatUsageLineTitle(line: PricingUsageLine): string {
+function formatUsageLineTitle(
+  line: PricingUsageLine,
+  subAgent?: ThreadSubAgentSummary,
+): string {
   if (line.scope === "monitor") {
-    return "Sub-agent usage";
+    return subAgent
+      ? subAgentPricingUsageTitle(subAgent)
+      : "Sub-agent usage";
   }
   if (isForkBaselineLine(line)) {
     return "Fork point";

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
@@ -44,3 +44,18 @@ export function subAgentUsageLabel(subAgent: ThreadSubAgentSummary): string {
   }
   return "Monitor";
 }
+
+export function subAgentPricingUsageTitle(
+  subAgent: ThreadSubAgentSummary,
+): string {
+  if (isSystemTitleHelperSubAgent(subAgent)) {
+    return "Thread naming";
+  }
+  if (isCodexNativeSubAgent(subAgent)) {
+    return "Codex sub-agent usage";
+  }
+  if (subAgent.monitorId.startsWith("review:")) {
+    return "Review usage";
+  }
+  return "Monitor usage";
+}


### PR DESCRIPTION
## Summary

- run each Codex title job in a fresh ephemeral thread while pooling only the App Server process/connection
- apply a modern ring-zero helper profile: empty base instructions, no environments or dynamic tools, and explicit suppression of apps, plugins, skills, hooks, orchestrator MCP, web search, reminders, fan-out, memories, goals, multi-agent, image generation, and related harness features
- disable every effective configured MCP server by name and reject the helper before `turn/start` if any thread-scoped MCP server exposes tools, including servers absent from the earlier configuration snapshot
- redact the internal `config/read` response before protocol observers see it, retaining server names only so commands, env, credentials, and secrets cannot enter raw captures or protocol logs
- unsubscribe every helper thread and never use deprecated rollback
- preserve normal interactive and multi-turn Codex behavior outside the one-shot helper path

## Root cause

The observed 7,009- and 9,177-token title jobs were each the first and only turn on distinct threads, so this was not rollback/history accumulation. The title prompts themselves were only 1,817 and 1,527 characters. Most input was cold Codex harness context: plugin/recommended-plugin guidance, capability guidance, and MCP/tool metadata that the old partial suppression profile did not remove. The larger second envelope followed the model change and was not prior helper history.

PwrSnap PR #322 supplied the process-pooling/fresh-thread pattern. A comparison with current OpenClaw found its newer ring-zero profile and post-start MCP checks, which are adapted here to PwrAgent conventions.

## Global AGENTS.md limitation

Current Codex has no thread-level switch for the process-owned global `CODEX_HOME/AGENTS.md`. OpenClaw bypasses it only for private stdio jobs by launching another process with an empty temporary `CODEX_HOME` and separately bridging authentication. A plain isolated home is unauthenticated in the PwrAgent default profile, and PwrAgent repository policy correctly forbids reading or copying Codex-owned auth storage.

The helper therefore retains one bounded global instruction source, reports its count without logging its path or contents, and still runs the title turn. Project instructions remain excluded through the isolated helper cwd and `project_doc_max_bytes: 0`. Fresh threads prevent the global block from accumulating across jobs.

An earlier review-follow-up revision failed closed on any `instructionSources` entry. Real thread `019fba38-7791-7fd1-9299-f47825eb58e6` proved that behavior was a product regression: no helper turn or usage row was created and PwrAgent silently used the truncated prompt fallback. Commit `4702dea3` restores the bounded model turn.

## Security follow-up

- MCP credentials remain protected when `PWRAGENT_PROTOCOL_CAPTURE=1` or `PWRAGENT_APP_SERVER_PROTOCOL_LOG` is enabled: the observer wrapper reconstructs the matching `config/read` response as names-only before forwarding either the parsed envelope or raw JSON.
- The post-start attestation rejects every tool-bearing MCP server, not only names from the pre-start snapshot. This closes the race and managed/virtual-server gap identified in review.
- Current Codex lists disabled configured MCP names in status results, but their tool maps are empty because the connection manager filters `enabled:false` servers. The attestation checks the model-facing capability rather than server-name presence.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` — 121 passed
- `pnpm typecheck`
- targeted ESLint — 0 errors (3 existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm --filter @pwragent/desktop build`
- `git diff --check`
- zero-token App Server probes for account and MCP isolation behavior
- minimal live App Server title turn: generated `Three Bad Brothers’ Origin Story`, 1 bounded global instruction source, 0 tool-bearing MCP servers, and successful unsubscribe
