### PR TITLE
fix(desktop): restore thread state after HMR

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -13558,6 +13558,58 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("reattaches active Codex threads from thread-list runtime status", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "thread-reattached",
+          title: "Still working after HMR",
+          titleSource: "explicit",
+          threadStatus: "active",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({ backend: "codex" });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 1,
+      threadIds: ["codex:thread-reattached"],
+    });
+    await expect(
+      registry.startTurn({
+        backend: "codex",
+        threadId: "thread-reattached",
+        input: [{ type: "text", text: "do not overlap the surviving turn" }],
+      }),
+    ).rejects.toThrow("A turn is already active for this thread.");
+
+    await codexClient.emit({
+      method: "thread/status/changed",
+      params: {
+        threadId: "thread-reattached",
+        status: { type: "idle" },
+      },
+    });
+
+    expect(registry.getInProgressThreadSnapshotForQuit()).toEqual({
+      count: 0,
+      threadIds: [],
+    });
+
+    await registry.close();
+  });
+
   it("reserves Codex turn starts before awaited pre-start work", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -13747,6 +13799,10 @@ command = "pnpm dev"
       overlayStore: createOverlayStoreMock(),
       threadTitleGenerationService: titleService,
     });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
 
     await expect(
       registry.startTurn({
@@ -13770,6 +13826,23 @@ command = "pnpm dev"
     expect(codexClient.lastRenameThreadParams).toEqual({
       threadId: "thread-title",
       name: "Leopard tea button",
+    });
+    await waitForCondition(() =>
+      events.some(
+        (event) =>
+          event.notification.method === "thread/name/updated"
+          && event.notification.params.threadId === "thread-title",
+      ),
+    );
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-title",
+          threadName: "Leopard tea button",
+        },
+      },
     });
 
     await registry.close();

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -586,6 +586,7 @@ class MockTransport implements JsonRpcTransport {
                 id: "thread-2",
                 title: "Ship desktop shell",
                 summary: "Hook up Electron and the sidebar",
+                status: { type: "active", activeFlags: [] },
                 updatedAt: 1_763_500_000,
                 session: {
                   cwd: "/Users/huntharo/pwrdrvr/PwrAgent"
@@ -1250,6 +1251,7 @@ describe("CodexAppServerClient", () => {
       id: "thread-2",
       title: "Ship desktop shell",
       titleSource: "explicit",
+      threadStatus: "active",
       source: "codex",
       linkedDirectories: [
         {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5670,6 +5670,13 @@ export class DesktopBackendRegistry {
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
   private readonly activeTurnKeys = new Set<string>();
+  /**
+   * Codex runtime activity recovered from `thread/list` / `thread/read`.
+   * The long-lived Codex registry keeps this truth across a desktop
+   * main-process HMR even when the replacement connection never observed the
+   * original `turn/started` notification.
+   */
+  private readonly backendActiveCodexThreadIds = new Set<string>();
   private readonly liveThreadUsageBaselines = new Map<
     string,
     TaskMonitorTokenUsageBreakdown
@@ -8299,6 +8306,18 @@ export class DesktopBackendRegistry {
       );
     }
     this.invalidateThreadListCache(backend);
+    if (!isAcpBackendId(backend)) {
+      await this.emit({
+        backend,
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: result.threadId,
+            threadName: request.name.trim(),
+          },
+        },
+      });
+    }
 
     return {
       backend,
@@ -8426,6 +8445,10 @@ export class DesktopBackendRegistry {
             before: request.before,
             limit: request.limit,
           });
+
+    if (backend === "codex") {
+      this.reconcileBackendCodexThreadStatus(request.threadId, replay.threadStatus);
+    }
 
     if (
       backend === "codex" &&
@@ -9460,6 +9483,9 @@ export class DesktopBackendRegistry {
     threadIds: string[];
   } {
     const threadKeys = new Set<string>();
+    for (const threadId of this.backendActiveCodexThreadIds) {
+      threadKeys.add(formatQuitThreadKey("codex", threadId));
+    }
     for (const key of this.activeTurnKeys) {
       const parsed = parseActiveTurnKey(key);
       if (parsed) {
@@ -11508,12 +11534,28 @@ export class DesktopBackendRegistry {
    * flight on this thread. `activeCodexTurnModes` is keyed by
    * `${threadId}:${turnId}`; one or more matching keys → active turn.
    */
+  private reconcileBackendCodexThreadStatus(
+    threadId: string,
+    status: string | undefined,
+  ): void {
+    if (status === "active") {
+      this.backendActiveCodexThreadIds.add(threadId);
+      return;
+    }
+    if (status) {
+      this.backendActiveCodexThreadIds.delete(threadId);
+    }
+  }
+
   private threadHasActiveTurn(
     threadId: string,
     backend: AppServerBackendKind = "codex",
   ): boolean {
     if (backend === "codex") {
       if (this.reservedCodexStartThreadIds.has(threadId)) {
+        return true;
+      }
+      if (this.backendActiveCodexThreadIds.has(threadId)) {
         return true;
       }
 
@@ -15289,6 +15331,10 @@ export class DesktopBackendRegistry {
       }),
     );
 
+    for (const thread of enrichedThreads) {
+      this.reconcileBackendCodexThreadStatus(thread.id, thread.threadStatus);
+    }
+
     return enrichedThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
@@ -18578,12 +18624,12 @@ export class DesktopBackendRegistry {
       await this.renameAcpSession(params.backend, params.threadId, params.title, {
         titleSource: "derived",
       });
-    } else if (params.backend === "codex") {
-      await this.withCodexThreadClient(params.threadId, async (client) =>
-        await this.renameWithClient(client, params.threadId, params.title)
-      );
     } else {
-      await this.renameWithClient(this.grokClient, params.threadId, params.title);
+      await this.renameThread({
+        backend: params.backend,
+        threadId: params.threadId,
+        name: params.title,
+      });
     }
   }
 
@@ -23227,6 +23273,16 @@ export class DesktopBackendRegistry {
 
     if (
       event.backend === "codex" &&
+      event.notification.method === "thread/status/changed"
+    ) {
+      this.reconcileBackendCodexThreadStatus(
+        event.notification.params.threadId,
+        readStatusType(event.notification.params.status),
+      );
+    }
+
+    if (
+      event.backend === "codex" &&
       event.notification.method === "thread/status/changed" &&
       readStatusType(event.notification.params.status) === "active"
     ) {
@@ -23254,6 +23310,9 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromStartedNotification(notification);
+      if (event.backend === "codex") {
+        this.backendActiveCodexThreadIds.add(notification.params.threadId);
+      }
       if (!isAcpBackendId(event.backend)) {
         this.schedulePendingThreadTitleGenerationFromLifecycle({
           backend: event.backend,
@@ -23300,6 +23359,9 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromTerminalNotification(notification);
+      if (event.backend === "codex") {
+        this.backendActiveCodexThreadIds.delete(notification.params.threadId);
+      }
       const managedReview = turnId
         ? this.findActiveReviewSubAgentForTerminal({
             backend: event.backend,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4966,11 +4966,13 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
           "first_user_message",
         ])
     );
+    const threadStatus = readThreadStatus(record);
 
     summaries.set(threadId, {
       id: threadId,
       title: titleInfo.title,
       titleSource: titleInfo.titleSource,
+      ...(threadStatus ? { threadStatus } : {}),
       summary:
         summary === titleInfo.title ||
         (titleInfo.titleSource === "derived" &&

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -9,7 +9,7 @@ export function getThreadRowStatus(
   thinkingThreadKeys?: Record<string, boolean>
 ): ThreadRowStatusKind | undefined {
   const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-  if (thinkingThreadKeys?.[threadKey]) {
+  if (thread.threadStatus === "active" || thinkingThreadKeys?.[threadKey]) {
     return "thinking";
   }
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1452,6 +1452,40 @@ describe("Sidebar", () => {
     expect(threadButton.querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
+  it("shows thinking from backend runtime status after renderer HMR", () => {
+    const activeThread = {
+      ...sharedThread,
+      threadStatus: "active" as const,
+    };
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[activeThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[activeThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: /Cross-project cleanup/i,
+    });
+
+    expect(
+      threadButton.querySelector('[data-thread-status="thinking"]')
+    ).not.toBeNull();
+  });
+
   it("shows an approval chip for threads waiting on an approval request", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -109,6 +109,86 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("keeps runtime thread status current across refreshes and lifecycle events", async () => {
+    let threadStatus: "active" | "idle" = "active";
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [
+        {
+          id: "thread-1",
+          title: "Surviving HMR turn",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          threadStatus,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread" as const,
+          },
+          updatedAt: 1_000,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.threadStatus).toBe("active");
+    });
+
+    threadStatus = "idle";
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("idle");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: { type: "active" },
+          },
+        },
+      });
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("active");
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/status/changed",
+          params: {
+            threadId: "thread-1",
+            status: { type: "idle" },
+          },
+        },
+      });
+    });
+    expect(result.current.threads[0]?.threadStatus).toBe("idle");
+  });
+
   it("clears a directory attention count after the selected thread is marked seen", async () => {
     const markThreadSeen = vi.fn(async () => ({
       backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -9044,10 +9044,13 @@ describe("useThreadSessionState", () => {
       })),
     };
 
-    const { result } = renderHook(() =>
+    const { result, rerender } = renderHook(() =>
       useThreadSessionState({
         desktopApi,
-        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          threadStatus: "active" as const,
+        },
       })
     );
 
@@ -9061,15 +9064,10 @@ describe("useThreadSessionState", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
-          method: "turn/completed",
+          method: "thread/status/changed",
           params: {
             threadId: "thread-1",
-            turnId: "turn-survived-hmr",
-            turn: {
-              id: "turn-survived-hmr",
-              status: "completed",
-              output: [],
-            },
+            status: { type: "idle" },
           },
         },
       });
@@ -9079,6 +9077,12 @@ describe("useThreadSessionState", () => {
       expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
       expect(result.current.threadBusy).toBe(false);
     });
+
+    rerender();
+
+    expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+    expect(result.current.pendingStatusText).toBeUndefined();
+    expect(result.current.threadBusy).toBe(false);
   });
 
   it("renders item/fileChange/outputDelta as a Changed file activity entry", async () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -9019,6 +9019,68 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("restores thinking from active backend status after renderer HMR", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "active" as const,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBe(true);
+      expect(result.current.pendingStatusText).toBe("Thinking");
+      expect(result.current.threadBusy).toBe(true);
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-survived-hmr",
+            turn: {
+              id: "turn-survived-hmr",
+              status: "completed",
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.thinkingThreadKeys["codex:thread-1"]).toBeUndefined();
+      expect(result.current.threadBusy).toBe(false);
+    });
+  });
+
   it("renders item/fileChange/outputDelta as a Changed file activity entry", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4,6 +4,7 @@ import type {
   AppServerCollaborationModeRequest,
   AppServerReviewTarget,
   AppServerThreadImagePart,
+  AppServerThreadStatus,
   AppServerTurnInputItem,
   ArchiveThreadCleanupResult,
   CodexThreadEnvironmentRuntime,
@@ -698,6 +699,7 @@ function threadSummariesEqual(
     left.projectKey === right.projectKey &&
     left.createdAt === right.createdAt &&
     left.updatedAt === right.updatedAt &&
+    left.threadStatus === right.threadStatus &&
     left.gitBranch === right.gitBranch &&
     left.observedGitBranch === right.observedGitBranch &&
     // Working state is probed on its own cadence (background refresh +
@@ -1414,6 +1416,37 @@ function applyThreadNameUpdate(
         threads,
       }
     : snapshot;
+}
+
+function applyThreadStatusUpdate(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    threadStatus: AppServerThreadStatus;
+  }
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (thread.source !== params.backend || thread.id !== params.threadId) {
+      return thread;
+    }
+    if (thread.threadStatus === params.threadStatus) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      threadStatus: params.threadStatus,
+    };
+  });
+
+  return changed ? { ...snapshot, threads } : snapshot;
 }
 
 function applyThreadPullRequestsUpdate(
@@ -3036,6 +3069,37 @@ export function useThreadNavigation(
           };
         });
         scheduleRefresh();
+        return;
+      }
+
+      if (method === "thread/status/changed") {
+        const { threadId, status } = event.notification.params as {
+          threadId: string;
+          status?: { type?: string };
+        };
+        const threadStatus = status?.type;
+        if (
+          threadStatus !== "active"
+          && threadStatus !== "idle"
+          && threadStatus !== "notLoaded"
+          && threadStatus !== "unknown"
+        ) {
+          return;
+        }
+
+        setState((current) => ({
+          ...current,
+          response: applyThreadStatusUpdate(current.response, {
+            backend: event.backend,
+            threadId,
+            threadStatus,
+          }),
+        }));
+        setOptimisticThread((current) =>
+          current?.source === event.backend && current.id === threadId
+            ? { ...current, threadStatus }
+            : current
+        );
         return;
       }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3235,6 +3235,7 @@ export function useThreadSessionState(params: {
   const lastLiveActivitySignatureRef = useRef<Record<string, string>>({});
   const requestVersionsRef = useRef<Record<string, number>>({});
   const staleThinkingLogKeysRef = useRef<Set<string>>(new Set());
+  const threadStatusSummarySeedRef = useRef<Record<string, string>>({});
   const [sessions, setSessions] = useState<ThreadSessionState>({});
 
   selectedThreadKeyRef.current = threadKey;
@@ -3544,16 +3545,20 @@ export function useThreadSessionState(params: {
     }
 
     if (thread.threadStatus === "active" || thread.threadStatus === "idle") {
-      const backendReportedActive = thread.threadStatus === "active";
-      updateSession(threadKey, (current) =>
-        current.backendReportedActive === backendReportedActive
-          ? current
-          : {
-              ...current,
-              backendReportedActive,
-              lastTouchedAt: Date.now(),
-            }
-      );
+      const summarySeed = `${thread.threadStatus}:${thread.updatedAt ?? "unknown"}`;
+      if (threadStatusSummarySeedRef.current[threadKey] !== summarySeed) {
+        threadStatusSummarySeedRef.current[threadKey] = summarySeed;
+        const backendReportedActive = thread.threadStatus === "active";
+        updateSession(threadKey, (current) =>
+          current.backendReportedActive === backendReportedActive
+            ? current
+            : {
+                ...current,
+                backendReportedActive,
+                lastTouchedAt: Date.now(),
+              }
+        );
+      }
     }
 
     const optimisticUserMessage = thread.optimisticUserMessage;

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -129,6 +129,7 @@ type TurnUsageAccumulator = {
 type ThreadSessionEntry = {
   activeTurnId?: string;
   activeTurnStartedAt?: number;
+  backendReportedActive?: boolean;
   completionHydrationRetries: number;
   contextWindow?: ThreadContextWindowState;
   error?: string;
@@ -163,6 +164,7 @@ type ThinkingStateReason = {
   entryType?: AppServerThreadEntry["type"];
   kind:
     | "activeTurn"
+    | "backendActive"
     | "liveOptimisticEntry"
     | "pendingAssistantMessage"
     | "pendingMcpInteraction"
@@ -1307,6 +1309,10 @@ function summarizeOptimisticEntryReason(
 
 function describeThinkingState(session: ThreadSessionEntry): ThinkingStateReason[] {
   const reasons: ThinkingStateReason[] = [];
+
+  if (session.backendReportedActive) {
+    reasons.push({ kind: "backendActive" });
+  }
 
   if (session.activeTurnId) {
     reasons.push({
@@ -3402,6 +3408,13 @@ export function useThreadSessionState(params: {
             ? current.completionHydrationRetries + 1
             : 0;
           const thinkingReasons = describeThinkingState(current);
+          const responseThreadStatus = readResponseThreadStatus(response);
+          const backendReportedActive =
+            responseThreadStatus === "active"
+              ? true
+              : responseThreadStatus === "idle"
+                ? false
+                : current.backendReportedActive;
           const now = Date.now();
           const ownUpdateSettlesAt =
             current.lastTouchedAt + OWN_UPDATE_IDLE_GRACE_MS;
@@ -3424,7 +3437,7 @@ export function useThreadSessionState(params: {
             )
             && now < ownUpdateSettlesAt;
           const shouldClearStaleThinking =
-            readResponseThreadStatus(response) === "idle"
+            responseThreadStatus === "idle"
             && thinkingReasons.length > 0
             && !hasPendingInteraction(current)
             && !ownUpdateStillSettling
@@ -3456,6 +3469,7 @@ export function useThreadSessionState(params: {
             activeTurnStartedAt: shouldClearStaleThinking
               ? undefined
               : current.activeTurnStartedAt,
+            backendReportedActive,
             error: undefined,
             expectOwnUpdate: false,
             failedHydrationVersion: undefined,
@@ -3527,6 +3541,19 @@ export function useThreadSessionState(params: {
   useEffect(() => {
     if (!thread || !threadKey) {
       return;
+    }
+
+    if (thread.threadStatus === "active" || thread.threadStatus === "idle") {
+      const backendReportedActive = thread.threadStatus === "active";
+      updateSession(threadKey, (current) =>
+        current.backendReportedActive === backendReportedActive
+          ? current
+          : {
+              ...current,
+              backendReportedActive,
+              lastTouchedAt: Date.now(),
+            }
+      );
     }
 
     const optimisticUserMessage = thread.optimisticUserMessage;
@@ -4045,6 +4072,7 @@ export function useThreadSessionState(params: {
             ...current,
             activeTurnId: turnId,
             activeTurnStartedAt: startedAt,
+            backendReportedActive: true,
             expectOwnUpdate: true,
             interacted: true,
             lastTouchedAt: nextLastTouchedAt,
@@ -4301,6 +4329,9 @@ export function useThreadSessionState(params: {
               activeTurnStartedAt: completedTurnMatchesActive
                 ? undefined
                 : current.activeTurnStartedAt,
+              backendReportedActive: completedTurnMatchesActive
+                ? false
+                : current.backendReportedActive,
               error: undefined,
               lastTouchedAt: nextLastTouchedAt,
               pendingAssistantMessage: completedTurnMatchesActive
@@ -4461,6 +4492,9 @@ export function useThreadSessionState(params: {
             activeTurnStartedAt: completedTurnMatchesActive
               ? undefined
               : current.activeTurnStartedAt,
+            backendReportedActive: completedTurnMatchesActive
+              ? false
+              : current.backendReportedActive,
             completionHydrationRetries: completedTurnMatchesActive
               ? 0
               : current.completionHydrationRetries,
@@ -4541,6 +4575,7 @@ export function useThreadSessionState(params: {
             ...current,
             activeTurnId: undefined,
             activeTurnStartedAt: undefined,
+            backendReportedActive: false,
             completionHydrationRetries: 0,
             error: undefined,
             expectOwnUpdate: false,
@@ -4575,6 +4610,7 @@ export function useThreadSessionState(params: {
             ...current,
             activeTurnId: undefined,
             activeTurnStartedAt: undefined,
+            backendReportedActive: false,
             completionHydrationRetries: 0,
             error: undefined,
             expectOwnUpdate: false,
@@ -4598,15 +4634,28 @@ export function useThreadSessionState(params: {
               ? event.notification.params.status.type
               : undefined;
 
+          if (statusType === "active") {
+            return {
+              ...current,
+              backendReportedActive: true,
+              lastTouchedAt: nextLastTouchedAt,
+            };
+          }
+
           if (statusType === "idle") {
             if (current.activeTurnId || current.pendingStatusText) {
-              return current;
+              return {
+                ...current,
+                backendReportedActive: false,
+                lastTouchedAt: nextLastTouchedAt,
+              };
             }
 
             return {
               ...current,
               activeTurnId: undefined,
               activeTurnStartedAt: undefined,
+              backendReportedActive: false,
               lastTouchedAt: nextLastTouchedAt,
               pendingAssistantMessage: undefined,
               pendingStatusText: undefined,
@@ -5180,7 +5229,9 @@ export function useThreadSessionState(params: {
   );
   const pendingStatusText =
     selectedSession?.pendingStatusText ??
-    (selectedSession?.activeTurnId ? "Thinking" : undefined);
+    (selectedSession?.activeTurnId || selectedSession?.backendReportedActive
+      ? "Thinking"
+      : undefined);
   const threadBusy = selectedSession ? hasThinkingState(selectedSession) : false;
 
   return {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -295,6 +295,8 @@ export type AppServerThreadSummary = {
   id: ThreadIdentifier;
   title: string;
   titleSource: AppServerThreadTitleSource;
+  /** Current backend runtime status when exposed by the thread-list protocol. */
+  threadStatus?: AppServerThreadStatus;
   summary?: string;
   projectKey?: string;
   createdAt?: number;


### PR DESCRIPTION
## Summary

- preserve Codex runtime thread status from `thread/list` and `thread/read`
- reconstruct active-thread state after desktop main/renderer HMR
- restore thinking indicators and prevent overlapping turns for surviving work
- invalidate cached thread lists and emit a local name update after generated-title renames

## Root cause

The long-lived Codex registry continued running turns across development HMR, but the replacement desktop connection relied on lifecycle notifications it had never observed. Thread-list normalization also discarded the backend runtime status, so the renderer could briefly infer activity and then clear it.

Generated title application had a related convergence gap: the helper successfully renamed the backend thread, but that path bypassed the registry thread-list cache invalidation and depended on a provider notification that could be missed during HMR. The backend therefore held the correct title while the renderer remained on “Untitled thread.”

## Developer impact

Developers running `pnpm dev` can now pull/reload while turns continue in the registry and still see reliable active indicators and generated titles after the desktop reconnects.

## Validation

- focused desktop test files — 707 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- targeted ESLint with `--quiet`
- `git diff origin/main...HEAD --check`