### PR TITLE
fix(desktop): exclude inherited subagent usage

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -16078,13 +16078,21 @@ command = "pnpm dev"
         turnId: "turn-review-1",
         model: "gpt-5.5",
         tokenUsage: {
+          // The review inherits 100k input / 5k output from the parent. Only
+          // the latest request belongs to this review and may be priced here.
           total: {
             fastMode: true,
+            inputTokens: 101_000,
+            cachedInputTokens: 90_200,
+            outputTokens: 5_050,
+            reasoningOutputTokens: 1_010,
+            serviceTier: "priority",
+          },
+          last: {
             inputTokens: 1_000,
             cachedInputTokens: 200,
             outputTokens: 50,
             reasoningOutputTokens: 10,
-            serviceTier: "priority",
           },
         },
       },
@@ -16601,7 +16609,15 @@ command = "pnpm dev"
         turnId: "turn-native-1",
         model: "gpt-5.4-mini",
         tokenUsage: {
+          // Native spawnAgent threads also inherit cumulative parent totals.
+          // The parent already paid for this baseline; the card starts at last.
           total: {
+            inputTokens: 101_000,
+            cachedInputTokens: 90_100,
+            outputTokens: 5_040,
+            reasoningOutputTokens: 1_010,
+          },
+          last: {
             inputTokens: 1_000,
             cachedInputTokens: 100,
             outputTokens: 40,
@@ -16627,11 +16643,52 @@ command = "pnpm dev"
         uncachedInputTokens: 900,
       },
     });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: nativeThreadId,
+        turnId: "turn-native-1",
+        model: "gpt-5.4-mini",
+        tokenUsage: {
+          total: {
+            inputTokens: 103_000,
+            cachedInputTokens: 91_600,
+            outputTokens: 5_100,
+            reasoningOutputTokens: 1_020,
+          },
+          last: {
+            inputTokens: 2_000,
+            cachedInputTokens: 1_500,
+            outputTokens: 60,
+            reasoningOutputTokens: 10,
+          },
+        },
+      },
+    });
+
+    const updatedUsageOverlay = await overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-parent",
+    });
+    expect(updatedUsageOverlay?.subAgents?.[0]?.monitorUsage).toMatchObject({
+      summary: expect.stringContaining(
+        "1,400 uncached in · 1,600 cached · 100 out (20 reasoning)",
+      ),
+      tokenUsage: {
+        cachedInputTokens: 1_600,
+        inputTokens: 3_000,
+        outputTokens: 100,
+        reasoningOutputTokens: 20,
+        totalTokens: 3_120,
+        uncachedInputTokens: 1_400,
+      },
+    });
     const pricing = await overlayStore.readThreadPricing({
       backend: "codex",
       threadId: "thread-parent",
     });
-    expect(upsertThreadUsageLine).toHaveBeenCalledTimes(1);
+    expect(upsertThreadUsageLine).toHaveBeenCalledTimes(2);
     expect(upsertThreadUsageLine).toHaveBeenCalledWith({
       line: expect.objectContaining({
         source: "monitor",
@@ -16650,9 +16707,14 @@ command = "pnpm dev"
       sourceItemId: `codex-native:${nativeThreadId}`,
       threadId: nativeThreadId,
       turnId: "turn-native-1",
+      inputTokens: 3_000,
+      cachedInputTokens: 1_600,
+      uncachedInputTokens: 1_400,
+      outputTokens: 100,
+      reasoningOutputTokens: 20,
     });
     expect(pricing.lines[0]?.totalCostMicros).toBeGreaterThan(0);
-    expect(upsertThreadSubAgent).toHaveBeenCalledTimes(2);
+    expect(upsertThreadSubAgent).toHaveBeenCalledTimes(3);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14933,11 +14933,14 @@ export class DesktopBackendRegistry {
         readTaskMonitorUsageFastMode(notification.params.tokenUsage) ??
         reviewRecord?.fastMode ??
         completedReviewRecord?.fastMode;
-      const usageSnapshot = buildTaskMonitorUsageSnapshot({
+      const usageSnapshot = this.buildIncrementalSubAgentUsageSnapshot({
+        backend: event.backend,
         fastMode,
         model,
         serviceTier,
+        threadId: notification.params.threadId,
         tokenUsage: notification.params.tokenUsage,
+        turnId: notification.params.turnId,
       });
       if (!usageSnapshot) {
         return;
@@ -15140,6 +15143,40 @@ export class DesktopBackendRegistry {
         records.totalUsage,
       ...(seededBaselineTokenUsage ? { seededBaselineTokenUsage } : {}),
     };
+  }
+
+  /**
+   * Build usage for a forked sub-agent turn without charging the child for the
+   * cumulative history inherited from its parent. Codex reports both the
+   * session-wide `total` and the latest request; the first observation seeds a
+   * stable `total - latest` baseline, and subsequent observations report only
+   * the child turn's growth beyond that baseline.
+   *
+   * When the protocol cannot provide a latest-request breakdown, derivation
+   * retains the existing whole-total fallback rather than inventing a fork
+   * baseline that cannot be measured safely.
+   */
+  private buildIncrementalSubAgentUsageSnapshot(params: {
+    backend: AppServerBackendKind;
+    fastMode?: boolean;
+    model?: string;
+    serviceTier?: string;
+    threadId: string;
+    tokenUsage: unknown;
+    turnId?: string;
+  }): TaskMonitorUsageSnapshot | undefined {
+    const derivedUsage = this.deriveLiveThreadTokenUsage({
+      backend: params.backend,
+      threadId: params.threadId,
+      tokenUsage: params.tokenUsage,
+      turnId: params.turnId,
+    });
+    return buildTaskMonitorUsageSnapshot({
+      fastMode: params.fastMode,
+      model: params.model,
+      serviceTier: params.serviceTier,
+      tokenUsage: derivedUsage.turnTokenUsage,
+    });
   }
 
   // Observe one `thread/tokenUsage/updated` and fold any newly-completed model
@@ -15540,18 +15577,21 @@ export class DesktopBackendRegistry {
       event.notification.params.tokenUsage,
     );
     const model = notificationModel ?? existing.preferredModel;
-    const usageSnapshot = buildTaskMonitorUsageSnapshot({
+    const monitorTurnId =
+      readOptionalString(notificationParams, ["turnId", "turn_id"]) ??
+      existing.monitorTurnId;
+    const usageSnapshot = this.buildIncrementalSubAgentUsageSnapshot({
+      backend: "codex",
       fastMode,
       model,
       serviceTier,
+      threadId: event.notification.params.threadId,
       tokenUsage: event.notification.params.tokenUsage,
+      turnId: monitorTurnId,
     });
     if (!usageSnapshot) {
       return;
     }
-    const monitorTurnId =
-      readOptionalString(notificationParams, ["turnId", "turn_id"]) ??
-      existing.monitorTurnId;
     const observedReplays = this.observeLiveThreadContextReplay({
       backend: "codex",
       threadId: event.notification.params.threadId,


### PR DESCRIPTION
## Summary

- I subtract a stable `total - latest` baseline before pricing Codex-native `spawnAgent` and managed-review sub-agent usage, so inherited parent history is not charged again on the child card or parent rollup.
- I preserve the existing whole-total fallback when Codex does not provide a latest-request breakdown.
- I added regression coverage for a nonzero inherited baseline and for later cumulative updates that must continue subtracting the original baseline.

## Verification

- I first ran the new inherited-baseline cases against the old implementation and confirmed that both failed by reporting the full cumulative totals.
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (404 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`

## Notes

- The root cause was a split usage path: ordinary live threads already derived per-turn deltas, while native spawn-agent and review cards passed session-wide cumulative totals directly into monitor pricing.
- This prevents future and re-emitted usage from double-counting inherited history. It does not rewrite already-persisted incorrect historical monitor rows.
