### PR TITLE
feat(desktop): pulse failed CI while checks run

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1444,6 +1444,7 @@ describe("app server ipc", () => {
             {
               prKey: "github.com/pwrdrvr/pwragent#845",
               checkState: "passing",
+              checksStillRunning: false,
               lifecycleState: "open",
               mergeState: "unknown",
               reviewState: "ready_for_review",

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -64,6 +64,7 @@ describe("buildBatchedPrQuery", () => {
     expect(query).toContain("pullRequest(number: $p0)");
     expect(query).toContain("pullRequest(number: $p1)");
     expect(query.match(/repository\(/g)).toHaveLength(2);
+    expect(query).toContain("contexts(first: 100)");
   });
 
   it("passes every input as a variable rather than interpolating it", () => {
@@ -167,6 +168,42 @@ describe("mapGraphqlPrNode", () => {
     expect(summary.checkState).toBe(chip);
     // `state` is the deprecated alias and must stay in lockstep with checkState.
     expect(summary.state).toBe(chip);
+  });
+
+  it("records checks still running alongside a failing rollup", () => {
+    const summary = mapGraphqlPrNode(
+      node({
+        commits: {
+          nodes: [{
+            commit: {
+              oid: "b".repeat(40),
+              statusCheckRollup: {
+                state: "FAILURE",
+                contexts: {
+                  nodes: [
+                    {
+                      __typename: "CheckRun",
+                      conclusion: "FAILURE",
+                      status: "COMPLETED",
+                    },
+                    {
+                      __typename: "CheckRun",
+                      conclusion: null,
+                      status: "IN_PROGRESS",
+                    },
+                  ],
+                },
+              },
+            },
+          }],
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      checkState: "failing",
+      checksStillRunning: true,
+    });
   });
 
   it("treats a missing rollup (no checks configured) as unknown, not passing", () => {

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -3,6 +3,7 @@ import {
   GithubGraphqlPrClient,
   branchRefKey,
   buildBatchedPrQuery,
+  buildBatchedStatusContextQuery,
   buildBranchPrQuery,
   mapGraphqlPrNode,
   parsePrRefFromUrl,
@@ -24,8 +25,15 @@ function node(overrides: Partial<GraphqlPrNode> = {}): GraphqlPrNode {
       nodes: [
         {
           commit: {
+            id: "commit-a",
             oid: "a".repeat(40),
-            statusCheckRollup: { state: "SUCCESS" },
+            statusCheckRollup: {
+              state: "SUCCESS",
+              contexts: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              },
+            },
           },
         },
       ],
@@ -65,6 +73,7 @@ describe("buildBatchedPrQuery", () => {
     expect(query).toContain("pullRequest(number: $p1)");
     expect(query.match(/repository\(/g)).toHaveLength(2);
     expect(query).toContain("contexts(first: 100)");
+    expect(query).toContain("pageInfo { hasNextPage endCursor }");
   });
 
   it("passes every input as a variable rather than interpolating it", () => {
@@ -86,6 +95,26 @@ describe("buildBatchedPrQuery", () => {
       o1: "other",
       n1: "infra",
       p1: 7,
+    });
+  });
+});
+
+describe("buildBatchedStatusContextQuery", () => {
+  it("uses commit ids and pagination cursors as variables", () => {
+    const { query, variables } = buildBatchedStatusContextQuery([
+      { commitId: "commit-1", cursor: "cursor-1" },
+      { commitId: "commit-2", cursor: "cursor-2" },
+    ]);
+
+    expect(query).toContain("r0: node(id: $id0)");
+    expect(query).toContain("r1: node(id: $id1)");
+    expect(query).toContain("contexts(first: 100, after: $c0)");
+    expect(query).toContain("contexts(first: 100, after: $c1)");
+    expect(variables).toEqual({
+      id0: "commit-1",
+      c0: "cursor-1",
+      id1: "commit-2",
+      c1: "cursor-2",
     });
   });
 });
@@ -325,6 +354,112 @@ describe("GithubGraphqlPrClient", () => {
 
     expect(request).toHaveBeenCalledTimes(1);
     expect(prs.map((pr) => pr.number)).toEqual([12, 7]);
+  });
+
+  it("paginates contexts before clearing a failed PR's running marker", async () => {
+    const truncated = node({
+      commits: {
+        nodes: [{
+          commit: {
+            id: "commit-12",
+            oid: "b".repeat(40),
+            statusCheckRollup: {
+              state: "FAILURE",
+              contexts: {
+                pageInfo: { hasNextPage: true, endCursor: "page-1" },
+                nodes: [{
+                  __typename: "CheckRun",
+                  conclusion: "FAILURE",
+                  status: "COMPLETED",
+                }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    const continuationCursors: string[] = [];
+    const request = vi.fn(async (
+      query: string,
+      variables: Record<string, string | number>,
+    ) => {
+      if (query.includes("PollStatusContextPages")) {
+        continuationCursors.push(String(variables.c0));
+        if (variables.c0 === "page-1") {
+          return {
+            r0: {
+              statusCheckRollup: {
+                contexts: {
+                  pageInfo: { hasNextPage: true, endCursor: "page-2" },
+                  nodes: [{
+                    __typename: "CheckRun",
+                    conclusion: "FAILURE",
+                    status: "COMPLETED",
+                  }],
+                },
+              },
+            },
+          };
+        }
+        return {
+          r0: {
+            statusCheckRollup: {
+              contexts: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [{
+                  __typename: "CheckRun",
+                  conclusion: null,
+                  status: "IN_PROGRESS",
+                }],
+              },
+            },
+          },
+        };
+      }
+      return { r0: { pullRequest: truncated } };
+    });
+
+    const [pr] = await client(request).fetchPullRequests([refs[0]!]);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(continuationCursors).toEqual(["page-1", "page-2"]);
+    expect(pr).toMatchObject({
+      checkState: "failing",
+      checksStillRunning: true,
+    });
+  });
+
+  it("keeps cached status when a later context page cannot be resolved", async () => {
+    const truncated = node({
+      commits: {
+        nodes: [{
+          commit: {
+            id: "commit-12",
+            oid: "b".repeat(40),
+            statusCheckRollup: {
+              state: "FAILURE",
+              contexts: {
+                pageInfo: { hasNextPage: true, endCursor: "page-1" },
+                nodes: [{
+                  __typename: "CheckRun",
+                  conclusion: "FAILURE",
+                  status: "COMPLETED",
+                }],
+              },
+            },
+          },
+        }],
+      },
+    });
+    const request = vi.fn(async (query: string) => {
+      if (query.includes("PollStatusContextPages")) {
+        throw Object.assign(new Error("forbidden"), { status: 403 });
+      }
+      return { r0: { pullRequest: truncated } };
+    });
+
+    await expect(client(request).fetchPullRequests([refs[0]!])).resolves.toEqual([]);
+    expect(request).toHaveBeenCalledTimes(2);
   });
 
   it("chunks into separate requests once past the batch size", async () => {

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -5,6 +5,7 @@ import {
   deriveLifecycleState,
   deriveMergeState,
   deriveReviewState,
+  hasChecksStillRunning,
   parseGhAuthStatus,
   parseGhPrPayload,
 } from "../pr-status/github-pr-fetcher";
@@ -208,6 +209,34 @@ describe("derive PR states", () => {
     }
   });
 
+  it("keeps a failure while sibling checks are still running", () => {
+    const row = {
+      ...rawMergedPr(),
+      state: "OPEN",
+      statusCheckRollup: [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          status: "COMPLETED",
+          name: "Lint",
+        },
+        {
+          __typename: "CheckRun",
+          conclusion: null,
+          status: "IN_PROGRESS",
+          name: "Desktop E2E",
+        },
+      ],
+    };
+
+    expect(deriveChipState(row)).toBe("failing");
+    expect(hasChecksStillRunning(row.statusCheckRollup ?? [])).toBe(true);
+    expect(parseGhPrPayload(row)).toMatchObject({
+      checkState: "failing",
+      checksStillRunning: true,
+    });
+  });
+
   it("returns pending when any check is still running", () => {
     expect(
       deriveChipState({
@@ -229,6 +258,30 @@ describe("derive PR states", () => {
         ],
       }),
     ).toBe("pending");
+  });
+
+  it("derives status-context failures independently from pending siblings", () => {
+    const row = {
+      ...rawMergedPr(),
+      state: "OPEN",
+      statusCheckRollup: [
+        { __typename: "StatusContext", state: "FAILURE" },
+        { __typename: "StatusContext", state: "PENDING" },
+      ],
+    };
+
+    expect(deriveChipState(row)).toBe("failing");
+    expect(hasChecksStillRunning(row.statusCheckRollup ?? [])).toBe(true);
+  });
+
+  it("does not mistake a completed conclusion with a stale progress status for work in flight", () => {
+    expect(hasChecksStillRunning([
+      {
+        __typename: "CheckRun",
+        conclusion: "SUCCESS",
+        status: "IN_PROGRESS",
+      },
+    ])).toBe(false);
   });
 
   it("returns unknown when an OPEN PR has no checks at all", () => {

--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -39,6 +39,16 @@ const prPassing: PrSummary = pr({
   url: "https://github.com/pwrdrvr/PwrAgent/pull/179",
 });
 
+const prFailingWithRunningChecks: PrSummary = pr({
+  provider: "github.com",
+  number: 180,
+  org: "pwrdrvr",
+  repo: "PwrAgent",
+  state: "failing",
+  checksStillRunning: true,
+  url: "https://github.com/pwrdrvr/PwrAgent/pull/180",
+});
+
 const enterprisePrPassing: PrSummary = pr({
   provider: "ghe.pwrdrvr.test",
   number: 179,
@@ -107,6 +117,20 @@ describe("SqliteOverlayStore — thread PRs", () => {
     });
     expect(overlay?.prs).toEqual([prPassing]);
     expect(overlay?.prsRefreshKey).toBe("codex:thread-1:feat/pr-chip:/repo");
+  });
+
+  it("preserves a failure that still has running checks", async () => {
+    await store.setThreadPullRequests({
+      backend: "codex",
+      threadId: "thread-1",
+      prs: [prFailingWithRunningChecks],
+    });
+
+    const overlay = await store.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(overlay?.prs).toEqual([prFailingWithRunningChecks]);
   });
 
   it("replaces prs (last write wins) so state transitions land", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -24713,6 +24713,7 @@ function toThreadInspectionSearchSummary(
             number: pr.number,
             state: pr.state,
             ...(pr.checkState ? { checkState: pr.checkState } : {}),
+            ...(pr.checksStillRunning ? { checksStillRunning: true } : {}),
             ...(pr.lifecycleState ? { lifecycleState: pr.lifecycleState } : {}),
             ...(pr.reviewState ? { reviewState: pr.reviewState } : {}),
             ...(pr.mergeState ? { mergeState: pr.mergeState } : {}),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3466,8 +3466,9 @@ class DesktopAppServerService {
           (window) =>
             !window.isDestroyed() && window.isVisible() && !window.isMinimized(),
         ),
-      // One token per GraphQL REQUEST (which covers up to a batch of PRs), not
-      // per PR — the same bucket the on-demand scheduled refreshes draw from.
+      // One token per admitted GraphQL batch (which covers up to a batch of
+      // PRs), not per PR. Any paginated status-context reads stay within that
+      // admitted batch.
       tryTakeToken: () => this.prStatusTokenBucket.tryTake(),
       fetchPullRequests: async (refs) =>
         await this.getPrGraphqlClient().fetchPullRequests(refs),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -698,6 +698,7 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
       candidate.title === pr.title &&
       candidate.state === pr.state &&
       candidate.checkState === pr.checkState &&
+      candidate.checksStillRunning === pr.checksStillRunning &&
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&
@@ -791,6 +792,7 @@ function prLogStatuses(prs: PrSummary[]): Record<string, unknown>[] {
     return {
       prKey: getPrStatusKey(normalized),
       checkState: normalized.checkState,
+      checksStillRunning: normalized.checksStillRunning ?? false,
       lifecycleState: normalized.lifecycleState,
       mergeState: normalized.mergeState,
       reviewState: normalized.reviewState,

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -8,6 +8,7 @@ import {
   deriveLifecycleState,
   deriveMergeState,
   deriveReviewState,
+  hasChecksStillRunning,
   normalizeCommitShas,
   parsePullRequestProvider,
 } from "./pr-derivations";
@@ -26,10 +27,10 @@ const graphqlLog = getMainLogger("pwragent:pr-graphql");
  *
  * GraphQL can: aliased top-level `repository(...)` selections put N PRs from
  * arbitrary repos into ONE request. GitHub bills GraphQL on a node/point model
- * against 5,000 points/hr with a floor of 1 point per request, and every field
- * we select is a single node (or a `commits(last: 1)` connection), so a batch
- * of ~40 PRs across ~40 repos costs about the floor. That is the entire reason
- * the poller does not shell out to `gh`.
+ * against 5,000 points/hr. The query keeps its connections bounded to one head
+ * commit and at most 100 status contexts per PR, which lets it preserve
+ * failure-while-running state without returning check output. That is the
+ * entire reason the poller does not shell out to `gh`.
  *
  * Auth is still `gh`'s: we mint a token with `gh auth token` rather than asking
  * the operator for a PAT, so there is no new credential to store.
@@ -78,7 +79,11 @@ export function parsePrRefFromUrl(url: string): PrRef | undefined {
   return { owner: match[1]!, repo: match[2]!, number };
 }
 
-/** The PullRequest fields the poller reads. Kept minimal — see the cost note above. */
+/**
+ * The PullRequest fields the poller reads. `contexts` carries only enough
+ * state to distinguish a completed failure from a failure while sibling
+ * checks still run; we deliberately do not fetch names, URLs, or output.
+ */
 const PR_STATUS_FRAGMENT = `
 fragment PrStatus on PullRequest {
   number
@@ -93,7 +98,16 @@ fragment PrStatus on PullRequest {
     nodes {
       commit {
         oid
-        statusCheckRollup { state }
+        statusCheckRollup {
+          state
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun { conclusion status }
+              ... on StatusContext { state }
+            }
+          }
+        }
       }
     }
   }
@@ -113,12 +127,24 @@ export type GraphqlPrNode = {
       | {
         commit?: {
           oid?: string | null;
-          statusCheckRollup?: { state?: string | null } | null;
+          statusCheckRollup?: {
+            state?: string | null;
+            contexts?: {
+              nodes?: (GraphqlCheckContext | null)[] | null;
+            } | null;
+          } | null;
         } | null;
       }
       | null
     )[] | null;
   } | null;
+};
+
+type GraphqlCheckContext = {
+  __typename?: string;
+  conclusion?: string | null;
+  status?: string | null;
+  state?: string | null;
 };
 
 /** A single aliased `repository { pullRequest }` selection in the response. */
@@ -237,8 +263,14 @@ ${PR_STATUS_FRAGMENT}`;
 /** Map one GraphQL PullRequest node onto our shared PrSummary. */
 export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
   const headCommit = node.commits?.nodes?.[0]?.commit ?? undefined;
+  const checkContexts = headCommit?.statusCheckRollup?.contexts?.nodes ?? [];
   const checkState = deriveChipStateFromRollup(
     headCommit?.statusCheckRollup?.state,
+  );
+  const checksStillRunning = hasChecksStillRunning(
+    checkContexts.filter(
+      (context): context is GraphqlCheckContext => context !== null,
+    ),
   );
   // `mergeStateStatus` is deliberately absent: GraphQL gates it behind a preview
   // Accept header, and `mergeable` alone already answers mergeable/conflicting.
@@ -261,6 +293,7 @@ export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
     ...(node.title?.trim() ? { title: node.title.trim() } : {}),
     state: checkState,
     checkState,
+    ...(checksStillRunning ? { checksStillRunning: true } : {}),
     lifecycleState: deriveLifecycleState(shaped),
     reviewState: deriveReviewState(shaped),
     mergeState: deriveMergeState(shaped),

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -28,9 +28,10 @@ const graphqlLog = getMainLogger("pwragent:pr-graphql");
  * GraphQL can: aliased top-level `repository(...)` selections put N PRs from
  * arbitrary repos into ONE request. GitHub bills GraphQL on a node/point model
  * against 5,000 points/hr. The query keeps its connections bounded to one head
- * commit and at most 100 status contexts per PR, which lets it preserve
- * failure-while-running state without returning check output. That is the
- * entire reason the poller does not shell out to `gh`.
+ * commit and pages status contexts in batches of 100, stopping as soon as it
+ * finds a running check. That lets it preserve failure-while-running state
+ * without returning check output. That is the entire reason the poller does
+ * not shell out to `gh`.
  *
  * Auth is still `gh`'s: we mint a token with `gh auth token` rather than asking
  * the operator for a PAT, so there is no new credential to store.
@@ -38,6 +39,8 @@ const graphqlLog = getMainLogger("pwragent:pr-graphql");
 
 /** How many aliased PR lookups go into one GraphQL request. */
 const DEFAULT_BATCH_SIZE = 40;
+/** GitHub's maximum page size for status check contexts. */
+const STATUS_CONTEXT_PAGE_SIZE = 100;
 /** Retries per request before giving up on a batch. */
 const MAX_RETRIES = 4;
 /** Upper bound on any single backoff wait. */
@@ -83,6 +86,8 @@ export function parsePrRefFromUrl(url: string): PrRef | undefined {
  * The PullRequest fields the poller reads. `contexts` carries only enough
  * state to distinguish a completed failure from a failure while sibling
  * checks still run; we deliberately do not fetch names, URLs, or output.
+ * Later pages are fetched only when this page cannot already prove a check is
+ * running.
  */
 const PR_STATUS_FRAGMENT = `
 fragment PrStatus on PullRequest {
@@ -97,10 +102,12 @@ fragment PrStatus on PullRequest {
   commits(last: 1) {
     nodes {
       commit {
+        id
         oid
         statusCheckRollup {
           state
-          contexts(first: 100) {
+          contexts(first: ${STATUS_CONTEXT_PAGE_SIZE}) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               __typename
               ... on CheckRun { conclusion status }
@@ -112,6 +119,30 @@ fragment PrStatus on PullRequest {
     }
   }
 }`;
+
+type GraphqlCheckContext = {
+  __typename?: string;
+  conclusion?: string | null;
+  status?: string | null;
+  state?: string | null;
+};
+
+type GraphqlStatusContextPage = {
+  nodes?: (GraphqlCheckContext | null)[] | null;
+  pageInfo?: {
+    hasNextPage?: boolean | null;
+    endCursor?: string | null;
+  } | null;
+};
+
+type GraphqlCommit = {
+  id?: string | null;
+  oid?: string | null;
+  statusCheckRollup?: {
+    state?: string | null;
+    contexts?: GraphqlStatusContextPage | null;
+  } | null;
+};
 
 export type GraphqlPrNode = {
   number: number;
@@ -125,26 +156,11 @@ export type GraphqlPrNode = {
   commits?: {
     nodes?: (
       | {
-        commit?: {
-          oid?: string | null;
-          statusCheckRollup?: {
-            state?: string | null;
-            contexts?: {
-              nodes?: (GraphqlCheckContext | null)[] | null;
-            } | null;
-          } | null;
-        } | null;
+        commit?: GraphqlCommit | null;
       }
       | null
     )[] | null;
   } | null;
-};
-
-type GraphqlCheckContext = {
-  __typename?: string;
-  conclusion?: string | null;
-  status?: string | null;
-  state?: string | null;
 };
 
 /** A single aliased `repository { pullRequest }` selection in the response. */
@@ -152,6 +168,11 @@ type BatchedPrResponse = Record<
   string,
   { pullRequest?: GraphqlPrNode | null } | null
 >;
+
+type StatusContextPageRef = {
+  commitId: string;
+  cursor: string;
+};
 
 /**
  * Build one GraphQL document that looks up every ref by number, each under its
@@ -190,6 +211,52 @@ ${selections.join("\n")}
 ${PR_STATUS_FRAGMENT}`;
 
   return { query, variables };
+}
+
+/**
+ * Fetch one later page of status contexts for every supplied head commit.
+ *
+ * The initial PR query has already established these are `Commit` nodes, so
+ * this can use the global node ID instead of repeating repository/PR lookups.
+ * As with the primary batch, only generated aliases and variable names enter
+ * the document text; commit IDs and cursors remain variables.
+ */
+export function buildBatchedStatusContextQuery(refs: StatusContextPageRef[]): {
+  query: string;
+  variables: Record<string, string | number>;
+} {
+  const variableDecls: string[] = [];
+  const selections: string[] = [];
+  const variables: Record<string, string | number> = {};
+
+  refs.forEach((ref, index) => {
+    const id = `id${index}`;
+    const cursor = `c${index}`;
+    variableDecls.push(`$${id}: ID!`, `$${cursor}: String!`);
+    selections.push(`
+  r${index}: node(id: $${id}) {
+    ... on Commit {
+      statusCheckRollup {
+        contexts(first: ${STATUS_CONTEXT_PAGE_SIZE}, after: $${cursor}) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            __typename
+            ... on CheckRun { conclusion status }
+            ... on StatusContext { state }
+          }
+        }
+      }
+    }
+  }`);
+    variables[id] = ref.commitId;
+    variables[cursor] = ref.cursor;
+  });
+
+  return {
+    query: `query PollStatusContextPages(${variableDecls.join(", ")}) {${selections.join("\n")}
+}`,
+    variables,
+  };
 }
 
 /**
@@ -261,17 +328,22 @@ ${PR_STATUS_FRAGMENT}`;
 }
 
 /** Map one GraphQL PullRequest node onto our shared PrSummary. */
-export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
-  const headCommit = node.commits?.nodes?.[0]?.commit ?? undefined;
+export function mapGraphqlPrNode(
+  node: GraphqlPrNode,
+  checksStillRunningOverride?: boolean,
+): PrSummary {
+  const headCommit = getHeadCommit(node);
   const checkContexts = headCommit?.statusCheckRollup?.contexts?.nodes ?? [];
   const checkState = deriveChipStateFromRollup(
     headCommit?.statusCheckRollup?.state,
   );
-  const checksStillRunning = hasChecksStillRunning(
-    checkContexts.filter(
-      (context): context is GraphqlCheckContext => context !== null,
-    ),
-  );
+  const checksStillRunning =
+    checksStillRunningOverride
+    ?? hasChecksStillRunning(
+      checkContexts.filter(
+        (context): context is GraphqlCheckContext => context !== null,
+      ),
+    );
   // `mergeStateStatus` is deliberately absent: GraphQL gates it behind a preview
   // Accept header, and `mergeable` alone already answers mergeable/conflicting.
   const shaped = {
@@ -301,6 +373,19 @@ export function mapGraphqlPrNode(node: GraphqlPrNode): PrSummary {
     ...(commitShas.length > 0 ? { commitShas } : {}),
     url: node.url,
   };
+}
+
+function getHeadCommit(node: GraphqlPrNode): GraphqlCommit | undefined {
+  return node.commits?.nodes?.[0]?.commit ?? undefined;
+}
+
+function readCheckContexts(
+  page: GraphqlStatusContextPage | null | undefined,
+): GraphqlCheckContext[] | undefined {
+  const nodes = page?.nodes;
+  return nodes?.filter(
+    (context): context is GraphqlCheckContext => context !== null,
+  );
 }
 
 /**
@@ -460,25 +545,148 @@ export class GithubGraphqlPrClient {
       if (!data) {
         continue;
       }
-      batch.forEach((ref, index) => {
+      const answers = batch.map((ref, index) => {
         const repository = data[`r${index}`] as
           | { pullRequests?: { nodes?: (GraphqlPrNode | null)[] | null } | null }
           | null
           | undefined;
-        if (!repository) {
-          // Alias did not resolve — leave the key absent so the caller falls back.
+        return {
+          ref,
+          repository,
+          nodes: (repository?.pullRequests?.nodes ?? []).filter(
+            (node): node is GraphqlPrNode => Boolean(node),
+          ),
+        };
+      });
+      const checksStillRunning = await this.resolveChecksStillRunning(
+        answers.flatMap((answer) => answer.nodes),
+        token,
+      );
+      answers.forEach(({ ref, repository, nodes }) => {
+        if (!repository || nodes.some((node) => !checksStillRunning.has(node))) {
+          // An unresolved alias or context page is not an authoritative answer;
+          // leave the key absent so the caller falls back to `gh`.
           return;
         }
-        const nodes = repository.pullRequests?.nodes ?? [];
         results.set(
           branchRefKey(ref),
-          nodes
-            .filter((node): node is GraphqlPrNode => Boolean(node))
-            .map(mapGraphqlPrNode),
+          nodes.map((node) => mapGraphqlPrNode(node, checksStillRunning.get(node)!)),
         );
       });
     }
     return results;
+  }
+
+  /**
+   * Resolve whether each PR has a running check without treating the first
+   * context page as terminal. A failed follow-up page leaves that PR unresolved
+   * so callers retain the last known status instead of clearing its indicator.
+   */
+  private async resolveChecksStillRunning(
+    nodes: GraphqlPrNode[],
+    token: string,
+  ): Promise<Map<GraphqlPrNode, boolean>> {
+    const resolved = new Map<GraphqlPrNode, boolean>();
+    const pendingNodes = new Map<GraphqlPrNode, string>();
+    const pendingByCommitId = new Map<string, StatusContextPageRef>();
+    const seenCursorsByCommitId = new Map<string, Set<string>>();
+
+    const queueNextPage = (commitId: string, cursor: string): boolean => {
+      if (pendingByCommitId.has(commitId)) {
+        return true;
+      }
+      const seen = seenCursorsByCommitId.get(commitId) ?? new Set<string>();
+      if (seen.has(cursor)) {
+        return false;
+      }
+      seen.add(cursor);
+      seenCursorsByCommitId.set(commitId, seen);
+      pendingByCommitId.set(commitId, { commitId, cursor });
+      return true;
+    };
+
+    for (const node of nodes) {
+      const headCommit = getHeadCommit(node);
+      const rollup = headCommit?.statusCheckRollup;
+      if (!rollup) {
+        resolved.set(node, false);
+        continue;
+      }
+      const contexts = readCheckContexts(rollup.contexts);
+      if (!contexts) {
+        continue;
+      }
+      if (hasChecksStillRunning(contexts)) {
+        resolved.set(node, true);
+        continue;
+      }
+      const pageInfo = rollup.contexts?.pageInfo;
+      if (pageInfo?.hasNextPage === false) {
+        resolved.set(node, false);
+        continue;
+      }
+      const commitId = headCommit?.id?.trim();
+      const cursor = pageInfo?.endCursor?.trim();
+      if (
+        pageInfo?.hasNextPage === true
+        && commitId
+        && cursor
+        && queueNextPage(commitId, cursor)
+      ) {
+        pendingNodes.set(node, commitId);
+      }
+    }
+
+    const completedByCommitId = new Map<string, boolean>();
+    while (pendingByCommitId.size > 0) {
+      const pending = [...pendingByCommitId.values()];
+      pendingByCommitId.clear();
+      for (const batch of chunk(pending, this.batchSize)) {
+        const data = await this.runBatchQuery(
+          buildBatchedStatusContextQuery(batch),
+          token,
+          batch.length,
+        );
+        if (!data) {
+          continue;
+        }
+        batch.forEach((ref, index) => {
+          const page = (data[`r${index}`] as GraphqlCommit | null | undefined)
+            ?.statusCheckRollup?.contexts;
+          const contexts = readCheckContexts(page);
+          if (!contexts) {
+            return;
+          }
+          if (hasChecksStillRunning(contexts)) {
+            completedByCommitId.set(ref.commitId, true);
+            return;
+          }
+          const pageInfo = page?.pageInfo;
+          if (pageInfo?.hasNextPage === false) {
+            completedByCommitId.set(ref.commitId, false);
+            return;
+          }
+          const cursor = pageInfo?.endCursor?.trim();
+          if (pageInfo?.hasNextPage === true && cursor) {
+            queueNextPage(ref.commitId, cursor);
+          }
+        });
+      }
+    }
+
+    for (const [node, commitId] of pendingNodes) {
+      if (completedByCommitId.has(commitId)) {
+        resolved.set(node, completedByCommitId.get(commitId)!);
+      }
+    }
+
+    if (resolved.size < nodes.length) {
+      graphqlLog.debug("PR status context pagination incomplete; retaining prior state", {
+        prCount: nodes.length,
+        unresolved: nodes.length - resolved.size,
+      });
+    }
+    return resolved;
   }
 
   /**
@@ -561,23 +769,33 @@ export class GithubGraphqlPrClient {
       return [];
     }
 
+    const nodes = refs
+      .map((_, index) => data![`r${index}`]?.pullRequest)
+      .filter((node): node is GraphqlPrNode => Boolean(node));
+    const checksStillRunning = await this.resolveChecksStillRunning(nodes, token);
     const prs: PrSummary[] = [];
     let dropped = 0;
+    let incompleteContexts = 0;
     refs.forEach((ref, index) => {
       const node = data[`r${index}`]?.pullRequest;
       if (!node) {
         dropped += 1;
         return;
       }
-      prs.push(mapGraphqlPrNode(node));
+      if (!checksStillRunning.has(node)) {
+        incompleteContexts += 1;
+        return;
+      }
+      prs.push(mapGraphqlPrNode(node, checksStillRunning.get(node)!));
     });
 
-    if (dropped > 0) {
-      // Never silently truncate — a dropped alias means we polled a PR and got
-      // nothing back, which is a real (if benign) coverage gap worth seeing.
-      graphqlLog.debug("PR poll batch dropped unresolved aliases", {
+    if (dropped > 0 || incompleteContexts > 0) {
+      // Never silently clear a status: an unresolved alias or incomplete
+      // context pagination is a coverage gap, so callers keep cached state.
+      graphqlLog.debug("PR poll batch skipped incomplete status results", {
         refCount: refs.length,
         dropped,
+        incompleteContexts,
       });
     }
     return prs;

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -19,6 +19,7 @@ export {
   deriveLifecycleState,
   deriveMergeState,
   deriveReviewState,
+  hasChecksStillRunning,
   parseGhPrPayload,
 } from "./pr-derivations";
 export type { GhCheckRunPayload, GhPrPayload } from "./pr-derivations";

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -15,13 +15,15 @@ import { DEFAULT_PULL_REQUEST_PROVIDER } from "@pwragent/shared";
  *  - `github-pr-fetcher.ts` — the `gh pr list --json …` subprocess, used for
  *    on-selection / hover / post-turn detail fetches. Its `statusCheckRollup`
  *    is an ARRAY of individual check runs.
- *  - `github-graphql-client.ts` — the in-process batched poller. Its
- *    `statusCheckRollup` is GitHub's single pre-aggregated rollup ENUM.
+ *  - `github-graphql-client.ts` — the in-process batched poller. It reads
+ *    GitHub's pre-aggregated rollup ENUM plus minimal per-context activity so
+ *    a failed check can remain visibly in flight while sibling checks run.
  *
  * The lifecycle/review/merge derivations are shape-compatible and shared
- * verbatim. Only the check-state derivation differs, so it has one function
- * per transport (`deriveChipState` vs `deriveChipStateFromRollup`) and they
- * are held to the same outputs by a parity test.
+ * verbatim. The check-state derivation differs by transport
+ * (`deriveChipState` vs `deriveChipStateFromRollup`), while
+ * `hasChecksStillRunning` reads the individual contexts both transports
+ * expose.
  */
 
 /** Subset of fields returned by `gh pr list --json …` that we actually read. */
@@ -44,7 +46,8 @@ export type GhPrPayload = {
 export type GhCheckRunPayload = {
   __typename?: string;
   conclusion?: string | null;
-  status?: string;
+  status?: string | null;
+  state?: string | null;
   name?: string;
 };
 
@@ -54,6 +57,7 @@ export type GhCheckRunPayload = {
  */
 export function parseGhPrPayload(row: GhPrPayload): PrSummary {
   const checkState = deriveChipState(row);
+  const checksStillRunning = hasChecksStillRunning(row.statusCheckRollup ?? []);
   const headSha = normalizeCommitShas([
     row.commits?.[row.commits.length - 1]?.oid,
   ])[0];
@@ -65,6 +69,7 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     ...(row.title?.trim() ? { title: row.title.trim() } : {}),
     state: checkState,
     checkState,
+    ...(checksStillRunning ? { checksStillRunning: true } : {}),
     lifecycleState: deriveLifecycleState(row),
     reviewState: deriveReviewState(row),
     mergeState: deriveMergeState(row),
@@ -146,23 +151,61 @@ export function deriveChipState(row: GhPrPayload): PrChipState {
     "STALE",
   ]);
 
-  let pendingCount = 0;
+  let hasFailure = false;
+  let hasPending = false;
+  let hasUnknown = false;
   for (const check of checks) {
-    if (check.conclusion && failingConclusions.has(check.conclusion)) {
-      return "failing";
-    }
-    if (check.conclusion && passingConclusions.has(check.conclusion)) {
+    const conclusion = check.conclusion?.trim();
+    if (conclusion && failingConclusions.has(conclusion)) {
+      hasFailure = true;
       continue;
     }
-    if (!check.conclusion) {
-      pendingCount += 1;
+    if (conclusion && passingConclusions.has(conclusion)) {
+      continue;
+    }
+    if (check.state) {
+      const state = deriveChipStateFromRollup(check.state);
+      if (state === "failing") {
+        hasFailure = true;
+      } else if (state === "pending") {
+        hasPending = true;
+      } else if (state === "unknown") {
+        hasUnknown = true;
+      }
+      continue;
+    }
+    if (isCheckStillRunning(check)) {
+      hasPending = true;
       continue;
     }
     // Conclusion we don't recognize as either pass or fail — be conservative.
-    return "unknown";
+    hasUnknown = true;
   }
-  if (pendingCount > 0) return "pending";
+  if (hasFailure) return "failing";
+  if (hasPending) return "pending";
+  if (hasUnknown) return "unknown";
   return "passing";
+}
+
+/**
+ * True only when a rollup context is still non-terminal. A check conclusion
+ * wins over a stale `status` value — GitHub can transiently return a completed
+ * conclusion alongside an old IN_PROGRESS status.
+ */
+export function hasChecksStillRunning(
+  checks: readonly GhCheckRunPayload[],
+): boolean {
+  return checks.some(isCheckStillRunning);
+}
+
+function isCheckStillRunning(check: GhCheckRunPayload): boolean {
+  if (check.conclusion?.trim()) {
+    return false;
+  }
+  if (check.state) {
+    return check.state === "PENDING" || check.state === "EXPECTED";
+  }
+  return check.status !== "COMPLETED";
 }
 
 /**

--- a/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
+++ b/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
@@ -18,10 +18,10 @@ const schedulerLog = getMainLogger("pwragent:pr-poller");
  * AppServerService — that keeps it unit-testable without booting the app, and
  * keeps the module graph acyclic.
  *
- * Budget shape: one GraphQL request covers up to `BATCH_SIZE` PRs across
- * arbitrary repos for ~1 rate-limit point, and we take one token bucket slot
- * per request (not per PR), so a full sweep of a few hundred PRs is a handful
- * of points.
+ * Budget shape: one admitted GraphQL batch covers up to `BATCH_SIZE` PRs
+ * across arbitrary repos. PRs with more than 100 status contexts can require
+ * paginated follow-ups, but those are coalesced per page and stop as soon as a
+ * running check is found.
  */
 
 /**

--- a/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/PrChip.tsx
@@ -68,9 +68,14 @@ export function PrChip(props: PrChipProps) {
   const surfaceAffordances = isOpen && !props.withStatusPills;
   const isDraft = surfaceAffordances && pr.reviewState === "draft";
   const isConflicting = surfaceAffordances && pr.mergeState === "conflicting";
+  const hasFailingChecksStillRunning =
+    isOpen
+    && resolveCheckState(pr) === "failing"
+    && pr.checksStillRunning === true;
   const className = [
     "pr-chip",
     `pr-chip--${chipState}`,
+    hasFailingChecksStillRunning ? "pr-chip--checks-running" : "",
     isDraft ? "pr-chip--draft" : "",
     isConflicting ? "pr-chip--conflicting" : "",
   ]
@@ -200,7 +205,7 @@ function prStatusLabel(pr: PrSummary): string {
     parts.push("merge conflict");
   }
 
-  parts.push(checkStateTooltipLabel(resolveCheckState(pr)));
+  parts.push(checkStateTooltipLabel(resolveCheckState(pr), pr.checksStillRunning));
   return parts.join(" · ");
 }
 
@@ -240,12 +245,17 @@ function normalizeLegacyCheckState(state: PrSummary["state"]): NonNullable<PrSum
   return "unknown";
 }
 
-function checkStateTooltipLabel(state: NonNullable<PrSummary["checkState"]>): string {
+function checkStateTooltipLabel(
+  state: NonNullable<PrSummary["checkState"]>,
+  checksStillRunning: boolean | undefined,
+): string {
   switch (state) {
     case "passing":
       return "checks passing";
     case "failing":
-      return "checks failing";
+      return checksStillRunning
+        ? "checks failing · checks still running"
+        : "checks failing";
     case "pending":
       return "checks pending";
     case "unknown":

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/PrChip.test.tsx
@@ -145,6 +145,21 @@ describe("PrChip", () => {
     expect(chip).toHaveAttribute("aria-label", expect.stringContaining("checks passing"));
   });
 
+  it("pulses only a failed-check dot while sibling checks are still running", () => {
+    const chip = renderChip(basePr({
+      state: "failing",
+      checkState: "failing",
+      checksStillRunning: true,
+    }));
+
+    expect(chip).toHaveClass("pr-chip--failing");
+    expect(chip).toHaveClass("pr-chip--checks-running");
+    expect(chip).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("checks failing · checks still running"),
+    );
+  });
+
   it("keeps the check-state dot color and adds a bar for an open draft", () => {
     const chip = renderChip(
       basePr({ reviewState: "draft", checkState: "passing" }),

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -105,6 +105,34 @@ describe("usePullRequestRefresh", () => {
     expect(onRefreshNavigation).not.toHaveBeenCalled();
   });
 
+  it("refreshes navigation when a failing PR gains running-check metadata", async () => {
+    const currentPr = {
+      ...buildResponse().prs[0]!,
+      state: "failing" as const,
+      checkState: "failing" as const,
+    };
+    const response = buildResponse({
+      prs: [{ ...currentPr, checksStillRunning: true }],
+    });
+    const onRefreshNavigation = vi.fn(async () => undefined);
+    const refreshThreadPullRequests = vi.fn(async () => response);
+    const desktopApi = {
+      refreshThreadPullRequests,
+    } satisfies DesktopApi;
+
+    renderHook(() =>
+      usePullRequestRefresh({
+        desktopApi,
+        onRefreshNavigation,
+        selectedThread: buildThread({ prs: [currentPr] }),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onRefreshNavigation).toHaveBeenCalledOnce();
+    });
+  });
+
   it("does not refresh again when the selected thread object is replaced", async () => {
     const response = buildResponse({ prs: [] });
     const refreshThreadPullRequests = vi.fn(async () => response);

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -227,6 +227,7 @@ function prSummariesEqual(
       candidate.title === pr.title &&
       candidate.state === pr.state &&
       candidate.checkState === pr.checkState &&
+      candidate.checksStillRunning === pr.checksStillRunning &&
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -91,8 +91,12 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
                     <RailStatusChip
                       tone={checkTone(checkState)}
                       alert={checkState === "failing"}
+                      blink={
+                        checkState === "failing"
+                        && pr.checksStillRunning === true
+                      }
                     >
-                      {checkLabel(checkState)}
+                      {checkLabel(checkState, pr.checksStillRunning)}
                     </RailStatusChip>
                   ) : null}
                 </p>
@@ -149,12 +153,17 @@ function checkTone(state: CheckState): RailChipTone {
   }
 }
 
-function checkLabel(state: CheckState): string {
+function checkLabel(
+  state: CheckState,
+  checksStillRunning: boolean | undefined,
+): string {
   switch (state) {
     case "passing":
       return "Checks passing";
     case "failing":
-      return "Checks failing";
+      return checksStillRunning
+        ? "Checks failing · still running"
+        : "Checks failing";
     case "pending":
       return "Checks pending";
     case "unknown":

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/RailStatusChip.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/RailStatusChip.tsx
@@ -15,6 +15,8 @@ type RailStatusChipProps = {
    * sub-agents and failing/conflicting PR checks.
    */
   alert?: boolean;
+  /** Pulse just the leading dot while this status is actively changing. */
+  blink?: boolean;
   children: ReactNode;
 };
 
@@ -31,7 +33,11 @@ export function RailStatusChip(props: RailStatusChipProps) {
     <span className={`rail-chip${props.alert ? " rail-chip--alert" : ""}`}>
       <span
         aria-hidden="true"
-        className={`rail-chip__dot rail-chip__dot--${props.tone}`}
+        className={[
+          "rail-chip__dot",
+          `rail-chip__dot--${props.tone}`,
+          props.blink ? "rail-chip__dot--blink" : "",
+        ].filter(Boolean).join(" ")}
       />
       {props.children}
     </span>

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/PullRequestsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/PullRequestsPanel.test.tsx
@@ -87,6 +87,34 @@ describe("PullRequestsPanel", () => {
     expect(screen.getByText("Checks failing")).toHaveClass("rail-chip--alert");
   });
 
+  it("labels and pulses a failure while checks are still running", () => {
+    render(
+      <PullRequestsPanel
+        thread={threadWithPrs([
+          {
+            provider: "github.com",
+            number: 13,
+            org: "pwrdrvr",
+            repo: "PwrAgent",
+            title: "mixed CI state",
+            state: "failing",
+            checkState: "failing",
+            checksStillRunning: true,
+            lifecycleState: "open",
+            reviewState: "ready_for_review",
+            url: "https://github.com/pwrdrvr/PwrAgent/pull/13",
+          },
+        ])}
+      />,
+    );
+
+    const checksPill = screen.getByText("Checks failing · still running");
+    expect(checksPill.querySelector(".rail-chip__dot--blink")).not.toBeNull();
+    expect(screen.getByRole("button", {
+      name: /checks failing · checks still running/,
+    })).toHaveClass("pr-chip--checks-running");
+  });
+
   it("defers draft + conflict to the pills — the card's chip stays check-state", () => {
     // Regression guard for `withStatusPills`: a draft + conflicting PR whose
     // checks pass would, on a standalone chip, render a red dot + draft bar.

--- a/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
+++ b/apps/desktop/src/renderer/src/lib/pull-request-links.tsx
@@ -35,6 +35,7 @@ function samePullRequestChip(
     && left.title === right.title
     && left.state === right.state
     && left.checkState === right.checkState
+    && left.checksStillRunning === right.checksStillRunning
     && left.lifecycleState === right.lifecycleState
     && left.reviewState === right.reviewState
     && left.mergeState === right.mergeState

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -603,6 +603,7 @@ function prSummariesEqual(
       candidate.title === pr.title &&
       candidate.state === pr.state &&
       candidate.checkState === pr.checkState &&
+      candidate.checksStillRunning === pr.checksStillRunning &&
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3868,6 +3868,13 @@ textarea,
   background: var(--status-error);
 }
 
+/* A failed check does not make its sibling jobs terminal. Keep the error hue,
+   but use the existing gentle status pulse to say that the rollup is still
+   moving. Only the dot animates — the PR chip stays still and legible. */
+.pr-chip--checks-running .pr-chip__dot {
+  animation: status-blink 1.6s ease-in-out infinite;
+}
+
 .pr-chip--pending .pr-chip__dot {
   background: var(--status-warning);
 }
@@ -13870,6 +13877,10 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--status-suspended);
 }
 
+.rail-chip__dot--blink {
+  animation: status-blink 1.6s ease-in-out infinite;
+}
+
 /* Title sits on its own row, full width, and wraps (clamped) instead of
    truncating mid-word in a shared flex row. */
 .rail-card__title {
@@ -17953,7 +17964,9 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .status-dot--blink {
+  .status-dot--blink,
+  .pr-chip--checks-running .pr-chip__dot,
+  .rail-chip__dot--blink {
     animation: none;
   }
 }

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -254,6 +254,12 @@ export type PrSummary = {
    */
   state: PrChipState | PrLegacyChipState;
   checkState?: PrChipState;
+  /**
+   * GitHub reported at least one non-terminal check in the same status
+   * snapshot. This is intentionally separate from `checkState`: a PR can
+   * have a failed check while other checks are still running.
+   */
+  checksStillRunning?: boolean;
   lifecycleState?: PrLifecycleState;
   reviewState?: PrReviewState;
   mergeState?: PrMergeState;

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -543,6 +543,7 @@ export function buildNavigationSnapshotHash(params: {
         title: pr.title ?? null,
         state: pr.state,
         checkState: pr.checkState ?? null,
+        checksStillRunning: pr.checksStillRunning ?? null,
         lifecycleState: pr.lifecycleState ?? null,
         reviewState: pr.reviewState ?? null,
         mergeState: pr.mergeState ?? null,


### PR DESCRIPTION
## Summary

- I preserved GitHub's in-progress check signal alongside the existing failure rollup, so a failed check no longer hides sibling jobs that are still running.
- I pulse only the red status dot for that mixed state; a completed failure remains solid red, and pending-only checks remain orange.
- I carry the signal through the GraphQL poller, `gh` detail refresh, caches, navigation updates, tool summaries, and the Pull Requests panel.

## Verification

- I ran the focused PR-status suite: 121 tests passed.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:colors`, and `pnpm lint:boundaries` successfully. ESLint retains the repository's pre-existing warning baseline with no errors.
- I verified the GraphQL context query against GitHub's live schema and started the isolated desktop dev profile successfully before shutting it down.

## Notes

- Reduced-motion preferences suppress the pulse while retaining the explicit accessible status text.
