### PR TITLE
feat(desktop): enable background PR polling by default

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1819,7 +1819,7 @@ describe("DesktopSettingsService", () => {
     );
   });
 
-  it("defaults background PR polling to off and persists it", async () => {
+  it("defaults background PR polling to on and persists an explicit opt-out", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     const service = new DesktopSettingsService({
@@ -1828,26 +1828,26 @@ describe("DesktopSettingsService", () => {
       secretStore: new MemoryDesktopSecretStore(),
     });
 
-    // Opt-in: with the flag absent, background polling stays off entirely.
+    // With the flag absent, background polling is enabled by default.
     const initial = await service.readSettings();
     expect(initial.experimental.backgroundPrPolling).toEqual({
-      value: false,
+      value: true,
       source: "default",
     });
 
     await service.writeConfigPatch({
       experimental: {
-        backgroundPrPolling: true,
+        backgroundPrPolling: false,
       },
     });
 
     const updated = await service.readSettings();
     expect(updated.experimental.backgroundPrPolling).toEqual({
-      value: true,
+      value: false,
       source: "config",
     });
     expect(fs.readFileSync(configPath, "utf8")).toContain(
-      "background_pr_polling = true",
+      "background_pr_polling = false",
     );
   });
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -760,15 +760,15 @@ describe("SettingsScreen", () => {
 
     // The snapshot fixture omits `backgroundPrPolling` entirely, which is the
     // real shape an older/stale snapshot has — the toggle must still render
-    // (unchecked, from the shared default) rather than crash.
+    // (checked, from the shared default) rather than crash.
     const backgroundPrPollingSwitch = screen.getByRole("switch", {
       name: "Enable background pull request status",
     });
-    expect(backgroundPrPollingSwitch).toHaveAttribute("aria-checked", "false");
+    expect(backgroundPrPollingSwitch).toHaveAttribute("aria-checked", "true");
     fireEvent.click(backgroundPrPollingSwitch);
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
-        experimental: { backgroundPrPolling: true },
+        experimental: { backgroundPrPolling: false },
       });
     });
 

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -22,11 +22,10 @@ export const DESKTOP_WORKTREE_STORAGE_DEFAULT: DesktopWorktreeStorageLocation =
   "user-home";
 
 /**
- * Background PR status polling ships opt-in while it is experimental. With it
- * off, PR chips behave exactly as they did before the poller existed, so the
- * flag is a true kill switch rather than a tuning knob.
+ * Background PR status polling is enabled by default. An explicit false value
+ * remains a kill switch for operators who need to disable the poller.
  */
-export const DEFAULT_BACKGROUND_PR_POLLING = false;
+export const DEFAULT_BACKGROUND_PR_POLLING = true;
 
 export const DESKTOP_UPDATE_CHANNELS = ["latest", "prerelease"] as const;
 


### PR DESCRIPTION
## What changed

- treat a missing `experimental.background_pr_polling` setting as enabled
- preserve an explicit `false` value as the operator kill switch
- update settings-service and renderer coverage for the new default and opt-out path

## Why

Background pull-request refresh has matured enough to provide value by default. Operators can still disable it immediately in Settings if it causes trouble in their environment.

## Impact

Existing profiles without the config key begin background PR polling automatically. Profiles that explicitly set `background_pr_polling = false` remain disabled.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (113 tests)
- `pnpm lint:eslint` (passes with existing warnings)
- `pnpm typecheck`
- `pnpm lint:boundaries`
