### PR TITLE
fix(desktop): isolate child renderer environments

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -90,6 +90,30 @@ describe("AcpStdioJsonRpcTransport", () => {
     await expect(request).resolves.toEqual({ ok: true });
   });
 
+  it("does not pass PwrAgent's renderer URL to ACP agent sessions", async () => {
+    const child = new MockAcpChildProcess();
+    const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];
+    const spawn: AcpStdioSpawn = (command, args, options) => {
+      spawnCalls.push([command, args, options]);
+      return child;
+    };
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor({
+        env: {
+          ACP_TEST: "1",
+          ELECTRON_RENDERER_URL: "http://localhost:5175",
+        },
+      }),
+      spawn,
+    });
+
+    await transport.connect();
+
+    expect(spawnCalls[0]?.[2].env).toMatchObject({ ACP_TEST: "1" });
+    expect(spawnCalls[0]?.[2].env).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    await transport.close();
+  });
+
   it("adds Gemini session trust when launching persisted local descriptors", async () => {
     const child = new MockAcpChildProcess();
     const spawnCalls: Array<Parameters<AcpStdioSpawn>> = [];

--- a/apps/desktop/src/main/__tests__/application-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/application-discovery.test.ts
@@ -194,6 +194,36 @@ describe("application discovery", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it.skipIf(process.platform === "win32")("does not pass the renderer URL to launched workspace apps", async () => {
+    blockHostIntelliJDiscoveryPaths();
+    const binDir = path.join(tempDir, "bin");
+    const ideaPath = path.join(binDir, "idea");
+    const targetPath = path.join(tempDir, "source.kt");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(ideaPath, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(ideaPath, 0o755);
+    writeFileSync(targetPath, "line 1\n", "utf8");
+
+    await openDesktopApplication(
+      {
+        applicationId: "intellijidea",
+        kind: "editor",
+        targetPath,
+      },
+      {
+        env: {
+          ELECTRON_RENDERER_URL: "http://localhost:5175",
+          KEEP_APPLICATION_ENV: "yes",
+          PATH: binDir,
+        },
+      },
+    );
+
+    const options = spawnMock.mock.calls[0]?.[2];
+    expect(options.env).toMatchObject({ KEEP_APPLICATION_ENV: "yes" });
+    expect(options.env).not.toHaveProperty("ELECTRON_RENDERER_URL");
+  });
+
   it.skipIf(process.platform === "win32")("resolves the bundled VS Code CLI from an app-only install", async () => {
     const appPath = path.join(tempDir, "Visual Studio Code.app");
     const bundledCodePath = path.join(

--- a/apps/desktop/src/main/__tests__/automation-gate-runner.test.ts
+++ b/apps/desktop/src/main/__tests__/automation-gate-runner.test.ts
@@ -40,6 +40,27 @@ describe("ShellAutomationGateRunner", () => {
     });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "does not pass PwrAgent's renderer URL to automation gates",
+    async () => {
+      const originalRendererUrl = process.env.ELECTRON_RENDERER_URL;
+      process.env.ELECTRON_RENDERER_URL = "http://localhost:5175";
+      try {
+        const result = await new ShellAutomationGateRunner().runGate({
+          command: 'printf "%s" "${ELECTRON_RENDERER_URL-unset}"',
+        });
+
+        expect(result).toMatchObject({ status: "proceed", output: "unset" });
+      } finally {
+        if (originalRendererUrl === undefined) {
+          delete process.env.ELECTRON_RENDERER_URL;
+        } else {
+          process.env.ELECTRON_RENDERER_URL = originalRendererUrl;
+        }
+      }
+    },
+  );
+
   it("kills a runaway command on timeout and never hangs the caller", async () => {
     const startedAt = Date.now();
     const result = await new ShellAutomationGateRunner().runGate({

--- a/apps/desktop/src/main/__tests__/child-process-env.test.ts
+++ b/apps/desktop/src/main/__tests__/child-process-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPwrAgentChildProcessEnv,
+  mergePwrAgentChildProcessEnv,
+} from "../child-process-env";
+
+describe("PwrAgent child process environment", () => {
+  it("blocks the renderer URL after inherited and later override layers", () => {
+    const inherited = {
+      ELECTRON_RENDERER_URL: "http://localhost:5173",
+      PATH: "/usr/bin",
+      KEEP_PARENT: "parent",
+    } as NodeJS.ProcessEnv;
+    const overrides = {
+      ELECTRON_RENDERER_URL: "http://localhost:5175",
+      KEEP_PARENT: "overridden",
+      KEEP_OVERRIDE: "override",
+    } as NodeJS.ProcessEnv;
+
+    const env = buildPwrAgentChildProcessEnv(inherited, overrides);
+
+    expect(env).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    expect(env).toMatchObject({
+      PATH: "/usr/bin",
+      KEEP_PARENT: "overridden",
+      KEEP_OVERRIDE: "override",
+    });
+    expect(inherited.ELECTRON_RENDERER_URL).toBe("http://localhost:5173");
+    expect(overrides.ELECTRON_RENDERER_URL).toBe("http://localhost:5175");
+  });
+
+  it("removes every casing from a mutable hydrated environment after a merge", () => {
+    const target = {
+      Electron_Renderer_Url: "http://localhost:5173",
+      PATH: "/usr/bin",
+    } as NodeJS.ProcessEnv;
+
+    mergePwrAgentChildProcessEnv(target, {
+      ELECTRON_RENDERER_URL: "http://localhost:5175",
+      PATH: "/opt/homebrew/bin:/usr/bin",
+    });
+
+    expect(target).not.toHaveProperty("Electron_Renderer_Url");
+    expect(target).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    expect(target.PATH).toBe("/opt/homebrew/bin:/usr/bin");
+  });
+});

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5905,6 +5905,7 @@ describe("CodexAppServerClient", () => {
         environmentName: "PwrAgent",
         executionTarget: "local",
         shellEnvironment: {
+          ELECTRON_RENDERER_URL: "http://localhost:5175",
           PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
           NVM_DIR: "/Users/huntharo/.nvm",
         },
@@ -5933,6 +5934,11 @@ describe("CodexAppServerClient", () => {
       excludeTurns: true,
       threadSource: "user",
     });
+    expect(
+      (request?.params as { config?: Record<string, unknown> } | undefined)?.config?.[
+        "shell_environment_policy.set.ELECTRON_RENDERER_URL"
+      ],
+    ).toBeUndefined();
 
     await client.close();
   });
@@ -6208,6 +6214,7 @@ describe("CodexAppServerClient", () => {
         executionTarget: "local",
         cwd: "/Users/huntharo/pwrdrvr/PwrAgent",
         shellEnvironment: {
+          ELECTRON_RENDERER_URL: "http://localhost:5175",
           PATH: "/Users/huntharo/.nvm/versions/node/v26.0.0/bin:/usr/bin",
           NVM_DIR: "/Users/huntharo/.nvm",
         },
@@ -6228,6 +6235,11 @@ describe("CodexAppServerClient", () => {
         "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
       },
     });
+    expect(
+      (startPayload?.params as { config?: Record<string, unknown> } | undefined)?.config?.[
+        "shell_environment_policy.set.ELECTRON_RENDERER_URL"
+      ],
+    ).toBeUndefined();
 
     await client.close();
   });
@@ -7661,6 +7673,7 @@ describe("CodexAppServerClient", () => {
         executionTarget: "local",
         cwd: "/repo/app/.worktrees/thread-2/app",
         shellEnvironment: {
+          ELECTRON_RENDERER_URL: "http://localhost:5175",
           PATH: "/Users/huntharo/.nvm/versions/node/v24.14.1/bin:/usr/bin",
           NVM_DIR: "/Users/huntharo/.nvm",
         },
@@ -7702,6 +7715,11 @@ describe("CodexAppServerClient", () => {
         "shell_environment_policy.set.NVM_DIR": "/Users/huntharo/.nvm",
       },
     });
+    expect(
+      (resumePayload?.params as { config?: Record<string, unknown> } | undefined)?.config?.[
+        "shell_environment_policy.set.ELECTRON_RENDERER_URL"
+      ],
+    ).toBeUndefined();
     expect(turnStartPayload?.params).toMatchObject({
       threadId: "thread-2",
       cwd: "/repo/app/.worktrees/thread-2/app",

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -331,6 +331,10 @@ describe("codex environment runtime", () => {
           environmentName: "Env",
           executionTarget: "local",
           cwd: root,
+          shellEnvironment: {
+            ELECTRON_RENDERER_URL: "http://127.0.0.1:5175",
+            PWRAGENT_TEST_HYDRATED_ENV: "hydrated-override",
+          },
           actions: [
             {
               id: "start-dev",
@@ -353,7 +357,7 @@ describe("codex environment runtime", () => {
         "renderer=unset",
         "run_as_node=unset",
         "vite=unset",
-        "hydrated=hydrated",
+        "hydrated=hydrated-override",
         "",
       ].join("\n");
       await expect(
@@ -509,6 +513,40 @@ describe("codex environment runtime", () => {
         await expect(readFile(markerPath, "utf8")).resolves.toBe("shell-used");
       }
       await expect(readFile(outputPath, "utf8")).resolves.toBe("setup");
+    } finally {
+      await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+  });
+
+  it("does not pass PwrAgent's renderer URL to environment setup commands", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-setup-renderer-"));
+    const outputPath = path.join(root, "renderer-url.txt");
+
+    try {
+      await expect(
+        applyLocalCodexEnvironmentSelection({
+          cwd: root,
+          env: {
+            ...process.env,
+            ELECTRON_RENDERER_URL: "http://localhost:5175",
+            SHELL: spawnableShell("/bin/sh"),
+          },
+          selection: {
+            environment: {
+              id: "env",
+              name: "Env",
+              sourcePath: path.join(root, "environment.toml"),
+              setupScript:
+                `printf '%s' "\${ELECTRON_RENDERER_URL-unset}" > ${JSON.stringify(outputPath)}`,
+              actions: [],
+            },
+            executionTarget: "local",
+            runSetup: true,
+          },
+        }),
+      ).resolves.toMatchObject({ setupStatus: "completed" });
+
+      await expect(readFile(outputPath, "utf8")).resolves.toBe("unset");
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1160,6 +1160,35 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveCodexSpawnEnv().NVM_DIR).toBe("/Users/alice/.nvm");
   });
 
+  it("keeps the PwrAgent renderer URL out of Codex and terminal child environments", async () => {
+    const service = new DesktopSettingsService({
+      env: {
+        ELECTRON_RENDERER_URL: "http://localhost:5173",
+        PATH: "/usr/bin:/bin",
+      } as NodeJS.ProcessEnv,
+      secretStore: new MemoryDesktopSecretStore(),
+      resolveCodexShellEnv: () => ({
+        ELECTRON_RENDERER_URL: "http://localhost:5175",
+        PATH: "/opt/homebrew/bin:/usr/bin",
+        NVM_DIR: "/Users/alice/.nvm",
+      }),
+    });
+
+    const codexEnv = service.resolveCodexSpawnEnv();
+    const terminalEnv = await service.resolveTerminalSpawnEnvAsync();
+
+    expect(codexEnv).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    expect(terminalEnv).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    expect(codexEnv).toMatchObject({
+      PATH: "/opt/homebrew/bin:/usr/bin",
+      NVM_DIR: "/Users/alice/.nvm",
+    });
+    expect(terminalEnv).toMatchObject({
+      PATH: "/opt/homebrew/bin:/usr/bin",
+      NVM_DIR: "/Users/alice/.nvm",
+    });
+  });
+
   it("applies env overrides above TOML and keeps the Grok API key in keychain", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/git-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/git-discovery.test.ts
@@ -136,6 +136,7 @@ describe("Git discovery", () => {
     missingError.code = "ENOENT";
     const hydratedEnv = {
       PATH: "/nix/profile/bin:/usr/bin",
+      ELECTRON_RENDERER_URL: "http://localhost:5175",
     } as NodeJS.ProcessEnv;
     execFileMock.mockImplementation(
       (
@@ -147,7 +148,11 @@ describe("Git discovery", () => {
           result?: { stdout: string; stderr?: string },
         ) => void,
       ) => {
-        if (command === "git" && options.env === hydratedEnv) {
+        if (
+          command === "git"
+          && options.env?.PATH === hydratedEnv.PATH
+          && options.env?.ELECTRON_RENDERER_URL === undefined
+        ) {
           callback(null, {
             stdout: args[0] === "--version" ? "git version 2.49.0\n" : "ok\n",
           });
@@ -167,15 +172,24 @@ describe("Git discovery", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
       ["--version"],
-      expect.objectContaining({ env: hydratedEnv }),
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: hydratedEnv.PATH }),
+      }),
       expect.any(Function),
     );
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
       ["-C", "/repo", "status", "--short"],
-      expect.objectContaining({ env: hydratedEnv }),
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: hydratedEnv.PATH }),
+      }),
       expect.any(Function),
     );
+    for (const [, , options] of execFileMock.mock.calls) {
+      expect((options as { env?: NodeJS.ProcessEnv }).env).not.toHaveProperty(
+        "ELECTRON_RENDERER_URL",
+      );
+    }
   });
 
   it.skipIf(process.platform === "win32")("does not reuse app-server git resolution across different PATH values", async () => {
@@ -184,6 +198,7 @@ describe("Git discovery", () => {
     const finderEnv = { PATH: "/usr/bin:/bin" } as NodeJS.ProcessEnv;
     const hydratedEnv = {
       PATH: "/custom/bin:/usr/bin:/bin",
+      ELECTRON_RENDERER_URL: "http://localhost:5175",
     } as NodeJS.ProcessEnv;
     execFileMock.mockImplementation(
       (
@@ -196,9 +211,10 @@ describe("Git discovery", () => {
         ) => void,
       ) => {
         if (
-          command === "git" &&
-          args[0] === "--version" &&
-          options.env === hydratedEnv
+          command === "git"
+          && args[0] === "--version"
+          && options.env?.PATH === hydratedEnv.PATH
+          && options.env?.ELECTRON_RENDERER_URL === undefined
         ) {
           callback(null, { stdout: "git version 2.49.0\n" });
           return;

--- a/apps/desktop/src/main/__tests__/grok-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-stdio-transport.test.ts
@@ -110,6 +110,35 @@ describe("GrokStdioJsonRpcTransport", () => {
     await closePromise;
   });
 
+  it("does not pass PwrAgent's renderer URL to the Grok app server", async () => {
+    const child = new MockGrokChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new GrokStdioJsonRpcTransport({
+      apiKey: "test-key",
+      command: "node",
+      entryPath: "grok-app-server.mjs",
+      env: {
+        ELECTRON_RENDERER_URL: "http://localhost:5175",
+        KEEP_GROK_ENV: "yes",
+      },
+    });
+
+    await transport.connect();
+
+    expect(spawnMock.mock.calls[0]?.[2]?.env).toMatchObject({
+      ELECTRON_RUN_AS_NODE: "1",
+      KEEP_GROK_ENV: "yes",
+    });
+    expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty(
+      "ELECTRON_RENDERER_URL",
+    );
+
+    const closePromise = transport.close();
+    child.exitCode = 0;
+    child.emit("close", 0, null);
+    await closePromise;
+  });
+
   it("waits for the child process to close before resolving close", async () => {
     const child = new MockGrokChildProcess();
     spawnMock.mockReturnValue(child);

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -11,7 +11,9 @@ import {
 
 const settingsServiceMock = vi.hoisted(() => ({
   resolveIntegratedTerminalWindowsShell: vi.fn(() => "auto"),
-  resolveTerminalSpawnEnvAsync: vi.fn(async () => ({ SHELL: "/bin/sh" })),
+  resolveTerminalSpawnEnvAsync: vi.fn(
+    async (): Promise<NodeJS.ProcessEnv> => ({ SHELL: "/bin/sh" }),
+  ),
 }));
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
@@ -197,6 +199,43 @@ describe("resolveTerminalShell", () => {
     expect(second.sessionId).toBe(first.sessionId);
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(webContents.once).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pass PwrAgent's renderer URL to an integrated terminal", async () => {
+    const pty = fakePty();
+    let spawnOptions: { env?: NodeJS.ProcessEnv } | undefined;
+    const spawn = vi.fn((...args: unknown[]) => {
+      spawnOptions = args[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      return pty;
+    });
+    settingsServiceMock.resolveTerminalSpawnEnvAsync.mockResolvedValue({
+      ELECTRON_RENDERER_URL: "http://localhost:5175",
+      KEEP_TERMINAL_ENV: "yes",
+      SHELL: "/bin/sh",
+    });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => ({
+        spawn: spawn as unknown as typeof import("node-pty").spawn,
+      }),
+      platform: "darwin",
+    });
+
+    await service.createOrAttach(
+      {
+        threadKey: "codex:thread-renderer-env",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    expect(spawnOptions?.env).not.toHaveProperty("ELECTRON_RENDERER_URL");
+    expect(spawnOptions?.env).toMatchObject({
+      KEEP_TERMINAL_ENV: "yes",
+      TERM: "xterm-256color",
+      COLORTERM: "truecolor",
+    });
   });
 
   it("reports terminal sessions with a foreground command for quit confirmation", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-identity-ipc.test.ts
@@ -35,10 +35,13 @@ describe("runtime identity ipc", () => {
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
       ["-C", "/repo/PwrAgent", "branch", "--show-current"],
-      {
+      expect.objectContaining({
         encoding: "utf8",
+        env: expect.not.objectContaining({
+          ELECTRON_RENDERER_URL: expect.anything(),
+        }),
         stdio: ["ignore", "pipe", "ignore"],
-      }
+      }),
     );
   });
 

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -72,6 +72,41 @@ describe("stdio transport Codex CLI resolution", () => {
 });
 
 describe("StdioJsonRpcTransport", () => {
+  it("does not pass PwrAgent's renderer URL to the Codex app server", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: {
+        ELECTRON_RENDERER_URL: "http://localhost:5173",
+        PATH: "/usr/bin",
+      },
+      resolveEnv: async () => ({
+        ELECTRON_RENDERER_URL: "http://localhost:5175",
+        PATH: "/opt/homebrew/bin:/usr/bin",
+      }),
+      resolveArgs: async (env) => {
+        env.ELECTRON_RENDERER_URL = "http://localhost:5176";
+        return [];
+      },
+    });
+
+    await transport.connect();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "codex",
+      ["app-server"],
+      expect.objectContaining({
+        env: expect.objectContaining({ PATH: "/opt/homebrew/bin:/usr/bin" }),
+      }),
+    );
+    expect(spawnMock.mock.calls[0]?.[2]?.env).not.toHaveProperty(
+      "ELECTRON_RENDERER_URL",
+    );
+
+    await transport.close();
+  });
+
   it("drops late sends after an intentional close", async () => {
     const child = new MockCodexChildProcess();
     spawnMock.mockReturnValue(child);

--- a/apps/desktop/src/main/acp/acp-prerequisites.ts
+++ b/apps/desktop/src/main/acp/acp-prerequisites.ts
@@ -1,5 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 
 const execFile = promisify(execFileCallback);
 
@@ -61,7 +62,10 @@ async function defaultProbe(
   command: string,
   args: string[],
 ): Promise<{ stdout?: string; stderr?: string }> {
-  return await execFile(command, args, { timeout: 2_000 });
+  return await execFile(command, args, {
+    env: buildPwrAgentChildProcessEnv(process.env),
+    timeout: 2_000,
+  });
 }
 
 function parseVersion(output: string): string | undefined {

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -13,6 +13,7 @@ import {
   type JsonRpcObserver,
   type JsonRpcTransport,
 } from "@pwrdrvr/agent-transport";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 import { getMainLogger } from "../log.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60_000;
@@ -181,7 +182,11 @@ class AcpLineStdioTransport implements JsonRpcTransport {
     }
 
     const descriptor = normalizeAcpLaunchDescriptor(this.options.launchDescriptor);
-    const env = appendExecutableSearchPaths({ ...process.env, ...descriptor.env });
+    const env = buildPwrAgentChildProcessEnv(
+      appendExecutableSearchPaths(
+        buildPwrAgentChildProcessEnv(process.env, descriptor.env),
+      ),
+    );
     const spawnProcess = this.options.spawn ?? spawn;
     acpTransportLog.info("launch ACP agent", {
       backendId: descriptor.backendId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13,6 +13,7 @@ import type {
   MessagingApprovalDecision,
   MessagingBindingRecord,
 } from "@pwragent/messaging-interface";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
@@ -1156,7 +1157,7 @@ async function readCurrentGitBranch(sourcePath: string): Promise<string | undefi
   const result = await execFile(
     "git",
     ["-C", sourcePath, "rev-parse", "--abbrev-ref", "HEAD"],
-    { env: process.env },
+    { env: buildPwrAgentChildProcessEnv(process.env) },
   );
   const branch = result.stdout.trim();
   return branch || undefined;
@@ -22892,7 +22893,7 @@ export class DesktopBackendRegistry {
       const result = await execFile(
         "git",
         ["-C", cwd, "config", "--get", "remote.origin.url"],
-        { env: process.env, timeout: 2_000 },
+        { env: buildPwrAgentChildProcessEnv(process.env), timeout: 2_000 },
       );
       return parseGitRemoteRepositoryUrl(result.stdout);
     } catch {

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -21,6 +21,7 @@ import {
   readCodexEnvironmentActionRuns,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { windowsBashCandidates } from "../windows-shell";
 import type { CodexEnvironmentHydrationStoreLike } from "./codex-environment-hydration-store";
 
@@ -394,10 +395,11 @@ export async function applyLocalCodexEnvironmentSelection(params: {
         phase: "started",
         at: Date.now(),
       });
+      const commandEnv = buildPwrAgentChildProcessEnv(params.env ?? process.env);
       const result = await (params.commandRunner ?? runShellCommand)({
         cwd,
         command: selection.environment.setupScript,
-        env: params.env,
+        env: commandEnv,
         mode: "wait",
         captureShellEnvironment: true,
         timeoutMs:
@@ -470,9 +472,10 @@ export async function applyLocalCodexEnvironmentSelection(params: {
     runtime.shellEnvironment = cachedShellEnvironment;
   }
 
-  const actionEnv = runtime.shellEnvironment
-    ? { ...(params.env ?? process.env), ...runtime.shellEnvironment }
-    : params.env;
+  const actionEnv = buildPwrAgentChildProcessEnv(
+    params.env ?? process.env,
+    runtime.shellEnvironment,
+  );
 
   if (selection.action) {
     const runId = params.actionRunId ?? randomUUID();
@@ -577,9 +580,10 @@ export async function startLocalCodexEnvironmentAction(params: {
   const existingRuns = readCodexEnvironmentActionRuns(params.runtime);
 
   try {
-    const actionEnv = params.runtime.shellEnvironment
-      ? { ...(params.env ?? process.env), ...params.runtime.shellEnvironment }
-      : params.env;
+    const actionEnv = buildPwrAgentChildProcessEnv(
+      params.env ?? process.env,
+      params.runtime.shellEnvironment,
+    );
     const result = await (params.commandRunner ?? runShellCommand)({
       cwd: params.runtime.cwd,
       command: action.command,
@@ -703,7 +707,10 @@ function runShellCommand(
           if (signal === "SIGKILL") {
             taskkillArgs.push("/f");
           }
-          spawnSync("taskkill", taskkillArgs, { stdio: "ignore" });
+          spawnSync("taskkill", taskkillArgs, {
+            env: buildPwrAgentChildProcessEnv(process.env),
+            stdio: "ignore",
+          });
         }
       } catch (error) {
         environmentRuntimeLog.warn("codex-environment-command-kill-failed", {
@@ -1039,7 +1046,7 @@ function runShellCommand(
 function sanitizeLocalEnvironmentCommandEnv(
   env: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
-  const sanitized = { ...env };
+  const sanitized = buildPwrAgentChildProcessEnv(env);
   for (const key of Object.keys(sanitized)) {
     if (isParentElectronRuntimeEnvKey(key)) {
       delete sanitized[key];

--- a/apps/desktop/src/main/app-server/codex-environment-runtime.ts
+++ b/apps/desktop/src/main/app-server/codex-environment-runtime.ts
@@ -707,8 +707,17 @@ function runShellCommand(
           if (signal === "SIGKILL") {
             taskkillArgs.push("/f");
           }
-          spawnSync("taskkill", taskkillArgs, {
-            env: buildPwrAgentChildProcessEnv(process.env),
+          const taskkillEnv = buildPwrAgentChildProcessEnv(process.env);
+          const systemRoot = Object.entries(taskkillEnv).find(
+            ([key]) => key.toUpperCase() === "SYSTEMROOT",
+          )?.[1];
+          // The explicit environment is necessary to keep the renderer URL out
+          // of the helper, so resolve taskkill without relying on its PATH.
+          const taskkill = systemRoot
+            ? path.join(systemRoot, "System32", "taskkill.exe")
+            : "taskkill";
+          spawnSync(taskkill, taskkillArgs, {
+            env: taskkillEnv,
             stdio: "ignore",
           });
         }

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,5 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { gitCandidateInputs } from "../settings/git-discovery";
 
 const execFile = promisify(execFileCallback);
@@ -58,7 +59,8 @@ async function canRunGit(
 export async function resolveGitExecutable(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
-  const cacheKey = gitResolutionCacheKey(env);
+  const childEnv = buildPwrAgentChildProcessEnv(env);
+  const cacheKey = gitResolutionCacheKey(childEnv);
   const resolved = resolvedGitExecutableByEnv.get(cacheKey);
   if (resolved) {
     return resolved;
@@ -68,8 +70,8 @@ export async function resolveGitExecutable(
   if (!resolving) {
     resolving = (async () => {
       const failures: string[] = [];
-      for (const candidate of gitExecutableCandidates(env)) {
-        const result = await canRunGit(candidate, env);
+      for (const candidate of gitExecutableCandidates(childEnv)) {
+        const result = await canRunGit(candidate, childEnv);
         if (result.ok) {
           resolvedGitExecutableByEnv.set(cacheKey, candidate);
           return candidate;
@@ -95,7 +97,7 @@ export async function runGitCommand(
   stdout: string;
   stderr: string;
 }> {
-  const env = options.env ?? process.env;
+  const env = buildPwrAgentChildProcessEnv(options.env ?? process.env);
   const git = await resolveGitExecutable(env);
   const { stdout, stderr } = await execFile(git, ["-C", cwd, ...args], {
     encoding: "utf8",

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -10,6 +10,7 @@ import type {
   WorktreeOtherChangeEntry,
   WorktreeOtherChangeStatus,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { resolveGitExecutable, runGitCommand } from "./git-executable";
 
 function normalizeAbsolutePath(value: string): string {
@@ -602,7 +603,8 @@ async function listUntrackedDirectoryFilesLimited(
     return { repoPaths: [], truncated: true };
   }
 
-  const git = await resolveGitExecutable(gitEnv ?? process.env);
+  const childEnv = buildPwrAgentChildProcessEnv(gitEnv ?? process.env);
+  const git = await resolveGitExecutable(childEnv);
   return await new Promise((resolve) => {
     const repoPaths: string[] = [];
     let pending = "";
@@ -623,7 +625,7 @@ async function listUntrackedDirectoryFilesLimited(
         "--",
         repoPath,
       ],
-      { env: gitEnv ?? process.env },
+      { env: childEnv },
     );
 
     const finish = () => {

--- a/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
+++ b/apps/desktop/src/main/app-server/git-workspace-handoff-service.ts
@@ -13,6 +13,7 @@ import type {
   ThreadWorkspaceHandoffStashSummary,
 } from "@pwragent/shared";
 import { DESKTOP_WORKTREE_STORAGE_DEFAULT } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { computeWorktreePath } from "./git-directory-service";
 import { WorktreeArchiveService } from "./worktree-archive-service";
 
@@ -116,7 +117,7 @@ async function runGit(
 ): Promise<GitResult> {
   return await execFileAsync("git", args, {
     cwd,
-    env: env ?? process.env,
+    env: buildPwrAgentChildProcessEnv(env ?? process.env),
     maxBuffer: 1024 * 1024 * 10,
   });
 }

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -22,6 +22,7 @@ import {
   type ThreadMigrationSourceThreadSummary,
   type NavigationThreadSummary,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import { normalizeProfileName } from "../profile";
 import type { DesktopSettingsService } from "../settings/desktop-settings-service";
@@ -1008,7 +1009,9 @@ async function gitBranchExists(
       "rev-parse",
       "--verify",
       `${branchName}^{commit}`,
-    ]);
+    ], {
+      env: buildPwrAgentChildProcessEnv(process.env),
+    });
     return true;
   } catch {
     return false;

--- a/apps/desktop/src/main/app-server/worktree-archive-service.ts
+++ b/apps/desktop/src/main/app-server/worktree-archive-service.ts
@@ -8,6 +8,7 @@ import type {
   AppServerBackendKind,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const execFileAsync = promisify(execFile);
 
@@ -63,10 +64,7 @@ async function runGit(
 ): Promise<GitResult> {
   return await execFileAsync("git", args, {
     cwd,
-    env: {
-      ...process.env,
-      ...options.env,
-    },
+    env: buildPwrAgentChildProcessEnv(process.env, options.env),
     maxBuffer: 1024 * 1024 * 10,
   });
 }

--- a/apps/desktop/src/main/automations/automation-gate-runner.ts
+++ b/apps/desktop/src/main/automations/automation-gate-runner.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import type { AutomationGateConfig, AutomationGateRunResult } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { resolveWindowsBashShell } from "../windows-shell";
 
 const DEFAULT_GATE_TIMEOUT_MS = 60_000;
@@ -37,15 +38,16 @@ function runShellGate(config: AutomationGateConfig): Promise<AutomationGateRunRe
   const startedAt = Date.now();
   const timeoutMs = config.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS;
   const outputLimit = config.outputLimitChars ?? DEFAULT_GATE_OUTPUT_LIMIT_CHARS;
+  const childEnv = buildPwrAgentChildProcessEnv(process.env);
   const shell =
-    process.env.SHELL?.trim() ||
+    childEnv.SHELL?.trim() ||
     (process.platform === "win32" ? resolveWindowsBashShell() : "/bin/sh");
 
   return new Promise((resolve) => {
     const child = spawn(shell, ["-lc", command], {
       cwd: config.cwd,
       detached: Boolean(timeoutMs),
-      env: process.env,
+      env: childEnv,
       stdio: "pipe",
     });
 
@@ -87,6 +89,7 @@ function runShellGate(config: AutomationGateConfig): Promise<AutomationGateRunRe
           // workspace. Kill the whole process tree, matching the timeout path in
           // codex-environment-runtime.
           spawnSync("taskkill", ["/pid", String(child.pid), "/t", "/f"], {
+            env: buildPwrAgentChildProcessEnv(process.env),
             stdio: "ignore",
           });
         }

--- a/apps/desktop/src/main/child-process-env.ts
+++ b/apps/desktop/src/main/child-process-env.ts
@@ -1,0 +1,39 @@
+/**
+ * electron-vite uses this to tell PwrAgent's own Electron main process where
+ * its development renderer lives. Passing that endpoint to an unrelated
+ * Electron app makes that app load PwrAgent's renderer instead of its bundle.
+ */
+export const ELECTRON_RENDERER_URL_ENV = "ELECTRON_RENDERER_URL";
+
+/**
+ * Merge environment layers for a process outside PwrAgent. Later layers keep
+ * their normal override behavior, then PwrAgent-private renderer state is
+ * removed last so no merge order can reintroduce it.
+ *
+ * Mutates `target` to support the long-lived hydrated environment objects in
+ * DesktopSettingsService. Call `buildPwrAgentChildProcessEnv` for a new object.
+ */
+export function mergePwrAgentChildProcessEnv(
+  target: NodeJS.ProcessEnv,
+  ...sources: Array<NodeJS.ProcessEnv | undefined>
+): NodeJS.ProcessEnv {
+  for (const source of sources) {
+    if (source) {
+      Object.assign(target, source);
+    }
+  }
+  for (const key of Object.keys(target)) {
+    // Windows environment names are case-insensitive. Deleting every casing is
+    // harmless on POSIX and keeps the boundary correct on all supported hosts.
+    if (key.toUpperCase() === ELECTRON_RENDERER_URL_ENV) {
+      delete target[key];
+    }
+  }
+  return target;
+}
+
+export function buildPwrAgentChildProcessEnv(
+  ...sources: Array<NodeJS.ProcessEnv | undefined>
+): NodeJS.ProcessEnv {
+  return mergePwrAgentChildProcessEnv({}, ...sources);
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -49,6 +49,10 @@ import type {
   LinkedDirectorySummary,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
+import {
+  buildPwrAgentChildProcessEnv,
+  ELECTRON_RENDERER_URL_ENV,
+} from "../child-process-env";
 import type {
   ClientRequest as CodexClientRequest,
   InitializeParams as CodexInitializeParams,
@@ -5504,11 +5508,12 @@ function mergeCodexShellEnvironmentPolicyConfig(
   config: CodexThreadStartParams["config"] | undefined,
   runtime: CodexThreadEnvironmentRuntime | undefined,
 ): CodexThreadStartParams["config"] | undefined {
+  const sanitizedConfig = sanitizeCodexShellEnvironmentPolicyConfig(config);
   if (runtime?.executionTarget !== "local" || !runtime.shellEnvironment) {
-    return config;
+    return sanitizedConfig;
   }
   const shellEnvironment = Object.fromEntries(
-    Object.entries(runtime.shellEnvironment).filter(
+    Object.entries(buildPwrAgentChildProcessEnv(runtime.shellEnvironment)).filter(
       (entry): entry is [string, string] =>
         typeof entry[0] === "string" &&
         entry[0].length > 0 &&
@@ -5516,9 +5521,9 @@ function mergeCodexShellEnvironmentPolicyConfig(
     ),
   );
   if (!Object.keys(shellEnvironment).length) {
-    return config;
+    return sanitizedConfig;
   }
-  const baseConfig = isPlainRecord(config) ? config : {};
+  const baseConfig = isPlainRecord(sanitizedConfig) ? sanitizedConfig : {};
   return Object.entries(shellEnvironment).reduce<Record<string, unknown>>(
     (nextConfig, [key, value]) => {
       if (isShellEnvironmentVariableName(key)) {
@@ -5528,6 +5533,24 @@ function mergeCodexShellEnvironmentPolicyConfig(
     },
     { ...baseConfig },
   ) as CodexThreadStartParams["config"];
+}
+
+function sanitizeCodexShellEnvironmentPolicyConfig(
+  config: CodexThreadStartParams["config"] | undefined,
+): CodexThreadStartParams["config"] | undefined {
+  if (!isPlainRecord(config)) {
+    return config;
+  }
+  const sanitized = { ...config };
+  for (const key of Object.keys(sanitized)) {
+    const environmentKey = key.startsWith("shell_environment_policy.set.")
+      ? key.slice("shell_environment_policy.set.".length)
+      : undefined;
+    if (environmentKey?.toUpperCase() === ELECTRON_RENDERER_URL_ENV) {
+      delete sanitized[key];
+    }
+  }
+  return sanitized as CodexThreadStartParams["config"];
 }
 
 function mergeCodexDefaultModeRequestUserInputConfig(

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -5,6 +5,7 @@ import {
 import readline from "node:readline";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
 import { getMainLogger } from "../log";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import {
   compareCodexCliVersions,
   resolveCodexCommand,
@@ -75,16 +76,19 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     this.closeRequested = false;
     this.droppedSendAfterCloseLogged = false;
 
-    const env = this.options.resolveEnv
+    const resolvedEnv = this.options.resolveEnv
       ? await this.options.resolveEnv()
       : this.options.env ?? process.env;
+    const env = buildPwrAgentChildProcessEnv(resolvedEnv);
     const args = this.options.resolveArgs
       ? await this.options.resolveArgs(env)
       : this.options.args ?? [];
+    const commandEnv = buildPwrAgentChildProcessEnv(env);
     const command = await resolveCodexCommand({
       command: this.options.command,
-      env,
+      env: commandEnv,
     });
+    const childEnv = buildPwrAgentChildProcessEnv(commandEnv);
     codexTransportLog.info("launch app-server", {
       command: command.command,
       source: command.source,
@@ -93,7 +97,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
 
     const child = spawn(command.command, ["app-server", ...args], {
       stdio: ["pipe", "pipe", "pipe"],
-      env,
+      env: childEnv,
     });
 
     if (!child.stdin || !child.stdout || !child.stderr) {

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { LinkedDirectorySummary } from "@pwragent/shared";
 import { isToolManagedWorktreePath } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 
 const execFile = promisify(execFileCallback);
@@ -42,7 +43,7 @@ type GitMetadataEvidence = {
 
 async function runGit(projectKey: string, args: string[]): Promise<string> {
   const result = await execFile("git", ["-C", projectKey, ...args], {
-    env: process.env,
+    env: buildPwrAgentChildProcessEnv(process.env),
   });
   return result.stdout.trim();
 }

--- a/apps/desktop/src/main/credential-tester/credential-tester.ts
+++ b/apps/desktop/src/main/credential-tester/credential-tester.ts
@@ -6,6 +6,7 @@ import type {
   SettingsCredentialTestResult,
   SettingsCredentialTestStatus,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import type { CredentialValidationRequest } from "../messaging/messaging-runtime";
 import {
@@ -503,6 +504,7 @@ async function defaultRunCodexVersion(
   command: string,
 ): Promise<{ stdout: string; stderr: string }> {
   const { stdout, stderr } = await execFileAsync(command, ["--version"], {
+    env: buildPwrAgentChildProcessEnv(process.env),
     timeout: DEFAULT_PROBE_TIMEOUT_MS,
   });
   return {

--- a/apps/desktop/src/main/grok-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/grok-app-server/stdio-transport.ts
@@ -14,6 +14,7 @@ import {
   resolvePwragentRoot,
 } from "../profile";
 import { getMainLogger } from "../log";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const grokTransportLog = getMainLogger("pwragent:grok-transport");
 const STDERR_LOG_MAX_LINES_PER_WINDOW = 100;
@@ -206,12 +207,11 @@ function buildGrokAppServerEnv(params: {
       ? legacyStateRoot
       : path.join(activeProfileDir, "state", "grok-app-server");
 
-  const childEnv: NodeJS.ProcessEnv = {
-    ...params.baseEnv,
+  const childEnv = buildPwrAgentChildProcessEnv(params.baseEnv, {
     ELECTRON_RUN_AS_NODE: "1",
     [PROFILE_STATE_ROOT_ENV]: profileStateRoot,
     ...(params.apiKey ? { XAI_API_KEY: params.apiKey } : {}),
-  };
+  });
   delete childEnv[LOCAL_ENV_PATH_ENV];
   if (params.localEnvPath) {
     childEnv[LOCAL_ENV_PATH_ENV] = params.localEnvPath;

--- a/apps/desktop/src/main/ipc/image-normalization.ts
+++ b/apps/desktop/src/main/ipc/image-normalization.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { ipcMain, nativeImage } from "electron";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import type {
   ImageUploadFallbackRequest,
@@ -32,7 +33,10 @@ type ExecFileLike = (
 
 const defaultDependencies: ImageFallbackDependencies = {
   createImageFromBuffer: (buffer) => nativeImage.createFromBuffer(buffer),
-  execFile,
+  execFile: async (file, args) =>
+    await execFile(file, args, {
+      env: buildPwrAgentChildProcessEnv(process.env),
+    }),
   platform: process.platform,
 };
 

--- a/apps/desktop/src/main/ipc/profiles.ts
+++ b/apps/desktop/src/main/ipc/profiles.ts
@@ -155,6 +155,9 @@ export function openDesktopPwrAgentProfile(
     process.defaultApp ? process.argv.slice(1) : [],
     profile,
   );
+  // Deliberately retain ELECTRON_RENDERER_URL here. This is not a general
+  // child execution context: it relaunches PwrAgent itself, whose development
+  // main process needs electron-vite's renderer endpoint to render correctly.
   const child = spawn(process.execPath, args, {
     detached: true,
     env: {

--- a/apps/desktop/src/main/ipc/runtime-identity.ts
+++ b/apps/desktop/src/main/ipc/runtime-identity.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from "electron";
 import { execFileSync } from "node:child_process";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { RUNTIME_IDENTITY_CHANNEL } from "../../shared/ipc";
 import type { RuntimeIdentity } from "../../shared/runtime-identity";
 
@@ -7,6 +8,7 @@ function readGitValue(cwd: string, args: string[]): string | undefined {
   try {
     const value = execFileSync("git", ["-C", cwd, ...args], {
       encoding: "utf8",
+      env: buildPwrAgentChildProcessEnv(process.env),
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
 

--- a/apps/desktop/src/main/pr-status/git-remote.ts
+++ b/apps/desktop/src/main/pr-status/git-remote.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const execFileAsync = promisify(execFile);
 const GIT_REMOTE_TIMEOUT_MS = 2_000;
@@ -132,7 +133,12 @@ async function defaultReadRemoteUrl(cwd: string): Promise<string | undefined> {
     const { stdout } = await execFileAsync(
       "git",
       ["remote", "get-url", "origin"],
-      { cwd, maxBuffer: 64 * 1024, timeout: GIT_REMOTE_TIMEOUT_MS },
+      {
+        cwd,
+        env: buildPwrAgentChildProcessEnv(process.env),
+        maxBuffer: 64 * 1024,
+        timeout: GIT_REMOTE_TIMEOUT_MS,
+      },
     );
     return stdout.trim() || undefined;
   } catch {

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { graphql } from "@octokit/graphql";
 import type { PrSummary } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import {
   deriveChipStateFromRollup,
@@ -593,13 +594,14 @@ export class GithubGraphqlPrClient {
         ]);
       const discovery = await discoverGhCommands({
         configuredCommand: getDesktopSettingsService().resolveGhCommandPreference(),
-        env: process.env,
+        env: buildPwrAgentChildProcessEnv(process.env),
       });
       const command = discovery.selectedCommand;
       if (!command) {
         return null;
       }
       const { stdout } = await execFileAsync(command, ["auth", "token"], {
+        env: buildPwrAgentChildProcessEnv(process.env),
         timeout: 10_000,
         encoding: "utf8",
       });

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -5,6 +5,7 @@ import type {
   GhStatus,
   PrSummary,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import { discoverGhCommands } from "../settings/gh-discovery";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
@@ -527,6 +528,7 @@ function defaultExec(
     const command = await resolveGhCommand();
     const result = await execFileAsync(command, args, {
       cwd,
+      env: buildPwrAgentChildProcessEnv(process.env),
       timeout: timeoutMs,
       maxBuffer: 1024 * 1024,
       encoding: "utf8",
@@ -544,7 +546,11 @@ function defaultRunGhAuthStatus(
       const result = await execFileAsync(
         command,
         ["auth", "status", "--hostname", "github.com"],
-        { timeout: 5_000, encoding: "utf8" },
+        {
+          env: buildPwrAgentChildProcessEnv(process.env),
+          timeout: 5_000,
+          encoding: "utf8",
+        },
       );
       return { stdout: result.stdout, stderr: result.stderr, ok: true };
     } catch (error) {

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { LinkedDirectorySummary, PrSummary } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import type { GithubPrFetcher } from "./github-pr-fetcher";
 
 const execFileAsync = promisify(execFile);
@@ -129,6 +130,7 @@ async function readTrackedRemoteBranch(params: {
       ],
       {
         cwd: params.cwd,
+        env: buildPwrAgentChildProcessEnv(process.env),
         maxBuffer: 64 * 1024,
         timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
       },
@@ -182,6 +184,7 @@ async function readRemoteDefaultBranches(cwd: string): Promise<{
 }> {
   const { stdout } = await execFileAsync("git", ["remote"], {
     cwd,
+    env: buildPwrAgentChildProcessEnv(process.env),
     maxBuffer: 64 * 1024,
     timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
   });
@@ -233,6 +236,7 @@ async function readGitLine(
   try {
     const { stdout } = await execFileAsync("git", args, {
       cwd,
+      env: buildPwrAgentChildProcessEnv(process.env),
       maxBuffer: 64 * 1024,
       timeout: GIT_BRANCH_LOOKUP_TIMEOUT_MS,
     });

--- a/apps/desktop/src/main/settings/application-discovery.ts
+++ b/apps/desktop/src/main/settings/application-discovery.ts
@@ -14,6 +14,7 @@ import type {
   OpenDesktopApplicationRequest,
   OpenDesktopApplicationResponse,
 } from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 
 const execFile = promisify(execFileCallback);
@@ -332,7 +333,7 @@ async function discoverApplication(
 export async function discoverDesktopApplications(params?: {
   env?: NodeJS.ProcessEnv;
 }): Promise<DesktopApplicationsSnapshot> {
-  const env = params?.env ?? process.env;
+  const env = buildPwrAgentChildProcessEnv(params?.env ?? process.env);
   const [editors, terminals] = await Promise.all([
     Promise.all(EDITORS.map((application) => discoverApplication(application, env))),
     Promise.all(TERMINALS.map((application) => discoverApplication(application, env))),
@@ -369,7 +370,7 @@ export async function openDesktopApplication(
     throw new Error(`Workspace path does not exist: ${targetPath}`);
   }
 
-  const env = params?.env ?? process.env;
+  const env = buildPwrAgentChildProcessEnv(params?.env ?? process.env);
   const snapshot = await discoverDesktopApplications({ env });
   const application = [...snapshot.editors, ...snapshot.terminals].find(
     (candidate) =>

--- a/apps/desktop/src/main/settings/command-discovery.ts
+++ b/apps/desktop/src/main/settings/command-discovery.ts
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const execFile = promisify(execFileCallback);
 
@@ -173,7 +174,7 @@ async function readCommandVersion(params: {
 }> {
   try {
     const result = await execFile(params.command, params.versionArgs, {
-      env: params.env,
+      env: buildPwrAgentChildProcessEnv(params.env),
       timeout: 2_000,
     });
     const output = `${result.stdout}\n${result.stderr ?? ""}`;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -145,6 +145,10 @@ import { discoverDesktopApplications } from "./application-discovery";
 import { discoverGitCommands } from "./git-discovery";
 import { discoverGhCommands } from "./gh-discovery";
 import { getMainLogger } from "../log";
+import {
+  buildPwrAgentChildProcessEnv,
+  mergePwrAgentChildProcessEnv,
+} from "../child-process-env";
 // Login-shell PATH hydration is now shared via @pwrdrvr/agent-transport (it was
 // extracted FROM this file). Behavior-identical: same `mergeLoginShellEnvIntoEnv`
 // shape + the `resolveShellEnv` test seam; the kit takes an injected logger
@@ -305,7 +309,7 @@ async function resolveInteractiveLoginShellEnvAsync(
           ["-ilc", command],
           {
             encoding: "utf8",
-            env,
+            env: buildPwrAgentChildProcessEnv(env),
             maxBuffer: LOGIN_SHELL_ENV_MAX_BUFFER,
             timeout: LOGIN_SHELL_ENV_TIMEOUT_MS,
           },
@@ -320,7 +324,7 @@ async function resolveInteractiveLoginShellEnvAsync(
       });
       const shellEnv = extractMarkedEnv(output);
       if (shellEnv) {
-        return shellEnv;
+        return buildPwrAgentChildProcessEnv(shellEnv);
       }
       failures.push({ shell, error: "missing env markers" });
     } catch (error) {
@@ -1366,12 +1370,14 @@ export class DesktopSettingsService {
   resolveCodexSpawnEnv(): NodeJS.ProcessEnv {
     if (this.options.resolveCodexShellEnv) {
       return this.withStartupCodexHome(
-        mergeLoginShellEnvIntoEnv(this.env, {
-          resolveShellEnv: this.options.resolveCodexShellEnv,
-          // Preserve the in-tree copy's diagnostic logging (the kit defaults to
-          // no-op when no logger is injected).
-          logger: getMainLogger("pwragent:shell-environment"),
-        }),
+        buildPwrAgentChildProcessEnv(
+          mergeLoginShellEnvIntoEnv(buildPwrAgentChildProcessEnv(this.env), {
+            resolveShellEnv: this.options.resolveCodexShellEnv,
+            // Preserve the in-tree copy's diagnostic logging (the kit defaults to
+            // no-op when no logger is injected).
+            logger: getMainLogger("pwragent:shell-environment"),
+          }),
+        ),
       );
     }
 
@@ -1409,7 +1415,7 @@ export class DesktopSettingsService {
           hadNvmDir: Boolean(shellEnv.NVM_DIR),
           hadHomebrewPrefix: Boolean(shellEnv.HOMEBREW_PREFIX),
         });
-        Object.assign(targetEnv, shellEnv);
+        mergePwrAgentChildProcessEnv(targetEnv, shellEnv);
         if (this.startupCodexHome) {
           targetEnv.CODEX_HOME = this.startupCodexHome;
         }
@@ -1421,10 +1427,12 @@ export class DesktopSettingsService {
 
   async resolveTerminalSpawnEnvAsync(): Promise<NodeJS.ProcessEnv> {
     if (this.options.resolveCodexShellEnv) {
-      return mergeLoginShellEnvIntoEnv(this.env, {
-        resolveShellEnv: this.options.resolveCodexShellEnv,
-        logger: getMainLogger("pwragent:shell-environment"),
-      });
+      return buildPwrAgentChildProcessEnv(
+        mergeLoginShellEnvIntoEnv(buildPwrAgentChildProcessEnv(this.env), {
+          resolveShellEnv: this.options.resolveCodexShellEnv,
+          logger: getMainLogger("pwragent:shell-environment"),
+        }),
+      );
     }
 
     if (this.terminalSpawnEnvHydrationPromise) {
@@ -1452,7 +1460,7 @@ export class DesktopSettingsService {
         hadNvmDir: Boolean(shellEnv.NVM_DIR),
         hadHomebrewPrefix: Boolean(shellEnv.HOMEBREW_PREFIX),
       });
-      Object.assign(targetEnv, shellEnv);
+      mergePwrAgentChildProcessEnv(targetEnv, shellEnv);
       return targetEnv;
     });
 
@@ -1460,12 +1468,14 @@ export class DesktopSettingsService {
   }
 
   private ensureBaseCodexSpawnEnv(): NodeJS.ProcessEnv {
-    this.codexSpawnEnv ??= this.withStartupCodexHome({ ...this.env });
+    this.codexSpawnEnv ??= this.withStartupCodexHome(
+      buildPwrAgentChildProcessEnv(this.env),
+    );
     return this.codexSpawnEnv;
   }
 
   private ensureBaseTerminalSpawnEnv(): NodeJS.ProcessEnv {
-    this.terminalSpawnEnv ??= { ...this.env };
+    this.terminalSpawnEnv ??= buildPwrAgentChildProcessEnv(this.env);
     return this.terminalSpawnEnv;
   }
 

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../shared/integrated-terminal";
 import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const DEFAULT_COLUMNS = 80;
 const DEFAULT_ROWS = 18;
@@ -129,11 +130,10 @@ export class IntegratedTerminalService {
         cols: clampInteger(request.cols, DEFAULT_COLUMNS, 2, MAX_COLUMNS),
         rows: clampInteger(request.rows, DEFAULT_ROWS, 2, MAX_ROWS),
         cwd,
-        env: {
-          ...env,
+        env: buildPwrAgentChildProcessEnv(env, {
           TERM: "xterm-256color",
           COLORTERM: "truecolor",
-        },
+        }),
       });
     } catch (error) {
       const message = terminalStartErrorMessage(error);


### PR DESCRIPTION
## Summary

- I centralize child-process environment composition and prevent PwrAgent's private `ELECTRON_RENDERER_URL` from reaching terminals, Codex, environment setup/actions, and adjacent external child processes.
- I preserve normal inherited and deliberate override variables while enforcing a final sanitizer after every merge point.
- I retain the one intentional exception: a PwrAgent profile self-relaunch may keep its own electron-vite renderer endpoint.

## Verification

- I ran the focused desktop test suite: 24 files and 462 tests passed.
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, and `git diff --check origin/main...HEAD`.

## Notes

- The root cause was a PwrAgent development process inheriting electron-vite's renderer URL and passing it to unrelated Electron apps. PwrGit's Playwright run therefore started PwrGit's main process but loaded PwrAgent's renderer at `http://localhost:5175`.
- This change stops that app-private development state at the PwrAgent process boundary, including later environment merges that could otherwise reintroduce it.
