### PR TITLE
fix(desktop): handle failed Codex helper turns

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -6813,6 +6813,12 @@ describe("CodexAppServerClient", () => {
     expect(requests.map((request) => request.method)).not.toContain(
       "thread/rollback",
     );
+    const tracking = client as unknown as {
+      helperThreadIds: Set<string>;
+      helperThreadPredicates: Map<string, unknown>;
+    };
+    expect(tracking.helperThreadIds.size).toBe(0);
+    expect(tracking.helperThreadPredicates.size).toBe(0);
 
     await client.close();
   });
@@ -7153,6 +7159,127 @@ describe("CodexAppServerClient", () => {
     );
     expect(methods).not.toContain("turn/start");
     expect(methods).toContain("thread/unsubscribe");
+
+    await client.close();
+  });
+
+  it("unsubscribes and releases helper tracking when a title turn fails", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "thread-title-helper" },
+      instructionSources: [],
+    };
+    MockTransport.turnStartResult = {
+      turn: { id: "turn-title-helper" },
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    const titlePromise = client.generateTitle({
+      prompt: "Name the thread from this prompt",
+      promptVersion: "thread-title-v1",
+      schema: {
+        type: "object",
+        required: ["title"],
+        properties: { title: { type: "string" } },
+      },
+      schemaName: "thread_title",
+      timeoutMs: 5_000,
+    });
+    const transport = await waitForLatestTransportRequest("turn/start");
+
+    transport.emitInbound({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "thread-title-helper",
+        turn: {
+          id: "turn-title-helper",
+          status: "failed",
+          error: { message: "helper model failed" },
+        },
+      },
+    });
+
+    await expect(titlePromise).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_turn_failed",
+    });
+    const requests = transport.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/unsubscribe",
+        params: { threadId: "thread-title-helper" },
+      }),
+    );
+    const tracking = client as unknown as {
+      helperThreadIds: Set<string>;
+      helperThreadPredicates: Map<string, unknown>;
+      completedHelperTurnResults: Map<string, unknown>;
+      helperTurnTitleObjects: Map<string, unknown>;
+      helperTurnTokenUsage: Map<string, unknown>;
+    };
+    expect(tracking.helperThreadIds.size).toBe(0);
+    expect(tracking.helperThreadPredicates.size).toBe(0);
+    expect(tracking.completedHelperTurnResults.size).toBe(0);
+    expect(tracking.helperTurnTitleObjects.size).toBe(0);
+    expect(tracking.helperTurnTokenUsage.size).toBe(0);
+
+    await client.close();
+  });
+
+  it("unsubscribes and releases helper tracking when a title turn times out", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "thread-title-helper" },
+      instructionSources: [],
+    };
+    MockTransport.turnStartResult = {
+      turn: { id: "turn-title-helper" },
+    };
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    await expect(
+      client.generateTitle({
+        prompt: "Name the thread from this prompt",
+        promptVersion: "thread-title-v1",
+        schema: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string" } },
+        },
+        schemaName: "thread_title",
+        timeoutMs: 1,
+      }),
+    ).resolves.toEqual({
+      status: "failed",
+      reason: "codex_title_turn_timeout",
+    });
+
+    const transport = MockTransport.instances.at(-1)!;
+    const requests = transport.sentMessages.map(
+      (message) => JSON.parse(message) as { method?: string; params?: unknown },
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        method: "thread/unsubscribe",
+        params: { threadId: "thread-title-helper" },
+      }),
+    );
+    const tracking = client as unknown as {
+      helperThreadIds: Set<string>;
+      helperThreadPredicates: Map<string, unknown>;
+      helperTurnWaiters: Map<string, unknown>;
+    };
+    expect(tracking.helperThreadIds.size).toBe(0);
+    expect(tracking.helperThreadPredicates.size).toBe(0);
+    expect(tracking.helperTurnWaiters.size).toBe(0);
 
     await client.close();
   });

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -5996,7 +5996,7 @@ export class CodexAppServerClient {
       );
       const helperThreadId = extractThreadIdFromNotification(normalized, params);
       if (helperThreadId && this.helperThreadIds.has(helperThreadId)) {
-        this.handleHelperThreadNotification(method, normalized);
+        this.handleHelperThreadNotification(normalized.method, normalized);
         return;
       }
 


### PR DESCRIPTION
## Summary

- route normalized failed Codex turns through helper-turn handling
- verify helper IDs and predicates are released after successful title generation
- cover failed-turn and timeout unsubscribe/tracking cleanup

## Root cause

Codex reports failed turns as `turn/completed` notifications with `turn.status = "failed"`. The adapter normalized those notifications to `turn/failed`, but helper routing still passed the original method name into `handleHelperThreadNotification`. Failed helper turns were therefore treated as successful completions without structured output.

## Impact

Failed helper turns now report `codex_title_turn_failed` through the same normalized path as other Codex turns. The focused lifecycle coverage also locks in the interrupt/unsubscribe cleanup added on `main`, including release of local helper tracking after success, failure, and timeout.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts` — 124 passed
- `pnpm --filter @pwragent/desktop typecheck`
- ESLint on changed files — 0 errors (existing warnings only)
- `git diff --check`
