### PR TITLE
feat(desktop): chipify pasted thread references

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -40,7 +40,10 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  buildThreadMarkdownLink,
+  buildThreadUrl,
   buildReviewBranchOptions,
+  parseThreadUrl,
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import {
@@ -81,6 +84,12 @@ import {
 } from "../../lib/directory-references";
 import { expandTildePath } from "../../lib/tildify-path";
 import { normalizeImageFile } from "../../lib/image-normalization";
+import {
+  resolveThreadHref,
+  resolveThreadIdText,
+  useThreadLinks,
+  type ResolvedThreadLink,
+} from "../../lib/thread-links";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import {
@@ -1273,6 +1282,23 @@ export function createComposerFileToken(
   };
 }
 
+function createComposerThreadToken(
+  thread: ResolvedThreadLink,
+  index: number,
+): ComposerSkillToken {
+  const path = buildThreadUrl({
+    backend: thread.backend,
+    threadId: thread.threadId,
+  });
+  return {
+    kind: "thread",
+    name: thread.title.trim() || thread.threadId,
+    path,
+    id: `${path}:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+    index,
+  };
+}
+
 /**
  * Append path-only file references to outgoing text as one
  * `[@label](~/path)` line per file, separated from the typed draft by a
@@ -1337,12 +1363,19 @@ function serializeDraftWithSkillTokens(
     // onto it, the transcript renders it back as a chip, and
     // hydrateComposerDraft rebuilds the token from a prompt-only restore.
     // Skills keep their `[$name](path)` markdown.
-    output += token.kind === "directory" || token.kind === "file"
-      ? buildDirectoryReferenceMarkdown({
-          label: token.name,
-          path: token.path ?? "",
-        })
-      : buildSkillMentionMarkdown(token);
+    if (token.kind === "directory" || token.kind === "file") {
+      output += buildDirectoryReferenceMarkdown({
+        label: token.name,
+        path: token.path ?? "",
+      });
+    } else if (token.kind === "thread") {
+      const ref = parseThreadUrl(token.path ?? "");
+      output += ref
+        ? buildThreadMarkdownLink({ ...ref, title: token.name })
+        : token.path ?? token.name;
+    } else {
+      output += buildSkillMentionMarkdown(token);
+    }
     cursor = index;
   }
 
@@ -2389,6 +2422,7 @@ function CopyableComposerError(props: {
 }
 
 export function Composer(props: ComposerProps) {
+  const threadLinks = useThreadLinks();
   const inputRef = useRef<ComposerInputHandle>(null);
   const inputWrapRef = useRef<HTMLDivElement>(null);
   const autocompleteListRef = useRef<HTMLDivElement>(null);
@@ -2874,6 +2908,7 @@ export function Composer(props: ComposerProps) {
       })),
       skillTokens: snapshot.skillTokens.map((token) => ({
         index: token.index,
+        kind: token.kind,
         name: token.name,
         path: token.path,
       })),
@@ -5498,6 +5533,51 @@ export function Composer(props: ComposerProps) {
     });
   };
 
+  const applyThreadReference = (thread: ResolvedThreadLink): void => {
+    if (!inputRef.current) {
+      return;
+    }
+
+    const selectionStart = Math.min(
+      inputRef.current.selectionStart ?? draft.length,
+      draft.length,
+    );
+    const selectionEnd = Math.min(
+      inputRef.current.selectionEnd ?? selectionStart,
+      draft.length,
+    );
+    const before = draft.slice(0, selectionStart);
+    const after = draft.slice(selectionEnd);
+    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
+    const nextDraft = `${before}${nextAfter}`;
+    const tokenIndex = before.length;
+    const nextSelection = tokenIndex + 1;
+    const nextSkillTokens = [
+      ...adjustSkillTokenIndexesForTextChange({
+        currentDraft: draft,
+        nextDraft,
+        skillTokens,
+      }),
+      createComposerThreadToken(thread, tokenIndex),
+    ];
+
+    pendingProgrammaticComposerChangeRef.current = {
+      expectedDraft: nextDraft,
+      expectedSkillTokensSignature:
+        getComposerSkillTokensSignature(nextSkillTokens),
+      staleDraft: draft,
+      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
+    };
+    flushSync(() => {
+      setSkillTokens(nextSkillTokens);
+      setDraft(nextDraft);
+    });
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
+    });
+  };
+
   /**
    * "@ → Add directory…" / "+"-menu action: run the OS picker (which also
    * registers the pick as a tracked directory, without navigating) and
@@ -5906,6 +5986,21 @@ export function Composer(props: ComposerProps) {
   };
 
   const handlePaste = (event: ClipboardEvent<HTMLElement>): void => {
+    // Browser DataTransfer always exposes getData. A few renderer tests use a
+    // deliberately file-only clipboard stub, so keep that path compatible too.
+    const pastedText = typeof event.clipboardData.getData === "function"
+      ? event.clipboardData.getData("text/plain").trim()
+      : "";
+    const pastedThread =
+      resolveThreadHref(pastedText, threadLinks)
+      ?? resolveThreadIdText(pastedText, threadLinks);
+    if (pastedThread) {
+      event.preventDefault();
+      setSendError(undefined);
+      applyThreadReference(pastedThread);
+      return;
+    }
+
     const pastedFiles = getImageFilesFromDataTransfer(event.clipboardData);
     // Non-image FILES only (kind === "file" items) — plain text paste
     // must fall through to the editor untouched.

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -89,6 +89,7 @@ import {
   resolveThreadIdText,
   useThreadLinks,
   type ResolvedThreadLink,
+  type ThreadLinkContextValue,
 } from "../../lib/thread-links";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
@@ -1386,6 +1387,7 @@ function serializeDraftWithSkillTokens(
 function hydrateComposerDraft(
   canonicalDraft: string,
   skills: AppServerSkillSummary[],
+  threadLinks: ThreadLinkContextValue | undefined,
 ): {
   draft: string;
   skillTokens: ComposerSkillToken[];
@@ -1393,44 +1395,64 @@ function hydrateComposerDraft(
   let draft = "";
   const skillTokens: ComposerSkillToken[] = [];
 
-  for (const part of parseSkillMentionParts(canonicalDraft)) {
-    if (part.type === "text") {
-      draft += part.text;
-      continue;
-    }
+  const hydrateSkillAndDirectoryParts = (text: string): void => {
+    for (const part of parseSkillMentionParts(text)) {
+      if (part.type === "text") {
+        draft += part.text;
+        continue;
+      }
 
-    if (part.type === "directory") {
-      // Serialized paths are percent-encoded tilde form; the token
-      // carries the decoded absolute path so send-time attach can use
-      // it directly. File-reference chips serialize to the same
-      // `[@label](~/path)` form, so a restored file chip degrades to a
-      // directory-kind chip here — acceptable: the outgoing text is
-      // identical either way.
+      if (part.type === "directory") {
+        // Serialized paths are percent-encoded tilde form; the token
+        // carries the decoded absolute path so send-time attach can use
+        // it directly. File-reference chips serialize to the same
+        // `[@label](~/path)` form, so a restored file chip degrades to a
+        // directory-kind chip here — acceptable: the outgoing text is
+        // identical either way.
+        skillTokens.push(
+          createComposerDirectoryToken(
+            {
+              label: part.name,
+              path: expandTildePath(decodeMarkdownDestination(part.path)),
+            },
+            draft.length,
+          ),
+        );
+        continue;
+      }
+
+      const matchingSkill =
+        skills.find((skill) => skill.path === part.path) ??
+        skills.find((skill) => skill.name === part.name);
       skillTokens.push(
-        createComposerDirectoryToken(
-          {
-            label: part.name,
-            path: expandTildePath(decodeMarkdownDestination(part.path)),
+        createComposerSkillToken(
+          matchingSkill ?? {
+            name: part.name,
+            path: part.path,
           },
           draft.length,
         ),
       );
-      continue;
     }
+  };
 
-    const matchingSkill =
-      skills.find((skill) => skill.path === part.path) ??
-      skills.find((skill) => skill.name === part.name);
-    skillTokens.push(
-      createComposerSkillToken(
-        matchingSkill ?? {
-          name: part.name,
-          path: part.path,
-        },
-        draft.length,
-      ),
-    );
+  // Thread titles may legitimately begin with `$` or `@`, so recognize the
+  // destination before passing surrounding Markdown through the skill and
+  // directory parser. Unknown thread links remain literal Markdown.
+  const threadLinkPattern = /\[((?:\\.|[^\]\\\r\n])*)\]\((pwragent:\/\/thread\/[^)\s]+)\)/gi;
+  let cursor = 0;
+  for (const match of canonicalDraft.matchAll(threadLinkPattern)) {
+    const matchIndex = match.index ?? 0;
+    hydrateSkillAndDirectoryParts(canonicalDraft.slice(cursor, matchIndex));
+    const resolvedThread = resolveThreadHref(match[2] ?? "", threadLinks);
+    if (resolvedThread) {
+      skillTokens.push(createComposerThreadToken(resolvedThread, draft.length));
+    } else {
+      draft += match[0];
+    }
+    cursor = matchIndex + match[0].length;
   }
+  hydrateSkillAndDirectoryParts(canonicalDraft.slice(cursor));
 
   return { draft, skillTokens };
 }
@@ -2463,7 +2485,11 @@ export function Composer(props: ComposerProps) {
   const hydratedInitialLaunchpad =
     savedInitialDraft || !props.launchpad
       ? undefined
-      : hydrateComposerDraft(props.launchpad.prompt ?? "", props.skills);
+      : hydrateComposerDraft(
+          props.launchpad.prompt ?? "",
+          props.skills,
+          threadLinks,
+        );
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
@@ -2757,7 +2783,7 @@ export function Composer(props: ComposerProps) {
   const setComposerDraftFromCanonical = (nextDraft: string): void => {
     deletedSkillTokenHistoryRef.current = [];
     setEditorDocument(undefined);
-    const hydrated = hydrateComposerDraft(nextDraft, props.skills);
+    const hydrated = hydrateComposerDraft(nextDraft, props.skills, threadLinks);
     setDraft(hydrated.draft);
     setSkillTokens(hydrated.skillTokens);
   };
@@ -3776,13 +3802,13 @@ export function Composer(props: ComposerProps) {
   useEffect(() => {
     deletedSkillTokenHistoryRef.current = [];
     if (skillTokens.length === 0 && draft.includes("](")) {
-      const hydrated = hydrateComposerDraft(draft, props.skills);
+      const hydrated = hydrateComposerDraft(draft, props.skills, threadLinks);
       if (hydrated.skillTokens.length > 0) {
         setDraft(hydrated.draft);
         setSkillTokens(hydrated.skillTokens);
       }
     }
-  }, [draft, props.skills, skillTokens.length]);
+  }, [draft, props.skills, skillTokens.length, threadLinks]);
 
   useEffect(() => {
     if (!autocompleteKind) {
@@ -5537,45 +5563,7 @@ export function Composer(props: ComposerProps) {
     if (!inputRef.current) {
       return;
     }
-
-    const selectionStart = Math.min(
-      inputRef.current.selectionStart ?? draft.length,
-      draft.length,
-    );
-    const selectionEnd = Math.min(
-      inputRef.current.selectionEnd ?? selectionStart,
-      draft.length,
-    );
-    const before = draft.slice(0, selectionStart);
-    const after = draft.slice(selectionEnd);
-    const nextAfter = /^\s/.test(after) ? after : ` ${after}`;
-    const nextDraft = `${before}${nextAfter}`;
-    const tokenIndex = before.length;
-    const nextSelection = tokenIndex + 1;
-    const nextSkillTokens = [
-      ...adjustSkillTokenIndexesForTextChange({
-        currentDraft: draft,
-        nextDraft,
-        skillTokens,
-      }),
-      createComposerThreadToken(thread, tokenIndex),
-    ];
-
-    pendingProgrammaticComposerChangeRef.current = {
-      expectedDraft: nextDraft,
-      expectedSkillTokensSignature:
-        getComposerSkillTokensSignature(nextSkillTokens),
-      staleDraft: draft,
-      staleSkillTokensSignature: getComposerSkillTokensSignature(skillTokens),
-    };
-    flushSync(() => {
-      setSkillTokens(nextSkillTokens);
-      setDraft(nextDraft);
-    });
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(nextSelection, nextSelection);
-    });
+    inputRef.current.insertMentionToken(createComposerThreadToken(thread, 0));
   };
 
   /**

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -13,11 +13,14 @@ import type { AppServerSkillSummary } from "@pwragent/shared";
  *   - file references (`kind: "file"`): `name` is the file's basename and
  *     `path` its absolute file path; serializes to the same
  *     `[@label](~/path)` markdown as directory references.
+ *   - thread references (`kind: "thread"`): `name` is the resolved thread
+ *     title and `path` its canonical `pwragent://thread/...` URL; serializes
+ *     to the same Markdown link the transcript recognizes as a thread chip.
  */
 export type ComposerSkillToken = AppServerSkillSummary & {
   id: string;
   index: number;
-  kind?: "directory" | "file";
+  kind?: "directory" | "file" | "thread";
 };
 
 export type ComposerInputChangeMetadata = {

--- a/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerInputTypes.ts
@@ -30,6 +30,7 @@ export type ComposerInputChangeMetadata = {
 export type ComposerInputHandle = {
   deleteSelection: () => void;
   focus: () => void;
+  insertMentionToken: (token: ComposerSkillToken) => boolean;
   readonly selectionEnd: number;
   readonly selectionStart: number;
   readonly skillTokenCount: number;

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1802,6 +1802,50 @@ function closeEditorHistory(editor: TiptapEditor): void {
   editor.view.dispatch(closeHistory(editor.state.tr));
 }
 
+function getSelectionDraftRange(
+  editor: TiptapEditor,
+  readMode: TiptapReadMode,
+): { end: number; start: number } {
+  return {
+    end: getDraftIndexAtPosition(
+      editor,
+      editor.state.selection.to,
+      readMode,
+    ),
+    start: getDraftIndexAtPosition(
+      editor,
+      editor.state.selection.from,
+      readMode,
+    ),
+  };
+}
+
+function insertMentionTokenAtSelection(params: {
+  editor: TiptapEditor;
+  readMode: TiptapReadMode;
+  token: ComposerSkillToken;
+}): boolean {
+  const { editor, readMode, token } = params;
+  const { from, to } = editor.state.selection;
+  const current = readTiptapContent(editor, readMode);
+  const selection = getSelectionDraftRange(editor, readMode);
+  const insertedContent: JSONContent[] = [
+    {
+      type: "mention",
+      attrs: getSkillMentionAttrs(token),
+    },
+  ];
+  if (!/^\s/.test(current.value.slice(selection.end))) {
+    insertedContent.push({ type: "text", text: " " });
+  }
+
+  return editor.commands.insertContentAt(
+    { from, to },
+    insertedContent,
+    { updateSelection: true },
+  );
+}
+
 function applyExternalSkillInsertion(params: {
   current: TiptapReadState;
   editor: TiptapEditor;
@@ -2364,11 +2408,11 @@ export const ComposerTiptapInput = forwardRef<
     });
     Object.defineProperty(editorDom, "selectionStart", {
       configurable: true,
-      get: () => selectionIndexRef.current,
+      get: () => getSelectionDraftRange(editor, readMode).start,
     });
     Object.defineProperty(editorDom, "selectionEnd", {
       configurable: true,
-      get: () => selectionIndexRef.current,
+      get: () => getSelectionDraftRange(editor, readMode).end,
     });
     Object.defineProperty(editorDom, "setSelectionRange", {
       configurable: true,
@@ -2557,11 +2601,21 @@ export const ComposerTiptapInput = forwardRef<
       }
       editor?.commands.focus();
     },
+    insertMentionToken: (token) => {
+      if (!editor) {
+        return false;
+      }
+      return insertMentionTokenAtSelection({ editor, readMode, token });
+    },
     get selectionEnd() {
-      return selectionIndexRef.current;
+      return editor
+        ? getSelectionDraftRange(editor, readMode).end
+        : selectionIndexRef.current;
     },
     get selectionStart() {
-      return selectionIndexRef.current;
+      return editor
+        ? getSelectionDraftRange(editor, readMode).start
+        : selectionIndexRef.current;
     },
     get skillTokenCount() {
       return editor

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -125,6 +125,51 @@ const SkillMention = Mention.extend({
     class: "chip skill-chip composer-tiptap-input__mention",
   },
   renderHTML: ({ node }) => {
+    if (node.attrs.kind === "thread") {
+      const label = String(node.attrs.name ?? "thread");
+      const path = typeof node.attrs.path === "string" ? node.attrs.path : "";
+      return [
+        "span",
+        {
+          class: "chip thread-chip composer-tiptap-input__mention",
+          "data-type": "mention",
+          "data-mention-kind": "thread",
+          "data-composer-skill-token-id": String(node.attrs.id ?? ""),
+          "data-id": String(node.attrs.id ?? ""),
+          "data-label": label,
+          "data-skill-name": label,
+          "data-thread-chip": "",
+          ...(path ? { "data-skill-path": path } : {}),
+          ...(path ? { "data-tooltip": `${label}\n${path}` } : {}),
+        },
+        // Tiptap DOM specs cannot render React components. Keep these paths
+        // in sync with the canonical ThreadIcon used by transcript chips.
+        [
+          "http://www.w3.org/2000/svg svg",
+          {
+            "aria-hidden": "true",
+            class: "thread-chip__icon",
+            fill: "none",
+            height: "1em",
+            stroke: "currentColor",
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+            "stroke-width": "2",
+            viewBox: "0 0 24 24",
+            width: "1em",
+          },
+          [
+            "path",
+            {
+              d: "M20 14a2 2 0 0 1-2 2H8l-4 3.5V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2Z",
+            },
+          ],
+          ["path", { d: "M8 8.5h8" }],
+          ["path", { d: "M8 12h5" }],
+        ],
+        ["span", { class: "thread-chip__label" }, label],
+      ];
+    }
     if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
       // Directory-reference chip: `name` is the tracked directory's
       // label, `path` its absolute path. File-reference chips are the
@@ -180,10 +225,15 @@ const SkillMention = Mention.extend({
       `$${skill.name}`,
     ];
   },
-  renderText: ({ node }) =>
-    node.attrs.kind === "directory" || node.attrs.kind === "file"
-      ? tildifyPath(String(node.attrs.path ?? node.attrs.name ?? ""))
-      : `$${String(node.attrs.name ?? node.attrs.id ?? "")}`,
+  renderText: ({ node }) => {
+    if (node.attrs.kind === "thread") {
+      return String(node.attrs.path ?? node.attrs.name ?? "");
+    }
+    if (node.attrs.kind === "directory" || node.attrs.kind === "file") {
+      return tildifyPath(String(node.attrs.path ?? node.attrs.name ?? ""));
+    }
+    return `$${String(node.attrs.name ?? node.attrs.id ?? "")}`;
+  },
   suggestion: {
     char: "\uFFFF",
     items: () => [],
@@ -835,6 +885,12 @@ function mentionAttrsToSkill(
   index: number,
 ): ComposerSkillToken {
   const name = typeof attrs.name === "string" ? attrs.name : String(attrs.id ?? "skill");
+  const kind =
+    attrs.kind === "directory"
+    || attrs.kind === "file"
+    || attrs.kind === "thread"
+      ? attrs.kind
+      : undefined;
   return {
     id: typeof attrs.id === "string" ? attrs.id : `${name}:${index}`,
     index,
@@ -846,11 +902,7 @@ function mentionAttrsToSkill(
       typeof attrs.shortDescription === "string"
         ? attrs.shortDescription
         : undefined,
-    ...(attrs.kind === "directory"
-      ? { kind: "directory" as const }
-      : attrs.kind === "file"
-        ? { kind: "file" as const }
-        : {}),
+    ...(kind ? { kind } : {}),
   };
 }
 
@@ -2468,6 +2520,15 @@ export const ComposerTiptapInput = forwardRef<
                 ? buildFileReferenceTooltip(path)
                 : buildDirectoryReferenceTooltip(path),
             );
+          }
+          return;
+        }
+        if (attrs["data-mention-kind"] === "thread") {
+          const label =
+            attrs["data-skill-name"] || node.textContent || "Thread";
+          const path = attrs["data-skill-path"];
+          if (path) {
+            node.setAttribute("data-tooltip", `${label}\n${path}`);
           }
           return;
         }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12492,6 +12492,265 @@ describe("Composer", () => {
     });
   });
 
+  it("replaces the selected composer text with a pasted thread chip", async () => {
+    const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: targetThreadId,
+      title: "Lovely child thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <ThreadLinkProvider
+        onShowThread={() => undefined}
+        threads={[currentThread, targetThread]}
+      >
+        <Composer
+          desktopApi={{ onAgentEvent: () => () => undefined }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, { target: { value: "keep replace tail" } });
+    const textNode = textbox.querySelector("p")?.firstChild;
+    expect(textNode).toBeInstanceOf(Text);
+    textbox.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(textNode!, 5);
+    range.setEnd(textNode!, 12);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => type === "text/plain" ? targetThreadId : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(textbox).toHaveValue("keep  tail");
+      expect(
+        within(textbox)
+          .getByText("Lovely child thread")
+          .closest("[data-mention-kind]"),
+      ).toHaveAttribute(
+        "data-mention-kind",
+        "thread",
+      );
+    });
+    expect(textbox).not.toHaveTextContent("replace");
+  });
+
+  it("preserves rich composer blocks and marks when pasting a thread chip", async () => {
+    const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: targetThreadId,
+      title: "Lovely child thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const draftStore = createComposerDraftStore();
+    draftStore.set("thread:codex:thread-1", {
+      draft: "## Heading\n\n- List item\n\n**keep bold** replace me",
+      editorDocument: {
+        type: "doc",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Heading" }],
+          },
+          {
+            type: "bulletList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "List item" }],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "keep bold",
+                marks: [{ type: "bold" }],
+              },
+              { type: "text", text: " replace me" },
+            ],
+          },
+        ],
+      },
+      imageAttachments: [],
+      skillTokens: [],
+    });
+
+    render(
+      <ThreadLinkProvider
+        onShowThread={() => undefined}
+        threads={[currentThread, targetThread]}
+      >
+        <Composer
+          composerImplementation="tiptap-wysiwyg-markdown-chips"
+          desktopApi={{ onAgentEvent: () => () => undefined }}
+          disabled={false}
+          draftStore={draftStore}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    const finalParagraph = textbox.querySelectorAll("p").item(1);
+    const replaceTextNode = finalParagraph.lastChild;
+    expect(replaceTextNode).toBeInstanceOf(Text);
+    textbox.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(replaceTextNode!, 1);
+    range.setEnd(replaceTextNode!, " replace me".length);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.dispatchEvent(new Event("selectionchange"));
+
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => type === "text/plain" ? targetThreadId : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(within(textbox).getByText("Lovely child thread")).toBeInTheDocument();
+    });
+    expect(textbox.querySelector("h2")).toHaveTextContent("Heading");
+    expect(textbox.querySelector("ul li")).toHaveTextContent("List item");
+    expect(textbox.querySelector("strong")).toHaveTextContent("keep bold");
+    expect(textbox).not.toHaveTextContent("replace me");
+  });
+
+  it("rehydrates an edited pending thread link as a thread chip", async () => {
+    const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: targetThreadId,
+      title: "$Lovely child thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <ThreadLinkProvider
+        onShowThread={() => undefined}
+        threads={[currentThread, targetThread]}
+      >
+        <Composer
+          activeTurnId="turn-1"
+          backends={[
+            {
+              ...backendSummary("codex", {
+                models: [
+                  {
+                    id: "gpt-5.5",
+                    label: "GPT-5.5",
+                    current: true,
+                    supportsReasoning: true,
+                    supportsSteering: true,
+                  },
+                ],
+              }),
+              capabilities: {
+                ...backendSummary("codex").capabilities,
+                steerTurn: true,
+              },
+            },
+          ]}
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            steerTurn: vi.fn(),
+          }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.paste(textbox, {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => type === "text/plain" ? targetThreadId : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+    fireEvent.keyDown(textbox, { key: "Enter", metaKey: true });
+
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    await waitFor(() => {
+      expect(
+        within(textbox)
+          .getByText("$Lovely child thread")
+          .closest("[data-mention-kind]"),
+      ).toHaveAttribute(
+        "data-mention-kind",
+        "thread",
+      );
+    });
+    expect(textbox).toHaveValue(" ");
+  });
+
   it("leaves an unknown pasted thread-shaped id as plain text", async () => {
     const currentThread: NavigationThreadSummary = {
       id: "thread-1",

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -17,6 +17,7 @@ import type { JSONContent } from "@tiptap/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { normalizeImageFile } from "../../../lib/image-normalization";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { Composer } from "../Composer";
 import type {
   ComposerDraftSnapshot,
@@ -12399,6 +12400,137 @@ describe("Composer", () => {
         ],
       });
     });
+  });
+
+  it.each([
+    "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+    "pwragent://thread/019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+  ])("chipifies a pasted known thread reference and sends its canonical link: %s", async (
+    pastedReference,
+  ) => {
+    const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: targetThreadId,
+      title: "Lovely child thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const startTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: currentThread.id,
+      turnId: "turn-1",
+    }));
+
+    render(
+      <ThreadLinkProvider
+        onShowThread={() => undefined}
+        threads={[currentThread, targetThread]}
+      >
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        getData: (type: string) =>
+          type === "text/plain" ? pastedReference : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+
+    const richInput = screen.getByTestId("composer-tiptap-input");
+    const chip = await waitFor(() => {
+      const currentChip = within(richInput)
+        .getByText("Lovely child thread")
+        .closest("[data-mention-kind]");
+      expect(currentChip).toHaveAttribute(
+        "data-mention-kind",
+        "thread",
+      );
+      return currentChip;
+    });
+    expect(chip).toHaveAttribute(
+      "data-skill-path",
+      `pwragent://thread/${targetThreadId}?backend=codex`,
+    );
+    expect(chip?.querySelector("svg")).toHaveAttribute("viewBox", "0 0 24 24");
+    expect(screen.getByLabelText("Reply")).toHaveValue(" ");
+
+    await clickButton("Send");
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: currentThread.id,
+        input: [
+          {
+            type: "text",
+            text: `[Lovely child thread](pwragent://thread/${targetThreadId}?backend=codex)`,
+          },
+        ],
+      });
+    });
+  });
+
+  it("leaves an unknown pasted thread-shaped id as plain text", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    render(
+      <ThreadLinkProvider
+        onShowThread={() => undefined}
+        threads={[currentThread]}
+      >
+        <Composer
+          desktopApi={{ onAgentEvent: () => () => undefined }}
+          disabled={false}
+          skills={[]}
+          thread={currentThread}
+        />
+      </ThreadLinkProvider>,
+    );
+
+    const unknownId = "019f0000-0000-7000-8000-000000000000";
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => type === "text/plain" ? unknownId : "",
+        items: [],
+        types: ["text/plain"],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Reply")).toHaveValue(unknownId);
+    });
+    expect(
+      screen.getByTestId("composer-tiptap-input").querySelector(".thread-chip"),
+    ).not.toBeInTheDocument();
   });
 
   it("sends the reply when Enter is pressed without Shift", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -430,6 +430,7 @@ function hashDraftContent(snapshot: ComposerDraftSnapshot): string {
     skillTokens: snapshot.skillTokens.map((token) => ({
       id: token.id,
       index: token.index,
+      kind: token.kind,
       name: token.name,
       path: token.path,
     })),

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -14315,6 +14315,10 @@ a.transcript-message__messaging-origin:focus-visible {
   vertical-align: 0.13em;
 }
 
+.composer-tiptap-input__mention.thread-chip {
+  cursor: default;
+}
+
 .composer__mentioned-skills {
   display: flex;
   flex-wrap: wrap;

--- a/packages/shared/src/contracts/composer-drafts.ts
+++ b/packages/shared/src/contracts/composer-drafts.ts
@@ -29,9 +29,11 @@ export type ComposerDraftSkillToken = {
    * composer directory-reference chip: `name` is the tracked directory's
    * label and `path` its absolute path. "file" marks a file-reference
    * chip: `name` is the file's basename and `path` its absolute file
-   * path. Both serialize to the same `[@label](~/path)` markdown.
+   * path. Both serialize to the same `[@label](~/path)` markdown. "thread"
+   * marks a known-thread reference: `name` is its display title and `path`
+   * is its canonical `pwragent://thread/...` URL.
    */
-  kind?: "directory" | "file";
+  kind?: "directory" | "file" | "thread";
 };
 
 export type ComposerDraftSnapshotRecord = {


### PR DESCRIPTION
## Summary

- convert pasted known thread UUIDs and `pwragent://thread/...` URLs into atomic composer chips
- reuse the transcript thread chip's title, icon, accent styling, and canonical Markdown link
- preserve thread chips through durable draft state and serialize them into outgoing messages
- leave unknown thread-shaped UUIDs and unresolved URLs as ordinary text
- retain existing file and image paste behavior

## Why

Known thread references already become friendly chips after a message is sent, but remained raw text while composing. This closes that visual and interaction gap while keeping hydration gated on a thread that exists in the current profile.

## User impact

Pasting a known thread UUID or PwrAgent thread URL now immediately shows the resolved thread title as a composer chip. The chip deletes and restores atomically through the existing mention-token mechanics, and the sent transcript receives the canonical thread link.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx` — 243 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing baseline warnings only
- `pnpm lint:boundaries`
- `git diff --check`
