### PR TITLE
fix(desktop): fall back to alternate clipboard images

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7338,7 +7338,10 @@ export function Composer(props: ComposerProps) {
     const pasteFileAttachments = fileAttachments;
 
     try {
-      const nextAttachments = await Promise.all(
+      // A clipboard can expose several renditions of the same image. One may
+      // be stale or unsupported while another is usable, so retain successes
+      // instead of letting a failed rendition reject the whole paste.
+      const attachmentResults = await Promise.allSettled(
         files.map(async ({ file, type }, index) => {
           const fallbackName = formatPastedImageName(type, index);
           if (isGifFile(file, type)) {
@@ -7388,6 +7391,15 @@ export function Composer(props: ComposerProps) {
           };
         })
       );
+      const nextAttachments = attachmentResults.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : []
+      );
+      if (nextAttachments.length === 0) {
+        const firstFailure = attachmentResults.find(
+          (result): result is PromiseRejectedResult => result.status === "rejected"
+        );
+        throw firstFailure?.reason ?? new Error("The pasted image could not be read.");
+      }
 
       if (activeComposerScopeKeyRef.current !== pasteScope.key) {
         const saved = draftStore.get(pasteScope.key) ?? {
@@ -10884,8 +10896,10 @@ function formatCompactNumber(value: number): string {
 function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImageFile[] {
   const files: ComposerImageFile[] = [];
   const seenFiles = new Set<string>();
-  let foundImageItem = false;
 
+  // DataTransfer.items and DataTransfer.files can expose separate clipboard
+  // image renditions. Preserve their order so the item stays preferred when
+  // both work, while allowing the files rendition to be a fallback.
   for (const item of Array.from(dataTransfer.items)) {
     if (item.kind !== "file") {
       continue;
@@ -10901,16 +10915,11 @@ function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImag
       continue;
     }
 
-    foundImageItem = true;
     const key = buildFileKey(file);
     if (!seenFiles.has(key)) {
       files.push({ file, type });
       seenFiles.add(key);
     }
-  }
-
-  if (foundImageItem) {
-    return files;
   }
 
   for (const file of Array.from(dataTransfer.files)) {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -466,6 +466,10 @@ type ComposerImageFile = {
   type: string;
 };
 
+type ComposerImageFileGroup = {
+  candidates: ComposerImageFile[];
+};
+
 type ModelOption = NonNullable<
   NonNullable<BackendSummary["launchpadOptions"]>["models"]
 >[number];
@@ -7134,8 +7138,8 @@ export function Composer(props: ComposerProps) {
    * whenever the per-message limit clamps or blocks the batch.
    */
   const gateImageFilesForAttachment = (
-    files: ComposerImageFile[],
-  ): ComposerImageFile[] | null => {
+    fileGroups: ComposerImageFileGroup[],
+  ): ComposerImageFileGroup[] | null => {
     if (!imagesSupported) {
       showComposerNotice({
         title: "Images not supported",
@@ -7153,15 +7157,15 @@ export function Composer(props: ComposerProps) {
       return null;
     }
 
-    if (files.length > remaining) {
+    if (fileGroups.length > remaining) {
       showComposerNotice({
         title: "Attachment limit reached",
         message: `You can attach up to ${MAX_COMPOSER_IMAGE_ATTACHMENTS} images per message.`,
       });
-      return files.slice(0, remaining);
+      return fileGroups.slice(0, remaining);
     }
 
-    return files;
+    return fileGroups;
   };
 
   /**
@@ -7272,13 +7276,13 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
+    const pastedFileGroups = getImageFileGroupsFromDataTransfer(event.clipboardData);
     // Non-image FILES only (kind === "file" items) — plain text paste
     // must fall through to the editor untouched.
     const pastedNonImageFiles = getNonImageFilesFromDataTransfer(
       event.clipboardData,
     );
-    if (pastedFiles.length === 0 && pastedNonImageFiles.length === 0) {
+    if (pastedFileGroups.length === 0 && pastedNonImageFiles.length === 0) {
       return;
     }
 
@@ -7287,10 +7291,10 @@ export function Composer(props: ComposerProps) {
     if (pastedNonImageFiles.length > 0) {
       attachFiles(pastedNonImageFiles);
     }
-    if (pastedFiles.length === 0) {
+    if (pastedFileGroups.length === 0) {
       return;
     }
-    const accepted = gateImageFilesForAttachment(pastedFiles);
+    const accepted = gateImageFilesForAttachment(pastedFileGroups);
     if (!accepted || accepted.length === 0) {
       return;
     }
@@ -7307,11 +7311,11 @@ export function Composer(props: ComposerProps) {
   };
 
   const handleDrop = (event: DragEvent<HTMLElement>): void => {
-    const droppedFiles = getImageFilesFromDataTransfer(event.dataTransfer);
+    const droppedFileGroups = getImageFileGroupsFromDataTransfer(event.dataTransfer);
     const droppedNonImageFiles = getNonImageFilesFromDataTransfer(
       event.dataTransfer,
     );
-    if (droppedFiles.length === 0 && droppedNonImageFiles.length === 0) {
+    if (droppedFileGroups.length === 0 && droppedNonImageFiles.length === 0) {
       return;
     }
 
@@ -7320,17 +7324,17 @@ export function Composer(props: ComposerProps) {
     if (droppedNonImageFiles.length > 0) {
       attachFiles(droppedNonImageFiles);
     }
-    if (droppedFiles.length === 0) {
+    if (droppedFileGroups.length === 0) {
       return;
     }
-    const accepted = gateImageFilesForAttachment(droppedFiles);
+    const accepted = gateImageFilesForAttachment(droppedFileGroups);
     if (!accepted || accepted.length === 0) {
       return;
     }
     void attachImages(accepted);
   };
 
-  const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
+  const attachImages = async (fileGroups: ComposerImageFileGroup[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
     const pasteDraft = draft;
     const pasteEditorDocument = editorDocument;
@@ -7338,57 +7342,66 @@ export function Composer(props: ComposerProps) {
     const pasteFileAttachments = fileAttachments;
 
     try {
-      // A clipboard can expose several renditions of the same image. One may
-      // be stale or unsupported while another is usable, so retain successes
-      // instead of letting a failed rendition reject the whole paste.
+      // A clipboard can expose several renditions of the same image. Try the
+      // preferred candidate first and fall back when it cannot be read, while
+      // retaining at most one successful attachment per logical image.
       const attachmentResults = await Promise.allSettled(
-        files.map(async ({ file, type }, index) => {
-          const fallbackName = formatPastedImageName(type, index);
-          if (isGifFile(file, type)) {
-            // GIFs skip normalization (to preserve animation), so they have no
-            // measured dimensions — the card shows only the size chip for them.
-            return {
-              id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
-              name: file.name || fallbackName,
-              size: file.size,
-              type: "image/gif",
-              url: await readFileAsImageDataUrl(file, "image/gif"),
-            };
+        fileGroups.map(async ({ candidates }, index) => {
+          let firstFailure: unknown;
+          for (const { file, type } of candidates) {
+            const fallbackName = formatPastedImageName(type, index);
+            try {
+              if (isGifFile(file, type)) {
+                // GIFs skip normalization (to preserve animation), so they have no
+                // measured dimensions — the card shows only the size chip for them.
+                return {
+                  id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+                  name: file.name || fallbackName,
+                  size: file.size,
+                  type: "image/gif",
+                  url: await readFileAsImageDataUrl(file, "image/gif"),
+                };
+              }
+
+              const normalized = await normalizeImageFile(file, {
+                fallback: props.desktopApi?.normalizeImageForUpload,
+                maxPatchCount: props.pastedImageMaxPatches,
+                sourceMimeType: type,
+              });
+              void props.desktopApi?.recordImageUploadNormalization?.({
+                fileName: file.name || fallbackName,
+                original: {
+                  height: normalized.original.height,
+                  mimeType: normalized.original.mimeType,
+                  size: normalized.original.size,
+                  width: normalized.original.width,
+                },
+                normalized: {
+                  height: normalized.height,
+                  mimeType: normalized.mimeType,
+                  size: normalized.size,
+                  width: normalized.width,
+                },
+                path: normalized.conversionPath,
+                resized:
+                  normalized.original.width !== normalized.width ||
+                  normalized.original.height !== normalized.height,
+              });
+              return {
+                id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
+                name: file.name || fallbackName,
+                size: normalized.size,
+                type: normalized.mimeType,
+                url: normalized.dataUrl,
+                width: normalized.width,
+                height: normalized.height,
+              };
+            } catch (error) {
+              firstFailure ??= error;
+            }
           }
 
-          const normalized = await normalizeImageFile(file, {
-            fallback: props.desktopApi?.normalizeImageForUpload,
-            maxPatchCount: props.pastedImageMaxPatches,
-            sourceMimeType: type,
-          });
-          void props.desktopApi?.recordImageUploadNormalization?.({
-            fileName: file.name || fallbackName,
-            original: {
-              height: normalized.original.height,
-              mimeType: normalized.original.mimeType,
-              size: normalized.original.size,
-              width: normalized.original.width,
-            },
-            normalized: {
-              height: normalized.height,
-              mimeType: normalized.mimeType,
-              size: normalized.size,
-              width: normalized.width,
-            },
-            path: normalized.conversionPath,
-            resized:
-              normalized.original.width !== normalized.width ||
-              normalized.original.height !== normalized.height,
-          });
-          return {
-            id: `pasted-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 8)}`,
-            name: file.name || fallbackName,
-            size: normalized.size,
-            type: normalized.mimeType,
-            url: normalized.dataUrl,
-            width: normalized.width,
-            height: normalized.height,
-          };
+          throw firstFailure ?? new Error("The pasted image could not be read.");
         })
       );
       const nextAttachments = attachmentResults.flatMap((result) =>
@@ -10893,13 +10906,15 @@ function formatCompactNumber(value: number): string {
   return String(Math.round(value));
 }
 
-function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImageFile[] {
-  const files: ComposerImageFile[] = [];
-  const seenFiles = new Set<string>();
+function getImageFileGroupsFromDataTransfer(
+  dataTransfer: DataTransfer,
+): ComposerImageFileGroup[] {
+  const fileGroups: ComposerImageFileGroup[] = [];
+  const itemFileKeys = new Set<string>();
 
   // DataTransfer.items and DataTransfer.files can expose separate clipboard
-  // image renditions. Preserve their order so the item stays preferred when
-  // both work, while allowing the files rendition to be a fallback.
+  // renditions of the same image. The collections are ordered, so pair files
+  // with the corresponding item as an alternative rather than a second image.
   for (const item of Array.from(dataTransfer.items)) {
     if (item.kind !== "file") {
       continue;
@@ -10916,12 +10931,14 @@ function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImag
     }
 
     const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push({ file, type });
-      seenFiles.add(key);
+    if (!itemFileKeys.has(key)) {
+      fileGroups.push({ candidates: [{ file, type }] });
+      itemFileKeys.add(key);
     }
   }
 
+  const seenFileKeys = new Set<string>();
+  let fileIndex = 0;
   for (const file of Array.from(dataTransfer.files)) {
     const type = inferTransferImageType(file);
     if (!type) {
@@ -10929,13 +10946,24 @@ function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImag
     }
 
     const key = buildFileKey(file);
-    if (!seenFiles.has(key)) {
-      files.push({ file, type });
-      seenFiles.add(key);
+    if (seenFileKeys.has(key)) {
+      continue;
+    }
+    seenFileKeys.add(key);
+
+    const correspondingGroup = fileGroups[fileIndex];
+    fileIndex += 1;
+    if (itemFileKeys.has(key)) {
+      continue;
+    }
+    if (correspondingGroup) {
+      correspondingGroup.candidates.push({ file, type });
+    } else {
+      fileGroups.push({ candidates: [{ file, type }] });
     }
   }
 
-  return files;
+  return fileGroups;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -15217,6 +15217,7 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(screen.getAllByRole("img")).toHaveLength(1);
     });
+    expect(normalizeImageFile).toHaveBeenCalledTimes(2);
 
     await clickButton("Send");
 
@@ -15233,6 +15234,102 @@ describe("Composer", () => {
         ],
       });
     });
+  });
+
+  it("falls back to a files image when the clipboard item rendition cannot decode", async () => {
+    const itemImageFile = new File([new Uint8Array([1, 2, 3])], "clipboard-item.png", {
+      type: "image/png",
+      lastModified: 111,
+    });
+    const filesImageFile = new File([new Uint8Array([4, 5, 6])], "clipboard-files.png", {
+      type: "image/png",
+      lastModified: 222,
+    });
+    vi.mocked(normalizeImageFile).mockRejectedValueOnce(
+      new Error("Unsupported or unreadable image format: image/png")
+    );
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [filesImageFile],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => itemImageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("clipboard-files.png")).toBeInTheDocument();
+    expect(normalizeImageFile).toHaveBeenCalledTimes(2);
+    expect(
+      screen.queryByText("Unsupported or unreadable image format: image/png")
+    ).not.toBeInTheDocument();
+  });
+
+  it("reports a paste error when no clipboard image rendition can decode", async () => {
+    const itemImageFile = new File([new Uint8Array([1, 2, 3])], "clipboard-item.png", {
+      type: "image/png",
+      lastModified: 111,
+    });
+    const filesImageFile = new File([new Uint8Array([4, 5, 6])], "clipboard-files.png", {
+      type: "image/png",
+      lastModified: 222,
+    });
+    vi.mocked(normalizeImageFile)
+      .mockRejectedValueOnce(new Error("item image cannot decode"))
+      .mockRejectedValueOnce(new Error("files image cannot decode"));
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [filesImageFile],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => itemImageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByText("item image cannot decode")).toBeInTheDocument();
+    expect(normalizeImageFile).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("attaches a dropped non-image file as a path-only reference and appends it to the sent text", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -15217,7 +15217,7 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(screen.getAllByRole("img")).toHaveLength(1);
     });
-    expect(normalizeImageFile).toHaveBeenCalledTimes(2);
+    expect(normalizeImageFile).toHaveBeenCalledTimes(1);
 
     await clickButton("Send");
 
@@ -15283,6 +15283,94 @@ describe("Composer", () => {
     expect(
       screen.queryByText("Unsupported or unreadable image format: image/png")
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps a files fallback eligible when one attachment slot remains", async () => {
+    const initialFiles = Array.from(
+      { length: 4 },
+      (_, index) =>
+        new File([new Uint8Array([index])], `existing-${index}.png`, {
+          type: "image/png",
+        })
+    );
+    const itemImageFile = new File([new Uint8Array([4])], "clipboard-item.png", {
+      type: "image/png",
+      lastModified: 111,
+    });
+    const filesImageFile = new File([new Uint8Array([5])], "clipboard-files.png", {
+      type: "image/png",
+      lastModified: 222,
+    });
+
+    for (const file of initialFiles) {
+      vi.mocked(normalizeImageFile).mockImplementationOnce(async () => ({
+        conversionPath: "renderer" as const,
+        dataUrl: `data:image/png;base64,${btoa(file.name)}`,
+        height: 24,
+        mimeType: "image/png" as const,
+        original: {
+          height: 24,
+          mimeType: "image/png",
+          name: file.name,
+          size: file.size,
+          width: 32,
+        },
+        size: 3,
+        width: 32,
+      }));
+    }
+
+    const { container } = render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Build Codex client",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        items: initialFiles.map((file) => ({
+          kind: "file",
+          type: "image/png",
+          getAsFile: () => file,
+        })),
+      },
+    });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll(".composer__attachment-preview")).toHaveLength(4);
+    });
+    vi.mocked(normalizeImageFile).mockClear();
+    vi.mocked(normalizeImageFile).mockRejectedValueOnce(
+      new Error("Unsupported or unreadable image format: image/png")
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [filesImageFile],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => itemImageFile,
+          },
+        ],
+      },
+    });
+
+    expect(await screen.findByAltText("clipboard-files.png")).toBeInTheDocument();
+    expect(normalizeImageFile).toHaveBeenCalledTimes(2);
+    expect(container.querySelectorAll(".composer__attachment-preview")).toHaveLength(5);
   });
 
   it("reports a paste error when no clipboard image rendition can decode", async () => {


### PR DESCRIPTION
## Summary

- retain image candidates from both `DataTransfer.items` and `DataTransfer.files`
- attach successful renditions even when another clipboard rendition cannot be decoded
- preserve deduplication and report a paste error only when every rendition fails
- add regression coverage for fallback, all-fail, and duplicate scenarios

## Why

Some macOS clipboard sources publish multiple image renditions. PwrAgent previously preferred `DataTransfer.items` exclusively and used `Promise.all`, so an unsupported or stale rendition could reject a paste even when `DataTransfer.files` held a valid image.

## User impact

Pasting a PwrSnap capture (or any multi-rendition clipboard image) now succeeds when at least one valid image representation is available.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 209 passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec eslint apps/desktop/src/renderer/src/features/composer/Composer.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 0 errors (existing hook-dependency warnings remain)
