### PR TITLE
feat(desktop): add GitHub commit-author identity cache

### DIFF
--- a/apps/desktop/src/main/__tests__/github-commit-author-identity.test.ts
+++ b/apps/desktop/src/main/__tests__/github-commit-author-identity.test.ts
@@ -1,0 +1,327 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  GithubCommitAuthorIdentityInput,
+  GithubCommitAuthorIdentityProof,
+} from "@pwragent/shared";
+import { GhCliCommitAuthorIdentityTransport } from "../github/commit-author-identity-gh-transport";
+import {
+  buildGithubCommitAuthorIdentityCacheKey,
+  GithubCommitAuthorIdentityResolver,
+  type GithubCommitAuthorIdentityRemoteCommit,
+  type GithubCommitAuthorIdentityTransport,
+} from "../github/commit-author-identity-resolver";
+import { GithubCommitAuthorIdentityCacheStore } from "../github/commit-author-identity-store";
+import { StateDb } from "../state/state-db";
+
+const AUTHOR = {
+  name: "Ada Lovelace",
+  email: "ada@example.test",
+};
+const PROOF: GithubCommitAuthorIdentityProof = {
+  owner: "octo-org",
+  repo: "example-repo",
+  commitSha: "0123456789abcdef0123456789abcdef01234567",
+};
+const INPUT: GithubCommitAuthorIdentityInput = { author: AUTHOR, proof: PROOF };
+
+let tempDir: string;
+let stateDb: StateDb;
+let cache: GithubCommitAuthorIdentityCacheStore;
+let now: number;
+let fetchCalls: number;
+let fetchImpl: () => Promise<GithubCommitAuthorIdentityRemoteCommit>;
+let resolver: GithubCommitAuthorIdentityResolver;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-github-identity-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  cache = new GithubCommitAuthorIdentityCacheStore(stateDb);
+  now = 1_000_000;
+  fetchCalls = 0;
+  fetchImpl = async () => resolvedRemoteCommit();
+  resolver = createResolver();
+});
+
+afterEach(() => {
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("GithubCommitAuthorIdentityResolver", () => {
+  it("returns cache data immediately, then persists a proof-backed identity", async () => {
+    const request = resolver.request(INPUT);
+
+    expect(request.lookup).toEqual({
+      cacheState: "miss",
+      refreshState: "in-flight",
+    });
+    const completion = await requireCompletion(request.completion);
+    expect(completion).toEqual({
+      identity: {
+        login: "ada",
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      },
+      cacheState: "fresh",
+      refreshState: "idle",
+    });
+    expect(fetchCalls).toBe(1);
+
+    const key = buildGithubCommitAuthorIdentityCacheKey(AUTHOR)!;
+    expect(cache.read(key)).toMatchObject({
+      status: "resolved",
+      identity: { login: "ada" },
+      fetchedAt: now,
+      expiresAt: now + 7 * 24 * 60 * 60 * 1000,
+    });
+    const raw = stateDb.raw
+      .prepare("SELECT * FROM github_commit_author_identity_cache WHERE identity_key = ?")
+      .get(key) as Record<string, unknown>;
+    const serialized = JSON.stringify(raw);
+    expect(serialized).not.toContain(AUTHOR.name);
+    expect(serialized).not.toContain(AUTHOR.email);
+    expect(serialized).not.toContain("gho_");
+
+    const cacheOnly = resolver.request({ author: AUTHOR });
+    expect(cacheOnly).toEqual({
+      lookup: {
+        identity: {
+          login: "ada",
+          avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+        },
+        cacheState: "fresh",
+        refreshState: "idle",
+      },
+    });
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("requires an exact GitHub commit, name, and email match before resolving", async () => {
+    fetchImpl = async () => ({
+      ...resolvedRemoteCommit(),
+      author: { name: AUTHOR.name, email: "different@example.test" },
+    });
+
+    const request = resolver.request(INPUT);
+    const completion = await requireCompletion(request.completion);
+
+    expect(completion).toEqual({
+      cacheState: "miss",
+      refreshState: "backing-off",
+    });
+    const entry = cache.read(buildGithubCommitAuthorIdentityCacheKey(AUTHOR)!);
+    expect(entry).toMatchObject({
+      status: "unavailable",
+      failureCount: 1,
+      nextRetryAt: now + 60_000,
+    });
+    expect(entry?.identity).toBeUndefined();
+
+    const retryGated = resolver.request(INPUT);
+    expect(retryGated).toEqual({
+      lookup: {
+        cacheState: "miss",
+        refreshState: "backing-off",
+      },
+    });
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("negative-caches an exact commit with no GitHub account", async () => {
+    fetchImpl = async () => ({
+      sha: PROOF.commitSha,
+      author: AUTHOR,
+      githubAuthor: null,
+    });
+
+    const initial = resolver.request(INPUT);
+    expect(await requireCompletion(initial.completion)).toEqual({
+      cacheState: "fresh",
+      refreshState: "idle",
+    });
+    expect(cache.read(buildGithubCommitAuthorIdentityCacheKey(AUTHOR)!)?.status).toBe(
+      "negative",
+    );
+
+    const repeated = resolver.request(INPUT);
+    expect(repeated).toEqual({
+      lookup: {
+        cacheState: "fresh",
+        refreshState: "idle",
+      },
+    });
+    expect(fetchCalls).toBe(1);
+  });
+
+  it("serves a stale verified identity while a single refresh runs", async () => {
+    const initial = resolver.request(INPUT);
+    await requireCompletion(initial.completion);
+
+    let releaseFetch: ((value: GithubCommitAuthorIdentityRemoteCommit) => void) | undefined;
+    fetchImpl = async () => await new Promise<GithubCommitAuthorIdentityRemoteCommit>((resolve) => {
+      releaseFetch = resolve;
+    });
+    now += 7 * 24 * 60 * 60 * 1000 + 1;
+
+    const stale = resolver.request(INPUT);
+    expect(stale.lookup).toEqual({
+      identity: {
+        login: "ada",
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+      },
+      cacheState: "stale",
+      refreshState: "in-flight",
+    });
+    expect(fetchCalls).toBe(1);
+
+    await Promise.resolve();
+    expect(fetchCalls).toBe(2);
+    releaseFetch?.({
+      ...resolvedRemoteCommit(),
+      githubAuthor: {
+        login: "ada-lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4",
+      },
+    });
+
+    expect(await requireCompletion(stale.completion)).toEqual({
+      identity: {
+        login: "ada-lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4",
+      },
+      cacheState: "fresh",
+      refreshState: "idle",
+    });
+  });
+
+  it("backs off transient failures without rejecting the caller", async () => {
+    fetchImpl = async () => {
+      throw new Error("offline");
+    };
+    resolver = createResolver({ initialBackoffMs: 1_000, maxBackoffMs: 8_000 });
+
+    const first = resolver.request(INPUT);
+    expect(await requireCompletion(first.completion)).toEqual({
+      cacheState: "miss",
+      refreshState: "backing-off",
+    });
+    expect(fetchCalls).toBe(1);
+    expect(cache.read(buildGithubCommitAuthorIdentityCacheKey(AUTHOR)!)?.nextRetryAt).toBe(
+      now + 1_000,
+    );
+
+    now += 999;
+    expect(resolver.request(INPUT)).toEqual({
+      lookup: { cacheState: "miss", refreshState: "backing-off" },
+    });
+    expect(fetchCalls).toBe(1);
+
+    now += 1;
+    const second = resolver.request(INPUT);
+    await requireCompletion(second.completion);
+    expect(fetchCalls).toBe(2);
+    expect(cache.read(buildGithubCommitAuthorIdentityCacheKey(AUTHOR)!)?.nextRetryAt).toBe(
+      now + 2_000,
+    );
+  });
+
+  it("never performs an email-only or short-SHA lookup", () => {
+    expect(resolver.request({ author: AUTHOR })).toEqual({
+      lookup: {
+        cacheState: "miss",
+        refreshState: "not-eligible",
+      },
+    });
+    expect(resolver.request({
+      author: AUTHOR,
+      proof: { ...PROOF, commitSha: PROOF.commitSha.slice(0, 12) },
+    })).toEqual({
+      lookup: {
+        cacheState: "miss",
+        refreshState: "not-eligible",
+      },
+    });
+    expect(fetchCalls).toBe(0);
+  });
+});
+
+describe("GhCliCommitAuthorIdentityTransport", () => {
+  it("uses gh api with no token-extraction command or credential parameter", async () => {
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const transport = new GhCliCommitAuthorIdentityTransport({
+      resolveGhCommand: async () => "/custom/bin/gh",
+      exec: async (command, args) => {
+        calls.push({ command, args });
+        return {
+          stdout: JSON.stringify({
+            sha: PROOF.commitSha,
+            commit: { author: AUTHOR },
+            author: {
+              login: "ada",
+              avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+            },
+          }),
+        };
+      },
+    });
+
+    await expect(transport.fetchCommit(PROOF)).resolves.toEqual(resolvedRemoteCommit());
+    expect(calls).toEqual([
+      {
+        command: "/custom/bin/gh",
+        args: [
+          "api",
+          "--hostname",
+          "github.com",
+          "repos/octo-org/example-repo/commits/0123456789abcdef0123456789abcdef01234567",
+          "--method",
+          "GET",
+          "--header",
+          "Accept: application/vnd.github+json",
+          "--header",
+          "X-GitHub-Api-Version: 2022-11-28",
+        ],
+      },
+    ]);
+    expect(calls[0]?.args).not.toContain("auth");
+    expect(calls[0]?.args).not.toContain("token");
+  });
+});
+
+function createResolver(options?: {
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+}): GithubCommitAuthorIdentityResolver {
+  const transport: GithubCommitAuthorIdentityTransport = {
+    fetchCommit: async () => {
+      fetchCalls += 1;
+      return await fetchImpl();
+    },
+  };
+  return new GithubCommitAuthorIdentityResolver({
+    cache,
+    transport,
+    now: () => now,
+    ...options,
+  });
+}
+
+function resolvedRemoteCommit(): GithubCommitAuthorIdentityRemoteCommit {
+  return {
+    sha: PROOF.commitSha,
+    author: AUTHOR,
+    githubAuthor: {
+      login: "ada",
+      avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4",
+    },
+  };
+}
+
+async function requireCompletion(
+  completion: Promise<unknown> | undefined,
+): Promise<unknown> {
+  expect(completion).toBeDefined();
+  return await completion!;
+}

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -64,6 +64,55 @@ describe("StateDb", () => {
     expect(prLookupColumns.map((column) => column.name)).toContain("provider");
   });
 
+  it("creates a privacy-preserving GitHub commit-author identity cache", () => {
+    const columns = stateDb.raw
+      .prepare("PRAGMA table_info(github_commit_author_identity_cache)")
+      .all() as Array<{ name: string }>;
+    const indexes = stateDb.raw
+      .prepare("PRAGMA index_list(github_commit_author_identity_cache)")
+      .all() as Array<{ name: string }>;
+
+    expect(columns.map((column) => column.name)).toEqual([
+      "identity_key",
+      "status",
+      "github_login",
+      "avatar_url",
+      "fetched_at",
+      "expires_at",
+      "failure_count",
+      "next_retry_at",
+      "updated_at",
+    ]);
+    expect(columns.map((column) => column.name)).not.toEqual(
+      expect.arrayContaining(["author_name", "author_email", "token"]),
+    );
+    expect(indexes.map((index) => index.name)).toEqual(
+      expect.arrayContaining([
+        "idx_github_commit_author_identity_cache_expiry",
+        "idx_github_commit_author_identity_cache_retry",
+      ]),
+    );
+  });
+
+  it("migrates version 34 databases to the commit-author identity cache", () => {
+    const dbPath = path.join(tempDir, "state.db");
+    stateDb.raw.exec("DROP TABLE github_commit_author_identity_cache");
+    stateDb.raw.pragma("user_version = 34");
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    const table = stateDb.raw
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+      )
+      .get("github_commit_author_identity_cache") as { name: string } | undefined;
+    expect(table?.name).toBe("github_commit_author_identity_cache");
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+  });
+
   it("creates thread usage pricing ledger tables", () => {
     const tables = stateDb.raw
       .prepare(

--- a/apps/desktop/src/main/github/commit-author-identity-gh-transport.ts
+++ b/apps/desktop/src/main/github/commit-author-identity-gh-transport.ts
@@ -1,0 +1,130 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { GithubCommitAuthorIdentityProof } from "@pwragent/shared";
+import type {
+  GithubCommitAuthorIdentityRemoteCommit,
+  GithubCommitAuthorIdentityTransport,
+} from "./commit-author-identity-resolver.js";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type GhCliCommitAuthorIdentityTransportOptions = {
+  /** Override command discovery in tests or a non-desktop host. */
+  resolveGhCommand?: () => Promise<string | undefined>;
+  /** Override process execution in tests. No token is accepted or returned. */
+  exec?: (command: string, args: string[]) => Promise<{ stdout: string }>;
+  timeoutMs?: number;
+};
+
+/**
+ * GitHub transport that delegates credentials to the configured `gh` CLI.
+ *
+ * This intentionally calls `gh api` instead of extracting `gh auth token` or
+ * accepting a PAT. The resolver receives only a parsed commit response, so no
+ * auth token can enter the persistent cache, public contract, or logs.
+ */
+export class GhCliCommitAuthorIdentityTransport
+  implements GithubCommitAuthorIdentityTransport {
+  private readonly resolveGhCommand: () => Promise<string | undefined>;
+  private readonly exec: (command: string, args: string[]) => Promise<{ stdout: string }>;
+
+  constructor(options: GhCliCommitAuthorIdentityTransportOptions = {}) {
+    this.resolveGhCommand = options.resolveGhCommand ?? defaultResolveGhCommand;
+    this.exec = options.exec ?? defaultExec(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  }
+
+  async fetchCommit(
+    proof: GithubCommitAuthorIdentityProof,
+  ): Promise<GithubCommitAuthorIdentityRemoteCommit> {
+    const command = await this.resolveGhCommand();
+    if (!command) {
+      throw new Error("gh CLI is unavailable");
+    }
+    const endpoint = [
+      "repos",
+      encodeURIComponent(proof.owner),
+      encodeURIComponent(proof.repo),
+      "commits",
+      encodeURIComponent(proof.commitSha),
+    ].join("/");
+    const { stdout } = await this.exec(command, [
+      "api",
+      "--hostname",
+      "github.com",
+      endpoint,
+      "--method",
+      "GET",
+      "--header",
+      "Accept: application/vnd.github+json",
+      "--header",
+      "X-GitHub-Api-Version: 2022-11-28",
+    ]);
+    return parseGithubCommitResponse(JSON.parse(stdout));
+  }
+}
+
+async function defaultResolveGhCommand(): Promise<string | undefined> {
+  // Matches the configured-command discovery boundary used by PwrAgent's PR
+  // integrations. Dynamic imports keep this transport usable in plain Node
+  // tests without eagerly loading desktop settings/Electron dependencies.
+  const [{ discoverGhCommands }, { getDesktopSettingsService }] = await Promise.all([
+    import("../settings/gh-discovery.js"),
+    import("../settings/desktop-settings-singleton.js"),
+  ]);
+  const discovery = await discoverGhCommands({
+    configuredCommand: getDesktopSettingsService().resolveGhCommandPreference(),
+    env: process.env,
+  });
+  return discovery.selectedCommand;
+}
+
+function defaultExec(
+  timeoutMs: number,
+): (command: string, args: string[]) => Promise<{ stdout: string }> {
+  return async (command, args) => {
+    const result = await execFileAsync(command, args, {
+      timeout: Math.max(1, timeoutMs),
+      maxBuffer: 1024 * 1024,
+      encoding: "utf8",
+    });
+    return { stdout: result.stdout };
+  };
+}
+
+function parseGithubCommitResponse(value: unknown): GithubCommitAuthorIdentityRemoteCommit {
+  const response = asRecord(value);
+  const commit = asRecord(response?.commit);
+  const commitAuthor = asRecord(commit?.author);
+  const githubAuthor = response?.author === null
+    ? null
+    : asRecord(response?.author);
+
+  return {
+    sha: readString(response?.sha),
+    author: commitAuthor
+      ? {
+        name: readString(commitAuthor.name),
+        email: readString(commitAuthor.email),
+      }
+      : undefined,
+    githubAuthor: githubAuthor
+      ? {
+        login: readString(githubAuthor.login),
+        avatarUrl: readString(githubAuthor.avatar_url),
+      }
+      : githubAuthor === null
+        ? null
+        : undefined,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/apps/desktop/src/main/github/commit-author-identity-resolver.ts
+++ b/apps/desktop/src/main/github/commit-author-identity-resolver.ts
@@ -1,0 +1,519 @@
+import { createHash } from "node:crypto";
+import type {
+  GithubCommitAuthorIdentity,
+  GithubCommitAuthorIdentityAuthor,
+  GithubCommitAuthorIdentityCacheEntry,
+  GithubCommitAuthorIdentityInput,
+  GithubCommitAuthorIdentityLookup,
+  GithubCommitAuthorIdentityProof,
+  GithubCommitAuthorIdentityRequest,
+} from "@pwragent/shared";
+
+/** How long a proof-backed GitHub identity stays fresh before revalidation. */
+export const GITHUB_COMMIT_AUTHOR_IDENTITY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** How long an authoritative "no GitHub account for this commit" stays fresh. */
+export const GITHUB_COMMIT_AUTHOR_IDENTITY_NEGATIVE_TTL_MS = 24 * 60 * 60 * 1000;
+/** First delay before retrying a failed CLI/auth/network lookup. */
+export const GITHUB_COMMIT_AUTHOR_IDENTITY_INITIAL_BACKOFF_MS = 60 * 1000;
+/** Upper bound for exponential retry gates; there is no background retry loop. */
+export const GITHUB_COMMIT_AUTHOR_IDENTITY_MAX_BACKOFF_MS = 60 * 60 * 1000;
+
+/**
+ * Minimal canonical form returned by a GitHub transport for one exact commit.
+ *
+ * A `null` `githubAuthor` means GitHub authoritatively returned no associated
+ * account. `undefined` means the response was incomplete and must never be
+ * negative-cached.
+ */
+export type GithubCommitAuthorIdentityRemoteCommit = {
+  sha?: string | null;
+  author?: {
+    name?: string | null;
+    email?: string | null;
+  } | null;
+  githubAuthor?: {
+    login?: string | null;
+    avatarUrl?: string | null;
+  } | null;
+};
+
+/**
+ * Credential-opaque transport seam. The resolver never receives, stores, or
+ * logs an auth token; a desktop adapter may delegate authentication to `gh`.
+ */
+export type GithubCommitAuthorIdentityTransport = {
+  fetchCommit(
+    proof: GithubCommitAuthorIdentityProof,
+  ): Promise<GithubCommitAuthorIdentityRemoteCommit>;
+};
+
+/** Optional redacted diagnostic sink; never receives author data or tokens. */
+export type GithubCommitAuthorIdentityLogger = {
+  debug(
+    message: string,
+    metadata: {
+      reason: "inconclusive" | "transport";
+      failureCount: number;
+      retryAfterMs: number;
+    },
+  ): void;
+};
+
+/**
+ * Persistence seam for the resolver. PwrGit can supply its own durable store
+ * without depending on PwrAgent's SQLite implementation.
+ */
+export type GithubCommitAuthorIdentityCache = {
+  read(identityKey: string): GithubCommitAuthorIdentityCacheEntry | undefined;
+  writeResolved(params: {
+    identityKey: string;
+    identity: GithubCommitAuthorIdentity;
+    fetchedAt: number;
+    expiresAt: number;
+  }): void;
+  writeNegative(params: {
+    identityKey: string;
+    fetchedAt: number;
+    expiresAt: number;
+  }): void;
+  recordFailure(params: {
+    identityKey: string;
+    failureCount: number;
+    nextRetryAt: number;
+    updatedAt: number;
+  }): void;
+};
+
+export type GithubCommitAuthorIdentityResolverOptions = {
+  cache: GithubCommitAuthorIdentityCache;
+  transport: GithubCommitAuthorIdentityTransport;
+  logger?: GithubCommitAuthorIdentityLogger;
+  now?: () => number;
+  resolvedTtlMs?: number;
+  negativeTtlMs?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+};
+
+type NormalizedAuthor = GithubCommitAuthorIdentityAuthor;
+
+type PreparedLookup = {
+  identityKey: string;
+  author: NormalizedAuthor;
+  proof?: GithubCommitAuthorIdentityProof;
+};
+
+type RemoteOutcome =
+  | { kind: "resolved"; identity: GithubCommitAuthorIdentity }
+  | { kind: "negative" }
+  | { kind: "inconclusive" };
+
+/**
+ * Best-effort resolver for adding GitHub presentation fields to a known Git
+ * commit author.
+ *
+ * `request` returns synchronously from SQLite and starts work only when the
+ * row is stale/missing and a full GitHub commit proof is present. Its optional
+ * completion promise is safe to observe for an eventual repaint and never
+ * rejects; callers should always render their local Git author immediately.
+ */
+export class GithubCommitAuthorIdentityResolver {
+  private readonly cache: GithubCommitAuthorIdentityCache;
+  private readonly transport: GithubCommitAuthorIdentityTransport;
+  private readonly logger: GithubCommitAuthorIdentityLogger | undefined;
+  private readonly now: () => number;
+  private readonly resolvedTtlMs: number;
+  private readonly negativeTtlMs: number;
+  private readonly initialBackoffMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly inFlightByIdentityKey = new Map<
+    string,
+    Promise<GithubCommitAuthorIdentityLookup>
+  >();
+
+  constructor(options: GithubCommitAuthorIdentityResolverOptions) {
+    this.cache = options.cache;
+    this.transport = options.transport;
+    this.logger = options.logger;
+    this.now = options.now ?? Date.now;
+    this.resolvedTtlMs = positiveDuration(
+      options.resolvedTtlMs,
+      GITHUB_COMMIT_AUTHOR_IDENTITY_TTL_MS,
+    );
+    this.negativeTtlMs = positiveDuration(
+      options.negativeTtlMs,
+      GITHUB_COMMIT_AUTHOR_IDENTITY_NEGATIVE_TTL_MS,
+    );
+    this.initialBackoffMs = positiveDuration(
+      options.initialBackoffMs,
+      GITHUB_COMMIT_AUTHOR_IDENTITY_INITIAL_BACKOFF_MS,
+    );
+    this.maxBackoffMs = Math.max(
+      this.initialBackoffMs,
+      positiveDuration(
+        options.maxBackoffMs,
+        GITHUB_COMMIT_AUTHOR_IDENTITY_MAX_BACKOFF_MS,
+      ),
+    );
+  }
+
+  /**
+   * Return cache data immediately and, when eligible, start one deduplicated
+   * background lookup. A fresh negative row is deliberately indistinguishable
+   * from an ordinary absence to presentation code: keep showing local Git
+   * identity and do not suggest a guessed GitHub account.
+   */
+  request(input: GithubCommitAuthorIdentityInput): GithubCommitAuthorIdentityRequest {
+    const prepared = prepareLookup(input);
+    if (!prepared) {
+      return {
+        lookup: {
+          cacheState: "miss",
+          refreshState: "not-eligible",
+        },
+      };
+    }
+
+    const now = this.now();
+    const cached = this.readCache(prepared.identityKey);
+    if (isFresh(cached, now)) {
+      return { lookup: toLookup(cached, now, "idle") };
+    }
+    if (!prepared.proof) {
+      return {
+        lookup: toLookup(cached, now, "not-eligible"),
+      };
+    }
+    if (cached?.nextRetryAt && cached.nextRetryAt > now) {
+      return {
+        lookup: toLookup(cached, now, "backing-off"),
+      };
+    }
+
+    const completion = this.startRefresh(prepared);
+    return {
+      lookup: toLookup(cached, now, "in-flight"),
+      completion,
+    };
+  }
+
+  private startRefresh(
+    prepared: PreparedLookup,
+  ): Promise<GithubCommitAuthorIdentityLookup> {
+    const existing = this.inFlightByIdentityKey.get(prepared.identityKey);
+    if (existing) {
+      return existing;
+    }
+
+    const completion = Promise.resolve()
+      .then(async () => {
+        await this.refresh(prepared);
+        const now = this.now();
+        const cached = this.readCache(prepared.identityKey);
+        return toLookup(
+          cached,
+          now,
+          refreshStateAfterCompletion(cached, now),
+        );
+      })
+      .catch(() => ({
+        // `refresh` absorbs expected failures. This guard keeps the public
+        // completion promise non-rejecting even if cache I/O itself misbehaves.
+        cacheState: "miss" as const,
+        refreshState: "backing-off" as const,
+      }));
+
+    this.inFlightByIdentityKey.set(prepared.identityKey, completion);
+    void completion.then(() => {
+      if (this.inFlightByIdentityKey.get(prepared.identityKey) === completion) {
+        this.inFlightByIdentityKey.delete(prepared.identityKey);
+      }
+    });
+    return completion;
+  }
+
+  private async refresh(prepared: PreparedLookup): Promise<void> {
+    if (!prepared.proof) {
+      return;
+    }
+
+    try {
+      const response = await this.transport.fetchCommit(prepared.proof);
+      const completedAt = this.now();
+      const outcome = evaluateRemoteCommit(
+        response,
+        prepared.author,
+        prepared.proof,
+      );
+      if (outcome.kind === "resolved") {
+        this.cache.writeResolved({
+          identityKey: prepared.identityKey,
+          identity: outcome.identity,
+          fetchedAt: completedAt,
+          expiresAt: completedAt + this.resolvedTtlMs,
+        });
+        return;
+      }
+      if (outcome.kind === "negative") {
+        this.cache.writeNegative({
+          identityKey: prepared.identityKey,
+          fetchedAt: completedAt,
+          expiresAt: completedAt + this.negativeTtlMs,
+        });
+        return;
+      }
+      this.recordFailure(prepared.identityKey, completedAt, "inconclusive");
+    } catch {
+      this.recordFailure(prepared.identityKey, this.now(), "transport");
+    }
+  }
+
+  private readCache(
+    identityKey: string,
+  ): GithubCommitAuthorIdentityCacheEntry | undefined {
+    try {
+      return this.cache.read(identityKey);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private recordFailure(
+    identityKey: string,
+    now: number,
+    reason: "inconclusive" | "transport",
+  ): void {
+    const failureCount = Math.min(
+      16,
+      (this.readCache(identityKey)?.failureCount ?? 0) + 1,
+    );
+    const retryAfterMs = backoffMs(
+      failureCount,
+      this.initialBackoffMs,
+      this.maxBackoffMs,
+    );
+    try {
+      this.cache.recordFailure({
+        identityKey,
+        failureCount,
+        nextRetryAt: now + retryAfterMs,
+        updatedAt: now,
+      });
+    } catch {
+      // Do not turn a cache write issue into UI-visible commit-card failure.
+    }
+    this.logger?.debug("GitHub commit-author identity lookup deferred", {
+      reason,
+      failureCount,
+      retryAfterMs,
+    });
+  }
+}
+
+/**
+ * Return the stable, one-way SQLite key for a valid author pair. Cache entries
+ * are intentionally not keyed by repo or commit because a direct commit proof
+ * establishes a reusable mapping for the same name/email pair.
+ */
+export function buildGithubCommitAuthorIdentityCacheKey(
+  author: GithubCommitAuthorIdentityAuthor,
+): string | undefined {
+  const normalized = normalizeAuthor(author);
+  if (!normalized) {
+    return undefined;
+  }
+  return createHash("sha256")
+    .update(`github-commit-author-identity:v1\0${normalized.email}\0${normalized.name}`)
+    .digest("hex");
+}
+
+function prepareLookup(
+  input: GithubCommitAuthorIdentityInput,
+): PreparedLookup | undefined {
+  const author = normalizeAuthor(input?.author);
+  if (!author) {
+    return undefined;
+  }
+  const identityKey = buildGithubCommitAuthorIdentityCacheKey(author);
+  if (!identityKey) {
+    return undefined;
+  }
+  const proof = normalizeProof(input?.proof);
+  return {
+    identityKey,
+    author,
+    ...(proof ? { proof } : {}),
+  };
+}
+
+function normalizeAuthor(value: unknown): NormalizedAuthor | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const name = normalizeName(value.name);
+  const email = normalizeEmail(value.email);
+  return name && email ? { name, email } : undefined;
+}
+
+function normalizeProof(
+  value: GithubCommitAuthorIdentityProof | undefined,
+): GithubCommitAuthorIdentityProof | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const owner = normalizeGithubPathSegment(value.owner);
+  const repo = normalizeGithubPathSegment(value.repo);
+  const commitSha = normalizeCommitSha(value.commitSha);
+  return owner && repo && commitSha ? { owner, repo, commitSha } : undefined;
+}
+
+function evaluateRemoteCommit(
+  response: GithubCommitAuthorIdentityRemoteCommit,
+  expectedAuthor: NormalizedAuthor,
+  expectedProof: GithubCommitAuthorIdentityProof,
+): RemoteOutcome {
+  if (normalizeCommitSha(response.sha) !== expectedProof.commitSha) {
+    return { kind: "inconclusive" };
+  }
+  const remoteAuthor = normalizeAuthor(response.author);
+  if (
+    !remoteAuthor
+    || remoteAuthor.name !== expectedAuthor.name
+    || remoteAuthor.email !== expectedAuthor.email
+  ) {
+    return { kind: "inconclusive" };
+  }
+  if (response.githubAuthor === null) {
+    return { kind: "negative" };
+  }
+  const identity = normalizeGithubIdentity(response.githubAuthor);
+  return identity ? { kind: "resolved", identity } : { kind: "inconclusive" };
+}
+
+function normalizeGithubIdentity(
+  value: GithubCommitAuthorIdentityRemoteCommit["githubAuthor"],
+): GithubCommitAuthorIdentity | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const login = safeText(value.login, 255);
+  if (!login) {
+    return undefined;
+  }
+  const avatarUrl = normalizeAvatarUrl(value.avatarUrl);
+  return {
+    login,
+    ...(avatarUrl ? { avatarUrl } : {}),
+  };
+}
+
+function toLookup(
+  entry: GithubCommitAuthorIdentityCacheEntry | undefined,
+  now: number,
+  refreshState: GithubCommitAuthorIdentityLookup["refreshState"],
+): GithubCommitAuthorIdentityLookup {
+  const cacheState = !entry || entry.status === "unavailable"
+    ? "miss"
+    : entry.expiresAt > now
+      ? "fresh"
+      : "stale";
+  return {
+    ...(entry?.identity ? { identity: entry.identity } : {}),
+    cacheState,
+    refreshState,
+  };
+}
+
+function isFresh(
+  entry: GithubCommitAuthorIdentityCacheEntry | undefined,
+  now: number,
+): boolean {
+  return Boolean(entry && entry.status !== "unavailable" && entry.expiresAt > now);
+}
+
+function refreshStateAfterCompletion(
+  entry: GithubCommitAuthorIdentityCacheEntry | undefined,
+  now: number,
+): GithubCommitAuthorIdentityLookup["refreshState"] {
+  return entry?.nextRetryAt && entry.nextRetryAt > now ? "backing-off" : "idle";
+}
+
+function normalizeName(value: unknown): string | undefined {
+  const name = safeText(value, 512);
+  return name?.normalize("NFC");
+}
+
+function normalizeEmail(value: unknown): string | undefined {
+  const email = safeText(value, 320)?.normalize("NFC").toLowerCase();
+  return email && email.includes("@") && !/\s/.test(email) ? email : undefined;
+}
+
+function normalizeGithubPathSegment(value: unknown): string | undefined {
+  const segment = safeText(value, 100);
+  return segment && /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(segment)
+    ? segment
+    : undefined;
+}
+
+function normalizeCommitSha(value: unknown): string | undefined {
+  const sha = safeText(value, 40)?.toLowerCase();
+  return sha && /^[a-f0-9]{40}$/.test(sha) ? sha : undefined;
+}
+
+function normalizeAvatarUrl(value: unknown): string | undefined {
+  const raw = safeText(value, 2_048);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === "https:" && !parsed.username && !parsed.password
+      ? parsed.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized
+    && normalized.length <= maxLength
+    && !hasControlCharacter(normalized)
+    ? normalized
+    : undefined;
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1F || code === 0x7F) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function backoffMs(
+  failureCount: number,
+  initialBackoffMs: number,
+  maxBackoffMs: number,
+): number {
+  return Math.min(
+    maxBackoffMs,
+    initialBackoffMs * 2 ** Math.max(0, failureCount - 1),
+  );
+}
+
+function positiveDuration(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}

--- a/apps/desktop/src/main/github/commit-author-identity-store.ts
+++ b/apps/desktop/src/main/github/commit-author-identity-store.ts
@@ -1,0 +1,218 @@
+import type {
+  GithubCommitAuthorIdentity,
+  GithubCommitAuthorIdentityCacheEntry,
+  GithubCommitAuthorIdentityCacheStatus,
+} from "@pwragent/shared";
+import type { StateDb } from "../state/state-db.js";
+
+type CacheRow = {
+  identity_key: string;
+  status: string;
+  github_login: string | null;
+  avatar_url: string | null;
+  fetched_at: number;
+  expires_at: number;
+  failure_count: number;
+  next_retry_at: number | null;
+  updated_at: number;
+};
+
+/**
+ * SQLite persistence for proof-backed GitHub commit-author identities.
+ *
+ * The schema deliberately carries only a one-way identity key, GitHub fields,
+ * and cache timing. Raw Git author names/emails and authentication material do
+ * not enter the state database through this store.
+ */
+export class GithubCommitAuthorIdentityCacheStore {
+  constructor(private readonly stateDb: StateDb) {}
+
+  read(identityKey: string): GithubCommitAuthorIdentityCacheEntry | undefined {
+    const row = this.stateDb.raw
+      .prepare(
+        `SELECT
+           identity_key,
+           status,
+           github_login,
+           avatar_url,
+           fetched_at,
+           expires_at,
+           failure_count,
+           next_retry_at,
+           updated_at
+         FROM github_commit_author_identity_cache
+         WHERE identity_key = ?`,
+      )
+      .get(identityKey) as CacheRow | undefined;
+
+    return row ? parseCacheRow(row) : undefined;
+  }
+
+  writeResolved(params: {
+    identityKey: string;
+    identity: GithubCommitAuthorIdentity;
+    fetchedAt: number;
+    expiresAt: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO github_commit_author_identity_cache(
+           identity_key,
+           status,
+           github_login,
+           avatar_url,
+           fetched_at,
+           expires_at,
+           failure_count,
+           next_retry_at,
+           updated_at
+         ) VALUES (?, 'resolved', ?, ?, ?, ?, 0, NULL, ?)
+         ON CONFLICT(identity_key) DO UPDATE SET
+           status = excluded.status,
+           github_login = excluded.github_login,
+           avatar_url = excluded.avatar_url,
+           fetched_at = excluded.fetched_at,
+           expires_at = excluded.expires_at,
+           failure_count = 0,
+           next_retry_at = NULL,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at >= github_commit_author_identity_cache.updated_at`,
+      )
+      .run(
+        params.identityKey,
+        params.identity.login,
+        params.identity.avatarUrl ?? null,
+        params.fetchedAt,
+        params.expiresAt,
+        params.fetchedAt,
+      );
+  }
+
+  writeNegative(params: {
+    identityKey: string;
+    fetchedAt: number;
+    expiresAt: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO github_commit_author_identity_cache(
+           identity_key,
+           status,
+           github_login,
+           avatar_url,
+           fetched_at,
+           expires_at,
+           failure_count,
+           next_retry_at,
+           updated_at
+         ) VALUES (?, 'negative', NULL, NULL, ?, ?, 0, NULL, ?)
+         ON CONFLICT(identity_key) DO UPDATE SET
+           status = excluded.status,
+           github_login = NULL,
+           avatar_url = NULL,
+           fetched_at = excluded.fetched_at,
+           expires_at = excluded.expires_at,
+           failure_count = 0,
+           next_retry_at = NULL,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at >= github_commit_author_identity_cache.updated_at`,
+      )
+      .run(params.identityKey, params.fetchedAt, params.expiresAt, params.fetchedAt);
+  }
+
+  /**
+   * Persist a retry gate without discarding a stale resolved identity. A newer
+   * fresh success always wins over an older transport failure.
+   */
+  recordFailure(params: {
+    identityKey: string;
+    failureCount: number;
+    nextRetryAt: number;
+    updatedAt: number;
+  }): void {
+    this.stateDb.raw
+      .prepare(
+        `INSERT INTO github_commit_author_identity_cache(
+           identity_key,
+           status,
+           github_login,
+           avatar_url,
+           fetched_at,
+           expires_at,
+           failure_count,
+           next_retry_at,
+           updated_at
+         ) VALUES (?, 'unavailable', NULL, NULL, 0, 0, ?, ?, ?)
+         ON CONFLICT(identity_key) DO UPDATE SET
+           failure_count = excluded.failure_count,
+           next_retry_at = excluded.next_retry_at,
+           updated_at = excluded.updated_at
+         WHERE excluded.updated_at >= github_commit_author_identity_cache.updated_at
+           AND (
+             github_commit_author_identity_cache.status = 'unavailable'
+             OR github_commit_author_identity_cache.expires_at <= excluded.updated_at
+           )`,
+      )
+      .run(
+        params.identityKey,
+        params.failureCount,
+        params.nextRetryAt,
+        params.updatedAt,
+      );
+  }
+}
+
+function parseCacheRow(row: CacheRow): GithubCommitAuthorIdentityCacheEntry | undefined {
+  if (
+    !isCacheStatus(row.status)
+    || !isTimestamp(row.fetched_at)
+    || !isTimestamp(row.expires_at)
+    || !isTimestamp(row.updated_at)
+    || !Number.isSafeInteger(row.failure_count)
+    || row.failure_count < 0
+  ) {
+    return undefined;
+  }
+
+  const nextRetryAt = isTimestamp(row.next_retry_at)
+    ? row.next_retry_at
+    : undefined;
+  if (row.status === "resolved") {
+    const login = row.github_login?.trim();
+    if (!login) {
+      return undefined;
+    }
+    const avatarUrl = row.avatar_url?.trim();
+    return {
+      identityKey: row.identity_key,
+      status: row.status,
+      identity: {
+        login,
+        ...(avatarUrl ? { avatarUrl } : {}),
+      },
+      fetchedAt: row.fetched_at,
+      expiresAt: row.expires_at,
+      failureCount: row.failure_count,
+      ...(nextRetryAt ? { nextRetryAt } : {}),
+      updatedAt: row.updated_at,
+    };
+  }
+
+  return {
+    identityKey: row.identity_key,
+    status: row.status,
+    fetchedAt: row.fetched_at,
+    expiresAt: row.expires_at,
+    failureCount: row.failure_count,
+    ...(nextRetryAt ? { nextRetryAt } : {}),
+    updatedAt: row.updated_at,
+  };
+}
+
+function isCacheStatus(value: string): value is GithubCommitAuthorIdentityCacheStatus {
+  return value === "resolved" || value === "negative" || value === "unavailable";
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}

--- a/apps/desktop/src/main/github/index.ts
+++ b/apps/desktop/src/main/github/index.ts
@@ -1,0 +1,22 @@
+export {
+  GhCliCommitAuthorIdentityTransport,
+  type GhCliCommitAuthorIdentityTransportOptions,
+} from "./commit-author-identity-gh-transport.js";
+export {
+  buildGithubCommitAuthorIdentityCacheKey,
+  GithubCommitAuthorIdentityResolver,
+  GITHUB_COMMIT_AUTHOR_IDENTITY_INITIAL_BACKOFF_MS,
+  GITHUB_COMMIT_AUTHOR_IDENTITY_MAX_BACKOFF_MS,
+  GITHUB_COMMIT_AUTHOR_IDENTITY_NEGATIVE_TTL_MS,
+  GITHUB_COMMIT_AUTHOR_IDENTITY_TTL_MS,
+  type GithubCommitAuthorIdentityCache,
+  type GithubCommitAuthorIdentityLogger,
+  type GithubCommitAuthorIdentityRemoteCommit,
+  type GithubCommitAuthorIdentityResolverOptions,
+  type GithubCommitAuthorIdentityTransport,
+} from "./commit-author-identity-resolver.js";
+export { GithubCommitAuthorIdentityCacheStore } from "./commit-author-identity-store.js";
+export type {
+  GithubCommitAuthorIdentityCacheEntry,
+  GithubCommitAuthorIdentityCacheStatus,
+} from "@pwragent/shared";

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -9,7 +9,7 @@ import {
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 34;
+export const CURRENT_STATE_DB_USER_VERSION = 35;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -511,6 +511,25 @@ CREATE INDEX IF NOT EXISTS idx_pr_lookup_cache_fetched
   ON pr_lookup_cache(fetched_at DESC);
 `;
 
+const GITHUB_COMMIT_AUTHOR_IDENTITY_CACHE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS github_commit_author_identity_cache (
+  identity_key  TEXT PRIMARY KEY,
+  status        TEXT NOT NULL CHECK (status IN ('resolved', 'negative', 'unavailable')),
+  github_login  TEXT,
+  avatar_url    TEXT,
+  fetched_at    INTEGER NOT NULL,
+  expires_at    INTEGER NOT NULL,
+  failure_count INTEGER NOT NULL DEFAULT 0,
+  next_retry_at INTEGER,
+  updated_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_github_commit_author_identity_cache_expiry
+  ON github_commit_author_identity_cache(status, expires_at);
+CREATE INDEX IF NOT EXISTS idx_github_commit_author_identity_cache_retry
+  ON github_commit_author_identity_cache(next_retry_at)
+  WHERE next_retry_at IS NOT NULL;
+`;
+
 const PR_AUTO_DISPATCH_SCHEMA = `
 CREATE TABLE IF NOT EXISTS pr_auto_dispatch_claims (
   backend       TEXT NOT NULL,
@@ -774,6 +793,10 @@ const REVOKED_BINDINGS_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
 const APP_RUNTIME_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
 const COMPOSER_DRAFT_JOURNAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const COMPOSER_DRAFT_JOURNAL_CAP = 300;
+const GITHUB_COMMIT_AUTHOR_IDENTITY_RESOLVED_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const GITHUB_COMMIT_AUTHOR_IDENTITY_NEGATIVE_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const GITHUB_COMMIT_AUTHOR_IDENTITY_UNAVAILABLE_RETENTION_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Per-platform cap for the messaging activity log. Older rows are
  * evicted FIFO so the table stays small even on busy platforms. Tuned
@@ -1035,6 +1058,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 34) {
       db.transaction(() => {
         db.exec(PR_AUTO_DISPATCH_SCHEMA);
+        db.pragma("user_version = 34");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 35) {
+      db.transaction(() => {
+        db.exec(GITHUB_COMMIT_AUTHOR_IDENTITY_CACHE_SCHEMA);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1089,6 +1118,19 @@ export class StateDb {
           "DELETE FROM app_runtime_instances WHERE heartbeat_at < ? AND exited_at IS NOT NULL",
         )
         .run(now - APP_RUNTIME_INSTANCE_RETENTION_MS);
+      this.db
+        .prepare(
+          `DELETE FROM github_commit_author_identity_cache
+           WHERE (status = 'resolved' AND expires_at < ?)
+              OR (status = 'negative' AND expires_at < ?)
+              OR (status = 'unavailable' AND updated_at < ?)`,
+        )
+        .run(
+          now - GITHUB_COMMIT_AUTHOR_IDENTITY_RESOLVED_RETENTION_MS,
+          now - GITHUB_COMMIT_AUTHOR_IDENTITY_NEGATIVE_RETENTION_MS,
+          now - GITHUB_COMMIT_AUTHOR_IDENTITY_UNAVAILABLE_RETENTION_MS,
+        );
+
       this.db
         .prepare("DELETE FROM deliveries WHERE created_at < ?")
         .run(now - DELIVERIES_RETENTION_MS);
@@ -1187,6 +1229,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     db.exec(THREAD_SEARCH_SCHEMA);
     db.exec(PR_STATUS_CACHE_SCHEMA);
     db.exec(PR_LOOKUP_CACHE_SCHEMA);
+    db.exec(GITHUB_COMMIT_AUTHOR_IDENTITY_CACHE_SCHEMA);
     db.exec(PR_AUTO_DISPATCH_SCHEMA);
     ensureThreadSearchFtsThreadIdColumn(db);
     ensurePullRequestProviderColumns(db);

--- a/docs/github-commit-author-identity-contract.md
+++ b/docs/github-commit-author-identity-contract.md
@@ -1,0 +1,164 @@
+# GitHub Commit-Author Identity Contract
+
+This subsystem enriches a local Git commit author with a GitHub login and avatar
+only after GitHub proves the mapping for the exact commit. It is deliberately a
+main-process service with no renderer, IPC handler, or PwrAgent-specific UI.
+
+## Public surface
+
+The portable data contract is exported by `@pwragent/shared` from
+`contracts/github-commit-author-identity.ts`:
+
+```ts
+export type GithubCommitAuthorIdentityInput = {
+  author: { name: string; email: string };
+  proof?: { owner: string; repo: string; commitSha: string };
+};
+
+export type GithubCommitAuthorIdentity = {
+  login: string;
+  avatarUrl?: string;
+};
+
+export type GithubCommitAuthorIdentityLookup = {
+  identity?: GithubCommitAuthorIdentity;
+  cacheState: "fresh" | "stale" | "miss";
+  refreshState: "idle" | "in-flight" | "backing-off" | "not-eligible";
+};
+```
+
+The implementation surface is exported by
+`apps/desktop/src/main/github/index.ts`:
+
+- `GithubCommitAuthorIdentityResolver` owns lookup policy, deduplication, TTL,
+  negative caching, and retry gating.
+- `GithubCommitAuthorIdentityCache` is the four-method durable-cache interface.
+  `GithubCommitAuthorIdentityCacheStore` is PwrAgent's SQLite implementation.
+- `GithubCommitAuthorIdentityTransport` is the one-method fetch interface.
+  `GhCliCommitAuthorIdentityTransport` is PwrAgent's `gh api` adapter.
+- `GithubCommitAuthorIdentityLogger` is an optional redacted diagnostic sink;
+  the resolver is silent unless a host supplies it.
+
+The resolver accepts interfaces rather than desktop singletons, so PwrGit can
+reuse the contract and resolver with its own cache and process wiring.
+
+## Required proof and reliability rule
+
+A first network lookup requires all of the following:
+
+- a non-empty local Git author name and email;
+- a GitHub `owner` and `repo`; and
+- the full, 40-character GitHub commit SHA from the local commit, never a
+  short SHA, branch, tag, or email query.
+
+The `gh api` transport requests this exact REST resource:
+
+```text
+GET /repos/{owner}/{repo}/commits/{commitSha}
+```
+
+The resolver accepts a GitHub identity only when the response has all of these
+properties:
+
+1. Its returned SHA equals the supplied full SHA.
+2. Its Git commit author `name` and `email` equal the normalized local Git
+   author fields.
+3. GitHub returned an associated `author.login` for that commit.
+
+A valid login is returned with an HTTPS avatar URL when GitHub supplied one.
+The service never searches users by email or name, treats a partial/mismatched
+response as inconclusive, and never substitutes a GitHub name for the local
+Git author display.
+
+When GitHub authoritatively returns `author: null` for an otherwise exact
+commit, the resolver records an explicit no-match. A missing/malformed
+response, a network failure, missing `gh`, an auth failure, a permission
+failure, or an author/SHA mismatch is *not* a no-match.
+
+## Non-blocking use
+
+`request` reads SQLite synchronously and returns its presentation-neutral
+snapshot immediately. It starts at most one background request per normalized
+author pair and returns an optional, never-rejecting completion promise.
+
+```ts
+const request = resolver.request({
+  author: {
+    name: commit.authorName,
+    email: commit.authorEmail,
+  },
+  proof: githubRemote
+    ? {
+      owner: githubRemote.owner,
+      repo: githubRemote.repo,
+      commitSha: commit.hash,
+    }
+    : undefined,
+});
+
+// Always render local Git data. Add these fields only when present.
+contextCard.setGithubIdentity(request.lookup.identity);
+
+// Schedule a repaint; do not await before opening the card.
+void request.completion?.then(({ identity }) => {
+  contextCard.setGithubIdentity(identity);
+});
+```
+
+With no proof, `request` is cache-only. It may safely return a previously
+proved identity for the same local name/email pair, but it cannot initiate a
+network request. An invalid input, short SHA, or non-GitHub remote is similarly
+`not-eligible` and does not guess.
+
+For a cross-repository PwrGit adoption, implement the exported
+`GithubCommitAuthorIdentityCache` interface against PwrGit's state store and
+pass a transport that returns the canonical
+`GithubCommitAuthorIdentityRemoteCommit` shape. The PwrAgent SQLite store and
+`gh` transport may also be adopted together where their dependencies are
+available. No PwrAgent app process or UI API is required.
+
+## Cache and retry behavior
+
+| Outcome | Returned immediately | Persistent behavior |
+| --- | --- | --- |
+| Verified GitHub identity | Fresh result, or a safe stale result during refresh | Login/avatar TTL: 7 days |
+| Exact commit with no associated GitHub account | No added GitHub fields | Negative TTL: 24 hours |
+| Network, `gh`, auth, permission, malformed, or mismatch failure | Existing stale verified identity if available; otherwise no fields | Retry gate: 1 minute, exponential to 1 hour |
+
+There is no hidden polling or retry timer. A subsequent consumer request after
+the gate expires performs the next attempt. This keeps offline sessions quiet
+and prevents a commit-card hover from pinning work or retrying aggressively.
+
+PwrAgent's persistent table is `github_commit_author_identity_cache`. It uses a
+SHA-256 key derived from the normalized name/email pair and stores only that
+opaque key, GitHub login/avatar, timestamps, status, and retry metadata. State
+GC retains stale verified mappings for 90 days after expiry, negative rows for
+7 days after expiry, and unavailable/backoff rows for 1 day.
+
+## Credential and logging boundary
+
+`GhCliCommitAuthorIdentityTransport` deliberately reuses PwrAgent's configured
+`gh` command discovery, but not the PR GraphQL client's token flow. It invokes
+`gh api --hostname github.com`; it does not call `gh auth token`, read
+`GITHUB_TOKEN`, accept a token argument, persist a token, or expose one through
+the contract. When a host supplies the optional logger, the resolver emits only
+a generic deferred reason plus retry counts/duration—never raw response text,
+author data, command output, or credentials.
+
+The existing GraphQL PR poller remains the right boundary for batched PR status
+across repositories. An identity lookup needs an exact single-commit proof, so
+credential delegation through `gh api` is both narrower and safer here.
+
+## PwrGit adoption checklist
+
+- Derive `owner`/`repo` only from a recognized GitHub remote and use the
+  existing full `Commit.hash` as `commitSha`.
+- Keep the card's local `authorName` and `authorEmail` as the primary display.
+  Show the GitHub login/avatar only when `lookup.identity` exists.
+- Request without awaiting, then repaint from `completion` or an equivalent
+  main-process event.
+- Use no proof for non-GitHub remotes, missing origins, or short/untrusted SHAs.
+- Treat every absent identity as ordinary fallback UI, not as an error or a
+  request to authenticate.
+- Keep the cache's opaque-key/no-token property if implementing a PwrGit-native
+  adapter.

--- a/packages/shared/src/contracts/github-commit-author-identity.ts
+++ b/packages/shared/src/contracts/github-commit-author-identity.ts
@@ -1,0 +1,99 @@
+/**
+ * The local Git author fields that identify the person shown beside a commit.
+ *
+ * These are intentionally kept separate from `GithubCommitAuthorIdentity`:
+ * callers must always keep rendering the local Git identity as the source of
+ * truth, and may only add the GitHub fields when a resolver returns them.
+ */
+export type GithubCommitAuthorIdentityAuthor = {
+  name: string;
+  email: string;
+};
+
+/**
+ * Evidence that lets a resolver prove an author-to-GitHub-account mapping.
+ *
+ * `commitSha` must be the full GitHub commit object id, not a short SHA or a
+ * branch name. A resolver compares the returned commit id and Git author
+ * fields before it accepts an account identity.
+ */
+export type GithubCommitAuthorIdentityProof = {
+  owner: string;
+  repo: string;
+  commitSha: string;
+};
+
+/**
+ * Input to a commit-author identity lookup.
+ *
+ * A proof is optional only so a caller can reuse a previously proven cache
+ * entry. Without one, the resolver must not start a network lookup or infer a
+ * GitHub account from an email address.
+ */
+export type GithubCommitAuthorIdentityInput = {
+  author: GithubCommitAuthorIdentityAuthor;
+  proof?: GithubCommitAuthorIdentityProof;
+};
+
+/** GitHub account fields safe to add beside a local Git commit author. */
+export type GithubCommitAuthorIdentity = {
+  login: string;
+  /** HTTPS avatar URL when GitHub returned one; absent is valid. */
+  avatarUrl?: string;
+};
+
+/** Persistent state of a proof-backed identity cache entry. */
+export type GithubCommitAuthorIdentityCacheStatus =
+  | "resolved"
+  | "negative"
+  | "unavailable";
+
+/**
+ * Portable record shape for a durable identity cache adapter. `identityKey` is
+ * an opaque one-way key derived from the normalized local Git author pair.
+ */
+export type GithubCommitAuthorIdentityCacheEntry = {
+  identityKey: string;
+  status: GithubCommitAuthorIdentityCacheStatus;
+  identity?: GithubCommitAuthorIdentity;
+  fetchedAt: number;
+  expiresAt: number;
+  failureCount: number;
+  nextRetryAt?: number;
+  updatedAt: number;
+};
+
+/** Freshness of the persistent author-identity cache entry. */
+export type GithubCommitAuthorIdentityCacheState = "fresh" | "stale" | "miss";
+
+/**
+ * The resolver's background-work state. These are intentionally presentation
+ * neutral: clients can keep showing their local Git author while a lookup is
+ * in flight, backed off, or ineligible for a first fetch.
+ */
+export type GithubCommitAuthorIdentityRefreshState =
+  | "idle"
+  | "in-flight"
+  | "backing-off"
+  | "not-eligible";
+
+/** Immediate, non-blocking result of a commit-author identity request. */
+export type GithubCommitAuthorIdentityLookup = {
+  /** Present only after a proof-backed GitHub match has been accepted. */
+  identity?: GithubCommitAuthorIdentity;
+  cacheState: GithubCommitAuthorIdentityCacheState;
+  refreshState: GithubCommitAuthorIdentityRefreshState;
+};
+
+/**
+ * Result returned by a resolver request.
+ *
+ * `lookup` is always available immediately. `completion`, when present,
+ * never rejects and resolves after the best-effort background fetch has
+ * updated the cache. UI adapters can subscribe to it to schedule a repaint,
+ * but they must not await it before displaying commit context.
+ */
+export type GithubCommitAuthorIdentityRequest = {
+  lookup: GithubCommitAuthorIdentityLookup;
+  completion?: Promise<GithubCommitAuthorIdentityLookup>;
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from "./contracts/messaging";
 export * from "./contracts/messaging-tools";
 export * from "./contracts/navigation";
 export * from "./contracts/settings";
+export * from "./contracts/github-commit-author-identity";
 export * from "./contracts/subagent-transcript";
 export * from "./contracts/thread-link";
 export * from "./contracts/thread-tools";


### PR DESCRIPTION
## Summary

- I added a reusable, proof-backed GitHub commit-author identity resolver with a portable shared contract, SQLite cache adapter, and `gh api` transport.
- I made resolution conservative: an identity is accepted only when an exact 40-character commit SHA and normalized local Git author name/email match the GitHub commit response.
- I added persistent resolved, negative, and unavailable/backoff cache handling; no raw Git author fields or auth tokens are stored in the cache.
- I documented the PwrGit consumption contract and non-blocking context-card adoption path.

## Verification

- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm test apps/desktop/src/main/__tests__/github-commit-author-identity.test.ts apps/desktop/src/main/__tests__/state-db.test.ts` (29 tests passed).
- I ran `pnpm lint:sql`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:codex-storage`, and `pnpm lint:colors`.
- I ran `pnpm build`.

## Notes

- The resolver never performs email/name user search, invokes `gh api` without extracting a token, and fails softly for offline, missing-`gh`, authentication, permission, or network errors.
- I intentionally left PwrGit UI and IPC untouched; it can adopt the documented interface once this lands.
