### PR TITLE
fix(desktop): refresh PRs after branch adoption

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4372,6 +4372,116 @@ describe("app server ipc", () => {
     });
   });
 
+  it("preserves PR history when late branch adoption overlaps the post-turn lookup", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const oldBranchPr = githubPr({
+      number: 816,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "PR discovered from the pre-adoption branch",
+      state: "passing",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/816",
+    });
+    const adoptedBranchPr = githubPr({
+      number: 817,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "PR discovered from the adopted branch",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/817",
+    });
+    let overlayState: Awaited<ReturnType<typeof setThreadPullRequests>> | undefined;
+    const resolveFetches: Array<(prs: PrSummary[]) => void> = [];
+    const persistOverlay = async (
+      request: Parameters<typeof setThreadPullRequests>[0],
+    ): Promise<NonNullable<typeof overlayState>> => {
+      overlayState = {
+        backend: request.backend,
+        threadId: request.threadId,
+        executionMode: "default",
+        extraLinkedDirectories: [],
+        prs: request.prs,
+        prsFetchedAt: request.fetchedAt ?? Date.now(),
+        prsRefreshKey: request.refreshKey,
+      };
+      return overlayState;
+    };
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [
+          {
+            id: "directory:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "worktree",
+            worktreePath: "/repo/wt",
+          },
+        ],
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        updatedAt: 2000,
+      },
+    ] as never);
+    getThreadOverlayState.mockImplementation(async () => overlayState);
+    setThreadPullRequests
+      .mockImplementationOnce(persistOverlay)
+      .mockImplementationOnce(persistOverlay);
+    detectPullRequestsForThread.mockImplementation(
+      async () => await new Promise<PrSummary[]>((resolve) => {
+        resolveFetches.push(resolve);
+      }),
+    );
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(resolveFetches).toHaveLength(1);
+    });
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/branch/updated",
+        params: {
+          threadId: "thread-1",
+          branch: "fix/adopted-after-completion",
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(resolveFetches).toHaveLength(2);
+    });
+
+    resolveFetches[0]?.([oldBranchPr]);
+    resolveFetches[1]?.([adoptedBranchPr]);
+
+    await vi.waitFor(() => {
+      expect(overlayState?.prs?.map((pr) => pr.number)).toEqual([816, 817]);
+    });
+  });
+
   it("refreshes post-turn pull requests for a scoped linked worktree branch", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -4281,6 +4281,97 @@ describe("app server ipc", () => {
     });
   });
 
+  it("refreshes pull requests when branch adoption finishes after turn completion", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const discoveredPr = githubPr({
+      number: 815,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      title: "Refresh late-adopted branch PRs",
+      state: "pending",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/815",
+    });
+
+    listThreads.mockResolvedValueOnce([
+      {
+        id: "thread-1",
+        title: "Thread one",
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: "/repo/wt",
+        linkedDirectories: [
+          {
+            id: "directory:/repo/app",
+            label: "app",
+            path: "/repo/app",
+            kind: "worktree",
+            worktreePath: "/repo/wt",
+          },
+        ],
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        updatedAt: 2000,
+      },
+    ] as never);
+    detectPullRequestsForThread
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([discoveredPr]);
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalled();
+    });
+    detectPullRequestsForThread.mockClear();
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "t1",
+          turn: { id: "t1", status: "completed" },
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(detectPullRequestsForThread).toHaveBeenCalledWith({
+        fetcher: expect.any(Object),
+        branch: "HEAD",
+        directoryPaths: ["/repo/wt"],
+        allowPrimedBranchLookup: false,
+      });
+    });
+
+    emitRegistryEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/branch/updated",
+        params: {
+          threadId: "thread-1",
+          branch: "fix/adopted-after-completion",
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(setThreadPullRequests).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        prs: [discoveredPr],
+        fetchedAt: expect.any(Number),
+        refreshKey: buildThreadPrRequestKey({
+          backend: "codex",
+          threadId: "thread-1",
+          branch: "fix/adopted-after-completion",
+          directoryPaths: ["/repo/wt"],
+        }),
+      });
+    });
+  });
+
   it("refreshes post-turn pull requests for a scoped linked worktree branch", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2096,10 +2096,16 @@ class DesktopAppServerService {
       });
     }
 
-    if (method === "turn/completed") {
-      // A finished turn is real activity on this thread even when it is off
-      // screen — thaw its PRs if the poller had iceboxed them.
-      this.prPollingScheduler?.noteThreadInteraction([threadKey]);
+    if (method === "turn/completed" || method === "thread/branch/updated") {
+      if (method === "turn/completed") {
+        // A finished turn is real activity on this thread even when it is off
+        // screen — thaw its PRs if the poller had iceboxed them.
+        this.prPollingScheduler?.noteThreadInteraction([threadKey]);
+      }
+
+      // Codex can publish turn/completed before its asynchronous branch
+      // adoption finishes. Refresh again from the causally newer branch event
+      // so a PR created on that branch does not wait for thread selection.
       const prContexts = this.prRefreshContextByThreadKey.get(threadKey);
       if (prContexts?.length) {
         for (const prContext of prContexts) {
@@ -2108,7 +2114,8 @@ class DesktopAppServerService {
             provider: "github.com",
             trigger: "post-turn",
           }).catch((error) => {
-            appServerLog.warn("post-turn PR refresh failed", {
+            appServerLog.warn("turn-boundary PR refresh failed", {
+              method,
               threadId,
               error: error instanceof Error ? error.message : String(error),
             });

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -862,6 +862,7 @@ class DesktopAppServerService {
     string,
     Map<string, PrLookupSubscriber>
   >();
+  private readonly pendingPrOverlayWrites = new Map<string, Promise<void>>();
   private readonly prStatusTokenBucket = new PrStatusTokenBucket();
   private lastPrObservationTimestamp = 0;
   private prStatusRegistryLoaded = false;
@@ -2818,39 +2819,83 @@ class DesktopAppServerService {
     let changedThreadCount = 0;
     await Promise.all(
       [...subscribers.values()].map(async (subscriber) => {
-        const nextPrs = this.mergePrHistory(subscriber.previousPrs, params.prs);
-        const updated = await this.getOverlayStore().setThreadPullRequests({
+        await this.enqueuePullRequestOverlayWrite({
           backend: subscriber.backend,
           threadId: subscriber.threadId,
-          prs: nextPrs,
-          fetchedAt: params.fetchedAt,
-          refreshKey: subscriber.requestKey,
-        });
-        const persistedPrs = updated.prs ?? [];
-        if ((updated.prsFetchedAt ?? 0) > params.fetchedAt) {
-          appServerLog.info("thread PR overlay observation ignored", {
-            backend: subscriber.backend,
-            threadId: subscriber.threadId,
-            requestKey: subscriber.requestKey,
-            observedAt: params.fetchedAt,
-            currentObservedAt: updated.prsFetchedAt,
-            currentRequestKey: updated.prsRefreshKey,
-          });
-          return;
-        }
+          write: async () => {
+            const overlay = this.getOverlayStore();
+            // Branch changes use a different lookup key, so their refresh can
+            // overlap the preceding branch's lookup. Re-read inside the
+            // per-thread write queue to retain history from either lookup.
+            const latest = await overlay.getThreadOverlayState({
+              backend: subscriber.backend,
+              threadId: subscriber.threadId,
+            });
+            const previousPersistedPrs = latest?.prs ?? subscriber.previousPrs;
+            const latestPrs = this.mergePrHistory(
+              latest?.prs ?? [],
+              latest?.detachedPrs ?? [],
+            );
+            const previousPrs = this.mergePrHistory(
+              subscriber.previousPrs,
+              latestPrs,
+            );
+            const nextPrs = this.mergePrHistory(previousPrs, params.prs);
+            const updated = await overlay.setThreadPullRequests({
+              backend: subscriber.backend,
+              threadId: subscriber.threadId,
+              prs: nextPrs,
+              fetchedAt: params.fetchedAt,
+              refreshKey: subscriber.requestKey,
+            });
+            const persistedPrs = updated.prs ?? [];
+            if ((updated.prsFetchedAt ?? 0) > params.fetchedAt) {
+              appServerLog.info("thread PR overlay observation ignored", {
+                backend: subscriber.backend,
+                threadId: subscriber.threadId,
+                requestKey: subscriber.requestKey,
+                observedAt: params.fetchedAt,
+                currentObservedAt: updated.prsFetchedAt,
+                currentRequestKey: updated.prsRefreshKey,
+              });
+              return;
+            }
 
-        if (!prSummariesEqual(subscriber.previousPrs, persistedPrs)) {
-          changedThreadCount += 1;
-          await this.publishThreadPullRequestsUpdated({
-            backend: subscriber.backend,
-            threadId: subscriber.threadId,
-            prs: persistedPrs,
-            detachedPrs: updated.detachedPrs ?? [],
-          });
-        }
+            if (!prSummariesEqual(previousPersistedPrs, persistedPrs)) {
+              changedThreadCount += 1;
+              await this.publishThreadPullRequestsUpdated({
+                backend: subscriber.backend,
+                threadId: subscriber.threadId,
+                prs: persistedPrs,
+                detachedPrs: updated.detachedPrs ?? [],
+              });
+            }
+          },
+        });
       }),
     );
     return { changedThreadCount, subscriberCount: subscribers.size };
+  }
+
+  private enqueuePullRequestOverlayWrite<T>(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    write: () => Promise<T>;
+  }): Promise<T> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const previous = this.pendingPrOverlayWrites.get(threadKey) ?? Promise.resolve();
+    const result = previous.then(params.write);
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.pendingPrOverlayWrites.set(threadKey, settled);
+    void settled.then(() => {
+      if (this.pendingPrOverlayWrites.get(threadKey) === settled) {
+        this.pendingPrOverlayWrites.delete(threadKey);
+      }
+    });
+    return result;
   }
 
   private async persistPullRequestLookupHit(params: {
@@ -4371,6 +4416,7 @@ class DesktopAppServerService {
     this.pendingPrLookupRefreshes.clear();
     this.queuedAuthoritativePrLookupRefreshes.clear();
     this.prLookupSubscribers.clear();
+    this.pendingPrOverlayWrites.clear();
     this.prStatusRegistryLoaded = false;
     this.prLookupRegistryLoaded = false;
     this.pendingDirectoryGitStatusRefreshes.clear();


### PR DESCRIPTION
## Summary

- refresh a thread pull requests when its adopted branch is published
- preserve the existing post-turn reconciliation while covering late branch adoption
- add regression coverage for the production ordering: turn completion on `HEAD`, then branch adoption

## Root cause

Codex can publish `turn/completed` before PwrAgent asynchronous branch adoption finishes. The existing post-turn lookup therefore ran against stale `HEAD`, while the later `thread/branch/updated` event only updated the remembered context and did not launch another lookup. The PR stayed undiscovered until selecting the thread triggered a user refresh.

## Impact

PRs created during a turn now appear on off-screen thread rows after branch adoption, without requiring the operator to open the thread.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`