### PR TITLE
feat(desktop): show directory active thread counts

### DIFF
--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -10,6 +10,12 @@ async function createThreadRowStatusFixture(): Promise<{
 }> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-thread-row-status-"));
   const fixturePath = path.join(rootDir, "thread-row-status.fixture.json");
+  const linkedDirectory = {
+    id: "thread-row-status-directory",
+    label: "Thread row status fixture",
+    path: rootDir,
+    kind: "local",
+  };
 
   await writeFile(
     fixturePath,
@@ -45,7 +51,7 @@ async function createThreadRowStatusFixture(): Promise<{
                 summary: "A thread we start from the app",
                 source: "codex",
                 executionMode: "default",
-                linkedDirectories: [],
+                linkedDirectories: [linkedDirectory],
                 updatedAt: 1_000,
               },
               {
@@ -55,7 +61,7 @@ async function createThreadRowStatusFixture(): Promise<{
                 summary: "A thread we switch to while the first one runs",
                 source: "codex",
                 executionMode: "default",
-                linkedDirectories: [],
+                linkedDirectories: [linkedDirectory],
                 updatedAt: 1_500,
               },
             ],
@@ -170,7 +176,7 @@ async function createThreadRowStatusFixture(): Promise<{
                 summary: "A thread we start from the app",
                 source: "codex",
                 executionMode: "default",
-                linkedDirectories: [],
+                linkedDirectories: [linkedDirectory],
                 updatedAt: 2_000,
               },
               {
@@ -180,7 +186,7 @@ async function createThreadRowStatusFixture(): Promise<{
                 summary: "A thread we switch to while the first one runs",
                 source: "codex",
                 executionMode: "default",
-                linkedDirectories: [],
+                linkedDirectories: [linkedDirectory],
                 updatedAt: 1_500,
               },
             ],
@@ -232,6 +238,18 @@ test("shows initiated background turns as thinking, then unread once they finish
     await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toBeVisible();
     await expect(initiatedRow.locator('[data-thread-status="unread"]')).toHaveCount(0);
 
+    const directoriesTab = app.window.getByRole("tab", {
+      name: "Directories, 1 active thread",
+    });
+    await expect(directoriesTab).toBeVisible();
+    await directoriesTab.click();
+    await expect(
+      app.window
+        .locator(".directory-row__summary")
+        .filter({ hasText: "Thread row status fixture" })
+        .getByTitle("1 active thread"),
+    ).toBeVisible();
+
     await app.advance({ stepId: "turn-started-1" });
     await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toBeVisible();
 
@@ -240,6 +258,10 @@ test("shows initiated background turns as thinking, then unread once they finish
     await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toHaveCount(0);
     await expect(initiatedRow.locator('[data-thread-status="unread"]')).toBeVisible();
     await expect(initiatedRow.locator(".thread-row__status-cookie")).toBeVisible();
+    await expect(app.window.getByRole("tab", { name: "Directories" })).toBeVisible();
+    await expect(
+      app.window.locator('[data-active-thread-count="1"]'),
+    ).toHaveCount(0);
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/e2e/thread-row-status.spec.ts
+++ b/apps/desktop/e2e/thread-row-status.spec.ts
@@ -249,6 +249,12 @@ test("shows initiated background turns as thinking, then unread once they finish
         .filter({ hasText: "Thread row status fixture" })
         .getByTitle("1 active thread"),
     ).toBeVisible();
+    await expect(
+      app.window
+        .locator(".directory-row__summary")
+        .filter({ hasText: "Thread row status fixture" })
+        .getByTitle("1 thread to review"),
+    ).toHaveCount(0);
 
     await app.advance({ stepId: "turn-started-1" });
     await expect(initiatedRow.locator('[data-thread-status="thinking"]')).toBeVisible();
@@ -262,6 +268,12 @@ test("shows initiated background turns as thinking, then unread once they finish
     await expect(
       app.window.locator('[data-active-thread-count="1"]'),
     ).toHaveCount(0);
+    await expect(
+      app.window
+        .locator(".directory-row__summary")
+        .filter({ hasText: "Thread row status fixture" })
+        .getByTitle("1 thread to review"),
+    ).toBeVisible();
   } finally {
     await app.close();
     await fixture.cleanup();

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -37,7 +37,12 @@ import {
   type DropIndicatorState,
 } from "./drag-drop";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import { ThreadRow } from "./ThreadRow";
+import {
+  formatActiveThreadCount,
+  isThreadActive,
+} from "./ThreadRowStatus";
 
 type DirectoriesListProps = {
   approvalRequestThreadKeys?: Record<string, boolean>;
@@ -587,6 +592,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const visibleThreads = directory.threadKeys
       .map((threadKey) => threadsByKey.get(threadKey))
       .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
+    const activeThreadCount = visibleThreads.filter((thread) =>
+      isThreadActive(thread, props.thinkingThreadKeys),
+    ).length;
     const visibleThreadKeys = new Set(
       visibleThreads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
     );
@@ -1040,6 +1048,16 @@ export function DirectoriesList(props: DirectoriesListProps) {
             </span>
 
             <span className="directory-row__summary-meta">
+              {activeThreadCount > 0 ? (
+                <span
+                  className="directory-row__active-count"
+                  data-active-thread-count={activeThreadCount}
+                  title={formatActiveThreadCount(activeThreadCount)}
+                >
+                  <ThinkingScanner compact />
+                  <span>{activeThreadCount} active</span>
+                </span>
+              ) : null}
               {directory.needsAttentionCount > 0 ? (
                 <span className="count-pill directory-row__attention">
                   {directory.needsAttentionCount}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -41,7 +41,9 @@ import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import { ThreadRow } from "./ThreadRow";
 import {
   formatActiveThreadCount,
+  formatReviewThreadCount,
   isThreadActive,
+  isThreadAwaitingReview,
 } from "./ThreadRowStatus";
 
 type DirectoriesListProps = {
@@ -595,6 +597,21 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const activeThreadCount = visibleThreads.filter((thread) =>
       isThreadActive(thread, props.thinkingThreadKeys),
     ).length;
+    // A live turn can also be in the Inbox after emitting new output. Keep it
+    // in the activity count only, so a directory never reports the same thread
+    // as both active and waiting to be reviewed.
+    const reviewThreadCount = visibleThreads.filter(
+      (thread) =>
+        isThreadAwaitingReview(thread)
+        && !isThreadActive(thread, props.thinkingThreadKeys),
+    ).length;
+    const directorySummaryLabel = [
+      directory.label,
+      activeThreadCount > 0 ? formatActiveThreadCount(activeThreadCount) : undefined,
+      reviewThreadCount > 0 ? formatReviewThreadCount(reviewThreadCount) : undefined,
+    ]
+      .filter((label): label is string => Boolean(label))
+      .join(", ");
     const visibleThreadKeys = new Set(
       visibleThreads.map((thread) => buildThreadIdentityKey(thread.source, thread.id)),
     );
@@ -985,6 +1002,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
           }
         >
           <button
+            aria-label={directorySummaryLabel}
             aria-expanded={expanded}
             className={`thread-row thread-row--compact directory-row__summary${
               selectedLaunchpad ? " is-selected" : ""
@@ -1058,9 +1076,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   <span>{activeThreadCount} active</span>
                 </span>
               ) : null}
-              {directory.needsAttentionCount > 0 ? (
-                <span className="count-pill directory-row__attention">
-                  {directory.needsAttentionCount}
+              {reviewThreadCount > 0 ? (
+                <span
+                  className="directory-row__review-count"
+                  data-review-thread-count={reviewThreadCount}
+                  title={formatReviewThreadCount(reviewThreadCount)}
+                >
+                  <span aria-hidden="true" className="thread-row__status-cookie" />
+                  <span>{reviewThreadCount} to review</span>
                 </span>
               ) : null}
             </span>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -53,6 +53,11 @@ import {
 } from "../../lib/backend-status-format";
 import { DirectoriesList } from "./DirectoriesList";
 import { RecentsList } from "./RecentsList";
+import {
+  formatActiveThreadCount,
+  isThreadActive,
+} from "./ThreadRowStatus";
+import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
 type ThreadContextMenuPosition = {
   x: number;
@@ -301,6 +306,13 @@ export function Sidebar(props: SidebarProps) {
     props.browseMode === "recents"
       ? props.recentThreads ?? props.threads
       : props.inboxThreads ?? props.threads;
+  const activeThreadCount = useMemo(
+    () =>
+      props.threads.filter((thread) =>
+        isThreadActive(thread, props.thinkingThreadKeys),
+      ).length,
+    [props.thinkingThreadKeys, props.threads],
+  );
   const revealSelectedThreadRequest = props.revealSelectedThreadRequest;
   const selectedItemKey = props.selectedItemKey;
   const navigationThreads = props.threads;
@@ -1004,7 +1016,14 @@ export function Sidebar(props: SidebarProps) {
               key={mode}
               mode={mode}
               active={props.browseMode === mode}
-              tooltipText={browseModeTooltips[mode]}
+              activeThreadCount={
+                mode === "directories" ? activeThreadCount : undefined
+              }
+              tooltipText={
+                mode === "directories" && activeThreadCount > 0
+                  ? `${browseModeTooltips[mode]} · ${formatActiveThreadCount(activeThreadCount)}`
+                  : browseModeTooltips[mode]
+              }
               onSelect={() => props.onBrowseModeChange(mode)}
             />
           ))}
@@ -1702,10 +1721,14 @@ function ProfileIdentityButton(props: {
 function LensTab(props: {
   mode: BrowseMode;
   active: boolean;
+  activeThreadCount?: number;
   tooltipText: string;
   onSelect: () => void;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const activeThreadLabel = props.activeThreadCount
+    ? formatActiveThreadCount(props.activeThreadCount)
+    : undefined;
 
   return (
     <>
@@ -1715,6 +1738,11 @@ function LensTab(props: {
         // button) since browsers don't auto-wire arrow-key navigation from role
         // alone — adding role here only changes how screen readers announce it.
         role="tab"
+        aria-label={
+          activeThreadLabel
+            ? `${browseModeLabels[props.mode]}, ${activeThreadLabel}`
+            : undefined
+        }
         aria-selected={props.active}
         className={`lens-switch__button${props.active ? " is-active" : ""}`}
         type="button"
@@ -1743,6 +1771,12 @@ function LensTab(props: {
         ) : (
           <span className="lens-switch__label">{browseModeLabels[props.mode]}</span>
         )}
+        {props.activeThreadCount ? (
+          <span aria-hidden="true" className="lens-switch__active-count">
+            <ThinkingScanner compact />
+            <span>{props.activeThreadCount}</span>
+          </span>
+        ) : null}
       </button>
       {tooltip.tooltipNode}
     </>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -25,6 +25,19 @@ export function formatActiveThreadCount(count: number): string {
   return `${count} active thread${count === 1 ? "" : "s"}`;
 }
 
+/**
+ * Inbox membership includes both a thread that is new to the operator and an
+ * existing thread updated since it was last seen. Directory summaries call
+ * this "to review" rather than collapsing it into the live-turn count.
+ */
+export function isThreadAwaitingReview(thread: NavigationThreadSummary): boolean {
+  return thread.inbox.inInbox;
+}
+
+export function formatReviewThreadCount(count: number): string {
+  return `${count} thread${count === 1 ? "" : "s"} to review`;
+}
+
 export function getThreadRowStatus(
   thread: NavigationThreadSummary,
   thinkingThreadKeys?: Record<string, boolean>

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -4,12 +4,32 @@ import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 
 export type ThreadRowStatusKind = "thinking" | "unread";
 
+/**
+ * A thread is live when the backend reports an active turn or the renderer has
+ * just initiated one and is waiting for that status to round-trip. Keep this
+ * predicate shared with aggregate activity counts so their numbers match the
+ * animated thread-row marker exactly.
+ */
+export function isThreadActive(
+  thread: NavigationThreadSummary,
+  thinkingThreadKeys?: Record<string, boolean>,
+): boolean {
+  const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+  return (
+    thread.threadStatus === "active"
+    || thinkingThreadKeys?.[threadKey] === true
+  );
+}
+
+export function formatActiveThreadCount(count: number): string {
+  return `${count} active thread${count === 1 ? "" : "s"}`;
+}
+
 export function getThreadRowStatus(
   thread: NavigationThreadSummary,
   thinkingThreadKeys?: Record<string, boolean>
 ): ThreadRowStatusKind | undefined {
-  const threadKey = buildThreadIdentityKey(thread.source, thread.id);
-  if (thread.threadStatus === "active" || thinkingThreadKeys?.[threadKey]) {
+  if (isThreadActive(thread, thinkingThreadKeys)) {
     return "thinking";
   }
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1287,9 +1287,11 @@ describe("Sidebar", () => {
     );
 
     const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    fireEvent.click(
-      within(browseSection as HTMLElement).getByRole("button", { name: "PwrAgent1" })
-    );
+    const directorySummary = within(browseSection as HTMLElement)
+      .getAllByRole("button", { name: /PwrAgent/i })
+      .find((button) => button.hasAttribute("aria-expanded"));
+    expect(directorySummary).toBeDefined();
+    fireEvent.click(directorySummary!);
     const worktreeThreadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: /Cross-project cleanup/i,
     });
@@ -1486,7 +1488,7 @@ describe("Sidebar", () => {
     ).not.toBeNull();
   });
 
-  it("shows live-thread counts in the Directories tab and each directory", () => {
+  it("separates active and reviewable threads in directory counts", () => {
     const backendActiveThread = {
       ...sharedThread,
       id: "thread-backend-active",
@@ -1503,10 +1505,17 @@ describe("Sidebar", () => {
       id: "thread-idle",
       title: "Idle thread",
       threadStatus: "idle" as const,
+      inbox: {
+        inInbox: true,
+        reason: "updated-since-seen" as const,
+        lastSeenUpdatedAt: sharedThread.updatedAt - 1,
+      },
     };
     const directory: NavigationDirectorySummary = {
       ...directories[0]!,
-      needsAttentionCount: 0,
+      // The summary's persisted Inbox aggregate includes all three threads,
+      // but the renderer must not count the two active ones again as review.
+      needsAttentionCount: 3,
       threadKeys: [
         "codex:thread-backend-active",
         "codex:thread-locally-thinking",
@@ -1545,6 +1554,9 @@ describe("Sidebar", () => {
     const activeCount = within(summary!).getByTitle("2 active threads");
     expect(activeCount).toHaveAttribute("data-active-thread-count", "2");
     expect(activeCount).toHaveTextContent("2 active");
+    const reviewCount = within(summary!).getByTitle("1 thread to review");
+    expect(reviewCount).toHaveAttribute("data-review-thread-count", "1");
+    expect(reviewCount).toHaveTextContent("1 to review");
   });
 
   it("shows an approval chip for threads waiting on an approval request", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1486,6 +1486,67 @@ describe("Sidebar", () => {
     ).not.toBeNull();
   });
 
+  it("shows live-thread counts in the Directories tab and each directory", () => {
+    const backendActiveThread = {
+      ...sharedThread,
+      id: "thread-backend-active",
+      title: "Backend-reported active thread",
+      threadStatus: "active" as const,
+    };
+    const locallyThinkingThread = {
+      ...sharedThread,
+      id: "thread-locally-thinking",
+      title: "Locally initiated active thread",
+    };
+    const idleThread = {
+      ...sharedThread,
+      id: "thread-idle",
+      title: "Idle thread",
+      threadStatus: "idle" as const,
+    };
+    const directory: NavigationDirectorySummary = {
+      ...directories[0]!,
+      needsAttentionCount: 0,
+      threadKeys: [
+        "codex:thread-backend-active",
+        "codex:thread-locally-thinking",
+        "codex:thread-idle",
+      ],
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[directory]}
+        inboxThreads={[backendActiveThread, locallyThinkingThread, idleThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        thinkingThreadKeys={{ "codex:thread-locally-thinking": true }}
+        threads={[backendActiveThread, locallyThinkingThread, idleThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("tab", { name: "Directories, 2 active threads" }),
+    ).toBeInTheDocument();
+
+    const summary = screen
+      .getAllByRole("button", { name: /PwrAgent/i })
+      .find((button) => button.hasAttribute("aria-expanded"));
+    expect(summary).toBeDefined();
+    const activeCount = within(summary!).getByTitle("2 active threads");
+    expect(activeCount).toHaveAttribute("data-active-thread-count", "2");
+    expect(activeCount).toHaveTextContent("2 active");
+  });
+
   it("shows an approval chip for threads waiting on an approval request", () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2767,6 +2767,19 @@ textarea,
   display: none;
 }
 
+.lens-switch__active-count {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  margin-left: 4px;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
 @container (max-width: 300px) {
   .lens-switch__label--full {
     display: none;
@@ -4197,6 +4210,18 @@ textarea,
   height: 24px;
   padding: 0 7px;
   font-size: 11px;
+}
+
+.directory-row__active-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .directory-row__chevron {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4205,23 +4205,29 @@ textarea,
   min-width: 0;
 }
 
-.directory-row__attention {
-  min-width: 24px;
-  height: 24px;
-  padding: 0 7px;
-  font-size: 11px;
-}
-
-.directory-row__active-count {
+.directory-row__active-count,
+.directory-row__review-count {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  color: var(--accent-bright);
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+.directory-row__active-count {
+  color: var(--accent-bright);
+}
+
+.directory-row__review-count {
+  color: var(--text-secondary);
+}
+
+.directory-row__review-count .thread-row__status-cookie {
+  width: 9px;
+  height: 9px;
 }
 
 .directory-row__chevron {


### PR DESCRIPTION
## Summary

- I added a live active-thread total to the Directories tab and a per-directory active counter with the existing thinking scanner.
- I separated live work from inbox work on directory rows: active turns show as `N active`, while new or updated non-active threads show as `N to review`.
- I made the directory summary labels announce both states clearly and added renderer and replay-backed regression coverage for the transition from active to reviewable.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm --filter @pwragent/desktop build`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/thread-row-status.spec.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec eslint apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/e2e/thread-row-status.spec.ts`
- `pnpm lint:colors`
- `pnpm lint:boundaries`

## Notes

- The previous bare directory badge was an Inbox/needs-attention aggregate, so a running thread could be represented by both signals. The new review counter deliberately excludes live turns.
