### PR TITLE
fix(desktop): preserve live thread message provenance

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -797,6 +797,210 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("preserves live agent provenance when an earlier hydration finishes later", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    let resolveReadThread:
+      | ((response: AppServerReadThreadResponse) => void)
+      | undefined;
+    const readThread = vi.fn(
+      async () =>
+        await new Promise<AppServerReadThreadResponse>((resolve) => {
+          resolveReadThread = resolve;
+        })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(agentEventHandler).toBeDefined();
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "injected-message",
+              type: "userMessage",
+              origin: {
+                kind: "agent",
+                sourceThread: {
+                  backend: "codex",
+                  threadId: "source-thread",
+                  title: "Source thread",
+                },
+              },
+              content: [{ type: "text", text: "Please continue the audit." }],
+            },
+          },
+        },
+      });
+    });
+
+    await act(async () => {
+      resolveReadThread?.(
+        readThreadResponse({
+          entries: [
+            {
+              type: "message",
+              id: "injected-message",
+              role: "user",
+              text: "Please continue the audit.",
+            },
+          ],
+          hasPreviousPage: false,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.response?.threadStatus).toBe("idle");
+    });
+    expect(
+      result.current.response?.replay.entries.find(
+        (entry) => entry.id === "injected-message",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        origin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "source-thread",
+            title: "Source thread",
+          },
+        },
+      }),
+    );
+    expect(
+      result.current.response?.replay.messages.find(
+        (message) => message.id === "injected-message",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        origin: {
+          kind: "agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "source-thread",
+            title: "Source thread",
+          },
+        },
+      }),
+    );
+  });
+
+  it("keeps a live sub-agent message attributed to its source thread", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-monitor",
+            item: {
+              id: "monitor-result",
+              type: "userMessage",
+              origin: {
+                kind: "sub-agent",
+                sourceThread: {
+                  backend: "codex",
+                  threadId: "monitor-thread",
+                  title: "Watch CI",
+                },
+                subAgent: {
+                  kind: "monitor",
+                  monitorId: "monitor-1",
+                  task: "Watch CI",
+                  outcome: "success",
+                  summary: "All required checks passed.",
+                },
+              },
+              content: [{ type: "text", text: "All required checks passed." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.response?.replay.messages.find(
+        (message) => message.id === "monitor-result",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        origin: {
+          kind: "sub-agent",
+          sourceThread: {
+            backend: "codex",
+            threadId: "monitor-thread",
+            title: "Watch CI",
+          },
+          subAgent: {
+            kind: "monitor",
+            monitorId: "monitor-1",
+            task: "Watch CI",
+            outcome: "success",
+            summary: "All required checks passed.",
+          },
+        },
+      }),
+    );
+  });
+
   it("keeps an optimistic image user message ahead of a hydrated assistant final", async () => {
     const readThread = vi.fn(
       async ({

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -995,16 +995,53 @@ function carryForwardTranscriptEntryOrder(
   let changed = false;
   let entries = response.replay.entries.map((entry) => {
     const source = findUniqueTranscriptOrderSource(entry, sources);
-    if (!source || source.createdAt === entry.createdAt) {
+    if (!source) {
+      return entry;
+    }
+
+    // A read that began before main persisted an injected-message origin can
+    // resolve after the live item/completed event. Keep that richer live
+    // provenance instead of letting the stale response downgrade it to User.
+    const origin =
+      entry.type === "message"
+      && source.type === "message"
+      && !entry.origin
+      && source.origin
+        ? source.origin
+        : undefined;
+    const turn = source.turn && !entry.turn ? source.turn : undefined;
+    const createdAt = source.createdAt !== entry.createdAt
+      ? source.createdAt
+      : undefined;
+    if (!origin && !turn && createdAt === undefined) {
       return entry;
     }
 
     changed = true;
     return {
       ...entry,
-      createdAt: source.createdAt,
-      ...(source.turn && !entry.turn ? { turn: source.turn } : {}),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+      ...(turn ? { turn } : {}),
+      ...(origin ? { origin } : {}),
     };
+  });
+
+  const originsByMessageId = new Map(
+    entries
+      .filter(
+        (entry): entry is AppServerThreadMessageEntry =>
+          entry.type === "message" && Boolean(entry.origin)
+      )
+      .map((entry) => [entry.id, entry.origin] as const)
+  );
+  const messages = response.replay.messages.map((message) => {
+    const origin = originsByMessageId.get(message.id);
+    if (!origin || message.origin) {
+      return message;
+    }
+
+    changed = true;
+    return { ...message, origin };
   });
 
   const freshCurrentTurnId = latestTranscriptTurnId(response.replay.entries);
@@ -1061,6 +1098,7 @@ function carryForwardTranscriptEntryOrder(
         replay: {
           ...response.replay,
           entries,
+          messages,
         },
       }
     : response;
@@ -2889,15 +2927,21 @@ function threadMessageOriginFromUnknown(
     && record.kind !== "automation"
     && record.kind !== "messaging"
     && record.kind !== "pwragent"
+    && record.kind !== "sub-agent"
   ) {
     return undefined;
   }
   const messaging = threadMessageMessagingOriginFromUnknown(record.messaging);
+  const subAgent =
+    record.kind === "sub-agent"
+      ? threadMessageSubAgentOriginFromUnknown(record.subAgent)
+      : undefined;
   const source = record.sourceThread;
   if (!source || typeof source !== "object" || Array.isArray(source)) {
     return {
       kind: record.kind,
       ...(messaging ? { messaging } : {}),
+      ...(subAgent ? { subAgent } : {}),
     };
   }
   const sourceRecord = source as Record<string, unknown>;
@@ -2920,6 +2964,36 @@ function threadMessageOriginFromUnknown(
         : {}),
     },
     ...(messaging ? { messaging } : {}),
+    ...(subAgent ? { subAgent } : {}),
+  };
+}
+
+function threadMessageSubAgentOriginFromUnknown(
+  value: unknown,
+): AppServerThreadMessageOrigin["subAgent"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.kind !== "monitor"
+    || typeof record.monitorId !== "string"
+    || typeof record.task !== "string"
+    || typeof record.summary !== "string"
+    || (
+      record.outcome !== "success"
+      && record.outcome !== "failure"
+      && record.outcome !== "cancelled"
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "monitor",
+    monitorId: record.monitorId,
+    task: record.task,
+    outcome: record.outcome,
+    summary: record.summary,
   };
 }
 


### PR DESCRIPTION
## Summary

- I preserve live message provenance when an earlier transcript hydration response finishes after the richer `item/completed` event.
- I retain `sub-agent` monitor provenance in the live-event parser, so recipient transcripts identify the source thread rather than falling back to `User`.
- The root cause was a stale read overwriting the live origin, plus the parser omitting the supported `sub-agent` origin kind.

## Verification

- I verified the full renderer session-state and transcript-list suites: `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (164 passing).
- I verified the direct thread-to-thread delivery path: `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts -t 'sends a follow-up prompt to another thread from an active turn'`.
- I ran `pnpm typecheck`, `pnpm lint:eslint` (pre-existing warnings only), and `pnpm lint:boundaries`.

## Notes

- Existing persisted message-origin rows already hydrate correctly; this fixes the live-rendering race and the missed monitor/sub-agent channel going forward.
