### PR TITLE
fix(desktop): prevent duplicate steering messages

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -196,6 +196,7 @@ describe("agent ipc", () => {
         threadId: "thread-1",
         expectedTurnId: "turn-1",
         input: [{ type: "text", text: "Course correct" }],
+        requestId: "steer-1",
       }),
     ).toEqual({
       backend: "codex",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13682,10 +13682,82 @@ command = "pnpm dev"
         threadId: "thread-1",
         expectedTurnId: "turn-0",
         input: [{ type: "text", text: "Course correct" }],
+        requestId: "steer-error-1",
       }),
     ).rejects.toThrow("expected active turn id `turn-0` but found `turn-1`");
 
     expect(codexClient.steerTurnCallCount).toBe(1);
+
+    await registry.close();
+  });
+
+  it("coalesces concurrent identical steer requests before they reach the backend", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/steer"] },
+    });
+    const steerDeferred = createDeferred<{ threadId: string; turnId: string }>();
+    const steerSpy = vi
+      .spyOn(codexClient, "steerTurn")
+      .mockImplementation(async () => await steerDeferred.promise);
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock({ executionMode: "full-access" }),
+    });
+    const request = {
+      backend: "codex" as const,
+      threadId: "thread-1",
+      expectedTurnId: "turn-1",
+      input: [{ type: "text" as const, text: "Course correct once" }],
+      requestId: "steer-once-1",
+    };
+
+    const responses = [
+      registry.steerTurn(request),
+      registry.steerTurn(request),
+      registry.steerTurn(request),
+    ];
+    await flushAsync();
+
+    expect(steerSpy).toHaveBeenCalledTimes(1);
+
+    steerDeferred.resolve({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(Promise.all(responses)).resolves.toEqual([
+      { backend: "codex", threadId: "thread-1", turnId: "turn-1" },
+      { backend: "codex", threadId: "thread-1", turnId: "turn-1" },
+      { backend: "codex", threadId: "thread-1", turnId: "turn-1" },
+    ]);
+    await expect(registry.steerTurn(request)).resolves.toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(steerSpy).toHaveBeenCalledTimes(1);
+
+    await expect(
+      registry.steerTurn({
+        ...request,
+        input: [{ type: "text", text: "Different input" }],
+      }),
+    ).rejects.toThrow("steer-once-1 was reused with different input");
+    expect(steerSpy).toHaveBeenCalledTimes(1);
+
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          output: [],
+        },
+      },
+    });
+    await registry.steerTurn(request);
+    expect(steerSpy).toHaveBeenCalledTimes(2);
 
     await registry.close();
   });
@@ -13719,6 +13791,7 @@ command = "pnpm dev"
         threadId: "thread-1",
         expectedTurnId: "turn-1",
         input: [{ type: "text", text: "Course correct from messaging" }],
+        requestId: "messaging-steer-1",
       },
       { kind: "messaging" },
     );

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -10402,6 +10402,7 @@ describe("MessagingController", () => {
       backend: "codex",
       threadId: "thread-1",
       expectedTurnId: "turn-live",
+      requestId: expect.any(String),
       input: [
         {
           type: "text",
@@ -10581,6 +10582,7 @@ describe("MessagingController", () => {
       backend: "codex",
       threadId: "thread-1",
       expectedTurnId: "turn-1",
+      requestId: expect.any(String),
       input: [
         {
           type: "text",

--- a/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-turn-admission.test.ts
@@ -118,6 +118,29 @@ describe("MessagingTurnAdmission", () => {
     });
     expect(admission.shiftNextQueued(threadKey)).toBeUndefined();
   });
+
+  it("assigns queued IDs uniquely across independent admissions", () => {
+    const binding = buildBinding();
+    const buildAdmission = () => new MessagingTurnAdmission({
+      debounceMs: 0,
+      now: () => 1000,
+      onBundleReady: vi.fn(),
+    });
+    const firstAdmission = buildAdmission();
+    const secondAdmission = buildAdmission();
+    const enqueue = (admission: MessagingTurnAdmission, text: string) =>
+      admission.enqueue({
+        binding,
+        input: [{ type: "text", text }],
+        preview: text,
+        threadKey: threadKeyForBinding(binding),
+      });
+
+    const first = enqueue(firstAdmission, "from telegram");
+    const second = enqueue(secondAdmission, "from discord");
+
+    expect(first.id).not.toBe(second.id);
+  });
 });
 
 function buildBinding(): MessagingBindingRecord {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,6 +1,6 @@
 import { app } from "electron";
 import { execFile as execFileCallback } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { realpath, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -5457,6 +5457,40 @@ type PendingThreadMessageOrigin = {
   turnId?: string;
 };
 
+type AcceptedSteerRequest = {
+  promise: Promise<SteerTurnResponse>;
+  signature: string;
+};
+
+function buildSteerRequestKey(params: SteerTurnRequest): string {
+  return [
+    params.backend,
+    params.threadId,
+    params.expectedTurnId,
+    params.requestId,
+  ].join("\u0000");
+}
+
+function buildSteerTurnKeyPrefix(params: {
+  backend: AppServerBackendKind;
+  threadId: string;
+  turnId: string;
+}): string {
+  return [params.backend, params.threadId, params.turnId, ""].join("\u0000");
+}
+
+function buildSteerRequestSignature(
+  params: SteerTurnRequest,
+  messageOrigin?: AppServerThreadMessageOrigin,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      input: params.input,
+      messageOrigin: messageOrigin ?? null,
+    }))
+    .digest("hex");
+}
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -5534,6 +5568,13 @@ export class DesktopBackendRegistry {
   private readonly pendingThreadMessageOrigins = new Map<
     string,
     PendingThreadMessageOrigin
+  >();
+  // Keep accepted requests through the active turn, not just while the RPC is
+  // in flight. The backend can acknowledge a steer before its user item is
+  // observed, and completion signals in that window must not resubmit it.
+  private readonly acceptedSteerRequests = new Map<
+    string,
+    AcceptedSteerRequest
   >();
   private readonly activeCodexTurnModes = new Map<string, ThreadExecutionMode>();
   private readonly activeCodexReviewTurnKeys = new Set<string>();
@@ -10549,6 +10590,34 @@ export class DesktopBackendRegistry {
     params: SteerTurnRequest,
     messageOrigin?: AppServerThreadMessageOrigin,
   ): Promise<SteerTurnResponse> {
+    const requestKey = buildSteerRequestKey(params);
+    const signature = buildSteerRequestSignature(params, messageOrigin);
+    const accepted = this.acceptedSteerRequests.get(requestKey);
+    if (accepted) {
+      if (accepted.signature !== signature) {
+        throw new Error(
+          `Steer request id ${params.requestId} was reused with different input`,
+        );
+      }
+      return await accepted.promise;
+    }
+
+    const promise = this.submitSteerTurn(params, messageOrigin);
+    this.acceptedSteerRequests.set(requestKey, { promise, signature });
+    try {
+      return await promise;
+    } catch (error) {
+      if (this.acceptedSteerRequests.get(requestKey)?.promise === promise) {
+        this.acceptedSteerRequests.delete(requestKey);
+      }
+      throw error;
+    }
+  }
+
+  private async submitSteerTurn(
+    params: SteerTurnRequest,
+    messageOrigin?: AppServerThreadMessageOrigin,
+  ): Promise<SteerTurnResponse> {
     const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
       backend: params.backend,
       threadId: params.threadId,
@@ -13328,6 +13397,7 @@ export class DesktopBackendRegistry {
 
   async close(): Promise<void> {
     this.closed = true;
+    this.acceptedSteerRequests.clear();
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }
@@ -22627,6 +22697,16 @@ export class DesktopBackendRegistry {
         this.activeTurnKeys.delete(
           buildActiveTurnKey(event.backend, notification.params.threadId, turnId),
         );
+        const steerKeyPrefix = buildSteerTurnKeyPrefix({
+          backend: event.backend,
+          threadId: notification.params.threadId,
+          turnId,
+        });
+        for (const key of this.acceptedSteerRequests.keys()) {
+          if (key.startsWith(steerKeyPrefix)) {
+            this.acceptedSteerRequests.delete(key);
+          }
+        }
       }
       if (event.backend === "codex" && turnId) {
         const activeTurnModeKey = buildActiveTurnModeKey(

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -501,6 +501,7 @@ export function registerAgentIpcHandlers(): void {
         backend: request.backend,
         threadId: request.threadId,
         expectedTurnId: request.expectedTurnId,
+        requestId: request.requestId,
         ...summarizeTurnInput(request.input),
       });
 
@@ -511,6 +512,7 @@ export function registerAgentIpcHandlers(): void {
           backend: request.backend,
           threadId: request.threadId,
           expectedTurnId: request.expectedTurnId,
+          requestId: request.requestId,
           error: error instanceof Error ? error.message : String(error),
         });
         throw error;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -3326,6 +3326,7 @@ export class MessagingController {
         threadId: entry.binding.threadId,
         expectedTurnId: activeTurn.turnId,
         input: entry.input,
+        requestId: entry.id,
         messageOrigin: messageOriginForInboundEvent(entry.event),
       });
     } catch (error) {

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type {
   AppServerTurnInputItem,
 } from "@pwragent/shared";
@@ -117,7 +118,7 @@ export class MessagingTurnAdmission {
     const queued: MessagingQueuedTurnEntry = {
       ...entry,
       createdAt: now,
-      id: `queued:${++this.sequence}`,
+      id: `queued:${randomUUID()}`,
       status: "queued",
       updatedAt: now,
     };

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2514,6 +2514,10 @@ export function Composer(props: ComposerProps) {
   };
   const [interrupting, setInterrupting] = useState(false);
   const [steering, setSteering] = useState(false);
+  // React state only drives presentation. This ref synchronously suppresses
+  // duplicate renderer calls; the registry request ID provides the durable
+  // idempotency boundary shared with messaging.
+  const steeringRequestIdRef = useRef<string | undefined>(undefined);
   const [queuedTurns, setQueuedTurnsState] = useState<QueuedTurnDraft[]>(
     savedInitialQueuedTurns ?? []
   );
@@ -3680,6 +3684,7 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
+    steeringRequestIdRef.current = undefined;
     setScheduleMenuOpen(false);
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
@@ -3875,6 +3880,7 @@ export function Composer(props: ComposerProps) {
       updateSending(false);
       setInterrupting(false);
       setSteering(false);
+      steeringRequestIdRef.current = undefined;
     }
   }, [props.activeTurnId]);
 
@@ -4012,6 +4018,9 @@ export function Composer(props: ComposerProps) {
         event.notification.method === "item/completed" &&
         notificationIncludesDraftContent(event.notification.params, pendingSteer)
       ) {
+        if (steeringRequestIdRef.current === pendingSteer.id) {
+          steeringRequestIdRef.current = undefined;
+        }
         setPendingSteer(undefined);
         setSteering(false);
         props.onPendingStatusChange?.("Thinking");
@@ -4077,6 +4086,7 @@ export function Composer(props: ComposerProps) {
         updateSending(false);
         setInterrupting(false);
         setSteering(false);
+        steeringRequestIdRef.current = undefined;
         if (pendingSteer?.status === "pending") {
           if (queuedTurn) {
             setComposerDraftFromCanonical(pendingSteer.text);
@@ -4118,6 +4128,7 @@ export function Composer(props: ComposerProps) {
         updateSending(false);
         setInterrupting(false);
         setSteering(false);
+        steeringRequestIdRef.current = undefined;
         setPendingSteer(undefined);
         updateActiveTurnId(undefined);
         props.onActiveTurnIdChange?.(undefined);
@@ -4970,10 +4981,15 @@ export function Composer(props: ComposerProps) {
       pending.imageAttachments,
       pending.fileAttachments,
     );
-    if (payload.input.length === 0 || props.disabled || steering) {
+    if (
+      payload.input.length === 0 ||
+      props.disabled ||
+      steeringRequestIdRef.current !== undefined
+    ) {
       return;
     }
 
+    steeringRequestIdRef.current = pending.id;
     setSendError(undefined);
     setSteering(true);
     updatePendingSteer((current) =>
@@ -4989,8 +5005,12 @@ export function Composer(props: ComposerProps) {
         threadId: props.thread.id,
         expectedTurnId: turnId,
         input: payload.input,
+        requestId: pending.id,
       });
     } catch (error) {
+      if (steeringRequestIdRef.current === pending.id) {
+        steeringRequestIdRef.current = undefined;
+      }
       const staleSteer = parseStaleSteerError(error);
       if (staleSteer) {
         if (queuedTurn) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4304,6 +4304,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         expectedTurnId: "turn-1",
         input: [{ type: "text", text: "Change direction" }],
+        requestId: expect.any(String),
       });
     });
     expect(screen.getByText("Steering now")).toBeInTheDocument();
@@ -4440,6 +4441,7 @@ describe("Composer", () => {
             url: expect.stringMatching(/^data:image\/png;base64,/),
           },
         ],
+        requestId: expect.any(String),
       });
     });
     expect(screen.getByText("Steering now")).toBeInTheDocument();
@@ -4594,6 +4596,7 @@ describe("Composer", () => {
         threadId: "thread-1",
         expectedTurnId: "turn-1",
         input: [{ type: "text", text: "Keep steering direction" }],
+        requestId: expect.any(String),
       });
     });
   });
@@ -4919,6 +4922,118 @@ describe("Composer", () => {
     expect(screen.getByText("Pending steer")).toBeInTheDocument();
     expect(screen.getByText("Change direction")).toBeInTheDocument();
     expect(screen.getByText("steer failed")).toBeInTheDocument();
+  });
+
+  it("submits one steer when multiple injection opportunities arrive together", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const steerDeferred = createDeferred<{
+      backend: "codex";
+      threadId: string;
+      turnId: string;
+    }>();
+    const steerTurn = vi.fn(() => steerDeferred.promise);
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex", {
+              models: [
+                {
+                  id: "gpt-5.5",
+                  label: "GPT-5.5",
+                  current: true,
+                  supportsReasoning: true,
+                  supportsSteering: true,
+                },
+              ],
+            }),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          onAgentEvent: (callback) => {
+            agentEventHandler = callback as typeof agentEventHandler;
+            return () => undefined;
+          },
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Steer collision",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Change direction once" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), {
+      key: "Enter",
+      metaKey: true,
+    });
+
+    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: { type: "commandExecution" },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "exec_command/ended",
+          params: { threadId: "thread-1" },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            item: { type: "commandExecution" },
+          },
+        },
+      });
+    });
+
+    expect(steerTurn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      steerDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      });
+      await steerDeferred.promise;
+    });
   });
 
   it("sends a pending steer as the next turn when Codex reports no active turn", async () => {

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -299,6 +299,7 @@ export type SteerTurnRequest = {
   threadId: ThreadIdentifier;
   input: AppServerTurnInputItem[];
   expectedTurnId: string;
+  requestId: string;
 };
 
 export type SteerTurnResponse = {


### PR DESCRIPTION
## Summary

- add stable request IDs to steering submissions from both the desktop composer and messaging
- make the shared backend registry coalesce identical steering requests through turn completion
- keep React state presentation-only while using a synchronous renderer guard to suppress redundant IPC calls
- reject request ID reuse with different input and allow retries after failed submissions

## Root cause

The composer used asynchronous React state as the submission lock. When several completion notifications arrived in the same render window, each callback observed the same stale state and submitted the pending steering message again. In the reported session, that produced three distinct backend submissions and three transcript entries.

## Impact

A queued steering message is now delivered at most once per stable request ID, regardless of whether it originates in the desktop UI or a messaging integration. Correctness is enforced below React at the shared backend boundary.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` — 208 passed
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` — 404 passed
- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` — 321 passed
- agent IPC tests passed
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `git diff --check`
