### PR TITLE
fix(release): prevent incomplete Windows installs

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -97,7 +97,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "axe-core": "^4.11.4",
     "electron": "^41.2.1",
-    "electron-builder": "26.15.3",
+    "electron-builder": "26.15.6",
     "electron-vite": "^5.0.0",
     "tsx": "^4.20.6",
     "vite": "^7.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,8 +203,8 @@ importers:
         specifier: ^41.2.1
         version: 41.7.1
       electron-builder:
-        specifier: 26.15.3
-        version: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+        specifier: 26.15.6
+        version: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       electron-vite:
         specifier: ^5.0.0
         version: 5.0.0(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1))
@@ -1781,12 +1781,12 @@ packages:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
-  app-builder-lib@26.15.3:
-    resolution: {integrity: sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==}
+  app-builder-lib@26.15.6:
+    resolution: {integrity: sha512-lN6BliNJLnS2ruBdYd1j1rzd2yl4ZwKqyTtAwVznIkkadOR9cFvRz/tNQ6nd824AobnFZKhcdFrpIGDnr0PRSg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      dmg-builder: 26.15.3
-      electron-builder-squirrel-windows: 26.15.3
+      dmg-builder: 26.15.6
+      electron-builder-squirrel-windows: 26.15.6
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2150,8 +2150,8 @@ packages:
     resolution: {integrity: sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==}
     engines: {node: '>=18'}
 
-  dmg-builder@26.15.3:
-    resolution: {integrity: sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==}
+  dmg-builder@26.15.6:
+    resolution: {integrity: sha512-nr5vQxEhM0REomp1qiHbc6V99yrfBZy+wUU56VXADfSOlLj8PdLqsHiRe7b+FbqKesiyv4ax+k1GVwGonYKuCg==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -2182,11 +2182,11 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-builder-squirrel-windows@26.15.3:
-    resolution: {integrity: sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==}
+  electron-builder-squirrel-windows@26.15.6:
+    resolution: {integrity: sha512-Vgw0bVXtTjZmD3O0Wl1gbo4eiI0Mqp7FQBsFgMR+wNwySiPJ08jadS0PZiSwP2cKCVaEclBHbKeBVTwil+SJfQ==}
 
-  electron-builder@26.15.3:
-    resolution: {integrity: sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==}
+  electron-builder@26.15.6:
+    resolution: {integrity: sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5804,7 +5804,7 @@ snapshots:
 
   ansi-styles@5.2.0: {}
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -5825,11 +5825,11 @@ snapshots:
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.15.3(dmg-builder@26.15.3)
+      electron-builder-squirrel-windows: 26.15.6(dmg-builder@26.15.6)
       electron-publish: 26.15.3
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
@@ -6228,9 +6228,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  dmg-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.3.0
@@ -6264,23 +6264,23 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
+  electron-builder-squirrel-windows@26.15.6(dmg-builder@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
 
-  electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
+  electron-builder@26.15.6(electron-builder-squirrel-windows@26.15.6):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.6(dmg-builder@26.15.6)(electron-builder-squirrel-windows@26.15.6)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
       ci-info: 4.4.0
-      dmg-builder: 26.15.3(electron-builder-squirrel-windows@26.15.3)
+      dmg-builder: 26.15.6(electron-builder-squirrel-windows@26.15.6)
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       simple-update-notifier: 2.0.0


### PR DESCRIPTION
## Summary

- bump electron-builder from 26.15.3 to 26.15.6, the first fixed v26 release for install-time NSIS payload compression
- retain the dependency-security resolutions from #1089: app-builder-lib 26.15.6, builder-util-runtime 9.7.0, and tar 7.5.22
- avoid broader Electron, updater, packaging configuration, or release-metadata changes

## Security and packaging context

PR #1089 resolved Dependabot alerts #46, #47, #48, #49, #50, and #52, but electron-builder 26.15.3 has a separate Windows installer regression. Its modern 7-Zip compressor can select BCJ2 or ARM64 filters for files in the nested NSIS payload while the bundled NSIS extractor cannot decode those methods. Installation can exit successfully after silently omitting executables, DLLs, and native modules.

Inspection of the x64 PwrAgent installer produced by 26.15.3 confirmed that `PwrAgent.exe`, Chromium DLLs, x64 helper executables, and `elevate.exe` were stored with BCJ2; bundled ARM64 ConPTY helper files used ARM64. A successful packaging job therefore was not sufficient evidence that the installer was usable.

Upstream fixed this in electron-builder 26.15.6 by marking NSIS payloads as install-time-decodable and forcing the compatible BCJ filter. See [electron-builder issue #9983](https://github.com/electron-userland/electron-builder/issues/9983) and [fix PR #9988](https://github.com/electron-userland/electron-builder/pull/9988).

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm licenses:check`
- `pnpm build`
- inspected installed app-builder-lib compression arguments: NSIS payloads force `-mf=BCJ`, with no BCJ2 or ARM64 filter
- `pnpm --filter @pwragent/desktop package:dryrun` (universal macOS app, ZIP, and DMG)
- [CI run 30668967498](https://github.com/pwrdrvr/PwrAgent/actions/runs/30668967498): Build, Desktop E2E, dependency install, lint, live agent core, tests, Windows build/tests, and label-gated x64 NSIS packaging all passed
- [macOS preview run 30668960857](https://github.com/pwrdrvr/PwrAgent/actions/runs/30668960857): universal preview packaging passed (real Developer ID signing/notarization still requires release credentials)
- downloaded the Windows artifact and inspected embedded `$PLUGINSDIR/app-64.7z`: 189 entries use `BCJ LZMA2:20`, one uses `LZMA2:20 BCJ`, and 38 are uncompressed; no BCJ2, ARM64, ARMT, ARM, IA64, PPC, SPARC, or DELTA methods
- confirmed the nested payload contains `PwrAgent.exe`, `elevate.exe`, x64 and ARM64 ConPTY helpers, 10 DLLs, and 3 native `.node` files
- no failed CI logs

## Dependabot alerts preserved as resolved

- #49 app-builder-lib: 26.15.6 (requires >=26.15.0)
- #50 builder-util-runtime: 9.7.0 (requires >=9.7.0)
- #46, #47, #48, #52 tar: 7.5.22 (requires >=7.5.21)
