### PR TITLE
fix(desktop): flag unpublished detached work

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -80,6 +80,21 @@ export function ThreadMetaChips({
   const unpushedTooltip = `${unpushedCount} commit${
     unpushedCount === 1 ? "" : "s"
   } not pushed to a remote`;
+  const currentBranch =
+    thread.observedGitBranch?.trim() || thread.gitBranch?.trim();
+  const detachedAheadCount = gitWorking?.baseAheadCommitCount ?? 0;
+  const hasDetachedUnpublishedWork =
+    currentBranch === "HEAD" &&
+    unpushedCount > 0 &&
+    detachedAheadCount > 0;
+  const detachedUnpublishedTooltip = hasDetachedUnpublishedWork
+    ? formatDetachedUnpublishedTooltip({
+        aheadCount: detachedAheadCount,
+        baseBranch: gitWorking?.baseBranch,
+        behindCount: gitWorking?.baseBehindCommitCount,
+        unpushedCount,
+      })
+    : "";
   const linkedDirectoryChips = includeLinkedDirectories
     ? thread.linkedDirectories.length > 0
       ? linkedDirectoryMode === "kind"
@@ -278,7 +293,19 @@ export function ThreadMetaChips({
         </span>
       ) : null}
 
-      {unpushedCount > 0 ? (
+      {hasDetachedUnpublishedWork ? (
+        <span
+          aria-label={detachedUnpublishedTooltip}
+          role="img"
+          className="thread-row__chip thread-row__chip--unpublished"
+          onMouseEnter={(event) =>
+            gitStateTooltip.show(event.currentTarget, detachedUnpublishedTooltip)
+          }
+          onMouseLeave={gitStateTooltip.hide}
+        >
+          Unpublished · {detachedAheadCount.toLocaleString()} ahead
+        </span>
+      ) : unpushedCount > 0 ? (
         <span
           aria-label={unpushedTooltip}
           role="img"
@@ -306,6 +333,32 @@ function formatDirtyFileFallback(
     return `${gitWorking.untrackedFiles.toLocaleString()} new`;
   }
   return `${gitWorking.dirtyFiles.toLocaleString()} changed`;
+}
+
+function formatDetachedUnpublishedTooltip(params: {
+  aheadCount: number;
+  baseBranch?: string;
+  behindCount?: number;
+  unpushedCount: number;
+}): string {
+  const baseBranch = params.baseBranch?.trim();
+  const aheadDescription = baseBranch
+    ? `HEAD is ${params.aheadCount.toLocaleString()} commit${
+        params.aheadCount === 1 ? "" : "s"
+      } ahead of ${baseBranch}`
+    : `HEAD is ${params.aheadCount.toLocaleString()} commit${
+        params.aheadCount === 1 ? "" : "s"
+      } ahead of its base`;
+  const behindDescription =
+    baseBranch && params.behindCount && params.behindCount > 0
+      ? ` and ${params.behindCount.toLocaleString()} commit${
+          params.behindCount === 1 ? "" : "s"
+        } behind`
+      : "";
+
+  return `Unpublished detached work: ${params.unpushedCount.toLocaleString()} commit${
+    params.unpushedCount === 1 ? "" : "s"
+  } not on a remote; ${aheadDescription}${behindDescription}. Create a branch and push it to keep this work.`;
 }
 
 function formatBranchCopyLabel(params: {

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -303,7 +303,8 @@ export function ThreadMetaChips({
           }
           onMouseLeave={gitStateTooltip.hide}
         >
-          Unpublished · {detachedAheadCount.toLocaleString()} ahead
+          {unpushedCount.toLocaleString()} unpublished ·{" "}
+          {detachedAheadCount.toLocaleString()} ahead
         </span>
       ) : unpushedCount > 0 ? (
         <span

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -740,6 +740,85 @@ describe("ThreadRow chip flow", () => {
     );
   });
 
+  it("makes unpublished detached-HEAD work explicit", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 0,
+          unpushedCommits: 1,
+          baseBranch: "main",
+          baseAheadCommitCount: 1,
+          baseBehindCommitCount: 3,
+          isBehindBase: true,
+        },
+      },
+    });
+
+    const unpublishedChip = container.querySelector(
+      ".thread-row__chip--unpublished",
+    );
+    expect(unpublishedChip).toHaveTextContent("Unpublished · 1 ahead");
+    expect(unpublishedChip).toHaveAttribute(
+      "aria-label",
+      "Unpublished detached work: 1 commit not on a remote; HEAD is 1 commit ahead of main and 3 commits behind. Create a branch and push it to keep this work.",
+    );
+    expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
+
+  it("keeps the ordinary unpushed count for work on an attached branch", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitBranch: "feature/published-next",
+        observedGitBranch: "feature/published-next",
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 0,
+          unpushedCommits: 1,
+          baseBranch: "main",
+          baseAheadCommitCount: 1,
+          baseBehindCommitCount: 0,
+          isBehindBase: false,
+        },
+      },
+    });
+
+    expect(container.querySelector(".thread-row__chip--unpublished")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--unpushed")).toHaveTextContent("↑1");
+  });
+
+  it("does not call detached work unpublished when its commits are on a remote", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 0,
+          unpushedCommits: 0,
+          baseBranch: "main",
+          baseAheadCommitCount: 1,
+          baseBehindCommitCount: 0,
+          isBehindBase: false,
+        },
+      },
+    });
+
+    expect(container.querySelector(".thread-row__chip--unpublished")).toBeNull();
+    expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
+
   it("renders an untracked-only dirty chip with +/- stats when available", () => {
     const { container } = renderRow({
       thread: {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -763,12 +763,42 @@ describe("ThreadRow chip flow", () => {
     const unpublishedChip = container.querySelector(
       ".thread-row__chip--unpublished",
     );
-    expect(unpublishedChip).toHaveTextContent("Unpublished · 1 ahead");
+    expect(unpublishedChip).toHaveTextContent("1 unpublished · 1 ahead");
     expect(unpublishedChip).toHaveAttribute(
       "aria-label",
       "Unpublished detached work: 1 commit not on a remote; HEAD is 1 commit ahead of main and 3 commits behind. Create a branch and push it to keep this work.",
     );
     expect(container.querySelector(".thread-row__chip--unpushed")).toBeNull();
+  });
+
+  it("labels unpublished and base-ahead commits as separate counts", () => {
+    const { container } = renderRow({
+      thread: {
+        ...baseThread,
+        gitBranch: "HEAD",
+        observedGitBranch: "HEAD",
+        gitWorkingState: {
+          dirtyFiles: 0,
+          dirtyAdditions: 0,
+          dirtyDeletions: 0,
+          untrackedFiles: 0,
+          unpushedCommits: 1,
+          baseBranch: "main",
+          baseAheadCommitCount: 11,
+          baseBehindCommitCount: 0,
+          isBehindBase: false,
+        },
+      },
+    });
+
+    const unpublishedChip = container.querySelector(
+      ".thread-row__chip--unpublished",
+    );
+    expect(unpublishedChip).toHaveTextContent("1 unpublished · 11 ahead");
+    expect(unpublishedChip).toHaveAttribute(
+      "aria-label",
+      "Unpublished detached work: 1 commit not on a remote; HEAD is 11 commits ahead of main. Create a branch and push it to keep this work.",
+    );
   });
 
   it("keeps the ordinary unpushed count for work on an attached branch", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -353,16 +353,16 @@
 /* Suppress directory / PR / agent / binding chips in the list. Reaction
    and pin markers stay visible — reactions because they're user-curated
    signals, pin because the pin marker on its own is information-dense.
-   The "Scheduled"/"Queued" pending-send chips also stay visible: a pending
-   outbound message is a time-sensitive commitment the operator needs to
-   spot at a glance, so it survives the density strip like the pin marker.
+   The "Scheduled"/"Queued" pending-send and detached-work "Unpublished"
+   chips also stay visible: these time-sensitive commitments need to remain
+   visible at a glance, so they survive the density strip like the pin marker.
 
    Scope the rule to `.thread-row__chips` so non-list surfaces that
    carry a `.thread-row__chip--*` variant (e.g. the questionnaire's mode
    chip in the transcript) don't get collapsed when compact density is
    on. The skill chip in the composer and the standalone SkillChip use
    `.chip` directly and aren't affected by this rule. */
-:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued) {
+:root[data-density="compact"] .thread-row__chips .thread-row__chip:not(.thread-row__chip--reaction):not(.thread-row__chip--pin):not(.thread-row__chip--scheduled):not(.thread-row__chip--queued):not(.thread-row__chip--unpublished) {
   display: none;
 }
 
@@ -406,7 +406,7 @@
   top: 7px;
 }
 
-:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--reaction)):not(:has(.thread-row__chip--pin)) {
+:root[data-density="compact"] .thread-row:not(:has(.thread-row__chip--reaction)):not(:has(.thread-row__chip--pin)):not(:has(.thread-row__chip--unpublished)) {
   gap: 0;
 }
 
@@ -3992,6 +3992,17 @@ textarea,
   background: var(--bg-panel-elevated);
   color: var(--text-secondary);
   gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Detached HEAD commits have no branch to carry them forward. This is a
+   workflow warning rather than quiet git metadata, so pair amber treatment
+   with an explicit text label and keep it visible in compact density. */
+.thread-row__chip--unpublished {
+  border: 1px solid color-mix(in srgb, var(--status-warning) 48%, var(--border-subtle));
+  background: color-mix(in srgb, var(--status-warning) 14%, transparent);
+  color: var(--status-warning);
+  font-weight: 650;
   font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
## Summary

- I added a dedicated amber `Unpublished · N ahead` thread-card chip when work is on detached `HEAD`, ahead of its base, and not present on a remote.
- I added explicit hover and accessibility copy identifying the unpublished commit count, base divergence, and the need to create a branch and push the work.
- I kept the warning visible in compact density, preserved the existing `↑N` treatment for attached branches, and avoided warning for detached commits that are already published.

## Verification

- I ran 89 focused thread-row and theme-contract tests.
- I ran the workspace typecheck.
- I ran ESLint with zero errors; it reported only the repository's existing warnings.
- I ran renderer color lint and dependency-boundary validation.
- I verified the diff has no whitespace errors and the checkpoint commit has a valid SSH signature.

## Notes

- The root cause was a presentation gap: the thread row treated detached `HEAD` like an ordinary branch and exposed publication state only through the quiet generic unpushed-count chip. It never combined the existing normalized branch, base-ahead, and remote-publication facts into an actionable warning.
