### PR TITLE
feat(desktop): show native Codex agent threads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -17237,6 +17237,107 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("projects Codex spawned agent threads into the one-level child tree", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-root",
+          title: "Root thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          createdAt: 1_000,
+          updatedAt: 4_000,
+        },
+        {
+          id: "thread-child",
+          title: "First spawned agent",
+          titleSource: "derived",
+          source: "codex",
+          linkedDirectories: [],
+          createdAt: 2_000,
+          updatedAt: 3_000,
+          codexNativeSubAgent: {
+            parentThreadId: "thread-root",
+            depth: 1,
+            agentNickname: "first-child",
+          },
+        },
+        {
+          id: "thread-grandchild",
+          title: "Nested spawned agent",
+          titleSource: "derived",
+          source: "codex",
+          linkedDirectories: [],
+          createdAt: 3_000,
+          updatedAt: 2_000,
+          codexNativeSubAgent: {
+            parentThreadId: "thread-child",
+            depth: 2,
+            agentNickname: "nested-child",
+          },
+        },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+
+    const threads = await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "thread-root",
+      "thread-child",
+      "thread-grandchild",
+    ]);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-child",
+      }),
+    ).resolves.toMatchObject({ parentThreadId: "thread-root" });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-grandchild",
+      }),
+    ).resolves.toMatchObject({ parentThreadId: "thread-root" });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-root",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["thread-child", "thread-grandchild"],
+    });
+
+    await registry.listThreads({
+      backend: "codex",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-root",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["thread-child", "thread-grandchild"],
+    });
+
+    await registry.close();
+  });
+
   it("persists Codex native spawnAgent calls as sub-agent summaries", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -445,7 +445,8 @@ class MockTransport implements JsonRpcTransport {
         const matchesCodexWindow =
           params.params?.limit === 50 &&
           params.params?.sortKey === "updated_at" &&
-          JSON.stringify(params.params?.sourceKinds) === JSON.stringify(["cli", "vscode"]);
+          JSON.stringify(params.params?.sourceKinds) ===
+          JSON.stringify(["cli", "vscode", "subAgentThreadSpawn"]);
 
         this.messageHandler(
           JSON.stringify({
@@ -1294,7 +1295,7 @@ describe("CodexAppServerClient", () => {
             archived: false,
             limit: 50,
             sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
+            sourceKinds: ["cli", "vscode", "subAgentThreadSpawn"],
             useStateDbOnly: true,
           }
         }),
@@ -1338,6 +1339,67 @@ describe("CodexAppServerClient", () => {
         },
       ],
       source: "codex",
+    });
+
+    await client.close();
+  });
+
+  it("lists spawned agent threads with native parent provenance", async () => {
+    MockTransport.threadListResultBySearchTerm.set("native-subagent-source", [
+      {
+        id: "thread-parent",
+        preview: "Parent thread",
+        threadSource: "cli",
+        updatedAt: 1_777_500_000,
+        cwd: "/repo/app",
+      },
+      {
+        id: "thread-child",
+        preview: "Investigate the child task",
+        threadSource: "subAgentThreadSpawn",
+        parentThreadId: "thread-parent",
+        agentNickname: "route-scout",
+        agentRole: "explorer",
+        source: {
+          subAgent: {
+            thread_spawn: {
+              parent_thread_id: "thread-parent",
+              depth: 1,
+              agent_nickname: "route-scout",
+              agent_role: "explorer",
+            },
+          },
+        },
+        updatedAt: 1_777_500_100,
+        cwd: "/repo/app",
+      },
+      {
+        id: "thread-review-helper",
+        preview: "Review helper",
+        threadSource: "subAgentReview",
+        parentThreadId: "thread-parent",
+        source: { subAgent: "review" },
+        updatedAt: 1_777_500_200,
+        cwd: "/repo/app",
+      },
+    ]);
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const threads = await client.listThreads({ filter: "native-subagent-source" });
+
+    expect(threads.map((thread) => thread.id)).toEqual([
+      "thread-child",
+      "thread-parent",
+    ]);
+    expect(threads[0]?.codexNativeSubAgent).toEqual({
+      parentThreadId: "thread-parent",
+      depth: 1,
+      agentNickname: "route-scout",
+      agentRole: "explorer",
     });
 
     await client.close();
@@ -1966,7 +2028,7 @@ describe("CodexAppServerClient", () => {
             archived: false,
             limit: 50,
             sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
+            sourceKinds: ["cli", "vscode", "subAgentThreadSpawn"],
             useStateDbOnly: true,
           })
         }),
@@ -2281,7 +2343,7 @@ describe("CodexAppServerClient", () => {
           params: expect.objectContaining({
             searchTerm: "updated-at-sort",
             sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
+            sourceKinds: ["cli", "vscode", "subAgentThreadSpawn"],
             useStateDbOnly: true,
           }),
         }),
@@ -2319,7 +2381,7 @@ describe("CodexAppServerClient", () => {
           params: expect.objectContaining({
             searchTerm: "jsonl-mtime-repair",
             sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
+            sourceKinds: ["cli", "vscode", "subAgentThreadSpawn"],
             useStateDbOnly: true,
           }),
         }),
@@ -2390,7 +2452,7 @@ describe("CodexAppServerClient", () => {
             searchTerm: "search-product-parity",
             limit: 50,
             sortKey: "updated_at",
-            sourceKinds: ["cli", "vscode"],
+            sourceKinds: ["cli", "vscode", "subAgentThreadSpawn"],
           }),
         }),
       ]),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -15438,6 +15438,14 @@ export class DesktopBackendRegistry {
       backend: "codex",
       threadIds: threadsWithPending.map((thread) => thread.id),
     });
+    if (!params.archived && !params.filter?.trim()) {
+      const nativeSubAgentOverlays =
+        await this.reconcileCodexNativeSubAgentRelationships({
+          overlaysByThreadId,
+          threads: threadsWithPending,
+        });
+      Object.assign(overlaysByThreadId, nativeSubAgentOverlays);
+    }
     const visibleThreads = threadsWithPending.filter(
       (thread) => overlaysByThreadId[thread.id]?.archiveTombstonedAt === undefined,
     );
@@ -15494,6 +15502,109 @@ export class DesktopBackendRegistry {
     return enrichedThreads.sort(
       (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
     );
+  }
+
+  private async reconcileCodexNativeSubAgentRelationships(params: {
+    overlaysByThreadId: Record<string, ThreadOverlayState | undefined>;
+    threads: AppServerThreadSummary[];
+  }): Promise<Record<string, ThreadOverlayState | undefined>> {
+    const setThreadParent = this.overlayStore.setThreadParent;
+    const updateSubthreadOrder = this.overlayStore.updateSubthreadOrder;
+    if (!setThreadParent || !updateSubthreadOrder) {
+      return {};
+    }
+
+    const updatedOverlaysByThreadId: Record<
+      string,
+      ThreadOverlayState | undefined
+    > = {};
+    const spawnedThreads = params.threads
+      .filter(
+        (thread) =>
+          thread.source === "codex" && Boolean(thread.codexNativeSubAgent),
+      )
+      .sort((left, right) => {
+        const depthDifference =
+          (left.codexNativeSubAgent?.depth ?? Number.MAX_SAFE_INTEGER)
+          - (right.codexNativeSubAgent?.depth ?? Number.MAX_SAFE_INTEGER);
+        if (depthDifference !== 0) {
+          return depthDifference;
+        }
+        return (left.createdAt ?? 0) - (right.createdAt ?? 0);
+      });
+
+    for (const thread of spawnedThreads) {
+      const sourceThreadId = thread.codexNativeSubAgent?.parentThreadId.trim();
+      if (!sourceThreadId || sourceThreadId === thread.id) {
+        continue;
+      }
+      const sourceOverlay =
+        updatedOverlaysByThreadId[sourceThreadId]
+        ?? params.overlaysByThreadId[sourceThreadId]
+        ?? await this.overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: sourceThreadId,
+        })
+        ?? {
+          backend: "codex" as const,
+          threadId: sourceThreadId,
+          executionMode: "default" as const,
+          extraLinkedDirectories: [],
+        };
+      const groupParentThreadId = await this.resolveHandoffGroupParentThreadId({
+        backend: "codex",
+        sourceOverlay,
+        sourceThreadId,
+      });
+      const currentOverlay =
+        updatedOverlaysByThreadId[thread.id]
+        ?? params.overlaysByThreadId[thread.id];
+      const relationshipChanged =
+        currentOverlay?.parentThreadId !== groupParentThreadId;
+      if (relationshipChanged) {
+        updatedOverlaysByThreadId[thread.id] = await setThreadParent.call(
+          this.overlayStore,
+          {
+            backend: "codex",
+            threadId: thread.id,
+            parentThreadId: groupParentThreadId,
+          },
+        );
+      }
+
+      const parentOverlay = await this.overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: groupParentThreadId,
+      });
+      if (
+        !relationshipChanged
+        && parentOverlay?.subthreadOrder?.includes(thread.id)
+      ) {
+        continue;
+      }
+      const currentOrder =
+        groupParentThreadId === sourceThreadId
+        || parentOverlay?.subthreadOrder?.includes(sourceThreadId)
+          ? (parentOverlay?.subthreadOrder ?? [])
+          : [...(parentOverlay?.subthreadOrder ?? []), sourceThreadId];
+      const nextOrder = insertSubthreadIdAfter(
+        currentOrder,
+        sourceThreadId,
+        thread.id,
+      );
+      await updateSubthreadOrder.call(this.overlayStore, {
+        backend: "codex",
+        parentThreadId: groupParentThreadId,
+        threadIds: nextOrder,
+      });
+      updatedOverlaysByThreadId[groupParentThreadId] =
+        await this.overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: groupParentThreadId,
+        });
+    }
+
+    return updatedOverlaysByThreadId;
   }
 
   private async reconcileCodexDirectoryRelationshipsFromSource(params: {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -117,6 +117,11 @@ const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.6-luna";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
 const CODEX_THREAD_TITLE_CONFIG_READ_REASON = "thread-title-mcp-inventory";
+const CODEX_VISIBLE_THREAD_SOURCE_KINDS = [
+  "cli",
+  "vscode",
+  "subAgentThreadSpawn",
+] as const;
 const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
   tmpdir(),
   "pwragent",
@@ -259,6 +264,7 @@ type RawCodexThreadSummary = Omit<
   AppServerThreadSummary,
   "source" | "linkedDirectories"
 > & {
+  codexThreadSourceKind?: string;
   originator?: string;
   path?: string;
   projectKey?: string;
@@ -1445,12 +1451,21 @@ function isKnownCompanionAppCodexThread(thread: RawCodexThreadSummary): boolean 
   return isPwrSnapRuntimeContext(thread.title) || isPwrSnapRuntimeContext(thread.summary);
 }
 
+function isVisibleCodexThreadSource(thread: RawCodexThreadSummary): boolean {
+  const sourceKind = thread.codexThreadSourceKind?.trim();
+  return (
+    !sourceKind?.startsWith("subAgent")
+    || sourceKind === "subAgentThreadSpawn"
+  );
+}
+
 function filterVisibleCodexThreads(
   threads: RawCodexThreadSummary[]
 ): RawCodexThreadSummary[] {
   return threads.filter(
     (thread) =>
       isAllowedCodexSessionOriginator(thread.originator) &&
+      isVisibleCodexThreadSource(thread) &&
       !isKnownCompanionAppCodexThread(thread),
   );
 }
@@ -4908,6 +4923,86 @@ function isUnmaterializedThreadError(error: unknown): boolean {
   );
 }
 
+function readCodexThreadSourceKind(
+  record: Record<string, unknown>,
+  sessionRecord: Record<string, unknown> | null,
+): string | undefined {
+  const explicit =
+    pickString(record, ["threadSource", "thread_source"]) ??
+    pickString(sessionRecord ?? {}, ["threadSource", "thread_source"]);
+  if (explicit) {
+    return explicit;
+  }
+
+  const source =
+    asRecord(record.source) ??
+    asRecord(sessionRecord?.source);
+  const subAgent = source?.subAgent ?? source?.sub_agent;
+  if (typeof subAgent === "string") {
+    switch (subAgent) {
+      case "review":
+        return "subAgentReview";
+      case "compact":
+        return "subAgentCompact";
+      default:
+        return "subAgentOther";
+    }
+  }
+
+  const subAgentRecord = asRecord(subAgent);
+  if (!subAgentRecord) {
+    return undefined;
+  }
+  if (asRecord(subAgentRecord.thread_spawn) || asRecord(subAgentRecord.threadSpawn)) {
+    return "subAgentThreadSpawn";
+  }
+  return "subAgentOther";
+}
+
+function readCodexNativeSubAgent(
+  record: Record<string, unknown>,
+  sessionRecord: Record<string, unknown> | null,
+  sourceKind: string | undefined,
+): AppServerThreadSummary["codexNativeSubAgent"] {
+  const source =
+    asRecord(record.source) ??
+    asRecord(sessionRecord?.source);
+  const subAgent =
+    asRecord(source?.subAgent) ??
+    asRecord(source?.sub_agent);
+  const spawn =
+    asRecord(subAgent?.thread_spawn) ??
+    asRecord(subAgent?.threadSpawn);
+  if (sourceKind !== "subAgentThreadSpawn" && !spawn) {
+    return undefined;
+  }
+
+  const parentThreadId =
+    pickString(spawn ?? {}, ["parentThreadId", "parent_thread_id"]) ??
+    pickString(record, ["parentThreadId", "parent_thread_id"]) ??
+    pickString(sessionRecord ?? {}, ["parentThreadId", "parent_thread_id"]);
+  if (!parentThreadId) {
+    return undefined;
+  }
+
+  const depth = pickNumber(spawn ?? {}, ["depth"]);
+  const agentNickname =
+    pickString(record, ["agentNickname", "agent_nickname"]) ??
+    pickString(sessionRecord ?? {}, ["agentNickname", "agent_nickname"]) ??
+    pickString(spawn ?? {}, ["agentNickname", "agent_nickname"]);
+  const agentRole =
+    pickString(record, ["agentRole", "agent_role"]) ??
+    pickString(sessionRecord ?? {}, ["agentRole", "agent_role"]) ??
+    pickString(spawn ?? {}, ["agentRole", "agent_role"]);
+
+  return {
+    parentThreadId,
+    ...(depth !== undefined ? { depth } : {}),
+    ...(agentNickname ? { agentNickname } : {}),
+    ...(agentRole ? { agentRole } : {}),
+  };
+}
+
 function isRequestTimeoutError(error: unknown, method: string): boolean {
   const text = error instanceof Error ? error.message : String(error);
   return text.toLowerCase().includes(`json-rpc timeout: ${method.toLowerCase()}`);
@@ -4927,6 +5022,12 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
     }
 
     const sessionRecord = asRecord(record.session);
+    const codexThreadSourceKind = readCodexThreadSourceKind(record, sessionRecord);
+    const codexNativeSubAgent = readCodexNativeSubAgent(
+      record,
+      sessionRecord,
+      codexThreadSourceKind,
+    );
     const gitInfoRecord =
       asRecord(record.gitInfo) ??
       asRecord(record.git_info) ??
@@ -5016,6 +5117,8 @@ function extractThreadsFromValue(value: unknown): RawCodexThreadSummary[] {
         "remoteUrl",
         "remote_url",
       ]),
+      codexThreadSourceKind,
+      codexNativeSubAgent,
     });
   }
 
@@ -5046,7 +5149,7 @@ function buildThreadDiscoveryPayloads(
     cursor,
     limit,
     sortKey: "updated_at",
-    sourceKinds: ["cli", "vscode"],
+    sourceKinds: [...CODEX_VISIBLE_THREAD_SOURCE_KINDS],
     useStateDbOnly: true,
   };
 
@@ -6572,6 +6675,7 @@ export class CodexAppServerClient {
     if (!options.enrichDirectories) {
       return threads.map((thread) => {
         const {
+          codexThreadSourceKind: _codexThreadSourceKind,
           gitOriginUrl: _gitOriginUrl,
           originator: _originator,
           path: _path,
@@ -6616,6 +6720,7 @@ export class CodexAppServerClient {
         const projectKey = await resolveThreadProjectKey(thread);
         const enrichment = await this.threadDirectoryEnricher(projectKey);
         const {
+          codexThreadSourceKind: _codexThreadSourceKind,
           originator: _originator,
           path: _path,
           ...publicThread

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -320,6 +320,21 @@ export type AppServerThreadSummary = {
   };
   codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
   worktreeSnapshots?: WorktreeSnapshotSummary[];
+  /**
+   * Native Codex provenance for a thread created by `spawn_agent`.
+   *
+   * Codex persists these as ordinary agent threads and reports their provider
+   * parent independently from PwrAgent's UI-only `parentThreadId` overlay.
+   * PwrAgent uses this metadata to project the provider tree into its current
+   * one-level child-thread tray without conflating other sub-agent sources
+   * such as review and compaction helpers with visible work threads.
+   */
+  codexNativeSubAgent?: {
+    parentThreadId: ThreadIdentifier;
+    depth?: number;
+    agentNickname?: string;
+    agentRole?: string;
+  };
 };
 
 export type AppServerThreadMessage = {


### PR DESCRIPTION
## Summary

- I include Codex `subAgentThreadSpawn` sessions in thread discovery while keeping review and compaction helpers hidden.
- I preserve native parent, depth, nickname, and role metadata and project spawned agent threads into PwrAgent's existing one-level child-thread tree.
- I flatten grandchildren under the group root and place a child-spawned thread immediately after the child that requested it.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (540 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- Codex `spawn_agent` does not expose a visibility flag. It creates a persisted agent thread with native parent provenance; visibility is a client concern.
- The existing transcript subagent activity card remains available for progress and history while the spawned thread also appears in the thread tree.
