### PR TITLE
feat(desktop): clarify search shortcut tooltip

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -883,7 +883,7 @@ export function Sidebar(props: SidebarProps) {
             tooltipText={[
               `Open Search All  (${formatPrimaryAccel("F", { shift: true })})`,
               `Quick Thread List Search  (${formatPrimaryAccel("K")})`,
-              `Thread Chat Search  (${formatPrimaryAccel("F")})`,
+              `Context Search  (${formatPrimaryAccel("F")}) — Thread List in sidebar, Thread Chat elsewhere`,
             ].join("\n")}
             ariaPressed={props.threadSearchActive}
             className={`sidebar__icon-button${props.threadSearchActive ? " is-active" : ""}`}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -880,7 +880,11 @@ export function Sidebar(props: SidebarProps) {
         <div className="sidebar__masthead-actions">
           <MastheadActionButton
             ariaLabel="Search threads"
-            tooltipText={`Search threads  (${formatPrimaryAccel("F", { shift: true })})`}
+            tooltipText={[
+              `Open Search All  (${formatPrimaryAccel("F", { shift: true })})`,
+              `Quick Thread List Search  (${formatPrimaryAccel("K")})`,
+              `Thread Chat Search  (${formatPrimaryAccel("F")})`,
+            ].join("\n")}
             ariaPressed={props.threadSearchActive}
             className={`sidebar__icon-button${props.threadSearchActive ? " is-active" : ""}`}
             onClick={props.onOpenThreadSearch}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -666,6 +666,14 @@ describe("Sidebar", () => {
       />
     );
 
+    const searchButton = screen.getByRole("button", { name: "Search threads" });
+    fireEvent.mouseEnter(searchButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Open Search All  (Ctrl+Shift+F)\nQuick Thread List Search  (Ctrl+K)\nThread Chat Search  (Ctrl+F)",
+    );
+    fireEvent.mouseLeave(searchButton);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
     const automationsButton = screen.getByRole("button", { name: "Open automations" });
     fireEvent.mouseEnter(automationsButton);
     expect((await screen.findByRole("tooltip")).textContent).toBe("Open automations");

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -669,7 +669,7 @@ describe("Sidebar", () => {
     const searchButton = screen.getByRole("button", { name: "Search threads" });
     fireEvent.mouseEnter(searchButton);
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Open Search All  (Ctrl+Shift+F)\nQuick Thread List Search  (Ctrl+K)\nThread Chat Search  (Ctrl+F)",
+      "Open Search All  (Ctrl+Shift+F)\nQuick Thread List Search  (Ctrl+K)\nContext Search  (Ctrl+F) — Thread List in sidebar, Thread Chat elsewhere",
     );
     fireEvent.mouseLeave(searchButton);
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- I clarified the sidebar search tooltip with the three distinct search shortcuts.
- I keep the shortcut labels platform-aware: Command on macOS and Ctrl on Windows/Linux.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`.
- I ran `pnpm test apps/desktop/src/renderer/src/lib/__tests__/keyboard-accel.test.ts`.
- I ran `pnpm lint:eslint`; it passed with the repository's existing warnings only.

## Notes

- I did not change any shortcut behavior; this PR makes the existing search modes discoverable.
