### PR TITLE
fix(desktop): center worktree path

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6214,6 +6214,8 @@ textarea,
 }
 
 .settings-input--readonly {
+  display: flex;
+  align-items: center;
   cursor: default;
 }
 


### PR DESCRIPTION
## Summary

- I centered the readonly Worktrees effective-path text vertically inside its fixed-height control.
- The path is rendered as a `<code>` element, so it did not receive the native input centering that comparable controls have.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`.
- I ran `pnpm lint:eslint` (passes with the repository's existing warnings) and `pnpm lint:colors`.
- I rebuilt the desktop app and captured the Worktrees settings screen in Electron to verify the centered path visually.

## Notes

- I kept the fix limited to the existing readonly settings-input modifier.
