### PR TITLE
fix(desktop): name linked projects in directories

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -175,6 +175,16 @@ function hasPendingLaunchpadState(directory: NavigationDirectorySummary): boolea
  */
 const UNPINNED_THREAD_CAP = 10;
 
+function getDirectoryRowLinkedDirectoryMode(
+  thread: NavigationThreadSummary,
+): "kind" | "label" {
+  // A literal "worktree" or "local" chip is useful for a thread with one
+  // workspace. Once a thread spans projects, collapsing by kind hides the
+  // additional roots (and makes one root stand in for all of them). Reuse the
+  // label chips from Updated/Created so every linked project stays visible.
+  return thread.linkedDirectories.length > 1 ? "label" : "kind";
+}
+
 export function DirectoriesList(props: DirectoriesListProps) {
   const [expandedByKey, setExpandedByKey] = useState<Record<string, boolean>>({});
   // Per-directory "show all unpinned threads" toggle, keyed by directory.key.
@@ -639,7 +649,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   : undefined
               }
               includeLinkedDirectories
-              linkedDirectoryMode="kind"
+              linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(child)}
               nested
               revealSelectedThreadRequest={props.revealSelectedThreadRequest}
               selectedThreadKey={props.selectedItemKey}
@@ -774,7 +784,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             compact
             draggable={Boolean(props.onReorderThreadPins)}
             includeLinkedDirectories
-            linkedDirectoryMode="kind"
+            linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(thread)}
             revealSelectedThreadRequest={props.revealSelectedThreadRequest}
             selectedThreadKey={props.selectedItemKey}
             subthreadCount={subthreadCount}
@@ -1088,7 +1098,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           }
                           draggable={Boolean(props.onReorderThreadPins)}
                           includeLinkedDirectories
-                          linkedDirectoryMode="kind"
+                          linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(thread)}
                           revealSelectedThreadRequest={
                             props.revealSelectedThreadRequest
                           }

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1359,9 +1359,11 @@ describe("Sidebar", () => {
     );
 
     const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    fireEvent.click(
-      within(browseSection as HTMLElement).getByRole("button", { name: "PwrGit" }),
-    );
+    const pwrGitDirectorySummary = within(browseSection as HTMLElement)
+      .getAllByRole("button", { name: /^PwrGit(?:,|$)/ })
+      .find((button) => button.hasAttribute("aria-expanded"));
+    expect(pwrGitDirectorySummary).toBeDefined();
+    fireEvent.click(pwrGitDirectorySummary!);
     const threadButton = within(browseSection as HTMLElement).getByRole("button", {
       name: "Prepare PwrGit branding assets",
     });

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1247,7 +1247,7 @@ describe("Sidebar", () => {
     expect(within(threadButton).queryByText("worktree")).not.toBeInTheDocument();
   });
 
-  it("shows local versus worktree location chips in directory rows", () => {
+  it("keeps kind chips for single-directory rows", () => {
     const localThread = {
       ...sharedThread,
       id: "thread-local",
@@ -1300,6 +1300,83 @@ describe("Sidebar", () => {
     expect(within(worktreeThreadButton).getByText("worktree")).toBeInTheDocument();
     expect(within(worktreeThreadButton).queryByText("PwrAgent")).not.toBeInTheDocument();
     expect(within(localThreadButton).getByText("local")).toBeInTheDocument();
+  });
+
+  it("names every linked project in multi-directory rows", () => {
+    const multiDirectoryThread = {
+      ...sharedThread,
+      id: "thread-multiple-directories",
+      title: "Prepare PwrGit branding assets",
+      linkedDirectories: [
+        {
+          id: "dir-pwrgit",
+          label: "PwrGit",
+          path: "/Users/huntharo/github/PwrGit",
+          worktreePath: "/Users/huntharo/.codex/worktrees/pwrgit/PwrGit",
+          kind: "worktree" as const,
+        },
+        {
+          id: "dir-pwragnt",
+          label: "PwrAgnt",
+          path: "/Users/huntharo/github/PwrAgnt",
+          kind: "local" as const,
+        },
+        {
+          id: "dir-pwrsnap",
+          label: "PwrSnap",
+          path: "/Users/huntharo/github/PwrSnap",
+          kind: "local" as const,
+        },
+      ],
+    };
+    const pwrGitDirectory: NavigationDirectorySummary = {
+      key: "directory:/Users/huntharo/github/PwrGit",
+      kind: "directory",
+      label: "PwrGit",
+      path: "/Users/huntharo/github/PwrGit",
+      threadKeys: ["codex:thread-multiple-directories"],
+      needsAttentionCount: 0,
+      latestUpdatedAt: multiDirectoryThread.updatedAt,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        createThreadError={undefined}
+        directories={[pwrGitDirectory]}
+        inboxThreads={[multiDirectoryThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey={undefined}
+        threads={[multiDirectoryThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const browseSection = screen.getByRole("region", { name: "Thread browser" });
+    fireEvent.click(
+      within(browseSection as HTMLElement).getByRole("button", { name: "PwrGit" }),
+    );
+    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
+      name: "Prepare PwrGit branding assets",
+    });
+
+    expect(
+      within(threadButton).getByLabelText("Copy path for worktree PwrGit"),
+    ).toHaveTextContent("PwrGit");
+    expect(
+      within(threadButton).getByLabelText("Copy path for PwrAgnt"),
+    ).toHaveTextContent("PwrAgnt");
+    expect(
+      within(threadButton).getByLabelText("Copy path for PwrSnap"),
+    ).toHaveTextContent("PwrSnap");
+    expect(within(threadButton).queryByText("worktree")).not.toBeInTheDocument();
+    expect(within(threadButton).queryByText("local")).not.toBeInTheDocument();
   });
 
   it("opens the directory launchpad from the plus button", () => {


### PR DESCRIPTION
## Summary

- I changed multi-directory thread rows in Directories to show every linked project by name instead of collapsing secondary roots into one `local` chip.
- I kept the compact `worktree`/`local` state chips for threads with only one linked directory.
- I added regression coverage for a PwrGit worktree with PwrAgnt and PwrSnap attached as additional roots.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the repository's existing warning baseline)

## Notes

- The root cause was the Directories renderer's `kind` mode: it de-duplicated links by `local` versus `worktree`, so two local project roots rendered as a single ambiguous chip.
