### PR TITLE
fix(desktop): keep reference chips atomic on right-click

### DIFF
--- a/apps/desktop/e2e/thread-markdown.spec.ts
+++ b/apps/desktop/e2e/thread-markdown.spec.ts
@@ -32,12 +32,12 @@ test("renders markdown content in thread summaries and transcript messages", asy
     await expect(
       transcript.locator(".skill-chip", { hasText: "$frontend-design" })
     ).toBeVisible();
-    await expect(
-      transcript.getByRole("link", { name: "ce:work" })
-    ).toHaveAttribute(
-      "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
-    );
+    const explicitSkillChip = transcript.locator("[data-skill-chip]", {
+      hasText: "ce:work",
+    });
+    await expect(explicitSkillChip).toBeVisible();
+    await expect(explicitSkillChip).toHaveAttribute("draggable", "false");
+    await expect(transcript.getByRole("link", { name: "ce:work" })).toHaveCount(0);
     await expect(
       transcript.locator("strong", { hasText: "markdown" })
     ).toBeVisible();

--- a/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
@@ -97,8 +97,8 @@ export function ChipContextMenu(props: ChipContextMenuProps) {
       onContextMenu={(event) => event.preventDefault()}
     >
       <div className="thread-context-menu__section">
-        {items.map((item) => (
-          <div key={item.label}>
+        {items.map((item, index) => (
+          <div key={`${item.label}:${index}`}>
             {item.separated ? (
               <div className="thread-context-menu__separator" role="separator" />
             ) : null}

--- a/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
@@ -2,27 +2,39 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { createPortal } from "react-dom";
 import { copyText } from "../../lib/copy-text";
 
-export type CopyContextMenuPosition = {
+export type ChipContextMenuPosition = {
   x: number;
   y: number;
   anchorTop?: number;
 };
 
-export type CopyContextMenuTarget = {
+type ChipContextMenuCopyItem = {
+  action?: never;
+  copyValue: string;
   label: string;
-  value: string;
   separated?: boolean;
 };
 
-type CopyContextMenuProps = {
-  onClose: () => void;
-  position: CopyContextMenuPosition;
-  returnFocusTo: HTMLElement;
-  targets: CopyContextMenuTarget[];
+type ChipContextMenuActionItem = {
+  action: () => void;
+  copyValue?: never;
+  label: string;
+  separated?: boolean;
 };
 
-export function CopyContextMenu(props: CopyContextMenuProps) {
-  const { onClose, position: requestedPosition, returnFocusTo, targets } = props;
+export type ChipContextMenuItem =
+  | ChipContextMenuCopyItem
+  | ChipContextMenuActionItem;
+
+type ChipContextMenuProps = {
+  items: ChipContextMenuItem[];
+  onClose: () => void;
+  position: ChipContextMenuPosition;
+  returnFocusTo: HTMLElement;
+};
+
+export function ChipContextMenu(props: ChipContextMenuProps) {
+  const { items, onClose, position: requestedPosition, returnFocusTo } = props;
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({
     x: requestedPosition.x,
@@ -65,32 +77,37 @@ export function CopyContextMenu(props: CopyContextMenuProps) {
     menu.querySelector<HTMLButtonElement>("button")?.focus();
   }, [requestedPosition]);
 
-  const copy = (value: string): void => {
+  const select = (item: ChipContextMenuItem): void => {
     close(true);
-    void copyText(value);
+    if (item.action) {
+      item.action();
+      return;
+    }
+
+    void copyText(item.copyValue);
   };
 
   return createPortal(
     <div
       ref={menuRef}
-      className="thread-context-menu chip-copy-context-menu"
+      className="thread-context-menu chip-context-menu"
       role="menu"
       style={{ left: position.x, top: position.y }}
       onClick={(event) => event.stopPropagation()}
       onContextMenu={(event) => event.preventDefault()}
     >
       <div className="thread-context-menu__section">
-        {targets.map((target) => (
-          <div key={target.label}>
-            {target.separated ? (
+        {items.map((item) => (
+          <div key={item.label}>
+            {item.separated ? (
               <div className="thread-context-menu__separator" role="separator" />
             ) : null}
             <button
               role="menuitem"
               type="button"
-              onClick={() => copy(target.value)}
+              onClick={() => select(item)}
             >
-              {target.label}
+              {item.label}
             </button>
           </div>
         ))}
@@ -101,7 +118,7 @@ export function CopyContextMenu(props: CopyContextMenuProps) {
 }
 
 function placeContextMenu(
-  requestedPosition: CopyContextMenuPosition,
+  requestedPosition: ChipContextMenuPosition,
   menuRect: DOMRect,
 ): { x: number; y: number } {
   const viewportMargin = 8;

--- a/apps/desktop/src/renderer/src/features/chrome/CopyContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/CopyContextMenu.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { copyText } from "../../lib/copy-text";
+
+export type CopyContextMenuPosition = {
+  x: number;
+  y: number;
+  anchorTop?: number;
+};
+
+export type CopyContextMenuTarget = {
+  label: string;
+  value: string;
+  separated?: boolean;
+};
+
+type CopyContextMenuProps = {
+  onClose: () => void;
+  position: CopyContextMenuPosition;
+  targets: CopyContextMenuTarget[];
+};
+
+export function CopyContextMenu(props: CopyContextMenuProps) {
+  const { onClose, position: requestedPosition, targets } = props;
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({
+    x: requestedPosition.x,
+    y: requestedPosition.y,
+  });
+
+  useEffect(() => {
+    const closeOnClick = (): void => onClose();
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("click", closeOnClick);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("click", closeOnClick);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [onClose]);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) {
+      return;
+    }
+
+    setPosition(placeContextMenu(requestedPosition, menu.getBoundingClientRect()));
+    menu.querySelector<HTMLButtonElement>("button")?.focus();
+  }, [requestedPosition]);
+
+  const copy = (value: string): void => {
+    onClose();
+    void copyText(value);
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="thread-context-menu chip-copy-context-menu"
+      role="menu"
+      style={{ left: position.x, top: position.y }}
+      onClick={(event) => event.stopPropagation()}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <div className="thread-context-menu__section">
+        {targets.map((target) => (
+          <div key={target.label}>
+            {target.separated ? (
+              <div className="thread-context-menu__separator" role="separator" />
+            ) : null}
+            <button
+              role="menuitem"
+              type="button"
+              onClick={() => copy(target.value)}
+            >
+              {target.label}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function placeContextMenu(
+  requestedPosition: CopyContextMenuPosition,
+  menuRect: DOMRect,
+): { x: number; y: number } {
+  const viewportMargin = 8;
+  const triggerGap = 4;
+  const menuWidth = menuRect.width || 220;
+  const menuHeight = menuRect.height;
+  const maxX = window.innerWidth - menuWidth - viewportMargin;
+  const maxY = window.innerHeight - menuHeight - viewportMargin;
+  const wouldOverflowBottom =
+    menuHeight > 0
+    && requestedPosition.y + menuHeight + viewportMargin > window.innerHeight;
+  const flippedTop = requestedPosition.anchorTop !== undefined
+    ? requestedPosition.anchorTop - menuHeight - triggerGap
+    : requestedPosition.y - menuHeight - triggerGap;
+
+  return {
+    x: Math.max(viewportMargin, Math.min(requestedPosition.x, maxX)),
+    y: Math.max(
+      viewportMargin,
+      Math.min(wouldOverflowBottom ? flippedTop : requestedPosition.y, maxY),
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/features/chrome/CopyContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/CopyContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { copyText } from "../../lib/copy-text";
 
@@ -17,32 +17,43 @@ export type CopyContextMenuTarget = {
 type CopyContextMenuProps = {
   onClose: () => void;
   position: CopyContextMenuPosition;
+  returnFocusTo: HTMLElement;
   targets: CopyContextMenuTarget[];
 };
 
 export function CopyContextMenu(props: CopyContextMenuProps) {
-  const { onClose, position: requestedPosition, targets } = props;
+  const { onClose, position: requestedPosition, returnFocusTo, targets } = props;
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({
     x: requestedPosition.x,
     y: requestedPosition.y,
   });
 
+  const close = useCallback((restoreFocus: boolean): void => {
+    onClose();
+    if (restoreFocus && returnFocusTo.isConnected) {
+      returnFocusTo.focus({ preventScroll: true });
+    }
+  }, [onClose, returnFocusTo]);
+
   useEffect(() => {
-    const closeOnClick = (): void => onClose();
+    const closeOnClick = (): void => close(false);
     const closeOnEscape = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
-        onClose();
+        close(true);
       }
     };
+    const closeOnContextMenu = (): void => close(false);
 
     window.addEventListener("click", closeOnClick);
+    window.addEventListener("contextmenu", closeOnContextMenu, true);
     window.addEventListener("keydown", closeOnEscape);
     return () => {
       window.removeEventListener("click", closeOnClick);
+      window.removeEventListener("contextmenu", closeOnContextMenu, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
-  }, [onClose]);
+  }, [close]);
 
   useLayoutEffect(() => {
     const menu = menuRef.current;
@@ -55,7 +66,7 @@ export function CopyContextMenu(props: CopyContextMenuProps) {
   }, [requestedPosition]);
 
   const copy = (value: string): void => {
-    onClose();
+    close(true);
     void copyText(value);
   };
 

--- a/apps/desktop/src/renderer/src/features/chrome/ThreadChipContextMenu.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/ThreadChipContextMenu.ts
@@ -1,0 +1,32 @@
+import { buildThreadUrl, type ThreadLinkRef } from "@pwragent/shared";
+import type { ChipContextMenuItem } from "./ChipContextMenu";
+
+export function threadCopyTargets(
+  link: ThreadLinkRef & { gitBranch?: string; title?: string },
+  label: string,
+): ChipContextMenuItem[] {
+  const targets: ChipContextMenuItem[] = [
+    {
+      label: "Copy Thread Link",
+      copyValue: buildThreadUrl(link),
+    },
+    {
+      label: "Copy Thread ID",
+      copyValue: link.threadId,
+      separated: true,
+    },
+    {
+      label: "Copy Thread Name",
+      copyValue: label,
+    },
+  ];
+
+  if (link.gitBranch) {
+    targets.push({
+      label: "Copy Branch Name",
+      copyValue: link.gitBranch,
+    });
+  }
+
+  return targets;
+}

--- a/apps/desktop/src/renderer/src/features/chrome/ThreadChipContextMenu.ts
+++ b/apps/desktop/src/renderer/src/features/chrome/ThreadChipContextMenu.ts
@@ -1,8 +1,18 @@
-import { buildThreadUrl, type ThreadLinkRef } from "@pwragent/shared";
+import {
+  buildThreadUrl,
+  type LinkedDirectorySummary,
+  type ThreadLinkRef,
+} from "@pwragent/shared";
 import type { ChipContextMenuItem } from "./ChipContextMenu";
 
+export type ThreadChipMenuLink = ThreadLinkRef & {
+  gitBranch?: string;
+  linkedDirectories?: LinkedDirectorySummary[];
+  title?: string;
+};
+
 export function threadCopyTargets(
-  link: ThreadLinkRef & { gitBranch?: string; title?: string },
+  link: ThreadChipMenuLink,
   label: string,
 ): ChipContextMenuItem[] {
   const targets: ChipContextMenuItem[] = [
@@ -28,5 +38,42 @@ export function threadCopyTargets(
     });
   }
 
+  const directories = uniqueThreadDirectories(link.linkedDirectories ?? []);
+  if (directories.length === 1) {
+    targets.push({
+      label: "Copy Thread Directory",
+      copyValue: directories[0]!.copyPath,
+    });
+  } else if (directories.length > 1) {
+    for (const directory of directories) {
+      targets.push({
+        label: `Copy Thread Directory — ${directory.label} (${directory.kind})`,
+        copyValue: directory.copyPath,
+      });
+    }
+  }
+
   return targets;
+}
+
+function uniqueThreadDirectories(
+  directories: LinkedDirectorySummary[],
+): Array<{ copyPath: string; kind: LinkedDirectorySummary["kind"]; label: string }> {
+  const byCopyPath = new Map<
+    string,
+    { copyPath: string; kind: LinkedDirectorySummary["kind"]; label: string }
+  >();
+  for (const directory of directories) {
+    const copyPath = directory.kind === "worktree"
+      ? directory.worktreePath ?? directory.path
+      : directory.path;
+    if (!byCopyPath.has(copyPath)) {
+      byCopyPath.set(copyPath, {
+        copyPath,
+        kind: directory.kind,
+        label: directory.label,
+      });
+    }
+  }
+  return [...byCopyPath.values()];
 }

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7938,6 +7938,10 @@ export function Composer(props: ComposerProps) {
             label={isLaunchpad ? "New thread" : "Reply"}
             markdownConversion
             placeholder={composerPlaceholder}
+            resolveThreadLink={(ref) => {
+              const resolved = threadLinks?.resolve(ref);
+              return resolved ? threadLinks?.getSnapshot(resolved) : undefined;
+            }}
             selectionRequest={composerSelectionRequest}
             editorDocument={editorDocument}
             skillTokens={skillTokens}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -36,7 +36,10 @@ import {
   ChipContextMenu,
   type ChipContextMenuPosition,
 } from "../chrome/ChipContextMenu";
-import { threadCopyTargets } from "../chrome/ThreadChipContextMenu";
+import {
+  threadCopyTargets,
+  type ThreadChipMenuLink,
+} from "../chrome/ThreadChipContextMenu";
 import type {
   ComposerInputChangeMetadata,
   ComposerInputHandle,
@@ -63,6 +66,7 @@ type ComposerTiptapInputProps = {
   onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
   onPaste?: (event: ClipboardEvent<HTMLDivElement>) => void;
   placeholder: string;
+  resolveThreadLink?: (link: ThreadLinkRef) => ThreadChipMenuLink | undefined;
   selectionRequest?: {
     id: string;
     index: number;
@@ -90,7 +94,7 @@ type ControlledHistoryEntry = TiptapReadState & {
 
 type ComposerThreadContextMenuState = {
   label: string;
-  link: ThreadLinkRef;
+  link: ThreadChipMenuLink;
   position: ChipContextMenuPosition;
   returnFocusTo: HTMLElement;
 };
@@ -2687,7 +2691,7 @@ export const ComposerTiptapInput = forwardRef<
         const rect = target.getBoundingClientRect();
         setThreadContextMenu({
           label: target.dataset.skillName || target.textContent || link.threadId,
-          link,
+          link: propsRef.current.resolveThreadLink?.(link) ?? link,
           position: {
             x: event.clientX,
             y: event.clientY,

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -5,6 +5,7 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
   type ClipboardEvent,
   type DragEvent,
   type KeyboardEvent,
@@ -15,7 +16,11 @@ import Mention from "@tiptap/extension-mention";
 import StarterKit from "@tiptap/starter-kit";
 import { closeHistory } from "prosemirror-history";
 import { EditorContent, useEditor, type JSONContent } from "@tiptap/react";
-import type { AppServerSkillSummary } from "@pwragent/shared";
+import {
+  parseThreadUrl,
+  type AppServerSkillSummary,
+  type ThreadLinkRef,
+} from "@pwragent/shared";
 import {
   parseBacktickFenceLine,
   repairNestedLanguageFences,
@@ -27,6 +32,11 @@ import {
   findDirectoryReferenceTrigger,
 } from "../../lib/directory-references";
 import { tildifyPath } from "../../lib/tildify-path";
+import {
+  ChipContextMenu,
+  type ChipContextMenuPosition,
+} from "../chrome/ChipContextMenu";
+import { threadCopyTargets } from "../chrome/ThreadChipContextMenu";
 import type {
   ComposerInputChangeMetadata,
   ComposerInputHandle,
@@ -76,6 +86,13 @@ type DeletedSingleSkillState = TiptapReadState & {
 type ControlledHistoryEntry = TiptapReadState & {
   editorDocument: JSONContent;
   selectionIndex: number;
+};
+
+type ComposerThreadContextMenuState = {
+  label: string;
+  link: ThreadLinkRef;
+  position: ChipContextMenuPosition;
+  returnFocusTo: HTMLElement;
 };
 
 type TiptapEditor = NonNullable<ReturnType<typeof useEditor>>;
@@ -139,6 +156,8 @@ const SkillMention = Mention.extend({
           "data-label": label,
           "data-skill-name": label,
           "data-thread-chip": "",
+          "aria-haspopup": "menu",
+          draggable: "false",
           ...(path ? { "data-skill-path": path } : {}),
           ...(path ? { "data-tooltip": `${label}\n${path}` } : {}),
         },
@@ -1926,6 +1945,8 @@ export const ComposerTiptapInput = forwardRef<
 >(function ComposerTiptapInput(props, ref) {
   const propsRef = useRef(props);
   const editorRef = useRef<TiptapEditor | null>(null);
+  const [threadContextMenu, setThreadContextMenu] =
+    useState<ComposerThreadContextMenuState>();
   const selectionIndexRef = useRef(props.value.length);
   const pendingExternalSignatureRef = useRef<string | undefined>(undefined);
   const pendingSelectionIndexRef = useRef<number | undefined>(undefined);
@@ -2647,6 +2668,34 @@ export const ComposerTiptapInput = forwardRef<
       data-placeholder={props.placeholder}
       data-testid="composer-tiptap-input"
       data-value={props.value}
+      onContextMenu={(event) => {
+        const target = event.target instanceof Element
+          ? event.target.closest<HTMLElement>('[data-mention-kind="thread"]')
+          : null;
+        if (!target || !event.currentTarget.contains(target)) {
+          return;
+        }
+
+        const link = parseThreadUrl(target.dataset.skillPath ?? "");
+        if (!link) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        window.getSelection()?.removeAllRanges();
+        const rect = target.getBoundingClientRect();
+        setThreadContextMenu({
+          label: target.dataset.skillName || target.textContent || link.threadId,
+          link,
+          position: {
+            x: event.clientX,
+            y: event.clientY,
+            anchorTop: rect.top,
+          },
+          returnFocusTo: editor?.view.dom ?? target,
+        });
+      }}
       onKeyDownCapture={(event) => {
         if (!editor || event.defaultPrevented) {
           return;
@@ -2710,6 +2759,17 @@ export const ComposerTiptapInput = forwardRef<
       }}
     >
       <EditorContent editor={editor} />
+      {threadContextMenu ? (
+        <ChipContextMenu
+          items={threadCopyTargets(
+            threadContextMenu.link,
+            threadContextMenu.label,
+          )}
+          onClose={() => setThreadContextMenu(undefined)}
+          position={threadContextMenu.position}
+          returnFocusTo={threadContextMenu.returnFocusTo}
+        />
+      ) : null}
     </div>
   );
 });

--- a/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
@@ -17,11 +17,22 @@ import {
 type SkillChipProps = {
   editorName?: string;
   label?: string;
-  onOpenInEditor?: (skill: AppServerSkillSummary & { path: string }) => void;
+  onOpenInEditor?: (skill: SkillChipActionTarget) => void;
   onRemove?: () => void;
-  onViewMarkdown?: (skill: AppServerSkillSummary & { path: string }) => void;
+  onViewMarkdown?: (skill: SkillChipActionTarget) => void;
   skill: AppServerSkillSummary;
+  target?: {
+    column?: number;
+    line?: number;
+    path: string;
+  };
   transcript?: boolean;
+};
+
+type SkillChipActionTarget = AppServerSkillSummary & {
+  column?: number;
+  line?: number;
+  path: string;
 };
 
 export function SkillChip(props: SkillChipProps) {
@@ -30,6 +41,14 @@ export function SkillChip(props: SkillChipProps) {
     useState<ChipContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
   const path = props.skill.path?.trim();
+  const actionTarget = path
+    ? {
+        ...props.skill,
+        column: props.target?.column,
+        line: props.target?.line,
+        path: props.target?.path ?? path,
+      }
+    : undefined;
   const transcriptPath = props.transcript ? path : undefined;
   const isTranscriptSkill = Boolean(transcriptPath);
   const tooltip = transcriptPath
@@ -43,26 +62,26 @@ export function SkillChip(props: SkillChipProps) {
   const handleActivate = (
     event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
   ): void => {
-    if (!path || !props.onViewMarkdown) {
+    if (!actionTarget || !props.onViewMarkdown) {
       return;
     }
 
     event.preventDefault();
     event.stopPropagation();
     tooltipController.hide();
-    props.onViewMarkdown({ ...props.skill, path });
+    props.onViewMarkdown(actionTarget);
   };
 
-  const contextMenuItems = path
+  const contextMenuItems = actionTarget
     ? skillContextMenuItems({
         editorName: props.editorName,
         onOpenInEditor: props.onOpenInEditor
-          ? () => props.onOpenInEditor?.({ ...props.skill, path })
+          ? () => props.onOpenInEditor?.(actionTarget)
           : undefined,
         onViewMarkdown: props.onViewMarkdown
-          ? () => props.onViewMarkdown?.({ ...props.skill, path })
+          ? () => props.onViewMarkdown?.(actionTarget)
           : undefined,
-        path,
+        path: actionTarget.path,
       })
     : [];
 

--- a/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/SkillChip.tsx
@@ -1,35 +1,183 @@
 import type { AppServerSkillSummary } from "@pwragent/shared";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import { buildSkillTooltip } from "../../lib/skill-mentions";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import {
+  ChipContextMenu,
+  type ChipContextMenuItem,
+  type ChipContextMenuPosition,
+} from "../chrome/ChipContextMenu";
 
 type SkillChipProps = {
+  editorName?: string;
   label?: string;
+  onOpenInEditor?: (skill: AppServerSkillSummary & { path: string }) => void;
   onRemove?: () => void;
+  onViewMarkdown?: (skill: AppServerSkillSummary & { path: string }) => void;
   skill: AppServerSkillSummary;
+  transcript?: boolean;
 };
 
 export function SkillChip(props: SkillChipProps) {
-  const tooltip = buildSkillTooltip(props.skill);
+  const contextMenuInvokerRef = useRef<HTMLSpanElement>(null);
+  const [contextMenuPosition, setContextMenuPosition] =
+    useState<ChipContextMenuPosition>();
+  const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
+  const path = props.skill.path?.trim();
+  const transcriptPath = props.transcript ? path : undefined;
+  const isTranscriptSkill = Boolean(transcriptPath);
+  const tooltip = transcriptPath
+    ? buildTranscriptSkillTooltip(props.skill, transcriptPath)
+    : buildSkillTooltip(props.skill);
+  const updateTooltip = tooltipController.update;
+  useEffect(() => {
+    updateTooltip(tooltip);
+  }, [tooltip, updateTooltip]);
+
+  const handleActivate = (
+    event: MouseEvent<HTMLSpanElement> | KeyboardEvent<HTMLSpanElement>,
+  ): void => {
+    if (!path || !props.onViewMarkdown) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    tooltipController.hide();
+    props.onViewMarkdown({ ...props.skill, path });
+  };
+
+  const contextMenuItems = path
+    ? skillContextMenuItems({
+        editorName: props.editorName,
+        onOpenInEditor: props.onOpenInEditor
+          ? () => props.onOpenInEditor?.({ ...props.skill, path })
+          : undefined,
+        onViewMarkdown: props.onViewMarkdown
+          ? () => props.onViewMarkdown?.({ ...props.skill, path })
+          : undefined,
+        path,
+      })
+    : [];
 
   return (
-    <span
-      className={`chip skill-chip tooltip-target${props.onRemove ? " skill-chip--removable" : ""}`}
-      data-tooltip={tooltip || undefined}
-      tabIndex={tooltip && !props.onRemove ? 0 : -1}
-    >
-      <span aria-hidden="true" className="thread-row__chip-icon">
-        🧰
+    <>
+      <span
+        aria-haspopup={isTranscriptSkill ? "menu" : undefined}
+        aria-label={props.onViewMarkdown ? `View skill ${props.skill.name}` : undefined}
+        className={[
+          "chip",
+          "skill-chip",
+          isTranscriptSkill ? "skill-chip--transcript" : "tooltip-target",
+          props.onRemove ? "skill-chip--removable" : "",
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        data-skill-chip={isTranscriptSkill ? "" : undefined}
+        data-tooltip={!isTranscriptSkill ? tooltip || undefined : undefined}
+        draggable={isTranscriptSkill ? false : undefined}
+        role={props.onViewMarkdown ? "button" : undefined}
+        tabIndex={tooltip && !props.onRemove ? 0 : -1}
+        onBlur={isTranscriptSkill ? tooltipController.hide : undefined}
+        onClick={props.onViewMarkdown ? handleActivate : undefined}
+        onContextMenu={isTranscriptSkill ? (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          window.getSelection()?.removeAllRanges();
+          tooltipController.hide();
+          const rect = event.currentTarget.getBoundingClientRect();
+          contextMenuInvokerRef.current = event.currentTarget;
+          setContextMenuPosition({
+            x: event.clientX,
+            y: event.clientY,
+            anchorTop: rect.top,
+          });
+        } : undefined}
+        onDragStart={isTranscriptSkill ? (event) => event.preventDefault() : undefined}
+        onFocus={isTranscriptSkill
+          ? (event) => tooltipController.show(event.currentTarget, tooltip)
+          : undefined}
+        onKeyDown={props.onViewMarkdown ? (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            handleActivate(event);
+          }
+        } : undefined}
+        onMouseEnter={isTranscriptSkill
+          ? (event) => tooltipController.show(event.currentTarget, tooltip)
+          : undefined}
+        onMouseLeave={isTranscriptSkill ? tooltipController.hide : undefined}
+      >
+        <span aria-hidden="true" className="thread-row__chip-icon">
+          🧰
+        </span>
+        <span className="skill-chip__label">
+          {props.label ?? `$${props.skill.name}`}
+        </span>
+        {props.onRemove ? (
+          <button
+            aria-label={`Remove $${props.skill.name}`}
+            className="skill-chip__remove"
+            type="button"
+            onClick={props.onRemove}
+          >
+            x
+          </button>
+        ) : null}
       </span>
-      <span className="skill-chip__label">{props.label ?? `$${props.skill.name}`}</span>
-      {props.onRemove ? (
-        <button
-          aria-label={`Remove $${props.skill.name}`}
-          className="skill-chip__remove"
-          type="button"
-          onClick={props.onRemove}
-        >
-          x
-        </button>
+      {isTranscriptSkill ? tooltipController.tooltipNode : null}
+      {contextMenuPosition && contextMenuInvokerRef.current ? (
+        <ChipContextMenu
+          items={contextMenuItems}
+          onClose={() => setContextMenuPosition(undefined)}
+          position={contextMenuPosition}
+          returnFocusTo={contextMenuInvokerRef.current}
+        />
       ) : null}
-    </span>
+    </>
   );
+}
+
+function skillContextMenuItems(options: {
+  editorName?: string;
+  onOpenInEditor?: () => void;
+  onViewMarkdown?: () => void;
+  path: string;
+}): ChipContextMenuItem[] {
+  const items: ChipContextMenuItem[] = [];
+  if (options.onViewMarkdown) {
+    items.push({
+      action: options.onViewMarkdown,
+      label: "View Skill Markdown",
+    });
+  }
+  if (options.onOpenInEditor && options.editorName) {
+    items.push({
+      action: options.onOpenInEditor,
+      label: `Open Skill Markdown in ${options.editorName}`,
+    });
+  }
+  items.push({
+    copyValue: options.path,
+    label: "Copy Skill Path",
+    separated: items.length > 0,
+  });
+  return items;
+}
+
+function buildTranscriptSkillTooltip(
+  skill: AppServerSkillSummary,
+  path: string,
+): string {
+  const description = skill.shortDescription?.trim() || skill.description?.trim();
+  return [
+    path,
+    description,
+    "Click to view markdown · Right-click for skill actions",
+  ].filter(Boolean).join("\n");
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12473,8 +12473,27 @@ describe("Composer", () => {
       "data-skill-path",
       `pwragent://thread/${targetThreadId}?backend=codex`,
     );
+    expect(chip).toHaveAttribute("aria-haspopup", "menu");
+    expect(chip).toHaveAttribute("draggable", "false");
     expect(chip?.querySelector("svg")).toHaveAttribute("viewBox", "0 0 24 24");
     expect(screen.getByLabelText("Reply")).toHaveValue(" ");
+
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+    fireEvent(chip!, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+    expect(screen.getByRole("menuitem", { name: "Copy Thread Link" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Thread ID" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Thread Name" }))
+      .toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
 
     await clickButton("Send");
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12422,7 +12422,15 @@ describe("Composer", () => {
       title: "Lovely child thread",
       titleSource: "explicit",
       source: "codex",
-      linkedDirectories: [],
+      linkedDirectories: [
+        {
+          id: "dir-worktree",
+          kind: "worktree",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          worktreePath: "/Users/huntharo/.codex/worktrees/child/PwrAgent",
+        },
+      ],
       inbox: { inInbox: false },
     };
     const startTurn = vi.fn(async () => ({
@@ -12492,6 +12500,8 @@ describe("Composer", () => {
     expect(screen.getByRole("menuitem", { name: "Copy Thread ID" }))
       .toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Copy Thread Name" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Thread Directory" }))
       .toBeInTheDocument();
     fireEvent.keyDown(window, { key: "Escape" });
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -417,9 +417,11 @@ export function Sidebar(props: SidebarProps) {
     };
 
     window.addEventListener("click", closeMenu);
+    window.addEventListener("contextmenu", closeMenu, true);
     window.addEventListener("keydown", closeOnEscape);
     return () => {
       window.removeEventListener("click", closeMenu);
+      window.removeEventListener("contextmenu", closeMenu, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [contextMenu]);
@@ -437,9 +439,11 @@ export function Sidebar(props: SidebarProps) {
     };
 
     window.addEventListener("click", closeMenu);
+    window.addEventListener("contextmenu", closeMenu, true);
     window.addEventListener("keydown", closeOnEscape);
     return () => {
       window.removeEventListener("click", closeMenu);
+      window.removeEventListener("contextmenu", closeMenu, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [directoryContextMenu]);
@@ -457,9 +461,11 @@ export function Sidebar(props: SidebarProps) {
     };
 
     window.addEventListener("click", closeMenu);
+    window.addEventListener("contextmenu", closeMenu, true);
     window.addEventListener("keydown", closeOnEscape);
     return () => {
       window.removeEventListener("click", closeMenu);
+      window.removeEventListener("contextmenu", closeMenu, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [profileMenuOpen]);

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -847,6 +847,30 @@ describe("Sidebar", () => {
     expect(onCreateSubthread).toHaveBeenCalledWith(sharedThread, "same-worktree");
   });
 
+  it("closes its context menu when another renderer menu opens", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[sharedThread]}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={[sharedThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Cross-project cleanup" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.contextMenu(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
   it("opens a local sub-thread launchpad only for local parent threads", () => {
     const onCreateSubthread = vi.fn(async () => undefined);
     render(

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,7 +1,8 @@
-import { useEffect, type KeyboardEvent, type MouseEvent } from "react";
+import { useEffect, useState, type KeyboardEvent, type MouseEvent } from "react";
 import type { PrSummary } from "@pwragent/shared";
 import { CloseIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { PrChipContextMenu } from "./PrChipContextMenu";
 
 type PrChipProps = {
   pr: PrSummary;
@@ -26,6 +27,11 @@ type PrChipProps = {
 
 export function PrChip(props: PrChipProps) {
   const { pr } = props;
+  const [contextMenuPosition, setContextMenuPosition] = useState<{
+    x: number;
+    y: number;
+    anchorTop?: number;
+  }>();
   const tooltipController = useViewportTooltip({
     className: "viewport-tooltip",
   });
@@ -89,25 +95,31 @@ export function PrChip(props: PrChipProps) {
       <span
         role="button"
         tabIndex={0}
+        aria-haspopup="menu"
         aria-label={`Open ${pr.org}/${pr.repo}#${pr.number} (${status}) in browser`}
         className={className}
         data-pr-chip=""
+        draggable={false}
         onBlur={tooltipController.hide}
         onClick={handleActivate}
         onContextMenu={(event) => {
-          if (!props.onOpenContextMenu) {
-            return;
-          }
           event.preventDefault();
           event.stopPropagation();
+          window.getSelection()?.removeAllRanges();
           tooltipController.hide();
           const rect = event.currentTarget.getBoundingClientRect();
-          props.onOpenContextMenu(pr, {
+          const position = {
             x: event.clientX,
             y: event.clientY,
             anchorTop: rect.top,
-          });
+          };
+          if (props.onOpenContextMenu) {
+            props.onOpenContextMenu(pr, position);
+          } else {
+            setContextMenuPosition(position);
+          }
         }}
+        onDragStart={(event) => event.preventDefault()}
         onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {
@@ -139,6 +151,13 @@ export function PrChip(props: PrChipProps) {
         {isDraft ? <span className="pr-chip__draft-bar" aria-hidden="true" /> : null}
       </span>
       {tooltipController.tooltipNode}
+      {contextMenuPosition ? (
+        <PrChipContextMenu
+          position={contextMenuPosition}
+          pr={pr}
+          onClose={() => setContextMenuPosition(undefined)}
+        />
+      ) : null}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState, type KeyboardEvent, type MouseEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import type { PrSummary } from "@pwragent/shared";
 import { CloseIcon } from "../../icons";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -27,6 +33,7 @@ type PrChipProps = {
 
 export function PrChip(props: PrChipProps) {
   const { pr } = props;
+  const contextMenuInvokerRef = useRef<HTMLSpanElement>(null);
   const [contextMenuPosition, setContextMenuPosition] = useState<{
     x: number;
     y: number;
@@ -116,6 +123,7 @@ export function PrChip(props: PrChipProps) {
           if (props.onOpenContextMenu) {
             props.onOpenContextMenu(pr, position);
           } else {
+            contextMenuInvokerRef.current = event.currentTarget;
             setContextMenuPosition(position);
           }
         }}
@@ -151,10 +159,11 @@ export function PrChip(props: PrChipProps) {
         {isDraft ? <span className="pr-chip__draft-bar" aria-hidden="true" /> : null}
       </span>
       {tooltipController.tooltipNode}
-      {contextMenuPosition ? (
+      {contextMenuPosition && contextMenuInvokerRef.current ? (
         <PrChipContextMenu
           position={contextMenuPosition}
           pr={pr}
+          returnFocusTo={contextMenuInvokerRef.current}
           onClose={() => setContextMenuPosition(undefined)}
         />
       ) : null}

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
@@ -9,6 +9,7 @@ type PrChipContextMenuProps = {
   onClose: () => void;
   position: CopyContextMenuPosition;
   pr: PrSummary;
+  returnFocusTo: HTMLElement;
 };
 
 export function PrChipContextMenu(props: PrChipContextMenuProps) {
@@ -16,6 +17,7 @@ export function PrChipContextMenu(props: PrChipContextMenuProps) {
     <CopyContextMenu
       onClose={props.onClose}
       position={props.position}
+      returnFocusTo={props.returnFocusTo}
       targets={pullRequestCopyTargets(props.pr)}
     />
   );
@@ -59,14 +61,9 @@ function pullRequestUrls(pr: PrSummary): {
   try {
     const full = new URL(pr.url);
     const segments = full.pathname.split("/").filter(Boolean);
-    const markerIndex = segments.findIndex(
-      (segment) => segment === "pull" || segment === "merge_requests",
-    );
+    const markerIndex = findPullRequestMarkerIndex(segments, pr.number);
     const numberIndex = markerIndex + 1;
-    if (
-      markerIndex >= 0
-      && segments[numberIndex] === String(pr.number)
-    ) {
+    if (markerIndex >= 0) {
       const repositoryEnd = segments[markerIndex - 1] === "-"
         ? markerIndex - 1
         : markerIndex;
@@ -86,6 +83,23 @@ function pullRequestUrls(pr: PrSummary): {
     pullRequestUrl: pr.url,
     repositoryUrl,
   };
+}
+
+function findPullRequestMarkerIndex(
+  segments: string[],
+  pullRequestNumber: number,
+): number {
+  const numberText = String(pullRequestNumber);
+  for (let index = segments.length - 2; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (
+      (segment === "pull" || segment === "merge_requests")
+      && segments[index + 1] === numberText
+    ) {
+      return index;
+    }
+  }
+  return -1;
 }
 
 function urlWithPath(source: URL, segments: string[]): string {

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
@@ -1,99 +1,29 @@
 import type { PrSummary } from "@pwragent/shared";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { copyText } from "../../lib/copy-text";
-
-type ContextMenuPosition = {
-  x: number;
-  y: number;
-  anchorTop?: number;
-};
+import {
+  CopyContextMenu,
+  type CopyContextMenuPosition,
+  type CopyContextMenuTarget,
+} from "../chrome/CopyContextMenu";
 
 type PrChipContextMenuProps = {
   onClose: () => void;
-  position: ContextMenuPosition;
+  position: CopyContextMenuPosition;
   pr: PrSummary;
 };
 
-type CopyTarget = {
-  label: string;
-  value: string;
-  separated?: boolean;
-};
-
 export function PrChipContextMenu(props: PrChipContextMenuProps) {
-  const { onClose, position: requestedPosition, pr } = props;
-  const menuRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState({
-    x: requestedPosition.x,
-    y: requestedPosition.y,
-  });
-  const targets = useMemo(() => pullRequestCopyTargets(pr), [pr]);
-
-  useEffect(() => {
-    const closeOnClick = (): void => onClose();
-    const closeOnEscape = (event: KeyboardEvent): void => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-
-    window.addEventListener("click", closeOnClick);
-    window.addEventListener("keydown", closeOnEscape);
-    return () => {
-      window.removeEventListener("click", closeOnClick);
-      window.removeEventListener("keydown", closeOnEscape);
-    };
-  }, [onClose]);
-
-  useLayoutEffect(() => {
-    const menu = menuRef.current;
-    if (!menu) {
-      return;
-    }
-
-    setPosition(placeContextMenu(requestedPosition, menu.getBoundingClientRect()));
-    menu.querySelector<HTMLButtonElement>("button")?.focus();
-  }, [requestedPosition]);
-
-  const copy = (value: string): void => {
-    onClose();
-    void copyText(value);
-  };
-
-  return createPortal(
-    <div
-      ref={menuRef}
-      className="thread-context-menu pr-chip-context-menu"
-      role="menu"
-      style={{ left: position.x, top: position.y }}
-      onClick={(event) => event.stopPropagation()}
-      onContextMenu={(event) => event.preventDefault()}
-    >
-      <div className="thread-context-menu__section">
-        {targets.map((target) => (
-          <div key={target.label}>
-            {target.separated ? (
-              <div className="thread-context-menu__separator" role="separator" />
-            ) : null}
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() => copy(target.value)}
-            >
-              {target.label}
-            </button>
-          </div>
-        ))}
-      </div>
-    </div>,
-    document.body,
+  return (
+    <CopyContextMenu
+      onClose={props.onClose}
+      position={props.position}
+      targets={pullRequestCopyTargets(props.pr)}
+    />
   );
 }
 
-export function pullRequestCopyTargets(pr: PrSummary): CopyTarget[] {
+export function pullRequestCopyTargets(pr: PrSummary): CopyContextMenuTarget[] {
   const urls = pullRequestUrls(pr);
-  const targets: CopyTarget[] = [];
+  const targets: CopyContextMenuTarget[] = [];
 
   if (urls.fullUrl !== urls.pullRequestUrl) {
     targets.push({
@@ -180,30 +110,4 @@ function fullUrlCopyLabel(url: string): string {
     // A malformed provider URL still remains copyable as the full link.
   }
   return "Copy Full Link URL";
-}
-
-function placeContextMenu(
-  requestedPosition: ContextMenuPosition,
-  menuRect: DOMRect,
-): { x: number; y: number } {
-  const viewportMargin = 8;
-  const triggerGap = 4;
-  const menuWidth = menuRect.width || 220;
-  const menuHeight = menuRect.height;
-  const maxX = window.innerWidth - menuWidth - viewportMargin;
-  const maxY = window.innerHeight - menuHeight - viewportMargin;
-  const wouldOverflowBottom =
-    menuHeight > 0
-    && requestedPosition.y + menuHeight + viewportMargin > window.innerHeight;
-  const flippedTop = requestedPosition.anchorTop !== undefined
-    ? requestedPosition.anchorTop - menuHeight - triggerGap
-    : requestedPosition.y - menuHeight - triggerGap;
-
-  return {
-    x: Math.max(viewportMargin, Math.min(requestedPosition.x, maxX)),
-    y: Math.max(
-      viewportMargin,
-      Math.min(wouldOverflowBottom ? flippedTop : requestedPosition.y, maxY),
-    ),
-  };
 }

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
@@ -1,52 +1,52 @@
 import type { PrSummary } from "@pwragent/shared";
 import {
-  CopyContextMenu,
-  type CopyContextMenuPosition,
-  type CopyContextMenuTarget,
-} from "../chrome/CopyContextMenu";
+  ChipContextMenu,
+  type ChipContextMenuItem,
+  type ChipContextMenuPosition,
+} from "../chrome/ChipContextMenu";
 
 type PrChipContextMenuProps = {
   onClose: () => void;
-  position: CopyContextMenuPosition;
+  position: ChipContextMenuPosition;
   pr: PrSummary;
   returnFocusTo: HTMLElement;
 };
 
 export function PrChipContextMenu(props: PrChipContextMenuProps) {
   return (
-    <CopyContextMenu
+    <ChipContextMenu
+      items={pullRequestCopyTargets(props.pr)}
       onClose={props.onClose}
       position={props.position}
       returnFocusTo={props.returnFocusTo}
-      targets={pullRequestCopyTargets(props.pr)}
     />
   );
 }
 
-export function pullRequestCopyTargets(pr: PrSummary): CopyContextMenuTarget[] {
+export function pullRequestCopyTargets(pr: PrSummary): ChipContextMenuItem[] {
   const urls = pullRequestUrls(pr);
-  const targets: CopyContextMenuTarget[] = [];
+  const targets: ChipContextMenuItem[] = [];
 
   if (urls.fullUrl !== urls.pullRequestUrl) {
     targets.push({
       label: fullUrlCopyLabel(urls.fullUrl),
-      value: urls.fullUrl,
+      copyValue: urls.fullUrl,
     });
   }
 
   targets.push(
     {
       label: "Copy Pull Request URL",
-      value: urls.pullRequestUrl,
+      copyValue: urls.pullRequestUrl,
       separated: targets.length > 0,
     },
     {
       label: "Copy Pull Request Number",
-      value: String(pr.number),
+      copyValue: String(pr.number),
     },
     {
       label: "Copy Repository URL",
-      value: urls.repositoryUrl,
+      copyValue: urls.repositoryUrl,
     },
   );
 

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChipContextMenu.tsx
@@ -1,0 +1,209 @@
+import type { PrSummary } from "@pwragent/shared";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { copyText } from "../../lib/copy-text";
+
+type ContextMenuPosition = {
+  x: number;
+  y: number;
+  anchorTop?: number;
+};
+
+type PrChipContextMenuProps = {
+  onClose: () => void;
+  position: ContextMenuPosition;
+  pr: PrSummary;
+};
+
+type CopyTarget = {
+  label: string;
+  value: string;
+  separated?: boolean;
+};
+
+export function PrChipContextMenu(props: PrChipContextMenuProps) {
+  const { onClose, position: requestedPosition, pr } = props;
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState({
+    x: requestedPosition.x,
+    y: requestedPosition.y,
+  });
+  const targets = useMemo(() => pullRequestCopyTargets(pr), [pr]);
+
+  useEffect(() => {
+    const closeOnClick = (): void => onClose();
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("click", closeOnClick);
+    window.addEventListener("keydown", closeOnEscape);
+    return () => {
+      window.removeEventListener("click", closeOnClick);
+      window.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [onClose]);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) {
+      return;
+    }
+
+    setPosition(placeContextMenu(requestedPosition, menu.getBoundingClientRect()));
+    menu.querySelector<HTMLButtonElement>("button")?.focus();
+  }, [requestedPosition]);
+
+  const copy = (value: string): void => {
+    onClose();
+    void copyText(value);
+  };
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="thread-context-menu pr-chip-context-menu"
+      role="menu"
+      style={{ left: position.x, top: position.y }}
+      onClick={(event) => event.stopPropagation()}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <div className="thread-context-menu__section">
+        {targets.map((target) => (
+          <div key={target.label}>
+            {target.separated ? (
+              <div className="thread-context-menu__separator" role="separator" />
+            ) : null}
+            <button
+              role="menuitem"
+              type="button"
+              onClick={() => copy(target.value)}
+            >
+              {target.label}
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function pullRequestCopyTargets(pr: PrSummary): CopyTarget[] {
+  const urls = pullRequestUrls(pr);
+  const targets: CopyTarget[] = [];
+
+  if (urls.fullUrl !== urls.pullRequestUrl) {
+    targets.push({
+      label: fullUrlCopyLabel(urls.fullUrl),
+      value: urls.fullUrl,
+    });
+  }
+
+  targets.push(
+    {
+      label: "Copy Pull Request URL",
+      value: urls.pullRequestUrl,
+      separated: targets.length > 0,
+    },
+    {
+      label: "Copy Pull Request Number",
+      value: String(pr.number),
+    },
+    {
+      label: "Copy Repository URL",
+      value: urls.repositoryUrl,
+    },
+  );
+
+  return targets;
+}
+
+function pullRequestUrls(pr: PrSummary): {
+  fullUrl: string;
+  pullRequestUrl: string;
+  repositoryUrl: string;
+} {
+  try {
+    const full = new URL(pr.url);
+    const segments = full.pathname.split("/").filter(Boolean);
+    const markerIndex = segments.findIndex(
+      (segment) => segment === "pull" || segment === "merge_requests",
+    );
+    const numberIndex = markerIndex + 1;
+    if (
+      markerIndex >= 0
+      && segments[numberIndex] === String(pr.number)
+    ) {
+      const repositoryEnd = segments[markerIndex - 1] === "-"
+        ? markerIndex - 1
+        : markerIndex;
+      return {
+        fullUrl: pr.url,
+        pullRequestUrl: urlWithPath(full, segments.slice(0, numberIndex + 1)),
+        repositoryUrl: urlWithPath(full, segments.slice(0, repositoryEnd)),
+      };
+    }
+  } catch {
+    // Fall back to the provider + identity fields below.
+  }
+
+  const repositoryUrl = `https://${pr.provider}/${encodeURIComponent(pr.org)}/${encodeURIComponent(pr.repo)}`;
+  return {
+    fullUrl: pr.url,
+    pullRequestUrl: pr.url,
+    repositoryUrl,
+  };
+}
+
+function urlWithPath(source: URL, segments: string[]): string {
+  const target = new URL(source.origin);
+  target.pathname = `/${segments.join("/")}`;
+  return target.toString().replace(/\/$/, "");
+}
+
+function fullUrlCopyLabel(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (/^#(?:discussion_r|issuecomment-)\d+$/i.test(parsed.hash)) {
+      return "Copy Full Comment URL";
+    }
+    if (/^#pullrequestreview-\d+$/i.test(parsed.hash)) {
+      return "Copy Full Review URL";
+    }
+    if (parsed.pathname.split("/").includes("files")) {
+      return "Copy Full Code Review URL";
+    }
+  } catch {
+    // A malformed provider URL still remains copyable as the full link.
+  }
+  return "Copy Full Link URL";
+}
+
+function placeContextMenu(
+  requestedPosition: ContextMenuPosition,
+  menuRect: DOMRect,
+): { x: number; y: number } {
+  const viewportMargin = 8;
+  const triggerGap = 4;
+  const menuWidth = menuRect.width || 220;
+  const menuHeight = menuRect.height;
+  const maxX = window.innerWidth - menuWidth - viewportMargin;
+  const maxY = window.innerHeight - menuHeight - viewportMargin;
+  const wouldOverflowBottom =
+    menuHeight > 0
+    && requestedPosition.y + menuHeight + viewportMargin > window.innerHeight;
+  const flippedTop = requestedPosition.anchorTop !== undefined
+    ? requestedPosition.anchorTop - menuHeight - triggerGap
+    : requestedPosition.y - menuHeight - triggerGap;
+
+  return {
+    x: Math.max(viewportMargin, Math.min(requestedPosition.x, maxX)),
+    y: Math.max(
+      viewportMargin,
+      Math.min(wouldOverflowBottom ? flippedTop : requestedPosition.y, maxY),
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -92,20 +92,20 @@ describe("PrChip", () => {
     }))).toEqual([
       {
         label: "Copy Full Code Review URL",
-        value: "https://github.com/pwrdrvr/PwrAgent/pull/743/files?diff=split",
+        copyValue: "https://github.com/pwrdrvr/PwrAgent/pull/743/files?diff=split",
       },
       {
         label: "Copy Pull Request URL",
-        value: "https://github.com/pwrdrvr/PwrAgent/pull/743",
+        copyValue: "https://github.com/pwrdrvr/PwrAgent/pull/743",
         separated: true,
       },
       {
         label: "Copy Pull Request Number",
-        value: "743",
+        copyValue: "743",
       },
       {
         label: "Copy Repository URL",
-        value: "https://github.com/pwrdrvr/PwrAgent",
+        copyValue: "https://github.com/pwrdrvr/PwrAgent",
       },
     ]);
   });
@@ -118,20 +118,20 @@ describe("PrChip", () => {
     }))).toEqual([
       {
         label: "Copy Full Code Review URL",
-        value: "https://github.com/pull/merge_requests/pull/743/files?diff=split",
+        copyValue: "https://github.com/pull/merge_requests/pull/743/files?diff=split",
       },
       {
         label: "Copy Pull Request URL",
-        value: "https://github.com/pull/merge_requests/pull/743",
+        copyValue: "https://github.com/pull/merge_requests/pull/743",
         separated: true,
       },
       {
         label: "Copy Pull Request Number",
-        value: "743",
+        copyValue: "743",
       },
       {
         label: "Copy Repository URL",
-        value: "https://github.com/pull/merge_requests",
+        copyValue: "https://github.com/pull/merge_requests",
       },
     ]);
   });

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -1,10 +1,17 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PrSummary } from "@pwragent/shared";
 import { PrChip } from "../PrChip";
+import { pullRequestCopyTargets } from "../PrChipContextMenu";
 
-afterEach(cleanup);
+const copyText = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("../../../lib/copy-text", () => ({ copyText }));
+
+afterEach(() => {
+  cleanup();
+  copyText.mockClear();
+});
 
 // New-shape row (post #734): `state` stays check-only while review / lifecycle
 // / merge dimensions ride on their own fields. The chip layers draft + conflict
@@ -38,6 +45,71 @@ function renderChip(pr: PrSummary, opts: { withStatusPills?: boolean } = {}) {
 }
 
 describe("PrChip", () => {
+  it("is a non-draggable atomic control", () => {
+    const chip = renderChip(basePr());
+    expect(chip).toHaveAttribute("draggable", "false");
+    expect(chip).toHaveAttribute("aria-haspopup", "menu");
+  });
+
+  it("replaces the browser selection menu with PR copy actions", () => {
+    const fullUrl =
+      "https://github.com/pwrdrvr/PwrAgent/pull/743#discussion_r1234";
+    const chip = renderChip(basePr({ url: fullUrl }));
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+
+    fireEvent(chip, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Full Comment URL",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Pull Request URL",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Pull Request Number",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Repository URL",
+    })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", {
+      name: "Copy Full Comment URL",
+    }));
+    expect(copyText).toHaveBeenCalledWith(fullUrl);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("derives canonical copy values for deep pull request links", () => {
+    expect(pullRequestCopyTargets(basePr({
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/743/files?diff=split",
+    }))).toEqual([
+      {
+        label: "Copy Full Code Review URL",
+        value: "https://github.com/pwrdrvr/PwrAgent/pull/743/files?diff=split",
+      },
+      {
+        label: "Copy Pull Request URL",
+        value: "https://github.com/pwrdrvr/PwrAgent/pull/743",
+        separated: true,
+      },
+      {
+        label: "Copy Pull Request Number",
+        value: "743",
+      },
+      {
+        label: "Copy Repository URL",
+        value: "https://github.com/pwrdrvr/PwrAgent",
+      },
+    ]);
+  });
+
   it("colors the dot by check state with no draft affordance for a ready PR", () => {
     const chip = renderChip(basePr({ checkState: "passing" }));
     expect(chip).toHaveClass("pr-chip--passing");

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -110,6 +110,32 @@ describe("PrChip", () => {
     ]);
   });
 
+  it("ignores marker-like owner and repository names when deriving PR URLs", () => {
+    expect(pullRequestCopyTargets(basePr({
+      org: "pull",
+      repo: "merge_requests",
+      url: "https://github.com/pull/merge_requests/pull/743/files?diff=split",
+    }))).toEqual([
+      {
+        label: "Copy Full Code Review URL",
+        value: "https://github.com/pull/merge_requests/pull/743/files?diff=split",
+      },
+      {
+        label: "Copy Pull Request URL",
+        value: "https://github.com/pull/merge_requests/pull/743",
+        separated: true,
+      },
+      {
+        label: "Copy Pull Request Number",
+        value: "743",
+      },
+      {
+        label: "Copy Repository URL",
+        value: "https://github.com/pull/merge_requests",
+      },
+    ]);
+  });
+
   it("colors the dot by check state with no draft affordance for a ready PR", () => {
     const chip = renderChip(basePr({ checkState: "passing" }));
     expect(chip).toHaveClass("pr-chip--passing");

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -5,10 +5,10 @@ import { useLiveThreadLink } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import {
-  CopyContextMenu,
-  type CopyContextMenuPosition,
-  type CopyContextMenuTarget,
-} from "../chrome/CopyContextMenu";
+  ChipContextMenu,
+  type ChipContextMenuItem,
+  type ChipContextMenuPosition,
+} from "../chrome/ChipContextMenu";
 
 type ThreadChipProps = {
   /**
@@ -25,7 +25,7 @@ export function ThreadChip(props: ThreadChipProps) {
   const link = useLiveThreadLink(props.link);
   const contextMenuInvokerRef = useRef<HTMLSpanElement>(null);
   const [contextMenuPosition, setContextMenuPosition] =
-    useState<CopyContextMenuPosition>();
+    useState<ChipContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
 
   const label = link.title.trim() || props.fallbackLabel?.trim() || link.threadId;
@@ -86,10 +86,10 @@ export function ThreadChip(props: ThreadChipProps) {
       </span>
       {tooltipController.tooltipNode}
       {contextMenuPosition && contextMenuInvokerRef.current ? (
-        <CopyContextMenu
+        <ChipContextMenu
+          items={threadCopyTargets(link, label)}
           position={contextMenuPosition}
           returnFocusTo={contextMenuInvokerRef.current}
-          targets={threadCopyTargets(link, label)}
           onClose={() => setContextMenuPosition(undefined)}
         />
       ) : null}
@@ -100,30 +100,30 @@ export function ThreadChip(props: ThreadChipProps) {
 export function threadCopyTargets(
   link: ResolvedThreadLink,
   label: string,
-): CopyContextMenuTarget[] {
-  const targets: CopyContextMenuTarget[] = [
+): ChipContextMenuItem[] {
+  const targets: ChipContextMenuItem[] = [
     {
       label: "Copy Thread Link",
-      value: buildThreadUrl({
+      copyValue: buildThreadUrl({
         backend: link.backend,
         threadId: link.threadId,
       }),
     },
     {
       label: "Copy Thread ID",
-      value: link.threadId,
+      copyValue: link.threadId,
       separated: true,
     },
     {
       label: "Copy Thread Name",
-      value: label,
+      copyValue: label,
     },
   ];
 
   if (link.gitBranch) {
     targets.push({
       label: "Copy Branch Name",
-      value: link.gitBranch,
+      copyValue: link.gitBranch,
     });
   }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,14 +1,15 @@
 import { useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
-import { buildThreadUrl } from "@pwragent/shared";
 import { ThreadIcon } from "../../icons";
 import { useLiveThreadLink } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
 import {
   ChipContextMenu,
-  type ChipContextMenuItem,
   type ChipContextMenuPosition,
 } from "../chrome/ChipContextMenu";
+import { threadCopyTargets } from "../chrome/ThreadChipContextMenu";
+
+export { threadCopyTargets } from "../chrome/ThreadChipContextMenu";
 
 type ThreadChipProps = {
   /**
@@ -95,37 +96,4 @@ export function ThreadChip(props: ThreadChipProps) {
       ) : null}
     </>
   );
-}
-
-export function threadCopyTargets(
-  link: ResolvedThreadLink,
-  label: string,
-): ChipContextMenuItem[] {
-  const targets: ChipContextMenuItem[] = [
-    {
-      label: "Copy Thread Link",
-      copyValue: buildThreadUrl({
-        backend: link.backend,
-        threadId: link.threadId,
-      }),
-    },
-    {
-      label: "Copy Thread ID",
-      copyValue: link.threadId,
-      separated: true,
-    },
-    {
-      label: "Copy Thread Name",
-      copyValue: label,
-    },
-  ];
-
-  if (link.gitBranch) {
-    targets.push({
-      label: "Copy Branch Name",
-      copyValue: link.gitBranch,
-    });
-  }
-
-  return targets;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent, type MouseEvent } from "react";
+import { useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import { buildThreadUrl } from "@pwragent/shared";
 import { ThreadIcon } from "../../icons";
 import { useLiveThreadLink } from "../../lib/thread-links";
@@ -23,6 +23,7 @@ type ThreadChipProps = {
 
 export function ThreadChip(props: ThreadChipProps) {
   const link = useLiveThreadLink(props.link);
+  const contextMenuInvokerRef = useRef<HTMLSpanElement>(null);
   const [contextMenuPosition, setContextMenuPosition] =
     useState<CopyContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
@@ -63,6 +64,7 @@ export function ThreadChip(props: ThreadChipProps) {
           window.getSelection()?.removeAllRanges();
           tooltipController.hide();
           const rect = event.currentTarget.getBoundingClientRect();
+          contextMenuInvokerRef.current = event.currentTarget;
           setContextMenuPosition({
             x: event.clientX,
             y: event.clientY,
@@ -83,9 +85,10 @@ export function ThreadChip(props: ThreadChipProps) {
         <span className="thread-chip__label">{label}</span>
       </span>
       {tooltipController.tooltipNode}
-      {contextMenuPosition ? (
+      {contextMenuPosition && contextMenuInvokerRef.current ? (
         <CopyContextMenu
           position={contextMenuPosition}
+          returnFocusTo={contextMenuInvokerRef.current}
           targets={threadCopyTargets(link, label)}
           onClose={() => setContextMenuPosition(undefined)}
         />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadChip.tsx
@@ -1,8 +1,14 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import { useState, type KeyboardEvent, type MouseEvent } from "react";
+import { buildThreadUrl } from "@pwragent/shared";
 import { ThreadIcon } from "../../icons";
 import { useLiveThreadLink } from "../../lib/thread-links";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { ResolvedThreadLink } from "../../lib/thread-links";
+import {
+  CopyContextMenu,
+  type CopyContextMenuPosition,
+  type CopyContextMenuTarget,
+} from "../chrome/CopyContextMenu";
 
 type ThreadChipProps = {
   /**
@@ -17,6 +23,8 @@ type ThreadChipProps = {
 
 export function ThreadChip(props: ThreadChipProps) {
   const link = useLiveThreadLink(props.link);
+  const [contextMenuPosition, setContextMenuPosition] =
+    useState<CopyContextMenuPosition>();
   const tooltipController = useViewportTooltip({ className: "viewport-tooltip" });
 
   const label = link.title.trim() || props.fallbackLabel?.trim() || link.threadId;
@@ -41,12 +49,27 @@ export function ThreadChip(props: ThreadChipProps) {
     <>
       <span
         aria-label={`Open thread ${label}`}
+        aria-haspopup="menu"
         className="chip thread-chip"
         data-thread-chip=""
+        draggable={false}
         role="button"
         tabIndex={0}
         onBlur={tooltipController.hide}
         onClick={handleActivate}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          window.getSelection()?.removeAllRanges();
+          tooltipController.hide();
+          const rect = event.currentTarget.getBoundingClientRect();
+          setContextMenuPosition({
+            x: event.clientX,
+            y: event.clientY,
+            anchorTop: rect.top,
+          });
+        }}
+        onDragStart={(event) => event.preventDefault()}
         onFocus={(event) => tooltipController.show(event.currentTarget, tooltip)}
         onKeyDown={(event) => {
           if (event.key === "Enter" || event.key === " ") {
@@ -60,6 +83,46 @@ export function ThreadChip(props: ThreadChipProps) {
         <span className="thread-chip__label">{label}</span>
       </span>
       {tooltipController.tooltipNode}
+      {contextMenuPosition ? (
+        <CopyContextMenu
+          position={contextMenuPosition}
+          targets={threadCopyTargets(link, label)}
+          onClose={() => setContextMenuPosition(undefined)}
+        />
+      ) : null}
     </>
   );
+}
+
+export function threadCopyTargets(
+  link: ResolvedThreadLink,
+  label: string,
+): CopyContextMenuTarget[] {
+  const targets: CopyContextMenuTarget[] = [
+    {
+      label: "Copy Thread Link",
+      value: buildThreadUrl({
+        backend: link.backend,
+        threadId: link.threadId,
+      }),
+    },
+    {
+      label: "Copy Thread ID",
+      value: link.threadId,
+      separated: true,
+    },
+    {
+      label: "Copy Thread Name",
+      value: label,
+    },
+  ];
+
+  if (link.gitBranch) {
+    targets.push({
+      label: "Copy Branch Name",
+      value: link.gitBranch,
+    });
+  }
+
+  return targets;
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -115,6 +115,8 @@ type MarkdownViewerTarget = LocalFileTarget & {
   label: string;
 };
 
+type SkillActionTarget = AppServerSkillSummary & LocalFileTarget;
+
 export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdownProps) {
   const markdownText = useMemo(
     () => protectComposerHyphenListItems(repairNestedLanguageFences(props.text)),
@@ -191,13 +193,15 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
   );
 
   const viewSkillMarkdown = useCallback(
-    (skill: AppServerSkillSummary & { path: string }): void => {
+    (skill: SkillActionTarget): void => {
       if (!props.desktopApi?.readMarkdownFile) {
         return;
       }
 
       setMarkdownViewerTarget({
+        column: skill.column,
         label: `$${skill.name}`,
+        line: skill.line,
         path: skill.path,
       });
     },
@@ -205,8 +209,12 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
   );
 
   const openSkillMarkdownInEditor = useCallback(
-    (skill: AppServerSkillSummary & { path: string }): void => {
-      openLocalFileInEditor({ path: skill.path });
+    (skill: SkillActionTarget): void => {
+      openLocalFileInEditor({
+        column: skill.column,
+        line: skill.line,
+        path: skill.path,
+      });
     },
     [openLocalFileInEditor]
   );
@@ -219,7 +227,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         const isLocalMarkdownFile = Boolean(
           localTarget && isMarkdownFilePath(localTarget.path)
         );
-        const skillPath = normalizeSkillPath(href);
+        const skillPath = localTarget?.path;
         const label = extractTextContent(anchorProps.children).trim();
         const source = sourceForNode(markdownText, anchorProps.node);
 
@@ -300,6 +308,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
                 ? viewSkillMarkdown
                 : undefined}
               skill={skill}
+              target={localTarget}
               transcript={true}
             />
           );
@@ -912,18 +921,6 @@ function sourceForNode(
   return markdown.slice(start, end);
 }
 
-function normalizeSkillPath(href: string): string | undefined {
-  if (href.startsWith("file://")) {
-    return stripFileLineSuffix(decodeURIComponent(href.replace(/^file:\/\//, "")));
-  }
-
-  if (href.startsWith("/")) {
-    return stripFileLineSuffix(href);
-  }
-
-  return undefined;
-}
-
 function isSkillMarkdownPath(filePath: string): boolean {
   return /(?:^|\/)SKILL\.md$/i.test(filePath);
 }
@@ -981,10 +978,6 @@ function denormalizeMarkdownUrl(url: string): string {
   }
 
   return url;
-}
-
-function stripFileLineSuffix(filePath: string): string {
-  return splitFileLineSuffix(filePath).path;
 }
 
 function splitFileLineSuffix(filePath: string): {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -190,6 +190,27 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
     [openLocalFileInEditor, props.desktopApi]
   );
 
+  const viewSkillMarkdown = useCallback(
+    (skill: AppServerSkillSummary & { path: string }): void => {
+      if (!props.desktopApi?.readMarkdownFile) {
+        return;
+      }
+
+      setMarkdownViewerTarget({
+        label: `$${skill.name}`,
+        path: skill.path,
+      });
+    },
+    [props.desktopApi]
+  );
+
+  const openSkillMarkdownInEditor = useCallback(
+    (skill: AppServerSkillSummary & { path: string }): void => {
+      openLocalFileInEditor({ path: skill.path });
+    },
+    [openLocalFileInEditor]
+  );
+
   const components = useMemo<Components>(
     () => ({
       a(anchorProps) {
@@ -264,7 +285,20 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
             path: skillPath,
           };
 
-          return <SkillChip label={label || undefined} skill={skill} />;
+          return (
+            <SkillChip
+              editorName={editorApplication?.name}
+              label={label || undefined}
+              onOpenInEditor={editorApplication && props.desktopApi?.openApplication
+                ? openSkillMarkdownInEditor
+                : undefined}
+              onViewMarkdown={props.desktopApi?.readMarkdownFile
+                ? viewSkillMarkdown
+                : undefined}
+              skill={skill}
+              transcript={true}
+            />
+          );
         }
 
         if (!href) {
@@ -466,10 +500,12 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       markdownText,
       openLocalFileInEditor,
       openLocalFileLink,
+      openSkillMarkdownInEditor,
       props.desktopApi,
       pullRequestLinks,
       skillsByPath,
       threadLinks,
+      viewSkillMarkdown,
     ]
   );
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -278,10 +278,14 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
 
         if (
           skillPath &&
-          (skillsByPath.has(skillPath) || label.startsWith("$"))
+          (
+            isSkillMarkdownPath(skillPath)
+            || skillsByPath.has(skillPath)
+            || label.startsWith("$")
+          )
         ) {
           const skill = skillsByPath.get(skillPath) ?? {
-            name: label.replace(/^\$/, "") || skillPath.split("/").pop() || "skill",
+            name: skillNameFromPath(skillPath, label),
             path: skillPath,
           };
 
@@ -918,6 +922,18 @@ function normalizeSkillPath(href: string): string | undefined {
   }
 
   return undefined;
+}
+
+function isSkillMarkdownPath(filePath: string): boolean {
+  return /(?:^|\/)SKILL\.md$/i.test(filePath);
+}
+
+function skillNameFromPath(filePath: string, label: string): string {
+  const segments = filePath.split("/").filter(Boolean);
+  if (segments.at(-1)?.toLowerCase() === "skill.md" && segments.length > 1) {
+    return segments.at(-2) ?? "skill";
+  }
+  return label.replace(/^\$/, "") || segments.at(-1) || "skill";
 }
 
 function localFileTargetFromHref(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/pull-request-links.test.tsx
@@ -440,7 +440,7 @@ describe("pull request links in transcript markdown", () => {
       .toBeInTheDocument();
   });
 
-  it("leaves GitHub review comment permalinks as distinct transcript links", () => {
+  it("renders GitHub review comment permalinks as atomic PR chips", () => {
     const commentUrls = [
       `${PR_URL}#discussion_r3549020872`,
       `${PR_URL}#discussion_r3549020877`,
@@ -448,12 +448,10 @@ describe("pull request links in transcript markdown", () => {
     ];
     renderWithPullRequests(commentUrls.join("\n\n"), [prSummary()]);
 
-    expect(screen.queryByRole("button", {
+    expect(screen.getAllByRole("button", {
       name: /Open Giphy\/giphy-services#13290/,
-    })).not.toBeInTheDocument();
-    for (const url of commentUrls) {
-      expect(screen.getByRole("link", { name: url })).toHaveAttribute("href", url);
-    }
+    })).toHaveLength(3);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 
   it("leaves PR links as normal links on surfaces without navigation metadata", () => {
@@ -485,16 +483,16 @@ describe("parseGitHubPullRequestUrl", () => {
     });
   });
 
-  it("rejects GitHub pull request comment permalinks", () => {
+  it("accepts GitHub pull request comment permalinks and preserves the target URL", () => {
     expect(parseGitHubPullRequestUrl(
       `${PR_URL}#discussion_r3549020872`,
-    )).toBeUndefined();
+    )?.url).toBe(`${PR_URL}#discussion_r3549020872`);
     expect(parseGitHubPullRequestUrl(
       `${PR_URL}#issuecomment-3549020872`,
-    )).toBeUndefined();
+    )?.url).toBe(`${PR_URL}#issuecomment-3549020872`);
     expect(parseGitHubPullRequestUrl(
       `${PR_URL}#pullrequestreview-3549020872`,
-    )).toBeUndefined();
+    )?.url).toBe(`${PR_URL}#pullrequestreview-3549020872`);
   });
 
   it("rejects issues, invalid numbers, non-GitHub hosts, and insecure URLs", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -51,7 +51,18 @@ describe("thread links in transcript markdown", () => {
     renderWithLinks(
       `Created [the handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex)`,
       {
-        threads: [threadSummary({ gitBranch: "agent/thread-chip-menu" })],
+        threads: [threadSummary({
+          gitBranch: "agent/thread-chip-menu",
+          linkedDirectories: [
+            {
+              id: "dir-worktree",
+              kind: "worktree",
+              label: "PwrAgent",
+              path: "/Users/huntharo/pwrdrvr/PwrAgent",
+              worktreePath: "/Users/huntharo/.codex/worktrees/thread-menu/PwrAgent",
+            },
+          ],
+        })],
       },
     );
     const chip = screen.getByRole("button", {
@@ -80,6 +91,9 @@ describe("thread links in transcript markdown", () => {
     })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", {
       name: "Copy Branch Name",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Thread Directory",
     })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy Thread Link" }));
@@ -126,6 +140,15 @@ describe("thread links in transcript markdown", () => {
       threadId: CHILD_THREAD_ID,
       title: "RELATED query deranking issue",
       gitBranch: "agent/thread-chip-menu",
+      linkedDirectories: [
+        {
+          id: "dir-worktree",
+          kind: "worktree",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+          worktreePath: "/Users/huntharo/.codex/worktrees/thread-menu/PwrAgent",
+        },
+      ],
     }, "RELATED query deranking issue")).toEqual([
       {
         label: "Copy Thread Link",
@@ -143,6 +166,47 @@ describe("thread links in transcript markdown", () => {
       {
         label: "Copy Branch Name",
         copyValue: "agent/thread-chip-menu",
+      },
+      {
+        label: "Copy Thread Directory",
+        copyValue: "/Users/huntharo/.codex/worktrees/thread-menu/PwrAgent",
+      },
+    ]);
+  });
+
+  it("offers each distinct thread directory when a thread links several", () => {
+    expect(threadCopyTargets({
+      backend: "codex",
+      threadId: CHILD_THREAD_ID,
+      linkedDirectories: [
+        {
+          id: "dir-local",
+          kind: "local",
+          label: "PwrAgent",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+        },
+        {
+          id: "dir-worktree",
+          kind: "worktree",
+          label: "Docs",
+          path: "/Users/huntharo/pwrdrvr/docs.pwragent.ai",
+          worktreePath: "/Users/huntharo/.codex/worktrees/docs/docs.pwragent.ai",
+        },
+        {
+          id: "dir-duplicate",
+          kind: "local",
+          label: "Duplicate",
+          path: "/Users/huntharo/pwrdrvr/PwrAgent",
+        },
+      ],
+    }, "RELATED query deranking issue").slice(3)).toEqual([
+      {
+        label: "Copy Thread Directory — PwrAgent (local)",
+        copyValue: "/Users/huntharo/pwrdrvr/PwrAgent",
+      },
+      {
+        label: "Copy Thread Directory — Docs (worktree)",
+        copyValue: "/Users/huntharo/.codex/worktrees/docs/docs.pwragent.ai",
       },
     ]);
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -87,6 +87,37 @@ describe("thread links in transcript markdown", () => {
       `pwragent://thread/${CHILD_THREAD_ID}?backend=codex`,
     );
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(chip).toHaveFocus();
+  });
+
+  it("keeps one copy menu open and restores focus on Escape", () => {
+    const secondThreadId = "019f5d79-a595-73f2-84d9-a0976762c304";
+    renderWithLinks(
+      [
+        `[first](pwragent://thread/${CHILD_THREAD_ID}?backend=codex)`,
+        `[second](pwragent://thread/${secondThreadId}?backend=codex)`,
+      ].join(" "),
+      {
+        threads: [
+          threadSummary({ title: "First thread" }),
+          threadSummary({ id: secondThreadId, title: "Second thread" }),
+        ],
+      },
+    );
+    const firstChip = screen.getByRole("button", { name: "Open thread First thread" });
+    const secondChip = screen.getByRole("button", { name: "Open thread Second thread" });
+
+    fireEvent.contextMenu(firstChip, { clientX: 80, clientY: 60 });
+    expect(screen.getAllByRole("menu")).toHaveLength(1);
+
+    secondChip.focus();
+    fireEvent.contextMenu(secondChip, { clientX: 160, clientY: 90 });
+    expect(screen.getAllByRole("menu")).toHaveLength(1);
+    expect(screen.getByRole("menuitem", { name: "Copy Thread Link" })).toHaveFocus();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(secondChip).toHaveFocus();
   });
 
   it("builds exact copy values from live thread metadata", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -1,11 +1,18 @@
 import "@testing-library/jest-dom/vitest";
 import type { AppServerBackendKind, NavigationThreadSummary } from "@pwragent/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
+import { threadCopyTargets } from "../ThreadChip";
 import { ThreadMarkdown } from "../ThreadMarkdown";
 
 const CHILD_THREAD_ID = "019f5d79-a595-73f2-84d9-a0976762c303";
+const copyText = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("../../../lib/copy-text", () => ({ copyText }));
+
+afterEach(() => {
+  copyText.mockClear();
+});
 
 function threadSummary(
   overrides: Partial<NavigationThreadSummary> = {},
@@ -40,6 +47,75 @@ function renderWithLinks(
 }
 
 describe("thread links in transcript markdown", () => {
+  it("replaces partial text selection with thread-specific copy actions", () => {
+    renderWithLinks(
+      `Created [the handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex)`,
+      {
+        threads: [threadSummary({ gitBranch: "agent/thread-chip-menu" })],
+      },
+    );
+    const chip = screen.getByRole("button", {
+      name: "Open thread RELATED query deranking issue",
+    });
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+
+    fireEvent(chip, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+    expect(chip).toHaveAttribute("draggable", "false");
+    expect(chip).toHaveAttribute("aria-haspopup", "menu");
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Thread Link",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Thread ID",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Thread Name",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", {
+      name: "Copy Branch Name",
+    })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Thread Link" }));
+    expect(copyText).toHaveBeenCalledWith(
+      `pwragent://thread/${CHILD_THREAD_ID}?backend=codex`,
+    );
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("builds exact copy values from live thread metadata", () => {
+    expect(threadCopyTargets({
+      backend: "codex",
+      threadId: CHILD_THREAD_ID,
+      title: "RELATED query deranking issue",
+      gitBranch: "agent/thread-chip-menu",
+    }, "RELATED query deranking issue")).toEqual([
+      {
+        label: "Copy Thread Link",
+        value: `pwragent://thread/${CHILD_THREAD_ID}?backend=codex`,
+      },
+      {
+        label: "Copy Thread ID",
+        value: CHILD_THREAD_ID,
+        separated: true,
+      },
+      {
+        label: "Copy Thread Name",
+        value: "RELATED query deranking issue",
+      },
+      {
+        label: "Copy Branch Name",
+        value: "agent/thread-chip-menu",
+      },
+    ]);
+  });
+
   it("renders a pwragent thread link as a chip showing the thread's live title", () => {
     renderWithLinks(
       `Created [the handoff](pwragent://thread/${CHILD_THREAD_ID}?backend=codex)`,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx
@@ -129,20 +129,20 @@ describe("thread links in transcript markdown", () => {
     }, "RELATED query deranking issue")).toEqual([
       {
         label: "Copy Thread Link",
-        value: `pwragent://thread/${CHILD_THREAD_ID}?backend=codex`,
+        copyValue: `pwragent://thread/${CHILD_THREAD_ID}?backend=codex`,
       },
       {
         label: "Copy Thread ID",
-        value: CHILD_THREAD_ID,
+        copyValue: CHILD_THREAD_ID,
         separated: true,
       },
       {
         label: "Copy Thread Name",
-        value: "RELATED query deranking issue",
+        copyValue: "RELATED query deranking issue",
       },
       {
         label: "Copy Branch Name",
-        value: "agent/thread-chip-menu",
+        copyValue: "agent/thread-chip-menu",
       },
     ]);
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -348,6 +348,7 @@ describe("ThreadMarkdown", () => {
   it("shows skill paths and replaces text selection with skill file actions", async () => {
     const skillPath = "/Users/huntharo/.codex/skills/frontend-design/SKILL.md";
     const openApplication = vi.fn(async () => ({ opened: true as const }));
+    const openMarkdownFileViewer = vi.fn(async () => ({ opened: true as const }));
     const readMarkdownFile = vi.fn(async () => ({
       path: skillPath,
       content: "# Frontend design\n\nVerify renderer UI work.",
@@ -377,7 +378,7 @@ describe("ThreadMarkdown", () => {
             discovery: { candidates: [] },
           },
         }}
-        desktopApi={{ openApplication, readMarkdownFile }}
+        desktopApi={{ openApplication, openMarkdownFileViewer, readMarkdownFile }}
         skills={[
           {
             name: "frontend-design",
@@ -386,7 +387,7 @@ describe("ThreadMarkdown", () => {
             enabled: true,
           },
         ]}
-        text={`Load [$frontend-design](${skillPath})`}
+        text={`Load [$frontend-design](${skillPath}:17:4)`}
       />
     );
 
@@ -430,6 +431,18 @@ describe("ThreadMarkdown", () => {
     expect(screen.getByRole("heading", { name: "Frontend design" }))
       .toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole("button", { name: "Open in detached files window" }));
+    await waitFor(() => {
+      expect(openMarkdownFileViewer).toHaveBeenCalledWith(expect.objectContaining({
+        file: {
+          column: 4,
+          label: "$frontend-design",
+          line: 17,
+          path: skillPath,
+        },
+      }));
+    });
+
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
     fireEvent.contextMenu(chip, { clientX: 120, clientY: 80 });
     fireEvent.click(screen.getByRole("menuitem", {
@@ -441,8 +454,8 @@ describe("ThreadMarkdown", () => {
         applicationId: "zed",
         kind: "editor",
         targetPath: skillPath,
-        targetLine: undefined,
-        targetColumn: undefined,
+        targetLine: 17,
+        targetColumn: 4,
       });
     });
   });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -1,7 +1,19 @@
 import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadMarkdown } from "../ThreadMarkdown";
+
+const copyText = vi.hoisted(() => vi.fn(async (
+  text: string,
+  desktopApi?: { copyText?: (value: string) => Promise<void> },
+) => {
+  await desktopApi?.copyText?.(text);
+}));
+vi.mock("../../../lib/copy-text", () => ({ copyText }));
+
+afterEach(() => {
+  copyText.mockClear();
+});
 
 const sanitizedReviewFindingsTable = `| # | Sev | File | Issue | Fix |
 |---:|:---:|---|---|---|
@@ -307,6 +319,108 @@ describe("ThreadMarkdown", () => {
 
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "$frontend-design" })).not.toBeInTheDocument();
+  });
+
+  it("shows skill paths and replaces text selection with skill file actions", async () => {
+    const skillPath = "/Users/huntharo/.codex/skills/frontend-design/SKILL.md";
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+    const readMarkdownFile = vi.fn(async () => ({
+      path: skillPath,
+      content: "# Frontend design\n\nVerify renderer UI work.",
+    }));
+
+    render(
+      <ThreadMarkdown
+        applications={{
+          editors: [
+            {
+              id: "zed",
+              kind: "editor",
+              name: "Zed",
+              source: "application",
+              appPath: "/Applications/Zed.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "zed", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
+        desktopApi={{ openApplication, readMarkdownFile }}
+        skills={[
+          {
+            name: "frontend-design",
+            description: "Design and verify renderer UI work.",
+            path: skillPath,
+            enabled: true,
+          },
+        ]}
+        text={`Load [$frontend-design](${skillPath})`}
+      />
+    );
+
+    const chip = screen.getByRole("button", { name: "View skill frontend-design" });
+    expect(chip).toHaveAttribute("draggable", "false");
+    expect(chip).toHaveAttribute("aria-haspopup", "menu");
+
+    fireEvent.mouseEnter(chip);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(skillPath);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Right-click for skill actions",
+    );
+
+    const contextMenuEvent = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      clientX: 120,
+      clientY: 80,
+    });
+    fireEvent(chip, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+    expect(screen.getByRole("menuitem", { name: "View Skill Markdown" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Open Skill Markdown in Zed" }))
+      .toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Copy Skill Path" }))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy Skill Path" }));
+    expect(copyText).toHaveBeenCalledWith(skillPath);
+    expect(chip).toHaveFocus();
+
+    fireEvent.contextMenu(chip, { clientX: 120, clientY: 80 });
+    fireEvent.click(screen.getByRole("menuitem", { name: "View Skill Markdown" }));
+
+    expect(await screen.findByRole("dialog", {
+      name: "Markdown document: $frontend-design",
+    })).toBeInTheDocument();
+    expect(readMarkdownFile).toHaveBeenCalledWith({ path: skillPath });
+    expect(screen.getByRole("heading", { name: "Frontend design" }))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.contextMenu(chip, { clientX: 120, clientY: 80 });
+    fireEvent.click(screen.getByRole("menuitem", {
+      name: "Open Skill Markdown in Zed",
+    }));
+
+    await waitFor(() => {
+      expect(openApplication).toHaveBeenCalledWith({
+        applicationId: "zed",
+        kind: "editor",
+        targetPath: skillPath,
+        targetLine: undefined,
+        targetColumn: undefined,
+      });
+    });
   });
 
   it("renders emoji, italic, strikethrough, and inline code", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -54,16 +54,16 @@ describe("ThreadMarkdown", () => {
   it("renders markdown formatting and local file links", () => {
     render(
       <ThreadMarkdown
-        text={"Use **bold** text and open [`ce:work`](/Users/huntharo/.codex/skills/ce-work/SKILL.md)."}
+        text={"Use **bold** text and open [`AGENTS.md`](/Users/huntharo/PwrAgent/AGENTS.md)."}
       />
     );
 
     expect(screen.getByText("bold", { selector: "strong" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
+      "file:///Users/huntharo/PwrAgent/AGENTS.md"
     );
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "title",
       "Open in PwrAgent"
     );
@@ -319,6 +319,30 @@ describe("ThreadMarkdown", () => {
 
     expect(screen.getByText("$frontend-design")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "$frontend-design" })).not.toBeInTheDocument();
+  });
+
+  it("renders explicit SKILL.md links as chips without live skill inventory", () => {
+    const skillPath = [
+      "/Users/huntharo/.codex/plugins/cache/openai-curated-remote/github",
+      "0.1.8-2841cf9749ae/skills/yeet/SKILL.md",
+    ].join("/");
+    const { container } = render(
+      <ThreadMarkdown
+        text={`[Open the GitHub Publish Skill](${skillPath})`}
+      />
+    );
+
+    const chip = screen.getByText("Open the GitHub Publish Skill")
+      .closest("[data-skill-chip]");
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute("draggable", "false");
+    expect(screen.queryByRole("link", { name: "Open the GitHub Publish Skill" }))
+      .not.toBeInTheDocument();
+    expect(container.querySelector(".thread-markdown__editor-link")).toBeNull();
+
+    fireEvent.contextMenu(chip!, { clientX: 120, clientY: 80 });
+    expect(screen.getByRole("menuitem", { name: "Copy Skill Path" }))
+      .toBeInTheDocument();
   });
 
   it("shows skill paths and replaces text selection with skill file actions", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -322,15 +322,15 @@ describe("TranscriptList", () => {
       />
     );
 
-    expect(screen.getByRole("link", { name: "ce:work" })).toHaveAttribute(
-      "href",
-      "file:///Users/huntharo/.codex/skills/ce-work/SKILL.md"
-    );
+    const skillChip = screen.getByText("ce:work").closest("[data-skill-chip]");
+    expect(skillChip).toBeInTheDocument();
+    expect(skillChip).toHaveAttribute("draggable", "false");
+    expect(screen.queryByRole("link", { name: "ce:work" })).not.toBeInTheDocument();
     expect(screen.getByText("Check Unit 4", { selector: "strong" })).toBeInTheDocument();
     expect(screen.getByText("Keep Unit 3 isolated")).toBeInTheDocument();
     expect(screen.getByText("pnpm test -- --project desktop-renderer")).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "ce:work" }).closest("article")
+      skillChip?.closest("article")
     ).toHaveClass("transcript-message--user");
     expect(
       screen.getByText("pnpm test -- --project desktop-renderer").closest("article")

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -385,10 +385,6 @@ export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
     return undefined;
   }
 
-  if (isGitHubPullRequestCommentHash(parsed.hash)) {
-    return undefined;
-  }
-
   const segments = parsed.pathname.split("/").filter(Boolean);
   if (segments.length < 4 || segments[2] !== "pull") {
     return undefined;
@@ -412,10 +408,6 @@ export function parseGitHubPullRequestUrl(href: string): PrSummary | undefined {
     state: "unknown",
     url: href,
   };
-}
-
-function isGitHubPullRequestCommentHash(hash: string): boolean {
-  return /^#(?:discussion_r|issuecomment-|pullrequestreview-)\d+$/i.test(hash);
 }
 
 function decodeUrlSegment(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/lib/thread-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/thread-links.tsx
@@ -2,6 +2,7 @@ import {
   isThreadLinkId,
   parseThreadUrl,
   type AppServerBackendKind,
+  type LinkedDirectorySummary,
   type NavigationThreadSummary,
   type ThreadLinkRef,
 } from "@pwragent/shared";
@@ -21,6 +22,7 @@ export type ResolvedThreadLink = {
   threadId: string;
   title: string;
   gitBranch?: string;
+  linkedDirectories?: LinkedDirectorySummary[];
 };
 
 export type ThreadLinkContextValue = {
@@ -45,6 +47,7 @@ function threadSummaryLink(thread: NavigationThreadSummary): ResolvedThreadLink 
     threadId: thread.id,
     title: thread.title,
     gitBranch: thread.gitBranch,
+    linkedDirectories: thread.linkedDirectories,
   };
 }
 
@@ -55,7 +58,23 @@ function sameThreadLink(
   return Boolean(
     left
     && left.title === right.title
-    && left.gitBranch === right.gitBranch,
+    && left.gitBranch === right.gitBranch
+    && linkedDirectoryMetadata(left.linkedDirectories)
+      === linkedDirectoryMetadata(right.linkedDirectories)
+  );
+}
+
+function linkedDirectoryMetadata(
+  directories: LinkedDirectorySummary[] | undefined,
+): string {
+  return JSON.stringify(
+    (directories ?? []).map((directory) => [
+      directory.id,
+      directory.label,
+      directory.kind,
+      directory.path,
+      directory.worktreePath ?? null,
+    ]),
   );
 }
 
@@ -66,6 +85,7 @@ function threadLinkMetadataKey(threads: NavigationThreadSummary[]): string {
       thread.id,
       thread.title,
       thread.gitBranch ?? null,
+      linkedDirectoryMetadata(thread.linkedDirectories),
     ]),
   );
 }

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -418,6 +418,13 @@ describe("Tangerine Terminal theme contract", () => {
     expect(pricingRunningTotalRule).toContain("user-select: text;");
   });
 
+  it("keeps pull request chips atomic instead of text-selectable", () => {
+    const prChipRule = extractRuleBody(css, ".pr-chip");
+
+    expect(prChipRule).toContain("-webkit-user-select: none;");
+    expect(prChipRule).toContain("user-select: none;");
+  });
+
   it("anchors the context rail below the header and reserves one shared width for the chat", () => {
     // The rail is anchored to `.thread-view__layout` (absolute), NOT the
     // window, so it starts below the thread header. The header therefore owns

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -418,11 +418,14 @@ describe("Tangerine Terminal theme contract", () => {
     expect(pricingRunningTotalRule).toContain("user-select: text;");
   });
 
-  it("keeps pull request chips atomic instead of text-selectable", () => {
+  it("keeps transcript link chips atomic instead of text-selectable", () => {
     const prChipRule = extractRuleBody(css, ".pr-chip");
+    const threadChipRule = extractRuleBody(css, ".thread-chip");
 
     expect(prChipRule).toContain("-webkit-user-select: none;");
     expect(prChipRule).toContain("user-select: none;");
+    expect(threadChipRule).toContain("-webkit-user-select: none;");
+    expect(threadChipRule).toContain("user-select: none;");
   });
 
   it("anchors the context rail below the header and reserves one shared width for the chat", () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -420,10 +420,13 @@ describe("Tangerine Terminal theme contract", () => {
 
   it("keeps transcript link chips atomic instead of text-selectable", () => {
     const prChipRule = extractRuleBody(css, ".pr-chip");
+    const skillChipRule = extractRuleBody(css, ".skill-chip--transcript");
     const threadChipRule = extractRuleBody(css, ".thread-chip");
 
     expect(prChipRule).toContain("-webkit-user-select: none;");
     expect(prChipRule).toContain("user-select: none;");
+    expect(skillChipRule).toContain("-webkit-user-select: none;");
+    expect(skillChipRule).toContain("user-select: none;");
     expect(threadChipRule).toContain("-webkit-user-select: none;");
     expect(threadChipRule).toContain("user-select: none;");
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3808,10 +3808,6 @@ textarea,
     border-color 120ms ease;
 }
 
-.pr-chip-context-menu {
-  min-width: 220px;
-}
-
 .pr-chip:hover,
 .pr-chip:focus-visible {
   border-color: var(--accent-border);
@@ -4447,6 +4443,10 @@ textarea,
   border-radius: 8px;
   background: var(--bg-panel-elevated);
   box-shadow: var(--shadow-popover);
+}
+
+.chip-copy-context-menu {
+  min-width: 220px;
 }
 
 .thread-context-menu button {
@@ -12067,6 +12067,8 @@ a.transcript-message__messaging-origin:focus-visible {
   vertical-align: middle;
   border: 1px solid var(--accent-border);
   cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .thread-chip:hover,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4445,7 +4445,7 @@ textarea,
   box-shadow: var(--shadow-popover);
 }
 
-.chip-copy-context-menu {
+.chip-context-menu {
   min-width: 220px;
 }
 
@@ -11997,6 +11997,22 @@ a.transcript-message__messaging-origin:focus-visible {
   max-width: 100%;
   vertical-align: middle;
   border: 1px solid var(--border-subtle);
+}
+
+.skill-chip--transcript {
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.skill-chip--transcript:hover,
+.skill-chip--transcript:focus-visible {
+  background: var(--accent-soft);
+}
+
+.skill-chip--transcript:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 /* Composer directory-reference mention chip (`@label`). Same silhouette

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3801,9 +3801,15 @@ textarea,
   font-size: 11px;
   font-weight: 500;
   line-height: 1;
+  -webkit-user-select: none;
+  user-select: none;
   transition:
     background 120ms ease,
     border-color 120ms ease;
+}
+
+.pr-chip-context-menu {
+  min-width: 220px;
 }
 
 .pr-chip:hover,


### PR DESCRIPTION
## What changed

- make transcript PR, thread, and skill chips non-selectable and non-draggable so they remain atomic controls
- make pasted composer thread chips atomic and give them the same Thread Link, ID, Name, Branch, and Directory actions supported by their live metadata
- replace browser selection menus with one shared, viewport-aware chip action popover
- give PR chips actions for the full deep/comment/review URL, canonical pull request URL, number, and repository URL
- give thread chips actions for the canonical thread link, thread ID, live thread name, branch name, and active directory when available
- copy the active worktree path for worktree threads; expose one labeled action per distinct directory for multi-directory threads
- show a skill's full disk path in a viewport-safe hover tooltip, with its description and action guidance
- let skill chips open their `SKILL.md` in PwrAgent's markdown viewer on click or from the context menu
- give skill chips actions to open the markdown in the configured editor and copy the full skill path
- render explicit `SKILL.md` links as skill chips even when plugin skills are absent from the current live inventory
- render GitHub review-comment permalinks as live PR chips while preserving their exact authored target
- close an existing transcript/sidebar menu before any subsequent right-click and restore keyboard focus after Escape or an action
- derive canonical PR and repository URLs from the structural marker paired with the PR number, including repositories with marker-like names

## Root cause

Reference chips did not consistently own right-click behavior or disable text selection. Chromium could therefore select part of a chip and expose its generic **Copy** action. Skill chips additionally relied on a CSS pseudo-tooltip that could be clipped by transcript overflow, and they had no route into the existing markdown viewer. The composer thread chips introduced on `main` are Tiptap DOM atoms rather than React `ThreadChip` components, so they needed an explicit bridge into the shared action menu. Plugin-cache `SKILL.md` links also needed path-based recognition when the skill was absent from the current app-server inventory.

## User impact

Right-clicking a transcript or pasted composer thread chip now treats it as one object and presents domain-specific actions, including its active directory. Skill chips identify the exact file they represent on hover and make that markdown immediately viewable, openable, and copyable.

## Validation

- 317 focused renderer tests
- workspace TypeScript typecheck
- ESLint (0 errors; existing warning baseline only)
- dependency-boundary lint
