### PR TITLE
fix(desktop): unpin threads from pin marker

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -112,6 +112,10 @@ type DirectoriesListProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onUnbindMessagingBinding?: (
     thread: NavigationThreadSummary,
     binding: MessagingThreadBindingSummary,
@@ -715,6 +719,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
               }
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
             );
@@ -807,6 +812,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
             onSelectThread={props.onSelectThread}
             onSetReaction={props.onSetReaction}
+            onSetThreadPin={props.onSetThreadPin}
             onUnbindMessagingBinding={props.onUnbindMessagingBinding}
           />
           {renderStaticSubthreads(thread)}
@@ -1174,6 +1180,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                           }
                           onSelectThread={props.onSelectThread}
                           onSetReaction={props.onSetReaction}
+                          onSetThreadPin={props.onSetThreadPin}
 	                          onUnbindMessagingBinding={props.onUnbindMessagingBinding}
 	                        />
                               {renderStaticSubthreads(thread)}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -61,6 +61,10 @@ type RecentsListProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onUnbindMessagingBinding?: (
     thread: NavigationThreadSummary,
     binding: MessagingThreadBindingSummary,
@@ -228,6 +232,7 @@ export function RecentsList(props: RecentsListProps) {
               }
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           );
@@ -343,6 +348,7 @@ export function RecentsList(props: RecentsListProps) {
           onRevealSelectedThreadComplete={props.onRevealSelectedThreadComplete}
           onSelectThread={props.onSelectThread}
           onSetReaction={props.onSetReaction}
+          onSetThreadPin={props.onSetThreadPin}
           onUnbindMessagingBinding={props.onUnbindMessagingBinding}
         />
         {renderSubthreads(thread)}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1048,6 +1048,7 @@ export function Sidebar(props: SidebarProps) {
               onOpenPullRequestContextMenu={openPullRequestContextMenu}
               onSelectThread={props.onSelectThread}
               onSetReaction={props.onSetThreadReaction}
+              onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
             />
           ) : (
@@ -1076,6 +1077,7 @@ export function Sidebar(props: SidebarProps) {
                 onSetSubthreadsCollapsed={props.onSetSubthreadsCollapsed}
                 onSelectThread={props.onSelectThread}
                 onSetReaction={props.onSetThreadReaction}
+                onSetThreadPin={props.onSetThreadPin}
                 onUnbindMessagingBinding={props.onUnbindMessagingBinding}
               />
             )

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -12,6 +12,8 @@ type ThreadMetaChipsProps = {
   /** A shell is alive for this thread — the row is how you find it again. */
   hasIntegratedTerminal?: boolean;
   hasInputRequest?: boolean;
+  /** Removes this top-level thread from the pinned section. */
+  onUnpin?: () => void;
   /**
    * When set, renders the "Scheduled" (future send time) or "Queued"
    * (waiting on the active turn) chip. Resolved upstream so a thread with
@@ -27,6 +29,7 @@ export function ThreadMetaChips({
   hasApprovalRequest = false,
   hasIntegratedTerminal = false,
   hasInputRequest = false,
+  onUnpin,
   queuedMessageState,
   includeLinkedDirectories = false,
   linkedDirectoryMode = "label",
@@ -43,6 +46,8 @@ export function ThreadMetaChips({
   // edge-clipped — the viewport tooltip is what the neighbouring chips use.
   const terminalTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const branchDrifted = isBranchDrifted(thread.gitBranch, thread.observedGitBranch);
+  const pinIsActionable = Boolean(onUnpin);
+  const pinTooltipText = pinIsActionable ? "Click to unpin" : "Pinned";
   const branchChip = thread.gitBranch ?? thread.observedGitBranch;
   const gitWorking = thread.gitWorkingState;
   const hasDirtyState = Boolean(
@@ -220,11 +225,47 @@ export function ThreadMetaChips({
 
       {thread.pinnedRank && !thread.parentThreadId ? (
         <span
-          aria-label="Pinned"
-          role="img"
+          aria-label={pinIsActionable ? "Unpin thread" : "Pinned"}
+          role={pinIsActionable ? "button" : "img"}
+          tabIndex={pinIsActionable ? 0 : undefined}
           className="thread-row__chip thread-row__chip--pin"
-          onMouseEnter={(event) => pinTooltip.show(event.currentTarget, "Pinned")}
+          // Deliberately use click, rather than pointer-down: the browser only
+          // dispatches click here when the pointer is released over the pin.
+          // Moving off the marker before release therefore leaves it pinned.
+          onClick={
+            pinIsActionable
+              ? (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  pinTooltip.hide();
+                  onUnpin?.();
+                }
+              : undefined
+          }
+          onKeyDown={
+            pinIsActionable
+              ? (event) => {
+                  if (event.key !== "Enter" && event.key !== " ") {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  event.stopPropagation();
+                  pinTooltip.hide();
+                  onUnpin?.();
+                }
+              : undefined
+          }
+          onMouseEnter={(event) =>
+            pinTooltip.show(event.currentTarget, pinTooltipText)
+          }
           onMouseLeave={pinTooltip.hide}
+          onFocus={
+            pinIsActionable
+              ? (event) => pinTooltip.show(event.currentTarget, pinTooltipText)
+              : undefined
+          }
+          onBlur={pinIsActionable ? pinTooltip.hide : undefined}
         >
           <span aria-hidden="true" className="thread-row__chip-icon">
             <PinIcon size={12} />

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -103,6 +103,10 @@ type ThreadRowProps = {
     emoji: string,
     present: boolean,
   ) => Promise<void>;
+  onSetThreadPin?: (
+    thread: NavigationThreadSummary,
+    pinned: boolean,
+  ) => Promise<void>;
   onOpenPullRequest?: (url: string) => void;
 };
 
@@ -121,6 +125,7 @@ export function ThreadRow(props: ThreadRowProps) {
   const addReactionRef = useRef<HTMLSpanElement>(null);
   const reactions = props.thread.reactions ?? [];
   const canReact = Boolean(props.onSetReaction);
+  const onSetThreadPin = props.onSetThreadPin;
   const bindings = props.thread.messagingBindings ?? [];
   // Pull straight from the navigation snapshot — main persists PR state
   // to the overlay store and surfaces it through the snapshot, so the
@@ -293,6 +298,13 @@ export function ThreadRow(props: ThreadRowProps) {
             hasApprovalRequest={props.approvalRequestThreadKeys?.[threadKey] === true}
             hasIntegratedTerminal={props.terminalThreadKeys?.[threadKey] === true}
             hasInputRequest={props.inputRequestThreadKeys?.[threadKey] === true}
+            onUnpin={
+              onSetThreadPin
+                ? () => {
+                    void onSetThreadPin(props.thread, false);
+                  }
+                : undefined
+            }
             queuedMessageState={props.queuedMessageThreadKeys?.[threadKey]}
             includeLinkedDirectories={props.includeLinkedDirectories}
             linkedDirectoryMode={props.linkedDirectoryMode}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1864,7 +1864,7 @@ describe("Sidebar", () => {
     });
     expect(rows[0]).toHaveTextContent("Updated thread");
     expect(
-      within(rows[0]).getByRole("img", { name: "Pinned" }),
+      within(rows[0]).getByRole("button", { name: "Unpin thread" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("separator", { name: "Unpinned threads" })).toBeInTheDocument();
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx
@@ -197,6 +197,37 @@ describe("ThreadRow chip flow", () => {
     expect(onUnbindMessagingBinding).not.toHaveBeenCalled();
   });
 
+  it("unpins only when the pin click finishes on the marker", () => {
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const { onSelectThread } = renderRow({
+      thread: {
+        ...baseThread,
+        pinnedRank: "1024",
+        reactions: [],
+      },
+      onSetThreadPin,
+    });
+
+    const pin = screen.getByRole("button", { name: "Unpin thread" });
+    const rowButton = screen.getByRole("button", { name: /Chip flow thread/i });
+    expect(pin.tagName).toBe("SPAN");
+    expect(pin).toHaveClass("thread-row__chip--pin");
+
+    // The marker mutates on click, not press: releasing on the surrounding
+    // row after leaving the pin must leave the thread pinned.
+    fireEvent.mouseDown(pin);
+    fireEvent.mouseLeave(pin);
+    fireEvent.mouseUp(rowButton);
+    expect(onSetThreadPin).not.toHaveBeenCalled();
+
+    fireEvent.click(pin);
+    expect(onSetThreadPin).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-chips" }),
+      false,
+    );
+    expect(onSelectThread).not.toHaveBeenCalled();
+  });
+
   it("does not invoke onSelectThread when the add-reaction smiley is clicked", () => {
     const { container, onSelectThread } = renderRow();
     const addReaction = container.querySelector(

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3622,10 +3622,10 @@ textarea,
 }
 
 /* Pin marker — an icon-only orange pill. The pushpin glyph + the accent
-   tint carry the "pinned" signal without spending a word of row width;
-   the literal label lives in aria-label / title for assistive tech and
-   hover. Square-ish (min-width == height) so it reads as a marker, not a
-   text chip. */
+   tint carry the "pinned" signal without spending a word of row width.
+   When it has an unpin callback, it becomes an explicit click target;
+   its hover label explains the action. Square-ish (min-width == height)
+   so it reads as a marker, not a text chip. */
 .thread-row__chip--pin {
   min-width: 24px;
   justify-content: center;
@@ -3633,6 +3633,16 @@ textarea,
   border: 1px solid var(--accent-border);
   background: var(--accent-soft);
   color: var(--accent-bright);
+}
+
+.thread-row__chip--pin[role="button"] {
+  cursor: pointer;
+}
+
+.thread-row__chip--pin[role="button"]:hover,
+.thread-row__chip--pin[role="button"]:focus-visible {
+  border-color: var(--accent-strong);
+  background: var(--bg-row-active);
 }
 
 .thread-row__chip--approval,


### PR DESCRIPTION
## Summary

- I made a pinned thread's pin marker an explicit unpin control.
- I use the completed click event, so pressing the pin, moving off it, and releasing does not change the pinned state.
- I added keyboard access, hover feedback, and coverage for the release-on-marker interaction.

## Verification

- I ran `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/thread-row-chips.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` (131 tests passed).
- I ran `pnpm --filter @pwragent/desktop typecheck`.
- I ran `pnpm lint:eslint`, `pnpm lint:boundaries`, and `pnpm lint:colors`.

## Notes

- The full ESLint pass completed with the repository's existing warnings and no errors.
