### PR TITLE
feat(desktop): auto-dispatch PR repair turns

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -368,12 +368,16 @@ const beginThreadPrAutoDispatch = vi.fn(async () => ({
   status: "disabled" as const,
 }));
 const restoreThreadPrAutoDispatchAfterBusy = vi.fn(async () => undefined);
+const renewThreadPrAutoDispatchLease = vi.fn(async () => false);
 const finishThreadPrAutoDispatch = vi.fn(async () => undefined);
 const cancelThreadPrAutoDispatch = vi.fn(async () => false);
 const cancelPendingThreadPrAutoDispatchForPr = vi.fn(async () => false);
 const resolveThreadPrAutoDispatchIncident = vi.fn(async () => undefined);
 const getThreadPrAutoDispatchPending = vi.fn(async () => undefined);
 const listPendingThreadPrAutoDispatches = vi.fn(async () => []);
+const recoverOrphanedThreadPrAutoDispatches = vi.fn(async () => ({
+  recoveredCount: 0,
+}));
 const isGhAvailable = vi.fn(async () => true);
 const getAuthStatus = vi.fn(async () => ({
   installed: true,
@@ -492,12 +496,14 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     scheduleThreadPrAutoDispatch,
     beginThreadPrAutoDispatch,
     restoreThreadPrAutoDispatchAfterBusy,
+    renewThreadPrAutoDispatchLease,
     finishThreadPrAutoDispatch,
     cancelThreadPrAutoDispatch,
     cancelPendingThreadPrAutoDispatchForPr,
     resolveThreadPrAutoDispatchIncident,
     getThreadPrAutoDispatchPending,
     listPendingThreadPrAutoDispatches,
+    recoverOrphanedThreadPrAutoDispatches,
     readDirectoryGitStatusCache,
     writeDirectoryGitStatusCacheEntry,
     readThreadGitWorkingStateCache,
@@ -600,12 +606,14 @@ describe("app server ipc", () => {
     scheduleThreadPrAutoDispatch.mockClear();
     beginThreadPrAutoDispatch.mockClear();
     restoreThreadPrAutoDispatchAfterBusy.mockClear();
+    renewThreadPrAutoDispatchLease.mockClear();
     finishThreadPrAutoDispatch.mockClear();
     cancelThreadPrAutoDispatch.mockClear();
     cancelPendingThreadPrAutoDispatchForPr.mockClear();
     resolveThreadPrAutoDispatchIncident.mockClear();
     getThreadPrAutoDispatchPending.mockClear();
     listPendingThreadPrAutoDispatches.mockClear();
+    recoverOrphanedThreadPrAutoDispatches.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
     getAuthStatus.mockClear();

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -250,6 +250,7 @@ function emitRegistryEvent(event: unknown): void {
 }
 const publishLocalEvent = vi.fn(async () => undefined);
 const setThreadPullRequestStatusToolHandler = vi.fn();
+const setThreadPrAutoDispatchHandler = vi.fn();
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
   directoryKey: string;
   directoryKind: string;
@@ -359,6 +360,20 @@ const readPrStatusCache = vi.fn(async () => ({}));
 const writePrStatusCacheEntries = vi.fn(async () => undefined);
 const readPrLookupCache = vi.fn(async () => ({}));
 const writePrLookupCacheEntry = vi.fn(async () => undefined);
+const resetThreadPrAutoDispatchForOperator = vi.fn(async () => false);
+const scheduleThreadPrAutoDispatch = vi.fn(async () => ({
+  status: "disabled" as const,
+}));
+const beginThreadPrAutoDispatch = vi.fn(async () => ({
+  status: "disabled" as const,
+}));
+const restoreThreadPrAutoDispatchAfterBusy = vi.fn(async () => undefined);
+const finishThreadPrAutoDispatch = vi.fn(async () => undefined);
+const cancelThreadPrAutoDispatch = vi.fn(async () => false);
+const cancelPendingThreadPrAutoDispatchForPr = vi.fn(async () => false);
+const resolveThreadPrAutoDispatchIncident = vi.fn(async () => undefined);
+const getThreadPrAutoDispatchPending = vi.fn(async () => undefined);
+const listPendingThreadPrAutoDispatches = vi.fn(async () => []);
 const isGhAvailable = vi.fn(async () => true);
 const getAuthStatus = vi.fn(async () => ({
   installed: true,
@@ -473,6 +488,16 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
     writePrStatusCacheEntries,
     readPrLookupCache,
     writePrLookupCacheEntry,
+    resetThreadPrAutoDispatchForOperator,
+    scheduleThreadPrAutoDispatch,
+    beginThreadPrAutoDispatch,
+    restoreThreadPrAutoDispatchAfterBusy,
+    finishThreadPrAutoDispatch,
+    cancelThreadPrAutoDispatch,
+    cancelPendingThreadPrAutoDispatchForPr,
+    resolveThreadPrAutoDispatchIncident,
+    getThreadPrAutoDispatchPending,
+    listPendingThreadPrAutoDispatches,
     readDirectoryGitStatusCache,
     writeDirectoryGitStatusCacheEntry,
     readThreadGitWorkingStateCache,
@@ -503,6 +528,7 @@ vi.mock("../app-server/backend-registry", () => ({
     onEvent,
     publishLocalEvent,
     setThreadPullRequestStatusToolHandler,
+    setThreadPrAutoDispatchHandler,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
     rememberCompleteNavigationSnapshot,
@@ -552,6 +578,7 @@ describe("app server ipc", () => {
     registryEventListeners.length = 0;
     publishLocalEvent.mockClear();
     setThreadPullRequestStatusToolHandler.mockClear();
+    setThreadPrAutoDispatchHandler.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
     registerDirectoryFromDiskService.mockClear();
@@ -569,6 +596,16 @@ describe("app server ipc", () => {
     readPrLookupCache.mockReset();
     readPrLookupCache.mockResolvedValue({});
     writePrLookupCacheEntry.mockClear();
+    resetThreadPrAutoDispatchForOperator.mockClear();
+    scheduleThreadPrAutoDispatch.mockClear();
+    beginThreadPrAutoDispatch.mockClear();
+    restoreThreadPrAutoDispatchAfterBusy.mockClear();
+    finishThreadPrAutoDispatch.mockClear();
+    cancelThreadPrAutoDispatch.mockClear();
+    cancelPendingThreadPrAutoDispatchForPr.mockClear();
+    resolveThreadPrAutoDispatchIncident.mockClear();
+    getThreadPrAutoDispatchPending.mockClear();
+    listPendingThreadPrAutoDispatches.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
     getAuthStatus.mockClear();
@@ -585,6 +622,18 @@ describe("app server ipc", () => {
   afterEach(async () => {
     const { disposeAppServerIpcHandlers } = await import("../ipc/app-server");
     await disposeAppServerIpcHandlers();
+  });
+
+  it("registers main-process PR auto-dispatch handlers", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+
+    registerAppServerIpcHandlers();
+
+    expect(setThreadPrAutoDispatchHandler).toHaveBeenCalledWith({
+      preferenceChanged: expect.any(Function),
+      cancelPending: expect.any(Function),
+      sendPendingNow: expect.any(Function),
+    });
   });
 
   it("aggregates navigation snapshots across backends by default", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23656,6 +23656,119 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("keeps an injected turn origin when replay arrives before its user item event", async () => {
+    const userEntry: AppServerThreadReplay["entries"][number] = {
+      type: "message",
+      id: "message-provider-assigned",
+      role: "user",
+      text: "Repair the attached PR.",
+      turn: { id: "turn-1", status: "failed" },
+    };
+    const replay: AppServerThreadReplay = {
+      entries: [userEntry],
+      messages: [
+        {
+          id: "message-provider-assigned",
+          role: "user",
+          text: "Repair the attached PR.",
+        },
+      ],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ replay }),
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "target-thread",
+      input: [{ type: "text", text: "Repair the attached PR." }],
+      messageOrigin: { kind: "pwragent" },
+    });
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "target-thread",
+    });
+
+    expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "target-thread",
+      messageId: "user:turn-1",
+      origin: { kind: "pwragent" },
+    });
+    expect(response.replay.entries[0]).toMatchObject({
+      id: "message-provider-assigned",
+      origin: { kind: "pwragent" },
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      id: "message-provider-assigned",
+      origin: { kind: "pwragent" },
+    });
+
+    await registry.close();
+  });
+
+  it("persists an injected origin from a started user item", async () => {
+    const codexClient = new MockBackendClient({});
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    await registry.startTurn({
+      backend: "codex",
+      threadId: "target-thread",
+      input: [{ type: "text", text: "Repair the attached PR." }],
+      messageOrigin: { kind: "pwragent" },
+    });
+    await codexClient.emit({
+      method: "item/started",
+      params: {
+        threadId: "target-thread",
+        turnId: "turn-1",
+        item: {
+          id: "message-provider-assigned",
+          type: "userMessage",
+          text: "Repair the attached PR.",
+        },
+      },
+    });
+
+    expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "target-thread",
+      messageId: "message-provider-assigned",
+      origin: { kind: "pwragent" },
+    });
+    expect(events.at(-1)).toMatchObject({
+      notification: {
+        method: "item/started",
+        params: {
+          item: {
+            id: "message-provider-assigned",
+            origin: { kind: "pwragent" },
+          },
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
   it("does not copy one message origin to another user message in the same turn", async () => {
     const userEntries: AppServerThreadReplay["entries"] = [
       {
@@ -23694,7 +23807,7 @@ script = "printf setup"
     await overlayStore.upsertThreadMessageOrigin!({
       backend: "codex",
       threadId: "target-thread",
-      messageId: "message-injected",
+      messageId: "user:turn-1",
       origin: { kind: "automation" },
     });
     const registry = new DesktopBackendRegistry({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -574,6 +574,26 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setThreadPrAutoDispatchEnabled: async ({
+      backend,
+      threadId,
+      enabled,
+    }: {
+      backend: AppServerBackendKind;
+      threadId: string;
+      enabled: boolean;
+    }) => {
+      const key = `${backend}:${threadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next = { ...current, prAutoDispatchEnabled: enabled };
+      overlays.set(key, next);
+      return next;
+    },
     turnOffCodexFastEverywhere: async () => {
       let threadCount = 0;
       const updatedThreadIds: string[] = [];
@@ -2121,6 +2141,34 @@ function rememberCollapsedDirectoryWithPinnedThread(params: {
 }
 
 describe("DesktopBackendRegistry", () => {
+  it("evaluates the current PR state when auto-fix is enabled", async () => {
+    const preferenceChanged = vi.fn(async () => undefined);
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+    });
+    registry.setThreadPrAutoDispatchHandler({
+      preferenceChanged,
+      cancelPending: vi.fn(async () => true),
+    });
+
+    try {
+      await registry.setThreadPrAutoDispatch({
+        backend: "codex",
+        threadId: "thread-1",
+        enabled: true,
+      });
+      expect(preferenceChanged).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        enabled: true,
+      });
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("routes structured generation to the configured Codex backend", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
     const generateStructuredObject = vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2143,6 +2143,7 @@ function rememberCollapsedDirectoryWithPinnedThread(params: {
 describe("DesktopBackendRegistry", () => {
   it("evaluates the current PR state when auto-fix is enabled", async () => {
     const preferenceChanged = vi.fn(async () => undefined);
+    const sendPendingNow = vi.fn(async () => true);
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
       grokClient: new MockBackendClient({ threads: [] }),
@@ -2151,6 +2152,7 @@ describe("DesktopBackendRegistry", () => {
     registry.setThreadPrAutoDispatchHandler({
       preferenceChanged,
       cancelPending: vi.fn(async () => true),
+      sendPendingNow,
     });
 
     try {
@@ -2163,6 +2165,21 @@ describe("DesktopBackendRegistry", () => {
         backend: "codex",
         threadId: "thread-1",
         enabled: true,
+      });
+      await expect(registry.sendThreadPrAutoDispatchNow({
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+      })).resolves.toEqual({
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
+        accepted: true,
+      });
+      expect(sendPendingNow).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        fingerprint: "fingerprint-1",
       });
     } finally {
       await registry.close();

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -143,6 +143,7 @@ describe("mapGraphqlPrNode", () => {
       lifecycleState: "open",
       reviewState: "ready_for_review",
       mergeState: "mergeable",
+      headSha: "a".repeat(40),
       commitShas: ["a".repeat(40)],
       url: "https://github.com/pwrdrvr/PwrAgent/pull/12",
     });

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -53,6 +53,7 @@ describe("parseGhPrPayload", () => {
       lifecycleState: "merged",
       reviewState: "ready_for_review",
       mergeState: "unknown",
+      headSha: "b".repeat(40),
       commitShas: ["a".repeat(40), "b".repeat(40)],
       url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
     });
@@ -560,6 +561,7 @@ describe("GithubPrFetcher", () => {
           lifecycleState: "merged",
           reviewState: "ready_for_review",
           mergeState: "unknown",
+          headSha: "b".repeat(40),
           commitShas: ["a".repeat(40), "b".repeat(40)],
           url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
         },
@@ -610,6 +612,7 @@ describe("GithubPrFetcher", () => {
         lifecycleState: "merged",
         reviewState: "ready_for_review",
         mergeState: "unknown",
+        headSha: "b".repeat(40),
         commitShas: ["a".repeat(40), "b".repeat(40)],
         url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
       });

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -14,6 +14,7 @@ import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import {
   MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
   PR_AUTO_DISPATCH_DELAY_MS,
+  PR_AUTO_DISPATCH_LEASE_MS,
   PrAutoDispatchCoordinator,
 } from "../pr-status/pr-auto-dispatch";
 
@@ -72,6 +73,7 @@ function createHarness(options: {
   let busy = options.busy ?? false;
   let gate = options.gate ?? true;
   let currentPr = options.currentPr ?? pr();
+  let refreshedPr: PrSummary | undefined;
   const pendingUpdates: Array<ThreadPrAutoDispatchPending | null> = [];
   const submitTurnIfIdle = vi.fn(async (_request: {
     input: AppServerTurnInputItem[];
@@ -82,6 +84,10 @@ function createHarness(options: {
     store: options.targetStore ?? store,
     registry: { submitTurnIfIdle },
     getCurrentPr: () => currentPr,
+    refreshPendingPrs: async (pending) => {
+      if (refreshedPr) currentPr = refreshedPr;
+      return new Set(pending.map((item) => item.prKey));
+    },
     isPrAttached: () => true,
     isBackgroundPollingEnabled: () => gate,
     now: () => clock,
@@ -100,6 +106,9 @@ function createHarness(options: {
     },
     setGate: (value: boolean) => {
       gate = value;
+    },
+    setRefreshedPr: (value: PrSummary) => {
+      refreshedPr = value;
     },
     submitTurnIfIdle,
   };
@@ -170,6 +179,31 @@ describe("PrAutoDispatchCoordinator", () => {
     expect(thread?.prAutoDispatchPending?.scheduledAt).toBe(
       clock + PR_AUTO_DISPATCH_DELAY_MS,
     );
+  });
+
+  it("does not schedule terminal PRs and cancels a pending repair when one closes", async () => {
+    const harness = createHarness();
+    expect((await observe(
+      harness.coordinator,
+      pr({ lifecycleState: "merged" }),
+    ))[0]?.status).toBe("not-actionable");
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
+
+    await observe(harness.coordinator);
+    const closed = pr({ lifecycleState: "closed" });
+    harness.setCurrentPr(closed);
+    expect((await observe(harness.coordinator, closed))[0]?.status).toBe(
+      "not-actionable",
+    );
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
   });
 
   it("dispatches only after the countdown and includes structured PR context", async () => {
@@ -336,6 +370,79 @@ describe("PrAutoDispatchCoordinator", () => {
     await runCountdown();
     expect(afterRestart.submitTurnIfIdle).toHaveBeenCalledTimes(1);
     expect((await observe(afterRestart.coordinator))[0]?.status).toBe("duplicate");
+  });
+
+  it("waits for provider refresh before resuming an overdue paused repair", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    harness.coordinator.pause();
+    harness.setGate(false);
+    clock += PR_AUTO_DISPATCH_DELAY_MS;
+    await vi.advanceTimersByTimeAsync(PR_AUTO_DISPATCH_DELAY_MS);
+    harness.setRefreshedPr(pr({
+      state: "passing",
+      checkState: "passing",
+    }));
+    harness.setGate(true);
+
+    await harness.coordinator.resume();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeUndefined();
+  });
+
+  it("reclaims an orphaned dispatch lease after restart without double-spending", async () => {
+    const first = createHarness();
+    await observe(first.coordinator);
+    first.coordinator.close();
+    const pending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(await store.beginThreadPrAutoDispatch({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: pending!.pending.fingerprint,
+      leaseExpiresAt: clock + PR_AUTO_DISPATCH_LEASE_MS,
+      maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+      now: clock,
+      ownerId: "dead-process",
+    })).toMatchObject({ status: "ready", attemptCount: 1 });
+
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+    const afterRestart = createHarness();
+    await afterRestart.coordinator.resume();
+
+    clock += PR_AUTO_DISPATCH_LEASE_MS - 1;
+    await vi.advanceTimersByTimeAsync(PR_AUTO_DISPATCH_LEASE_MS - 1);
+    expect(afterRestart.submitTurnIfIdle).not.toHaveBeenCalled();
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(1);
+
+    clock += 1;
+    await vi.advanceTimersByTimeAsync(1);
+    expect((await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    }))?.pending.scheduledAt).toBe(clock + PR_AUTO_DISPATCH_DELAY_MS);
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(0);
+
+    await runCountdown();
+    expect(afterRestart.submitTurnIfIdle).toHaveBeenCalledTimes(1);
   });
 
   it("atomically rejects busy submission and restores the countdown without spending an attempt", async () => {

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -3,23 +3,29 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildPullRequestStatusKey,
   materializeNavigationThreads,
   type AppServerTurnInputItem,
   type PrSummary,
+  type ThreadPrAutoDispatchPending,
 } from "@pwragent/shared";
 import { StateDb } from "../state/state-db";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import {
   MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+  PR_AUTO_DISPATCH_DELAY_MS,
   PrAutoDispatchCoordinator,
 } from "../pr-status/pr-auto-dispatch";
-import { computePrStatusTransition } from "../pr-status/pr-transitions";
 
 let stateDb: StateDb;
 let store: SqliteOverlayStore;
 let tempDir: string;
+let clock: number;
+const extraDbs: StateDb[] = [];
 
 beforeEach(async () => {
+  vi.useFakeTimers();
+  clock = 1_000;
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-pr-auto-dispatch-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"));
   store = new SqliteOverlayStore(stateDb);
@@ -31,8 +37,10 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  for (const db of extraDbs.splice(0)) db.close();
   stateDb.close();
   rmSync(tempDir, { recursive: true, force: true });
+  vi.useRealTimers();
 });
 
 function pr(overrides: Partial<PrSummary> = {}): PrSummary {
@@ -43,8 +51,8 @@ function pr(overrides: Partial<PrSummary> = {}): PrSummary {
     org: "pwrdrvr",
     repo: "PwrAgent",
     title: "Auto-fix attached PR failures",
-    state: "pending",
-    checkState: "pending",
+    state: "failing",
+    checkState: "failing",
     lifecycleState: "open",
     reviewState: "ready_for_review",
     mergeState: "mergeable",
@@ -55,79 +63,75 @@ function pr(overrides: Partial<PrSummary> = {}): PrSummary {
   };
 }
 
-function failingTransition(headSha = "a".repeat(40)) {
-  return computePrStatusTransition(
-    pr({ headSha, checkState: "pending", state: "pending" }),
-    pr({ headSha, checkState: "failing", state: "failing" }),
-    ["codex:thread-1"],
-  )!;
-}
-
-function passingTransition(headSha = "a".repeat(40)) {
-  return computePrStatusTransition(
-    pr({ headSha, checkState: "failing", state: "failing" }),
-    pr({ headSha, checkState: "passing", state: "passing" }),
-    ["codex:thread-1"],
-  )!;
-}
-
-function conflictingTransition(headSha = "a".repeat(40)) {
-  return computePrStatusTransition(
-    pr({ headSha, mergeState: "mergeable" }),
-    pr({ headSha, mergeState: "conflicting" }),
-    ["codex:thread-1"],
-  )!;
-}
-
-function newFailingHeadTransition(previousHead: string, nextHead: string) {
-  return computePrStatusTransition(
-    pr({
-      headSha: previousHead,
-      commitShas: [previousHead],
-      checkState: "failing",
-      state: "failing",
-    }),
-    pr({
-      headSha: nextHead,
-      commitShas: [nextHead],
-      checkState: "failing",
-      state: "failing",
-    }),
-    ["codex:thread-1"],
-  )!;
-}
-
-function createHarness(options: { busy?: boolean } = {}) {
-  const submitTurn = vi.fn(async (_request: {
+function createHarness(options: {
+  targetStore?: SqliteOverlayStore;
+  busy?: boolean;
+  gate?: boolean;
+  currentPr?: PrSummary;
+} = {}) {
+  let busy = options.busy ?? false;
+  let gate = options.gate ?? true;
+  let currentPr = options.currentPr ?? pr();
+  const pendingUpdates: Array<ThreadPrAutoDispatchPending | null> = [];
+  const submitTurnIfIdle = vi.fn(async (_request: {
     input: AppServerTurnInputItem[];
-  }) => ({
-    status: "started" as const,
-    turnId: "turn-auto-1",
-  }));
+  }) => busy
+    ? { status: "busy" as const }
+    : { status: "started" as const, turnId: "turn-auto-1" });
   const coordinator = new PrAutoDispatchCoordinator({
-    store,
-    registry: {
-      canStartThreadTurnImmediately: () => !options.busy,
-      submitTurn,
+    store: options.targetStore ?? store,
+    registry: { submitTurnIfIdle },
+    getCurrentPr: () => currentPr,
+    isPrAttached: () => true,
+    isBackgroundPollingEnabled: () => gate,
+    now: () => clock,
+    onPendingChanged: ({ pending }) => {
+      pendingUpdates.push(pending);
     },
   });
-  return { coordinator, submitTurn };
+  return {
+    coordinator,
+    pendingUpdates,
+    setBusy: (value: boolean) => {
+      busy = value;
+    },
+    setCurrentPr: (value: PrSummary) => {
+      currentPr = value;
+    },
+    setGate: (value: boolean) => {
+      gate = value;
+    },
+    submitTurnIfIdle,
+  };
+}
+
+async function observe(
+  coordinator: PrAutoDispatchCoordinator,
+  currentPr = pr(),
+  backgroundPollingEnabled = true,
+) {
+  return await coordinator.handleStatusSnapshot({
+    pr: currentPr,
+    threadKeys: ["codex:thread-1"],
+    observedAt: clock,
+    backgroundPollingEnabled,
+  });
+}
+
+async function runCountdown(): Promise<void> {
+  clock += PR_AUTO_DISPATCH_DELAY_MS;
+  await vi.advanceTimersByTimeAsync(PR_AUTO_DISPATCH_DELAY_MS);
 }
 
 describe("PrAutoDispatchCoordinator", () => {
-  it("does nothing when the global background-polling gate is off", async () => {
-    const { coordinator, submitTurn } = createHarness();
-    const outcomes = await coordinator.handleTransition({
-      transition: failingTransition(),
-      source: "background-poll",
-      observedAt: 1_000,
-      backgroundPollingEnabled: false,
-    });
+  it("keeps the saved preference but schedules nothing while the global gate is off", async () => {
+    const harness = createHarness({ gate: false });
+    const outcomes = await observe(harness.coordinator, pr(), false);
 
     expect(outcomes).toEqual([
       { threadKey: "codex:thread-1", status: "gate-off" },
     ]);
-    expect(submitTurn).not.toHaveBeenCalled();
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
     expect(
       (await store.getThreadOverlayState({
         backend: "codex",
@@ -136,73 +140,24 @@ describe("PrAutoDispatchCoordinator", () => {
     ).toBe(true);
   });
 
-  it("rechecks the global gate before claiming a dispatch", async () => {
-    let backgroundPollingEnabled = true;
-    const submitTurn = vi.fn(async () => ({
-      status: "started" as const,
-      turnId: "turn-auto-1",
-    }));
-    const coordinator = new PrAutoDispatchCoordinator({
-      store,
-      registry: {
-        canStartThreadTurnImmediately: () => {
-          backgroundPollingEnabled = false;
-          return true;
-        },
-        submitTurn,
-      },
-      isBackgroundPollingEnabled: () => backgroundPollingEnabled,
-    });
+  it("schedules the current failed PR immediately and exposes a 30-second on-deck item", async () => {
+    const harness = createHarness();
+    const outcomes = await observe(harness.coordinator);
 
-    const outcomes = await coordinator.handleTransition({
-      transition: failingTransition(),
-      source: "background-poll",
-      observedAt: 1_000,
-      backgroundPollingEnabled: true,
-    });
-
-    expect(outcomes).toEqual([
-      { threadKey: "codex:thread-1", status: "gate-off" },
-    ]);
-    expect(submitTurn).not.toHaveBeenCalled();
+    expect(outcomes[0]).toMatchObject({ status: "scheduled" });
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
     const overlay = await store.getThreadOverlayState({
       backend: "codex",
       threadId: "thread-1",
     });
-    expect(overlay?.prAutoDispatchHandledFingerprints).toBeUndefined();
-    expect(overlay?.prAutoDispatchAttemptCounts).toBeUndefined();
-  });
-
-  it("claims before dispatch and never replays the same fingerprint after restart", async () => {
-    const first = createHarness();
-    const transition = failingTransition();
-    const firstOutcomes = await first.coordinator.handleTransition({
-      transition,
-      source: "background-poll",
-      observedAt: 1_000,
-      backgroundPollingEnabled: true,
+    expect(overlay?.prAutoDispatchPending).toMatchObject({
+      prNumber: 1105,
+      eventKinds: ["ci-failure"],
+      scheduledAt: clock + PR_AUTO_DISPATCH_DELAY_MS,
     });
-
-    expect(firstOutcomes[0]?.status).toBe("dispatched");
-    expect(first.submitTurn).toHaveBeenCalledTimes(1);
-    expect(first.submitTurn.mock.calls[0]?.[0].input[0]).toEqual(
-      expect.objectContaining({
-        type: "text",
-        text: expect.stringContaining(`- Head SHA: ${"a".repeat(40)}`),
-      }),
-    );
-
-    const dbPath = path.join(tempDir, "state.db");
-    stateDb.close();
-    stateDb = StateDb.open(dbPath);
-    store = new SqliteOverlayStore(stateDb);
-    const restoredOverlay = await store.getThreadOverlayState({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-    const restoredThread = materializeNavigationThreads({
+    const thread = materializeNavigationThreads({
       firstSnapshot: true,
-      overlayByThreadKey: { "codex:thread-1": restoredOverlay },
+      overlayByThreadKey: { "codex:thread-1": overlay },
       previousKnownThreadKeys: [],
       threads: [{
         id: "thread-1",
@@ -212,123 +167,209 @@ describe("PrAutoDispatchCoordinator", () => {
         linkedDirectories: [],
       }],
     })[0];
-    expect(restoredThread?.prAutoDispatchEnabled).toBe(true);
-    const afterRestart = createHarness();
-    const replayOutcomes = await afterRestart.coordinator.handleTransition({
-      transition,
-      source: "background-poll",
-      observedAt: 2_000,
-      backgroundPollingEnabled: true,
-    });
-
-    expect(replayOutcomes[0]?.status).toBe("duplicate");
-    expect(afterRestart.submitTurn).not.toHaveBeenCalled();
-  });
-
-  it("does not queue an automatic turn while the thread is active or queued", async () => {
-    const busy = createHarness({ busy: true });
-    const transition = failingTransition();
-    const busyOutcomes = await busy.coordinator.handleTransition({
-      transition,
-      source: "background-poll",
-      observedAt: 1_000,
-      backgroundPollingEnabled: true,
-    });
-
-    expect(busyOutcomes[0]?.status).toBe("busy");
-    expect(busy.submitTurn).not.toHaveBeenCalled();
-
-    const idle = createHarness();
-    const idleOutcomes = await idle.coordinator.handleTransition({
-      transition,
-      source: "background-poll",
-      observedAt: 2_000,
-      backgroundPollingEnabled: true,
-    });
-    expect(idleOutcomes[0]?.status).toBe("dispatched");
-    expect(idle.submitTurn).toHaveBeenCalledTimes(1);
-  });
-
-  it("single-flights concurrent observations while dispatch is pending", async () => {
-    let releaseSubmit!: () => void;
-    const submitPending = new Promise<void>((resolve) => {
-      releaseSubmit = resolve;
-    });
-    const submitTurn = vi.fn(async (_request: {
-      input: AppServerTurnInputItem[];
-    }) => {
-      await submitPending;
-      return { status: "started" as const, turnId: "turn-auto-1" };
-    });
-    const coordinator = new PrAutoDispatchCoordinator({
-      store,
-      registry: {
-        canStartThreadTurnImmediately: () => true,
-        submitTurn,
-      },
-    });
-    const request = {
-      transition: conflictingTransition(),
-      source: "background-poll",
-      observedAt: 1_000,
-      backgroundPollingEnabled: true,
-    };
-    const first = coordinator.handleTransition(request);
-    await vi.waitFor(() => expect(submitTurn).toHaveBeenCalledTimes(1));
-    const second = await coordinator.handleTransition(request);
-
-    expect(second[0]?.status).toBe("pending");
-    releaseSubmit();
-    expect((await first)[0]?.status).toBe("dispatched");
-    expect(submitTurn).toHaveBeenCalledTimes(1);
-    expect(submitTurn.mock.calls[0]?.[0].input[0]).toEqual(
-      expect.objectContaining({
-        text: expect.stringContaining("- Event kinds: merge-conflict"),
-      }),
+    expect(thread?.prAutoDispatchPending?.scheduledAt).toBe(
+      clock + PR_AUTO_DISPATCH_DELAY_MS,
     );
   });
 
-  it("re-arms for a new head fingerprint but caps a continuous failure incident", async () => {
-    const { coordinator, submitTurn } = createHarness();
-    const heads = ["a", "b", "c"].map((value) => value.repeat(40));
-    const transitions = [
-      failingTransition(heads[0]!),
-      newFailingHeadTransition(heads[0]!, heads[1]!),
-    ];
-    for (const [index, transition] of transitions.entries()) {
-      const outcomes = await coordinator.handleTransition({
-        transition,
-        source: "background-poll",
-        observedAt: 1_000 + index,
-        backgroundPollingEnabled: true,
-      });
-      expect(outcomes[0]?.status).toBe("dispatched");
-    }
+  it("dispatches only after the countdown and includes structured PR context", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
 
-    const capped = await coordinator.handleTransition({
-      transition: newFailingHeadTransition(heads[1]!, heads[2]!),
-      source: "background-poll",
-      observedAt: 2_000,
-      backgroundPollingEnabled: true,
+    await vi.advanceTimersByTimeAsync(PR_AUTO_DISPATCH_DELAY_MS - 1);
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+    clock += PR_AUTO_DISPATCH_DELAY_MS;
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+    expect(harness.submitTurnIfIdle.mock.calls[0]?.[0].input[0]).toEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining(`- Head SHA: ${"a".repeat(40)}`),
+      }),
+    );
+    expect(
+      await store.getThreadPrAutoDispatchPending({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("lets the operator cancel and does not recreate the same fingerprint", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    const pending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
     });
-    expect(capped[0]?.status).toBe("attempt-limit");
-    expect(submitTurn).toHaveBeenCalledTimes(
+
+    expect(await harness.coordinator.cancelPending({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: pending!.pending.fingerprint,
+    })).toBe(true);
+    expect((await observe(harness.coordinator))[0]?.status).toBe("duplicate");
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+
+    const reenabled = await harness.coordinator.handleStatusSnapshot({
+      pr: pr(),
+      threadKeys: ["codex:thread-1"],
+      observedAt: clock,
+      backgroundPollingEnabled: true,
+      operatorInitiated: true,
+    });
+    expect(reenabled[0]?.status).toBe("scheduled");
+  });
+
+  it("survives restart without replaying or losing a pending repair", async () => {
+    const first = createHarness();
+    await observe(first.coordinator);
+    first.coordinator.close();
+
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+    const afterRestart = createHarness();
+    await afterRestart.coordinator.resume();
+    expect((await observe(afterRestart.coordinator))[0]?.status).toBe("pending");
+
+    await runCountdown();
+    expect(afterRestart.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+    expect((await observe(afterRestart.coordinator))[0]?.status).toBe("duplicate");
+  });
+
+  it("atomically rejects busy submission and restores the countdown without spending an attempt", async () => {
+    const harness = createHarness({ busy: true });
+    await observe(harness.coordinator);
+    await runCountdown();
+
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(0);
+    expect((await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    }))?.pending.scheduledAt).toBe(clock + PR_AUTO_DISPATCH_DELAY_MS);
+
+    harness.setBusy(false);
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(2);
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(1);
+  });
+
+  it("does not reset the finite incident budget while a repair head is pending", async () => {
+    const harness = createHarness();
+    const heads = ["a", "b", "c", "d"].map((value) => value.repeat(40));
+
+    harness.setCurrentPr(pr({ headSha: heads[0] }));
+    await observe(harness.coordinator, pr({ headSha: heads[0] }));
+    await runCountdown();
+
+    const pendingB = pr({
+      headSha: heads[1],
+      state: "pending",
+      checkState: "pending",
+    });
+    harness.setCurrentPr(pendingB);
+    await observe(harness.coordinator, pendingB);
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(1);
+
+    const failingB = pr({ headSha: heads[1] });
+    harness.setCurrentPr(failingB);
+    await observe(harness.coordinator, failingB);
+    await runCountdown();
+
+    const pendingC = pr({
+      headSha: heads[2],
+      state: "pending",
+      checkState: "pending",
+    });
+    harness.setCurrentPr(pendingC);
+    await observe(harness.coordinator, pendingC);
+    const failingC = pr({ headSha: heads[2] });
+    harness.setCurrentPr(failingC);
+    expect((await observe(harness.coordinator, failingC))[0]?.status).toBe(
+      "attempt-limit",
+    );
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(
       MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
     );
 
-    await coordinator.handleTransition({
-      transition: passingTransition("c".repeat(40)),
-      source: "background-poll",
-      observedAt: 3_000,
-      backgroundPollingEnabled: true,
+    const passingC = pr({
+      headSha: heads[2],
+      state: "passing",
+      checkState: "passing",
     });
-    const rearmed = await coordinator.handleTransition({
-      transition: failingTransition("d".repeat(40)),
-      source: "background-poll",
-      observedAt: 4_000,
-      backgroundPollingEnabled: true,
+    harness.setCurrentPr(passingC);
+    await observe(harness.coordinator, passingC);
+    const failingD = pr({ headSha: heads[3] });
+    harness.setCurrentPr(failingD);
+    expect((await observe(harness.coordinator, failingD))[0]?.status).toBe(
+      "scheduled",
+    );
+  });
+
+  it("uses a unique SQLite claim across two app instances", async () => {
+    const secondDb = StateDb.open(path.join(tempDir, "state.db"));
+    extraDbs.push(secondDb);
+    const secondStore = new SqliteOverlayStore(secondDb);
+    const first = createHarness();
+    const second = createHarness({ targetStore: secondStore });
+
+    const [firstOutcome, secondOutcome] = await Promise.all([
+      observe(first.coordinator),
+      observe(second.coordinator),
+    ]);
+    expect([firstOutcome[0]?.status, secondOutcome[0]?.status].sort()).toEqual([
+      "pending",
+      "scheduled",
+    ]);
+
+    await runCountdown();
+    expect(
+      first.submitTurnIfIdle.mock.calls.length
+      + second.submitTurnIfIdle.mock.calls.length,
+    ).toBe(1);
+  });
+
+  it("drops a scheduled repair when the PR recovers or is detached before send", async () => {
+    let attached = true;
+    let currentPr = pr();
+    const submitTurnIfIdle = vi.fn(async () => ({
+      status: "started" as const,
+      turnId: "turn-auto-1",
+    }));
+    const coordinator = new PrAutoDispatchCoordinator({
+      store,
+      registry: { submitTurnIfIdle },
+      getCurrentPr: () => currentPr,
+      isPrAttached: () => attached,
+      isBackgroundPollingEnabled: () => true,
+      now: () => clock,
     });
-    expect(rearmed[0]?.status).toBe("dispatched");
-    expect(submitTurn).toHaveBeenCalledTimes(3);
+    await observe(coordinator, currentPr);
+    currentPr = pr({ state: "passing", checkState: "passing" });
+    await runCountdown();
+    expect(submitTurnIfIdle).not.toHaveBeenCalled();
+
+    currentPr = pr({ headSha: "b".repeat(40) });
+    await observe(coordinator, currentPr);
+    attached = false;
+    await runCountdown();
+    expect(submitTurnIfIdle).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -1,0 +1,334 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  materializeNavigationThreads,
+  type AppServerTurnInputItem,
+  type PrSummary,
+} from "@pwragent/shared";
+import { StateDb } from "../state/state-db";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import {
+  MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+  PrAutoDispatchCoordinator,
+} from "../pr-status/pr-auto-dispatch";
+import { computePrStatusTransition } from "../pr-status/pr-transitions";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-pr-auto-dispatch-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new SqliteOverlayStore(stateDb);
+  await store.setThreadPrAutoDispatchEnabled({
+    backend: "codex",
+    threadId: "thread-1",
+    enabled: true,
+  });
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function pr(overrides: Partial<PrSummary> = {}): PrSummary {
+  const headSha = overrides.headSha ?? "a".repeat(40);
+  return {
+    provider: "github.com",
+    number: 1105,
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    title: "Auto-fix attached PR failures",
+    state: "pending",
+    checkState: "pending",
+    lifecycleState: "open",
+    reviewState: "ready_for_review",
+    mergeState: "mergeable",
+    headSha,
+    commitShas: [headSha],
+    url: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+    ...overrides,
+  };
+}
+
+function failingTransition(headSha = "a".repeat(40)) {
+  return computePrStatusTransition(
+    pr({ headSha, checkState: "pending", state: "pending" }),
+    pr({ headSha, checkState: "failing", state: "failing" }),
+    ["codex:thread-1"],
+  )!;
+}
+
+function passingTransition(headSha = "a".repeat(40)) {
+  return computePrStatusTransition(
+    pr({ headSha, checkState: "failing", state: "failing" }),
+    pr({ headSha, checkState: "passing", state: "passing" }),
+    ["codex:thread-1"],
+  )!;
+}
+
+function conflictingTransition(headSha = "a".repeat(40)) {
+  return computePrStatusTransition(
+    pr({ headSha, mergeState: "mergeable" }),
+    pr({ headSha, mergeState: "conflicting" }),
+    ["codex:thread-1"],
+  )!;
+}
+
+function newFailingHeadTransition(previousHead: string, nextHead: string) {
+  return computePrStatusTransition(
+    pr({
+      headSha: previousHead,
+      commitShas: [previousHead],
+      checkState: "failing",
+      state: "failing",
+    }),
+    pr({
+      headSha: nextHead,
+      commitShas: [nextHead],
+      checkState: "failing",
+      state: "failing",
+    }),
+    ["codex:thread-1"],
+  )!;
+}
+
+function createHarness(options: { busy?: boolean } = {}) {
+  const submitTurn = vi.fn(async (_request: {
+    input: AppServerTurnInputItem[];
+  }) => ({
+    status: "started" as const,
+    turnId: "turn-auto-1",
+  }));
+  const coordinator = new PrAutoDispatchCoordinator({
+    store,
+    registry: {
+      canStartThreadTurnImmediately: () => !options.busy,
+      submitTurn,
+    },
+  });
+  return { coordinator, submitTurn };
+}
+
+describe("PrAutoDispatchCoordinator", () => {
+  it("does nothing when the global background-polling gate is off", async () => {
+    const { coordinator, submitTurn } = createHarness();
+    const outcomes = await coordinator.handleTransition({
+      transition: failingTransition(),
+      source: "background-poll",
+      observedAt: 1_000,
+      backgroundPollingEnabled: false,
+    });
+
+    expect(outcomes).toEqual([
+      { threadKey: "codex:thread-1", status: "gate-off" },
+    ]);
+    expect(submitTurn).not.toHaveBeenCalled();
+    expect(
+      (await store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }))?.prAutoDispatchEnabled,
+    ).toBe(true);
+  });
+
+  it("rechecks the global gate before claiming a dispatch", async () => {
+    let backgroundPollingEnabled = true;
+    const submitTurn = vi.fn(async () => ({
+      status: "started" as const,
+      turnId: "turn-auto-1",
+    }));
+    const coordinator = new PrAutoDispatchCoordinator({
+      store,
+      registry: {
+        canStartThreadTurnImmediately: () => {
+          backgroundPollingEnabled = false;
+          return true;
+        },
+        submitTurn,
+      },
+      isBackgroundPollingEnabled: () => backgroundPollingEnabled,
+    });
+
+    const outcomes = await coordinator.handleTransition({
+      transition: failingTransition(),
+      source: "background-poll",
+      observedAt: 1_000,
+      backgroundPollingEnabled: true,
+    });
+
+    expect(outcomes).toEqual([
+      { threadKey: "codex:thread-1", status: "gate-off" },
+    ]);
+    expect(submitTurn).not.toHaveBeenCalled();
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.prAutoDispatchHandledFingerprints).toBeUndefined();
+    expect(overlay?.prAutoDispatchAttemptCounts).toBeUndefined();
+  });
+
+  it("claims before dispatch and never replays the same fingerprint after restart", async () => {
+    const first = createHarness();
+    const transition = failingTransition();
+    const firstOutcomes = await first.coordinator.handleTransition({
+      transition,
+      source: "background-poll",
+      observedAt: 1_000,
+      backgroundPollingEnabled: true,
+    });
+
+    expect(firstOutcomes[0]?.status).toBe("dispatched");
+    expect(first.submitTurn).toHaveBeenCalledTimes(1);
+    expect(first.submitTurn.mock.calls[0]?.[0].input[0]).toEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining(`- Head SHA: ${"a".repeat(40)}`),
+      }),
+    );
+
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.close();
+    stateDb = StateDb.open(dbPath);
+    store = new SqliteOverlayStore(stateDb);
+    const restoredOverlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    const restoredThread = materializeNavigationThreads({
+      firstSnapshot: true,
+      overlayByThreadKey: { "codex:thread-1": restoredOverlay },
+      previousKnownThreadKeys: [],
+      threads: [{
+        id: "thread-1",
+        title: "Fix CI",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+      }],
+    })[0];
+    expect(restoredThread?.prAutoDispatchEnabled).toBe(true);
+    const afterRestart = createHarness();
+    const replayOutcomes = await afterRestart.coordinator.handleTransition({
+      transition,
+      source: "background-poll",
+      observedAt: 2_000,
+      backgroundPollingEnabled: true,
+    });
+
+    expect(replayOutcomes[0]?.status).toBe("duplicate");
+    expect(afterRestart.submitTurn).not.toHaveBeenCalled();
+  });
+
+  it("does not queue an automatic turn while the thread is active or queued", async () => {
+    const busy = createHarness({ busy: true });
+    const transition = failingTransition();
+    const busyOutcomes = await busy.coordinator.handleTransition({
+      transition,
+      source: "background-poll",
+      observedAt: 1_000,
+      backgroundPollingEnabled: true,
+    });
+
+    expect(busyOutcomes[0]?.status).toBe("busy");
+    expect(busy.submitTurn).not.toHaveBeenCalled();
+
+    const idle = createHarness();
+    const idleOutcomes = await idle.coordinator.handleTransition({
+      transition,
+      source: "background-poll",
+      observedAt: 2_000,
+      backgroundPollingEnabled: true,
+    });
+    expect(idleOutcomes[0]?.status).toBe("dispatched");
+    expect(idle.submitTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("single-flights concurrent observations while dispatch is pending", async () => {
+    let releaseSubmit!: () => void;
+    const submitPending = new Promise<void>((resolve) => {
+      releaseSubmit = resolve;
+    });
+    const submitTurn = vi.fn(async (_request: {
+      input: AppServerTurnInputItem[];
+    }) => {
+      await submitPending;
+      return { status: "started" as const, turnId: "turn-auto-1" };
+    });
+    const coordinator = new PrAutoDispatchCoordinator({
+      store,
+      registry: {
+        canStartThreadTurnImmediately: () => true,
+        submitTurn,
+      },
+    });
+    const request = {
+      transition: conflictingTransition(),
+      source: "background-poll",
+      observedAt: 1_000,
+      backgroundPollingEnabled: true,
+    };
+    const first = coordinator.handleTransition(request);
+    await vi.waitFor(() => expect(submitTurn).toHaveBeenCalledTimes(1));
+    const second = await coordinator.handleTransition(request);
+
+    expect(second[0]?.status).toBe("pending");
+    releaseSubmit();
+    expect((await first)[0]?.status).toBe("dispatched");
+    expect(submitTurn).toHaveBeenCalledTimes(1);
+    expect(submitTurn.mock.calls[0]?.[0].input[0]).toEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("- Event kinds: merge-conflict"),
+      }),
+    );
+  });
+
+  it("re-arms for a new head fingerprint but caps a continuous failure incident", async () => {
+    const { coordinator, submitTurn } = createHarness();
+    const heads = ["a", "b", "c"].map((value) => value.repeat(40));
+    const transitions = [
+      failingTransition(heads[0]!),
+      newFailingHeadTransition(heads[0]!, heads[1]!),
+    ];
+    for (const [index, transition] of transitions.entries()) {
+      const outcomes = await coordinator.handleTransition({
+        transition,
+        source: "background-poll",
+        observedAt: 1_000 + index,
+        backgroundPollingEnabled: true,
+      });
+      expect(outcomes[0]?.status).toBe("dispatched");
+    }
+
+    const capped = await coordinator.handleTransition({
+      transition: newFailingHeadTransition(heads[1]!, heads[2]!),
+      source: "background-poll",
+      observedAt: 2_000,
+      backgroundPollingEnabled: true,
+    });
+    expect(capped[0]?.status).toBe("attempt-limit");
+    expect(submitTurn).toHaveBeenCalledTimes(
+      MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+    );
+
+    await coordinator.handleTransition({
+      transition: passingTransition("c".repeat(40)),
+      source: "background-poll",
+      observedAt: 3_000,
+      backgroundPollingEnabled: true,
+    });
+    const rearmed = await coordinator.handleTransition({
+      transition: failingTransition("d".repeat(40)),
+      source: "background-poll",
+      observedAt: 4_000,
+      backgroundPollingEnabled: true,
+    });
+    expect(rearmed[0]?.status).toBe("dispatched");
+    expect(submitTurn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -263,6 +263,63 @@ describe("PrAutoDispatchCoordinator", () => {
     expect(reenabled[0]?.status).toBe("scheduled");
   });
 
+  it("treats toggling back on as an explicit retry with a fresh attempt budget", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    const firstPending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    await harness.coordinator.sendPendingNow({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: firstPending!.pending.fingerprint,
+    });
+
+    expect((await observe(harness.coordinator))[0]?.status).toBe("duplicate");
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(1);
+
+    expect(await harness.coordinator.resetForOperator({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBe(true);
+    expect(await store.getThreadPrAutoDispatchAttemptCount({
+      backend: "codex",
+      threadId: "thread-1",
+      prKey: buildPullRequestStatusKey(pr()),
+    })).toBe(0);
+
+    const reenabled = await harness.coordinator.handleStatusSnapshot({
+      pr: pr(),
+      threadKeys: ["codex:thread-1"],
+      observedAt: clock,
+      backgroundPollingEnabled: true,
+      operatorInitiated: true,
+    });
+    expect(reenabled[0]?.status).toBe("scheduled");
+    const retryPending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    await harness.coordinator.sendPendingNow({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: retryPending!.pending.fingerprint,
+    });
+
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(2);
+    expect(harness.submitTurnIfIdle.mock.calls[1]?.[0].input[0]).toEqual(
+      expect.objectContaining({
+        type: "text",
+        text: expect.stringContaining("Automatic attempt: 1/2"),
+      }),
+    );
+  });
+
   it("survives restart without replaying or losing a pending repair", async () => {
     const first = createHarness();
     await observe(first.coordinator);

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -196,6 +196,46 @@ describe("PrAutoDispatchCoordinator", () => {
     ).toBeUndefined();
   });
 
+  it("sends a scheduled repair immediately when the operator chooses Send now", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    const pending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(await harness.coordinator.sendPendingNow({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: pending!.pending.fingerprint,
+    })).toBe(true);
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+
+    await runCountdown();
+    expect(harness.submitTurnIfIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let Send now bypass the global polling gate", async () => {
+    const harness = createHarness();
+    await observe(harness.coordinator);
+    const pending = await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    harness.setGate(false);
+
+    expect(await harness.coordinator.sendPendingNow({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: pending!.pending.fingerprint,
+    })).toBe(false);
+    expect(harness.submitTurnIfIdle).not.toHaveBeenCalled();
+    expect(await store.getThreadPrAutoDispatchPending({
+      backend: "codex",
+      threadId: "thread-1",
+    })).toBeDefined();
+  });
+
   it("lets the operator cancel and does not recreate the same fingerprint", async () => {
     const harness = createHarness();
     await observe(harness.coordinator);

--- a/apps/desktop/src/main/__tests__/pr-transitions.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-transitions.test.ts
@@ -29,10 +29,30 @@ describe("computePrStatusTransition", () => {
   });
 
   it("returns undefined when nothing meaningful changed", () => {
-    // Only the commit SHA moved — a new commit with identical status is not a
+    // Historical commit context moving without an explicit head is not a
     // status transition.
     expect(
       computePrStatusTransition(pr(), pr({ commitShas: ["b".repeat(40)] })),
+    ).toBeUndefined();
+  });
+
+  it("captures a new head SHA so failed-state fingerprints can re-arm", () => {
+    const transition = computePrStatusTransition(
+      pr({ headSha: "a".repeat(40), checkState: "failing" }),
+      pr({ headSha: "b".repeat(40), checkState: "failing" }),
+    );
+    expect(transition?.changed.headSha).toEqual({
+      from: "a".repeat(40),
+      to: "b".repeat(40),
+    });
+  });
+
+  it("treats the first hydrated head SHA as cache enrichment, not an event", () => {
+    expect(
+      computePrStatusTransition(
+        pr({ headSha: undefined, checkState: "failing" }),
+        pr({ headSha: "b".repeat(40), checkState: "failing" }),
+      ),
     ).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-turn-queue.test.ts
@@ -100,6 +100,57 @@ describe("ThreadTurnQueue", () => {
     ]);
   });
 
+  it("rejects an immediate-only submission without placing it on the queue", async () => {
+    const events: ThreadTurnQueueLifecycleEvent[] = [];
+    const queue = new ThreadTurnQueue({
+      isThreadActive: () => true,
+      startTurn: async (entry) => ({
+        backend: entry.backend,
+        threadId: entry.threadId,
+        turnId: `turn-${entry.id}`,
+      }),
+      onLifecycle: (event) => {
+        events.push(event);
+      },
+    });
+
+    await expect(queue.submitIfIdle(buildEntry({ origin: "automation" })))
+      .resolves.toEqual({ status: "busy" });
+    expect(queue.getQueuedEntries({ backend: "codex", threadId: "thread-1" }))
+      .toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  it("claims the starting slot before another submission can race it", async () => {
+    let releaseStart!: () => void;
+    const starting = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const queue = new ThreadTurnQueue({
+      startTurn: async (entry) => {
+        await starting;
+        return {
+          backend: entry.backend,
+          threadId: entry.threadId,
+          turnId: `turn-${entry.id}`,
+        };
+      },
+    });
+
+    const automatic = queue.submitIfIdle(buildEntry({
+      id: "automatic",
+      origin: "automation",
+    }));
+    const manual = await queue.submit(buildEntry({ id: "manual" }));
+    expect(manual).toMatchObject({ status: "queued", position: 1 });
+
+    releaseStart();
+    await expect(automatic).resolves.toMatchObject({
+      status: "started",
+      turnId: "turn-automatic",
+    });
+  });
+
   it("guards duplicate terminal release signals", async () => {
     let active = true;
     const startedEntries: string[] = [];

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -125,6 +125,8 @@ import {
   type SetThreadPrAutoDispatchResponse,
   type CancelThreadPrAutoDispatchRequest,
   type CancelThreadPrAutoDispatchResponse,
+  type SendThreadPrAutoDispatchNowRequest,
+  type SendThreadPrAutoDispatchNowResponse,
   type ApplyThreadModelMigrationRequest,
   type ApplyThreadModelMigrationResponse,
   type TurnOffCodexFastEverywhereResponse,
@@ -1459,6 +1461,9 @@ type ThreadPullRequestStatusToolHandler = (
 type ThreadPrAutoDispatchHandler = {
   preferenceChanged: (request: SetThreadPrAutoDispatchRequest) => Promise<void>;
   cancelPending: (request: CancelThreadPrAutoDispatchRequest) => Promise<boolean>;
+  sendPendingNow: (
+    request: SendThreadPrAutoDispatchNowRequest,
+  ) => Promise<boolean>;
 };
 
 type ThreadTitleGenerationLogStatus =
@@ -12052,6 +12057,15 @@ export class DesktopBackendRegistry {
       await this.threadPrAutoDispatchHandler?.cancelPending(params)
       ?? false;
     return { ...params, cancelled };
+  }
+
+  async sendThreadPrAutoDispatchNow(
+    params: SendThreadPrAutoDispatchNowRequest,
+  ): Promise<SendThreadPrAutoDispatchNowResponse> {
+    const accepted =
+      await this.threadPrAutoDispatchHandler?.sendPendingNow(params)
+      ?? false;
+    return { ...params, accepted };
   }
 
   private async setThreadModelSettingsInternal(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -121,6 +121,8 @@ import {
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
   type SetThreadModelSettingsResponse,
+  type SetThreadPrAutoDispatchRequest,
+  type SetThreadPrAutoDispatchResponse,
   type ApplyThreadModelMigrationRequest,
   type ApplyThreadModelMigrationResponse,
   type TurnOffCodexFastEverywhereResponse,
@@ -9563,7 +9565,10 @@ export class DesktopBackendRegistry {
     backend: AppServerBackendKind;
     threadId: string;
   }): boolean {
-    return this.threadTurnQueue.canStartImmediately(params);
+    return (
+      !this.threadHasActiveTurn(params.threadId, params.backend)
+      && this.threadTurnQueue.canStartImmediately(params)
+    );
   }
 
   getActiveTurnForThread(params: {
@@ -11981,6 +11986,27 @@ export class DesktopBackendRegistry {
         ? { modelSettingsManuallyUpdatedAt }
         : {}),
     });
+  }
+
+  async setThreadPrAutoDispatch(
+    params: SetThreadPrAutoDispatchRequest,
+  ): Promise<SetThreadPrAutoDispatchResponse> {
+    await this.overlayStore.setThreadPrAutoDispatchEnabled({
+      backend: params.backend,
+      threadId: params.threadId,
+      enabled: params.enabled,
+    });
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/prAutoDispatch/updated",
+        params: {
+          threadId: params.threadId,
+          enabled: params.enabled,
+        },
+      },
+    });
+    return params;
   }
 
   private async setThreadModelSettingsInternal(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -123,6 +123,8 @@ import {
   type SetThreadModelSettingsResponse,
   type SetThreadPrAutoDispatchRequest,
   type SetThreadPrAutoDispatchResponse,
+  type CancelThreadPrAutoDispatchRequest,
+  type CancelThreadPrAutoDispatchResponse,
   type ApplyThreadModelMigrationRequest,
   type ApplyThreadModelMigrationResponse,
   type TurnOffCodexFastEverywhereResponse,
@@ -381,6 +383,7 @@ import {
   ThreadTurnQueue,
   type ThreadTurnQueueLifecycleEvent,
   type ThreadTurnQueueOrigin,
+  type ThreadTurnQueueImmediateSubmissionResult,
   type ThreadTurnQueueSubmissionResult,
 } from "./thread-turn-queue";
 import { materializeLocalImageInputs } from "./image-input-files";
@@ -1452,6 +1455,11 @@ type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle"> & 
 type ThreadPullRequestStatusToolHandler = (
   args: CheckThreadPullRequestStatusToolArgs,
 ) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
+
+type ThreadPrAutoDispatchHandler = {
+  preferenceChanged: (request: SetThreadPrAutoDispatchRequest) => Promise<void>;
+  cancelPending: (request: CancelThreadPrAutoDispatchRequest) => Promise<boolean>;
+};
 
 type ThreadTitleGenerationLogStatus =
   | ThreadTitleGenerationResult["status"]
@@ -5860,6 +5868,7 @@ export class DesktopBackendRegistry {
   private threadPullRequestStatusToolHandler:
     | ThreadPullRequestStatusToolHandler
     | undefined;
+  private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -6273,8 +6282,8 @@ export class DesktopBackendRegistry {
       startTurn: async (entry) => await this.startTurnNow(entry),
       isThreadActive: ({ backend, threadId }) =>
         backend === "codex"
-          ? this.threadHasActiveTurn(threadId) ||
-            this.threadHasBlockingWorkspaceMove({ backend, threadId })
+          ? this.threadHasActiveTurn(threadId)
+            || this.threadHasBlockingWorkspaceMove({ backend, threadId })
           : false,
       onLifecycle: async (event) => await this.emitTurnQueueLifecycle(event),
     });
@@ -6471,6 +6480,12 @@ export class DesktopBackendRegistry {
     handler: ThreadPullRequestStatusToolHandler | null | undefined,
   ): void {
     this.threadPullRequestStatusToolHandler = handler ?? undefined;
+  }
+
+  setThreadPrAutoDispatchHandler(
+    handler: ThreadPrAutoDispatchHandler | null | undefined,
+  ): void {
+    this.threadPrAutoDispatchHandler = handler ?? undefined;
   }
 
   /**
@@ -9550,6 +9565,26 @@ export class DesktopBackendRegistry {
     });
   }
 
+  async submitTurnIfIdle(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    origin?: ThreadTurnQueueOrigin;
+    messageOrigin?: AppServerThreadMessageOrigin;
+  }): Promise<ThreadTurnQueueImmediateSubmissionResult> {
+    const { origin = "manual", ...entry } = params;
+    if (
+      this.threadHasActiveTurn(params.threadId, params.backend)
+      || this.threadHasBlockingWorkspaceMove(params)
+    ) {
+      return { status: "busy" };
+    }
+    return await this.threadTurnQueue.submitIfIdle({
+      ...entry,
+      origin,
+    });
+  }
+
   cancelQueuedTurn(entryId: string, reason?: string): void {
     this.threadTurnQueue.cancelEntry(entryId, reason);
   }
@@ -12006,7 +12041,17 @@ export class DesktopBackendRegistry {
         },
       },
     });
+    await this.threadPrAutoDispatchHandler?.preferenceChanged(params);
     return params;
+  }
+
+  async cancelThreadPrAutoDispatch(
+    params: CancelThreadPrAutoDispatchRequest,
+  ): Promise<CancelThreadPrAutoDispatchResponse> {
+    const cancelled =
+      await this.threadPrAutoDispatchHandler?.cancelPending(params)
+      ?? false;
+    return { ...params, cancelled };
   }
 
   private async setThreadModelSettingsInternal(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4700,15 +4700,33 @@ function mergeThreadMessageOrigins(
   if (Object.keys(originsByMessageId).length === 0) {
     return replay;
   }
+  const firstUserMessageTurnIds = new Set<string>();
+  const resolvedOriginsByMessageId: Record<string, AppServerThreadMessageOrigin> = {};
   const entries = replay.entries.map((entry): AppServerThreadEntry => {
     if (entry.type !== "message" || entry.role !== "user") {
       return entry;
     }
-    const origin = originsByMessageId[entry.id];
+    const turnId = entry.turn?.id;
+    const isFirstUserMessageForTurn = Boolean(
+      turnId && !firstUserMessageTurnIds.has(turnId),
+    );
+    if (turnId) {
+      firstUserMessageTurnIds.add(turnId);
+    }
+    const origin =
+      originsByMessageId[entry.id]
+      ?? (turnId && isFirstUserMessageForTurn
+        ? originsByMessageId[buildTurnUserMessageOriginId(turnId)]
+        : undefined);
+    if (origin) {
+      resolvedOriginsByMessageId[entry.id] = origin;
+    }
     return origin ? { ...entry, origin } : entry;
   });
   const messages = replay.messages.map((message) => {
-    const origin = originsByMessageId[message.id];
+    const origin =
+      originsByMessageId[message.id]
+      ?? resolvedOriginsByMessageId[message.id];
     return origin && message.role === "user" ? { ...message, origin } : message;
   });
   return {
@@ -4836,6 +4854,10 @@ function inferLegacyTaskMonitorMessageOrigins(params: {
 
 function taskMonitorCompletionTime(subAgent: ThreadSubAgentSummary): number {
   return subAgent.completedAt ?? subAgent.updatedAt ?? subAgent.createdAt;
+}
+
+function buildTurnUserMessageOriginId(turnId: string): string {
+  return `user:${turnId}`;
 }
 
 function resolveThreadMessageOrigin(params: {
@@ -8662,7 +8684,14 @@ export class DesktopBackendRegistry {
           });
     const messageIds = [
       ...replayWithImmutableUsage.entries.flatMap((entry) =>
-        entry.type === "message" && entry.role === "user" ? [entry.id] : [],
+        entry.type === "message" && entry.role === "user"
+          ? [
+              entry.id,
+              ...(entry.turn?.id
+                ? [buildTurnUserMessageOriginId(entry.turn.id)]
+                : []),
+            ]
+          : [],
       ),
       ...replayWithImmutableUsage.messages.flatMap((message) =>
         message.role === "user" ? [message.id] : [],
@@ -9830,7 +9859,7 @@ export class DesktopBackendRegistry {
         await this.persistThreadMessageOrigin({
           backend: params.backend,
           threadId: result.threadId,
-          messageId: `user:${result.turnId}`,
+          messageId: buildTurnUserMessageOriginId(result.turnId),
           origin: resolveThreadMessageOrigin(params),
         });
         this.forgetPendingThreadMessageOrigin(pendingMessageOriginId);
@@ -10056,6 +10085,12 @@ export class DesktopBackendRegistry {
       retryableCodexTurnStart.turnId = result.turnId;
     }
     this.bindPendingThreadMessageOrigin(pendingMessageOriginId, result.turnId);
+    await this.persistThreadMessageOrigin({
+      backend: params.backend,
+      threadId: result.threadId,
+      messageId: buildTurnUserMessageOriginId(result.turnId),
+      origin: resolveThreadMessageOrigin(params),
+    });
     this.rebindPendingReviewStartsForStartedTurn({
       backend: params.backend,
       threadId: params.threadId,
@@ -10230,11 +10265,14 @@ export class DesktopBackendRegistry {
       }
       return event;
     }
-    if (event.notification.method !== "item/completed") {
+    if (
+      event.notification.method !== "item/started"
+      && event.notification.method !== "item/completed"
+    ) {
       return event;
     }
     const notification = event.notification as {
-      method: "item/completed";
+      method: "item/started" | "item/completed";
       params: {
         threadId: string;
         turnId?: string;
@@ -10264,7 +10302,9 @@ export class DesktopBackendRegistry {
       messageId: notification.params.item.id,
       origin: pending.origin,
     });
-    this.pendingThreadMessageOrigins.delete(pending.id);
+    if (event.notification.method === "item/completed") {
+      this.pendingThreadMessageOrigins.delete(pending.id);
+    }
     return {
       ...event,
       notification: {

--- a/apps/desktop/src/main/app-server/thread-turn-queue.ts
+++ b/apps/desktop/src/main/app-server/thread-turn-queue.ts
@@ -48,6 +48,10 @@ export type ThreadTurnQueueSubmissionResult =
       position: number;
     };
 
+export type ThreadTurnQueueImmediateSubmissionResult =
+  | Extract<ThreadTurnQueueSubmissionResult, { status: "started" }>
+  | { status: "busy" };
+
 export type ThreadTurnQueueLifecycleEvent =
   | {
       type: "queued";
@@ -118,6 +122,34 @@ export class ThreadTurnQueue {
       return { status: "queued", entry, position };
     }
 
+    const started = await this.startEntry(entry);
+    return {
+      status: "started",
+      entry,
+      turnId: started.turnId,
+    };
+  }
+
+  /**
+   * Atomically reject instead of queueing when the thread is busy. The
+   * availability check and `startingKeys` claim happen in the same JS turn,
+   * so another submit cannot slip between them and push this entry on deck.
+   */
+  async submitIfIdle(
+    input: Omit<ThreadTurnQueueEntry, "id" | "createdAt"> &
+      Partial<Pick<ThreadTurnQueueEntry, "id" | "createdAt">>,
+  ): Promise<ThreadTurnQueueImmediateSubmissionResult> {
+    const entry: ThreadTurnQueueEntry = {
+      ...input,
+      id: input.id ?? `thread-turn:${randomUUID()}`,
+      createdAt: input.createdAt ?? this.now(),
+    };
+    if (!this.canStartImmediately({
+      backend: entry.backend,
+      threadId: entry.threadId,
+    })) {
+      return { status: "busy" };
+    }
     const started = await this.startEntry(entry);
     return {
       status: "started",

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -36,6 +36,8 @@ import {
   type SetThreadExecutionModeResponse,
   type SetThreadModelSettingsRequest,
   type SetThreadModelSettingsResponse,
+  type SetThreadPrAutoDispatchRequest,
+  type SetThreadPrAutoDispatchResponse,
   type TurnOffCodexFastEverywhereResponse,
   type SteerTurnRequest,
   type SteerTurnResponse,
@@ -73,6 +75,7 @@ import {
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
+  AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -572,6 +575,17 @@ export function registerAgentIpcHandlers(): void {
       request: SetThreadModelSettingsRequest
     ): Promise<SetThreadModelSettingsResponse> => {
       return await registry.setThreadModelSettings(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL);
+  ipcMain.handle(
+    AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+    async (
+      _event,
+      request: SetThreadPrAutoDispatchRequest,
+    ): Promise<SetThreadPrAutoDispatchResponse> => {
+      return await registry.setThreadPrAutoDispatch(request);
     },
   );
 

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -40,6 +40,8 @@ import {
   type SetThreadPrAutoDispatchResponse,
   type CancelThreadPrAutoDispatchRequest,
   type CancelThreadPrAutoDispatchResponse,
+  type SendThreadPrAutoDispatchNowRequest,
+  type SendThreadPrAutoDispatchNowResponse,
   type TurnOffCodexFastEverywhereResponse,
   type SteerTurnRequest,
   type SteerTurnResponse,
@@ -79,6 +81,7 @@ import {
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+  AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -328,6 +331,17 @@ export function registerAgentIpcHandlers(): void {
       request: CancelThreadPrAutoDispatchRequest,
     ): Promise<CancelThreadPrAutoDispatchResponse> => {
       return await registry.cancelThreadPrAutoDispatch(request);
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL);
+  ipcMain.handle(
+    AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL,
+    async (
+      _event,
+      request: SendThreadPrAutoDispatchNowRequest,
+    ): Promise<SendThreadPrAutoDispatchNowResponse> => {
+      return await registry.sendThreadPrAutoDispatchNow(request);
     },
   );
 

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -38,6 +38,8 @@ import {
   type SetThreadModelSettingsResponse,
   type SetThreadPrAutoDispatchRequest,
   type SetThreadPrAutoDispatchResponse,
+  type CancelThreadPrAutoDispatchRequest,
+  type CancelThreadPrAutoDispatchResponse,
   type TurnOffCodexFastEverywhereResponse,
   type SteerTurnRequest,
   type SteerTurnResponse,
@@ -76,6 +78,7 @@ import {
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+  AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -314,6 +317,17 @@ export function registerAgentIpcHandlers(): void {
         },
         operation: async () => await registry.listBackends(request),
       });
+    },
+  );
+
+  ipcMain.removeHandler(AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL);
+  ipcMain.handle(
+    AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+    async (
+      _event,
+      request: CancelThreadPrAutoDispatchRequest,
+    ): Promise<CancelThreadPrAutoDispatchResponse> => {
+      return await registry.cancelThreadPrAutoDispatch(request);
     },
   );
 

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3725,6 +3725,7 @@ class DesktopAppServerService {
       await coordinator.cancelAllPendingForThread(request);
       return;
     }
+    await coordinator.resetForOperator(request);
     if (!this.backgroundPrPollingEnabled) return;
 
     const overlay = await this.getOverlayStore().getThreadOverlayState(request);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -30,6 +30,7 @@ import {
   type DetachDirectoryFromThreadResponse,
   type CheckThreadPullRequestStatusToolArgs,
   type CancelThreadPrAutoDispatchRequest,
+  type SendThreadPrAutoDispatchNowRequest,
   type SetThreadPrAutoDispatchRequest,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
@@ -3773,6 +3774,12 @@ class DesktopAppServerService {
     return await this.getPrAutoDispatchCoordinator().cancelPending(request);
   }
 
+  async sendThreadPrAutoDispatchNow(
+    request: SendThreadPrAutoDispatchNowRequest,
+  ): Promise<boolean> {
+    return await this.getPrAutoDispatchCoordinator().sendPendingNow(request);
+  }
+
   /**
    * Fold a poll result into the registry + cache, and publish only what
    * actually changed. Returns the changed prKeys so the scheduler can keep its
@@ -4788,6 +4795,8 @@ export function registerAppServerIpcHandlers(): void {
       await appServerService.handleThreadPrAutoDispatchPreference(request),
     cancelPending: async (request) =>
       await appServerService.cancelThreadPrAutoDispatch(request),
+    sendPendingNow: async (request) =>
+      await appServerService.sendThreadPrAutoDispatchNow(request),
   });
 
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -203,6 +203,7 @@ import type { BranchRef } from "../pr-status/github-graphql-client";
 import { resolveGitHubRepoForDirectory } from "../pr-status/git-remote";
 import { PrPollingScheduler } from "../pr-status/pr-polling-scheduler";
 import type { PrPollTarget } from "../pr-status/pr-polling-scheduler";
+import { PrAutoDispatchCoordinator } from "../pr-status/pr-auto-dispatch";
 import { isTerminalPullRequest, mergeCommitShas } from "../pr-status/pr-derivations";
 import {
   computePrStatusTransition,
@@ -211,7 +212,7 @@ import {
 import type { PrStatusTransition } from "../pr-status/pr-transitions";
 import { selectDiscoveryDueThreadKeys } from "../pr-status/pr-discovery";
 
-/** Listener registered via `onPrStatusTransition` — the future CI-event seam. */
+/** Listener registered via `onPrStatusTransition`. */
 type PrStatusTransitionListener = (transition: PrStatusTransition) => void;
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
@@ -586,7 +587,10 @@ function normalizePullRequestProvider(provider: string | undefined): string {
 
 function normalizePrSummary(pr: PrSummary): PrSummary {
   const checkState = normalizePrCheckState(pr.checkState ?? pr.state);
-  return {
+  const headSha = normalizeCommitShas(
+    pr.headSha ? [pr.headSha] : undefined,
+  )?.[0];
+  const normalized: PrSummary = {
     ...pr,
     provider: normalizePullRequestProvider(pr.provider),
     state: checkState,
@@ -596,6 +600,12 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     mergeState: pr.mergeState ?? "unknown",
     commitShas: normalizeCommitShas(pr.commitShas),
   };
+  if (headSha) {
+    normalized.headSha = headSha;
+  } else {
+    delete normalized.headSha;
+  }
+  return normalized;
 }
 
 function normalizeCommitShas(commitShas: string[] | undefined): string[] | undefined {
@@ -686,6 +696,7 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&
+      candidate.headSha === pr.headSha &&
       JSON.stringify(candidate.commitShas ?? []) === JSON.stringify(pr.commitShas ?? []) &&
       candidate.url === pr.url
     );
@@ -869,6 +880,8 @@ class DesktopAppServerService {
   private prLookupRegistryLoaded = false;
   private prGraphqlClient: GithubGraphqlPrClient | undefined;
   private prPollingScheduler: PrPollingScheduler | undefined;
+  private backgroundPrPollingEnabled = false;
+  private prAutoDispatchCoordinator: PrAutoDispatchCoordinator | undefined;
   private prDiscoveryTimer: NodeJS.Timeout | undefined;
   /** Per-thread last discovery branch-lookup time, driving the slow rotation. */
   private readonly prDiscoveryLastRefreshedAt = new Map<string, number>();
@@ -881,7 +894,7 @@ class DesktopAppServerService {
   private prPollingFocusThreadKeys: ReadonlySet<string> = new Set();
   /** prKey → backend to publish its status updates on. Rebuilt per poll pass. */
   private readonly prPollBackendByKey = new Map<string, AppServerBackendKind>();
-  /** Subscribers to PR status transitions (the future CI-event ingestor seam). */
+  /** Subscribers to typed PR status transitions. */
   private readonly prStatusTransitionListeners = new Set<PrStatusTransitionListener>();
   private readonly previousDirectoriesByBackend = new Map<
     AppServerBackendScope,
@@ -3049,10 +3062,8 @@ class DesktopAppServerService {
   }
 
   /**
-   * Subscribe to PR status transitions. This is the seam the future CI-event
-   * ingestor hooks into (brainstorm) — it can turn a `checkState → failing`
-   * into an inbound thread event without the poller knowing it exists. Returns
-   * an unsubscribe function.
+   * Subscribe to PR status transitions without coupling consumers to polling.
+   * Returns an unsubscribe function.
    */
   onPrStatusTransition(listener: PrStatusTransitionListener): () => void {
     this.prStatusTransitionListeners.add(listener);
@@ -3083,6 +3094,27 @@ class DesktopAppServerService {
           });
         }
       }
+      void this.getPrAutoDispatchCoordinator().handleTransition({
+        transition,
+        source: observation.source,
+        observedAt: observation.observedAt,
+        backgroundPollingEnabled: this.backgroundPrPollingEnabled,
+      }).then((outcomes) => {
+        for (const outcome of outcomes) {
+          const log = outcome.status === "failed"
+            ? appServerLog.warn.bind(appServerLog)
+            : appServerLog.info.bind(appServerLog);
+          log("pr auto dispatch", {
+            prKey: transition.prKey,
+            ...outcome,
+          });
+        }
+      }).catch((error) => {
+        appServerLog.warn("pr auto dispatch failed", {
+          prKey: transition.prKey,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
   }
 
@@ -3091,7 +3123,7 @@ class DesktopAppServerService {
    * transition actually fired (rare), so the O(threads) scan is cheap. A PR
    * touched only via a path that has not yet been remembered in a navigation
    * snapshot resolves to `[]` — acceptable for the logging consumer, and the
-   * future ingestor can re-resolve at delivery time.
+   * auto-dispatch coordinator can re-resolve on a later observation.
    */
   private findThreadKeysForPrKey(prKey: string): string[] {
     const threadKeys: string[] = [];
@@ -3328,6 +3360,9 @@ class DesktopAppServerService {
         if (!this.prPollingSettingsUnsubscribe) {
           this.prPollingSettingsUnsubscribe = settingsService.onConfigWritten(
             () => {
+              // Pause dispatch pessimistically while the new snapshot is read.
+              // This closes the settings-write race for the global kill switch.
+              this.backgroundPrPollingEnabled = false;
               this.syncPrPollingSchedulerState();
             },
           );
@@ -3341,6 +3376,8 @@ class DesktopAppServerService {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+
+      this.backgroundPrPollingEnabled = enabled;
 
       if (!enabled) {
         this.stopPrPollingScheduler();
@@ -4397,6 +4434,7 @@ class DesktopAppServerService {
     this.prFetcher = undefined;
     this.prPollingScheduler?.stop();
     this.prPollingScheduler = undefined;
+    this.backgroundPrPollingEnabled = false;
     if (this.prDiscoveryTimer) {
       clearInterval(this.prDiscoveryTimer);
       this.prDiscoveryTimer = undefined;
@@ -4408,6 +4446,7 @@ class DesktopAppServerService {
     this.prPollingFocusThreadKeys = new Set();
     this.prPollBackendByKey.clear();
     this.prStatusTransitionListeners.clear();
+    this.prAutoDispatchCoordinator = undefined;
     this.pendingNavigationSnapshots.clear();
     this.pendingThreadPullRequestRefreshes.clear();
     this.pendingEditCommitResolves.clear();
@@ -4449,6 +4488,17 @@ class DesktopAppServerService {
 
   private getOverlayStore(): AppServerOverlayStoreLike {
     return getDesktopOverlayStore();
+  }
+
+  private getPrAutoDispatchCoordinator(): PrAutoDispatchCoordinator {
+    if (!this.prAutoDispatchCoordinator) {
+      this.prAutoDispatchCoordinator = new PrAutoDispatchCoordinator({
+        store: this.getOverlayStore(),
+        registry: getDesktopBackendRegistry(),
+        isBackgroundPollingEnabled: () => this.backgroundPrPollingEnabled,
+      });
+    }
+    return this.prAutoDispatchCoordinator;
   }
 
   private getFocusedDiffService(modelOverride?: string): FocusedDiffService {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -114,6 +114,7 @@ import {
   type RestoreThreadResponse,
   type ThreadGitWorkingState,
   type ThreadOverlayState,
+  type ThreadPrAutoDispatchPending,
   type UpdateDirectoryLaunchpadRequest,
   type UpdateDirectoryLaunchpadResponse,
   type UpdateSubthreadOrderRequest,
@@ -3828,6 +3829,33 @@ class DesktopAppServerService {
     return changed.map((pr) => getPrStatusKey(pr));
   }
 
+  private async refreshPendingPrAutoDispatches(
+    pending: ThreadPrAutoDispatchPending[],
+  ): Promise<ReadonlySet<string>> {
+    const refsByPrKey = new Map(
+      pending.flatMap((item) => {
+        const ref = parsePrRefFromUrl(item.prUrl);
+        return ref ? [[item.prKey, ref] as const] : [];
+      }),
+    );
+    if (refsByPrKey.size === 0) {
+      return new Set();
+    }
+    if (!this.prStatusTokenBucket.tryTake()) {
+      throw new Error("PR status refresh budget is temporarily exhausted");
+    }
+    const refreshed = await this.getPrGraphqlClient().fetchPullRequests(
+      [...refsByPrKey.values()],
+    );
+    if (refreshed.length > 0) {
+      await this.applyPolledPrStatuses(
+        refreshed,
+        this.nextPrObservationTimestamp(),
+      );
+    }
+    return new Set(refreshed.map((pr) => getPrStatusKey(pr)));
+  }
+
   async getGhStatus(request: GetGhStatusRequest): Promise<GhStatus> {
     const fetcher = this.getPrFetcher();
     if (request.recheck) {
@@ -4614,6 +4642,8 @@ class DesktopAppServerService {
         registry: getDesktopBackendRegistry(),
         isBackgroundPollingEnabled: () => this.backgroundPrPollingEnabled,
         getCurrentPr: (prKey) => this.prStatusRegistry.get(prKey)?.pr,
+        refreshPendingPrs: async (pending) =>
+          await this.refreshPendingPrAutoDispatches(pending),
         isPrAttached: ({ backend, threadId, prKey }) =>
           this.attachedPrsByThreadKey
             .get(buildThreadIdentityKey(backend, threadId))

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -29,6 +29,8 @@ import {
   type DetachDirectoryFromThreadRequest,
   type DetachDirectoryFromThreadResponse,
   type CheckThreadPullRequestStatusToolArgs,
+  type CancelThreadPrAutoDispatchRequest,
+  type SetThreadPrAutoDispatchRequest,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
   type PersistThreadUsageActivityRequest,
@@ -198,6 +200,7 @@ import { detectPullRequestsForThread } from "../pr-status/pr-detection";
 import {
   GithubGraphqlPrClient,
   branchRefKey,
+  parsePrRefFromUrl,
 } from "../pr-status/github-graphql-client";
 import type { BranchRef } from "../pr-status/github-graphql-client";
 import { resolveGitHubRepoForDirectory } from "../pr-status/git-remote";
@@ -882,6 +885,11 @@ class DesktopAppServerService {
   private prPollingScheduler: PrPollingScheduler | undefined;
   private backgroundPrPollingEnabled = false;
   private prAutoDispatchCoordinator: PrAutoDispatchCoordinator | undefined;
+  /** Visible thread→PR attachments, including explicit directoryless refs. */
+  private readonly attachedPrsByThreadKey = new Map<
+    string,
+    { backend: AppServerBackendKind; prs: PrSummary[] }
+  >();
   private prDiscoveryTimer: NodeJS.Timeout | undefined;
   /** Per-thread last discovery branch-lookup time, driving the slow rotation. */
   private readonly prDiscoveryLastRefreshedAt = new Map<string, number>();
@@ -1296,6 +1304,10 @@ class DesktopAppServerService {
     await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
     const canonicalSnapshot = this.applyCanonicalPrStatuses(snapshot.threads);
+    this.rememberThreadPrAttachments(canonicalSnapshot.threads, {
+      replace: backend === "all" && !request.filter?.trim() && !activeRecentRefresh,
+    });
+    void this.getPrAutoDispatchCoordinator().resume();
     await this.loadDirectoryGitStatusCache();
     for (const directory of snapshot.directories) {
       this.lastDirectoriesByKey.set(directory.key, directory);
@@ -1440,6 +1452,54 @@ class DesktopAppServerService {
         continue;
       }
       this.prRefreshContextByThreadKey.set(threadKey, contexts);
+    }
+  }
+
+  private rememberThreadPrAttachments(
+    threads: NavigationSnapshot["threads"],
+    options: { replace: boolean },
+  ): void {
+    const liveThreadKeys = new Set<string>();
+    for (const thread of threads) {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      liveThreadKeys.add(threadKey);
+      this.attachedPrsByThreadKey.set(threadKey, {
+        backend: thread.source,
+        prs: thread.prs ?? [],
+      });
+    }
+    if (options.replace) {
+      for (const threadKey of this.attachedPrsByThreadKey.keys()) {
+        if (!liveThreadKeys.has(threadKey)) {
+          this.attachedPrsByThreadKey.delete(threadKey);
+        }
+      }
+    }
+  }
+
+  private rememberThreadPrAttachmentUpdate(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prs: PrSummary[];
+  }): void {
+    this.attachedPrsByThreadKey.set(
+      buildThreadIdentityKey(params.backend, params.threadId),
+      { backend: params.backend, prs: params.prs },
+    );
+  }
+
+  private applyPrStatusToAttachments(pr: PrSummary): void {
+    const prKey = getPrStatusKey(pr);
+    for (const [threadKey, attachment] of this.attachedPrsByThreadKey) {
+      let changed = false;
+      const prs = attachment.prs.map((candidate) => {
+        if (getPrStatusKey(candidate) !== prKey) return candidate;
+        changed = true;
+        return pr;
+      });
+      if (changed) {
+        this.attachedPrsByThreadKey.set(threadKey, { ...attachment, prs });
+      }
     }
   }
 
@@ -2138,6 +2198,19 @@ class DesktopAppServerService {
         }
       }
     }
+  }
+
+  handleAgentEventForPrAttachments(event: AgentEvent): void {
+    if (event.notification.method !== "thread/pullRequests/updated") return;
+    const params = event.notification.params as {
+      threadId: string;
+      prs: PrSummary[];
+    };
+    this.rememberThreadPrAttachmentUpdate({
+      backend: event.backend,
+      threadId: params.threadId,
+      prs: params.prs,
+    });
   }
 
   async markThreadSeen(
@@ -3045,6 +3118,7 @@ class DesktopAppServerService {
         pr,
         fetchedAt,
       });
+      this.applyPrStatusToAttachments(pr);
     }
     if (transitions.length > 0) {
       this.emitPrStatusTransitions(transitions, { observedAt: fetchedAt, source });
@@ -3094,51 +3168,14 @@ class DesktopAppServerService {
           });
         }
       }
-      void this.getPrAutoDispatchCoordinator().handleTransition({
-        transition,
-        source: observation.source,
-        observedAt: observation.observedAt,
-        backgroundPollingEnabled: this.backgroundPrPollingEnabled,
-      }).then((outcomes) => {
-        for (const outcome of outcomes) {
-          const log = outcome.status === "failed"
-            ? appServerLog.warn.bind(appServerLog)
-            : appServerLog.info.bind(appServerLog);
-          log("pr auto dispatch", {
-            prKey: transition.prKey,
-            ...outcome,
-          });
-        }
-      }).catch((error) => {
-        appServerLog.warn("pr auto dispatch failed", {
-          prKey: transition.prKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
     }
   }
 
-  /**
-   * Best-effort: which threads currently display this PR. Only runs when a
-   * transition actually fired (rare), so the O(threads) scan is cheap. A PR
-   * touched only via a path that has not yet been remembered in a navigation
-   * snapshot resolves to `[]` — acceptable for the logging consumer, and the
-   * auto-dispatch coordinator can re-resolve on a later observation.
-   */
+  /** Resolve only visible attachments; detached lookup history never qualifies. */
   private findThreadKeysForPrKey(prKey: string): string[] {
     const threadKeys: string[] = [];
-    for (const [threadKey, contexts] of this.prRefreshContextByThreadKey) {
-      const displays = contexts.some((context) => {
-        const lookup = this.prLookupRegistry.get(
-          getPullRequestLookupKey({
-            provider: DEFAULT_PULL_REQUEST_PROVIDER,
-            branch: context.branch,
-            directoryPaths: context.directoryPaths,
-          }),
-        );
-        return lookup?.prs.some((pr) => getPrStatusKey(pr) === prKey) ?? false;
-      });
-      if (displays) {
+    for (const [threadKey, attachment] of this.attachedPrsByThreadKey) {
+      if (attachment.prs.some((pr) => getPrStatusKey(pr) === prKey)) {
         threadKeys.push(threadKey);
       }
     }
@@ -3274,6 +3311,7 @@ class DesktopAppServerService {
     prs: PrSummary[];
     detachedPrs?: PrSummary[];
   }): Promise<void> {
+    this.rememberThreadPrAttachmentUpdate(params);
     const worktreePath = this.rememberMergedPrCommitShasForThread({
       ...params,
       prs: [...params.prs, ...(params.detachedPrs ?? [])],
@@ -3380,10 +3418,12 @@ class DesktopAppServerService {
       this.backgroundPrPollingEnabled = enabled;
 
       if (!enabled) {
+        this.prAutoDispatchCoordinator?.pause();
         this.stopPrPollingScheduler();
         return;
       }
       this.ensurePrPollingSchedulerStarted();
+      void this.getPrAutoDispatchCoordinator().resume();
     })();
   }
 
@@ -3622,49 +3662,115 @@ class DesktopAppServerService {
    * Every tracked, non-terminal PR the poller should keep fresh, with the
    * threads that display it.
    *
-   * Walks the remembered per-thread refresh contexts (populated on every
-   * navigation snapshot) back through the lookup registry. That pairing is
-   * what lets the poller cover EVERY open project rather than only whichever
-   * thread the renderer happens to have selected.
+   * Uses the visible per-thread attachment set populated by navigation and
+   * attachment events. This includes explicit PRs on directoryless threads
+   * and excludes detached PRs even though lookup history retains them for
+   * non-UI bookkeeping.
    */
   private collectPrPollTargets(): PrPollTarget[] {
     const byKey = new Map<string, PrPollTarget>();
     this.prPollBackendByKey.clear();
 
-    for (const [threadKey, contexts] of this.prRefreshContextByThreadKey) {
-      for (const context of contexts) {
-        const lookup = this.prLookupRegistry.get(
-          getPullRequestLookupKey({
-            provider: DEFAULT_PULL_REQUEST_PROVIDER,
-            branch: context.branch,
-            directoryPaths: context.directoryPaths,
-          }),
-        );
-        if (!lookup) {
+    for (const [threadKey, attachment] of this.attachedPrsByThreadKey) {
+      for (const pr of attachment.prs) {
+        const prKey = getPrStatusKey(pr);
+        const latest = this.prStatusRegistry.get(prKey)?.pr ?? pr;
+        if (isTerminalPullRequest(latest)) continue;
+        this.prPollBackendByKey.set(prKey, attachment.backend);
+        const existing = byKey.get(prKey);
+        if (existing) {
+          if (!existing.threadKeys.includes(threadKey)) {
+            existing.threadKeys.push(threadKey);
+          }
           continue;
         }
-        for (const pr of lookup.prs) {
-          const prKey = getPrStatusKey(pr);
-          // The lookup entry holds the PRs as of its own fetch; the status
-          // registry holds the newest state for each one. Trust the latter.
-          const latest = this.prStatusRegistry.get(prKey)?.pr ?? pr;
-          if (isTerminalPullRequest(latest)) {
-            continue;
-          }
-          this.prPollBackendByKey.set(prKey, context.backend);
-
-          const existing = byKey.get(prKey);
-          if (existing) {
-            if (!existing.threadKeys.includes(threadKey)) {
-              existing.threadKeys.push(threadKey);
-            }
-            continue;
-          }
-          byKey.set(prKey, { prKey, pr: latest, threadKeys: [threadKey] });
-        }
+        byKey.set(prKey, { prKey, pr: latest, threadKeys: [threadKey] });
       }
     }
     return [...byKey.values()];
+  }
+
+  private async handlePrAutoDispatchSnapshots(
+    prs: PrSummary[],
+    observedAt: number,
+    onlyThreadKey?: string,
+    operatorInitiated = false,
+  ): Promise<void> {
+    const coordinator = this.getPrAutoDispatchCoordinator();
+    for (const pr of prs) {
+      const prKey = getPrStatusKey(pr);
+      const threadKeys = onlyThreadKey
+        ? [onlyThreadKey]
+        : this.findThreadKeysForPrKey(prKey);
+      if (threadKeys.length === 0) continue;
+      const outcomes = await coordinator.handleStatusSnapshot({
+        pr,
+        threadKeys,
+        observedAt,
+        backgroundPollingEnabled: this.backgroundPrPollingEnabled,
+        operatorInitiated,
+      });
+      for (const outcome of outcomes) {
+        appServerLog.info("pr auto dispatch", { prKey, ...outcome });
+      }
+    }
+  }
+
+  async handleThreadPrAutoDispatchPreference(
+    request: SetThreadPrAutoDispatchRequest,
+  ): Promise<void> {
+    const coordinator = this.getPrAutoDispatchCoordinator();
+    if (!request.enabled) {
+      await coordinator.cancelAllPendingForThread(request);
+      return;
+    }
+    if (!this.backgroundPrPollingEnabled) return;
+
+    const overlay = await this.getOverlayStore().getThreadOverlayState(request);
+    const prs = this.canonicalizePrs(overlay?.prs ?? []);
+    const threadKey = buildThreadIdentityKey(request.backend, request.threadId);
+    this.rememberThreadPrAttachmentUpdate({ ...request, prs });
+    await this.handlePrAutoDispatchSnapshots(
+      prs,
+      this.nextPrObservationTimestamp(),
+      threadKey,
+      true,
+    );
+
+    const refs = [
+      ...new Map(
+        prs.flatMap((pr) => {
+          const ref = parsePrRefFromUrl(pr.url);
+          return ref ? [[`${ref.owner}/${ref.repo}#${ref.number}`, ref] as const] : [];
+        }),
+      ).values(),
+    ];
+    if (refs.length === 0) return;
+    const refreshed = await this.getPrGraphqlClient().fetchPullRequests(refs);
+    if (refreshed.length === 0) return;
+    const fetchedAt = this.nextPrObservationTimestamp();
+    const changed = this.rememberPrStatuses(
+      refreshed,
+      fetchedAt,
+      "auto-fix-enable",
+    );
+    await this.writePrStatusesToCache(refreshed, fetchedAt);
+    await this.publishPullRequestStatusUpdates({
+      backend: request.backend,
+      prs: changed,
+    });
+    await this.handlePrAutoDispatchSnapshots(
+      refreshed,
+      fetchedAt,
+      threadKey,
+      true,
+    );
+  }
+
+  async cancelThreadPrAutoDispatch(
+    request: CancelThreadPrAutoDispatchRequest,
+  ): Promise<boolean> {
+    return await this.getPrAutoDispatchCoordinator().cancelPending(request);
   }
 
   /**
@@ -3687,6 +3793,7 @@ class DesktopAppServerService {
     });
 
     const changed = this.rememberPrStatuses(merged, fetchedAt, "background-poll");
+    await this.handlePrAutoDispatchSnapshots(merged, fetchedAt);
     if (changed.length === 0) {
       return [];
     }
@@ -4446,7 +4553,9 @@ class DesktopAppServerService {
     this.prPollingFocusThreadKeys = new Set();
     this.prPollBackendByKey.clear();
     this.prStatusTransitionListeners.clear();
+    this.prAutoDispatchCoordinator?.close();
     this.prAutoDispatchCoordinator = undefined;
+    this.attachedPrsByThreadKey.clear();
     this.pendingNavigationSnapshots.clear();
     this.pendingThreadPullRequestRefreshes.clear();
     this.pendingEditCommitResolves.clear();
@@ -4496,6 +4605,20 @@ class DesktopAppServerService {
         store: this.getOverlayStore(),
         registry: getDesktopBackendRegistry(),
         isBackgroundPollingEnabled: () => this.backgroundPrPollingEnabled,
+        getCurrentPr: (prKey) => this.prStatusRegistry.get(prKey)?.pr,
+        isPrAttached: ({ backend, threadId, prKey }) =>
+          this.attachedPrsByThreadKey
+            .get(buildThreadIdentityKey(backend, threadId))
+            ?.prs.some((pr) => getPrStatusKey(pr) === prKey) ?? false,
+        onPendingChanged: async ({ backend, threadId, pending }) => {
+          await getDesktopBackendRegistry().publishLocalEvent({
+            backend,
+            notification: {
+              method: "thread/prAutoDispatch/pendingUpdated",
+              params: { threadId, pending },
+            },
+          });
+        },
       });
     }
     return this.prAutoDispatchCoordinator;
@@ -4655,10 +4778,17 @@ export function registerAppServerIpcHandlers(): void {
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = getDesktopBackendRegistry().onEvent((event) => {
     appServerService.handleAgentEventForWorkingState(event);
+    appServerService.handleAgentEventForPrAttachments(event);
   });
   getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(
     async (args) => await appServerService.checkThreadPullRequestStatusForTool(args),
   );
+  getDesktopBackendRegistry().setThreadPrAutoDispatchHandler({
+    preferenceChanged: async (request) =>
+      await appServerService.handleThreadPrAutoDispatchPreference(request),
+    cancelPending: async (request) =>
+      await appServerService.cancelThreadPrAutoDispatch(request),
+  });
 
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.handle(
@@ -5229,6 +5359,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
   getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(undefined);
+  getDesktopBackendRegistry().setThreadPrAutoDispatchHandler(undefined);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1159,6 +1159,7 @@ export class MessagingController {
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
       event.notification.method === "thread/prAutoDispatch/updated" ||
+      event.notification.method === "thread/prAutoDispatch/pendingUpdated" ||
       event.notification.method === "thread/codexEnvironment/updated" ||
       event.notification.method === "thread/parent/set" ||
       event.notification.method === "thread/parent/cleared" ||

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1158,6 +1158,7 @@ export class MessagingController {
     if (
       event.notification.method === "thread/executionMode/updated" ||
       event.notification.method === "thread/modelSettings/updated" ||
+      event.notification.method === "thread/prAutoDispatch/updated" ||
       event.notification.method === "thread/codexEnvironment/updated" ||
       event.notification.method === "thread/parent/set" ||
       event.notification.method === "thread/parent/cleared" ||

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -249,6 +249,7 @@ export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
     mergeStateStatus: null,
   };
   const commitShas = normalizeCommitShas([headCommit?.oid]);
+  const headSha = commitShas[0];
 
   return {
     provider: parsePullRequestProvider(node.url),
@@ -263,6 +264,7 @@ export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
     lifecycleState: deriveLifecycleState(shaped),
     reviewState: deriveReviewState(shaped),
     mergeState: deriveMergeState(shaped),
+    ...(headSha ? { headSha } : {}),
     ...(commitShas.length > 0 ? { commitShas } : {}),
     url: node.url,
   };

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -52,6 +52,10 @@ type PrAutoDispatchStore = {
     maxAttempts: number;
     allowCancelledRearm?: boolean;
   }): Promise<PrAutoDispatchScheduleResult>;
+  resetThreadPrAutoDispatchForOperator(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<boolean>;
   beginThreadPrAutoDispatch(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -254,6 +258,17 @@ export class PrAutoDispatchCoordinator {
       await this.notifyPending(params, null);
     }
     return cancelled;
+  }
+
+  async resetForOperator(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<boolean> {
+    const reset = await this.options.store
+      .resetThreadPrAutoDispatchForOperator(params);
+    this.clearTimer(this.threadKey(params));
+    if (reset) await this.notifyPending(params, null);
+    return reset;
   }
 
   async sendPendingNow(params: {

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -1,0 +1,306 @@
+import { createHash } from "node:crypto";
+import type {
+  AppServerBackendKind,
+  AppServerTurnInputItem,
+  ThreadOverlayState,
+} from "@pwragent/shared";
+import { parseThreadIdentityKey } from "@pwragent/shared";
+import type { PrStatusTransition } from "./pr-transitions";
+
+export const MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT = 2;
+
+export type PrAutoDispatchOutcome = {
+  threadKey: string;
+  status:
+    | "dispatched"
+    | "gate-off"
+    | "not-actionable"
+    | "missing-head"
+    | "disabled"
+    | "busy"
+    | "pending"
+    | "duplicate"
+    | "attempt-limit"
+    | "failed";
+  fingerprint?: string;
+  error?: string;
+};
+
+type PrAutoDispatchStore = {
+  getThreadOverlayState(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<ThreadOverlayState | undefined>;
+  claimThreadPrAutoDispatch(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prKey: string;
+    fingerprint: string;
+    maxAttempts: number;
+  }): Promise<{
+    claimed: boolean;
+    reason?: "disabled" | "duplicate" | "attempt-limit";
+    attemptCount: number;
+  }>;
+  resetThreadPrAutoDispatchIncident(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prKey: string;
+  }): Promise<void>;
+};
+
+type PrAutoDispatchRegistry = {
+  canStartThreadTurnImmediately(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): boolean;
+  submitTurn(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    input: AppServerTurnInputItem[];
+    origin: "automation";
+    messageOrigin: { kind: "pwragent" };
+  }): Promise<unknown>;
+};
+
+type PrAutoDispatchEvent = {
+  eventKinds: Array<"ci-failure" | "merge-conflict">;
+  fingerprint: string;
+  headSha: string;
+};
+
+export class PrAutoDispatchCoordinator {
+  private readonly pendingThreadKeys = new Set<string>();
+
+  constructor(
+    private readonly options: {
+      store: PrAutoDispatchStore;
+      registry: PrAutoDispatchRegistry;
+      isBackgroundPollingEnabled?: () => boolean;
+    },
+  ) {}
+
+  async handleTransition(params: {
+    transition: PrStatusTransition;
+    source: string;
+    observedAt: number;
+    backgroundPollingEnabled: boolean;
+  }): Promise<PrAutoDispatchOutcome[]> {
+    const threadKeys = params.transition.threadKeys;
+    if (
+      !params.backgroundPollingEnabled
+      || params.source !== "background-poll"
+    ) {
+      return threadKeys.map((threadKey) => ({ threadKey, status: "gate-off" }));
+    }
+
+    if (prIsHealthy(params.transition)) {
+      await Promise.all(
+        threadKeys.map(async (threadKey) => {
+          const identity = parseThreadIdentityKey(threadKey);
+          if (!identity) return;
+          await this.options.store.resetThreadPrAutoDispatchIncident({
+            ...identity,
+            prKey: params.transition.prKey,
+          });
+        }),
+      );
+    }
+
+    const event = buildPrAutoDispatchEvent(params.transition);
+    if (!event) {
+      const becameActionable =
+        params.transition.changed.checkState?.to === "failing"
+        || params.transition.changed.mergeState?.to === "conflicting";
+      const status = becameActionable ? "missing-head" : "not-actionable";
+      return threadKeys.map((threadKey) => ({ threadKey, status }));
+    }
+
+    const outcomes: PrAutoDispatchOutcome[] = [];
+    for (const threadKey of threadKeys) {
+      outcomes.push(await this.dispatchForThread({
+        event,
+        observedAt: params.observedAt,
+        threadKey,
+        transition: params.transition,
+      }));
+    }
+    return outcomes;
+  }
+
+  private async dispatchForThread(params: {
+    event: PrAutoDispatchEvent;
+    observedAt: number;
+    threadKey: string;
+    transition: PrStatusTransition;
+  }): Promise<PrAutoDispatchOutcome> {
+    const identity = parseThreadIdentityKey(params.threadKey);
+    if (!identity) {
+      return { threadKey: params.threadKey, status: "disabled" };
+    }
+    if (this.pendingThreadKeys.has(params.threadKey)) {
+      return {
+        threadKey: params.threadKey,
+        status: "pending",
+        fingerprint: params.event.fingerprint,
+      };
+    }
+
+    this.pendingThreadKeys.add(params.threadKey);
+    try {
+      if (this.options.isBackgroundPollingEnabled?.() === false) {
+        return { threadKey: params.threadKey, status: "gate-off" };
+      }
+      const overlay = await this.options.store.getThreadOverlayState(identity);
+      if (overlay?.prAutoDispatchEnabled !== true) {
+        return { threadKey: params.threadKey, status: "disabled" };
+      }
+      if (!this.options.registry.canStartThreadTurnImmediately(identity)) {
+        return {
+          threadKey: params.threadKey,
+          status: "busy",
+          fingerprint: params.event.fingerprint,
+        };
+      }
+      if (this.options.isBackgroundPollingEnabled?.() === false) {
+        return { threadKey: params.threadKey, status: "gate-off" };
+      }
+
+      const claim = await this.options.store.claimThreadPrAutoDispatch({
+        ...identity,
+        prKey: params.transition.prKey,
+        fingerprint: params.event.fingerprint,
+        maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+      });
+      if (!claim.claimed) {
+        return {
+          threadKey: params.threadKey,
+          status: claim.reason ?? "disabled",
+          fingerprint: params.event.fingerprint,
+        };
+      }
+
+      try {
+        if (this.options.isBackgroundPollingEnabled?.() === false) {
+          return {
+            threadKey: params.threadKey,
+            status: "gate-off",
+            fingerprint: params.event.fingerprint,
+          };
+        }
+        await this.options.registry.submitTurn({
+          ...identity,
+          input: [{
+            type: "text",
+            text: buildPrAutoDispatchPrompt({
+              ...params,
+              attemptCount: claim.attemptCount,
+            }),
+          }],
+          origin: "automation",
+          messageOrigin: { kind: "pwragent" },
+        });
+        return {
+          threadKey: params.threadKey,
+          status: "dispatched",
+          fingerprint: params.event.fingerprint,
+        };
+      } catch (error) {
+        return {
+          threadKey: params.threadKey,
+          status: "failed",
+          fingerprint: params.event.fingerprint,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    } finally {
+      this.pendingThreadKeys.delete(params.threadKey);
+    }
+  }
+}
+
+export function buildPrAutoDispatchEvent(
+  transition: PrStatusTransition,
+): PrAutoDispatchEvent | undefined {
+  const eventKinds: PrAutoDispatchEvent["eventKinds"] = [];
+  const headChanged = transition.changed.headSha !== undefined;
+  if (
+    transition.changed.checkState?.to === "failing"
+    || (headChanged && transition.pr.checkState === "failing")
+  ) {
+    eventKinds.push("ci-failure");
+  }
+  if (
+    transition.changed.mergeState?.to === "conflicting"
+    || (headChanged && transition.pr.mergeState === "conflicting")
+  ) {
+    eventKinds.push("merge-conflict");
+  }
+  if (eventKinds.length === 0) {
+    return undefined;
+  }
+
+  const headSha = transition.headSha ?? transition.pr.headSha;
+  if (!headSha) {
+    return undefined;
+  }
+  const fingerprintPayload = {
+    version: 1,
+    prKey: transition.prKey,
+    headSha,
+    eventKinds,
+    checkState: eventKinds.includes("ci-failure")
+      ? transition.pr.checkState
+      : undefined,
+    mergeState: eventKinds.includes("merge-conflict")
+      ? transition.pr.mergeState
+      : undefined,
+  };
+  return {
+    eventKinds,
+    headSha,
+    fingerprint: createHash("sha256")
+      .update(JSON.stringify(fingerprintPayload))
+      .digest("hex"),
+  };
+}
+
+function prIsHealthy(transition: PrStatusTransition): boolean {
+  return (
+    transition.pr.checkState !== "failing"
+    && transition.pr.mergeState !== "conflicting"
+  );
+}
+
+function buildPrAutoDispatchPrompt(params: {
+  attemptCount: number;
+  event: PrAutoDispatchEvent;
+  observedAt: number;
+  transition: PrStatusTransition;
+}): string {
+  const changes = Object.entries(params.transition.changed)
+    .map(([field, change]) =>
+      `${field}: ${String(change?.from ?? "unknown")} -> ${String(change?.to ?? "unknown")}`,
+    )
+    .join("\n");
+  return [
+    "PwrAgent automatically dispatched this bounded repair turn because an attached pull request entered an actionable state.",
+    "",
+    "Pull request event",
+    `- PR: ${params.transition.prKey}`,
+    `- URL: ${params.transition.url}`,
+    `- Title: ${params.transition.title ?? "(untitled)"}`,
+    `- Head SHA: ${params.event.headSha}`,
+    `- Event kinds: ${params.event.eventKinds.join(", ")}`,
+    `- Check state: ${params.transition.pr.checkState ?? "unknown"}`,
+    `- Merge state: ${params.transition.pr.mergeState ?? "unknown"}`,
+    `- Observed at: ${new Date(params.observedAt).toISOString()}`,
+    `- Automatic attempt: ${params.attemptCount}/${MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT}`,
+    `- Dedupe fingerprint: ${params.event.fingerprint}`,
+    "",
+    "Observed transition",
+    changes || "(no details)",
+    "",
+    "Investigate the current PR checks or merge conflict, make only scoped fixes, run relevant validation, and update the attached PR when appropriate. Verify current provider state before changing code. If the condition is external, transient, or no safe fix is available, explain that and stop; do not create another retry loop.",
+  ].join("\n");
+}

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -256,6 +256,19 @@ export class PrAutoDispatchCoordinator {
     return cancelled;
   }
 
+  async sendPendingNow(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+  }): Promise<boolean> {
+    if (this.options.isBackgroundPollingEnabled?.() === false) return false;
+    const record = await this.options.store.getThreadPrAutoDispatchPending(params);
+    if (!record || record.pending.fingerprint !== params.fingerprint) return false;
+    this.clearTimer(this.threadKey(params));
+    await this.dispatchPending(params, params.fingerprint);
+    return true;
+  }
+
   async cancelAllPendingForThread(params: {
     backend: AppServerBackendKind;
     threadId: string;

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -2,16 +2,27 @@ import { createHash } from "node:crypto";
 import type {
   AppServerBackendKind,
   AppServerTurnInputItem,
+  PrSummary,
   ThreadOverlayState,
+  ThreadPrAutoDispatchEventKind,
+  ThreadPrAutoDispatchPending,
 } from "@pwragent/shared";
-import { parseThreadIdentityKey } from "@pwragent/shared";
-import type { PrStatusTransition } from "./pr-transitions";
+import {
+  buildPullRequestStatusKey,
+  parseThreadIdentityKey,
+} from "@pwragent/shared";
+import type {
+  PrAutoDispatchPendingRecord,
+  PrAutoDispatchScheduleResult,
+} from "../state/overlay-store-sqlite";
 
 export const MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT = 2;
+export const PR_AUTO_DISPATCH_DELAY_MS = 30_000;
 
 export type PrAutoDispatchOutcome = {
   threadKey: string;
   status:
+    | "scheduled"
     | "dispatched"
     | "gate-off"
     | "not-actionable"
@@ -21,6 +32,8 @@ export type PrAutoDispatchOutcome = {
     | "pending"
     | "duplicate"
     | "attempt-limit"
+    | "cancelled"
+    | "stale"
     | "failed";
   fingerprint?: string;
   error?: string;
@@ -31,275 +44,460 @@ type PrAutoDispatchStore = {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<ThreadOverlayState | undefined>;
-  claimThreadPrAutoDispatch(params: {
+  scheduleThreadPrAutoDispatch(params: {
     backend: AppServerBackendKind;
     threadId: string;
-    prKey: string;
+    pending: ThreadPrAutoDispatchPending;
+    prompt: string;
+    maxAttempts: number;
+    allowCancelledRearm?: boolean;
+  }): Promise<PrAutoDispatchScheduleResult>;
+  beginThreadPrAutoDispatch(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
     fingerprint: string;
     maxAttempts: number;
-  }): Promise<{
-    claimed: boolean;
-    reason?: "disabled" | "duplicate" | "attempt-limit";
-    attemptCount: number;
-  }>;
-  resetThreadPrAutoDispatchIncident(params: {
+    now: number;
+  }): Promise<
+    | { status: "ready"; attemptCount: number; record: PrAutoDispatchPendingRecord }
+    | { status: "disabled" | "stale" | "attempt-limit" }
+  >;
+  restoreThreadPrAutoDispatchAfterBusy(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+    scheduledAt: number;
+    now: number;
+  }): Promise<ThreadPrAutoDispatchPending | undefined>;
+  finishThreadPrAutoDispatch(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+    status: "dispatched" | "failed";
+    now: number;
+  }): Promise<void>;
+  cancelThreadPrAutoDispatch(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+    now?: number;
+    status?: "cancelled" | "resolved" | "superseded";
+  }): Promise<boolean>;
+  cancelPendingThreadPrAutoDispatchForPr(params: {
     backend: AppServerBackendKind;
     threadId: string;
     prKey: string;
+    now: number;
+  }): Promise<boolean>;
+  resolveThreadPrAutoDispatchIncident(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    prKey: string;
+    resolvedKinds: ThreadPrAutoDispatchEventKind[];
+    now: number;
   }): Promise<void>;
+  getThreadPrAutoDispatchPending(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<PrAutoDispatchPendingRecord | undefined>;
+  listPendingThreadPrAutoDispatches(): Promise<Array<
+    PrAutoDispatchPendingRecord & {
+      backend: AppServerBackendKind;
+      threadId: string;
+    }
+  >>;
 };
 
 type PrAutoDispatchRegistry = {
-  canStartThreadTurnImmediately(params: {
-    backend: AppServerBackendKind;
-    threadId: string;
-  }): boolean;
-  submitTurn(params: {
+  submitTurnIfIdle(params: {
     backend: AppServerBackendKind;
     threadId: string;
     input: AppServerTurnInputItem[];
     origin: "automation";
     messageOrigin: { kind: "pwragent" };
-  }): Promise<unknown>;
+  }): Promise<
+    | { status: "started"; turnId: string }
+    | { status: "busy" }
+  >;
 };
 
-type PrAutoDispatchEvent = {
-  eventKinds: Array<"ci-failure" | "merge-conflict">;
+export type PrAutoDispatchEvent = {
+  eventKinds: ThreadPrAutoDispatchEventKind[];
   fingerprint: string;
   headSha: string;
+  prKey: string;
 };
 
 export class PrAutoDispatchCoordinator {
-  private readonly pendingThreadKeys = new Set<string>();
+  private readonly timers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     private readonly options: {
       store: PrAutoDispatchStore;
       registry: PrAutoDispatchRegistry;
       isBackgroundPollingEnabled?: () => boolean;
+      isPrAttached?: (params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        prKey: string;
+      }) => boolean;
+      getCurrentPr?: (prKey: string) => PrSummary | undefined;
+      onPendingChanged?: (params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        pending: ThreadPrAutoDispatchPending | null;
+      }) => void | Promise<void>;
+      now?: () => number;
     },
   ) {}
 
-  async handleTransition(params: {
-    transition: PrStatusTransition;
-    source: string;
+  async handleStatusSnapshot(params: {
+    pr: PrSummary;
+    threadKeys: string[];
     observedAt: number;
     backgroundPollingEnabled: boolean;
+    operatorInitiated?: boolean;
   }): Promise<PrAutoDispatchOutcome[]> {
-    const threadKeys = params.transition.threadKeys;
-    if (
-      !params.backgroundPollingEnabled
-      || params.source !== "background-poll"
-    ) {
-      return threadKeys.map((threadKey) => ({ threadKey, status: "gate-off" }));
-    }
-
-    if (prIsHealthy(params.transition)) {
-      await Promise.all(
-        threadKeys.map(async (threadKey) => {
-          const identity = parseThreadIdentityKey(threadKey);
-          if (!identity) return;
-          await this.options.store.resetThreadPrAutoDispatchIncident({
-            ...identity,
-            prKey: params.transition.prKey,
-          });
-        }),
-      );
-    }
-
-    const event = buildPrAutoDispatchEvent(params.transition);
-    if (!event) {
-      const becameActionable =
-        params.transition.changed.checkState?.to === "failing"
-        || params.transition.changed.mergeState?.to === "conflicting";
-      const status = becameActionable ? "missing-head" : "not-actionable";
-      return threadKeys.map((threadKey) => ({ threadKey, status }));
-    }
-
-    const outcomes: PrAutoDispatchOutcome[] = [];
-    for (const threadKey of threadKeys) {
-      outcomes.push(await this.dispatchForThread({
-        event,
-        observedAt: params.observedAt,
+    if (!params.backgroundPollingEnabled) {
+      return params.threadKeys.map((threadKey) => ({
         threadKey,
-        transition: params.transition,
+        status: "gate-off",
       }));
+    }
+
+    const eventKinds = getPrAutoDispatchEventKinds(params.pr);
+    const event = buildPrAutoDispatchEvent(params.pr);
+    const prKey = buildPullRequestStatusKey(params.pr);
+    const resolvedKinds = getDefinitivelyResolvedEventKinds(params.pr);
+    const outcomes: PrAutoDispatchOutcome[] = [];
+
+    for (const threadKey of params.threadKeys) {
+      const identity = parseThreadIdentityKey(threadKey);
+      if (!identity) {
+        outcomes.push({ threadKey, status: "disabled" });
+        continue;
+      }
+
+      await this.options.store.resolveThreadPrAutoDispatchIncident({
+        ...identity,
+        prKey,
+        resolvedKinds,
+        now: params.observedAt,
+      });
+
+      if (!event) {
+        const cancelled = await this.options.store
+          .cancelPendingThreadPrAutoDispatchForPr({
+            ...identity,
+            prKey,
+            now: params.observedAt,
+          });
+        if (cancelled) {
+          this.clearTimer(threadKey);
+          await this.notifyPending(identity, null);
+        }
+        outcomes.push({
+          threadKey,
+          status: eventKinds.length > 0 ? "missing-head" : "not-actionable",
+        });
+        continue;
+      }
+
+      const pending: ThreadPrAutoDispatchPending = {
+        fingerprint: event.fingerprint,
+        prKey: event.prKey,
+        prNumber: params.pr.number,
+        ...(params.pr.title ? { prTitle: params.pr.title } : {}),
+        prUrl: params.pr.url,
+        headSha: event.headSha,
+        eventKinds: event.eventKinds,
+        createdAt: params.observedAt,
+        scheduledAt: params.observedAt + PR_AUTO_DISPATCH_DELAY_MS,
+      };
+      const result = await this.options.store.scheduleThreadPrAutoDispatch({
+        ...identity,
+        pending,
+        prompt: buildPrAutoDispatchPrompt({
+          event,
+          observedAt: params.observedAt,
+          pr: params.pr,
+        }),
+        maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+        allowCancelledRearm: params.operatorInitiated,
+      });
+      outcomes.push({
+        threadKey,
+        status: result.status,
+        fingerprint: event.fingerprint,
+      });
+      if (result.pending) {
+        this.arm(identity, result.pending);
+      }
+      if (result.status === "scheduled") {
+        await this.notifyPending(identity, pending);
+      }
     }
     return outcomes;
   }
 
-  private async dispatchForThread(params: {
-    event: PrAutoDispatchEvent;
-    observedAt: number;
-    threadKey: string;
-    transition: PrStatusTransition;
-  }): Promise<PrAutoDispatchOutcome> {
-    const identity = parseThreadIdentityKey(params.threadKey);
-    if (!identity) {
-      return { threadKey: params.threadKey, status: "disabled" };
+  async cancelPending(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+  }): Promise<boolean> {
+    const cancelled = await this.options.store.cancelThreadPrAutoDispatch({
+      ...params,
+      now: this.now(),
+    });
+    if (cancelled) {
+      this.clearTimer(this.threadKey(params));
+      await this.notifyPending(params, null);
     }
-    if (this.pendingThreadKeys.has(params.threadKey)) {
-      return {
-        threadKey: params.threadKey,
-        status: "pending",
-        fingerprint: params.event.fingerprint,
-      };
+    return cancelled;
+  }
+
+  async cancelAllPendingForThread(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<boolean> {
+    const record = await this.options.store.getThreadPrAutoDispatchPending(params);
+    if (!record) return false;
+    return await this.cancelPending({
+      ...params,
+      fingerprint: record.pending.fingerprint,
+    });
+  }
+
+  async resume(): Promise<void> {
+    if (this.options.isBackgroundPollingEnabled?.() === false) return;
+    const records = await this.options.store.listPendingThreadPrAutoDispatches();
+    for (const record of records) {
+      this.arm(record, record.pending);
     }
+  }
 
-    this.pendingThreadKeys.add(params.threadKey);
-    try {
-      if (this.options.isBackgroundPollingEnabled?.() === false) {
-        return { threadKey: params.threadKey, status: "gate-off" };
-      }
-      const overlay = await this.options.store.getThreadOverlayState(identity);
-      if (overlay?.prAutoDispatchEnabled !== true) {
-        return { threadKey: params.threadKey, status: "disabled" };
-      }
-      if (!this.options.registry.canStartThreadTurnImmediately(identity)) {
-        return {
-          threadKey: params.threadKey,
-          status: "busy",
-          fingerprint: params.event.fingerprint,
-        };
-      }
-      if (this.options.isBackgroundPollingEnabled?.() === false) {
-        return { threadKey: params.threadKey, status: "gate-off" };
-      }
+  pause(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
 
-      const claim = await this.options.store.claimThreadPrAutoDispatch({
+  close(): void {
+    this.pause();
+  }
+
+  private arm(
+    identity: { backend: AppServerBackendKind; threadId: string },
+    pending: ThreadPrAutoDispatchPending,
+  ): void {
+    if (this.options.isBackgroundPollingEnabled?.() === false) return;
+    const threadKey = this.threadKey(identity);
+    this.clearTimer(threadKey);
+    const timer = setTimeout(() => {
+      this.timers.delete(threadKey);
+      void this.dispatchPending(identity, pending.fingerprint);
+    }, Math.max(0, pending.scheduledAt - this.now()));
+    timer.unref?.();
+    this.timers.set(threadKey, timer);
+  }
+
+  private async dispatchPending(
+    identity: { backend: AppServerBackendKind; threadId: string },
+    fingerprint: string,
+  ): Promise<void> {
+    if (this.options.isBackgroundPollingEnabled?.() === false) return;
+    const record = await this.options.store.getThreadPrAutoDispatchPending(identity);
+    if (!record || record.pending.fingerprint !== fingerprint) return;
+
+    const currentPr = this.options.getCurrentPr?.(record.pending.prKey);
+    const currentEvent = currentPr
+      ? buildPrAutoDispatchEvent(currentPr)
+      : undefined;
+    const attached = this.options.isPrAttached?.({
+      ...identity,
+      prKey: record.pending.prKey,
+    }) ?? true;
+    if (
+      !attached
+      || !currentEvent
+      || currentEvent.fingerprint !== fingerprint
+    ) {
+      await this.options.store.cancelThreadPrAutoDispatch({
         ...identity,
-        prKey: params.transition.prKey,
-        fingerprint: params.event.fingerprint,
-        maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+        fingerprint,
+        now: this.now(),
+        status: "superseded",
       });
-      if (!claim.claimed) {
-        return {
-          threadKey: params.threadKey,
-          status: claim.reason ?? "disabled",
-          fingerprint: params.event.fingerprint,
-        };
-      }
-
-      try {
-        if (this.options.isBackgroundPollingEnabled?.() === false) {
-          return {
-            threadKey: params.threadKey,
-            status: "gate-off",
-            fingerprint: params.event.fingerprint,
-          };
-        }
-        await this.options.registry.submitTurn({
-          ...identity,
-          input: [{
-            type: "text",
-            text: buildPrAutoDispatchPrompt({
-              ...params,
-              attemptCount: claim.attemptCount,
-            }),
-          }],
-          origin: "automation",
-          messageOrigin: { kind: "pwragent" },
-        });
-        return {
-          threadKey: params.threadKey,
-          status: "dispatched",
-          fingerprint: params.event.fingerprint,
-        };
-      } catch (error) {
-        return {
-          threadKey: params.threadKey,
-          status: "failed",
-          fingerprint: params.event.fingerprint,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    } finally {
-      this.pendingThreadKeys.delete(params.threadKey);
+      await this.notifyPending(identity, null);
+      return;
     }
+
+    const now = this.now();
+    const begin = await this.options.store.beginThreadPrAutoDispatch({
+      ...identity,
+      fingerprint,
+      maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
+      now,
+    });
+    if (begin.status !== "ready") {
+      if (begin.status === "disabled") {
+        await this.options.store.cancelThreadPrAutoDispatch({
+          ...identity,
+          fingerprint,
+          now,
+        });
+      }
+      if (begin.status !== "stale") {
+        await this.notifyPending(identity, null);
+      }
+      return;
+    }
+
+    if (this.options.isBackgroundPollingEnabled?.() === false) {
+      await this.restoreAfterBusy(identity, fingerprint, now);
+      return;
+    }
+
+    try {
+      const submission = await this.options.registry.submitTurnIfIdle({
+        ...identity,
+        input: [{
+          type: "text",
+          text: [
+            begin.record.prompt,
+            `- Automatic attempt: ${begin.attemptCount}/${MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT}`,
+          ].join("\n"),
+        }],
+        origin: "automation",
+        messageOrigin: { kind: "pwragent" },
+      });
+      if (submission.status === "busy") {
+        await this.restoreAfterBusy(identity, fingerprint, now);
+        return;
+      }
+      await this.options.store.finishThreadPrAutoDispatch({
+        ...identity,
+        fingerprint,
+        status: "dispatched",
+        now: this.now(),
+      });
+      await this.notifyPending(identity, null);
+    } catch {
+      await this.options.store.finishThreadPrAutoDispatch({
+        ...identity,
+        fingerprint,
+        status: "failed",
+        now: this.now(),
+      });
+      await this.notifyPending(identity, null);
+    }
+  }
+
+  private async restoreAfterBusy(
+    identity: { backend: AppServerBackendKind; threadId: string },
+    fingerprint: string,
+    now: number,
+  ): Promise<void> {
+    const pending = await this.options.store.restoreThreadPrAutoDispatchAfterBusy({
+      ...identity,
+      fingerprint,
+      scheduledAt: now + PR_AUTO_DISPATCH_DELAY_MS,
+      now,
+    });
+    if (!pending) return;
+    await this.notifyPending(identity, pending);
+    this.arm(identity, pending);
+  }
+
+  private async notifyPending(
+    identity: { backend: AppServerBackendKind; threadId: string },
+    pending: ThreadPrAutoDispatchPending | null,
+  ): Promise<void> {
+    await this.options.onPendingChanged?.({ ...identity, pending });
+  }
+
+  private clearTimer(threadKey: string): void {
+    const timer = this.timers.get(threadKey);
+    if (timer) clearTimeout(timer);
+    this.timers.delete(threadKey);
+  }
+
+  private threadKey(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): string {
+    return `${params.backend}:${params.threadId}`;
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
   }
 }
 
-export function buildPrAutoDispatchEvent(
-  transition: PrStatusTransition,
-): PrAutoDispatchEvent | undefined {
-  const eventKinds: PrAutoDispatchEvent["eventKinds"] = [];
-  const headChanged = transition.changed.headSha !== undefined;
-  if (
-    transition.changed.checkState?.to === "failing"
-    || (headChanged && transition.pr.checkState === "failing")
-  ) {
-    eventKinds.push("ci-failure");
-  }
-  if (
-    transition.changed.mergeState?.to === "conflicting"
-    || (headChanged && transition.pr.mergeState === "conflicting")
-  ) {
-    eventKinds.push("merge-conflict");
-  }
-  if (eventKinds.length === 0) {
-    return undefined;
-  }
+export function getPrAutoDispatchEventKinds(
+  pr: PrSummary,
+): ThreadPrAutoDispatchEventKind[] {
+  const eventKinds: ThreadPrAutoDispatchEventKind[] = [];
+  if (pr.checkState === "failing") eventKinds.push("ci-failure");
+  if (pr.mergeState === "conflicting") eventKinds.push("merge-conflict");
+  return eventKinds;
+}
 
-  const headSha = transition.headSha ?? transition.pr.headSha;
-  if (!headSha) {
-    return undefined;
-  }
+export function buildPrAutoDispatchEvent(
+  pr: PrSummary,
+): PrAutoDispatchEvent | undefined {
+  const eventKinds = getPrAutoDispatchEventKinds(pr);
+  if (eventKinds.length === 0 || !pr.headSha) return undefined;
+  const prKey = buildPullRequestStatusKey(pr);
   const fingerprintPayload = {
-    version: 1,
-    prKey: transition.prKey,
-    headSha,
+    version: 2,
+    prKey,
+    headSha: pr.headSha,
     eventKinds,
-    checkState: eventKinds.includes("ci-failure")
-      ? transition.pr.checkState
-      : undefined,
-    mergeState: eventKinds.includes("merge-conflict")
-      ? transition.pr.mergeState
-      : undefined,
+    checkState: eventKinds.includes("ci-failure") ? pr.checkState : undefined,
+    mergeState: eventKinds.includes("merge-conflict") ? pr.mergeState : undefined,
   };
   return {
     eventKinds,
-    headSha,
+    headSha: pr.headSha,
+    prKey,
     fingerprint: createHash("sha256")
       .update(JSON.stringify(fingerprintPayload))
       .digest("hex"),
   };
 }
 
-function prIsHealthy(transition: PrStatusTransition): boolean {
-  return (
-    transition.pr.checkState !== "failing"
-    && transition.pr.mergeState !== "conflicting"
-  );
+function getDefinitivelyResolvedEventKinds(
+  pr: PrSummary,
+): ThreadPrAutoDispatchEventKind[] {
+  const resolved: ThreadPrAutoDispatchEventKind[] = [];
+  // Pending/unknown are intentionally not healthy: a repair push normally
+  // passes through pending before it can fail, and resetting here would turn
+  // the finite attempt budget into an unbounded loop.
+  if (pr.checkState === "passing") resolved.push("ci-failure");
+  if (pr.mergeState === "mergeable") resolved.push("merge-conflict");
+  return resolved;
 }
 
 function buildPrAutoDispatchPrompt(params: {
-  attemptCount: number;
   event: PrAutoDispatchEvent;
   observedAt: number;
-  transition: PrStatusTransition;
+  pr: PrSummary;
 }): string {
-  const changes = Object.entries(params.transition.changed)
-    .map(([field, change]) =>
-      `${field}: ${String(change?.from ?? "unknown")} -> ${String(change?.to ?? "unknown")}`,
-    )
-    .join("\n");
   return [
-    "PwrAgent automatically dispatched this bounded repair turn because an attached pull request entered an actionable state.",
+    "PwrAgent scheduled this bounded repair turn because an attached pull request needs attention.",
     "",
     "Pull request event",
-    `- PR: ${params.transition.prKey}`,
-    `- URL: ${params.transition.url}`,
-    `- Title: ${params.transition.title ?? "(untitled)"}`,
+    `- PR: ${params.event.prKey}`,
+    `- URL: ${params.pr.url}`,
+    `- Title: ${params.pr.title ?? "(untitled)"}`,
     `- Head SHA: ${params.event.headSha}`,
     `- Event kinds: ${params.event.eventKinds.join(", ")}`,
-    `- Check state: ${params.transition.pr.checkState ?? "unknown"}`,
-    `- Merge state: ${params.transition.pr.mergeState ?? "unknown"}`,
+    `- Check state: ${params.pr.checkState ?? "unknown"}`,
+    `- Merge state: ${params.pr.mergeState ?? "unknown"}`,
     `- Observed at: ${new Date(params.observedAt).toISOString()}`,
-    `- Automatic attempt: ${params.attemptCount}/${MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT}`,
     `- Dedupe fingerprint: ${params.event.fingerprint}`,
-    "",
-    "Observed transition",
-    changes || "(no details)",
     "",
     "Investigate the current PR checks or merge conflict, make only scoped fixes, run relevant validation, and update the attached PR when appropriate. Verify current provider state before changing code. If the condition is external, transient, or no safe fix is available, explain that and stop; do not create another retry loop.",
   ].join("\n");

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type {
   AppServerBackendKind,
   AppServerTurnInputItem,
@@ -13,11 +13,16 @@ import {
 } from "@pwragent/shared";
 import type {
   PrAutoDispatchPendingRecord,
+  PrAutoDispatchRecoveryResult,
   PrAutoDispatchScheduleResult,
 } from "../state/overlay-store-sqlite";
+import { isTerminalPullRequest } from "./pr-derivations";
 
 export const MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT = 2;
 export const PR_AUTO_DISPATCH_DELAY_MS = 30_000;
+export const PR_AUTO_DISPATCH_LEASE_MS = 60_000;
+const PR_AUTO_DISPATCH_LEASE_HEARTBEAT_MS = 20_000;
+const PR_AUTO_DISPATCH_RESUME_RETRY_MS = 15_000;
 
 export type PrAutoDispatchOutcome = {
   threadKey: string;
@@ -60,8 +65,10 @@ type PrAutoDispatchStore = {
     backend: AppServerBackendKind;
     threadId: string;
     fingerprint: string;
+    leaseExpiresAt: number;
     maxAttempts: number;
     now: number;
+    ownerId: string;
   }): Promise<
     | { status: "ready"; attemptCount: number; record: PrAutoDispatchPendingRecord }
     | { status: "disabled" | "stale" | "attempt-limit" }
@@ -70,13 +77,23 @@ type PrAutoDispatchStore = {
     backend: AppServerBackendKind;
     threadId: string;
     fingerprint: string;
+    ownerId: string;
     scheduledAt: number;
     now: number;
   }): Promise<ThreadPrAutoDispatchPending | undefined>;
+  renewThreadPrAutoDispatchLease(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    fingerprint: string;
+    leaseExpiresAt: number;
+    now: number;
+    ownerId: string;
+  }): Promise<boolean>;
   finishThreadPrAutoDispatch(params: {
     backend: AppServerBackendKind;
     threadId: string;
     fingerprint: string;
+    ownerId: string;
     status: "dispatched" | "failed";
     now: number;
   }): Promise<void>;
@@ -110,6 +127,10 @@ type PrAutoDispatchStore = {
       threadId: string;
     }
   >>;
+  recoverOrphanedThreadPrAutoDispatches(params: {
+    now: number;
+    scheduledAt: number;
+  }): Promise<PrAutoDispatchRecoveryResult>;
 };
 
 type PrAutoDispatchRegistry = {
@@ -134,6 +155,10 @@ export type PrAutoDispatchEvent = {
 
 export class PrAutoDispatchCoordinator {
   private readonly timers = new Map<string, NodeJS.Timeout>();
+  private readonly ownerId = randomUUID();
+  private recoveryTimer: NodeJS.Timeout | undefined;
+  private resumePromise: Promise<void> | undefined;
+  private resumed = false;
 
   constructor(
     private readonly options: {
@@ -146,6 +171,9 @@ export class PrAutoDispatchCoordinator {
         prKey: string;
       }) => boolean;
       getCurrentPr?: (prKey: string) => PrSummary | undefined;
+      refreshPendingPrs?: (
+        pending: ThreadPrAutoDispatchPending[],
+      ) => Promise<ReadonlySet<string>>;
       onPendingChanged?: (params: {
         backend: AppServerBackendKind;
         threadId: string;
@@ -298,10 +326,13 @@ export class PrAutoDispatchCoordinator {
 
   async resume(): Promise<void> {
     if (this.options.isBackgroundPollingEnabled?.() === false) return;
-    const records = await this.options.store.listPendingThreadPrAutoDispatches();
-    for (const record of records) {
-      this.arm(record, record.pending);
-    }
+    if (this.resumed) return;
+    if (this.resumePromise) return await this.resumePromise;
+    this.resumePromise = this.resumeFromStore()
+      .finally(() => {
+        this.resumePromise = undefined;
+      });
+    return await this.resumePromise;
   }
 
   pause(): void {
@@ -309,6 +340,9 @@ export class PrAutoDispatchCoordinator {
       clearTimeout(timer);
     }
     this.timers.clear();
+    if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
+    this.recoveryTimer = undefined;
+    this.resumed = false;
   }
 
   close(): void {
@@ -365,8 +399,10 @@ export class PrAutoDispatchCoordinator {
     const begin = await this.options.store.beginThreadPrAutoDispatch({
       ...identity,
       fingerprint,
+      leaseExpiresAt: now + PR_AUTO_DISPATCH_LEASE_MS,
       maxAttempts: MAX_PR_AUTO_DISPATCH_ATTEMPTS_PER_INCIDENT,
       now,
+      ownerId: this.ownerId,
     });
     if (begin.status !== "ready") {
       if (begin.status === "disabled") {
@@ -387,6 +423,7 @@ export class PrAutoDispatchCoordinator {
       return;
     }
 
+    const stopLeaseHeartbeat = this.startLeaseHeartbeat(identity, fingerprint);
     try {
       const submission = await this.options.registry.submitTurnIfIdle({
         ...identity,
@@ -407,6 +444,7 @@ export class PrAutoDispatchCoordinator {
       await this.options.store.finishThreadPrAutoDispatch({
         ...identity,
         fingerprint,
+        ownerId: this.ownerId,
         status: "dispatched",
         now: this.now(),
       });
@@ -415,10 +453,13 @@ export class PrAutoDispatchCoordinator {
       await this.options.store.finishThreadPrAutoDispatch({
         ...identity,
         fingerprint,
+        ownerId: this.ownerId,
         status: "failed",
         now: this.now(),
       });
       await this.notifyPending(identity, null);
+    } finally {
+      stopLeaseHeartbeat();
     }
   }
 
@@ -430,12 +471,89 @@ export class PrAutoDispatchCoordinator {
     const pending = await this.options.store.restoreThreadPrAutoDispatchAfterBusy({
       ...identity,
       fingerprint,
+      ownerId: this.ownerId,
       scheduledAt: now + PR_AUTO_DISPATCH_DELAY_MS,
       now,
     });
     if (!pending) return;
     await this.notifyPending(identity, pending);
     this.arm(identity, pending);
+  }
+
+  private async resumeFromStore(): Promise<void> {
+    const now = this.now();
+    const recovery = await this.options.store.recoverOrphanedThreadPrAutoDispatches({
+      now,
+      scheduledAt: now + PR_AUTO_DISPATCH_DELAY_MS,
+    });
+    let records = await this.options.store.listPendingThreadPrAutoDispatches();
+    let refreshedPrKeys: ReadonlySet<string> | undefined;
+    if (records.length > 0 && this.options.refreshPendingPrs) {
+      try {
+        refreshedPrKeys = await this.options.refreshPendingPrs(
+          records.map((record) => record.pending),
+        );
+        records = await this.options.store.listPendingThreadPrAutoDispatches();
+      } catch {
+        this.armRecovery(this.now() + PR_AUTO_DISPATCH_RESUME_RETRY_MS);
+        return;
+      }
+    }
+    if (this.options.isBackgroundPollingEnabled?.() === false) {
+      this.resumed = false;
+      return;
+    }
+    for (const record of records) {
+      if (refreshedPrKeys && !refreshedPrKeys.has(record.pending.prKey)) {
+        continue;
+      }
+      this.arm(record, record.pending);
+    }
+    const skippedRefresh =
+      refreshedPrKeys
+      && records.some((record) => !refreshedPrKeys.has(record.pending.prKey));
+    this.resumed = !skippedRefresh;
+    this.armRecovery(
+      skippedRefresh
+        ? this.now() + PR_AUTO_DISPATCH_RESUME_RETRY_MS
+        : recovery.nextLeaseExpiresAt
+          ?? this.now() + PR_AUTO_DISPATCH_LEASE_MS,
+    );
+  }
+
+  private armRecovery(at: number | undefined): void {
+    if (this.recoveryTimer) clearTimeout(this.recoveryTimer);
+    this.recoveryTimer = undefined;
+    if (at === undefined || this.options.isBackgroundPollingEnabled?.() === false) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.recoveryTimer = undefined;
+      this.resumed = false;
+      void this.resume();
+    }, Math.max(0, at - this.now()));
+    timer.unref?.();
+    this.recoveryTimer = timer;
+  }
+
+  private startLeaseHeartbeat(
+    identity: { backend: AppServerBackendKind; threadId: string },
+    fingerprint: string,
+  ): () => void {
+    const timer = setInterval(() => {
+      const now = this.now();
+      void this.options.store
+        .renewThreadPrAutoDispatchLease({
+          ...identity,
+          fingerprint,
+          leaseExpiresAt: now + PR_AUTO_DISPATCH_LEASE_MS,
+          now,
+          ownerId: this.ownerId,
+        })
+        .catch(() => undefined);
+    }, PR_AUTO_DISPATCH_LEASE_HEARTBEAT_MS);
+    timer.unref?.();
+    return () => clearInterval(timer);
   }
 
   private async notifyPending(
@@ -466,6 +584,7 @@ export class PrAutoDispatchCoordinator {
 export function getPrAutoDispatchEventKinds(
   pr: PrSummary,
 ): ThreadPrAutoDispatchEventKind[] {
+  if (isTerminalPullRequest(pr)) return [];
   const eventKinds: ThreadPrAutoDispatchEventKind[] = [];
   if (pr.checkState === "failing") eventKinds.push("ci-failure");
   if (pr.mergeState === "conflicting") eventKinds.push("merge-conflict");

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -54,6 +54,9 @@ export type GhCheckRunPayload = {
  */
 export function parseGhPrPayload(row: GhPrPayload): PrSummary {
   const checkState = deriveChipState(row);
+  const headSha = normalizeCommitShas([
+    row.commits?.[row.commits.length - 1]?.oid,
+  ])[0];
   return {
     provider: parsePullRequestProvider(row.url),
     number: row.number,
@@ -65,6 +68,7 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     lifecycleState: deriveLifecycleState(row),
     reviewState: deriveReviewState(row),
     mergeState: deriveMergeState(row),
+    ...(headSha ? { headSha } : {}),
     ...parseCommitShas(row.commits),
     url: row.url,
   };

--- a/apps/desktop/src/main/pr-status/pr-transitions.ts
+++ b/apps/desktop/src/main/pr-status/pr-transitions.ts
@@ -11,13 +11,11 @@ import { buildPullRequestStatusKey } from "@pwragent/shared";
  * A PR status transition — the typed record of a meaningful field flipping
  * between two observations of the same PR.
  *
- * This is the SEAM for the future "CI event → start a turn" feature (see the
- * brainstorm). Today the only consumer logs it. Tomorrow an ingestor can
- * subscribe and, on `checkState: pending → failing`, synthesize an inbound
- * thread event that starts a turn — WITHOUT the poller changing, and with the
- * source swappable from polling to real webhooks. Everything a webhook payload
- * would need (which field flipped, from/to, the PR, its commits, the threads it
- * touches) is captured here so the future feature does not have to re-fetch.
+ * This is the seam between PR observation and event consumers. The bounded
+ * auto-dispatch coordinator consumes actionable background-poll transitions;
+ * other subscribers can observe the same record without coupling policy to
+ * the poller. The source can later move from polling to webhooks without
+ * changing fingerprint or dispatch semantics.
  */
 
 export type PrStatusFieldChange<T> = {
@@ -32,6 +30,7 @@ export type PrStatusFieldChange<T> = {
  */
 export type PrStatusTransitionChanges = {
   checkState?: PrStatusFieldChange<PrChipState | undefined>;
+  headSha?: PrStatusFieldChange<string | undefined>;
   lifecycleState?: PrStatusFieldChange<PrLifecycleState | undefined>;
   mergeState?: PrStatusFieldChange<PrMergeState | undefined>;
   reviewState?: PrStatusFieldChange<PrReviewState | undefined>;
@@ -43,11 +42,14 @@ export type PrStatusTransition = {
   prKey: string;
   url: string;
   title?: string;
+  /** Full current status snapshot used to derive fingerprints and repair prompts. */
+  pr: PrSummary;
+  /** Exact head commit for this observation. Missing heads are not auto-dispatched. */
+  headSha?: string;
   /**
    * Commits known for this PR. The poller only fetches the head commit, so
-   * this is usually a single SHA; the `gh` path can carry more. The future CI
-   * ingestor will widen the GraphQL fragment to per-check detail when it needs
-   * the exact head SHA the checks ran on (brainstorm Open Decision 5).
+   * this is usually a single SHA; the `gh` path can carry more. `headSha`
+   * separately identifies the exact commit used by auto-dispatch fingerprints.
    */
   commitShas?: string[];
   changed: PrStatusTransitionChanges;
@@ -56,12 +58,14 @@ export type PrStatusTransition = {
 };
 
 /**
- * The PR fields a transition tracks. `commitShas` is deliberately NOT here: a
- * new commit with unchanged status is not a status transition (the fast poll
- * fetches only the head commit anyway, and the sha rides along as context).
+ * The PR fields a transition tracks. `headSha` is included because a new head
+ * materially re-arms bounded auto-dispatch even when a poll misses the brief
+ * pending-check state between two failing observations. Historical
+ * `commitShas` remain context only.
  */
 const TRACKED_FIELDS = [
   "checkState",
+  "headSha",
   "lifecycleState",
   "mergeState",
   "reviewState",
@@ -114,6 +118,12 @@ export function computePrStatusTransition(
   for (const field of TRACKED_FIELDS) {
     const from = readField(previous, field);
     const to = readField(next, field);
+    // Older durable cache rows predate `headSha`. Treat the first populated
+    // head as hydration, not a new event, so an upgrade cannot auto-dispatch
+    // every already-failing PR on its first poll.
+    if (field === "headSha" && (!from || !to)) {
+      continue;
+    }
     if (from !== to) {
       // The union type is safe here: `field` selects matching from/to types.
       (changed as Record<string, PrStatusFieldChange<unknown>>)[field] = { from, to };
@@ -128,6 +138,8 @@ export function computePrStatusTransition(
     prKey: buildPullRequestStatusKey(next),
     url: next.url,
     ...(next.title ? { title: next.title } : {}),
+    pr: next,
+    ...(next.headSha ? { headSha: next.headSha } : {}),
     ...(next.commitShas && next.commitShas.length > 0
       ? { commitShas: next.commitShas }
       : {}),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -75,8 +75,17 @@ export type PrStatusCacheEntry = {
 };
 
 export type PrAutoDispatchPendingRecord = {
+  dispatchLease?: {
+    expiresAt: number;
+    ownerId: string;
+  };
   pending: ThreadPrAutoDispatchPending;
   prompt: string;
+};
+
+export type PrAutoDispatchRecoveryResult = {
+  nextLeaseExpiresAt?: number;
+  recoveredCount: number;
 };
 
 export type PrAutoDispatchScheduleResult = {
@@ -120,6 +129,13 @@ function parsePrAutoDispatchKinds(value: string): ThreadPrAutoDispatchEventKind[
   } catch {
     return [];
   }
+}
+
+function clearPrAutoDispatchLease(
+  record: PrAutoDispatchPendingRecord,
+): PrAutoDispatchPendingRecord {
+  const { dispatchLease: _dispatchLease, ...pendingRecord } = record;
+  return pendingRecord;
 }
 
 export type PrLookupCacheEntry = {
@@ -2552,8 +2568,10 @@ export class SqliteOverlayStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     fingerprint: string;
+    leaseExpiresAt: number;
     maxAttempts: number;
     now: number;
+    ownerId: string;
   }): Promise<
     | { status: "ready"; attemptCount: number; record: PrAutoDispatchPendingRecord }
     | { status: "disabled" | "stale" | "attempt-limit" }
@@ -2595,12 +2613,19 @@ export class SqliteOverlayStore {
       const updated = this.stateDb.raw
         .prepare(
           `UPDATE pr_auto_dispatch_claims
-           SET status = 'dispatching', updated_at = ?
+           SET status = 'dispatching', updated_at = ?, payload = ?
            WHERE backend = ? AND thread_id = ? AND fingerprint = ?
              AND status = 'pending'`,
         )
         .run(
           params.now,
+          JSON.stringify({
+            ...record,
+            dispatchLease: {
+              expiresAt: params.leaseExpiresAt,
+              ownerId: params.ownerId,
+            },
+          } satisfies PrAutoDispatchPendingRecord),
           params.backend,
           params.threadId,
           params.fingerprint,
@@ -2631,6 +2656,7 @@ export class SqliteOverlayStore {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     fingerprint: string;
+    ownerId: string;
     scheduledAt: number;
     now: number;
   }): Promise<ThreadPrAutoDispatchPending | undefined> {
@@ -2652,7 +2678,11 @@ export class SqliteOverlayStore {
       if (!claim || claim.status !== "dispatching" || !record) {
         return undefined;
       }
+      if (record.dispatchLease?.ownerId !== params.ownerId) {
+        return undefined;
+      }
       const pending = { ...record.pending, scheduledAt: params.scheduledAt };
+      const pendingRecord = clearPrAutoDispatchLease({ ...record, pending });
       this.stateDb.raw
         .prepare(
           `UPDATE pr_auto_dispatch_claims
@@ -2663,7 +2693,7 @@ export class SqliteOverlayStore {
         .run(
           params.scheduledAt,
           params.now,
-          JSON.stringify({ ...record, pending }),
+          JSON.stringify(pendingRecord),
           params.backend,
           params.threadId,
           params.fingerprint,
@@ -2685,14 +2715,110 @@ export class SqliteOverlayStore {
     return restore();
   }
 
+  async renewThreadPrAutoDispatchLease(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    leaseExpiresAt: number;
+    now: number;
+    ownerId: string;
+  }): Promise<boolean> {
+    const renew = this.stateDb.raw.transaction(() => {
+      const claim = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+        )
+        .get(
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        ) as PrAutoDispatchClaimRow | undefined;
+      const record = claim
+        ? parsePrAutoDispatchPendingRecord(claim.payload)
+        : undefined;
+      if (
+        !claim
+        || claim.status !== "dispatching"
+        || !record
+        || record.dispatchLease?.ownerId !== params.ownerId
+      ) {
+        return false;
+      }
+      const result = this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_claims
+           SET updated_at = ?, payload = ?
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+             AND status = 'dispatching'`,
+        )
+        .run(
+          params.now,
+          JSON.stringify({
+            ...record,
+            dispatchLease: {
+              expiresAt: params.leaseExpiresAt,
+              ownerId: params.ownerId,
+            },
+          } satisfies PrAutoDispatchPendingRecord),
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        );
+      return result.changes > 0;
+    });
+    return renew();
+  }
+
   async finishThreadPrAutoDispatch(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     fingerprint: string;
+    ownerId: string;
     status: "dispatched" | "failed";
     now: number;
   }): Promise<void> {
-    this.updatePrAutoDispatchClaimStatus(params);
+    const finish = this.stateDb.raw.transaction(() => {
+      const claim = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+        )
+        .get(
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        ) as PrAutoDispatchClaimRow | undefined;
+      const record = claim
+        ? parsePrAutoDispatchPendingRecord(claim.payload)
+        : undefined;
+      if (
+        !claim
+        || claim.status !== "dispatching"
+        || !record
+        || record.dispatchLease?.ownerId !== params.ownerId
+      ) {
+        return;
+      }
+      this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_claims
+           SET status = ?, updated_at = ?, payload = ?
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+             AND status = 'dispatching'`,
+        )
+        .run(
+          params.status,
+          params.now,
+          JSON.stringify(clearPrAutoDispatchLease(record)),
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        );
+    });
+    finish();
   }
 
   async cancelThreadPrAutoDispatch(params: {
@@ -2803,6 +2929,74 @@ export class SqliteOverlayStore {
         ? [{ ...record, backend: row.backend, threadId: row.thread_id }]
         : [];
     });
+  }
+
+  async recoverOrphanedThreadPrAutoDispatches(params: {
+    now: number;
+    scheduledAt: number;
+  }): Promise<PrAutoDispatchRecoveryResult> {
+    const recover = this.stateDb.raw.transaction((): PrAutoDispatchRecoveryResult => {
+      const rows = this.stateDb.raw
+        .prepare(
+          `SELECT backend, thread_id, pr_key, fingerprint, payload
+           FROM pr_auto_dispatch_claims
+           WHERE status = 'dispatching'`,
+        )
+        .all() as Array<{
+          backend: ThreadOverlayState["backend"];
+          fingerprint: string;
+          payload: string;
+          pr_key: string;
+          thread_id: string;
+        }>;
+      let nextLeaseExpiresAt: number | undefined;
+      let recoveredCount = 0;
+      for (const row of rows) {
+        const record = parsePrAutoDispatchPendingRecord(row.payload);
+        const leaseExpiresAt = record?.dispatchLease?.expiresAt;
+        if (leaseExpiresAt !== undefined && leaseExpiresAt > params.now) {
+          nextLeaseExpiresAt = nextLeaseExpiresAt === undefined
+            ? leaseExpiresAt
+            : Math.min(nextLeaseExpiresAt, leaseExpiresAt);
+          continue;
+        }
+        if (!record) {
+          continue;
+        }
+        const pending = { ...record.pending, scheduledAt: params.scheduledAt };
+        const updated = this.stateDb.raw
+          .prepare(
+            `UPDATE pr_auto_dispatch_claims
+             SET status = 'pending', scheduled_at = ?, updated_at = ?, payload = ?
+             WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+               AND status = 'dispatching'`,
+          )
+          .run(
+            params.scheduledAt,
+            params.now,
+            JSON.stringify(clearPrAutoDispatchLease({ ...record, pending })),
+            row.backend,
+            row.thread_id,
+            row.fingerprint,
+          );
+        if (updated.changes === 0) {
+          continue;
+        }
+        recoveredCount += 1;
+        this.stateDb.raw
+          .prepare(
+            `UPDATE pr_auto_dispatch_incidents
+             SET attempt_count = MAX(0, attempt_count - 1), updated_at = ?
+             WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+          )
+          .run(params.now, row.backend, row.thread_id, row.pr_key);
+      }
+      return {
+        ...(nextLeaseExpiresAt !== undefined ? { nextLeaseExpiresAt } : {}),
+        recoveredCount,
+      };
+    });
+    return recover();
   }
 
   async getThreadPrAutoDispatchAttemptCount(params: {
@@ -4436,12 +4630,14 @@ export type OverlayStoreLike = Pick<
   | "scheduleThreadPrAutoDispatch"
   | "beginThreadPrAutoDispatch"
   | "restoreThreadPrAutoDispatchAfterBusy"
+  | "renewThreadPrAutoDispatchLease"
   | "finishThreadPrAutoDispatch"
   | "cancelThreadPrAutoDispatch"
   | "cancelPendingThreadPrAutoDispatchForPr"
   | "resolveThreadPrAutoDispatchIncident"
   | "getThreadPrAutoDispatchPending"
   | "listPendingThreadPrAutoDispatches"
+  | "recoverOrphanedThreadPrAutoDispatches"
   | "getThreadPrAutoDispatchAttemptCount"
   | "turnOffCodexFastEverywhere"
   | "setThreadExpectedBranch"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -25,6 +25,8 @@ import type {
   ThreadToolInvocationSummary,
   ThreadPermissionTransition,
   ThreadPricingSummary,
+  ThreadPrAutoDispatchEventKind,
+  ThreadPrAutoDispatchPending,
   ThreadSubAgentSummary,
   ThreadTurnFailure,
   ThreadUsageLineRecord,
@@ -71,6 +73,54 @@ export type PrStatusCacheEntry = {
   fetchedAt: number;
   pr: PrSummary;
 };
+
+export type PrAutoDispatchPendingRecord = {
+  pending: ThreadPrAutoDispatchPending;
+  prompt: string;
+};
+
+export type PrAutoDispatchScheduleResult = {
+  status: "scheduled" | "disabled" | "duplicate" | "attempt-limit" | "pending";
+  pending?: ThreadPrAutoDispatchPending;
+};
+
+type PrAutoDispatchClaimRow = {
+  payload: string;
+  pr_key: string;
+  status: string;
+};
+
+type PrAutoDispatchIncidentRow = {
+  active_kinds: string;
+  attempt_count: number;
+};
+
+function parsePrAutoDispatchPendingRecord(
+  payload: string,
+): PrAutoDispatchPendingRecord | undefined {
+  try {
+    const parsed = JSON.parse(payload) as PrAutoDispatchPendingRecord;
+    return parsed?.pending?.fingerprint && typeof parsed.prompt === "string"
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parsePrAutoDispatchKinds(value: string): ThreadPrAutoDispatchEventKind[] {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (kind): kind is ThreadPrAutoDispatchEventKind =>
+            kind === "ci-failure" || kind === "merge-conflict",
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
 
 export type PrLookupCacheEntry = {
   lookupKey: string;
@@ -2327,65 +2377,414 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
-  async claimThreadPrAutoDispatch(params: {
+  async scheduleThreadPrAutoDispatch(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
-    prKey: string;
-    fingerprint: string;
+    pending: ThreadPrAutoDispatchPending;
+    prompt: string;
     maxAttempts: number;
-  }): Promise<{
-    claimed: boolean;
-    reason?: "disabled" | "duplicate" | "attempt-limit";
-    attemptCount: number;
-  }> {
-    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
-    const current = this.getThread(threadKey);
-    const attemptCount = current?.prAutoDispatchAttemptCounts?.[params.prKey] ?? 0;
-    if (current?.prAutoDispatchEnabled !== true) {
-      return { claimed: false, reason: "disabled", attemptCount };
-    }
-    if (current.prAutoDispatchHandledFingerprints?.includes(params.fingerprint)) {
-      return { claimed: false, reason: "duplicate", attemptCount };
-    }
-    if (attemptCount >= params.maxAttempts) {
-      return { claimed: false, reason: "attempt-limit", attemptCount };
-    }
+    allowCancelledRearm?: boolean;
+  }): Promise<PrAutoDispatchScheduleResult> {
+    const schedule = this.stateDb.raw.transaction((): PrAutoDispatchScheduleResult => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      const current = this.getThread(threadKey);
+      if (current?.prAutoDispatchEnabled !== true) {
+        return { status: "disabled" };
+      }
 
-    const nextAttemptCount = attemptCount + 1;
-    const nextState: ThreadOverlayState = {
-      ...current,
-      prAutoDispatchHandledFingerprints: [
-        ...(current.prAutoDispatchHandledFingerprints ?? []),
-        params.fingerprint,
-      ],
-      prAutoDispatchAttemptCounts: {
-        ...(current.prAutoDispatchAttemptCounts ?? {}),
-        [params.prKey]: nextAttemptCount,
-      },
-    };
-    this.putThread(threadKey, nextState);
-    return { claimed: true, attemptCount: nextAttemptCount };
+      const duplicate = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+        )
+        .get(
+          params.backend,
+          params.threadId,
+          params.pending.fingerprint,
+        ) as PrAutoDispatchClaimRow | undefined;
+      if (duplicate) {
+        if (
+          params.allowCancelledRearm
+          && ["cancelled", "resolved", "superseded"].includes(duplicate.status)
+        ) {
+          this.stateDb.raw
+            .prepare(
+              `DELETE FROM pr_auto_dispatch_claims
+               WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+            )
+            .run(
+              params.backend,
+              params.threadId,
+              params.pending.fingerprint,
+            );
+        } else {
+          const record = parsePrAutoDispatchPendingRecord(duplicate.payload);
+          return {
+            status: duplicate.status === "pending" ? "pending" : "duplicate",
+            ...(record ? { pending: record.pending } : {}),
+          };
+        }
+      }
+
+      const incident = this.readPrAutoDispatchIncident({
+        backend: params.backend,
+        threadId: params.threadId,
+        prKey: params.pending.prKey,
+      });
+      if ((incident?.attempt_count ?? 0) >= params.maxAttempts) {
+        return { status: "attempt-limit" };
+      }
+
+      const activeClaim = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ?
+             AND status IN ('pending', 'dispatching')
+           LIMIT 1`,
+        )
+        .get(params.backend, params.threadId) as PrAutoDispatchClaimRow | undefined;
+      if (activeClaim) {
+        const activeRecord = parsePrAutoDispatchPendingRecord(activeClaim.payload);
+        if (activeClaim.pr_key !== params.pending.prKey) {
+          return {
+            status: "pending",
+            ...(activeRecord ? { pending: activeRecord.pending } : {}),
+          };
+        }
+        if (activeClaim.status === "dispatching") {
+          return { status: "pending" };
+        }
+        this.stateDb.raw
+          .prepare(
+            `UPDATE pr_auto_dispatch_claims
+             SET status = 'superseded', updated_at = ?
+             WHERE backend = ? AND thread_id = ? AND status = 'pending'`,
+          )
+          .run(
+            params.pending.createdAt,
+            params.backend,
+            params.threadId,
+          );
+      }
+
+      const payload = JSON.stringify({
+        pending: params.pending,
+        prompt: params.prompt,
+      } satisfies PrAutoDispatchPendingRecord);
+      const inserted = this.stateDb.raw
+        .prepare(
+          `INSERT OR IGNORE INTO pr_auto_dispatch_claims(
+             backend, thread_id, pr_key, fingerprint, status,
+             scheduled_at, created_at, updated_at, payload
+           ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
+        )
+        .run(
+          params.backend,
+          params.threadId,
+          params.pending.prKey,
+          params.pending.fingerprint,
+          params.pending.scheduledAt,
+          params.pending.createdAt,
+          params.pending.createdAt,
+          payload,
+        );
+      if (inserted.changes === 0) {
+        return { status: "duplicate" };
+      }
+
+      const activeKinds = [
+        ...new Set([
+          ...parsePrAutoDispatchKinds(incident?.active_kinds ?? "[]"),
+          ...params.pending.eventKinds,
+        ]),
+      ];
+      this.stateDb.raw
+        .prepare(
+          `INSERT INTO pr_auto_dispatch_incidents(
+             backend, thread_id, pr_key, attempt_count, active_kinds, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(backend, thread_id, pr_key) DO UPDATE SET
+             active_kinds = excluded.active_kinds,
+             updated_at = excluded.updated_at`,
+        )
+        .run(
+          params.backend,
+          params.threadId,
+          params.pending.prKey,
+          incident?.attempt_count ?? 0,
+          JSON.stringify(activeKinds),
+          params.pending.createdAt,
+        );
+      return { status: "scheduled", pending: params.pending };
+    });
+    return schedule();
   }
 
-  async resetThreadPrAutoDispatchIncident(params: {
+  async beginThreadPrAutoDispatch(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    maxAttempts: number;
+    now: number;
+  }): Promise<
+    | { status: "ready"; attemptCount: number; record: PrAutoDispatchPendingRecord }
+    | { status: "disabled" | "stale" | "attempt-limit" }
+  > {
+    const begin = this.stateDb.raw.transaction(() => {
+      const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+      if (this.getThread(threadKey)?.prAutoDispatchEnabled !== true) {
+        return { status: "disabled" as const };
+      }
+      const claim = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+        )
+        .get(
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        ) as PrAutoDispatchClaimRow | undefined;
+      const record = claim
+        ? parsePrAutoDispatchPendingRecord(claim.payload)
+        : undefined;
+      if (!claim || claim.status !== "pending" || !record) {
+        return { status: "stale" as const };
+      }
+      const incident = this.readPrAutoDispatchIncident({
+        backend: params.backend,
+        threadId: params.threadId,
+        prKey: claim.pr_key,
+      });
+      if ((incident?.attempt_count ?? 0) >= params.maxAttempts) {
+        this.updatePrAutoDispatchClaimStatus({
+          ...params,
+          status: "attempt-limit",
+        });
+        return { status: "attempt-limit" as const };
+      }
+      const updated = this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_claims
+           SET status = 'dispatching', updated_at = ?
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+             AND status = 'pending'`,
+        )
+        .run(
+          params.now,
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        );
+      if (updated.changes === 0) {
+        return { status: "stale" as const };
+      }
+      const attemptCount = (incident?.attempt_count ?? 0) + 1;
+      this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_incidents
+           SET attempt_count = ?, updated_at = ?
+           WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+        )
+        .run(
+          attemptCount,
+          params.now,
+          params.backend,
+          params.threadId,
+          claim.pr_key,
+        );
+      return { status: "ready" as const, attemptCount, record };
+    });
+    return begin();
+  }
+
+  async restoreThreadPrAutoDispatchAfterBusy(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    scheduledAt: number;
+    now: number;
+  }): Promise<ThreadPrAutoDispatchPending | undefined> {
+    const restore = this.stateDb.raw.transaction(() => {
+      const claim = this.stateDb.raw
+        .prepare(
+          `SELECT pr_key, status, payload
+           FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+        )
+        .get(
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        ) as PrAutoDispatchClaimRow | undefined;
+      const record = claim
+        ? parsePrAutoDispatchPendingRecord(claim.payload)
+        : undefined;
+      if (!claim || claim.status !== "dispatching" || !record) {
+        return undefined;
+      }
+      const pending = { ...record.pending, scheduledAt: params.scheduledAt };
+      this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_claims
+           SET status = 'pending', scheduled_at = ?, updated_at = ?, payload = ?
+           WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+             AND status = 'dispatching'`,
+        )
+        .run(
+          params.scheduledAt,
+          params.now,
+          JSON.stringify({ ...record, pending }),
+          params.backend,
+          params.threadId,
+          params.fingerprint,
+        );
+      this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_incidents
+           SET attempt_count = MAX(0, attempt_count - 1), updated_at = ?
+           WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+        )
+        .run(
+          params.now,
+          params.backend,
+          params.threadId,
+          claim.pr_key,
+        );
+      return pending;
+    });
+    return restore();
+  }
+
+  async finishThreadPrAutoDispatch(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    status: "dispatched" | "failed";
+    now: number;
+  }): Promise<void> {
+    this.updatePrAutoDispatchClaimStatus(params);
+  }
+
+  async cancelThreadPrAutoDispatch(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    now?: number;
+    status?: "cancelled" | "resolved" | "superseded";
+  }): Promise<boolean> {
+    const result = this.stateDb.raw
+      .prepare(
+        `UPDATE pr_auto_dispatch_claims
+         SET status = ?, updated_at = ?
+         WHERE backend = ? AND thread_id = ? AND fingerprint = ?
+           AND status = 'pending'`,
+      )
+      .run(
+        params.status ?? "cancelled",
+        params.now ?? Date.now(),
+        params.backend,
+        params.threadId,
+        params.fingerprint,
+      );
+    return result.changes > 0;
+  }
+
+  async cancelPendingThreadPrAutoDispatchForPr(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
     prKey: string;
+    now: number;
+  }): Promise<boolean> {
+    const result = this.stateDb.raw
+      .prepare(
+        `UPDATE pr_auto_dispatch_claims
+         SET status = 'superseded', updated_at = ?
+         WHERE backend = ? AND thread_id = ? AND pr_key = ?
+           AND status = 'pending'`,
+      )
+      .run(params.now, params.backend, params.threadId, params.prKey);
+    return result.changes > 0;
+  }
+
+  async resolveThreadPrAutoDispatchIncident(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    prKey: string;
+    resolvedKinds: ThreadPrAutoDispatchEventKind[];
+    now: number;
   }): Promise<void> {
-    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
-    const current = this.getThread(threadKey);
-    if (!current?.prAutoDispatchAttemptCounts?.[params.prKey]) {
-      return;
-    }
-    const nextAttemptCounts = { ...current.prAutoDispatchAttemptCounts };
-    delete nextAttemptCounts[params.prKey];
-    this.putThread(threadKey, {
-      ...current,
-      prAutoDispatchAttemptCounts:
-        Object.keys(nextAttemptCounts).length > 0
-          ? nextAttemptCounts
-          : undefined,
+    if (params.resolvedKinds.length === 0) return;
+    const resolve = this.stateDb.raw.transaction(() => {
+      const incident = this.readPrAutoDispatchIncident(params);
+      if (!incident) return;
+      const resolved = new Set(params.resolvedKinds);
+      const activeKinds = parsePrAutoDispatchKinds(incident.active_kinds)
+        .filter((kind) => !resolved.has(kind));
+      if (activeKinds.length === 0) {
+        this.stateDb.raw
+          .prepare(
+            `DELETE FROM pr_auto_dispatch_incidents
+             WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+          )
+          .run(params.backend, params.threadId, params.prKey);
+        return;
+      }
+      this.stateDb.raw
+        .prepare(
+          `UPDATE pr_auto_dispatch_incidents
+           SET active_kinds = ?, updated_at = ?
+           WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+        )
+        .run(
+          JSON.stringify(activeKinds),
+          params.now,
+          params.backend,
+          params.threadId,
+          params.prKey,
+        );
     });
+    resolve();
+  }
+
+  async getThreadPrAutoDispatchPending(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<PrAutoDispatchPendingRecord | undefined> {
+    return this.readThreadPrAutoDispatchPending(params);
+  }
+
+  async listPendingThreadPrAutoDispatches(): Promise<Array<
+    PrAutoDispatchPendingRecord & {
+      backend: ThreadOverlayState["backend"];
+      threadId: string;
+    }
+  >> {
+    const rows = this.stateDb.raw
+      .prepare(
+        `SELECT backend, thread_id, payload
+         FROM pr_auto_dispatch_claims
+         WHERE status = 'pending'
+         ORDER BY scheduled_at ASC`,
+      )
+      .all() as Array<{ backend: ThreadOverlayState["backend"]; thread_id: string; payload: string }>;
+    return rows.flatMap((row) => {
+      const record = parsePrAutoDispatchPendingRecord(row.payload);
+      return record
+        ? [{ ...record, backend: row.backend, threadId: row.thread_id }]
+        : [];
+    });
+  }
+
+  async getThreadPrAutoDispatchAttemptCount(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    prKey: string;
+  }): Promise<number> {
+    return this.readPrAutoDispatchIncident(params)?.attempt_count ?? 0;
   }
 
   async setThreadCodexEnvironmentRuntime(params: {
@@ -2759,11 +3158,72 @@ export class SqliteOverlayStore {
       );
   }
 
+  private readPrAutoDispatchIncident(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    prKey: string;
+  }): PrAutoDispatchIncidentRow | undefined {
+    return this.stateDb.raw
+      .prepare(
+        `SELECT attempt_count, active_kinds
+         FROM pr_auto_dispatch_incidents
+         WHERE backend = ? AND thread_id = ? AND pr_key = ?`,
+      )
+      .get(params.backend, params.threadId, params.prKey) as
+        | PrAutoDispatchIncidentRow
+        | undefined;
+  }
+
+  private readThreadPrAutoDispatchPending(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): PrAutoDispatchPendingRecord | undefined {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT payload
+         FROM pr_auto_dispatch_claims
+         WHERE backend = ? AND thread_id = ? AND status = 'pending'
+         LIMIT 1`,
+      )
+      .get(params.backend, params.threadId) as { payload: string } | undefined;
+    return row ? parsePrAutoDispatchPendingRecord(row.payload) : undefined;
+  }
+
+  private updatePrAutoDispatchClaimStatus(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    fingerprint: string;
+    status: "attempt-limit" | "dispatched" | "failed";
+    now: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `UPDATE pr_auto_dispatch_claims
+         SET status = ?, updated_at = ?
+         WHERE backend = ? AND thread_id = ? AND fingerprint = ?`,
+      )
+      .run(
+        params.status,
+        params.now,
+        params.backend,
+        params.threadId,
+        params.fingerprint,
+      );
+  }
+
   private getThread(threadKey: string): ThreadOverlayState | undefined {
     const row = this.stateDb.raw
       .prepare("SELECT payload FROM threads WHERE thread_id = ?")
       .get(threadKey) as { payload: string } | undefined;
-    return row ? normalizeThreadOverlayState(JSON.parse(row.payload)) : undefined;
+    if (!row) return undefined;
+    const overlay = normalizeThreadOverlayState(JSON.parse(row.payload));
+    const pending = this.readThreadPrAutoDispatchPending({
+      backend: overlay.backend,
+      threadId: overlay.threadId,
+    });
+    return pending
+      ? { ...overlay, prAutoDispatchPending: pending.pending }
+      : overlay;
   }
 
   /**
@@ -2796,11 +3256,13 @@ export class SqliteOverlayStore {
   }
 
   private putThread(threadKey: string, state: ThreadOverlayState): void {
-    // Queue-only fields are registry-memory state; never persist them.
-    // They reset to undefined on app restart by design.
+    // Execution-mode queue fields are registry-memory state. PR auto-dispatch
+    // pending state is durable too, but its transactional claim table is the
+    // source of truth; never duplicate either category in overlay JSON.
     const {
       queuedExecutionMode: _queuedExecutionMode,
       queuedExecutionModeAt: _queuedExecutionModeAt,
+      prAutoDispatchPending: _prAutoDispatchPending,
       ...persistable
     } = state;
     this.stateDb.raw
@@ -3944,8 +4406,16 @@ export type OverlayStoreLike = Pick<
   | "setThreadExecutionMode"
   | "setThreadModelSettings"
   | "setThreadPrAutoDispatchEnabled"
-  | "claimThreadPrAutoDispatch"
-  | "resetThreadPrAutoDispatchIncident"
+  | "scheduleThreadPrAutoDispatch"
+  | "beginThreadPrAutoDispatch"
+  | "restoreThreadPrAutoDispatchAfterBusy"
+  | "finishThreadPrAutoDispatch"
+  | "cancelThreadPrAutoDispatch"
+  | "cancelPendingThreadPrAutoDispatchForPr"
+  | "resolveThreadPrAutoDispatchIncident"
+  | "getThreadPrAutoDispatchPending"
+  | "listPendingThreadPrAutoDispatches"
+  | "getThreadPrAutoDispatchAttemptCount"
   | "turnOffCodexFastEverywhere"
   | "setThreadExpectedBranch"
   | "setThreadObservedBranch"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -88,7 +88,10 @@ function normalizePullRequestProvider(provider: string | undefined): string {
 
 function normalizePrSummary(pr: PrSummary): PrSummary {
   const checkState = normalizePrCheckState(pr.checkState ?? pr.state);
-  return {
+  const headSha = normalizeCommitShas(
+    pr.headSha ? [pr.headSha] : undefined,
+  )?.[0];
+  const normalized: PrSummary = {
     ...pr,
     provider: normalizePullRequestProvider(pr.provider),
     state: checkState,
@@ -98,6 +101,12 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
     mergeState: pr.mergeState ?? "unknown",
     commitShas: normalizeCommitShas(pr.commitShas),
   };
+  if (headSha) {
+    normalized.headSha = headSha;
+  } else {
+    delete normalized.headSha;
+  }
+  return normalized;
 }
 
 function normalizeDetachedPrKeys(keys: string[] | undefined): string[] {
@@ -2298,6 +2307,87 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async setThreadPrAutoDispatchEnabled(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    enabled: boolean;
+  }): Promise<ThreadOverlayState> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey) ?? {
+      backend: params.backend,
+      threadId: params.threadId,
+      executionMode: "default" as const,
+      extraLinkedDirectories: [],
+    };
+    const nextState: ThreadOverlayState = {
+      ...current,
+      prAutoDispatchEnabled: params.enabled,
+    };
+    this.putThread(threadKey, nextState);
+    return nextState;
+  }
+
+  async claimThreadPrAutoDispatch(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    prKey: string;
+    fingerprint: string;
+    maxAttempts: number;
+  }): Promise<{
+    claimed: boolean;
+    reason?: "disabled" | "duplicate" | "attempt-limit";
+    attemptCount: number;
+  }> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey);
+    const attemptCount = current?.prAutoDispatchAttemptCounts?.[params.prKey] ?? 0;
+    if (current?.prAutoDispatchEnabled !== true) {
+      return { claimed: false, reason: "disabled", attemptCount };
+    }
+    if (current.prAutoDispatchHandledFingerprints?.includes(params.fingerprint)) {
+      return { claimed: false, reason: "duplicate", attemptCount };
+    }
+    if (attemptCount >= params.maxAttempts) {
+      return { claimed: false, reason: "attempt-limit", attemptCount };
+    }
+
+    const nextAttemptCount = attemptCount + 1;
+    const nextState: ThreadOverlayState = {
+      ...current,
+      prAutoDispatchHandledFingerprints: [
+        ...(current.prAutoDispatchHandledFingerprints ?? []),
+        params.fingerprint,
+      ],
+      prAutoDispatchAttemptCounts: {
+        ...(current.prAutoDispatchAttemptCounts ?? {}),
+        [params.prKey]: nextAttemptCount,
+      },
+    };
+    this.putThread(threadKey, nextState);
+    return { claimed: true, attemptCount: nextAttemptCount };
+  }
+
+  async resetThreadPrAutoDispatchIncident(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+    prKey: string;
+  }): Promise<void> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey);
+    if (!current?.prAutoDispatchAttemptCounts?.[params.prKey]) {
+      return;
+    }
+    const nextAttemptCounts = { ...current.prAutoDispatchAttemptCounts };
+    delete nextAttemptCounts[params.prKey];
+    this.putThread(threadKey, {
+      ...current,
+      prAutoDispatchAttemptCounts:
+        Object.keys(nextAttemptCounts).length > 0
+          ? nextAttemptCounts
+          : undefined,
+    });
+  }
+
   async setThreadCodexEnvironmentRuntime(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -3853,6 +3943,9 @@ export type OverlayStoreLike = Pick<
   | "upsertWorktreeSnapshot"
   | "setThreadExecutionMode"
   | "setThreadModelSettings"
+  | "setThreadPrAutoDispatchEnabled"
+  | "claimThreadPrAutoDispatch"
+  | "resetThreadPrAutoDispatchIncident"
   | "turnOffCodexFastEverywhere"
   | "setThreadExpectedBranch"
   | "setThreadObservedBranch"

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2377,6 +2377,32 @@ export class SqliteOverlayStore {
     return nextState;
   }
 
+  async resetThreadPrAutoDispatchForOperator(params: {
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<boolean> {
+    const reset = this.stateDb.raw.transaction(() => {
+      // A toggle off -> on is an explicit operator request to retry. Keep a
+      // genuinely in-flight claim so another turn cannot launch alongside it,
+      // but clear completed/failed/cancelled claims and the finite incident
+      // budget so the current provider condition can be scheduled again.
+      const claims = this.stateDb.raw
+        .prepare(
+          `DELETE FROM pr_auto_dispatch_claims
+           WHERE backend = ? AND thread_id = ? AND status != 'dispatching'`,
+        )
+        .run(params.backend, params.threadId);
+      const incidents = this.stateDb.raw
+        .prepare(
+          `DELETE FROM pr_auto_dispatch_incidents
+           WHERE backend = ? AND thread_id = ?`,
+        )
+        .run(params.backend, params.threadId);
+      return claims.changes > 0 || incidents.changes > 0;
+    });
+    return reset();
+  }
+
   async scheduleThreadPrAutoDispatch(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;
@@ -4406,6 +4432,7 @@ export type OverlayStoreLike = Pick<
   | "setThreadExecutionMode"
   | "setThreadModelSettings"
   | "setThreadPrAutoDispatchEnabled"
+  | "resetThreadPrAutoDispatchForOperator"
   | "scheduleThreadPrAutoDispatch"
   | "beginThreadPrAutoDispatch"
   | "restoreThreadPrAutoDispatchAfterBusy"

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 33;
+export const CURRENT_STATE_DB_USER_VERSION = 34;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -511,6 +511,36 @@ CREATE INDEX IF NOT EXISTS idx_pr_lookup_cache_fetched
   ON pr_lookup_cache(fetched_at DESC);
 `;
 
+const PR_AUTO_DISPATCH_SCHEMA = `
+CREATE TABLE IF NOT EXISTS pr_auto_dispatch_claims (
+  backend       TEXT NOT NULL,
+  thread_id     TEXT NOT NULL,
+  pr_key        TEXT NOT NULL,
+  fingerprint   TEXT NOT NULL,
+  status        TEXT NOT NULL,
+  scheduled_at  INTEGER NOT NULL,
+  created_at    INTEGER NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  payload       TEXT NOT NULL,
+  PRIMARY KEY (backend, thread_id, fingerprint)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_auto_dispatch_active_thread
+  ON pr_auto_dispatch_claims(backend, thread_id)
+  WHERE status IN ('pending', 'dispatching');
+CREATE INDEX IF NOT EXISTS idx_pr_auto_dispatch_pending_schedule
+  ON pr_auto_dispatch_claims(status, scheduled_at);
+
+CREATE TABLE IF NOT EXISTS pr_auto_dispatch_incidents (
+  backend       TEXT NOT NULL,
+  thread_id     TEXT NOT NULL,
+  pr_key        TEXT NOT NULL,
+  attempt_count INTEGER NOT NULL,
+  active_kinds  TEXT NOT NULL,
+  updated_at    INTEGER NOT NULL,
+  PRIMARY KEY (backend, thread_id, pr_key)
+);
+`;
+
 const THREAD_USAGE_PRICING_SCHEMA = `
 CREATE TABLE IF NOT EXISTS pricing_catalog_versions (
   catalog_id      TEXT NOT NULL,
@@ -999,6 +1029,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 33) {
       db.transaction(() => {
         db.exec(MESSAGING_DEFAULT_AGENT_ASSIGNMENT_SCHEMA);
+        db.pragma("user_version = 33");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 34) {
+      db.transaction(() => {
+        db.exec(PR_AUTO_DISPATCH_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1151,6 +1187,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);
+    db.exec(PR_AUTO_DISPATCH_SCHEMA);
     ensureThreadSearchFtsThreadIdColumn(db);
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -44,6 +44,8 @@ import type {
   SetThreadModelSettingsResponse,
   SetThreadPrAutoDispatchRequest,
   SetThreadPrAutoDispatchResponse,
+  CancelThreadPrAutoDispatchRequest,
+  CancelThreadPrAutoDispatchResponse,
   TurnOffCodexFastEverywhereResponse,
   SteerTurnRequest,
   SteerTurnResponse,
@@ -294,6 +296,7 @@ import {
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+  AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -1094,6 +1097,13 @@ const desktopApi = Object.freeze({
   ): Promise<SetThreadPrAutoDispatchResponse> =>
     await ipcRenderer.invoke(
       AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+      request,
+    ),
+  cancelThreadPrAutoDispatch: async (
+    request: CancelThreadPrAutoDispatchRequest,
+  ): Promise<CancelThreadPrAutoDispatchResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
       request,
     ),
   applyThreadModelMigration: async (

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -46,6 +46,8 @@ import type {
   SetThreadPrAutoDispatchResponse,
   CancelThreadPrAutoDispatchRequest,
   CancelThreadPrAutoDispatchResponse,
+  SendThreadPrAutoDispatchNowRequest,
+  SendThreadPrAutoDispatchNowResponse,
   TurnOffCodexFastEverywhereResponse,
   SteerTurnRequest,
   SteerTurnResponse,
@@ -297,6 +299,7 @@ import {
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
   AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+  AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -1104,6 +1107,13 @@ const desktopApi = Object.freeze({
   ): Promise<CancelThreadPrAutoDispatchResponse> =>
     await ipcRenderer.invoke(
       AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+      request,
+    ),
+  sendThreadPrAutoDispatchNow: async (
+    request: SendThreadPrAutoDispatchNowRequest,
+  ): Promise<SendThreadPrAutoDispatchNowResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL,
       request,
     ),
   applyThreadModelMigration: async (

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -42,6 +42,8 @@ import type {
   SetThreadAgentResponse,
   SetThreadModelSettingsRequest,
   SetThreadModelSettingsResponse,
+  SetThreadPrAutoDispatchRequest,
+  SetThreadPrAutoDispatchResponse,
   TurnOffCodexFastEverywhereResponse,
   SteerTurnRequest,
   SteerTurnResponse,
@@ -291,6 +293,7 @@ import {
   AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL,
   AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL,
+  AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
   AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL,
   AGENT_START_THREAD_CHANNEL,
   AGENT_START_REVIEW_CHANNEL,
@@ -1086,6 +1089,13 @@ const desktopApi = Object.freeze({
     request: SetThreadModelSettingsRequest
   ): Promise<SetThreadModelSettingsResponse> =>
     await ipcRenderer.invoke(AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL, request),
+  setThreadPrAutoDispatch: async (
+    request: SetThreadPrAutoDispatchRequest,
+  ): Promise<SetThreadPrAutoDispatchResponse> =>
+    await ipcRenderer.invoke(
+      AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL,
+      request,
+    ),
   applyThreadModelMigration: async (
     request: ApplyThreadModelMigrationRequest,
   ): Promise<ApplyThreadModelMigrationResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1212,6 +1212,13 @@ function DesktopAppShell(props: {
             enabled,
           )
       : undefined,
+    onCancelThreadPrAutoDispatch: navigation.selectedThread
+      ? async (fingerprint) =>
+          await navigation.cancelThreadPrAutoDispatch(
+            navigation.selectedThread!,
+            fingerprint,
+          )
+      : undefined,
     onRestoreWorktree: navigation.restoreWorktree,
     onTranscriptViewportChange: session.setViewport,
     onUpdateLaunchpad: navigation.updateDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1219,6 +1219,13 @@ function DesktopAppShell(props: {
             fingerprint,
           )
       : undefined,
+    onSendThreadPrAutoDispatchNow: navigation.selectedThread
+      ? async (fingerprint) =>
+          await navigation.sendThreadPrAutoDispatchNow(
+            navigation.selectedThread!,
+            fingerprint,
+          )
+      : undefined,
     onRestoreWorktree: navigation.restoreWorktree,
     onTranscriptViewportChange: session.setViewport,
     onUpdateLaunchpad: navigation.updateDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import {
   buildThreadIdentityKey,
+  DEFAULT_BACKGROUND_PR_POLLING,
   parseThreadIdentityKey,
   type AppServerBackendKind,
   type DesktopBootInfo,
@@ -1074,6 +1075,11 @@ function DesktopAppShell(props: {
     directories: navigation.directories,
     fullAccessRiskWarningDismissed:
       settings.snapshot?.experimental.fullAccessRiskWarningDismissed.value ?? false,
+    backgroundPrPollingEnabled:
+      settings.snapshot
+        ? settings.snapshot.experimental.backgroundPrPolling?.value
+          ?? DEFAULT_BACKGROUND_PR_POLLING
+        : false,
     pickDirectoryError: navigation.pickDirectoryError,
     pickingDirectory: navigation.pickingDirectory,
     onSelectDirectoryFromPicker: (directory) => {
@@ -1198,6 +1204,13 @@ function DesktopAppShell(props: {
     onSetThreadModelSettings: navigation.selectedThread
       ? async (patch) =>
           await navigation.setThreadModelSettings(navigation.selectedThread!, patch)
+      : undefined,
+    onSetThreadPrAutoDispatch: navigation.selectedThread
+      ? async (enabled) =>
+          await navigation.setThreadPrAutoDispatch(
+            navigation.selectedThread!,
+            enabled,
+          )
       : undefined,
     onRestoreWorktree: navigation.restoreWorktree,
     onTranscriptViewportChange: session.setViewport,

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -57,6 +57,7 @@ import {
   PlanIcon,
   PlayIcon,
   PlusIcon,
+  PullRequestIcon,
   SearchIcon,
 } from "../../icons";
 import { AppIcon } from "../../components/AppIcon";
@@ -135,6 +136,7 @@ type ComposerProps = {
   backends?: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
   codexFastAllowed?: boolean;
+  backgroundPrPollingEnabled?: boolean;
   providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
   desktopApi?: DesktopApi;
   /**
@@ -285,6 +287,7 @@ type ComposerProps = {
       >
     >
   ) => Promise<void>;
+  onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
   threadModelSettingsError?: string;
 };
 
@@ -6506,6 +6509,8 @@ export function Composer(props: ComposerProps) {
   };
 
   const currentSettings = props.launchpad ?? props.thread;
+  const backgroundPrPollingEnabled =
+    props.backgroundPrPollingEnabled ?? true;
   const modelOptions = backend?.launchpadOptions?.models ?? [];
   const selectedModelOption =
     modelOptions.find((option) => option.id === currentSettings?.model) ??
@@ -8597,6 +8602,31 @@ export function Composer(props: ComposerProps) {
               onClick={() => setPlanModeEnabled((current) => !current)}
             >
               <PlanIcon size={15} aria-hidden="true" />
+            </button>
+          ) : null}
+
+          {props.thread ? (
+            <button
+              type="button"
+              className={`composer__toggle tooltip-target${
+                props.thread.prAutoDispatchEnabled ? " is-active" : ""
+              }`}
+              aria-label="Auto-fix PR"
+              aria-pressed={Boolean(props.thread.prAutoDispatchEnabled)}
+              data-tooltip={
+                backgroundPrPollingEnabled
+                  ? "Auto-fix PR — handle new CI failures or merge conflicts"
+                  : "Auto-fix PR paused — turn on background PR polling in Settings"
+              }
+              disabled={!backgroundPrPollingEnabled}
+              onClick={() => {
+                if (!backgroundPrPollingEnabled) return;
+                void props.onSetThreadPrAutoDispatch?.(
+                  !props.thread?.prAutoDispatchEnabled,
+                );
+              }}
+            >
+              <PullRequestIcon size={15} aria-hidden="true" />
             </button>
           ) : null}
 

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -288,6 +288,7 @@ type ComposerProps = {
     >
   ) => Promise<void>;
   onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
+  onCancelThreadPrAutoDispatch?: (fingerprint: string) => Promise<void>;
   threadModelSettingsError?: string;
 };
 
@@ -2475,6 +2476,7 @@ export function Composer(props: ComposerProps) {
     : props.thread
       ? `thread:${props.thread.source}:${props.thread.id}`
       : "empty";
+  const prAutoDispatchPending = props.thread?.prAutoDispatchPending;
   const localDraftStore = useComposerDraftStore();
   const draftStore = props.draftStore ?? localDraftStore;
   const draftStoreHydrationVersion = draftStore.hydrationVersion ?? 0;
@@ -3330,7 +3332,15 @@ export function Composer(props: ComposerProps) {
     const hasFutureScheduledQueue = queuedTurns.some((entry) =>
       Boolean(getFutureScheduledSendAt(entry.scheduledSendAt))
     );
-    if (!futureScheduledDraftSendAt && !hasFutureScheduledQueue) {
+    const hasPendingPrAutoDispatch = Boolean(
+      prAutoDispatchPending
+      && getFutureScheduledSendAt(prAutoDispatchPending.scheduledAt),
+    );
+    if (
+      !futureScheduledDraftSendAt
+      && !hasFutureScheduledQueue
+      && !hasPendingPrAutoDispatch
+    ) {
       return;
     }
 
@@ -3341,7 +3351,7 @@ export function Composer(props: ComposerProps) {
     return () => {
       window.clearInterval(timer);
     };
-  }, [futureScheduledDraftSendAt, queuedTurns]);
+  }, [futureScheduledDraftSendAt, prAutoDispatchPending, queuedTurns]);
 
   useEffect(() => {
     if (scheduledDraftSendAt && !futureScheduledDraftSendAt) {
@@ -7603,6 +7613,48 @@ export function Composer(props: ComposerProps) {
               disabled={!props.onCancelExecutionModeQueue}
               onClick={() => {
                 void props.onCancelExecutionModeQueue?.();
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {prAutoDispatchPending ? (
+        <div
+          className="composer__queued composer__queued--scheduled"
+          aria-label="Scheduled PR auto-fix"
+        >
+          <div className="composer__queued-copy">
+            <span className="composer__queued-label">
+              {!backgroundPrPollingEnabled
+                ? "Auto-fix PR paused"
+                : `Auto-fix PR in ${formatScheduledSendCountdown(
+                    prAutoDispatchPending.scheduledAt,
+                    scheduleTick,
+                  )}`}
+            </span>
+            <span className="composer__queued-text">
+              #{prAutoDispatchPending.prNumber} · {prAutoDispatchPending.eventKinds
+                .map((kind) =>
+                  kind === "ci-failure" ? "CI failed" : "merge conflict",
+                )
+                .join(" + ")}
+              {prAutoDispatchPending.prTitle
+                ? ` · ${prAutoDispatchPending.prTitle}`
+                : ""}
+            </span>
+          </div>
+          <div className="composer__queued-actions">
+            <button
+              className="composer__secondary-action"
+              type="button"
+              disabled={!props.onCancelThreadPrAutoDispatch}
+              onClick={() => {
+                void props.onCancelThreadPrAutoDispatch?.(
+                  prAutoDispatchPending.fingerprint,
+                );
               }}
             >
               Cancel

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -289,6 +289,7 @@ type ComposerProps = {
   ) => Promise<void>;
   onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
   onCancelThreadPrAutoDispatch?: (fingerprint: string) => Promise<void>;
+  onSendThreadPrAutoDispatchNow?: (fingerprint: string) => Promise<void>;
   threadModelSettingsError?: string;
 };
 
@@ -7647,6 +7648,21 @@ export function Composer(props: ComposerProps) {
             </span>
           </div>
           <div className="composer__queued-actions">
+            <button
+              className="composer__secondary-action"
+              type="button"
+              disabled={
+                !backgroundPrPollingEnabled
+                || !props.onSendThreadPrAutoDispatchNow
+              }
+              onClick={() => {
+                void props.onSendThreadPrAutoDispatchNow?.(
+                  prAutoDispatchPending.fingerprint,
+                );
+              }}
+            >
+              Send now
+            </button>
             <button
               className="composer__secondary-action"
               type="button"

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -395,6 +395,51 @@ describe("Composer", () => {
     );
   });
 
+  it("shows a cancellable on-deck countdown for a scheduled PR repair", async () => {
+    const onCancelThreadPrAutoDispatch = vi.fn(async () => undefined);
+    render(
+      <Composer
+        backgroundPrPollingEnabled
+        disabled={false}
+        onCancelThreadPrAutoDispatch={onCancelThreadPrAutoDispatch}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Fix CI",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+          prAutoDispatchEnabled: true,
+          prAutoDispatchPending: {
+            fingerprint: "fingerprint-1",
+            prKey: "github.com/pwrdrvr/PwrAgent#1105",
+            prNumber: 1105,
+            prTitle: "Fix failed CI",
+            prUrl: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+            headSha: "a".repeat(40),
+            eventKinds: ["ci-failure"],
+            createdAt: Date.now(),
+            scheduledAt: Date.now() + 30_000,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Scheduled PR auto-fix")).toHaveTextContent(
+      "Auto-fix PR in",
+    );
+    expect(screen.getByLabelText("Scheduled PR auto-fix")).toHaveTextContent(
+      "#1105 · CI failed · Fix failed CI",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(onCancelThreadPrAutoDispatch).toHaveBeenCalledWith(
+        "fingerprint-1",
+      );
+    });
+  });
+
   it("lets launchpad errors be copied with the transcript copy control", async () => {
     const copyText = vi.fn(async () => undefined);
     const launchpadError =

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -397,11 +397,13 @@ describe("Composer", () => {
 
   it("shows a cancellable on-deck countdown for a scheduled PR repair", async () => {
     const onCancelThreadPrAutoDispatch = vi.fn(async () => undefined);
+    const onSendThreadPrAutoDispatchNow = vi.fn(async () => undefined);
     render(
       <Composer
         backgroundPrPollingEnabled
         disabled={false}
         onCancelThreadPrAutoDispatch={onCancelThreadPrAutoDispatch}
+        onSendThreadPrAutoDispatchNow={onSendThreadPrAutoDispatchNow}
         skills={[]}
         thread={{
           id: "thread-1",
@@ -432,6 +434,12 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Scheduled PR auto-fix")).toHaveTextContent(
       "#1105 · CI failed · Fix failed CI",
     );
+    fireEvent.click(screen.getByRole("button", { name: "Send now" }));
+    await waitFor(() => {
+      expect(onSendThreadPrAutoDispatchNow).toHaveBeenCalledWith(
+        "fingerprint-1",
+      );
+    });
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     await waitFor(() => {
       expect(onCancelThreadPrAutoDispatch).toHaveBeenCalledWith(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -347,6 +347,54 @@ function renderComposerWithRegressionSkills(
 }
 
 describe("Composer", () => {
+  it("persists the Auto-fix PR toggle and shows its global polling gate", async () => {
+    const onSetThreadPrAutoDispatch = vi.fn(async () => undefined);
+    const thread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Fix CI",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      prAutoDispatchEnabled: true,
+    };
+    const { rerender } = render(
+      <Composer
+        backgroundPrPollingEnabled
+        disabled={false}
+        onSetThreadPrAutoDispatch={onSetThreadPrAutoDispatch}
+        skills={[]}
+        thread={thread}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Auto-fix PR" });
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(onSetThreadPrAutoDispatch).toHaveBeenCalledWith(false);
+    });
+
+    rerender(
+      <Composer
+        backgroundPrPollingEnabled={false}
+        disabled={false}
+        onSetThreadPrAutoDispatch={onSetThreadPrAutoDispatch}
+        skills={[]}
+        thread={thread}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toHaveAttribute(
+      "data-tooltip",
+      expect.stringContaining("paused"),
+    );
+  });
+
   it("lets launchpad errors be copied with the transcript copy control", async () => {
     const copyText = vi.fn(async () => undefined);
     const launchpadError =

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -898,6 +898,7 @@ export type ThreadViewProps = {
   ) => Promise<void>;
   onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
   onCancelThreadPrAutoDispatch?: (fingerprint: string) => Promise<void>;
+  onSendThreadPrAutoDispatchNow?: (fingerprint: string) => Promise<void>;
   onArchiveWorktree?: (
     thread: NavigationThreadSummary,
     directory: NavigationThreadSummary["linkedDirectories"][number]
@@ -3031,6 +3032,7 @@ export function ThreadView(props: ThreadViewProps) {
             onSetThreadModelSettings={props.onSetThreadModelSettings}
             onSetThreadPrAutoDispatch={props.onSetThreadPrAutoDispatch}
             onCancelThreadPrAutoDispatch={props.onCancelThreadPrAutoDispatch}
+            onSendThreadPrAutoDispatchNow={props.onSendThreadPrAutoDispatchNow}
             backgroundPrPollingEnabled={props.backgroundPrPollingEnabled}
             onAttachDirectoryReferences={props.onAttachDirectoryReferences}
             onPickDirectoryForReference={props.onPickDirectoryForReference}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -767,6 +767,7 @@ export type ThreadViewProps = {
   pendingForkEnvironmentSetup?: PendingForkEnvironmentSetup;
   suppressBranchDriftDialog?: boolean;
   fullAccessRiskWarningDismissed?: boolean;
+  backgroundPrPollingEnabled?: boolean;
   /**
    * Project-directory picker (issue #223) — surfaced in the launchpad
    * composer when no thread is selected yet. Rendering happens inside
@@ -895,6 +896,7 @@ export type ThreadViewProps = {
       >
     >
   ) => Promise<void>;
+  onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
   onArchiveWorktree?: (
     thread: NavigationThreadSummary,
     directory: NavigationThreadSummary["linkedDirectories"][number]
@@ -3026,6 +3028,8 @@ export function ThreadView(props: ThreadViewProps) {
             onSetAcpRuntimeOption={props.onSetAcpRuntimeOption}
             onCancelExecutionModeQueue={props.onCancelExecutionModeQueue}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
+            onSetThreadPrAutoDispatch={props.onSetThreadPrAutoDispatch}
+            backgroundPrPollingEnabled={props.backgroundPrPollingEnabled}
             onAttachDirectoryReferences={props.onAttachDirectoryReferences}
             onPickDirectoryForReference={props.onPickDirectoryForReference}
             pendingRequestActive={Boolean(props.pendingRequest)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -897,6 +897,7 @@ export type ThreadViewProps = {
     >
   ) => Promise<void>;
   onSetThreadPrAutoDispatch?: (enabled: boolean) => Promise<void>;
+  onCancelThreadPrAutoDispatch?: (fingerprint: string) => Promise<void>;
   onArchiveWorktree?: (
     thread: NavigationThreadSummary,
     directory: NavigationThreadSummary["linkedDirectories"][number]
@@ -3029,6 +3030,7 @@ export function ThreadView(props: ThreadViewProps) {
             onCancelExecutionModeQueue={props.onCancelExecutionModeQueue}
             onSetThreadModelSettings={props.onSetThreadModelSettings}
             onSetThreadPrAutoDispatch={props.onSetThreadPrAutoDispatch}
+            onCancelThreadPrAutoDispatch={props.onCancelThreadPrAutoDispatch}
             backgroundPrPollingEnabled={props.backgroundPrPollingEnabled}
             onAttachDirectoryReferences={props.onAttachDirectoryReferences}
             onPickDirectoryForReference={props.onPickDirectoryForReference}

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7169,7 +7169,15 @@ describe("useThreadNavigation", () => {
         >[0],
       ) => request,
     );
+    const cancelThreadPrAutoDispatch = vi.fn(
+      async (
+        request: Parameters<
+          NonNullable<DesktopApi["cancelThreadPrAutoDispatch"]>
+        >[0],
+      ) => ({ ...request, cancelled: true }),
+    );
     const desktopApi: DesktopApi = {
+      cancelThreadPrAutoDispatch,
       getNavigationSnapshot,
       setThreadPrAutoDispatch,
       onAgentEvent: (callback) => {
@@ -7209,6 +7217,53 @@ describe("useThreadNavigation", () => {
     await waitFor(() => {
       expect(result.current.selectedThread?.prAutoDispatchEnabled).toBe(false);
     });
+
+    const pending = {
+      fingerprint: "fingerprint-1",
+      prKey: "github.com/pwrdrvr/PwrAgent#1105",
+      prNumber: 1105,
+      prUrl: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+      headSha: "a".repeat(40),
+      eventKinds: ["ci-failure" as const],
+      createdAt: 1_000,
+      scheduledAt: 31_000,
+    };
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/prAutoDispatch/pendingUpdated",
+            params: { threadId: "thread-1", pending },
+          },
+        });
+      }
+    });
+    expect(result.current.selectedThread?.prAutoDispatchPending).toEqual(pending);
+    await act(async () => {
+      await result.current.cancelThreadPrAutoDispatch(
+        result.current.selectedThread!,
+        pending.fingerprint,
+      );
+    });
+    expect(cancelThreadPrAutoDispatch).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
+    });
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/prAutoDispatch/pendingUpdated",
+            params: { threadId: "thread-1", pending: null },
+          },
+        });
+      }
+    });
+    expect(result.current.selectedThread?.prAutoDispatchPending).toBeUndefined();
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7137,6 +7137,81 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("persists and patches the per-thread PR auto-dispatch preference", async () => {
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [{
+        id: "thread-1",
+        title: "First thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        prAutoDispatchEnabled: false,
+        inbox: { inInbox: true, reason: "new-thread" as const },
+        updatedAt: 1_000,
+      }],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setThreadPrAutoDispatch = vi.fn(
+      async (
+        request: Parameters<
+          NonNullable<DesktopApi["setThreadPrAutoDispatch"]>
+        >[0],
+      ) => request,
+    );
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      setThreadPrAutoDispatch,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => listeners.delete(callback);
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.prAutoDispatchEnabled).toBe(false);
+    });
+    await act(async () => {
+      await result.current.setThreadPrAutoDispatch(
+        result.current.selectedThread!,
+        true,
+      );
+    });
+    expect(setThreadPrAutoDispatch).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      enabled: true,
+    });
+    expect(result.current.selectedThread?.prAutoDispatchEnabled).toBe(true);
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/prAutoDispatch/updated",
+            params: { threadId: "thread-1", enabled: false },
+          },
+        });
+      }
+    });
+    await waitFor(() => {
+      expect(result.current.selectedThread?.prAutoDispatchEnabled).toBe(false);
+    });
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves the current thread model when patching non-model settings", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7176,9 +7176,17 @@ describe("useThreadNavigation", () => {
         >[0],
       ) => ({ ...request, cancelled: true }),
     );
+    const sendThreadPrAutoDispatchNow = vi.fn(
+      async (
+        request: Parameters<
+          NonNullable<DesktopApi["sendThreadPrAutoDispatchNow"]>
+        >[0],
+      ) => ({ ...request, accepted: true }),
+    );
     const desktopApi: DesktopApi = {
       cancelThreadPrAutoDispatch,
       getNavigationSnapshot,
+      sendThreadPrAutoDispatchNow,
       setThreadPrAutoDispatch,
       onAgentEvent: (callback) => {
         listeners.add(callback);
@@ -7241,10 +7249,19 @@ describe("useThreadNavigation", () => {
     });
     expect(result.current.selectedThread?.prAutoDispatchPending).toEqual(pending);
     await act(async () => {
+      await result.current.sendThreadPrAutoDispatchNow(
+        result.current.selectedThread!,
+        pending.fingerprint,
+      );
       await result.current.cancelThreadPrAutoDispatch(
         result.current.selectedThread!,
         pending.fingerprint,
       );
+    });
+    expect(sendThreadPrAutoDispatchNow).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      fingerprint: "fingerprint-1",
     });
     expect(cancelThreadPrAutoDispatch).toHaveBeenCalledWith({
       backend: "codex",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadQueuedMessageIndicators.test.tsx
@@ -83,6 +83,24 @@ describe("useThreadQueuedMessageIndicators", () => {
     expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
   });
 
+  it("classifies a durable PR auto-fix countdown as scheduled", () => {
+    const thread = {
+      ...makeThread("a"),
+      prAutoDispatchPending: {
+        fingerprint: "fingerprint-1",
+        prKey: "github.com/pwrdrvr/PwrAgent#1105",
+        prNumber: 1105,
+        prUrl: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+        headSha: "a".repeat(40),
+        eventKinds: ["ci-failure" as const],
+        createdAt: Date.now(),
+        scheduledAt: Date.now() + 30_000,
+      },
+    };
+    const { result } = renderIndicators([thread]);
+    expect(result.current.indicators).toEqual({ "codex:a": "scheduled" });
+  });
+
   it("prefers 'scheduled' when a thread has both a scheduled and a plain queued turn", () => {
     const thread = makeThread("a");
     const { result } = renderIndicators([thread]);

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -101,6 +101,8 @@ import type {
   SetThreadParentResponse,
   SetThreadPinRequest,
   SetThreadPinResponse,
+  SetThreadPrAutoDispatchRequest,
+  SetThreadPrAutoDispatchResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -630,6 +632,9 @@ export type DesktopApi = {
   setThreadPin?: (
     request: SetThreadPinRequest
   ) => Promise<SetThreadPinResponse>;
+  setThreadPrAutoDispatch?: (
+    request: SetThreadPrAutoDispatchRequest,
+  ) => Promise<SetThreadPrAutoDispatchResponse>;
   setThreadAgent?: (
     request: SetThreadAgentRequest
   ) => Promise<SetThreadAgentResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,8 @@ import type {
   SetThreadPinResponse,
   SetThreadPrAutoDispatchRequest,
   SetThreadPrAutoDispatchResponse,
+  CancelThreadPrAutoDispatchRequest,
+  CancelThreadPrAutoDispatchResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -635,6 +637,9 @@ export type DesktopApi = {
   setThreadPrAutoDispatch?: (
     request: SetThreadPrAutoDispatchRequest,
   ) => Promise<SetThreadPrAutoDispatchResponse>;
+  cancelThreadPrAutoDispatch?: (
+    request: CancelThreadPrAutoDispatchRequest,
+  ) => Promise<CancelThreadPrAutoDispatchResponse>;
   setThreadAgent?: (
     request: SetThreadAgentRequest
   ) => Promise<SetThreadAgentResponse>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -105,6 +105,8 @@ import type {
   SetThreadPrAutoDispatchResponse,
   CancelThreadPrAutoDispatchRequest,
   CancelThreadPrAutoDispatchResponse,
+  SendThreadPrAutoDispatchNowRequest,
+  SendThreadPrAutoDispatchNowResponse,
   GetGhStatusRequest,
   GhStatus,
   ApproveMessagingPairingRequest,
@@ -640,6 +642,9 @@ export type DesktopApi = {
   cancelThreadPrAutoDispatch?: (
     request: CancelThreadPrAutoDispatchRequest,
   ) => Promise<CancelThreadPrAutoDispatchResponse>;
+  sendThreadPrAutoDispatchNow?: (
+    request: SendThreadPrAutoDispatchNowRequest,
+  ) => Promise<SendThreadPrAutoDispatchNowResponse>;
   setThreadAgent?: (
     request: SetThreadAgentRequest
   ) => Promise<SetThreadAgentResponse>;

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -716,6 +716,7 @@ function threadSummariesEqual(
     left.reasoningEffort === right.reasoningEffort &&
     left.serviceTier === right.serviceTier &&
     left.fastMode === right.fastMode &&
+    left.prAutoDispatchEnabled === right.prAutoDispatchEnabled &&
     JSON.stringify(left.acpRuntime ?? {}) === JSON.stringify(right.acpRuntime ?? {}) &&
     JSON.stringify(left.workspaceHandoff ?? {}) ===
       JSON.stringify(right.workspaceHandoff ?? {}) &&
@@ -1605,6 +1606,28 @@ function applyThreadModelSettingsUpdate(
     : snapshot;
 }
 
+function applyThreadPrAutoDispatchUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    enabled: boolean;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    changed = true;
+    return { ...thread, prAutoDispatchEnabled: params.enabled };
+  });
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
 function applyThreadAcpRuntimeUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -2318,6 +2341,10 @@ export function useThreadNavigation(
       >
     >
   ) => Promise<void>;
+  setThreadPrAutoDispatch: (
+    thread: NavigationThreadSummary,
+    enabled: boolean,
+  ) => Promise<void>;
   setThreadModelSettingsError?: string;
   updatingThreadExecutionMode?: ThreadExecutionMode;
   updateDirectoryLaunchpad: (
@@ -2404,6 +2431,7 @@ export function useThreadNavigation(
   const cancelThreadExecutionModeQueueRequest =
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
+  const setThreadPrAutoDispatchRequest = desktopApi?.setThreadPrAutoDispatch;
   const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
   const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
@@ -3306,6 +3334,26 @@ export function useThreadNavigation(
         setOptimisticThread((current) =>
           current?.source === event.backend && current.id === params.threadId
             ? { ...current, ...modelSettingsPatch }
+            : current
+        );
+        return;
+      }
+
+      if (method === "thread/prAutoDispatch/updated") {
+        const params = event.notification.params as {
+          threadId: string;
+          enabled: boolean;
+        };
+        setState((current) => ({
+          ...current,
+          response: applyThreadPrAutoDispatchUpdate(current.response, {
+            backend: event.backend,
+            ...params,
+          }),
+        }));
+        setOptimisticThread((current) =>
+          current?.source === event.backend && current.id === params.threadId
+            ? { ...current, prAutoDispatchEnabled: params.enabled }
             : current
         );
         return;
@@ -5906,6 +5954,49 @@ export function useThreadNavigation(
     [refresh, setThreadModelSettings]
   );
 
+  const updateThreadPrAutoDispatch = useCallback(
+    async (
+      thread: NavigationThreadSummary,
+      enabled: boolean,
+    ): Promise<void> => {
+      if (!setThreadPrAutoDispatchRequest) {
+        setSetThreadModelSettingsError(
+          "Desktop bridge is missing setThreadPrAutoDispatch().",
+        );
+        return;
+      }
+
+      setSetThreadModelSettingsError(undefined);
+      setOptimisticThread((current) =>
+        current && current.id === thread.id && current.source === thread.source
+          ? { ...current, prAutoDispatchEnabled: enabled }
+          : current
+      );
+      setState((current) => ({
+        ...current,
+        response: applyThreadPrAutoDispatchUpdate(current.response, {
+          backend: thread.source,
+          threadId: thread.id,
+          enabled,
+        }),
+      }));
+
+      try {
+        await setThreadPrAutoDispatchRequest({
+          backend: thread.source,
+          threadId: thread.id,
+          enabled,
+        });
+      } catch (error) {
+        setSetThreadModelSettingsError(
+          error instanceof Error ? error.message : String(error),
+        );
+        await refresh(buildThreadIdentityKey(thread.source, thread.id));
+      }
+    },
+    [refresh, setThreadPrAutoDispatchRequest],
+  );
+
   const updateAcpSessionRuntimeOption = useCallback(
     async (
       thread: NavigationThreadSummary,
@@ -6019,6 +6110,7 @@ export function useThreadNavigation(
     setThreadExecutionModeError,
     cancelThreadExecutionModeQueue,
     setThreadModelSettings: updateThreadModelSettings,
+    setThreadPrAutoDispatch: updateThreadPrAutoDispatch,
     setThreadModelSettingsError,
     updatingThreadExecutionMode,
     updateDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -717,6 +717,8 @@ function threadSummariesEqual(
     left.serviceTier === right.serviceTier &&
     left.fastMode === right.fastMode &&
     left.prAutoDispatchEnabled === right.prAutoDispatchEnabled &&
+    JSON.stringify(left.prAutoDispatchPending ?? null) ===
+      JSON.stringify(right.prAutoDispatchPending ?? null) &&
     JSON.stringify(left.acpRuntime ?? {}) === JSON.stringify(right.acpRuntime ?? {}) &&
     JSON.stringify(left.workspaceHandoff ?? {}) ===
       JSON.stringify(right.workspaceHandoff ?? {}) &&
@@ -1628,6 +1630,26 @@ function applyThreadPrAutoDispatchUpdate(
   return changed ? { ...snapshot, threads } : snapshot;
 }
 
+function applyThreadPrAutoDispatchPendingUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    pending: NavigationThreadSummary["prAutoDispatchPending"];
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) return snapshot;
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    changed = true;
+    return { ...thread, prAutoDispatchPending: params.pending };
+  });
+  return changed ? { ...snapshot, threads } : snapshot;
+}
+
 function applyThreadAcpRuntimeUpdate(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -2345,6 +2367,10 @@ export function useThreadNavigation(
     thread: NavigationThreadSummary,
     enabled: boolean,
   ) => Promise<void>;
+  cancelThreadPrAutoDispatch: (
+    thread: NavigationThreadSummary,
+    fingerprint: string,
+  ) => Promise<void>;
   setThreadModelSettingsError?: string;
   updatingThreadExecutionMode?: ThreadExecutionMode;
   updateDirectoryLaunchpad: (
@@ -2432,6 +2458,8 @@ export function useThreadNavigation(
     desktopApi?.cancelThreadExecutionModeQueue;
   const setThreadModelSettings = desktopApi?.setThreadModelSettings;
   const setThreadPrAutoDispatchRequest = desktopApi?.setThreadPrAutoDispatch;
+  const cancelThreadPrAutoDispatchRequest =
+    desktopApi?.cancelThreadPrAutoDispatch;
   const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
   const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
@@ -3354,6 +3382,28 @@ export function useThreadNavigation(
         setOptimisticThread((current) =>
           current?.source === event.backend && current.id === params.threadId
             ? { ...current, prAutoDispatchEnabled: params.enabled }
+            : current
+        );
+        return;
+      }
+
+      if (method === "thread/prAutoDispatch/pendingUpdated") {
+        const params = event.notification.params as {
+          threadId: string;
+          pending: NavigationThreadSummary["prAutoDispatchPending"] | null;
+        };
+        const pending = params.pending ?? undefined;
+        setState((current) => ({
+          ...current,
+          response: applyThreadPrAutoDispatchPendingUpdate(current.response, {
+            backend: event.backend,
+            threadId: params.threadId,
+            pending,
+          }),
+        }));
+        setOptimisticThread((current) =>
+          current?.source === event.backend && current.id === params.threadId
+            ? { ...current, prAutoDispatchPending: pending }
             : current
         );
         return;
@@ -5997,6 +6047,21 @@ export function useThreadNavigation(
     [refresh, setThreadPrAutoDispatchRequest],
   );
 
+  const cancelPendingThreadPrAutoDispatch = useCallback(
+    async (
+      thread: NavigationThreadSummary,
+      fingerprint: string,
+    ): Promise<void> => {
+      if (!cancelThreadPrAutoDispatchRequest) return;
+      await cancelThreadPrAutoDispatchRequest({
+        backend: thread.source,
+        threadId: thread.id,
+        fingerprint,
+      });
+    },
+    [cancelThreadPrAutoDispatchRequest],
+  );
+
   const updateAcpSessionRuntimeOption = useCallback(
     async (
       thread: NavigationThreadSummary,
@@ -6111,6 +6176,7 @@ export function useThreadNavigation(
     cancelThreadExecutionModeQueue,
     setThreadModelSettings: updateThreadModelSettings,
     setThreadPrAutoDispatch: updateThreadPrAutoDispatch,
+    cancelThreadPrAutoDispatch: cancelPendingThreadPrAutoDispatch,
     setThreadModelSettingsError,
     updatingThreadExecutionMode,
     updateDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2371,6 +2371,10 @@ export function useThreadNavigation(
     thread: NavigationThreadSummary,
     fingerprint: string,
   ) => Promise<void>;
+  sendThreadPrAutoDispatchNow: (
+    thread: NavigationThreadSummary,
+    fingerprint: string,
+  ) => Promise<void>;
   setThreadModelSettingsError?: string;
   updatingThreadExecutionMode?: ThreadExecutionMode;
   updateDirectoryLaunchpad: (
@@ -2460,6 +2464,8 @@ export function useThreadNavigation(
   const setThreadPrAutoDispatchRequest = desktopApi?.setThreadPrAutoDispatch;
   const cancelThreadPrAutoDispatchRequest =
     desktopApi?.cancelThreadPrAutoDispatch;
+  const sendThreadPrAutoDispatchNowRequest =
+    desktopApi?.sendThreadPrAutoDispatchNow;
   const setNavigationBrowseModeRequest = desktopApi?.setNavigationBrowseMode;
   const enabled = options.enabled ?? true;
   const lightweightNavigationRefresh = options.lightweightNavigationRefresh ?? false;
@@ -6062,6 +6068,21 @@ export function useThreadNavigation(
     [cancelThreadPrAutoDispatchRequest],
   );
 
+  const sendPendingThreadPrAutoDispatchNow = useCallback(
+    async (
+      thread: NavigationThreadSummary,
+      fingerprint: string,
+    ): Promise<void> => {
+      if (!sendThreadPrAutoDispatchNowRequest) return;
+      await sendThreadPrAutoDispatchNowRequest({
+        backend: thread.source,
+        threadId: thread.id,
+        fingerprint,
+      });
+    },
+    [sendThreadPrAutoDispatchNowRequest],
+  );
+
   const updateAcpSessionRuntimeOption = useCallback(
     async (
       thread: NavigationThreadSummary,
@@ -6177,6 +6198,7 @@ export function useThreadNavigation(
     setThreadModelSettings: updateThreadModelSettings,
     setThreadPrAutoDispatch: updateThreadPrAutoDispatch,
     cancelThreadPrAutoDispatch: cancelPendingThreadPrAutoDispatch,
+    sendThreadPrAutoDispatchNow: sendPendingThreadPrAutoDispatchNow,
     setThreadModelSettingsError,
     updatingThreadExecutionMode,
     updateDirectoryLaunchpad,

--- a/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadQueuedMessageIndicators.ts
@@ -48,6 +48,10 @@ export function useThreadQueuedMessageIndicators(params: {
     const indicators: Record<string, ThreadQueuedMessageState> = {};
     const now = Date.now();
     for (const thread of threads) {
+      if (thread.prAutoDispatchPending) {
+        indicators[buildThreadIdentityKey(thread.source, thread.id)] =
+          "scheduled";
+      }
       const queuedTurns = composerDraftStore.getQueuedTurns(
         getThreadScopeKey(thread),
       );
@@ -60,9 +64,11 @@ export function useThreadQueuedMessageIndicators(params: {
           && Number.isFinite(turn.scheduledSendAt)
           && turn.scheduledSendAt > now,
       );
-      indicators[buildThreadIdentityKey(thread.source, thread.id)] = hasScheduled
-        ? "scheduled"
-        : "queued";
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      indicators[threadKey] =
+        hasScheduled || indicators[threadKey] === "scheduled"
+          ? "scheduled"
+          : "queued";
     }
     return indicators;
     // `version` is intentionally a dependency (not referenced in the body):

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16498,7 +16498,7 @@ a.transcript-message__messaging-origin:focus-visible {
   accent-color: var(--accent);
 }
 
-/* Icon toggle chips (Fast / Plan). Square pill the same height as the
+/* Icon toggle chips (Fast / Plan / Auto-fix PR). Square pill the same height as the
    setting chips; only shown for models that support the feature. The
    "on" state carries the single accent so it reads as enabled at a glance;
    the name + description live in the hover tooltip. */

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -39,6 +39,8 @@ export const AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL =
 export const AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL = "agent:set-thread-model-settings";
 export const AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL =
   "agent:set-thread-pr-auto-dispatch";
+export const AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL =
+  "agent:cancel-thread-pr-auto-dispatch";
 export const AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL =
   "agent:apply-thread-model-migration";
 export const AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL =

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -41,6 +41,8 @@ export const AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL =
   "agent:set-thread-pr-auto-dispatch";
 export const AGENT_CANCEL_THREAD_PR_AUTO_DISPATCH_CHANNEL =
   "agent:cancel-thread-pr-auto-dispatch";
+export const AGENT_SEND_THREAD_PR_AUTO_DISPATCH_NOW_CHANNEL =
+  "agent:send-thread-pr-auto-dispatch-now";
 export const AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL =
   "agent:apply-thread-model-migration";
 export const AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL =

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -37,6 +37,8 @@ export const AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL =
 export const AGENT_SET_ACP_SESSION_RUNTIME_OPTION_CHANNEL =
   "agent:set-acp-session-runtime-option";
 export const AGENT_SET_THREAD_MODEL_SETTINGS_CHANNEL = "agent:set-thread-model-settings";
+export const AGENT_SET_THREAD_PR_AUTO_DISPATCH_CHANNEL =
+  "agent:set-thread-pr-auto-dispatch";
 export const AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL =
   "agent:apply-thread-model-migration";
 export const AGENT_TURN_OFF_CODEX_FAST_EVERYWHERE_CHANNEL =

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -372,6 +372,15 @@ export type SetThreadPrAutoDispatchRequest = {
 
 export type SetThreadPrAutoDispatchResponse = SetThreadPrAutoDispatchRequest;
 
+export type CancelThreadPrAutoDispatchRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  fingerprint: string;
+};
+
+export type CancelThreadPrAutoDispatchResponse =
+  CancelThreadPrAutoDispatchRequest & { cancelled: boolean };
+
 export type ApplyThreadModelMigrationRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -364,6 +364,14 @@ export type SetThreadModelSettingsRequest = {
 
 export type SetThreadModelSettingsResponse = SetThreadModelSettingsRequest;
 
+export type SetThreadPrAutoDispatchRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  enabled: boolean;
+};
+
+export type SetThreadPrAutoDispatchResponse = SetThreadPrAutoDispatchRequest;
+
 export type ApplyThreadModelMigrationRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -381,6 +381,12 @@ export type CancelThreadPrAutoDispatchRequest = {
 export type CancelThreadPrAutoDispatchResponse =
   CancelThreadPrAutoDispatchRequest & { cancelled: boolean };
 
+export type SendThreadPrAutoDispatchNowRequest =
+  CancelThreadPrAutoDispatchRequest;
+
+export type SendThreadPrAutoDispatchNowResponse =
+  SendThreadPrAutoDispatchNowRequest & { accepted: boolean };
+
 export type ApplyThreadModelMigrationRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -54,6 +54,8 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
   /** Automatically dispatch bounded repair turns for newly failing/conflicting attached PRs. */
   prAutoDispatchEnabled?: boolean;
+  /** Durable, cancellable PR repair waiting for its main-process send time. */
+  prAutoDispatchPending?: ThreadPrAutoDispatchPending;
   /** Last provider model-migration revision acknowledged by this thread. */
   modelMigrationRevision?: string;
   /** Last explicit model/reasoning change made outside a migration. */
@@ -264,6 +266,22 @@ export type PrSummary = {
    */
   commitShas?: string[];
   url: string;
+};
+
+export type ThreadPrAutoDispatchEventKind =
+  | "ci-failure"
+  | "merge-conflict";
+
+export type ThreadPrAutoDispatchPending = {
+  fingerprint: string;
+  prKey: string;
+  prNumber: number;
+  prTitle?: string;
+  prUrl: string;
+  headSha: string;
+  eventKinds: ThreadPrAutoDispatchEventKind[];
+  createdAt: number;
+  scheduledAt: number;
 };
 
 export function normalizePullRequestProvider(
@@ -1253,10 +1271,8 @@ export type ThreadOverlayState = {
   fastMode?: boolean;
   /** Saved operator preference; the global background-polling flag gates its effect. */
   prAutoDispatchEnabled?: boolean;
-  /** Durable one-shot claims that prevent replaying an automatic PR repair after restart. */
-  prAutoDispatchHandledFingerprints?: string[];
-  /** Consecutive automatic attempts per PR identity, reset after the PR becomes healthy. */
-  prAutoDispatchAttemptCounts?: Record<string, number>;
+  /** Joined from the durable dispatch table for navigation; never stored in overlay JSON. */
+  prAutoDispatchPending?: ThreadPrAutoDispatchPending;
   gitBranch?: string;
   observedGitBranch?: string;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -52,6 +52,8 @@ export type ThreadAgentMetadata = {
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
+  /** Automatically dispatch bounded repair turns for newly failing/conflicting attached PRs. */
+  prAutoDispatchEnabled?: boolean;
   /** Last provider model-migration revision acknowledged by this thread. */
   modelMigrationRevision?: string;
   /** Last explicit model/reasoning change made outside a migration. */
@@ -253,6 +255,8 @@ export type PrSummary = {
   lifecycleState?: PrLifecycleState;
   reviewState?: PrReviewState;
   mergeState?: PrMergeState;
+  /** Head commit observed with this status snapshot. */
+  headSha?: string;
   /**
    * Commit OIDs attached to this PR when the provider returns them. Used to
    * keep merged PR commits from reading as local-only after the remote head
@@ -1247,6 +1251,12 @@ export type ThreadOverlayState = {
   modelSettingsManuallyUpdatedAt?: number;
   serviceTier?: string;
   fastMode?: boolean;
+  /** Saved operator preference; the global background-polling flag gates its effect. */
+  prAutoDispatchEnabled?: boolean;
+  /** Durable one-shot claims that prevent replaying an automatic PR repair after restart. */
+  prAutoDispatchHandledFingerprints?: string[];
+  /** Consecutive automatic attempts per PR identity, reset after the PR becomes healthy. */
+  prAutoDispatchAttemptCounts?: Record<string, number>;
   gitBranch?: string;
   observedGitBranch?: string;
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -3,7 +3,10 @@ import type {
   MessagingChannelKind,
   MessagingConversationKind,
 } from "./messaging";
-import type { PrSummary } from "./navigation";
+import type {
+  PrSummary,
+  ThreadPrAutoDispatchPending,
+} from "./navigation";
 import type { ThreadPricingSummary, ThreadUsageLineRecord } from "../token-usage-pricing";
 
 export type AppServerBuiltinBackendKind = "codex" | "grok";
@@ -1312,6 +1315,13 @@ export type AppServerNotification =
       params: {
         threadId: string;
         enabled: boolean;
+      };
+    }
+  | {
+      method: "thread/prAutoDispatch/pendingUpdated";
+      params: {
+        threadId: string;
+        pending: ThreadPrAutoDispatchPending | null;
       };
     }
   | {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1308,6 +1308,13 @@ export type AppServerNotification =
       };
     }
   | {
+      method: "thread/prAutoDispatch/updated";
+      params: {
+        threadId: string;
+        enabled: boolean;
+      };
+    }
+  | {
       method: "thread/codexSettings/observed";
       params: {
         threadId: string;

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -238,6 +238,7 @@ export function materializeNavigationThreads(params: {
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
       fastMode: overlay?.fastMode ?? thread.fastMode,
       prAutoDispatchEnabled: overlay?.prAutoDispatchEnabled ?? false,
+      prAutoDispatchPending: overlay?.prAutoDispatchPending,
       codexEnvironmentRuntime:
         overlay?.codexEnvironmentRuntime ?? thread.codexEnvironmentRuntime,
       codexEnvironmentOptions: thread.codexEnvironmentOptions,
@@ -427,6 +428,12 @@ export function buildNavigationSnapshotHash(params: {
       serviceTier: thread.serviceTier ?? null,
       fastMode: thread.fastMode ?? null,
       prAutoDispatchEnabled: thread.prAutoDispatchEnabled ?? false,
+      prAutoDispatchPending: thread.prAutoDispatchPending
+        ? {
+            fingerprint: thread.prAutoDispatchPending.fingerprint,
+            scheduledAt: thread.prAutoDispatchPending.scheduledAt,
+          }
+        : null,
       codexEnvironmentRuntime: thread.codexEnvironmentRuntime
         ? {
             environmentId: thread.codexEnvironmentRuntime.environmentId,

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -237,6 +237,7 @@ export function materializeNavigationThreads(params: {
         overlay?.modelSettingsManuallyUpdatedAt,
       serviceTier: overlay?.serviceTier ?? thread.serviceTier,
       fastMode: overlay?.fastMode ?? thread.fastMode,
+      prAutoDispatchEnabled: overlay?.prAutoDispatchEnabled ?? false,
       codexEnvironmentRuntime:
         overlay?.codexEnvironmentRuntime ?? thread.codexEnvironmentRuntime,
       codexEnvironmentOptions: thread.codexEnvironmentOptions,
@@ -425,6 +426,7 @@ export function buildNavigationSnapshotHash(params: {
       reasoningEffort: thread.reasoningEffort ?? null,
       serviceTier: thread.serviceTier ?? null,
       fastMode: thread.fastMode ?? null,
+      prAutoDispatchEnabled: thread.prAutoDispatchEnabled ?? false,
       codexEnvironmentRuntime: thread.codexEnvironmentRuntime
         ? {
             environmentId: thread.codexEnvironmentRuntime.environmentId,


### PR DESCRIPTION
## Summary

- add a saved, thread-scoped **Auto-fix PR** composer toggle beside Plan Mode and Fast Mode
- evaluate currently attached PRs as soon as Auto-fix is enabled, including explicitly attached PRs on directoryless threads
- stage an actionable CI failure or merge conflict in the composer on-deck area for 30 seconds, with a visible countdown plus **Send now** and **Cancel** actions
- keep detection, durable scheduling, dispatch, and dedupe authoritative in the main process
- preserve the thread preference while the global background polling kill switch is off and present pending work as paused

#1104 has merged, and GitHub rebased this former stacked PR onto `main` automatically.

## Dispatch policy

1. Auto-fix is eligible only while global background PR polling is enabled, the attached thread has **Auto-fix PR** enabled, and the PR remains open.
2. Enabling the toggle evaluates the current visible attachments immediately, then refreshes their provider status. A currently failed or conflicting PR does not need another state transition to qualify.
3. An actionable state creates one durable on-deck item scheduled 30 seconds later. The operator can send it immediately or cancel it before dispatch.
4. At send time, the main process revalidates the global gate, current PR fingerprint, lifecycle, and actual thread attachment.
5. Automatic turns use an atomic reject-if-busy submission path. If the thread is active or queued, the item is postponed for another countdown and no attempt is spent.
6. Cancellation suppresses the same fingerprint until a materially new fingerprint appears. Explicitly turning Auto-fix off and back on clears completed fingerprint claims and resets the finite incident budget, so the current condition can be retried as attempt 1.
7. Merged or closed PRs are non-actionable and cancel any still-pending repair.
8. Resuming after global polling was paused refreshes pending PRs from the provider before overdue countdowns can dispatch.

The generated prompt includes provider/repository/PR identity and URL, title, exact head SHA, event kinds, current check and merge state, observation timestamp, attempt number, and dedupe fingerprint. It asks the agent to verify live provider state, make scoped fixes, validate them, update the PR when appropriate, or stop without creating another retry loop.

## Cost and loop safeguards

- A SHA-256 fingerprint includes PR identity, exact head SHA, event kinds, and relevant failing-check/conflict state.
- Fingerprint claims live in a dedicated SQLite table with a unique key, so claims are atomic across multiple app instances sharing a profile.
- Dispatching claims carry an owner lease with heartbeat renewal. After a crash or restart, an expired or legacy lease is reclaimed into a fresh countdown without spending an attempt; a live lease remains protected.
- The same fingerprint dispatches at most once. Renderer refreshes, app restarts, foreground status refreshes, and an unchanged failed result from the repair turn cannot replay it.
- Detection evaluates every authoritative status snapshot against durable claims, so a foreground refresh cannot consume a transition before the background path handles it.
- Dispatch targets come from visible thread attachments, honoring detached PRs and supporting explicit attachments on directoryless threads.
- A thread has at most one pending or dispatching automatic repair across processes.
- Each PR is capped at **two automatic attempts per continuous incident**. Pending or unknown CI does not reset the count; only definitive recovery clears the relevant incident condition.
- A new head SHA or changed actionable state creates a materially new fingerprint, subject to the finite incident cap.
- Busy submissions never enter the normal turn queue and do not consume an attempt.
- Turning off global polling pauses timers without erasing the saved thread preference or durable pending item. Resuming requires a current provider snapshot before any overdue item is armed.

## Validation

- focused Vitest coverage: 2 files, 84 tests passed
- full Vitest workspace: 399 files passed, 1 skipped; 5,379 tests passed, 3 skipped
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
