### PR TITLE
fix(desktop): keep subagent details dialog open

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -151,6 +151,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const railRef = useRef<HTMLElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const [revealed, setRevealed] = useState(false);
+  // A modal portaled to document.body is outside the rail in DOM and pointer
+  // geometry, but remains part of the same interaction. Keep the panel
+  // mounted while it is open so its own hover-dismissal cannot destroy it.
+  const [portaledInteractionOpen, setPortaledInteractionOpen] = useState(false);
   // Width is owned by ThreadView (single source of truth). Used only for the
   // resize delta math here; the rendered width comes from the inherited
   // `--context-rail-effective` custom property. No local copy → no desync.
@@ -165,10 +169,13 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     top?: number;
   }>();
   const pinned = props.pinned;
-  const open = pinned || revealed;
+  const open = pinned || revealed || portaledInteractionOpen;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const revealTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const revealIntentRef = useRef(0);
+  // The ref synchronously guards timers and in-flight cursor polls that were
+  // created by the previous render before the state update commits.
+  const portaledInteractionOpenRef = useRef(false);
   const lastMousePositionRef = useRef<{ x: number; y: number } | undefined>(undefined);
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
   const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
@@ -251,6 +258,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
   const hideRailNow = useCallback(() => {
     clearTimeout(hideTimerRef.current);
+    if (portaledInteractionOpenRef.current) {
+      outsideRailSinceRef.current = undefined;
+      return;
+    }
     clearRevealTimer();
     outsideRailSinceRef.current = undefined;
     setRevealed(false);
@@ -297,7 +308,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     (point?: { x: number; y: number }) => {
       clearTimeout(hideTimerRef.current);
       clearRevealTimer();
+      if (portaledInteractionOpenRef.current) {
+        outsideRailSinceRef.current = undefined;
+        return;
+      }
       hideTimerRef.current = setTimeout(() => {
+        if (portaledInteractionOpenRef.current) {
+          outsideRailSinceRef.current = undefined;
+          return;
+        }
         const latestPoint = lastMousePositionRef.current ?? point;
         if (latestPoint && isMouseInsideRail(latestPoint)) {
           return;
@@ -307,6 +326,20 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       }, 300);
     },
     [clearRevealTimer, hideRailNow, isMouseInsideRail]
+  );
+
+  const handlePortaledInteractionChange = useCallback(
+    (nextOpen: boolean) => {
+      portaledInteractionOpenRef.current = nextOpen;
+      setPortaledInteractionOpen(nextOpen);
+      if (nextOpen) {
+        clearTimeout(hideTimerRef.current);
+        clearRevealTimer();
+        outsideRailSinceRef.current = undefined;
+        setRevealed(true);
+      }
+    },
+    [clearRevealTimer],
   );
 
   useEffect(() => {
@@ -329,6 +362,12 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       };
       lastMousePositionRef.current = point;
 
+      if (portaledInteractionOpenRef.current) {
+        clearTimeout(hideTimerRef.current);
+        outsideRailSinceRef.current = undefined;
+        return;
+      }
+
       if (isMouseInsideRail(point)) {
         outsideRailSinceRef.current = undefined;
         return;
@@ -345,7 +384,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
 
   useEffect(() => {
     const readPointerSnapshot = props.desktopApi?.getWindowPointerSnapshot;
-    if (pinned || !revealed || !readPointerSnapshot) {
+    if (pinned || !revealed || portaledInteractionOpen || !readPointerSnapshot) {
       return;
     }
 
@@ -388,6 +427,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     hideRailNow,
     isScreenCursorInsideRail,
     pinned,
+    portaledInteractionOpen,
     props.desktopApi?.getWindowPointerSnapshot,
     revealed,
   ]);
@@ -491,7 +531,11 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         }
       }}
       onBlurCapture={(event) => {
-        if (!pinned && !event.currentTarget.contains(event.relatedTarget as Node | null)) {
+        if (
+          !pinned
+          && !portaledInteractionOpenRef.current
+          && !event.currentTarget.contains(event.relatedTarget as Node | null)
+        ) {
           hideRail();
         }
       }}
@@ -695,6 +739,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <SubAgentsPanel
             pricingDisplayOptions={props.pricingDisplayOptions}
             thread={props.thread}
+            onDetailsModalOpenChange={handlePortaledInteractionChange}
           />
         );
       case "automations":

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -20,6 +20,7 @@ import type {
 import { ThreadContextPanel } from "../ThreadContextPanel";
 import type { ContextTabId } from "../context-panels/context-tab";
 import { collectEditedFileGroups } from "../edited-file-groups";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
 
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
@@ -158,9 +159,14 @@ type PanelOverrides = Partial<
   >
 >;
 
-function renderPanel(overrides: PanelOverrides = {}) {
+function renderPanel(
+  overrides: PanelOverrides = {},
+  options?: {
+    onShowThread: ComponentProps<typeof ThreadLinkProvider>["onShowThread"];
+  },
+) {
   const onActiveTabChange = vi.fn<(tab: ContextTabId) => void>();
-  const result = render(
+  const panel = (
     <ThreadContextPanel
       activeTab="info"
       backends={[baseBackend]}
@@ -168,7 +174,17 @@ function renderPanel(overrides: PanelOverrides = {}) {
       thread={baseThread}
       onActiveTabChange={onActiveTabChange}
       {...overrides}
-    />,
+    />
+  );
+  const result = render(
+    options ? (
+      <ThreadLinkProvider
+        onShowThread={options.onShowThread}
+        threads={[overrides.thread ?? baseThread]}
+      >
+        {panel}
+      </ThreadLinkProvider>
+    ) : panel,
   );
   return { ...result, onActiveTabChange };
 }
@@ -2239,6 +2255,119 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(screen.queryByText(REVEALED_SIGNAL)).not.toBeInTheDocument();
+  });
+
+  it("keeps an unpinned rail open while using a portaled sub-agent dialog", async () => {
+    vi.useFakeTimers();
+    const onShowThread = vi.fn();
+    renderPanel(
+      {
+        activeTab: "subagents",
+        thread: {
+          ...baseThread,
+          subAgents: [
+            {
+              monitorId: "review:turn-review-1",
+              monitorThreadId: "review-thread-1",
+              task: "Review changes against main",
+              status: "success",
+              createdAt: 2_000,
+              completedAt: 3_000,
+              updatedAt: 3_000,
+            },
+          ],
+        },
+      },
+      { onShowThread },
+    );
+
+    const rail = screen.getByLabelText("Thread context");
+    mockRailRect(rail);
+    fireEvent.click(screen.getByRole("tab", { name: "Sub-agents" }));
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.mouseMove(document, { clientX: 500, clientY: 380 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(301);
+    });
+
+    expect(dialog).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Open transcript" }));
+    expect(onShowThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "review-thread-1",
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.mouseMove(document, { clientX: 500, clientY: 380 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(301);
+    });
+    expect(screen.queryByRole("tabpanel")).not.toBeInTheDocument();
+  });
+
+  it("does not let cursor polling close a portaled sub-agent dialog", async () => {
+    vi.useFakeTimers();
+    const getWindowPointerSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({
+        contentBounds: {
+          height: 800,
+          width: 1000,
+          x: 100,
+          y: 100,
+        },
+        cursor: {
+          x: 1080,
+          y: 220,
+        },
+        windowFocused: false,
+      })
+      .mockResolvedValue({
+        contentBounds: {
+          height: 800,
+          width: 1000,
+          x: 100,
+          y: 100,
+        },
+        cursor: {
+          x: 600,
+          y: 480,
+        },
+        windowFocused: false,
+      });
+    renderPanel({
+      activeTab: "subagents",
+      desktopApi: { getWindowPointerSnapshot },
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "review:turn-review-1",
+            monitorThreadId: "review-thread-1",
+            task: "Review changes against main",
+            status: "success",
+            createdAt: 2_000,
+            completedAt: 3_000,
+            updatedAt: 3_000,
+          },
+        ],
+      },
+    });
+
+    const rail = screen.getByLabelText("Thread context");
+    mockRailRect(rail);
+    fireEvent.mouseEnter(rail, { clientX: 980, clientY: 120 });
+    await advanceHoverRevealDelay();
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(getWindowPointerSnapshot).toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
   it("polls the window pointer and closes when the cursor remains outside the rail", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   NavigationThreadSummary,
   ThreadSubAgentSummary,
@@ -20,6 +20,7 @@ import {
 } from "./subagent-kind";
 
 type SubAgentsPanelProps = {
+  onDetailsModalOpenChange?: (open: boolean) => void;
   pricingDisplayOptions?: PricingDisplayOptions;
   thread: NavigationThreadSummary;
 };
@@ -27,7 +28,22 @@ type SubAgentsPanelProps = {
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
+  const { onDetailsModalOpenChange } = props;
   const [detailsFor, setDetailsFor] = useState<ThreadSubAgentSummary | null>(null);
+
+  useEffect(() => {
+    return () => onDetailsModalOpenChange?.(false);
+  }, [onDetailsModalOpenChange]);
+
+  const openDetails = (subAgent: ThreadSubAgentSummary): void => {
+    onDetailsModalOpenChange?.(true);
+    setDetailsFor(subAgent);
+  };
+
+  const closeDetails = (): void => {
+    setDetailsFor(null);
+    onDetailsModalOpenChange?.(false);
+  };
 
   return (
     <section className="context-panel__section">
@@ -101,7 +117,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                 <button
                   className="context-list__action"
                   type="button"
-                  onClick={() => setDetailsFor(subAgent)}
+                  onClick={() => openDetails(subAgent)}
                 >
                   Details
                 </button>
@@ -120,7 +136,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           defaultBackend={props.thread.source}
           pricingDisplayOptions={props.pricingDisplayOptions}
           subAgent={detailsFor}
-          onClose={() => setDetailsFor(null)}
+          onClose={closeDetails}
         />
       ) : null}
     </section>


### PR DESCRIPTION
## Summary

- keep the unpinned right context rail mounted while the portaled subagent Details dialog is open
- block both renderer hover dismissal and Electron cursor polling during the dialog interaction
- release the dismissal guard on every dialog close path so normal auto-hide resumes
- add regression coverage for opening the transcript and for cursor polling

## Root cause

The subagent Details dialog is portaled to `document.body`, outside the right rail's DOM and geometry. Moving or focusing from an unpinned rail into the dialog therefore looked like leaving the rail. Its close timer or Electron cursor poll could collapse the rail, unmounting the dialog before **Open transcript** could be clicked.

## User impact

Operators can now move into the Details dialog and open a subagent transcript while the right rail is unpinned.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx` — 61 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors (baseline warnings remain)
- `pnpm lint:boundaries`
- `git diff --check`
