### PR TITLE
fix(desktop): preserve drafts when retargeting projects

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2492,6 +2492,14 @@ export function Composer(props: ComposerProps) {
         );
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
+  const pendingDraftRetargetRef = useRef<
+    | {
+        snapshot: ComposerDraftSnapshot;
+        sourceScopeKey: string;
+        targetScopeKey: string;
+      }
+    | undefined
+  >(undefined);
   const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
   const recoveryCycleRef = useRef<{
     activeIndex?: number;
@@ -2804,6 +2812,33 @@ export function Composer(props: ComposerProps) {
     fileAttachments: [],
     skillTokens: [],
   });
+  const hasComposerDraftSnapshotContent = (
+    snapshot: ComposerDraftSnapshot,
+  ): boolean =>
+    Boolean(
+      snapshot.draft.trim()
+      || snapshot.skillTokens.length > 0
+      || snapshot.imageAttachments.length > 0
+      || (snapshot.fileAttachments?.length ?? 0) > 0,
+    );
+  const prepareDraftRetarget = (directoryKey: string): void => {
+    const targetScopeKey = `launchpad:${directoryKey}`;
+    const latest = latestDraftSnapshotRef.current;
+    if (
+      latest.scopeKey === targetScopeKey
+      || !latest.scopeKey.startsWith("launchpad:")
+      || !hasComposerDraftSnapshotContent(latest.snapshot)
+    ) {
+      pendingDraftRetargetRef.current = undefined;
+      return;
+    }
+
+    pendingDraftRetargetRef.current = {
+      snapshot: latest.snapshot,
+      sourceScopeKey: latest.scopeKey,
+      targetScopeKey,
+    };
+  };
   const resetComposerDraftAndState = (
     scopeKey: string,
   ): void => {
@@ -3359,19 +3394,38 @@ export function Composer(props: ComposerProps) {
     submittedDraftScopeKeysRef.current.delete(scopeKey);
   };
   const clearSubmittedComposerDraft = (scopeKey: string): void => {
-    const emptySnapshot: ComposerDraftSnapshot = {
-      draft: "",
-      editorDocument: undefined,
-      imageAttachments: [],
-      fileAttachments: [],
-      skillTokens: [],
-    };
+    const emptySnapshot = createEmptyComposerDraftSnapshot();
 
     const latest = latestDraftSnapshotRef.current;
     if (latest.scopeKey === scopeKey) {
       recordComposerDraftHistory(scopeKey, latest.snapshot, "sent");
     }
     clearComposerDraftSnapshot(scopeKey);
+    const restoredSnapshot = draftStore.popDraft(scopeKey);
+    submittedDraftScopeKeysRef.current.delete(scopeKey);
+    if (restoredSnapshot) {
+      pendingProgrammaticComposerChangeRef.current = {
+        expectedDraft: restoredSnapshot.draft,
+        expectedSkillTokensSignature: getComposerSkillTokensSignature(
+          restoredSnapshot.skillTokens,
+        ),
+        staleDraft: latest.snapshot.draft,
+        staleSkillTokensSignature: getComposerSkillTokensSignature(
+          latest.snapshot.skillTokens,
+        ),
+      };
+      saveComposerDraftSnapshot(scopeKey, restoredSnapshot);
+      latestDraftSnapshotRef.current = {
+        scopeKey,
+        snapshot: restoredSnapshot,
+      };
+      setDraft(restoredSnapshot.draft);
+      setEditorDocument(restoredSnapshot.editorDocument);
+      setImageAttachments(restoredSnapshot.imageAttachments);
+      setFileAttachments(restoredSnapshot.fileAttachments ?? []);
+      setSkillTokens(restoredSnapshot.skillTokens);
+      return;
+    }
     latestDraftSnapshotRef.current = {
       scopeKey,
       snapshot: emptySnapshot,
@@ -3391,6 +3445,8 @@ export function Composer(props: ComposerProps) {
     }
 
     void updateLaunchpad(directoryKey, {
+      editorDocument:
+        snapshot.editorDocument as Record<string, unknown> | undefined,
       imageAttachments:
         snapshot.imageAttachments.length > 0 ? snapshot.imageAttachments : undefined,
       fileAttachments:
@@ -3698,6 +3754,12 @@ export function Composer(props: ComposerProps) {
   }, []);
 
   useEffect(() => {
+    if (props.launchpadError) {
+      pendingDraftRetargetRef.current = undefined;
+    }
+  }, [props.launchpadError]);
+
+  useEffect(() => {
     const previousScopeKey = activeComposerScopeKeyRef.current;
     if (previousScopeKey === composerScopeKey) {
       return;
@@ -3705,14 +3767,55 @@ export function Composer(props: ComposerProps) {
 
     recoveryEligibilityVersionRef.current += 1;
     recoveryLookupSequenceRef.current += 1;
-    const previousSnapshot = {
+    const pendingRetarget = pendingDraftRetargetRef.current;
+    const retargetingDraft =
+      pendingRetarget?.sourceScopeKey === previousScopeKey
+      && pendingRetarget.targetScopeKey === composerScopeKey
+        ? pendingRetarget
+        : undefined;
+    const previousSnapshot = retargetingDraft?.snapshot ?? {
       draft,
       editorDocument,
       imageAttachments,
       fileAttachments,
       skillTokens,
     };
-    flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
+    if (retargetingDraft) {
+      pendingDraftRetargetRef.current = undefined;
+      const savedTargetDraft = draftStore.get(composerScopeKey);
+      const hydratedTargetDraft = hydrateComposerDraft(
+        props.launchpad?.prompt ?? "",
+        props.skills,
+        threadLinks,
+      );
+      const parkedTargetDraft = savedTargetDraft ?? {
+        draft: hydratedTargetDraft.draft,
+        editorDocument:
+          props.launchpad?.editorDocument as JSONContent | undefined,
+        imageAttachments: props.launchpad?.imageAttachments ?? [],
+        fileAttachments: props.launchpad?.fileAttachments ?? [],
+        skillTokens: hydratedTargetDraft.skillTokens,
+      };
+      if (hasComposerDraftSnapshotContent(parkedTargetDraft)) {
+        draftStore.pushDraft(composerScopeKey, parkedTargetDraft);
+      }
+
+      clearComposerDraftSnapshot(previousScopeKey);
+      const restoredSourceDraft = draftStore.popDraft(previousScopeKey);
+      if (restoredSourceDraft) {
+        saveComposerDraftSnapshot(previousScopeKey, restoredSourceDraft);
+        persistLaunchpadDraftSnapshot(previousScopeKey, restoredSourceDraft);
+      } else {
+        persistLaunchpadDraftSnapshot(
+          previousScopeKey,
+          createEmptyComposerDraftSnapshot(),
+        );
+      }
+      saveComposerDraftSnapshot(composerScopeKey, previousSnapshot);
+      persistLaunchpadDraftSnapshot(composerScopeKey, previousSnapshot);
+    } else {
+      flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
+    }
     if (!props.thread && previousScopeKey.startsWith("thread:")) {
       serverQueuedTurnEntryIdsRef.current.delete(previousScopeKey);
       globalQueuedTurnReleaseScopeKeys.delete(previousScopeKey);
@@ -3720,12 +3823,23 @@ export function Composer(props: ComposerProps) {
 
     activeComposerScopeKeyRef.current = composerScopeKey;
     const current = pasteScopeRef.current;
+    if (retargetingDraft && current.key === previousScopeKey) {
+      current.key = composerScopeKey;
+    }
     pasteScopeRef.current = {
       key: composerScopeKey,
       version: current.version + 1,
     };
 
-    if (props.thread) {
+    if (retargetingDraft) {
+      setDraft(previousSnapshot.draft);
+      setEditorDocument(previousSnapshot.editorDocument);
+      setImageAttachments(previousSnapshot.imageAttachments);
+      setFileAttachments(previousSnapshot.fileAttachments ?? []);
+      setSkillTokens(previousSnapshot.skillTokens);
+      setPendingSteerState(undefined);
+      setQueuedTurnsState([]);
+    } else if (props.thread) {
       const saved = draftStore.get(composerScopeKey);
       const savedPendingSteer = draftStore.getPendingSteer(composerScopeKey);
       const savedQueuedTurns = draftStore.getQueuedTurns(composerScopeKey);
@@ -8298,6 +8412,7 @@ export function Composer(props: ComposerProps) {
               picking={props.pickingDirectory}
               onSelect={(directory) => {
                 props.onClearPickDirectoryError?.();
+                prepareDraftRetarget(directory.key);
                 props.onSelectDirectoryFromPicker?.(directory);
               }}
               onSelectNoDirectory={

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -117,6 +117,7 @@ async function clickButton(name: string | RegExp): Promise<void> {
 
 function createComposerDraftStore(): ComposerDraftStore {
   const drafts = new Map<string, ComposerDraftSnapshot>();
+  const draftStacks = new Map<string, ComposerDraftSnapshot[]>();
   const pendingSteers = new Map<string, ComposerPendingSteerSnapshot>();
   const queuedTurns = new Map<string, ComposerQueuedTurnSnapshot[]>();
   return {
@@ -124,6 +125,20 @@ function createComposerDraftStore(): ComposerDraftStore {
       drafts.delete(scopeKey);
     },
     get: (scopeKey) => drafts.get(scopeKey),
+    popDraft: (scopeKey) => {
+      const current = draftStacks.get(scopeKey) ?? [];
+      const restored = current.at(-1);
+      const next = current.slice(0, -1);
+      if (next.length > 0) {
+        draftStacks.set(scopeKey, next);
+      } else {
+        draftStacks.delete(scopeKey);
+      }
+      return restored;
+    },
+    pushDraft: (scopeKey, snapshot) => {
+      draftStacks.set(scopeKey, [...(draftStacks.get(scopeKey) ?? []), snapshot]);
+    },
     deletePendingSteer: (scopeKey) => {
       pendingSteers.delete(scopeKey);
     },
@@ -295,30 +310,42 @@ function DraftRetargetingHarness(props: {
   )!;
 
   return (
-    <Composer
-      backends={[backendSummary("codex")]}
-      directories={retargetingDirectories}
-      directory={selectedDirectory}
-      launchpad={launchpads.get(selectedDirectoryKey)!}
-      onMaterializeLaunchpad={props.onMaterializeLaunchpad}
-      onPickAndRegisterDirectory={() => undefined}
-      onSelectDirectoryFromPicker={(directory) => {
-        setSelectedDirectoryKey(directory.key);
-      }}
-      onUpdateLaunchpad={async (directoryKey, patch) => {
-        setLaunchpads((current) => {
-          const launchpad = current.get(directoryKey)!;
-          const next = new Map(current);
-          next.set(directoryKey, {
-            ...launchpad,
-            ...patch,
-            updatedAt: launchpad.updatedAt + 1,
+    <>
+      <button
+        aria-label="Navigate to PwrSnap launchpad"
+        type="button"
+        onClick={() => setSelectedDirectoryKey(retargetingPwrSnap.key)}
+      />
+      <button
+        aria-label="Navigate to PwrGit launchpad"
+        type="button"
+        onClick={() => setSelectedDirectoryKey(retargetingPwrGit.key)}
+      />
+      <Composer
+        backends={[backendSummary("codex")]}
+        directories={retargetingDirectories}
+        directory={selectedDirectory}
+        launchpad={launchpads.get(selectedDirectoryKey)!}
+        onMaterializeLaunchpad={props.onMaterializeLaunchpad}
+        onPickAndRegisterDirectory={() => undefined}
+        onSelectDirectoryFromPicker={(directory) => {
+          setSelectedDirectoryKey(directory.key);
+        }}
+        onUpdateLaunchpad={async (directoryKey, patch) => {
+          setLaunchpads((current) => {
+            const launchpad = current.get(directoryKey)!;
+            const next = new Map(current);
+            next.set(directoryKey, {
+              ...launchpad,
+              ...patch,
+              updatedAt: launchpad.updatedAt + 1,
+            });
+            return next;
           });
-          return next;
-        });
-      }}
-      skills={[]}
-    />
+        }}
+        skills={[]}
+      />
+    </>
   );
 }
 
@@ -492,6 +519,8 @@ describe("Composer", () => {
       delete: deleteDraft,
       recordHistory,
       get: () => undefined,
+      popDraft: () => undefined,
+      pushDraft: vi.fn(),
       deletePendingSteer: vi.fn(),
       deleteQueuedTurn: vi.fn(),
       getPendingSteer: () => undefined,
@@ -10284,6 +10313,16 @@ describe("Composer", () => {
       "Move this text and image to PwrGit",
     );
     expect(screen.getByAltText("wrong-repo-composer.png")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Navigate to PwrSnap launchpad" }),
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("New thread")).toHaveValue("");
+    });
+    expect(
+      screen.queryByAltText("wrong-repo-composer.png"),
+    ).not.toBeInTheDocument();
   });
 
   it("reveals a project's previous draft after submitting the retargeted top draft", async () => {
@@ -10314,15 +10353,17 @@ describe("Composer", () => {
       [],
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Project: PwrGit" }));
-    fireEvent.click(screen.getByRole("option", { name: /PwrSnap/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Navigate to PwrSnap launchpad" }),
+    );
     await waitFor(() => {
       expect(
         screen.getByRole("button", { name: "Project: PwrSnap" }),
       ).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Project: PwrSnap" }));
-    fireEvent.click(screen.getByRole("option", { name: /PwrGit/ }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Navigate to PwrGit launchpad" }),
+    );
 
     await waitFor(() => {
       expect(screen.getByLabelText("New thread")).toHaveValue(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { StrictMode, useState } from "react";
+import { StrictMode, useState, type ComponentProps } from "react";
 import {
   applyNavigationLaunchpadProviderSettingsPatch,
   type BackendSummary,
@@ -223,6 +223,103 @@ function backendSummary(
     ],
     launchpadOptions,
   };
+}
+
+const retargetingPwrSnap: NavigationDirectorySummary = {
+  key: "directory:/repo/PwrSnap",
+  kind: "directory",
+  label: "PwrSnap",
+  path: "/repo/PwrSnap",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 2,
+};
+
+const retargetingPwrGit: NavigationDirectorySummary = {
+  key: "directory:/repo/PwrGit",
+  kind: "directory",
+  label: "PwrGit",
+  path: "/repo/PwrGit",
+  threadKeys: [],
+  needsAttentionCount: 0,
+  latestUpdatedAt: 1,
+};
+
+const retargetingDirectories = [retargetingPwrSnap, retargetingPwrGit];
+
+function createRetargetingLaunchpad(
+  directory: NavigationDirectorySummary,
+  prompt: string,
+): NavigationLaunchpadDraft {
+  return {
+    directoryKey: directory.key,
+    directoryKind: directory.kind,
+    directoryLabel: directory.label,
+    directoryPath: directory.path,
+    backend: "codex",
+    executionMode: "default",
+    prompt,
+    workMode: "local",
+    branchName: "main",
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function DraftRetargetingHarness(props: {
+  previousPwrGitDraft: string;
+  onMaterializeLaunchpad?: ComponentProps<
+    typeof Composer
+  >["onMaterializeLaunchpad"];
+}) {
+  const [selectedDirectoryKey, setSelectedDirectoryKey] = useState(
+    retargetingPwrSnap.key,
+  );
+  const [launchpads, setLaunchpads] = useState(
+    () => new Map<string, NavigationLaunchpadDraft>([
+      [
+        retargetingPwrSnap.key,
+        createRetargetingLaunchpad(retargetingPwrSnap, ""),
+      ],
+      [
+        retargetingPwrGit.key,
+        createRetargetingLaunchpad(
+          retargetingPwrGit,
+          props.previousPwrGitDraft,
+        ),
+      ],
+    ]),
+  );
+  const selectedDirectory = retargetingDirectories.find(
+    (directory) => directory.key === selectedDirectoryKey,
+  )!;
+
+  return (
+    <Composer
+      backends={[backendSummary("codex")]}
+      directories={retargetingDirectories}
+      directory={selectedDirectory}
+      launchpad={launchpads.get(selectedDirectoryKey)!}
+      onMaterializeLaunchpad={props.onMaterializeLaunchpad}
+      onPickAndRegisterDirectory={() => undefined}
+      onSelectDirectoryFromPicker={(directory) => {
+        setSelectedDirectoryKey(directory.key);
+      }}
+      onUpdateLaunchpad={async (directoryKey, patch) => {
+        setLaunchpads((current) => {
+          const launchpad = current.get(directoryKey)!;
+          const next = new Map(current);
+          next.set(directoryKey, {
+            ...launchpad,
+            ...patch,
+            updatedAt: launchpad.updatedAt + 1,
+          });
+          return next;
+        });
+      }}
+      skills={[]}
+    />
+  );
 }
 
 function acpGeminiBackendSummary(): BackendSummary {
@@ -10145,6 +10242,93 @@ describe("Composer", () => {
       "Review the pasted mockup"
     );
     expect(screen.getByAltText("mockup.png")).toBeInTheDocument();
+  });
+
+  it("moves the complete active draft onto the project selected from the composer", async () => {
+    render(
+      <DraftRetargetingHarness previousPwrGitDraft="An older PwrGit draft" />,
+    );
+    const imageFile = new File(
+      [new Uint8Array([1, 2, 3])],
+      "wrong-repo-composer.png",
+      { type: "image/png" },
+    );
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Move this text and image to PwrGit" },
+    });
+    fireEvent.paste(screen.getByLabelText("New thread"), {
+      clipboardData: {
+        files: [],
+        items: [
+          {
+            kind: "file",
+            type: "image/png",
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+    expect(
+      await screen.findByAltText("wrong-repo-composer.png"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Project: PwrSnap" }));
+    fireEvent.click(screen.getByRole("option", { name: /PwrGit/ }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Project: PwrGit" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("New thread")).toHaveValue(
+      "Move this text and image to PwrGit",
+    );
+    expect(screen.getByAltText("wrong-repo-composer.png")).toBeInTheDocument();
+  });
+
+  it("reveals a project's previous draft after submitting the retargeted top draft", async () => {
+    const onMaterializeLaunchpad = vi.fn(async () => undefined);
+    render(
+      <DraftRetargetingHarness
+        previousPwrGitDraft="The PwrGit draft that was already here"
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("New thread"), {
+      target: { value: "Submit this newer draft in PwrGit" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Project: PwrSnap" }));
+    fireEvent.click(screen.getByRole("option", { name: /PwrGit/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("New thread")).toHaveValue(
+        "Submit this newer draft in PwrGit",
+      );
+    });
+    await clickButton("Start thread");
+    expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+      retargetingPwrGit.key,
+      [{ type: "text", text: "Submit this newer draft in PwrGit" }],
+      undefined,
+      undefined,
+      [],
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Project: PwrGit" }));
+    fireEvent.click(screen.getByRole("option", { name: /PwrSnap/ }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Project: PwrSnap" }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Project: PwrSnap" }));
+    fireEvent.click(screen.getByRole("option", { name: /PwrGit/ }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("New thread")).toHaveValue(
+        "The PwrGit draft that was already here",
+      );
+    });
   });
 
   it("persists launchpad pasted images that finish after switching away", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -76,6 +76,36 @@ describe("useDurableComposerDraftStore", () => {
     );
   });
 
+  it("parks short stacked drafts in durable recovery history", () => {
+    const recordComposerDraftHistory = vi.fn<
+      NonNullable<DesktopApi["recordComposerDraftHistory"]>
+    >(async (request) => ({ candidate: request.draft }));
+    const desktopApi = {
+      recordComposerDraftHistory,
+    } as Partial<DesktopApi> as DesktopApi;
+    const { result } = renderHook(() =>
+      useDurableComposerDraftStore(useComposerDraftStore(), desktopApi),
+    );
+    const parkedDraft = buildSnapshot("Existing project draft");
+
+    act(() => {
+      result.current.pushDraft("launchpad:directory:/repo", parkedDraft);
+    });
+
+    expect(result.current.popDraft("launchpad:directory:/repo")).toBe(
+      parkedDraft,
+    );
+    expect(recordComposerDraftHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draft: expect.objectContaining({
+          scopeKey: "launchpad:directory:/repo",
+          status: "abandoned",
+          text: "Existing project draft",
+        }),
+      }),
+    );
+  });
+
   it("returns just-recorded sent prompts before durable history finishes", async () => {
     type RecordHistoryResponse = Awaited<
       ReturnType<NonNullable<DesktopApi["recordComposerDraftHistory"]>>

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -44,6 +44,10 @@ export type ComposerPendingSteerSnapshot = {
 export type ComposerDraftStore = {
   delete(scopeKey: string): void;
   get(scopeKey: string): ComposerDraftSnapshot | undefined;
+  /** Remove and return the most recently parked draft beneath this scope. */
+  popDraft(scopeKey: string): ComposerDraftSnapshot | undefined;
+  /** Park a draft beneath this scope's active draft. */
+  pushDraft(scopeKey: string, snapshot: ComposerDraftSnapshot): void;
   hydrationVersion?: number;
   deletePendingSteer(scopeKey: string): void;
   deleteQueuedTurn(scopeKey: string): void;
@@ -96,6 +100,7 @@ export function getNextReleasableQueuedTurn<
 
 export function useComposerDraftStore(): ComposerDraftStore {
   const storeRef = useRef(new Map<string, ComposerDraftSnapshot>());
+  const draftStackStoreRef = useRef(new Map<string, ComposerDraftSnapshot[]>());
   const pendingSteerStoreRef = useRef(new Map<string, ComposerPendingSteerSnapshot>());
   const queuedTurnStoreRef = useRef(new Map<string, ComposerQueuedTurnSnapshot[]>());
   // Reactivity bridge for the queued-turn Map. The Map itself is a ref
@@ -119,6 +124,24 @@ export function useComposerDraftStore(): ComposerDraftStore {
         storeRef.current.delete(scopeKey);
       },
       get: (scopeKey) => storeRef.current.get(scopeKey),
+      popDraft: (scopeKey) => {
+        const current = draftStackStoreRef.current.get(scopeKey) ?? [];
+        const restored = current.at(-1);
+        if (!restored) {
+          return undefined;
+        }
+        const next = current.slice(0, -1);
+        if (next.length === 0) {
+          draftStackStoreRef.current.delete(scopeKey);
+        } else {
+          draftStackStoreRef.current.set(scopeKey, next);
+        }
+        return restored;
+      },
+      pushDraft: (scopeKey, snapshot) => {
+        const current = draftStackStoreRef.current.get(scopeKey) ?? [];
+        draftStackStoreRef.current.set(scopeKey, [...current, snapshot]);
+      },
       deletePendingSteer: (scopeKey) => {
         pendingSteerStoreRef.current.delete(scopeKey);
       },

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -98,6 +98,28 @@ export function useDurableComposerDraftStore(
     [rememberLocalRecoveryCandidate],
   );
 
+  const persistDraftHistory = useCallback(
+    (
+      scopeKey: string,
+      snapshot: ComposerDraftSnapshot,
+      status: ComposerDraftLifecycle,
+      force = false,
+    ): void => {
+      if (!desktopApi?.recordComposerDraftHistory) {
+        return;
+      }
+      if (!force && !shouldRecordHistory(snapshot, status)) {
+        return;
+      }
+      const record = buildDraftRecord(scopeKey, snapshot, status, createdAtRef);
+      rememberLocalRecoveryCandidate(record);
+      void desktopApi.recordComposerDraftHistory({ draft: record }).catch((error) => {
+        console.warn("Failed to record composer draft history", error);
+      });
+    },
+    [desktopApi, rememberLocalRecoveryCandidate],
+  );
+
   useEffect(() => {
     if (!desktopApi?.listComposerDraftLatest) {
       return;
@@ -169,22 +191,16 @@ export function useDurableComposerDraftStore(
           request,
         );
       },
+      pushDraft: (scopeKey, snapshot) => {
+        baseStore.pushDraft(scopeKey, snapshot);
+        persistDraftHistory(scopeKey, snapshot, "abandoned", true);
+      },
       recordHistory: (
         scopeKey: string,
         snapshot: ComposerDraftSnapshot,
         status: ComposerDraftLifecycle,
       ): void => {
-        if (!desktopApi?.recordComposerDraftHistory) {
-          return;
-        }
-        if (!shouldRecordHistory(snapshot, status)) {
-          return;
-        }
-        const record = buildDraftRecord(scopeKey, snapshot, status, createdAtRef);
-        rememberLocalRecoveryCandidate(record);
-        void desktopApi.recordComposerDraftHistory({ draft: record }).catch((error) => {
-          console.warn("Failed to record composer draft history", error);
-        });
+        persistDraftHistory(scopeKey, snapshot, status);
       },
       set: (scopeKey, snapshot) => {
         baseStore.set(scopeKey, snapshot);
@@ -216,6 +232,7 @@ export function useDurableComposerDraftStore(
       desktopApi,
       flushPendingSave,
       hydrationVersion,
+      persistDraftHistory,
       rememberLocalRecoveryCandidate,
     ],
   );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -21,6 +21,8 @@ function createComposerDraftStore(): ComposerDraftStore {
   return {
     delete: vi.fn(),
     get: vi.fn(),
+    popDraft: vi.fn(),
+    pushDraft: vi.fn(),
     deletePendingSteer: vi.fn(),
     deleteQueuedTurn: (scopeKey) => {
       queuedTurns.delete(scopeKey);


### PR DESCRIPTION
## Summary

- I made project-picker retargeting carry the complete active composer snapshot, including rich editor state, pasted images, file attachments, and skill tokens, onto the selected project's draft stack.
- I park the selected project's existing draft underneath the moved draft and restore the source project's previous stacked draft, or clear the source when it has none.
- I pop and restore the parked project draft after the retargeted draft is submitted successfully, while suppressing stale editor change events that could re-save the submitted text.
- I record parked drafts in durable recovery history and preserve in-flight image normalization across the retarget.

## Verification

- `pnpm typecheck`
- `pnpm lint:eslint` — zero errors; existing warning baseline only.
- `pnpm lint:boundaries`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx` — 221 tests pass.
- `pnpm test` — full workspace suite passes.

## Notes

- Project switching remains silent: drafts are preserved automatically without prompting the operator.
- Generic navigation between launchpads remains orthogonal; draft movement occurs only when the project picker explicitly retargets the active composer.
