### PR TITLE
fix(desktop): default review to changed primary project

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -570,6 +570,48 @@ describe("MessagingController", () => {
     });
   });
 
+  it("defaults a multi-project review to the changed primary workspace", async () => {
+    const navigation = buildMultiProjectReviewNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      gitWorkingState: {
+        ...navigation.threads[0]!.gitWorkingState!,
+        baseAheadCommitCount: 1,
+      },
+      linkedDirectories: [...navigation.threads[0]!.linkedDirectories].reverse(),
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/review"));
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "review",
+      body: [
+        "Project: App",
+        "Review: Base Branch",
+        "Base Branch: release",
+      ].join("\n"),
+      review: {
+        cwd: "/worktrees/app",
+        repositoryPath: "/repo/app",
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "review:summary:start" }),
+    );
+
+    expect(harness.submitReview).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "release" },
+      delivery: "inline",
+      cwd: "/worktrees/app",
+    });
+  });
+
   it("resets a selected commit when changing review projects", async () => {
     const harness = await createHarness({
       navigation: buildMultiProjectReviewNavigationSnapshot(),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -4,6 +4,7 @@ import {
   applyNavigationLaunchpadProviderSettingsPatch,
   buildReviewBranchOptions,
   buildThreadIdentityKey,
+  findPreferredReviewWorkspaceCwd,
   isAcpBackendId,
   isAppServerBackendKind,
   isMessagingBindingTargetKind,
@@ -1868,9 +1869,10 @@ export class MessagingController {
         } =>
           Boolean(workspace.cwd),
       );
-    const selectedWorkspace = workspaces.length === 1
-      ? workspaces[0]
-      : undefined;
+    const preferredWorkspaceCwd = findPreferredReviewWorkspaceCwd(thread);
+    const selectedWorkspace = workspaces.find(
+      (workspace) => workspace.cwd.trim() === preferredWorkspaceCwd,
+    ) ?? (workspaces.length === 1 ? workspaces[0] : undefined);
     const defaultRepositoryPath =
       selectedWorkspace?.repositoryPath
       ?? workspaces[0]?.repositoryPath;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -43,6 +43,7 @@ import {
   buildThreadMarkdownLink,
   buildThreadUrl,
   buildReviewBranchOptions,
+  findPreferredReviewWorkspaceCwd,
   parseThreadUrl,
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
@@ -727,6 +728,7 @@ function createReviewConfig(params: {
   };
 }): ReviewConfigState {
   const workspaceOptions = buildReviewWorkspaceOptions(params.thread);
+  const preferredWorkspaceCwd = findPreferredReviewWorkspaceCwd(params.thread);
   const config: ReviewConfigState = {
     branch: buildReviewBranchOptions(params)[0] ?? "main",
     branchSource: "auto",
@@ -734,7 +736,8 @@ function createReviewConfig(params: {
     customInstructions: "",
     target: "baseBranch",
     workspaceCwd: params.reviewCommand?.cwd ?? (
-      workspaceOptions.length === 1 ? workspaceOptions[0]?.cwd : undefined
+      preferredWorkspaceCwd ??
+      (workspaceOptions.length === 1 ? workspaceOptions[0]?.cwd : undefined)
     ),
   };
   const target = params.reviewCommand?.target;

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5999,6 +5999,113 @@ describe("Composer", () => {
     });
   });
 
+  it("defaults a multi-project review to the changed primary workspace", async () => {
+    const startReview = vi.fn(async (request: StartReviewRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      reviewThreadId: request.threadId,
+      turnId: "turn-review-1",
+    }));
+    const appDirectory: NavigationDirectorySummary = {
+      key: "directory:app",
+      kind: "directory",
+      label: "App",
+      path: "/repo/app",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "feature/app",
+        defaultBranch: "main",
+        branches: ["feature/app", "main", "release"],
+        baseBranches: ["release", "main"],
+      },
+    };
+    const infraDirectory: NavigationDirectorySummary = {
+      key: "directory:infra",
+      kind: "directory",
+      label: "Infra",
+      path: "/repo/infra",
+      threadKeys: ["codex:thread-1"],
+      needsAttentionCount: 0,
+      gitStatus: {
+        currentBranch: "feature/infra",
+        defaultBranch: "develop",
+        branches: ["feature/infra", "develop"],
+        baseBranches: ["develop"],
+      },
+    };
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        directory={infraDirectory}
+        directories={[infraDirectory, appDirectory]}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          projectKey: "/worktrees/app/packages/service",
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 0,
+            baseBranch: "release",
+            baseAheadCommitCount: 1,
+          },
+          linkedDirectories: [
+            {
+              id: "directory:infra",
+              kind: "worktree",
+              label: "Infra",
+              path: "/repo/infra",
+              worktreePath: "/worktrees/infra",
+            },
+            {
+              id: "directory:app",
+              kind: "worktree",
+              label: "App",
+              path: "/repo/app",
+              worktreePath: "/worktrees/app",
+            },
+          ],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+
+    expect(screen.getByLabelText("Review project")).toHaveValue("/worktrees/app");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Base branch")).toHaveValue("release");
+    });
+    expect(screen.getByRole("button", { name: "Start review" })).toBeEnabled();
+
+    await clickButton("Start review");
+
+    await waitFor(() => {
+      expect(startReview).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-1",
+        target: { type: "baseBranch", branch: "release" },
+        delivery: "inline",
+        cwd: "/worktrees/app",
+      });
+    });
+  });
+
   it("reloads review base branches when the review project changes", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,

--- a/packages/shared/src/__tests__/review-branches.test.ts
+++ b/packages/shared/src/__tests__/review-branches.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "../contracts/navigation";
+import { findPreferredReviewWorkspaceCwd } from "../review-branches";
+
+describe("findPreferredReviewWorkspaceCwd", () => {
+  it("selects the changed primary project from multiple linked workspaces", () => {
+    expect(
+      findPreferredReviewWorkspaceCwd(
+        reviewThread({
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 0,
+            baseBranch: "main",
+            baseAheadCommitCount: 2,
+          },
+        }),
+      ),
+    ).toBe("/worktrees/app");
+  });
+
+  it("selects a dirty primary project even before its changes are committed", () => {
+    expect(
+      findPreferredReviewWorkspaceCwd(
+        reviewThread({
+          gitWorkingState: {
+            dirtyFiles: 1,
+            dirtyAdditions: 12,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 0,
+            baseBranch: "main",
+            baseAheadCommitCount: 0,
+          },
+        }),
+      ),
+    ).toBe("/worktrees/app");
+  });
+
+  it("keeps a clean primary project ambiguous", () => {
+    expect(
+      findPreferredReviewWorkspaceCwd(
+        reviewThread({
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 1,
+            baseBranch: "main",
+            baseAheadCommitCount: 0,
+          },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+function reviewThread(
+  overrides: Pick<NavigationThreadSummary, "gitWorkingState">,
+): Pick<
+  NavigationThreadSummary,
+  "gitWorkingState" | "linkedDirectories" | "projectKey"
+> {
+  return {
+    projectKey: "/worktrees/app/packages/api",
+    linkedDirectories: [
+      {
+        id: "directory:infra",
+        kind: "worktree",
+        label: "Infra",
+        path: "/repo/infra",
+        worktreePath: "/worktrees/infra",
+      },
+      {
+        id: "directory:app",
+        kind: "worktree",
+        label: "App",
+        path: "/repo/app",
+        worktreePath: "/worktrees/app",
+      },
+    ],
+    ...overrides,
+  };
+}

--- a/packages/shared/src/review-branches.ts
+++ b/packages/shared/src/review-branches.ts
@@ -141,3 +141,56 @@ export function buildReviewBranchOptions(params: {
   }
   return [...options];
 }
+
+/**
+ * Chooses the thread's primary workspace when it is a linked project with
+ * reviewable changes against its inferred base. This keeps multi-project
+ * reviews unambiguous by default without guessing for a clean primary
+ * workspace.
+ */
+export function findPreferredReviewWorkspaceCwd(
+  thread?: Pick<
+    NavigationThreadSummary,
+    "gitWorkingState" | "linkedDirectories" | "projectKey"
+  >,
+): string | undefined {
+  const projectKey = normalizeReviewWorkspacePath(thread?.projectKey);
+  const gitWorkingState = thread?.gitWorkingState;
+  if (
+    !projectKey ||
+    !gitWorkingState?.baseBranch ||
+    (
+      (gitWorkingState.baseAheadCommitCount ?? 0) <= 0 &&
+      gitWorkingState.dirtyFiles <= 0 &&
+      gitWorkingState.untrackedFiles <= 0
+    )
+  ) {
+    return undefined;
+  }
+
+  return (thread?.linkedDirectories ?? [])
+    .flatMap((directory) => {
+      const cwd = (directory.worktreePath ?? directory.path).trim();
+      const workspacePath = normalizeReviewWorkspacePath(cwd);
+      return workspacePath && reviewWorkspaceContains(workspacePath, projectKey)
+        ? [{ cwd, workspacePath }]
+        : [];
+    })
+    .sort((left, right) => right.workspacePath.length - left.workspacePath.length)[0]
+    ?.cwd;
+}
+
+function normalizeReviewWorkspacePath(value?: string): string | undefined {
+  const normalized = value?.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized || undefined;
+}
+
+function reviewWorkspaceContains(
+  workspacePath: string,
+  projectPath: string,
+): boolean {
+  return (
+    workspacePath === projectPath ||
+    projectPath.startsWith(`${workspacePath}/`)
+  );
+}


### PR DESCRIPTION
## Summary

- I made `/review` preselect the thread's primary linked project when that workspace has changes against its inferred base.
- I applied the same default in the desktop composer and messaging review picker, while keeping clean multi-project threads explicit.
- I added shared, desktop, and messaging regression coverage for the selection behavior.

## Verification

- I ran `pnpm typecheck`.
- I ran the focused shared, messaging, and composer suite: 544 tests passed.
- I ran `pnpm lint:eslint` (no errors; existing warnings remain).
- I ran `pnpm lint:boundaries`.

## Notes

- I opened this as a draft because it changes the default review target selection.
