### PR TITLE
fix(desktop): preserve prompt order after turn hydration

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3153,6 +3153,176 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps an observed prompt above hydrated work after a completed-turn refresh", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const liveTurn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 1_000,
+    };
+    const completedTurn = {
+      id: "turn-1",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 5_000,
+      durationMs: 4_000,
+    };
+    const readThread = vi
+      .fn()
+      .mockImplementationOnce(async ({ threadId }) =>
+        readThreadResponse({
+          entries: [],
+          hasPreviousPage: false,
+          supportsPagination: false,
+          threadId,
+        })
+      )
+      .mockImplementationOnce(async ({ threadId }) =>
+        readThreadResponse({
+          // Codex can return the just-finished tool aggregate before the
+          // initiating prompt. The renderer had already observed the prompt
+          // before the work, so this weaker hydration order must not win.
+          entries: [
+            {
+              type: "activity" as const,
+              id: "hydrated-tools",
+              summary: "Used 1 tool",
+              createdAt: 2_000,
+              details: [
+                {
+                  id: "tool-1",
+                  kind: "command" as const,
+                  label: "Read the latest screenshot",
+                  status: "completed" as const,
+                },
+              ],
+              turn: completedTurn,
+            },
+            {
+              type: "message" as const,
+              id: "hydrated-user",
+              role: "user" as const,
+              text: "Show me the latest screenshot.",
+              createdAt: 1_000,
+              turn: completedTurn,
+            },
+            {
+              type: "message" as const,
+              id: "hydrated-commentary",
+              role: "assistant" as const,
+              phase: "commentary" as const,
+              text: "I will fetch the latest capture.",
+              createdAt: 1_500,
+              turn: completedTurn,
+            },
+            {
+              type: "message" as const,
+              id: "hydrated-final",
+              role: "assistant" as const,
+              phase: "final" as const,
+              text: "Here it is.",
+              createdAt: 5_000,
+              turn: completedTurn,
+            },
+          ],
+          hasPreviousPage: false,
+          supportsPagination: false,
+          threadId,
+        })
+    );
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread,
+    };
+
+    const { result } = renderHook(
+      ({ thread }) => useThreadSessionState({ desktopApi, thread }),
+      {
+        initialProps: {
+          thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+        },
+      }
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry({
+        type: "message",
+        id: "optimistic-user",
+        role: "user",
+        text: "Show me the latest screenshot.",
+        createdAt: 1_000,
+        turn: liveTurn,
+      });
+      result.current.upsertLiveTranscriptEntry({
+        type: "message",
+        id: "live-commentary",
+        role: "assistant",
+        phase: "commentary",
+        text: "I will fetch the latest capture.",
+        createdAt: 1_500,
+        turn: liveTurn,
+      });
+      result.current.upsertLiveTranscriptEntry({
+        type: "activity",
+        id: "live-tools",
+        summary: "Used 1 tool",
+        createdAt: 2_000,
+        details: [
+          {
+            id: "tool-1",
+            kind: "command",
+            label: "Read the latest screenshot",
+            status: "completed",
+          },
+        ],
+        turn: liveTurn,
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Show me the latest screenshot.",
+      "message:I will fetch the latest capture.",
+      "activity:Used 1 tool",
+    ]);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              ...completedTurn,
+              output: [],
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(readThread).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(transcriptLabels(result.current.entries)).toEqual([
+        "message:Show me the latest screenshot.",
+        "message:I will fetch the latest capture.",
+        "activity:Used 1 tool",
+        "message:Here it is.",
+      ]);
+    });
+  });
+
   it("does not delete edited file diffs when a later hydration omits them", async () => {
     let now = 40_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -457,18 +457,22 @@ function mergeTranscriptEntries(
             ) {
               return false;
             }
+            const entrySequence = readRendererSequence(entry);
+            if (
+              typeof entrySequence === "number" &&
+              typeof optimisticSequence === "number"
+            ) {
+              // Completion can restamp an earlier message. The live sequence
+              // is the more precise record of the order the renderer observed.
+              return entrySequence > optimisticSequence;
+            }
             if (entryCreatedAt > optimisticCreatedAt) {
               return true;
             }
             if (entryCreatedAt < optimisticCreatedAt) {
               return false;
             }
-            const entrySequence = readRendererSequence(entry);
-            return (
-              typeof entrySequence === "number" &&
-              typeof optimisticSequence === "number" &&
-              entrySequence > optimisticSequence
-            );
+            return false;
           })
         : -1;
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -983,6 +983,73 @@ function findUniqueTranscriptOrderSource(
   return logicalMatches.length === 1 ? logicalMatches[0] : undefined;
 }
 
+type HydratedEntryOrderMatch = {
+  entry: AppServerThreadEntry;
+  hydrationIndex: number;
+  sourceIndex?: number;
+};
+
+type MatchedHydratedEntry = HydratedEntryOrderMatch & {
+  sourceIndex: number;
+};
+
+function reorderHydratedEntriesByKnownOrder(
+  entries: AppServerThreadEntry[],
+  sources: AppServerThreadEntry[]
+): AppServerThreadEntry[] {
+  if (entries.length < 2 || sources.length === 0) {
+    return entries;
+  }
+
+  const sourceIndexes = new Map<AppServerThreadEntry, number>();
+  sources.forEach((source, index) => {
+    sourceIndexes.set(source, index);
+  });
+  const hydratedEntries: HydratedEntryOrderMatch[] = entries.map(
+    (entry, hydrationIndex) => {
+      const source = findUniqueTranscriptOrderSource(entry, sources);
+      const sourceIndex = source ? sourceIndexes.get(source) : undefined;
+      return {
+        entry,
+        hydrationIndex,
+        ...(sourceIndex !== undefined ? { sourceIndex } : {}),
+      };
+    }
+  );
+  const matchedEntries = hydratedEntries.filter(
+    (entry): entry is MatchedHydratedEntry => typeof entry.sourceIndex === "number"
+  );
+  if (matchedEntries.length < 2) {
+    return entries;
+  }
+
+  const sourceOrderAlreadyMatches = matchedEntries.every(
+    (entry, index) =>
+      index === 0
+      || matchedEntries[index - 1]!.sourceIndex <= entry.sourceIndex
+  );
+  if (sourceOrderAlreadyMatches) {
+    return entries;
+  }
+
+  // Do not invent positions for newly hydrated entries. Refill only the slots
+  // for entries the live ledger can identify, preserving their observed order.
+  const orderedMatches = [...matchedEntries].sort(
+    (left, right) =>
+      left.sourceIndex - right.sourceIndex || left.hydrationIndex - right.hydrationIndex
+  );
+  let orderedMatchIndex = 0;
+  return hydratedEntries.map((entry) => {
+    if (entry.sourceIndex === undefined) {
+      return entry.entry;
+    }
+
+    const orderedEntry = orderedMatches[orderedMatchIndex]?.entry;
+    orderedMatchIndex += 1;
+    return orderedEntry ?? entry.entry;
+  });
+}
+
 function carryForwardTranscriptEntryOrder(
   response: AppServerReadThreadResponse,
   sources: AppServerThreadEntry[],
@@ -1025,6 +1092,11 @@ function carryForwardTranscriptEntryOrder(
       ...(origin ? { origin } : {}),
     };
   });
+  const reorderedEntries = reorderHydratedEntriesByKnownOrder(entries, sources);
+  if (reorderedEntries !== entries) {
+    changed = true;
+    entries = reorderedEntries;
+  }
 
   const originsByMessageId = new Map(
     entries
@@ -3463,9 +3535,13 @@ export function useThreadSessionState(params: {
             ...current.optimisticEntries,
             ...(current.pendingAssistantMessage ? [current.pendingAssistantMessage] : []),
           ];
+          const transcriptOrderSources = mergeTranscriptEntries(
+            current.response?.replay.entries ?? [],
+            liveTranscriptSources
+          );
           const orderedResponse = carryForwardTranscriptEntryOrder(
             response,
-            [...(current.response?.replay.entries ?? []), ...liveTranscriptSources],
+            transcriptOrderSources,
             liveTranscriptSources
           );
           const responseWithLoadedHistory = preserveLoadedTranscriptHistory(


### PR DESCRIPTION
## Summary

- I preserved the live transcript’s canonical entry order when a completed turn’s `thread/read` hydration returns matching items in a different array order.
- I added regression coverage based on the reported PwrSnap case: an observed user prompt and commentary remain above a hydrated tool aggregate, with the final response below it.
- The root cause was that hydration copied timestamps forward but retained its raw item array order, allowing a tool aggregate to render above the prompt that initiated the turn. Completion can also restamp earlier assistant entries, so reconciliation now trusts the renderer's monotonic live sequence over those synthetic timestamps.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` — 185 passing
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — passes with existing repository warnings only
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop build`
- `pnpm --filter @pwragent/desktop exec playwright test -c playwright.config.ts e2e/transcript-temporal-order.spec.ts` — 1 passing

## Notes

- I verified that the new regression test fails before the fix, with `Used 1 tool` above the initiating prompt, and passes after the fix.
