### PR TITLE
fix(desktop): start PR repair countdown at 30s

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2562,7 +2562,11 @@ export function Composer(props: ComposerProps) {
   const [recentFileReferences, setRecentFileReferences] = useState<
     ReferencePickerFile[]
   >([]);
-  const [scheduleTick, setScheduleTick] = useState(() => Date.now());
+  // The state only schedules the next countdown render. It must not be used as
+  // the clock itself: a newly received schedule can arrive long after the
+  // previous tick, briefly making its first countdown look much too long.
+  const [scheduleTick, setScheduleTick] = useState(0);
+  const scheduleNow = Date.now();
   const [scheduledDraftSendAt, setScheduledDraftSendAt] = useState<
     number | undefined
   >();
@@ -2785,7 +2789,7 @@ export function Composer(props: ComposerProps) {
   const nextReleasableQueuedTurn = getNextReleasableQueuedTurn(queuedTurns);
   const futureScheduledDraftSendAt = getFutureScheduledSendAt(
     scheduledDraftSendAt,
-    scheduleTick,
+    scheduleNow,
   );
   launchpadUpdateRef.current = props.onUpdateLaunchpad;
   latestDraftSnapshotRef.current = {
@@ -3381,7 +3385,7 @@ export function Composer(props: ComposerProps) {
     }
 
     const timer = window.setInterval(() => {
-      setScheduleTick(Date.now());
+      setScheduleTick((current) => current + 1);
     }, 1_000);
 
     return () => {
@@ -6712,7 +6716,7 @@ export function Composer(props: ComposerProps) {
   const launchpadSubmitting = isLaunchpad && sending;
   const fiveHourResetAt = getFiveHourRateLimitResetAt({
     backend,
-    now: scheduleTick,
+    now: scheduleNow,
     selectedModelOption,
   });
   const scheduledSendOptions: ScheduledSendMenuOption[] = [
@@ -6725,7 +6729,7 @@ export function Composer(props: ComposerProps) {
           {
             label: `Send in ${formatScheduledSendCountdown(
               fiveHourResetAt,
-              scheduleTick,
+              scheduleNow,
             )} (5h context reset)`,
             scheduledSendAt: fiveHourResetAt,
           },
@@ -7747,7 +7751,7 @@ export function Composer(props: ComposerProps) {
                 ? "Auto-fix PR paused"
                 : `Auto-fix PR in ${formatScheduledSendCountdown(
                     prAutoDispatchPending.scheduledAt,
-                    scheduleTick,
+                    scheduleNow,
                   )}`}
             </span>
             <span className="composer__queued-text">
@@ -7796,10 +7800,10 @@ export function Composer(props: ComposerProps) {
       {queuedTurns.map((queued, index) => {
         const scheduledSendAt = getFutureScheduledSendAt(
           queued.scheduledSendAt,
-          scheduleTick,
+          scheduleNow,
         );
         const queuedLabel = scheduledSendAt
-          ? `Sends in ${formatScheduledSendCountdown(scheduledSendAt, scheduleTick)}`
+          ? `Sends in ${formatScheduledSendCountdown(scheduledSendAt, scheduleNow)}`
           : index === 0
             ? "Queued next"
             : `Queued #${index + 1}`;
@@ -8128,7 +8132,7 @@ export function Composer(props: ComposerProps) {
                 {futureScheduledDraftSendAt
                   ? `Send in ${formatScheduledSendCountdown(
                       futureScheduledDraftSendAt,
-                      scheduleTick,
+                      scheduleNow,
                     )}`
                   : "Start review"}
               </button>
@@ -9143,7 +9147,7 @@ export function Composer(props: ComposerProps) {
                   disabled={scheduleButtonDisabled}
                   type="button"
                   onClick={() => {
-                    setScheduleTick(Date.now());
+                    setScheduleTick((current) => current + 1);
                     setScheduleMenuOpen((current) => !current);
                   }}
                 >
@@ -9157,11 +9161,11 @@ export function Composer(props: ComposerProps) {
                     scheduleArmed
                       ? `Send later, in ${formatScheduledSendCountdown(
                           futureScheduledDraftSendAt!,
-                          scheduleTick,
+                          scheduleNow,
                         )}. Uncheck to send now.`
                       : `Send now. Check to send later, in ${formatScheduledSendCountdown(
                           futureScheduledDraftSendAt!,
-                          scheduleTick,
+                          scheduleNow,
                         )}.`
                   }
                   className={[
@@ -9174,7 +9178,7 @@ export function Composer(props: ComposerProps) {
                   role="switch"
                   type="button"
                   onClick={() => {
-                    setScheduleTick(Date.now());
+                    setScheduleTick((current) => current + 1);
                     setScheduleArmed((current) => !current);
                   }}
                 >
@@ -9188,7 +9192,7 @@ export function Composer(props: ComposerProps) {
                     in{" "}
                     {formatScheduledSendCountdown(
                       futureScheduledDraftSendAt!,
-                      scheduleTick,
+                      scheduleNow,
                     )}
                   </span>
                 </button>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -572,6 +572,55 @@ describe("Composer", () => {
     });
   });
 
+  it("renders a newly received PR repair countdown from the current clock", () => {
+    const mountedAt = new Date("2026-08-01T12:00:00.000Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(mountedAt);
+    const thread: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Fix CI",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+      prAutoDispatchEnabled: true,
+    };
+    const { rerender } = render(
+      <Composer
+        backgroundPrPollingEnabled
+        disabled={false}
+        skills={[]}
+        thread={thread}
+      />,
+    );
+
+    vi.setSystemTime(mountedAt + 90_000);
+    rerender(
+      <Composer
+        backgroundPrPollingEnabled
+        disabled={false}
+        skills={[]}
+        thread={{
+          ...thread,
+          prAutoDispatchPending: {
+            fingerprint: "fingerprint-1",
+            prKey: "github.com/pwrdrvr/PwrAgent#1105",
+            prNumber: 1105,
+            prUrl: "https://github.com/pwrdrvr/PwrAgent/pull/1105",
+            headSha: "a".repeat(40),
+            eventKinds: ["ci-failure"],
+            createdAt: mountedAt + 90_000,
+            scheduledAt: mountedAt + 120_000,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Scheduled PR auto-fix")).toHaveTextContent(
+      "Auto-fix PR in 30s",
+    );
+  });
+
   it("lets launchpad errors be copied with the transcript copy control", async () => {
     const copyText = vi.fn(async () => undefined);
     const launchpadError =


### PR DESCRIPTION
## Summary

- I separated the composer’s countdown rerender tick from the live time used to calculate scheduled countdowns.
- I fixed the Auto-fix PR banner so a newly received repair starts from the current clock, rather than briefly calculating from the previous stale tick.
- I added a regression test that simulates a 90-second-old composer clock and verifies a newly scheduled repair renders as `Auto-fix PR in 30s`.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (219 passed)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`

## Notes

The scheduler already sets the repair deadline 30 seconds ahead. The misleading first flash came from the renderer storing the last timer timestamp and using it during the first render of a new pending repair; the next one-second tick then corrected it. The tick now only causes rerenders, while countdowns read the current clock.
