### PR TITLE
fix(desktop): identify monitor sub-agent handoffs

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23368,7 +23368,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("reconstructs provenance for monitor handoffs recorded before sub-agent origins", async () => {
+  it("reconstructs repeated legacy monitor handoffs one-to-one", async () => {
     const task = "Monitor GitHub CI for PR #1107 until all checks finish.";
     const summary = "All required checks passed.";
     const text = [
@@ -23384,16 +23384,31 @@ script = "printf setup"
       entries: [
         {
           type: "message",
-          id: "legacy-monitor-handoff",
+          id: "legacy-monitor-handoff-1",
           role: "user",
           text,
+          createdAt: 2_100,
+        },
+        {
+          type: "message",
+          id: "legacy-monitor-handoff-2",
+          role: "user",
+          text,
+          createdAt: 4_100,
         },
       ],
       messages: [
         {
-          id: "legacy-monitor-handoff",
+          id: "legacy-monitor-handoff-1",
           role: "user",
           text,
+          createdAt: 2_100,
+        },
+        {
+          id: "legacy-monitor-handoff-2",
+          role: "user",
+          text,
+          createdAt: 4_100,
         },
       ],
       pagination: {
@@ -23410,8 +23425,20 @@ script = "printf setup"
           extraLinkedDirectories: [],
           subAgents: [
             {
+              monitorId: "monitor-2",
+              monitorThreadId: "monitor-thread-2",
+              task,
+              status: "success",
+              outcome: "success",
+              lastMessage: summary,
+              createdAt: 3_000,
+              updatedAt: 4_000,
+              completedAt: 4_000,
+              backend: "codex",
+            },
+            {
               monitorId: "monitor-1",
-              monitorThreadId: "monitor-thread",
+              monitorThreadId: "monitor-thread-1",
               task,
               status: "success",
               outcome: "success",
@@ -23438,12 +23465,12 @@ script = "printf setup"
     });
 
     expect(response.replay.entries[0]).toMatchObject({
-      id: "legacy-monitor-handoff",
+      id: "legacy-monitor-handoff-1",
       origin: {
         kind: "sub-agent",
         sourceThread: {
           backend: "codex",
-          threadId: "monitor-thread",
+          threadId: "monitor-thread-1",
           title: task,
         },
         subAgent: {
@@ -23456,10 +23483,35 @@ script = "printf setup"
       },
     });
     expect(response.replay.messages[0]).toMatchObject({
-      id: "legacy-monitor-handoff",
+      id: "legacy-monitor-handoff-1",
       origin: {
         kind: "sub-agent",
         subAgent: { monitorId: "monitor-1" },
+      },
+    });
+    expect(response.replay.entries[1]).toMatchObject({
+      id: "legacy-monitor-handoff-2",
+      origin: {
+        kind: "sub-agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "monitor-thread-2",
+          title: task,
+        },
+        subAgent: {
+          kind: "monitor",
+          monitorId: "monitor-2",
+          outcome: "success",
+          summary,
+          task,
+        },
+      },
+    });
+    expect(response.replay.messages[1]).toMatchObject({
+      id: "legacy-monitor-handoff-2",
+      origin: {
+        kind: "sub-agent",
+        subAgent: { monitorId: "monitor-2" },
       },
     });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23368,6 +23368,104 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("reconstructs provenance for monitor handoffs recorded before sub-agent origins", async () => {
+    const task = "Monitor GitHub CI for PR #1107 until all checks finish.";
+    const summary = "All required checks passed.";
+    const text = [
+      "A lightweight PwrAgent monitor subagent finished a long-running task.",
+      "",
+      `Task: ${task}`,
+      "Outcome: success",
+      `Summary: ${summary}`,
+      "",
+      "Process this final monitor result.",
+    ].join("\n");
+    const replay: AppServerThreadReplay = {
+      entries: [
+        {
+          type: "message",
+          id: "legacy-monitor-handoff",
+          role: "user",
+          text,
+        },
+      ],
+      messages: [
+        {
+          id: "legacy-monitor-handoff",
+          role: "user",
+          text,
+        },
+      ],
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "monitor-1",
+              monitorThreadId: "monitor-thread",
+              task,
+              status: "success",
+              outcome: "success",
+              lastMessage: summary,
+              createdAt: 1_000,
+              updatedAt: 2_000,
+              completedAt: 2_000,
+              backend: "codex",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ replay }),
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+      threadTitleGenerationService: null,
+    });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(response.replay.entries[0]).toMatchObject({
+      id: "legacy-monitor-handoff",
+      origin: {
+        kind: "sub-agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "monitor-thread",
+          title: task,
+        },
+        subAgent: {
+          kind: "monitor",
+          monitorId: "monitor-1",
+          outcome: "success",
+          summary,
+          task,
+        },
+      },
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      id: "legacy-monitor-handoff",
+      origin: {
+        kind: "sub-agent",
+        subAgent: { monitorId: "monitor-1" },
+      },
+    });
+
+    await registry.close();
+  });
+
   it("does not copy one message origin to another user message in the same turn", async () => {
     const userEntries: AppServerThreadReplay["entries"] = [
       {
@@ -27096,6 +27194,73 @@ script = "printf setup"
     ).toContain(
       "Tell me whether to merge.",
     );
+    const handoffText =
+      codexClient.lastStartTurnParams?.input[0]?.type === "text"
+        ? codexClient.lastStartTurnParams.input[0].text
+        : "";
+    await codexClient.emit({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "monitor-handoff-message",
+          type: "userMessage",
+          text: handoffText,
+        },
+      },
+    });
+    expect(
+      events.find(
+        (event) =>
+          event.notification.method === "item/completed"
+          && (
+            event.notification.params.item as { id?: string } | undefined
+          )?.id === "monitor-handoff-message",
+      ),
+    ).toMatchObject({
+      notification: {
+        params: {
+          item: {
+            origin: {
+              kind: "sub-agent",
+              sourceThread: {
+                backend: "codex",
+                threadId: "monitor-thread",
+                title: "Watch PR #123 checks until they finish.",
+              },
+              subAgent: {
+                kind: "monitor",
+                monitorId,
+                outcome: "failure",
+                summary: "Tests failed in CI.",
+                task: "Watch PR #123 checks until they finish.",
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(overlayStore.upsertThreadMessageOrigin).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      messageId: "monitor-handoff-message",
+      origin: {
+        kind: "sub-agent",
+        sourceThread: {
+          backend: "codex",
+          threadId: "monitor-thread",
+          title: "Watch PR #123 checks until they finish.",
+        },
+        subAgent: {
+          kind: "monitor",
+          monitorId,
+          outcome: "failure",
+          summary: "Tests failed in CI.",
+          task: "Watch PR #123 checks until they finish.",
+        },
+      },
+    });
     expect(completionPayload).toMatchObject({
       monitorId,
       parentThreadId: "thread-1",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4703,6 +4703,90 @@ function mergeThreadMessageOrigins(
   };
 }
 
+function buildTaskMonitorMessageOrigin(params: {
+  monitorId: string;
+  monitorThreadId?: string;
+  outcome: CompleteMonitoringToolArgs["outcome"];
+  summary: string;
+  task: string;
+}): AppServerThreadMessageOrigin {
+  return {
+    kind: "sub-agent",
+    ...(params.monitorThreadId
+      ? {
+          sourceThread: {
+            backend: "codex",
+            threadId: params.monitorThreadId,
+            title: params.task,
+          },
+        }
+      : {}),
+    subAgent: {
+      kind: "monitor",
+      monitorId: params.monitorId,
+      outcome: params.outcome,
+      summary: params.summary,
+      task: params.task,
+    },
+  };
+}
+
+function inferLegacyTaskMonitorMessageOrigins(params: {
+  origins: Record<string, AppServerThreadMessageOrigin>;
+  replay: AppServerThreadReplay;
+  subAgents?: ThreadSubAgentSummary[];
+}): Record<string, AppServerThreadMessageOrigin> {
+  if (!params.subAgents?.length) {
+    return params.origins;
+  }
+
+  const origins = { ...params.origins };
+  const messages = [
+    ...params.replay.entries.filter(
+      (entry): entry is Extract<AppServerThreadEntry, { type: "message" }> =>
+        entry.type === "message" && entry.role === "user",
+    ),
+    ...params.replay.messages.filter((message) => message.role === "user"),
+  ];
+  for (const message of messages) {
+    if (
+      origins[message.id]
+      || !message.text.startsWith(
+        "A lightweight PwrAgent monitor subagent finished a long-running task.",
+      )
+    ) {
+      continue;
+    }
+    const task = message.text.match(/(?:^|\n)Task: ([^\n]+)/)?.[1]?.trim();
+    const outcome = message.text.match(
+      /(?:^|\n)Outcome: (success|failure|cancelled)(?:\n|$)/,
+    )?.[1] as CompleteMonitoringToolArgs["outcome"] | undefined;
+    if (!task || !outcome) {
+      continue;
+    }
+    const subAgent = params.subAgents.find(
+      (candidate) =>
+        candidate.task === task
+        && (candidate.outcome === outcome || candidate.status === outcome),
+    );
+    if (!subAgent) {
+      continue;
+    }
+    const summary = subAgent.lastMessage?.trim();
+    if (!summary || !message.text.includes(`Summary: ${summary}`)) {
+      continue;
+    }
+    origins[message.id] = buildTaskMonitorMessageOrigin({
+      monitorId: subAgent.monitorId,
+      monitorThreadId: subAgent.monitorThreadId,
+      outcome,
+      summary,
+      task,
+    });
+  }
+  return origins;
+}
+
 function resolveThreadMessageOrigin(params: {
   origin?: ThreadTurnQueueOrigin;
   messageOrigin?: AppServerThreadMessageOrigin;
@@ -7164,6 +7248,35 @@ export class DesktopBackendRegistry {
       await this.acpBackend.readReplay(backend, request.threadId),
       request,
     );
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend,
+      threadId: request.threadId,
+    });
+    const messageIds = [
+      ...replay.entries.flatMap((entry) =>
+        entry.type === "message" && entry.role === "user" ? [entry.id] : [],
+      ),
+      ...replay.messages.flatMap((message) =>
+        message.role === "user" ? [message.id] : [],
+      ),
+    ];
+    const persistedMessageOrigins =
+      typeof this.overlayStore.readThreadMessageOrigins === "function"
+        ? await this.overlayStore.readThreadMessageOrigins({
+            backend,
+            threadId: request.threadId,
+            messageIds,
+          })
+        : {};
+    const messageOrigins = inferLegacyTaskMonitorMessageOrigins({
+      origins: persistedMessageOrigins,
+      replay,
+      subAgents: overlay?.subAgents,
+    });
+    const replayWithMessageOrigins = mergeThreadMessageOrigins(
+      replay,
+      messageOrigins,
+    );
     const pricing =
       typeof this.overlayStore.readThreadPricing === "function"
         ? await this.overlayStore.readThreadPricing({
@@ -7176,8 +7289,10 @@ export class DesktopBackendRegistry {
       fetchedAt: Date.now(),
       pricing,
       threadId: request.threadId,
-      ...(replay.threadStatus ? { threadStatus: replay.threadStatus } : {}),
-      replay,
+      ...(replayWithMessageOrigins.threadStatus
+        ? { threadStatus: replayWithMessageOrigins.threadStatus }
+        : {}),
+      replay: replayWithMessageOrigins,
     };
   }
 
@@ -8480,7 +8595,7 @@ export class DesktopBackendRegistry {
             messageIds,
           })
         : {};
-    const messageOrigins = { ...persistedMessageOrigins };
+    let messageOrigins = { ...persistedMessageOrigins };
     const firstUserMessage = replayWithImmutableUsage.entries.find(
       (entry) => entry.type === "message" && entry.role === "user",
     );
@@ -8501,6 +8616,11 @@ export class DesktopBackendRegistry {
         },
       };
     }
+    messageOrigins = inferLegacyTaskMonitorMessageOrigins({
+      origins: messageOrigins,
+      replay: replayWithImmutableUsage,
+      subAgents: overlay?.subAgents,
+    });
     const replayWithMessageOrigins = mergeThreadMessageOrigins(
       replayWithImmutableUsage,
       messageOrigins,
@@ -21426,6 +21546,13 @@ export class DesktopBackendRegistry {
         }
       | undefined;
     if (params.triggerParentTurn) {
+      const messageOrigin = buildTaskMonitorMessageOrigin({
+        monitorId: params.record.monitorId,
+        monitorThreadId: params.record.monitorThreadId,
+        outcome: params.outcome,
+        summary: params.summary,
+        task: params.record.task,
+      });
       const submitted = await this.submitTurn({
         backend: params.record.parentBackend,
         threadId: params.record.parentThreadId,
@@ -21443,6 +21570,7 @@ export class DesktopBackendRegistry {
           },
         ],
         origin: "manual",
+        messageOrigin,
       });
       parentTurn =
         submitted.status === "started"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4747,7 +4747,25 @@ function inferLegacyTaskMonitorMessageOrigins(params: {
         entry.type === "message" && entry.role === "user",
     ),
     ...params.replay.messages.filter((message) => message.role === "user"),
-  ];
+  ]
+    .filter(
+      (message, index, all) =>
+        all.findIndex((candidate) => candidate.id === message.id) === index,
+    )
+    .map((message, index) => ({ message, index }))
+    .sort((left, right) => {
+      const leftTime = left.message.createdAt;
+      const rightTime = right.message.createdAt;
+      if (leftTime !== undefined && rightTime !== undefined) {
+        return rightTime - leftTime;
+      }
+      return right.index - left.index;
+    })
+    .map(({ message }) => message);
+  const availableSubAgents = [...params.subAgents].sort(
+    (left, right) =>
+      taskMonitorCompletionTime(right) - taskMonitorCompletionTime(left),
+  );
   for (const message of messages) {
     if (
       origins[message.id]
@@ -4764,18 +4782,32 @@ function inferLegacyTaskMonitorMessageOrigins(params: {
     if (!task || !outcome) {
       continue;
     }
-    const subAgent = params.subAgents.find(
-      (candidate) =>
+    const candidates = availableSubAgents.filter((candidate) => {
+      const candidateSummary = candidate.lastMessage?.trim();
+      return (
         candidate.task === task
-        && (candidate.outcome === outcome || candidate.status === outcome),
-    );
+        && (candidate.outcome === outcome || candidate.status === outcome)
+        && Boolean(
+          candidateSummary
+          && message.text.includes(`Summary: ${candidateSummary}`),
+        )
+      );
+    });
+    const messageTime = message.createdAt;
+    const subAgent =
+      messageTime === undefined
+        ? candidates[0]
+        : candidates.find(
+            (candidate) => taskMonitorCompletionTime(candidate) <= messageTime,
+          ) ?? candidates[0];
     if (!subAgent) {
       continue;
     }
     const summary = subAgent.lastMessage?.trim();
-    if (!summary || !message.text.includes(`Summary: ${summary}`)) {
+    if (!summary) {
       continue;
     }
+    availableSubAgents.splice(availableSubAgents.indexOf(subAgent), 1);
     origins[message.id] = buildTaskMonitorMessageOrigin({
       monitorId: subAgent.monitorId,
       monitorThreadId: subAgent.monitorThreadId,
@@ -4785,6 +4817,10 @@ function inferLegacyTaskMonitorMessageOrigins(params: {
     });
   }
   return origins;
+}
+
+function taskMonitorCompletionTime(subAgent: ThreadSubAgentSummary): number {
+  return subAgent.completedAt ?? subAgent.updatedAt ?? subAgent.createdAt;
 }
 
 function resolveThreadMessageOrigin(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/SubAgentTranscriptWindow.tsx
@@ -204,6 +204,7 @@ export function SubAgentTranscriptWindow() {
             loading={state.loading}
             loadingMore={state.loadingMore}
             pagination={state.response?.replay.pagination}
+            parentThreadId={target?.threadId}
             threadId={targetKey}
             onLoadOlder={loadOlder}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2916,6 +2916,7 @@ export function ThreadView(props: ThreadViewProps) {
               loading={props.loading}
               loadingMore={props.loadingMore}
               pagination={visibleTranscriptPagination}
+              parentThreadId={selectedThread!.id}
               // File-diff activity renders in the LiveWorkRail above
               // the composer (issue #495). Generic tool activity has no
               // rail body, so keep it in the transcript while the turn

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -2933,6 +2933,7 @@ export function ThreadView(props: ThreadViewProps) {
               restoredViewport={props.transcriptViewport}
               reglueRequestKey={transcriptReglueRequestKey}
               skills={props.skills}
+              subAgents={selectedThread!.subAgents}
               pendingProtocolActivityEntry={pendingProtocolActivityEntry}
               pendingUsageActivityEntry={pendingUsageActivityEntry}
               threadId={`${selectedThread!.source}:${selectedThread!.id}`}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -95,6 +95,7 @@ type TranscriptListProps = {
   pendingStatusText?: string;
   runningTurnUsageText?: string;
   pagination?: AppServerThreadReplayPagination;
+  parentThreadId?: string;
   permissionTransitions?: ThreadPermissionTransition[];
   messagingBindingTransitions?: ThreadMessagingBindingTransition[];
   turnFailures?: ThreadTurnFailure[];
@@ -1273,7 +1274,9 @@ export function TranscriptList(props: TranscriptListProps) {
                   expanded={expandedCommentaryGroupIds.has(item.id)}
                   fileViewerContext={props.fileViewerContext}
                   label={item.label}
+                  parentThreadId={props.parentThreadId ?? ""}
                   skills={skills}
+                  subAgents={props.subAgents}
                   onOpenImage={props.onOpenImage}
                   onToggle={() => {
                     toggleCommentaryGroup(item.id);
@@ -1307,6 +1310,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   applications={props.applications}
                   desktopApi={props.desktopApi}
                   message={item.entry}
+                  parentThreadId={props.parentThreadId ?? ""}
                   fileViewerContext={props.fileViewerContext}
                   skills={skills}
                   subAgents={props.subAgents}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -26,6 +26,7 @@ import type {
   ThreadMessagingBindingTransition,
   ThreadPermissionTransition,
   ThreadTurnFailure,
+  ThreadSubAgentSummary,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
 import {
@@ -102,6 +103,7 @@ type TranscriptListProps = {
   threadId?: string;
   fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
+  subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onViewportChange?: (viewport?: TranscriptViewport) => void;
   onRespondToPendingRequest?: (action: PendingRequestAction) => Promise<void>;
@@ -1307,6 +1309,7 @@ export function TranscriptList(props: TranscriptListProps) {
                   message={item.entry}
                   fileViewerContext={props.fileViewerContext}
                   skills={skills}
+                  subAgents={props.subAgents}
                   onOpenImage={props.onOpenImage}
                 />
               );

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -566,9 +566,13 @@ function renderMessageHeader(params: {
     return null;
   }
 
+  const attributionClassName = params.message.origin?.kind === "sub-agent"
+    ? "transcript-message__attribution transcript-message__attribution--stacked"
+    : "transcript-message__attribution";
+
   return (
     <header className="transcript-message__header">
-      <span className="transcript-message__attribution">
+      <span className={attributionClassName}>
         <span className="transcript-message__role">
           {labelForMessage(params.message)}
         </span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -14,6 +14,7 @@ import type {
   AppServerThreadMessageOrigin,
   AppServerThreadMessagePart,
   MarkdownFileViewerContext,
+  ThreadSubAgentSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
@@ -26,6 +27,9 @@ import { ThreadChip } from "./ThreadChip";
 import { TranscriptImage } from "./TranscriptImage";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
+import { SubAgentDetailsModal } from "./context-panels/SubAgentDetailsModal";
+import { RailStatusChip } from "./context-panels/RailStatusChip";
+import { subAgentTone } from "./context-panels/subagent-format";
 
 type TranscriptMessageProps = {
   applications?: DesktopApplicationsSnapshot;
@@ -36,6 +40,7 @@ type TranscriptMessageProps = {
   fileViewerContext?: MarkdownFileViewerContext;
   message: AppServerThreadMessageEntry;
   skills: AppServerSkillSummary[];
+  subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 };
 
@@ -55,6 +60,91 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
     [contentParts, props.message]
   );
   const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
+  const [monitorExpanded, setMonitorExpanded] = useState(false);
+  const [monitorDetailsOpen, setMonitorDetailsOpen] = useState(false);
+  const monitorOrigin = props.message.origin?.subAgent;
+  const monitorSubAgent = useMemo(
+    () => props.subAgents?.find(
+      (subAgent) => subAgent.monitorId === monitorOrigin?.monitorId,
+    ),
+    [monitorOrigin?.monitorId, props.subAgents],
+  );
+
+  if (
+    props.message.origin?.kind === "sub-agent"
+    && monitorOrigin?.kind === "monitor"
+  ) {
+    const statusTone = subAgentTone(monitorSubAgent?.status ?? monitorOrigin.outcome);
+    return (
+      <article
+        className="transcript-message transcript-message--injected transcript-message--monitor-result"
+      >
+        {renderMessageHeader({
+          continuation: false,
+          desktopApi: props.desktopApi,
+          message: props.message,
+          sourceThreadLink,
+          threadLinks,
+          text: messageCopyText,
+        })}
+        <div className="transcript-monitor-result__summary">
+          <button
+            type="button"
+            className="transcript-monitor-result__toggle"
+            aria-expanded={monitorExpanded}
+            onClick={() => setMonitorExpanded((current) => !current)}
+          >
+            <span
+              aria-hidden="true"
+              className="transcript-monitor-result__chevron"
+            />
+            <span>Monitor sub-agent completed</span>
+          </button>
+          <RailStatusChip
+            alert={statusTone === "error"}
+            tone={statusTone}
+          >
+            {monitorOutcomeLabel(monitorOrigin.outcome)}
+          </RailStatusChip>
+          {monitorSubAgent ? (
+            <button
+              type="button"
+              className="button button--ghost transcript-monitor-result__details"
+              onClick={() => setMonitorDetailsOpen(true)}
+            >
+              Details
+            </button>
+          ) : null}
+        </div>
+        {monitorExpanded ? (
+          <div className="transcript-monitor-result__content">
+            {messageSegments.map((segment, index) =>
+              renderMessageSegment({
+                segment,
+                index,
+                applications: props.applications,
+                desktopApi: props.desktopApi,
+                fileViewerContext: props.fileViewerContext,
+                onOpenImage: props.onOpenImage,
+                skills: props.skills,
+              }),
+            )}
+          </div>
+        ) : null}
+        {monitorDetailsOpen && monitorSubAgent ? (
+          <SubAgentDetailsModal
+            defaultBackend={
+              monitorSubAgent.backend
+              ?? props.message.origin.sourceThread?.backend
+              ?? "codex"
+            }
+            subAgent={monitorSubAgent}
+            onClose={() => setMonitorDetailsOpen(false)}
+          />
+        ) : null}
+      </article>
+    );
+  }
 
   if (messageSegments.length === 0) {
     return (
@@ -711,7 +801,25 @@ function labelForOrigin(origin: AppServerThreadMessageOrigin): string {
   if (origin.kind === "messaging") {
     return "Messaging";
   }
+  if (origin.kind === "sub-agent") {
+    return origin.subAgent?.kind === "monitor"
+      ? "Monitor sub-agent"
+      : "Sub-agent";
+  }
   return "PwrAgent";
+}
+
+function monitorOutcomeLabel(
+  outcome: NonNullable<AppServerThreadMessageOrigin["subAgent"]>["outcome"],
+): string {
+  switch (outcome) {
+    case "success":
+      return "Success";
+    case "failure":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+  }
 }
 
 function buildMessageCopyText(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -39,6 +39,7 @@ type TranscriptMessageProps = {
   >;
   fileViewerContext?: MarkdownFileViewerContext;
   message: AppServerThreadMessageEntry;
+  parentThreadId: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -138,6 +139,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
               ?? props.message.origin.sourceThread?.backend
               ?? "codex"
             }
+            parentThreadId={props.parentThreadId}
             subAgent={monitorSubAgent}
             onClose={() => setMonitorDetailsOpen(false)}
           />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -119,17 +119,19 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
         </div>
         {monitorExpanded ? (
           <div className="transcript-monitor-result__content">
-            {messageSegments.map((segment, index) =>
-              renderMessageSegment({
-                segment,
-                index,
-                applications: props.applications,
-                desktopApi: props.desktopApi,
-                fileViewerContext: props.fileViewerContext,
-                onOpenImage: props.onOpenImage,
-                skills: props.skills,
-              }),
-            )}
+            <div className="transcript-message__text">
+              {messageSegments.map((segment, index) =>
+                renderMessageSegment({
+                  segment,
+                  index,
+                  applications: props.applications,
+                  desktopApi: props.desktopApi,
+                  fileViewerContext: props.fileViewerContext,
+                  onOpenImage: props.onOpenImage,
+                  skills: props.skills,
+                }),
+              )}
+            </div>
           </div>
         ) : null}
         {monitorDetailsOpen && monitorSubAgent ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -5,6 +5,7 @@ import type {
   AppServerThreadImagePart,
   DesktopApplicationsSnapshot,
   MarkdownFileViewerContext,
+  ThreadSubAgentSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TranscriptActivity } from "./TranscriptActivity";
@@ -26,7 +27,9 @@ type TranscriptWorkPhaseGroupProps = {
   expanded: boolean;
   fileViewerContext?: MarkdownFileViewerContext;
   label: string;
+  parentThreadId?: string;
   skills: AppServerSkillSummary[];
+  subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onToggle: () => void;
 };
@@ -73,7 +76,9 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
               entry,
               fileViewerContext: props.fileViewerContext,
               onOpenImage: props.onOpenImage,
+              parentThreadId: props.parentThreadId ?? "",
               skills: props.skills,
+              subAgents: props.subAgents,
             })
           )}
         </div>
@@ -120,7 +125,9 @@ function renderEntry(params: {
   >;
   entry: AppServerThreadEntry;
   fileViewerContext?: MarkdownFileViewerContext;
+  parentThreadId: string;
   skills: AppServerSkillSummary[];
+  subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 }) {
   const entry = params.entry;
@@ -157,7 +164,9 @@ function renderEntry(params: {
       desktopApi={params.desktopApi}
       fileViewerContext={params.fileViewerContext}
       message={entry}
+      parentThreadId={params.parentThreadId}
       skills={params.skills}
+      subAgents={params.subAgents}
       onOpenImage={params.onOpenImage}
     />
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -284,6 +284,11 @@ describe("TranscriptList", () => {
     expect(
       container.querySelector(".transcript-monitor-result__content"),
     ).toHaveTextContent("Install Dependencies SUCCESS; Desktop E2E SUCCESS.");
+    expect(
+      container.querySelector(
+        ".transcript-monitor-result__content > .transcript-message__text",
+      ),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     expect(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -253,6 +253,7 @@ describe("TranscriptList", () => {
         ]}
         loading={false}
         loadingMore={false}
+        parentThreadId="parent-thread"
         subAgents={[subAgent]}
         onLoadOlder={async () => undefined}
       />,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -202,6 +202,90 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("attributes monitor handoffs and keeps their raw payload collapsed", () => {
+    const task = "Monitor GitHub CI for PR #1107 until all checks finish.";
+    const rawHandoff = [
+      "A lightweight PwrAgent monitor subagent finished a long-running task.",
+      "",
+      `Task: ${task}`,
+      "Outcome: success",
+      "Summary: All required checks passed.",
+      "Details:",
+      "Install Dependencies SUCCESS; Desktop E2E SUCCESS.",
+    ].join("\n");
+    const subAgent = {
+      monitorId: "monitor-1",
+      task,
+      status: "success" as const,
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      completedAt: 2_000,
+      backend: "codex" as const,
+      monitorThreadId: "monitor-thread",
+      outcome: "success" as const,
+      lastMessage: "All required checks passed.",
+    };
+
+    const { container } = render(
+      <TranscriptList
+        entries={[
+          {
+            type: "message",
+            id: "monitor-handoff",
+            role: "user",
+            text: rawHandoff,
+            origin: {
+              kind: "sub-agent",
+              sourceThread: {
+                backend: "codex",
+                threadId: "monitor-thread",
+                title: task,
+              },
+              subAgent: {
+                kind: "monitor",
+                monitorId: "monitor-1",
+                task,
+                outcome: "success",
+                summary: "All required checks passed.",
+              },
+            },
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        subAgents={[subAgent]}
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByText("Monitor sub-agent")).toBeInTheDocument();
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+    expect(screen.getByText("Monitor sub-agent completed")).toBeInTheDocument();
+    expect(screen.getByText("Success")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Install Dependencies SUCCESS; Desktop E2E SUCCESS."),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector(".transcript-message--monitor-result"),
+    ).toBeInTheDocument();
+
+    const toggle = screen.getByRole("button", {
+      name: "Monitor sub-agent completed",
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(
+      container.querySelector(".transcript-monitor-result__content"),
+    ).toHaveTextContent("Install Dependencies SUCCESS; Desktop E2E SUCCESS.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(
+      screen.getByRole("dialog", { name: `Sub-agent details: ${task}` }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("All required checks passed.")).toBeInTheDocument();
+  });
+
   it("shows a linked messaging origin with its full value in a tooltip", async () => {
     const { container } = render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -263,6 +263,11 @@ describe("TranscriptList", () => {
     expect(screen.queryByText("User")).not.toBeInTheDocument();
     expect(screen.getByText("Monitor sub-agent completed")).toBeInTheDocument();
     expect(screen.getByText("Success")).toBeInTheDocument();
+    const attribution = container.querySelector(
+      ".transcript-message__attribution--stacked",
+    );
+    expect(attribution).toContainElement(screen.getByText("Monitor sub-agent"));
+    expect(attribution).toContainElement(screen.getByText(task));
     expect(
       screen.queryByText("Install Dependencies SUCCESS; Desktop E2E SUCCESS."),
     ).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8874,6 +8874,76 @@ textarea,
   background: var(--bg-panel-elevated);
 }
 
+.transcript-message--monitor-result {
+  padding-bottom: 10px;
+}
+
+.transcript-monitor-result__summary {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.transcript-monitor-result__toggle {
+  display: inline-flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 28px;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  color: var(--text-primary);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  text-align: left;
+  cursor: pointer;
+}
+
+.transcript-monitor-result__toggle:focus-visible,
+.transcript-monitor-result__details:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.transcript-monitor-result__chevron {
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  color: var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.transcript-monitor-result__toggle[aria-expanded="true"]
+  .transcript-monitor-result__chevron {
+  transform: rotate(45deg);
+}
+
+.transcript-monitor-result__details {
+  flex: 0 0 auto;
+  min-height: 26px;
+  padding: 0 9px;
+  font-size: 11px;
+}
+
+.transcript-monitor-result__content {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.transcript-monitor-result__content .transcript-message__text-block:first-child {
+  margin-top: 0;
+}
+
 .transcript-message--table-wide {
   width: 100%;
   max-width: 100%;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9031,6 +9031,18 @@ textarea,
   gap: 8px;
 }
 
+.transcript-message__attribution--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  overflow: hidden;
+}
+
+.transcript-message__attribution--stacked .thread-chip,
+.transcript-message__attribution--stacked .transcript-message__source {
+  max-width: 100%;
+}
+
 .transcript-message__attribution .thread-chip {
   height: 20px;
 }
@@ -9120,10 +9132,12 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .transcript-message__role {
+  flex: 0 0 auto;
   font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .transcript-copy-button {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8940,6 +8940,10 @@ textarea,
   border-top: 1px solid var(--border-subtle);
 }
 
+.transcript-monitor-result__content > .transcript-message__text {
+  margin-top: 0;
+}
+
 .transcript-monitor-result__content .transcript-message__text-block:first-child {
   margin-top: 0;
 }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -333,7 +333,8 @@ export type AppServerThreadMessageOriginKind =
   | "agent"
   | "automation"
   | "messaging"
-  | "pwragent";
+  | "pwragent"
+  | "sub-agent";
 
 export type AppServerThreadMessageOrigin = {
   kind: AppServerThreadMessageOriginKind;
@@ -358,6 +359,13 @@ export type AppServerThreadMessageOrigin = {
       phoneNumber?: string;
       username?: string;
     };
+  };
+  subAgent?: {
+    kind: "monitor";
+    monitorId: string;
+    task: string;
+    outcome: "success" | "failure" | "cancelled";
+    summary: string;
   };
 };
 


### PR DESCRIPTION
## Summary

- I add first-class `sub-agent` provenance for monitor completion handoffs instead of submitting them as manual user messages.
- I render monitor handoffs as compact, collapsed transcript disclosures with outcome status, raw-payload expansion, and access to the existing sub-agent Details dialog.
- I reconstruct provenance for monitor handoffs recorded before this metadata existed, including ACP replay hydration, so existing transcripts no longer present these callbacks as user-authored messages.

## Verification

- I ran `pnpm typecheck`.
- I ran `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts` (476 tests passed).
- I ran `pnpm lint:eslint` (no errors; existing warning baseline only).
- I ran `pnpm lint:colors`.
- I ran `pnpm lint:codex-storage`.
- I ran `pnpm lint:boundaries`.
- I ran `git diff --check`.

## Notes

- The root cause was `finishTaskMonitorDelegation()` submitting the parent handoff with `origin: "manual"` and no structured `messageOrigin`, despite the turn queue already preserving provenance for other injected message sources.
- The full monitor callback remains available through the disclosure and copy action, but it is collapsed by default so the parent agent's concise response remains the primary transcript content.
