### PR TITLE
feat(desktop): open sub-agent transcripts in a read-only window

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -815,14 +815,51 @@ describe("app server ipc", () => {
     expect(readThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-large",
+      includeTurns: undefined,
       before: undefined,
       limit: undefined,
+      viewOnly: undefined,
     });
     expect(output.length).toBeLessThan(36_000);
     expect(output).toContain("PwrAgent renderer boundary: truncated");
     expect(output).toContain("$.replay.entries[0].details[0].command.output");
     expect(output).toContain("protocol-tail");
     expect(output).not.toContain("x".repeat(60_000));
+  });
+
+  it("forwards inspection-only transcript reads to the backend registry", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { APP_SERVER_READ_THREAD_CHANNEL } = await import("../../shared/ipc");
+    readThread.mockResolvedValueOnce({
+      backend: "codex",
+      fetchedAt: 1234,
+      threadId: "sub-agent-1",
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+      threadStatus: "idle",
+    } as never);
+
+    registerAppServerIpcHandlers();
+
+    await handlers.get(APP_SERVER_READ_THREAD_CHANNEL)?.(
+      {},
+      { backend: "codex", threadId: "sub-agent-1", viewOnly: true },
+    );
+
+    expect(readThread).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "sub-agent-1",
+      includeTurns: undefined,
+      before: undefined,
+      limit: undefined,
+      viewOnly: true,
+    });
   });
 
   it("strips readThread file diffs behind fetchable refs before crossing IPC", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7981,6 +7981,18 @@ script = "echo setup"
     await registry.readThread({
       backend: "codex",
       threadId: "thread-1",
+      viewOnly: true,
+    });
+
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+    await expect(
+      overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
+    ).resolves.toBeUndefined();
+    expect(events).toHaveLength(0);
+
+    await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
     });
 
     expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8350,7 +8350,12 @@ export class DesktopBackendRegistry {
             limit: request.limit,
           });
 
-    if (backend === "codex" && !request.before && request.includeTurns !== false) {
+    if (
+      backend === "codex" &&
+      !request.viewOnly &&
+      !request.before &&
+      request.includeTurns !== false
+    ) {
       await this.repairCodexThreadDirectoryRelationship({
         reason: "selected-thread",
         threadId: request.threadId,
@@ -8423,7 +8428,7 @@ export class DesktopBackendRegistry {
       replayWithImmutableUsage,
       messageOrigins,
     );
-    if (!request.before && shouldAppendTranscriptOverlays) {
+    if (!request.viewOnly && !request.before && shouldAppendTranscriptOverlays) {
       await this.persistReplayUsageLines(replayWithEnvironment);
     }
     const pricing =

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1045,6 +1045,7 @@ class DesktopAppServerService {
       includeTurns: request.includeTurns,
       before: request.before,
       limit: request.limit,
+      viewOnly: request.viewOnly,
     });
 
     logDebug("readThread", {

--- a/apps/desktop/src/main/ipc/applications.ts
+++ b/apps/desktop/src/main/ipc/applications.ts
@@ -5,6 +5,8 @@ import type {
   OpenDesktopApplicationResponse,
   OpenMarkdownFileViewerRequest,
   OpenMarkdownFileViewerResponse,
+  OpenSubAgentTranscriptWindowRequest,
+  OpenSubAgentTranscriptWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -19,11 +21,13 @@ import {
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
+  SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
 } from "../../shared/ipc";
 import {
   readMarkdownFileViewerSnapshot,
   showMarkdownFileViewerWindow,
 } from "../markdown-files-window";
+import { showSubAgentTranscriptWindow } from "../subagent-transcript-window";
 import { openDesktopApplication } from "../settings/application-discovery";
 
 const MAX_MARKDOWN_FILE_BYTES = 2 * 1024 * 1024;
@@ -157,6 +161,20 @@ export function registerApplicationIpcHandlers(): void {
     ): Promise<ReadMarkdownFileViewerSnapshotResponse> =>
       readMarkdownFileViewerSnapshot(request.contextKey),
   );
+
+  ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
+  ipcMain.handle(
+    SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
+    async (
+      event,
+      request: OpenSubAgentTranscriptWindowRequest,
+    ): Promise<OpenSubAgentTranscriptWindowResponse> => {
+      showSubAgentTranscriptWindow(request, {
+        sourceWindow: BrowserWindow.fromWebContents(event.sender),
+      });
+      return { opened: true };
+    },
+  );
 }
 
 export function disposeApplicationIpcHandlers(): void {
@@ -166,4 +184,5 @@ export function disposeApplicationIpcHandlers(): void {
   ipcMain.removeHandler(MARKDOWN_FILE_READ_CHANNEL);
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_OPEN_CHANNEL);
   ipcMain.removeHandler(MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL);
+  ipcMain.removeHandler(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL);
 }

--- a/apps/desktop/src/main/subagent-transcript-window.ts
+++ b/apps/desktop/src/main/subagent-transcript-window.ts
@@ -1,0 +1,119 @@
+import { BrowserWindow } from "electron";
+import type { OpenSubAgentTranscriptWindowRequest } from "@pwragent/shared";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_SUB_AGENT_TRANSCRIPT,
+  registerWindowChannels,
+} from "./window-channels";
+import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+  themedWindowBackgroundColor,
+} from "./settings/appearance-bootstrap";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:subagent-transcript-window");
+const SUB_AGENT_TRANSCRIPT_HASH = "sub-agent";
+const SUB_AGENT_TRANSCRIPT_WINDOW_WIDTH = 1_040;
+const SUB_AGENT_TRANSCRIPT_WINDOW_HEIGHT = 780;
+const SUB_AGENT_TRANSCRIPT_HASH_TITLE_MAX_LENGTH = 240;
+
+const transcriptWindows = new Map<string, BrowserWindow>();
+
+/**
+ * Opens an inspection-only transcript surface for a delegated agent.
+ *
+ * Sub-agents are addressable through the App Server's `thread/read`, but they
+ * are not necessarily materialized PwrAgent threads. Giving them a dedicated
+ * window keeps navigation, composer, and thread mutations unavailable while
+ * still letting an operator inspect the full child transcript.
+ */
+export function showSubAgentTranscriptWindow(
+  request: OpenSubAgentTranscriptWindowRequest,
+  source: WindowPlacementSource = {},
+): void {
+  const threadId = request.threadId.trim();
+  if (!threadId) {
+    throw new Error("Sub-agent transcript requires a thread id.");
+  }
+  const title = request.title.trim() || "Sub-agent transcript";
+  const windowKey = `${request.backend}:${threadId}`;
+  const current = transcriptWindows.get(windowKey);
+  if (current && !current.isDestroyed()) {
+    positionWindowForSourceDisplay(current, source);
+    showAndFocusAuxiliaryWindow(current);
+    return;
+  }
+
+  const windowTitle = `Sub-agent transcript — ${title}`;
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(
+      SUB_AGENT_TRANSCRIPT_WINDOW_WIDTH,
+      SUB_AGENT_TRANSCRIPT_WINDOW_HEIGHT,
+      source,
+    ),
+    width: SUB_AGENT_TRANSCRIPT_WINDOW_WIDTH,
+    height: SUB_AGENT_TRANSCRIPT_WINDOW_HEIGHT,
+    minWidth: 720,
+    minHeight: 520,
+    show: false,
+    title: windowTitle,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, windowTitle);
+  hideAuxiliaryWindowMenuBar(window);
+
+  applyWindowSecurityHardening(window);
+  registerWindowChannels(window, WINDOW_KIND_SUB_AGENT_TRANSCRIPT, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const hash = [
+    SUB_AGENT_TRANSCRIPT_HASH,
+    encodeURIComponent(request.backend),
+    encodeURIComponent(threadId),
+    encodeURIComponent(title.slice(0, SUB_AGENT_TRANSCRIPT_HASH_TITLE_MAX_LENGTH)),
+  ].join("/");
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${hash}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash });
+  }
+
+  showAuxiliaryWindowWhenReady(window);
+  transcriptWindows.set(windowKey, window);
+  window.on("closed", () => {
+    if (transcriptWindows.get(windowKey) === window) {
+      transcriptWindows.delete(windowKey);
+    }
+    log.debug("sub-agent transcript window closed", { windowKey });
+  });
+  log.debug("sub-agent transcript window created", { windowKey });
+}

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -37,13 +37,15 @@ export const WINDOW_KIND_CHANGELOG = "changelog" as const;
 export const WINDOW_KIND_LICENSE_DOCUMENT = "license-document" as const;
 export const WINDOW_KIND_APP_LOGS = "app-logs" as const;
 export const WINDOW_KIND_MARKDOWN_FILES = "markdown-files" as const;
+export const WINDOW_KIND_SUB_AGENT_TRANSCRIPT = "sub-agent-transcript" as const;
 export type WindowKind =
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
   | typeof WINDOW_KIND_CHANGELOG
   | typeof WINDOW_KIND_LICENSE_DOCUMENT
   | typeof WINDOW_KIND_APP_LOGS
-  | typeof WINDOW_KIND_MARKDOWN_FILES;
+  | typeof WINDOW_KIND_MARKDOWN_FILES
+  | typeof WINDOW_KIND_SUB_AGENT_TRANSCRIPT;
 
 interface Entry {
   kind: WindowKind;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -202,6 +202,8 @@ import type {
   OpenDesktopApplicationResponse,
   OpenMarkdownFileViewerRequest,
   OpenMarkdownFileViewerResponse,
+  OpenSubAgentTranscriptWindowRequest,
+  OpenSubAgentTranscriptWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -341,6 +343,7 @@ import {
   MARKDOWN_FILE_VIEWER_OPEN_CHANNEL,
   MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL,
   MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL,
+  SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL,
   DIAGNOSTICS_CAPTURE_HEAP_SNAPSHOT_CHANNEL,
   DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
   INTEGRATED_TERMINAL_CLOSE_CHANNEL,
@@ -849,6 +852,10 @@ const desktopApi = Object.freeze({
       ipcRenderer.off(MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL, listener);
     };
   },
+  openSubAgentTranscriptWindow: async (
+    request: OpenSubAgentTranscriptWindowRequest,
+  ): Promise<OpenSubAgentTranscriptWindowResponse> =>
+    await ipcRenderer.invoke(SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL, request),
   createIntegratedTerminal: async (
     request: IntegratedTerminalCreateRequest,
   ): Promise<IntegratedTerminalCreateResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AppServerBackendKind,
+  AppServerReadThreadResponse,
+  AppServerThreadEntry,
+  AppServerThreadMessage,
+} from "@pwragent/shared";
+import { CloseIcon } from "../../icons";
+import { formatBackendLabel } from "../../lib/backend-label";
+import { useDesktopApi } from "../../lib/desktop-api";
+import { THREAD_HISTORY_PAGE_LIMIT } from "../../lib/thread-history-limits";
+import { TranscriptList } from "./TranscriptList";
+
+const LIVE_TRANSCRIPT_REFRESH_MS = 2_000;
+
+type SubAgentTranscriptTarget = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+};
+
+type LoadState = {
+  error?: string;
+  loading: boolean;
+  loadingMore: boolean;
+  response?: AppServerReadThreadResponse;
+};
+
+/**
+ * An inspection-only transcript window for delegated agents.
+ *
+ * It intentionally owns no composer, normal thread navigation, or mutation
+ * controls. Native Codex child ids are readable via `thread/read`, even when
+ * they do not appear in PwrAgent's durable thread navigation snapshot.
+ */
+export function SubAgentTranscriptWindow() {
+  const desktopApi = useDesktopApi();
+  const target = useMemo(() => subAgentTranscriptTargetFromHash(), []);
+  const targetKey = target ? `${target.backend}:${target.threadId}` : undefined;
+  const [state, setState] = useState<LoadState>({
+    loading: Boolean(target),
+    loadingMore: false,
+  });
+  const refreshInFlightRef = useRef(false);
+  const refreshQueuedRef = useRef(false);
+  const loadedOlderRef = useRef(false);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    const reader = desktopApi?.readThread;
+    if (!target || !reader) {
+      setState((current) => ({
+        ...current,
+        error: target
+          ? "The desktop bridge is unavailable."
+          : "This sub-agent transcript address is invalid.",
+        loading: false,
+      }));
+      return;
+    }
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true;
+      return;
+    }
+
+    refreshInFlightRef.current = true;
+    do {
+      refreshQueuedRef.current = false;
+      try {
+        const response = await reader({
+          backend: target.backend,
+          threadId: target.threadId,
+          limit: THREAD_HISTORY_PAGE_LIMIT,
+          viewOnly: true,
+        });
+        setState((current) => ({
+          error: undefined,
+          loading: false,
+          loadingMore: current.loadingMore,
+          response: mergeLatestTranscriptResponse({
+            current: current.response,
+            fresh: response,
+            preserveOlderPages: loadedOlderRef.current,
+          }),
+        }));
+      } catch (error) {
+        setState((current) => ({
+          ...current,
+          error: error instanceof Error ? error.message : "Transcript could not be loaded.",
+          loading: false,
+        }));
+      }
+    } while (refreshQueuedRef.current);
+    refreshInFlightRef.current = false;
+  }, [desktopApi?.readThread, target]);
+
+  useEffect(() => {
+    loadedOlderRef.current = false;
+    setState({ loading: Boolean(target), loadingMore: false });
+    void refresh();
+  }, [refresh, target]);
+
+  const loadOlder = useCallback(async (): Promise<void> => {
+    const reader = desktopApi?.readThread;
+    const cursor = state.response?.replay.pagination.previousCursor;
+    if (!target || !reader || !cursor || state.loadingMore) {
+      return;
+    }
+
+    setState((current) => ({ ...current, loadingMore: true }));
+    try {
+      const olderResponse = await reader({
+        backend: target.backend,
+        threadId: target.threadId,
+        before: cursor,
+        limit: THREAD_HISTORY_PAGE_LIMIT,
+        viewOnly: true,
+      });
+      loadedOlderRef.current = true;
+      setState((current) => ({
+        error: undefined,
+        loading: false,
+        loadingMore: false,
+        response: mergeOlderTranscriptResponse({
+          current: current.response,
+          older: olderResponse,
+        }),
+      }));
+    } catch (error) {
+      setState((current) => ({
+        ...current,
+        error: error instanceof Error ? error.message : "Older transcript could not be loaded.",
+        loadingMore: false,
+      }));
+    }
+  }, [desktopApi?.readThread, state.loadingMore, state.response?.replay.pagination.previousCursor, target]);
+
+  const threadStatus = state.response?.threadStatus ?? state.response?.replay.threadStatus;
+  const isLive = threadStatus === "active";
+
+  useEffect(() => {
+    if (!isLive) {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      void refresh();
+    }, LIVE_TRANSCRIPT_REFRESH_MS);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [isLive, refresh]);
+
+  useEffect(() => {
+    if (target) {
+      document.title = `Sub-agent transcript — ${target.title}`;
+    }
+  }, [target]);
+
+  const entries = state.response?.replay.entries ?? [];
+
+  return (
+    <div className="subagent-transcript-window">
+      <section aria-label="Sub-agent transcript" className="activity-screen">
+        <header className="activity-titlebar">
+          <p className="activity-titlebar__brand">
+            Pwr<span className="activity-titlebar__brand-accent">Agent</span>
+          </p>
+          <div className="activity-titlebar__breadcrumb" aria-label="Sub-agents > Transcript">
+            <span className="activity-titlebar__eyebrow">Sub-agents</span>
+            <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+            <span className="activity-titlebar__current">Transcript</span>
+          </div>
+          <div className="activity-titlebar__spacer" />
+        </header>
+
+        <main className="subagent-transcript-window__content">
+          <header className="subagent-transcript-window__header">
+            <div className="subagent-transcript-window__identity">
+              <h1>{target?.title ?? "Sub-agent transcript"}</h1>
+              {target ? (
+                <p>
+                  <span>{formatBackendLabel(target.backend)}</span>
+                  <code>{target.threadId}</code>
+                </p>
+              ) : null}
+            </div>
+            <div className="subagent-transcript-window__actions">
+              {isLive ? <span className="subagent-transcript-window__live">Live</span> : null}
+              <button
+                type="button"
+                className="subagent-transcript-window__close"
+                aria-label="Close window"
+                title="Close"
+                onClick={() => window.close()}
+              >
+                <CloseIcon size={18} aria-hidden="true" />
+              </button>
+            </div>
+          </header>
+
+          <TranscriptList
+            desktopApi={desktopApi}
+            entries={entries}
+            error={state.error}
+            loading={state.loading}
+            loadingMore={state.loadingMore}
+            pagination={state.response?.replay.pagination}
+            threadId={targetKey}
+            onLoadOlder={loadOlder}
+          />
+        </main>
+      </section>
+    </div>
+  );
+}
+
+function mergeById<T extends { id: string }>(
+  first: T[],
+  second: T[],
+): T[] {
+  const merged = new Map<string, T>();
+  for (const item of [...first, ...second]) {
+    merged.set(item.id, item);
+  }
+  return [...merged.values()];
+}
+
+function mergeLatestTranscriptResponse(params: {
+  current?: AppServerReadThreadResponse;
+  fresh: AppServerReadThreadResponse;
+  preserveOlderPages: boolean;
+}): AppServerReadThreadResponse {
+  if (!params.current || !params.preserveOlderPages) {
+    return params.fresh;
+  }
+
+  return {
+    ...params.fresh,
+    replay: {
+      ...params.fresh.replay,
+      entries: mergeById<AppServerThreadEntry>(
+        params.current.replay.entries,
+        params.fresh.replay.entries,
+      ),
+      messages: mergeById<AppServerThreadMessage>(
+        params.current.replay.messages,
+        params.fresh.replay.messages,
+      ),
+      pagination: params.current.replay.pagination,
+    },
+  };
+}
+
+function mergeOlderTranscriptResponse(params: {
+  current?: AppServerReadThreadResponse;
+  older: AppServerReadThreadResponse;
+}): AppServerReadThreadResponse {
+  if (!params.current) {
+    return params.older;
+  }
+
+  return {
+    ...params.current,
+    fetchedAt: params.older.fetchedAt,
+    ...(params.older.threadStatus ? { threadStatus: params.older.threadStatus } : {}),
+    replay: {
+      ...params.current.replay,
+      entries: mergeById<AppServerThreadEntry>(
+        params.older.replay.entries,
+        params.current.replay.entries,
+      ),
+      messages: mergeById<AppServerThreadMessage>(
+        params.older.replay.messages,
+        params.current.replay.messages,
+      ),
+      pagination: params.older.replay.pagination,
+    },
+  };
+}
+
+function subAgentTranscriptTargetFromHash(): SubAgentTranscriptTarget | undefined {
+  const hash = window.location.hash.replace(/^#/, "");
+  const [kind, backendPart, threadIdPart, titlePart] = hash.split("/");
+  if (
+    kind !== "sub-agent" ||
+    !backendPart ||
+    !threadIdPart ||
+    !titlePart
+  ) {
+    return undefined;
+  }
+
+  try {
+    const backend = decodeURIComponent(backendPart);
+    const threadId = decodeURIComponent(threadIdPart).trim();
+    const title = decodeURIComponent(titlePart).trim();
+    if (!isAppServerBackendKind(backend) || !threadId || !title) {
+      return undefined;
+    }
+    return { backend, threadId, title };
+  } catch {
+    return undefined;
+  }
+}
+
+function isAppServerBackendKind(value: string): value is AppServerBackendKind {
+  return value === "codex" || value === "grok" || value.startsWith("acp:");
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
@@ -24,7 +24,11 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
     return null;
   }
 
-  const origin = call.origin === "codex-native" ? "Codex native agent" : "PwrAgent sub-agent";
+  const canOpenTranscript =
+    call.origin === "codex-native" && call.backend === "codex";
+  const origin = call.origin === "codex-native"
+    ? "Codex native agent"
+    : "PwrAgent sub-agent";
   const operation = operationLabel(call.operation);
   const status = lifecycleStatus(props.detail.status);
   const output = props.detail.command?.output;
@@ -60,7 +64,7 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
                 ) : null}
               </div>
               {agent.message ? <p className="transcript-subagent__message">{agent.message}</p> : null}
-              {openSubAgentTranscriptWindow ? (
+              {canOpenTranscript && openSubAgentTranscriptWindow ? (
                 <button
                   className="button button--ghost transcript-subagent__action"
                   type="button"

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptSubAgentCall.tsx
@@ -4,7 +4,7 @@ import type {
   AppServerThreadSubAgentCallDetail,
 } from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
-import { useThreadLinks } from "../../lib/thread-links";
+import { useDesktopApi } from "../../lib/desktop-api";
 
 type TranscriptSubAgentCallProps = {
   detail: AppServerThreadActivityDetail;
@@ -17,7 +17,8 @@ type TranscriptSubAgentCallProps = {
  */
 export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
   const [showOutput, setShowOutput] = useState(false);
-  const threadLinks = useThreadLinks();
+  const desktopApi = useDesktopApi();
+  const openSubAgentTranscriptWindow = desktopApi?.openSubAgentTranscriptWindow;
   const call = props.detail.command?.subAgent;
   if (!call) {
     return null;
@@ -59,12 +60,12 @@ export function TranscriptSubAgentCall(props: TranscriptSubAgentCallProps) {
                 ) : null}
               </div>
               {agent.message ? <p className="transcript-subagent__message">{agent.message}</p> : null}
-              {threadLinks ? (
+              {openSubAgentTranscriptWindow ? (
                 <button
                   className="button button--ghost transcript-subagent__action"
                   type="button"
                   onClick={() => {
-                    threadLinks.show({
+                    void openSubAgentTranscriptWindow({
                       backend: call.backend,
                       threadId: agent.threadId,
                       title: agentLabel,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/SubAgentTranscriptWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/SubAgentTranscriptWindow.test.tsx
@@ -1,0 +1,57 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SubAgentTranscriptWindow } from "../SubAgentTranscriptWindow";
+import { THREAD_HISTORY_PAGE_LIMIT } from "../../../lib/thread-history-limits";
+
+describe("SubAgentTranscriptWindow", () => {
+  const originalHash = window.location.hash;
+
+  afterEach(() => {
+    delete (window as Window & { pwragent?: unknown }).pwragent;
+    window.location.hash = originalHash;
+    vi.restoreAllMocks();
+  });
+
+  it("reads a native Codex child directly without requiring navigation membership", async () => {
+    const readThread = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 123,
+      threadId: "019ea380-6595-7cf0-8519-58dca9762bfb",
+      threadStatus: "idle" as const,
+      replay: {
+        entries: [
+          {
+            id: "child-final-message",
+            type: "message" as const,
+            role: "assistant" as const,
+            phase: "final" as const,
+            text: "The child transcript is available.",
+            createdAt: 123,
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    }));
+    (window as Window & { pwragent?: unknown }).pwragent = { readThread };
+    window.location.hash =
+      "#sub-agent/codex/019ea380-6595-7cf0-8519-58dca9762bfb/Bacon";
+
+    render(<SubAgentTranscriptWindow />);
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "019ea380-6595-7cf0-8519-58dca9762bfb",
+        limit: THREAD_HISTORY_PAGE_LIMIT,
+        viewOnly: true,
+      });
+    });
+    expect(screen.getByRole("heading", { name: "Bacon" })).toBeInTheDocument();
+    expect(screen.getByText("The child transcript is available.")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -32,6 +32,7 @@ const REVEALED_SIGNAL = "Execution context";
 
 afterEach(() => {
   cleanup();
+  delete (window as Window & { pwragent?: unknown }).pwragent;
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -460,6 +461,10 @@ describe("ThreadContextPanel", () => {
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
     renderPanel({
       activeTab: "subagents",
       pinned: true,
@@ -509,6 +514,15 @@ describe("ThreadContextPanel", () => {
     const modal = within(screen.getByRole("dialog"));
     expect(modal.getByText("Source")).toBeInTheDocument();
     expect(modal.getByText("Codex native spawnAgent")).toBeInTheDocument();
+    expect(modal.getByRole("button", { name: "Close" })).toBeInTheDocument();
+
+    fireEvent.click(modal.getByRole("button", { name: "Open transcript" }));
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "019ed7df-5876-7882-9b75-7fd647372da7",
+      title: "Peirce",
+    });
   });
 
   it("labels system title helper usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -20,7 +20,6 @@ import type {
 import { ThreadContextPanel } from "../ThreadContextPanel";
 import type { ContextTabId } from "../context-panels/context-tab";
 import { collectEditedFileGroups } from "../edited-file-groups";
-import { ThreadLinkProvider } from "../../../lib/thread-links";
 
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
@@ -160,14 +159,9 @@ type PanelOverrides = Partial<
   >
 >;
 
-function renderPanel(
-  overrides: PanelOverrides = {},
-  options?: {
-    onShowThread: ComponentProps<typeof ThreadLinkProvider>["onShowThread"];
-  },
-) {
+function renderPanel(overrides: PanelOverrides = {}) {
   const onActiveTabChange = vi.fn<(tab: ContextTabId) => void>();
-  const panel = (
+  const result = render(
     <ThreadContextPanel
       activeTab="info"
       backends={[baseBackend]}
@@ -176,16 +170,6 @@ function renderPanel(
       onActiveTabChange={onActiveTabChange}
       {...overrides}
     />
-  );
-  const result = render(
-    options ? (
-      <ThreadLinkProvider
-        onShowThread={options.onShowThread}
-        threads={[overrides.thread ?? baseThread]}
-      >
-        {panel}
-      </ThreadLinkProvider>
-    ) : panel,
   );
   return { ...result, onActiveTabChange };
 }
@@ -2320,7 +2304,6 @@ describe("ThreadContextPanel", () => {
 
   it("keeps an unpinned rail open while using a portaled sub-agent dialog", async () => {
     vi.useFakeTimers();
-    const onShowThread = vi.fn();
     renderPanel(
       {
         activeTab: "subagents",
@@ -2339,7 +2322,6 @@ describe("ThreadContextPanel", () => {
           ],
         },
       },
-      { onShowThread },
     );
 
     const rail = screen.getByLabelText("Thread context");
@@ -2354,11 +2336,10 @@ describe("ThreadContextPanel", () => {
     });
 
     expect(dialog).toBeInTheDocument();
-    fireEvent.click(within(dialog).getByRole("button", { name: "Open transcript" }));
-    expect(onShowThread).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "review-thread-1",
-    });
+    expect(
+      within(dialog).queryByRole("button", { name: "Open transcript" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
     fireEvent.mouseMove(document, { clientX: 500, clientY: 380 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -425,7 +425,11 @@ describe("ThreadContextPanel", () => {
     expect(screen.queryByText(/\$0\.024 list price/)).not.toBeInTheDocument();
   });
 
-  it("labels review sub-agent usage separately from monitor usage", () => {
+  it("does not offer the parent transcript for an inline review", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
     renderPanel({
       activeTab: "subagents",
       pinned: true,
@@ -458,6 +462,54 @@ describe("ThreadContextPanel", () => {
     expect(
       screen.getByText("Review usage: 800 uncached in · 200 cached · 50 out"),
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+
+    expect(
+      within(screen.getByRole("dialog")).queryByRole("button", {
+        name: "Open transcript",
+      }),
+    ).not.toBeInTheDocument();
+    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
+  });
+
+  it("opens a detached review's distinct child transcript", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
+    renderPanel({
+      activeTab: "subagents",
+      pinned: true,
+      thread: {
+        ...baseThread,
+        subAgents: [
+          {
+            monitorId: "review:turn-review-1",
+            task: "Review changes against main",
+            status: "success",
+            createdAt: 2000,
+            completedAt: 3000,
+            updatedAt: 3000,
+            monitorThreadId: "thread-review",
+            monitorTurnId: "turn-review-1",
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    fireEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Open transcript",
+      }),
+    );
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-review",
+      title: "Review changes against main",
+    });
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -473,7 +473,7 @@ describe("ThreadContextPanel", () => {
     expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
-  it("opens a detached review's distinct child transcript", () => {
+  it("does not offer a transcript for a detached review child", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -499,17 +499,12 @@ describe("ThreadContextPanel", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
-    fireEvent.click(
-      within(screen.getByRole("dialog")).getByRole("button", {
+    expect(
+      within(screen.getByRole("dialog")).queryByRole("button", {
         name: "Open transcript",
       }),
-    );
-
-    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
-      backend: "codex",
-      threadId: "thread-review",
-      title: "Review changes against main",
-    });
+    ).not.toBeInTheDocument();
+    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -112,7 +112,7 @@ describe("TranscriptCommandOutput", () => {
     });
   });
 
-  it("opens a PwrAgent-managed sub-agent transcript with its source backend", () => {
+  it("does not offer a transcript for a PwrAgent-managed sub-agent", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -143,13 +143,10 @@ describe("TranscriptCommandOutput", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
-
-    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
-      backend: "acp:gemini",
-      threadId: "monitor-thread-1",
-      title: "Build monitor",
-    });
+    expect(
+      screen.queryByRole("button", { name: "Open transcript" }),
+    ).not.toBeInTheDocument();
+    expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
   });
 
   it("renders structured ACP tool invocations without pretending they are shell commands", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -2,7 +2,6 @@ import "@testing-library/jest-dom/vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TranscriptCommandOutput } from "../TranscriptCommandOutput";
-import { ThreadLinkProvider } from "../../../lib/thread-links";
 
 describe("TranscriptCommandOutput", () => {
   afterEach(() => {
@@ -60,39 +59,40 @@ describe("TranscriptCommandOutput", () => {
   });
 
   it("renders structured native-agent waits as delegated work with transcript access", () => {
-    const onShowThread = vi.fn();
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
     render(
-      <ThreadLinkProvider onShowThread={onShowThread} threads={[]}>
-        <TranscriptCommandOutput
-          detail={{
-            id: "agent-wait-1",
-            kind: "command",
-            label: "Waited on agent 019fb3d1",
-            status: "completed",
-            command: {
-              displayCommand: "wait 019fb3d1",
-              rawCommand: "wait",
-              output: "The agent is still working.",
-              subAgent: {
-                backend: "codex",
-                origin: "codex-native",
-                operation: "wait",
-                model: "gpt-5.6-sol",
-                reasoningEffort: "high",
-                fastMode: true,
-                agents: [
-                  {
-                    threadId: "019fb3d1-28e0-7a30-b964-e93d7a1f3435",
-                    name: "Kieregaard",
-                    status: "running",
-                    message: "Implementing the replacement.",
-                  },
-                ],
-              },
+      <TranscriptCommandOutput
+        detail={{
+          id: "agent-wait-1",
+          kind: "command",
+          label: "Waited on agent 019fb3d1",
+          status: "completed",
+          command: {
+            displayCommand: "wait 019fb3d1",
+            rawCommand: "wait",
+            output: "The agent is still working.",
+            subAgent: {
+              backend: "codex",
+              origin: "codex-native",
+              operation: "wait",
+              model: "gpt-5.6-sol",
+              reasoningEffort: "high",
+              fastMode: true,
+              agents: [
+                {
+                  threadId: "019fb3d1-28e0-7a30-b964-e93d7a1f3435",
+                  name: "Kieregaard",
+                  status: "running",
+                  message: "Implementing the replacement.",
+                },
+              ],
             },
-          }}
-        />
-      </ThreadLinkProvider>,
+          },
+        }}
+      />,
     );
 
     expect(screen.getByText("Codex native agent")).toBeInTheDocument();
@@ -105,9 +105,50 @@ describe("TranscriptCommandOutput", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
 
-    expect(onShowThread).toHaveBeenCalledWith({
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "019fb3d1-28e0-7a30-b964-e93d7a1f3435",
+      title: "Kieregaard",
+    });
+  });
+
+  it("opens a PwrAgent-managed sub-agent transcript with its source backend", () => {
+    const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
+    (window as Window & { pwragent?: unknown }).pwragent = {
+      openSubAgentTranscriptWindow,
+    };
+    render(
+      <TranscriptCommandOutput
+        detail={{
+          id: "agent-monitor-1",
+          kind: "command",
+          label: "Created monitor",
+          status: "completed",
+          command: {
+            displayCommand: "create_monitor",
+            rawCommand: "create_monitor",
+            subAgent: {
+              backend: "acp:gemini",
+              origin: "pwragent",
+              operation: "spawn",
+              agents: [
+                {
+                  threadId: "monitor-thread-1",
+                  name: "Build monitor",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open transcript" }));
+
+    expect(openSubAgentTranscriptWindow).toHaveBeenCalledWith({
+      backend: "acp:gemini",
+      threadId: "monitor-thread-1",
+      title: "Build monitor",
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -18,6 +18,7 @@ import { subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
   defaultBackend: AppServerBackendKind;
+  parentThreadId: string;
   pricingDisplayOptions?: PricingDisplayOptions;
   subAgent: ThreadSubAgentSummary;
   onClose: () => void;
@@ -89,7 +90,10 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const usage = subAgent.monitorUsage;
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
   const fastMode = subAgent.preferredFastMode ?? usage?.fastMode;
-  const transcriptThreadId = subAgent.monitorThreadId;
+  const transcriptThreadId =
+    subAgent.monitorThreadId && subAgent.monitorThreadId !== props.parentThreadId
+      ? subAgent.monitorThreadId
+      : undefined;
   const backendLabel = subAgent.backend ? formatBackendLabel(subAgent.backend) : undefined;
   const usageEstimates = usage
     ? formatSubAgentUsageEstimates({

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -14,7 +14,7 @@ import {
   subAgentTone,
 } from "./subagent-format";
 import { RailStatusChip } from "./RailStatusChip";
-import { subAgentOriginLabel } from "./subagent-kind";
+import { isCodexNativeSubAgent, subAgentOriginLabel } from "./subagent-kind";
 
 type SubAgentDetailsModalProps = {
   defaultBackend: AppServerBackendKind;
@@ -91,7 +91,9 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
   const fastMode = subAgent.preferredFastMode ?? usage?.fastMode;
   const transcriptThreadId =
-    subAgent.monitorThreadId && subAgent.monitorThreadId !== props.parentThreadId
+    isCodexNativeSubAgent(subAgent) &&
+    subAgent.monitorThreadId &&
+    subAgent.monitorThreadId !== props.parentThreadId
       ? subAgent.monitorThreadId
       : undefined;
   const backendLabel = subAgent.backend ? formatBackendLabel(subAgent.backend) : undefined;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { AppServerBackendKind, ThreadSubAgentSummary } from "@pwragent/shared";
+import { CloseIcon } from "../../../icons";
 import { formatBackendLabel } from "../../../lib/backend-label";
-import { useThreadLinks } from "../../../lib/thread-links";
+import { useDesktopApi } from "../../../lib/desktop-api";
 import { formatTimestamp } from "./context-rail-shared";
 import {
   formatSubAgentUsageEstimates,
@@ -32,7 +33,8 @@ type SubAgentDetailsModalProps = {
 export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const { subAgent } = props;
   const contentRef = useRef<HTMLDivElement>(null);
-  const threadLinks = useThreadLinks();
+  const desktopApi = useDesktopApi();
+  const openSubAgentTranscriptWindow = desktopApi?.openSubAgentTranscriptWindow;
 
   // Dialog focus management: move focus into the dialog on open, keep Tab
   // cycling within it (so focus can't fall behind the scrim), restore focus
@@ -123,12 +125,12 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
             {subAgentStatusLabel(subAgent.status)}
           </RailStatusChip>
           <div className="subagent-modal__actions">
-            {threadLinks && transcriptThreadId ? (
+            {openSubAgentTranscriptWindow && transcriptThreadId ? (
               <button
                 type="button"
                 className="button button--ghost subagent-modal__open-transcript"
                 onClick={() => {
-                  threadLinks.show({
+                  void openSubAgentTranscriptWindow({
                     backend: subAgent.backend ?? props.defaultBackend,
                     threadId: transcriptThreadId,
                     title: subAgent.agentName ?? subAgent.task,
@@ -141,10 +143,12 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
             ) : null}
             <button
               type="button"
-              className="button button--ghost subagent-modal__close"
+              className="subagent-modal__close"
+              aria-label="Close"
+              title="Close"
               onClick={props.onClose}
             >
-              Close
+              <CloseIcon size={18} aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -134,6 +134,7 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
       {detailsFor ? (
         <SubAgentDetailsModal
           defaultBackend={props.thread.source}
+          parentThreadId={props.thread.id}
           pricingDisplayOptions={props.pricingDisplayOptions}
           subAgent={detailsFor}
           onClose={closeDetails}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -225,6 +225,8 @@ import type {
   OpenDesktopApplicationResponse,
   OpenMarkdownFileViewerRequest,
   OpenMarkdownFileViewerResponse,
+  OpenSubAgentTranscriptWindowRequest,
+  OpenSubAgentTranscriptWindowResponse,
   OpenPathRequest,
   OpenPathResponse,
   ReadMarkdownFileRequest,
@@ -575,6 +577,9 @@ export type DesktopApi = {
   onMarkdownFileViewerSnapshotChanged?: (
     callback: (snapshot: ReadMarkdownFileViewerSnapshotResponse) => void
   ) => () => void;
+  openSubAgentTranscriptWindow?: (
+    request: OpenSubAgentTranscriptWindowRequest
+  ) => Promise<OpenSubAgentTranscriptWindowResponse>;
   createIntegratedTerminal?: (
     request: IntegratedTerminalCreateRequest,
   ) => Promise<IntegratedTerminalCreateResponse>;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -119,6 +119,10 @@ const MarkdownFilesWindow = lazy(async () => ({
   default: (await import("./features/thread-detail/MarkdownFilesWindow"))
     .MarkdownFilesWindow,
 }));
+const SubAgentTranscriptWindow = lazy(async () => ({
+  default: (await import("./features/thread-detail/SubAgentTranscriptWindow"))
+    .SubAgentTranscriptWindow,
+}));
 
 /**
  * Routes recognized by `chooseRoot` below. The Messaging Activity
@@ -155,6 +159,10 @@ const routes: Array<{
   {
     match: (hash) => hash.startsWith("files/"),
     render: () => <MarkdownFilesWindow />,
+  },
+  {
+    match: (hash) => hash.startsWith("sub-agent/"),
+    render: () => <SubAgentTranscriptWindow />,
   },
 ];
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9686,6 +9686,108 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--danger-text);
 }
 
+.subagent-transcript-window {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-app);
+}
+
+.subagent-transcript-window__content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.subagent-transcript-window__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-panel-elevated);
+}
+
+.subagent-transcript-window__identity {
+  min-width: 0;
+}
+
+.subagent-transcript-window__identity h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 650;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.subagent-transcript-window__identity p {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.subagent-transcript-window__identity code {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
+.subagent-transcript-window__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.subagent-transcript-window__live {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--success-text);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.subagent-transcript-window__live::before {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--status-ok);
+  content: "";
+}
+
+.subagent-transcript-window__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.subagent-transcript-window__close:hover {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.subagent-transcript-window__close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .transcript-message__image-button {
   box-sizing: border-box;
   display: flex;
@@ -13803,7 +13905,28 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .subagent-modal__close {
+  display: inline-flex;
   flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.subagent-modal__close:hover {
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+.subagent-modal__close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .subagent-modal__actions {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -326,6 +326,8 @@ export const MARKDOWN_FILE_VIEWER_SNAPSHOT_READ_CHANNEL =
   "markdown-file-viewer:read-snapshot";
 export const MARKDOWN_FILE_VIEWER_SNAPSHOT_CHANGED_CHANNEL =
   "markdown-file-viewer:snapshot-changed";
+export const SUB_AGENT_TRANSCRIPT_WINDOW_OPEN_CHANNEL =
+  "sub-agent-transcript:open-window";
 export const INTEGRATED_TERMINAL_CREATE_CHANNEL =
   "integrated-terminal:create";
 export const INTEGRATED_TERMINAL_WRITE_CHANNEL = "integrated-terminal:write";

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -718,6 +718,12 @@ export type AppServerReadThreadRequest = {
   includeTurns?: boolean;
   before?: string;
   limit?: number;
+  /**
+   * Reads transcript data without applying PwrAgent's normal selected-thread
+   * enrichment writes. Used by inspection-only secondary windows such as the
+   * native sub-agent transcript viewer.
+   */
+  viewOnly?: boolean;
 };
 
 export type AppServerReadThreadResponse = {

--- a/packages/shared/src/contracts/subagent-transcript.ts
+++ b/packages/shared/src/contracts/subagent-transcript.ts
@@ -1,0 +1,19 @@
+import type { AppServerBackendKind } from "./normalized-app-server";
+
+/**
+ * Opens the dedicated, read-only transcript window for a delegated agent.
+ *
+ * A native Codex child has a transcript addressable through `thread/read`,
+ * but is not necessarily a durable PwrAgent navigation thread. Keeping this
+ * request separate prevents the viewer from accidentally gaining normal
+ * thread navigation or composer controls.
+ */
+export type OpenSubAgentTranscriptWindowRequest = {
+  backend: AppServerBackendKind;
+  threadId: string;
+  title: string;
+};
+
+export type OpenSubAgentTranscriptWindowResponse = {
+  opened: true;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from "./contracts/messaging";
 export * from "./contracts/messaging-tools";
 export * from "./contracts/navigation";
 export * from "./contracts/settings";
+export * from "./contracts/subagent-transcript";
 export * from "./contracts/thread-link";
 export * from "./contracts/thread-tools";
 export * from "./contracts/thread-search";


### PR DESCRIPTION
## Summary

- I added a dedicated, read-only desktop window for Codex native `spawnAgent` transcripts. It reads the child directly through the App Server instead of treating its ID as a normal navigation thread.
- I kept the viewer inspection-only: it has no composer, normal thread navigation, or mutation controls; active children refresh live; and older transcript pages remain available. I show its action only for native Codex children, so monitors, reviews, and helpers cannot open an unavailable or parent transcript.
- I made inspection reads skip selected-thread directory and usage-state writes, and replaced the sub-agent detail modal's textual Close button with an accessible X affordance.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/SubAgentTranscriptWindow.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx` (541 passing tests).
- I ran `pnpm typecheck`, `pnpm lint:eslint` (0 errors; existing warnings only), `pnpm lint:colors`, `pnpm lint:boundaries`, and `pnpm lint:codex-storage`.
- I ran `pnpm --filter @pwragent/desktop build`.

## Notes

- The root cause was that native Codex child IDs are addressable with `thread/read` but are not necessarily present in PwrAgent's normal navigation snapshot, which sent the former link to the empty "Pick a thread" state. PwrAgent monitors, review helpers, and system helpers are ephemeral operational sessions, so Codex does not retain a readable child transcript for them; inline native reviews also run in the parent thread.
