### PR TITLE
feat(desktop): filter archived threads

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ArchivedThreadsSettings.tsx
@@ -3,6 +3,7 @@ import {
   isToolManagedWorktreePath,
   type AppServerThreadSummary,
 } from "@pwragent/shared";
+import { SearchIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsPanelHead,
@@ -47,6 +48,7 @@ export function ArchivedThreadsSettings(props: {
   });
   const [restoringThreadKey, setRestoringThreadKey] = useState<string>();
   const [restoreMessage, setRestoreMessage] = useState<string>();
+  const [filter, setFilter] = useState("");
   const restoredThreadKeysRef = useRef(new Set<string>());
 
   const loadArchivedThreads = useCallback(async () => {
@@ -88,9 +90,23 @@ export function ArchivedThreadsSettings(props: {
     void loadArchivedThreads();
   }, [loadArchivedThreads]);
 
+  const filterQuery = filter.trim();
+  const isFiltering = filterQuery.length > 0;
   const projectGroups = useMemo(() => {
-    return groupArchivedThreadsByProject(state.threads, state.workspaceRoots);
-  }, [state.threads, state.workspaceRoots]);
+    const groups = groupArchivedThreadsByProject(
+      state.threads,
+      state.workspaceRoots,
+    );
+    return filterQuery ? filterArchivedProjectGroups(groups, filterQuery) : groups;
+  }, [filterQuery, state.threads, state.workspaceRoots]);
+  const visibleThreadCount = useMemo(
+    () =>
+      projectGroups.reduce(
+        (count, group) => count + group.threads.length,
+        0,
+      ),
+    [projectGroups],
+  );
 
   const fetchedAtLabel = useMemo(() => {
     return state.fetchedAt
@@ -155,6 +171,53 @@ export function ArchivedThreadsSettings(props: {
         }
       />
 
+      <div className="settings-archive-filter-control">
+        <div
+          className="settings-archive-filter"
+          role="search"
+          aria-label="Archived thread search"
+        >
+          <SearchIcon
+            aria-hidden
+            className="settings-archive-filter__icon"
+            size={15}
+          />
+          <input
+            className="settings-input settings-archive-filter__input"
+            aria-label="Filter archived threads"
+            placeholder="Filter by title, summary, project, branch, or source"
+            spellCheck={false}
+            type="search"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && isFiltering) {
+                event.preventDefault();
+                setFilter("");
+              }
+            }}
+          />
+          {isFiltering ? (
+            <button
+              aria-label="Clear archived thread filter"
+              className="button button--ghost settings-archive-filter__clear"
+              type="button"
+              onClick={() => setFilter("")}
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+        {isFiltering && !state.loading && visibleThreadCount > 0 ? (
+          <p className="settings-archive-filter__summary" role="status">
+            Showing {visibleThreadCount} matching archived{" "}
+            {visibleThreadCount === 1 ? "thread" : "threads"} in{" "}
+            {projectGroups.length}{" "}
+            {projectGroups.length === 1 ? "project folder" : "project folders"}.
+          </p>
+        ) : null}
+      </div>
+
       {(state.loading && state.threads.length === 0) ||
       (!state.loading && projectGroups.length === 0) ||
       restoreMessage ||
@@ -172,8 +235,13 @@ export function ArchivedThreadsSettings(props: {
             </p>
           ) : null}
           {!state.loading && projectGroups.length === 0 ? (
-            <p className="settings-empty settings-archive-empty">
-              No archived threads.
+            <p
+              className="settings-empty settings-archive-empty"
+              role={isFiltering ? "status" : undefined}
+            >
+              {isFiltering
+                ? `No archived threads match “${filterQuery}”.`
+                : "No archived threads."}
             </p>
           ) : null}
           {restoreMessage ? (
@@ -193,22 +261,24 @@ export function ArchivedThreadsSettings(props: {
       ) : null}
 
       {projectGroups.map((group) => {
-        const visibleThreads = group.threads.slice(
-          0,
-          ARCHIVED_THREADS_PER_PROJECT_LIMIT,
-        );
+        const visibleThreads = isFiltering
+          ? group.threads
+          : group.threads.slice(0, ARCHIVED_THREADS_PER_PROJECT_LIMIT);
         const hiddenThreadCount = group.threads.length - visibleThreads.length;
+        const groupThreadNoun = isFiltering
+          ? group.threads.length === 1
+            ? "match"
+            : "matches"
+          : group.threads.length === 1
+            ? "thread"
+            : "threads";
         return (
           <SettingsSection
             key={group.key}
             eyebrow="Project folder"
             title={group.label}
             description={group.path}
-            chip={
-              group.threads.length === 1
-                ? "1 thread"
-                : `${group.threads.length} threads`
-            }
+            chip={`${group.threads.length} ${groupThreadNoun}`}
             chipKind="muted"
           >
             <div className="settings-archive-project__threads">
@@ -225,7 +295,7 @@ export function ArchivedThreadsSettings(props: {
                   />
                 );
               })}
-              {hiddenThreadCount > 0 ? (
+              {!isFiltering && hiddenThreadCount > 0 ? (
                 <p className="settings-archive-status">
                   Showing {ARCHIVED_THREADS_PER_PROJECT_LIMIT} of{" "}
                   {group.threads.length} most recent archived threads.
@@ -336,6 +406,54 @@ function groupArchivedThreadsByProject(
       ? timestampDelta
       : left.label.localeCompare(right.label);
   });
+}
+
+function filterArchivedProjectGroups(
+  groups: ArchivedProjectGroup[],
+  query: string,
+): ArchivedProjectGroup[] {
+  const queryTerms = query
+    .toLocaleLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (queryTerms.length === 0) {
+    return groups;
+  }
+
+  return groups.flatMap((group) => {
+    const threads = group.threads.filter((thread) =>
+      archivedThreadMatchesFilter(thread, group, queryTerms),
+    );
+    return threads.length > 0 ? [{ ...group, threads }] : [];
+  });
+}
+
+function archivedThreadMatchesFilter(
+  thread: AppServerThreadSummary,
+  group: ArchivedProjectGroup,
+  queryTerms: string[],
+): boolean {
+  const searchText = [
+    group.label,
+    group.path,
+    thread.id,
+    thread.title,
+    thread.summary,
+    thread.projectKey,
+    thread.source,
+    thread.gitBranch,
+    thread.observedGitBranch,
+    ...thread.linkedDirectories.flatMap((directory) => [
+      directory.label,
+      directory.path,
+      directory.worktreePath,
+    ]),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join("\n")
+    .toLocaleLowerCase();
+
+  return queryTerms.every((term) => searchText.includes(term));
 }
 
 function resolveArchivedProject(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -1543,6 +1543,41 @@ describe("SettingsScreen", () => {
         "Showing 20 of 25 most recent archived threads.",
       ),
     ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter archived threads"), {
+      target: { value: "05" },
+    });
+
+    expect(
+      within(pwrAgentGroup).getByText("Archived thread 05"),
+    ).toBeInTheDocument();
+    expect(
+      within(pwrAgentGroup).queryByText("Archived thread 25"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1 match")).toBeInTheDocument();
+    expect(
+      screen.getByText("Showing 1 matching archived thread in 1 project folder."),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter archived threads"), {
+      target: { value: "Archived" },
+    });
+
+    expect(screen.getByText("25 matches")).toBeInTheDocument();
+    expect(
+      screen.getByText("Showing 25 matching archived threads in 1 project folder."),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter archived threads"), {
+      target: { value: "not found" },
+    });
+
+    expect(
+      screen.getByText("No archived threads match “not found”."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Showing 0 matching archived threads in 0 project folders."),
+    ).not.toBeInTheDocument();
   });
 
   it("does not re-add a restored thread when a stale archive refresh resolves", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -7093,6 +7093,69 @@ textarea,
   padding: 14px 18px;
 }
 
+.settings-archive-filter-control {
+  display: grid;
+  gap: 6px;
+  max-width: 640px;
+}
+
+.settings-archive-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 8px 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-muted);
+}
+
+.settings-archive-filter:focus-within {
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 1px var(--accent-shadow);
+}
+
+.settings-archive-filter__icon {
+  flex: 0 0 auto;
+}
+
+.settings-archive-filter__input {
+  flex: 1 1 auto;
+  width: auto;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+}
+
+.settings-archive-filter__input:focus,
+.settings-archive-filter__input:focus-visible {
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.settings-archive-filter__input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.settings-archive-filter__input::placeholder {
+  color: var(--text-muted);
+}
+
+.settings-archive-filter__clear {
+  min-height: 26px;
+  padding: 0 8px;
+}
+
+.settings-archive-filter__summary {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .settings-archive-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;


### PR DESCRIPTION
## Summary

- I added a case-insensitive filter to Archived Threads that checks thread title, summary, project metadata, branch, source, and ID.
- I show every matching archived thread, including matches outside the 20-thread per-project preview, with match counts, a clear control, and a no-results state.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` with zero errors (the repository's existing warnings remain).
- I ran `pnpm lint:colors`.
- I verified the populated Settings → Archived Threads view live in the desktop app.

## Notes

- This is a fast local filter over the archive data that the screen already loads; it does not introduce a new backend query.
