### PR TITLE
feat(desktop): surface transcript images

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -71,6 +71,7 @@ const readThread = vi.fn(async ({ threadId }: { threadId: string }) => ({
     hasPreviousPage: false,
   },
 }));
+const getThreadTranscriptImageRoots = vi.fn(async () => [] as string[]);
 const archiveThread = vi.fn(async (request: ArchiveThreadRequest) => ({
   backend: request.backend ?? "codex",
   threadId: request.threadId,
@@ -550,6 +551,7 @@ vi.mock("../app-server/backend-registry", () => ({
     renameThread,
     listThreads,
     readThread,
+    getThreadTranscriptImageRoots,
     readDirectoryStatuses,
     readDirectoryStatusEntries,
     readWorktreeWorkingStateEntries,
@@ -591,6 +593,7 @@ describe("app server ipc", () => {
     renameThread.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
+    getThreadTranscriptImageRoots.mockClear();
     reconcileNavigationSnapshot.mockClear();
     rememberCompleteNavigationSnapshot.mockClear();
     readDirectoryStatuses.mockClear();
@@ -1080,6 +1083,7 @@ describe("app server ipc", () => {
       limit: undefined,
       viewOnly: true,
     });
+    expect(getThreadTranscriptImageRoots).not.toHaveBeenCalled();
   });
 
   it("strips readThread file diffs behind fetchable refs before crossing IPC", async () => {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3823,6 +3823,98 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("projects typed MCP resource links into transcript image parts", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageUrl =
+      "http://127.0.0.1:51729/media?grant=full-image&signature=signed-media";
+    MockTransport.readThreadResultByThreadId.set("thread-mcp-resource-link", {
+      thread: {
+        turns: [
+          {
+            id: "turn-mcp-resource-link",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "mcp-capture-resource",
+                server: "pwrsnap",
+                tool: "pwrsnap_capture_resource",
+                status: "completed",
+                result: {
+                  structuredContent: {
+                    resourceUri: "pwrsnap://capture/example/composite",
+                    signedUrl: imageUrl,
+                    mimeType: "image/png",
+                    widthPx: 2_880,
+                    heightPx: 1_920,
+                  },
+                  content: [
+                    {
+                      type: "text",
+                      text: "PwrSnap capture resource.",
+                    },
+                    {
+                      type: "resource_link",
+                      uri: imageUrl,
+                      name: "composite capture",
+                      mimeType: "image/png",
+                      size: 10,
+                    },
+                  ],
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "There it is.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-mcp-resource-link" });
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+    const finalMessage = replay.messages.find((message) => message.id === "assistant-final");
+
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "There it is.",
+      parts: [
+        { type: "text", text: "There it is." },
+        {
+          type: "image",
+          url: imageUrl,
+          alt: "composite capture",
+        },
+      ],
+    });
+    expect(finalMessage).toMatchObject({
+      role: "assistant",
+      text: "There it is.",
+      parts: [
+        { type: "text", text: "There it is." },
+        {
+          type: "image",
+          url: imageUrl,
+          alt: "composite capture",
+        },
+      ],
+    });
+
+    await client.close();
+  });
+
   it("attaches images embedded in MCP resource result text to the final assistant message", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const imageBlob = "AQID";

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3684,6 +3684,145 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("attaches custom tool output images to the final assistant message", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageUrl = "data:image/jpeg;base64,AQID";
+    MockTransport.readThreadResultByThreadId.set("thread-custom-tool-image", {
+      thread: {
+        turns: [
+          {
+            id: "turn-custom-tool-image",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "userMessage",
+                id: "user-message",
+                text: "Show the most recent screenshot.",
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-commentary",
+                phase: "commentary",
+                text: "I found the screenshot.",
+              },
+              {
+                type: "response_item",
+                payload: {
+                  type: "custom_tool_call_output",
+                  call_id: "call-screenshot",
+                  output: [
+                    { type: "input_text", text: "PwrSnap screenshot" },
+                    { type: "input_image", image_url: imageUrl },
+                  ],
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "There it is.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-custom-tool-image" });
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+    const finalMessage = replay.messages.find((message) => message.id === "assistant-final");
+
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "There it is.",
+      parts: [
+        { type: "text", text: "There it is." },
+        { type: "image", url: imageUrl },
+      ],
+    });
+    expect(finalMessage).toMatchObject({
+      role: "assistant",
+      text: "There it is.",
+      parts: [
+        { type: "text", text: "There it is." },
+        { type: "image", url: imageUrl },
+      ],
+    });
+    expect(replay.entries).not.toContainEqual(expect.objectContaining({
+      id: "assistant-commentary",
+      parts: expect.arrayContaining([{ type: "image", url: imageUrl }]),
+    }));
+
+    await client.close();
+  });
+
+  it("attaches loopback image exports from MCP results to the final assistant message", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageUrl = "http://127.0.0.1:51729/media?grant=signed-image";
+    MockTransport.readThreadResultByThreadId.set("thread-mcp-image", {
+      thread: {
+        turns: [
+          {
+            id: "turn-mcp-image",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "mcp-export",
+                server: "pwrsnap",
+                tool: "pwrsnap_capture_export",
+                status: "completed",
+                result: {
+                  structuredContent: {
+                    signedUrl: imageUrl,
+                    mimeType: "image/jpeg",
+                    variant: "composite",
+                  },
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "There it is.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-mcp-image" });
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "There it is.",
+      parts: [
+        { type: "text", text: "There it is." },
+        { type: "image", url: imageUrl },
+      ],
+    });
+
+    await client.close();
+  });
+
   it("deduplicates Codex raw event user messages when a response item carries the image", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-raw-image-events", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3823,6 +3823,83 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("attaches images embedded in MCP resource result text to the final assistant message", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const imageBlob = "AQID";
+    MockTransport.readThreadResultByThreadId.set("thread-mcp-resource-image", {
+      thread: {
+        turns: [
+          {
+            id: "turn-mcp-resource-image",
+            startedAt: 1_763_500_150,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "mcp-resource",
+                server: "pwrsnap",
+                tool: "read_mcp_resource",
+                status: "completed",
+                result: {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        contents: [
+                          {
+                            uri: "pwrsnap://capture/example/composite",
+                            mimeType: "image/jpeg",
+                            blob: imageBlob,
+                          },
+                        ],
+                      }),
+                    },
+                  ],
+                },
+              },
+              {
+                type: "agentMessage",
+                id: "assistant-final",
+                phase: "final_answer",
+                text: "Shown.",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({ threadId: "thread-mcp-resource-image" });
+    const finalEntry = replay.entries.find(
+      (entry) => entry.type === "message" && entry.id === "assistant-final",
+    );
+    const finalMessage = replay.messages.find((message) => message.id === "assistant-final");
+
+    expect(finalEntry).toMatchObject({
+      type: "message",
+      role: "assistant",
+      text: "Shown.",
+      parts: [
+        { type: "text", text: "Shown." },
+        { type: "image", url: "data:image/jpeg;base64,AQID" },
+      ],
+    });
+    expect(finalMessage).toMatchObject({
+      role: "assistant",
+      text: "Shown.",
+      parts: [
+        { type: "text", text: "Shown." },
+        { type: "image", url: "data:image/jpeg;base64,AQID" },
+      ],
+    });
+
+    await client.close();
+  });
+
   it("deduplicates Codex raw event user messages when a response item carries the image", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-raw-image-events", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3766,7 +3766,8 @@ describe("CodexAppServerClient", () => {
 
   it("attaches loopback image exports from MCP results to the final assistant message", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
-    const imageUrl = "http://127.0.0.1:51729/media?grant=signed-image";
+    const imageUrl =
+      "http://127.0.0.1:51729/media?grant=signed-image&signature=signed-media";
     MockTransport.readThreadResultByThreadId.set("thread-mcp-image", {
       thread: {
         turns: [

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -213,6 +213,66 @@ describe("transcript image protocol", () => {
     await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([1, 2, 3]));
   });
 
+  it("adds approved local Markdown image links to transcript galleries", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const imagePath = path.join(tempDir, "worktree", "dmg-background.png");
+    const linkedImagePath = "/tmp/worktree/dmg-background.png";
+    const sourceUrl = pathToFileURL(linkedImagePath).toString();
+    const resolveLocalImageLink = vi.fn(async () => ({
+      ok: true as const,
+      path: imagePath,
+      mimeType: "image/png",
+    }));
+    const message = {
+      id: "message-image-link",
+      role: "assistant" as const,
+      text: "The background is [dmg-background.png](/tmp/worktree/dmg-background.png).",
+    };
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "thread-image-link",
+        replay: {
+          entries: [{ type: "message", ...message }],
+          messages: [message],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      {
+        resolveLocalImageLink,
+      }
+    );
+
+    expect(resolveLocalImageLink).toHaveBeenCalledTimes(1);
+    expect(resolveLocalImageLink).toHaveBeenCalledWith(linkedImagePath);
+    const expectedImagePart = {
+      type: "image",
+      url: `pwragent-image://file/${encodeURIComponent(pathToFileURL(imagePath).toString())}`,
+      sourceUrl,
+      alt: "dmg-background.png",
+    };
+    expect(response.replay.entries[0]).toMatchObject({
+      type: "message",
+      parts: [
+        { type: "text", text: message.text },
+        expectedImagePart,
+      ],
+    });
+    expect(response.replay.messages[0]).toMatchObject({
+      parts: [
+        { type: "text", text: message.text },
+        expectedImagePart,
+      ],
+    });
+  });
+
   it("keeps data image URLs when materialization writes fail", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -217,7 +217,8 @@ describe("transcript image protocol", () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"
     );
-    const signedUrl = "http://127.0.0.1:51729/media?grant=read-once-grant";
+    const signedUrl =
+      "http://127.0.0.1:51729/media?grant=read-once-grant&signature=valid-signature";
     const bytes = new Uint8Array([4, 5, 6]);
     const fetch = vi.fn(async () => ({
       ok: true,
@@ -285,7 +286,10 @@ describe("transcript image protocol", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
       signedUrl,
-      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      expect.objectContaining({
+        redirect: "error",
+        signal: expect.any(AbortSignal),
+      }),
     );
     const materializedPath =
       entryPart?.type === "image" ? filePathFromProtocolUrl(entryPart.url) : "";
@@ -330,22 +334,63 @@ describe("transcript image protocol", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("adds approved local Markdown image links to transcript galleries", async () => {
+  it("does not fetch unsigned or untrusted loopback image URLs", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const imageUrls = [
+      "http://127.0.0.1:51729/media?grant=missing-signature",
+      "http://127.0.0.1:51730/media?grant=other-service&signature=signature",
+      "http://localhost:51729/media?grant=wrong-origin&signature=signature",
+    ];
+    const fetch = vi.fn();
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "thread-untrusted-loopback-image",
+        replay: {
+          entries: [],
+          messages: [
+            {
+              id: "message-1",
+              role: "assistant",
+              text: "Images.",
+              parts: imageUrls.map((url) => ({ type: "image" as const, url })),
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      { fetch },
+    );
+
+    expect(response.replay.messages[0]?.parts).toEqual(
+      imageUrls.map((url) => ({ type: "image", url })),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("snapshots approved worktree Markdown image links into transcript galleries", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"
     );
     const imagePath = path.join(tempDir, "worktree", "dmg-background.png");
-    const linkedImagePath = "/tmp/worktree/dmg-background.png";
+    const linkedImagePath = imagePath;
     const sourceUrl = pathToFileURL(linkedImagePath).toString();
-    const resolveLocalImageLink = vi.fn(async () => ({
-      ok: true as const,
-      path: imagePath,
-      mimeType: "image/png",
-    }));
+    await mkdir(path.dirname(imagePath), { recursive: true });
+    await writeFile(imagePath, Buffer.from([7, 8, 9]));
+    const resolveApprovedLocalImageRoots = vi.fn(async () => [
+      path.join(tempDir, "worktree"),
+    ]);
     const message = {
       id: "message-image-link",
       role: "assistant" as const,
-      text: "The background is [dmg-background.png](/tmp/worktree/dmg-background.png).",
+      text: `The background is [dmg-background.png](${linkedImagePath}).`,
     };
 
     const response = await materializeTranscriptImageUrlsForRenderer(
@@ -363,18 +408,20 @@ describe("transcript image protocol", () => {
         },
       },
       {
-        resolveLocalImageLink,
-      }
+        resolveRoot: () => path.join(tempDir, "thread-images"),
+      },
+      {
+        resolveApprovedLocalImageRoots,
+      },
     );
 
-    expect(resolveLocalImageLink).toHaveBeenCalledTimes(1);
-    expect(resolveLocalImageLink).toHaveBeenCalledWith(linkedImagePath);
-    const expectedImagePart = {
+    expect(resolveApprovedLocalImageRoots).toHaveBeenCalledTimes(1);
+    const expectedImagePart = expect.objectContaining({
       type: "image",
-      url: `pwragent-image://file/${encodeURIComponent(pathToFileURL(imagePath).toString())}`,
+      url: expect.stringMatching(/^pwragent-image:\/\/file\//),
       sourceUrl,
       alt: "dmg-background.png",
-    };
+    });
     expect(response.replay.entries[0]).toMatchObject({
       type: "message",
       parts: [
@@ -388,6 +435,13 @@ describe("transcript image protocol", () => {
         expectedImagePart,
       ],
     });
+    const entryPart = response.replay.entries[0]?.type === "message"
+      ? response.replay.entries[0].parts?.[1]
+      : undefined;
+    const materializedPath =
+      entryPart?.type === "image" ? filePathFromProtocolUrl(entryPart.url) : "";
+    expect(materializedPath).toContain(path.join("thread-images"));
+    await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([7, 8, 9]));
   });
 
   it("keeps data image URLs when materialization writes fail", async () => {

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -213,6 +213,123 @@ describe("transcript image protocol", () => {
     await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([1, 2, 3]));
   });
 
+  it("materializes signed PwrSnap loopback images into thread-scoped files", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const signedUrl = "http://127.0.0.1:51729/media?grant=read-once-grant";
+    const bytes = new Uint8Array([4, 5, 6]);
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      headers: {
+        get: (name: string) => {
+          if (name === "content-type") {
+            return "image/jpeg";
+          }
+          if (name === "content-length") {
+            return String(bytes.byteLength);
+          }
+          return null;
+        },
+      },
+      arrayBuffer: async () => bytes.buffer,
+    }));
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "codex:thread/signed-image",
+        replay: {
+          entries: [
+            {
+              type: "message",
+              id: "entry-1",
+              role: "assistant",
+              text: "Shown.",
+              parts: [
+                { type: "text", text: "Shown." },
+                { type: "image", url: signedUrl },
+              ],
+            },
+          ],
+          messages: [
+            {
+              id: "message-1",
+              role: "assistant",
+              text: "Shown.",
+              parts: [{ type: "image", url: signedUrl }],
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      {
+        fetch,
+        resolveRoot: () => path.join(tempDir, "thread-images"),
+      }
+    );
+
+    const entryPart = response.replay.entries[0]?.type === "message"
+      ? response.replay.entries[0].parts?.[1]
+      : undefined;
+    const messagePart = response.replay.messages[0]?.parts?.[0];
+    expect(entryPart).toMatchObject({
+      type: "image",
+      url: expect.stringMatching(/^pwragent-image:\/\/file\//),
+    });
+    expect(messagePart).toEqual(entryPart);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      signedUrl,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const materializedPath =
+      entryPart?.type === "image" ? filePathFromProtocolUrl(entryPart.url) : "";
+    expect(path.basename(materializedPath)).toMatch(/^[a-f0-9]{64}\.jpg$/);
+    await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([4, 5, 6]));
+  });
+
+  it("does not fetch arbitrary HTTP image URLs", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const externalUrl = "https://example.com/untrusted-image.png";
+    const fetch = vi.fn();
+
+    const response = await materializeTranscriptImageUrlsForRenderer(
+      {
+        backend: "codex",
+        fetchedAt: 1,
+        threadId: "thread-external-image",
+        replay: {
+          entries: [],
+          messages: [
+            {
+              id: "message-1",
+              role: "assistant",
+              text: "Image.",
+              parts: [{ type: "image", url: externalUrl }],
+            },
+          ],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      },
+      { fetch },
+    );
+
+    expect(response.replay.messages[0]?.parts).toEqual([
+      { type: "image", url: externalUrl },
+    ]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("adds approved local Markdown image links to transcript galleries", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8879,6 +8879,38 @@ export class DesktopBackendRegistry {
     };
   }
 
+  async getThreadTranscriptImageRoots(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<string[]> {
+    this.assertNotBootstrap("getThreadTranscriptImageRoots");
+    const [thread, overlay] = await Promise.all([
+      this.findThreadForWorkspaceHandoff({
+        backend: params.backend,
+        callerReason: "transcript-image-roots",
+        threadId: params.threadId,
+      }),
+      this.overlayStore.getThreadOverlayState({
+        backend: params.backend,
+        threadId: params.threadId,
+      }),
+    ]);
+    const roots = new Set<string>();
+    for (const directory of dedupeLinkedDirectoriesByNormalizedIdentity([
+      ...(thread?.linkedDirectories ?? []),
+      ...(overlay?.extraLinkedDirectories ?? []),
+    ])) {
+      for (const candidate of [directory.path, directory.worktreePath]) {
+        const trimmed = candidate?.trim();
+        if (trimmed) {
+          roots.add(path.resolve(trimmed));
+        }
+      }
+    }
+
+    return [...roots];
+  }
+
   private async persistReplayUsageLines(
     replay: AppServerThreadReplay,
   ): Promise<void> {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3392,6 +3392,237 @@ function extractFunctionCallOutputFromReplayItem(
   return undefined;
 }
 
+function extractCustomToolOutputImagePartsFromReplayItem(
+  item: Record<string, unknown>
+): AppServerThreadImagePart[] {
+  const candidates = [item];
+  for (const key of ["payload", "item", "responseItem", "response_item"]) {
+    const nestedItem = asRecord(item[key]);
+    if (nestedItem) {
+      candidates.push(nestedItem);
+    }
+  }
+
+  return dedupeImageParts(
+    candidates.flatMap((candidate) => {
+      if (normalizeItemType(pickString(candidate, ["type"])) !== "customtoolcalloutput") {
+        return [];
+      }
+
+      return extractCustomToolOutputImageParts(candidate.output);
+    }),
+  );
+}
+
+function extractCustomToolOutputImageParts(value: unknown): AppServerThreadImagePart[] {
+  const parsed = parseStructuredValue(value);
+  const parts = [
+    ...extractStructuredMessageParts(value),
+    ...extractImagePartsFromValue(value),
+    ...(parsed === value
+      ? []
+      : [
+          ...extractStructuredMessageParts(parsed),
+          ...extractImagePartsFromValue(parsed),
+        ]),
+  ];
+
+  return parts.filter(
+    (part): part is AppServerThreadImagePart => part.type === "image",
+  );
+}
+
+function extractMcpToolResultImagePartsFromReplayItem(
+  item: Record<string, unknown>
+): AppServerThreadImagePart[] {
+  const candidates = [item];
+  for (const key of ["payload", "item", "responseItem", "response_item"]) {
+    const nestedItem = asRecord(item[key]);
+    if (nestedItem) {
+      candidates.push(nestedItem);
+    }
+  }
+
+  return dedupeImageParts(
+    candidates.flatMap((candidate) => {
+      if (normalizeItemType(pickString(candidate, ["type"])) !== "mcptoolcall") {
+        return [];
+      }
+
+      const result = asRecord(candidate.result);
+      const structuredContent =
+        asRecord(result?.structuredContent) ??
+        asRecord(result?.structured_content);
+      if (!structuredContent) {
+        return [];
+      }
+
+      const structuredImageParts = extractStructuredMessageParts(structuredContent).filter(
+        (part): part is AppServerThreadImagePart => part.type === "image",
+      );
+      const signedImagePart = buildMcpSignedImagePart(structuredContent);
+      return signedImagePart
+        ? [...structuredImageParts, signedImagePart]
+        : structuredImageParts;
+    }),
+  );
+}
+
+function buildMcpSignedImagePart(
+  structuredContent: Record<string, unknown>,
+): AppServerThreadImagePart | undefined {
+  const signedUrl = pickString(structuredContent, ["signedUrl", "signed_url"]);
+  const mimeType = pickString(structuredContent, ["mimeType", "mime_type"]);
+  if (!signedUrl || !mimeType?.toLowerCase().startsWith("image/") || !isLoopbackUrl(signedUrl)) {
+    return undefined;
+  }
+
+  const imagePart = buildImagePartFromUrl(signedUrl);
+  if (!imagePart) {
+    return undefined;
+  }
+
+  const alt = pickString(structuredContent, ["alt", "altText", "alt_text", "title", "name"]);
+  if (alt) {
+    imagePart.alt = alt;
+  }
+  return imagePart;
+}
+
+function isLoopbackUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  return (
+    hostname === "localhost"
+    || hostname === "127.0.0.1"
+    || hostname === "::1"
+    || hostname.endsWith(".localhost")
+  );
+}
+
+function dedupeImageParts(
+  imageParts: AppServerThreadImagePart[]
+): AppServerThreadImagePart[] {
+  const seenUrls = new Set<string>();
+  return imageParts.filter((imagePart) => {
+    if (seenUrls.has(imagePart.url)) {
+      return false;
+    }
+    seenUrls.add(imagePart.url);
+    return true;
+  });
+}
+
+function appendImagePartsToMessage<T extends {
+  parts?: AppServerThreadMessagePart[];
+  text: string;
+}>(
+  message: T,
+  imageParts: AppServerThreadImagePart[],
+): T {
+  const existingImageUrls = new Set(
+    (message.parts ?? [])
+      .filter((part): part is AppServerThreadImagePart => part.type === "image")
+      .map((part) => part.url),
+  );
+  const missingImageParts = imageParts.filter((imagePart) => {
+    if (existingImageUrls.has(imagePart.url)) {
+      return false;
+    }
+    existingImageUrls.add(imagePart.url);
+    return true;
+  });
+  if (missingImageParts.length === 0) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: [
+      ...(message.parts ?? (message.text ? [{ type: "text", text: message.text }] : [])),
+      ...missingImageParts,
+    ],
+  };
+}
+
+function attachCustomToolOutputImagesToTurn(params: {
+  createdAt?: number;
+  entries: AppServerThreadEntry[];
+  imageParts: AppServerThreadImagePart[];
+  startIndex: number;
+  turn?: AppServerThreadTurnMetadata;
+}): void {
+  if (params.imageParts.length === 0) {
+    return;
+  }
+
+  let fallbackAssistantIndex: number | undefined;
+  for (let index = params.entries.length - 1; index >= params.startIndex; index -= 1) {
+    const entry = params.entries[index];
+    if (entry?.type !== "message" || entry.role !== "assistant") {
+      continue;
+    }
+    if (entry.phase === "final") {
+      params.entries[index] = appendImagePartsToMessage(entry, params.imageParts);
+      return;
+    }
+    fallbackAssistantIndex ??= index;
+  }
+
+  if (fallbackAssistantIndex !== undefined) {
+    const entry = params.entries[fallbackAssistantIndex];
+    if (entry?.type === "message") {
+      params.entries[fallbackAssistantIndex] = appendImagePartsToMessage(entry, params.imageParts);
+    }
+    return;
+  }
+
+  params.entries.push({
+    type: "message",
+    id: `tool-output-images-${params.turn?.id ?? params.entries.length + 1}`,
+    role: "assistant",
+    text: "",
+    parts: params.imageParts,
+    createdAt: params.createdAt,
+    ...(params.turn ? { turn: params.turn } : {}),
+  });
+}
+
+function mergeEntryImagePartsIntoReplayMessages(
+  messages: AppServerThreadReplay["messages"],
+  entries: AppServerThreadEntry[],
+): AppServerThreadReplay["messages"] {
+  const entriesById = new Map(
+    entries.flatMap((entry) =>
+      entry.type === "message" && entry.parts?.some((part) => part.type === "image")
+        ? [[entry.id, entry] as const]
+        : [],
+    ),
+  );
+
+  return messages.map((message) => {
+    const entry = entriesById.get(message.id);
+    if (!entry || entry.role !== message.role) {
+      return message;
+    }
+
+    const imageParts = entry.parts?.filter(
+      (part): part is AppServerThreadImagePart => part.type === "image",
+    ) ?? [];
+    return appendImagePartsToMessage(message, imageParts);
+  });
+}
+
 function attachFunctionCallOutput(
   items: Record<string, unknown>[],
   output: { callId: string; output: string }
@@ -4115,6 +4346,7 @@ function extractThreadEntries(
   const entries: AppServerThreadEntry[] = [];
 
   for (const turn of turns) {
+    const turnStartIndex = entries.length;
     const turnMetadata = extractTurnMetadata(turn);
     const turnPricingContext = extractTokenUsagePricingContext(turn);
     const createdAt = normalizeEpochTimestamp(
@@ -4125,6 +4357,12 @@ function extractThreadEntries(
           .map((entry) => asRecord(entry))
           .filter((entry): entry is Record<string, unknown> => entry !== null)
       : [];
+    const assistantImageParts = dedupeImageParts(
+      rawItems.flatMap((item) => [
+        ...extractCustomToolOutputImagePartsFromReplayItem(item),
+        ...extractMcpToolResultImagePartsFromReplayItem(item),
+      ]),
+    );
     const assistantReviewTexts = collectAssistantReviewTexts(rawItems);
     const suppressedAssistantTexts = collectReviewSuppressionTexts(rawItems);
     for (const text of assistantReviewTexts) {
@@ -4242,6 +4480,13 @@ function extractThreadEntries(
     }
 
     flushActivityItems();
+    attachCustomToolOutputImagesToTurn({
+      createdAt: turnMetadata?.completedAt ?? createdAt,
+      entries,
+      imageParts: assistantImageParts,
+      startIndex: turnStartIndex,
+      turn: turnMetadata,
+    });
   }
 
   return entries;
@@ -4275,7 +4520,10 @@ export function extractThreadReplayFromReadResult(
   options: { threadId?: string } = {}
 ): AppServerThreadReplay {
   const entries = extractThreadEntries(value, options);
-  const messages = extractConversationMessages(value);
+  const messages = mergeEntryImagePartsIntoReplayMessages(
+    extractConversationMessages(value),
+    entries,
+  );
   const agentName = extractCodexNativeAgentName(value);
   let lastUserMessage: string | undefined;
   let lastAssistantMessage: string | undefined;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -209,6 +209,17 @@ const SUPPORTED_CODEX_MODEL_ORDER = [
 ] as const;
 const SUPPORTED_CODEX_MODELS = new Set<string>(SUPPORTED_CODEX_MODEL_ORDER);
 const MAX_INLINE_FILE_DIFF_CHARS = 512 * 1024;
+const MAX_MCP_RESOURCE_IMAGE_BASE64_CHARS = Math.ceil((16 * 1024 * 1024) / 3) * 4;
+const MCP_RESOURCE_IMAGE_MIME_TYPES = new Set([
+  "image/avif",
+  "image/bmp",
+  "image/gif",
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+]);
+const BASE64_IMAGE_BLOB_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
 type CodexReviewStartPayload = CodexReviewStartParams & {
   cwd?: string;
@@ -3453,17 +3464,20 @@ function extractMcpToolResultImagePartsFromReplayItem(
       const structuredContent =
         asRecord(result?.structuredContent) ??
         asRecord(result?.structured_content);
-      if (!structuredContent) {
-        return [];
-      }
-
-      const structuredImageParts = extractStructuredMessageParts(structuredContent).filter(
-        (part): part is AppServerThreadImagePart => part.type === "image",
-      );
-      const signedImagePart = buildMcpSignedImagePart(structuredContent);
-      return signedImagePart
-        ? [...structuredImageParts, signedImagePart]
-        : structuredImageParts;
+      const structuredImageParts = structuredContent
+        ? extractStructuredMessageParts(structuredContent).filter(
+            (part): part is AppServerThreadImagePart => part.type === "image",
+          )
+        : [];
+      const signedImagePart = structuredContent
+        ? buildMcpSignedImagePart(structuredContent)
+        : undefined;
+      const resourceImageParts = extractMcpResourceImageParts(result?.content);
+      return [
+        ...structuredImageParts,
+        ...(signedImagePart ? [signedImagePart] : []),
+        ...resourceImageParts,
+      ];
     }),
   );
 }
@@ -3487,6 +3501,63 @@ function buildMcpSignedImagePart(
     imagePart.alt = alt;
   }
   return imagePart;
+}
+
+function extractMcpResourceImageParts(content: unknown): AppServerThreadImagePart[] {
+  const contentBlocks = Array.isArray(content) ? content : [content];
+  return dedupeImageParts(
+    contentBlocks.flatMap((contentBlock) => {
+      const contentRecord = asRecord(contentBlock);
+      const parsedText = parseStructuredValue(
+        typeof contentBlock === "string"
+          ? contentBlock
+          : pickString(contentRecord ?? {}, ["text"]),
+      );
+      const resourceCandidates = [
+        contentRecord,
+        asRecord(contentRecord?.resource),
+        asRecord(parsedText),
+      ];
+
+      return resourceCandidates.flatMap((candidate) => {
+        if (!candidate) {
+          return [];
+        }
+
+        const resources = Array.isArray(candidate.contents)
+          ? candidate.contents
+          : [candidate];
+        return resources.flatMap((resource) => {
+          const imagePart = buildMcpResourceImagePart(asRecord(resource) ?? undefined);
+          return imagePart ? [imagePart] : [];
+        });
+      });
+    }),
+  );
+}
+
+function buildMcpResourceImagePart(
+  resource: Record<string, unknown> | undefined,
+): AppServerThreadImagePart | undefined {
+  const mimeType = pickString(resource ?? {}, ["mimeType", "mime_type"])
+    ?.trim()
+    .toLowerCase();
+  const blob = pickString(resource ?? {}, ["blob"]);
+  if (
+    !mimeType
+    || !MCP_RESOURCE_IMAGE_MIME_TYPES.has(mimeType)
+    || !blob
+    || blob.length > MAX_MCP_RESOURCE_IMAGE_BASE64_CHARS
+    || blob.length % 4 === 1
+    || !BASE64_IMAGE_BLOB_PATTERN.test(blob)
+  ) {
+    return undefined;
+  }
+
+  return {
+    type: "image",
+    url: `data:${mimeType};base64,${blob}`,
+  };
 }
 
 function isLoopbackUrl(value: string): boolean {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3472,9 +3472,11 @@ function extractMcpToolResultImagePartsFromReplayItem(
       const signedImagePart = structuredContent
         ? buildMcpSignedImagePart(structuredContent)
         : undefined;
+      const resourceLinkImageParts = extractMcpResourceLinkImageParts(result?.content);
       const resourceImageParts = extractMcpResourceImageParts(result?.content);
       return [
         ...structuredImageParts,
+        ...resourceLinkImageParts,
         ...(signedImagePart ? [signedImagePart] : []),
         ...resourceImageParts,
       ];
@@ -3487,7 +3489,11 @@ function buildMcpSignedImagePart(
 ): AppServerThreadImagePart | undefined {
   const signedUrl = pickString(structuredContent, ["signedUrl", "signed_url"]);
   const mimeType = pickString(structuredContent, ["mimeType", "mime_type"]);
-  if (!signedUrl || !mimeType?.toLowerCase().startsWith("image/") || !isLoopbackUrl(signedUrl)) {
+  if (
+    !signedUrl
+    || !mimeType?.toLowerCase().startsWith("image/")
+    || !isPwrSnapSignedMediaUrl(signedUrl)
+  ) {
     return undefined;
   }
 
@@ -3501,6 +3507,45 @@ function buildMcpSignedImagePart(
     imagePart.alt = alt;
   }
   return imagePart;
+}
+
+function extractMcpResourceLinkImageParts(content: unknown): AppServerThreadImagePart[] {
+  const contentBlocks = Array.isArray(content) ? content : [content];
+  return dedupeImageParts(
+    contentBlocks.flatMap((contentBlock) => {
+      const resourceLink = asRecord(contentBlock);
+      if (!resourceLink) {
+        return [];
+      }
+      const type = normalizeItemType(
+        pickString(resourceLink, ["type", "contentType", "content_type"]),
+      );
+      const uri = pickString(resourceLink, ["uri", "url"]);
+      const mimeType = pickString(resourceLink, ["mimeType", "mime_type"]);
+      if (
+        type !== "resourcelink"
+        || !uri
+        || !mimeType?.toLowerCase().startsWith("image/")
+        || !isPwrSnapSignedMediaUrl(uri)
+      ) {
+        return [];
+      }
+
+      const imagePart = buildImagePartFromUrl(uri);
+      if (!imagePart) {
+        return [];
+      }
+
+      const alt = pickString(resourceLink, [
+        "name",
+        "title",
+        "alt",
+        "altText",
+        "alt_text",
+      ]);
+      return [{ ...imagePart, ...(alt ? { alt } : {}) }];
+    }),
+  );
 }
 
 function extractMcpResourceImageParts(content: unknown): AppServerThreadImagePart[] {
@@ -3560,7 +3605,7 @@ function buildMcpResourceImagePart(
   };
 }
 
-function isLoopbackUrl(value: string): boolean {
+function isPwrSnapSignedMediaUrl(value: string): boolean {
   let parsed: URL;
   try {
     parsed = new URL(value);
@@ -3568,17 +3613,21 @@ function isLoopbackUrl(value: string): boolean {
     return false;
   }
 
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+    || parsed.pathname !== "/media"
+  ) {
     return false;
   }
 
   const hostname = parsed.hostname.toLowerCase();
-  return (
+  const isLoopback = (
     hostname === "localhost"
     || hostname === "127.0.0.1"
     || hostname === "::1"
     || hostname.endsWith(".localhost")
   );
+  return isLoopback && Boolean(parsed.searchParams.get("grant"));
 }
 
 function dedupeImageParts(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -49,6 +49,7 @@ import type {
   LinkedDirectorySummary,
 } from "@pwragent/shared";
 import { getMainLogger } from "../log";
+import { isPwrSnapSignedMediaUrl } from "../pwrsnap-media-url";
 import {
   buildPwrAgentChildProcessEnv,
   ELECTRON_RENDERER_URL_ENV,
@@ -3603,31 +3604,6 @@ function buildMcpResourceImagePart(
     type: "image",
     url: `data:${mimeType};base64,${blob}`,
   };
-}
-
-function isPwrSnapSignedMediaUrl(value: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-
-  if (
-    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-    || parsed.pathname !== "/media"
-  ) {
-    return false;
-  }
-
-  const hostname = parsed.hostname.toLowerCase();
-  const isLoopback = (
-    hostname === "localhost"
-    || hostname === "127.0.0.1"
-    || hostname === "::1"
-    || hostname.endsWith(".localhost")
-  );
-  return isLoopback && Boolean(parsed.searchParams.get("grant"));
 }
 
 function dedupeImageParts(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1107,7 +1107,8 @@ class DesktopAppServerService {
     request: AppServerReadThreadRequest
   ): Promise<AppServerReadThreadResponse> {
     const backend = request.backend ?? "codex";
-    const response = await getDesktopBackendRegistry().readThread({
+    const registry = getDesktopBackendRegistry();
+    const response = await registry.readThread({
       backend,
       threadId: request.threadId,
       includeTurns: request.includeTurns,
@@ -1126,7 +1127,17 @@ class DesktopAppServerService {
       threadStatus: response.threadStatus ?? response.replay.threadStatus,
     });
 
-    const materialized = await materializeTranscriptImageUrlsForRenderer(response);
+    const materialized = await materializeTranscriptImageUrlsForRenderer(
+      response,
+      {},
+      {
+        resolveApprovedLocalImageRoots: async () =>
+          await registry.getThreadTranscriptImageRoots({
+            backend,
+            threadId: request.threadId,
+          }),
+      },
+    );
     return sanitizeRendererPayload(
       shapeReadThreadFileDiffsForRenderer(materialized),
     );

--- a/apps/desktop/src/main/pwrsnap-media-url.ts
+++ b/apps/desktop/src/main/pwrsnap-media-url.ts
@@ -1,0 +1,25 @@
+const PWRSNAP_MEDIA_ORIGIN = "http://127.0.0.1:51729";
+
+/**
+ * PwrSnap's local MCP server issues short-lived, signed media URLs from its
+ * fixed loopback origin. Keep this narrow: transcript materialization fetches
+ * these URLs from the main process, so accepting arbitrary loopback origins
+ * would make an MCP result an SSRF primitive against local services.
+ */
+export function isPwrSnapSignedMediaUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  return (
+    parsed.origin === PWRSNAP_MEDIA_ORIGIN
+    && parsed.pathname === "/media"
+    && !parsed.username
+    && !parsed.password
+    && Boolean(parsed.searchParams.get("grant"))
+    && Boolean(parsed.searchParams.get("signature"))
+  );
+}

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -713,7 +713,7 @@ function localImageLinkPath(destination: string): string | undefined {
     }
   }
 
-  if (trimmed.startsWith("/")) {
+  if (path.isAbsolute(trimmed)) {
     return safelyDecodeUriComponent(trimmed);
   }
 

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -3,6 +3,7 @@ import type {
   AppServerBackendKind,
   AppServerReadThreadResponse,
   AppServerThreadEntry,
+  AppServerThreadImagePart,
   AppServerThreadMessage,
   AppServerThreadMessageEntry,
   AppServerThreadMessagePart,
@@ -37,6 +38,8 @@ const DATA_IMAGE_EXTENSIONS = new Map<string, string>([
   ["image/webp", "webp"],
 ]);
 
+const MARKDOWN_LINKED_IMAGE_PATTERN = /!?\[([^\]\r\n]*)\]\(\s*(?:<([^>\r\n]+)>|([^\s)]+))[^)]*\)/g;
+
 export type TranscriptImageProtocolOptions = {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
@@ -48,6 +51,7 @@ export type TranscriptImageMaterializerDependencies = {
     threadId: string;
   }) => string;
   mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
+  resolveLocalImageLink: (sourcePath: string) => Promise<TranscriptImageFileResolution>;
   writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
 };
 
@@ -66,6 +70,7 @@ const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies =
       ),
     ),
   mkdir,
+  resolveLocalImageLink: resolveTranscriptImageFile,
   writeFile,
 };
 
@@ -92,6 +97,10 @@ export async function materializeTranscriptImageUrlsForRenderer(
 ): Promise<AppServerReadThreadResponse> {
   const deps = { ...defaultMaterializerDependencies, ...dependencies };
   const materializedFileWrites = new Map<string, Promise<void>>();
+  const markdownLinkImageResolutions = new Map<
+    string,
+    Promise<TranscriptImageFileResolution>
+  >();
 
   return {
     ...response,
@@ -104,6 +113,7 @@ export async function materializeTranscriptImageUrlsForRenderer(
             response,
             deps,
             materializedFileWrites,
+            markdownLinkImageResolutions,
           ),
         ),
       ),
@@ -114,6 +124,7 @@ export async function materializeTranscriptImageUrlsForRenderer(
             response,
             deps,
             materializedFileWrites,
+            markdownLinkImageResolutions,
           ),
         ),
       ),
@@ -139,6 +150,7 @@ async function materializeTranscriptEntryImageUrls(
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
   materializedFileWrites: Map<string, Promise<void>>,
+  markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
 ): Promise<AppServerThreadEntry> {
   if (entry.type !== "message") {
     return entry;
@@ -149,6 +161,7 @@ async function materializeTranscriptEntryImageUrls(
     response,
     deps,
     materializedFileWrites,
+    markdownLinkImageResolutions,
   )) as AppServerThreadMessageEntry;
 }
 
@@ -157,19 +170,25 @@ async function materializeTranscriptMessageImageUrls<T extends AppServerThreadMe
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
   materializedFileWrites: Map<string, Promise<void>>,
+  markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
 ): Promise<T> {
+  const messageWithMarkdownLinkImages = await appendMarkdownLinkImageParts(
+    message,
+    deps,
+    markdownLinkImageResolutions,
+  );
   if (
-    !message.parts?.some(
+    !messageWithMarkdownLinkImages.parts?.some(
       (part) => part.type === "image" && isMaterializableImageUrl(part.url),
     )
   ) {
-    return message;
+    return messageWithMarkdownLinkImages;
   }
 
   return {
-    ...message,
+    ...messageWithMarkdownLinkImages,
     parts: await Promise.all(
-      message.parts.map((part) =>
+      messageWithMarkdownLinkImages.parts.map((part) =>
         materializeTranscriptMessagePartImageUrl(
           part,
           response,
@@ -224,6 +243,174 @@ async function materializeTranscriptMessagePartImageUrl(
   } catch {
     return part;
   }
+}
+
+async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
+  message: T,
+  deps: TranscriptImageMaterializerDependencies,
+  markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+): Promise<T> {
+  const textParts = message.parts?.filter(
+    (part): part is Extract<AppServerThreadMessagePart, { type: "text" }> =>
+      part.type === "text",
+  ) ?? (message.text ? [{ type: "text", text: message.text }] : []);
+  const imageLinks = textParts.flatMap((part) => extractMarkdownLinkedImageParts(part.text));
+  if (imageLinks.length === 0) {
+    return message;
+  }
+
+  const existingParts = message.parts ?? textParts;
+  const existingSourceUrls = new Set(
+    existingParts.flatMap((part) =>
+      part.type === "image"
+        ? [part.sourceUrl, isFileImageUrl(part.url) ? part.url : undefined]
+        : [],
+    ).filter((url): url is string => Boolean(url)),
+  );
+  const imageParts: AppServerThreadImagePart[] = [];
+
+  for (const imageLink of imageLinks) {
+    const resolution = await resolveMarkdownLinkedImage(
+      imageLink.sourcePath,
+      deps,
+      markdownLinkImageResolutions,
+    );
+    if (!resolution.ok) {
+      continue;
+    }
+
+    const sourceUrl = pathToFileURL(imageLink.sourcePath).toString();
+    if (existingSourceUrls.has(sourceUrl)) {
+      continue;
+    }
+    existingSourceUrls.add(sourceUrl);
+    imageParts.push({
+      type: "image",
+      url: toTranscriptImageProtocolUrl(pathToFileURL(resolution.path).toString()),
+      sourceUrl,
+      alt: imageLink.alt || path.basename(resolution.path),
+    });
+  }
+
+  if (imageParts.length === 0) {
+    return message;
+  }
+
+  return {
+    ...message,
+    parts: [...existingParts, ...imageParts],
+  };
+}
+
+function resolveMarkdownLinkedImage(
+  sourcePath: string,
+  deps: TranscriptImageMaterializerDependencies,
+  resolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+): Promise<TranscriptImageFileResolution> {
+  const existing = resolutions.get(sourcePath);
+  if (existing) {
+    return existing;
+  }
+
+  const resolution = deps.resolveLocalImageLink(sourcePath).catch(() => ({
+    ok: false as const,
+    status: 500,
+    message: "could not resolve Markdown-linked image",
+  }));
+  resolutions.set(sourcePath, resolution);
+  return resolution;
+}
+
+function extractMarkdownLinkedImageParts(text: string): Array<{
+  alt?: string;
+  sourcePath: string;
+}> {
+  const output: Array<{ alt?: string; sourcePath: string }> = [];
+  let fenceMarker: "`" | "~" | undefined;
+
+  for (const line of text.split(/\r?\n/u)) {
+    const fence = /^\s{0,3}(`{3,}|~{3,})/.exec(line)?.[1];
+    if (fence) {
+      const marker = fence[0] as "`" | "~";
+      if (!fenceMarker) {
+        fenceMarker = marker;
+      } else if (fenceMarker === marker) {
+        fenceMarker = undefined;
+      }
+      continue;
+    }
+    if (fenceMarker) {
+      continue;
+    }
+
+    MARKDOWN_LINKED_IMAGE_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = MARKDOWN_LINKED_IMAGE_PATTERN.exec(line))) {
+      if (isInsideInlineCode(line, match.index)) {
+        continue;
+      }
+
+      const sourcePath = localImageLinkPath(match[2] ?? match[3] ?? "");
+      if (!sourcePath || !mimeTypeForImagePath(sourcePath)) {
+        continue;
+      }
+      output.push({
+        alt: match[1]?.trim() || undefined,
+        sourcePath,
+      });
+    }
+  }
+
+  return output;
+}
+
+function localImageLinkPath(destination: string): string | undefined {
+  const trimmed = destination.trim();
+  if (trimmed.startsWith("file://")) {
+    try {
+      return fileURLToPath(trimmed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (trimmed.startsWith("/")) {
+    return safelyDecodeUriComponent(trimmed);
+  }
+
+  if (trimmed.startsWith("~/")) {
+    return path.join(os.homedir(), safelyDecodeUriComponent(trimmed.slice(2)));
+  }
+
+  return undefined;
+}
+
+function safelyDecodeUriComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function isInsideInlineCode(line: string, offset: number): boolean {
+  let markerLength = 0;
+  for (let index = 0; index < offset; index += 1) {
+    if (line[index] !== "`" || line[index - 1] === "\\") {
+      continue;
+    }
+    let length = 1;
+    while (line[index + length] === "`") {
+      length += 1;
+    }
+    if (markerLength === 0) {
+      markerLength = length;
+    } else if (markerLength === length) {
+      markerLength = 0;
+    }
+    index += length - 1;
+  }
+  return markerLength > 0;
 }
 
 function rewriteTranscriptEntryImageUrls(entry: AppServerThreadEntry): AppServerThreadEntry {

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveActiveProfilePath, resolvePwragentRoot } from "./profile";
+import { isPwrSnapSignedMediaUrl } from "./pwrsnap-media-url";
 import { resolveDefaultCodexHome } from "@pwrdrvr/codex-discovery";
 
 export const TRANSCRIPT_IMAGE_PROTOCOL_SCHEME = "pwragent-image";
@@ -44,8 +45,17 @@ const MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES = 64 * 1024 * 1024;
 const FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS = 10_000;
 
 export type TranscriptImageProtocolOptions = {
+  /** Extra local roots approved for the current thread's Markdown image links. */
+  additionalAllowedRoots?: readonly string[];
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+};
+
+export type TranscriptImageMaterializationOptions = {
+  /** Linked project/worktree roots approved for this thread's Markdown image links. */
+  approvedLocalImageRoots?: readonly string[];
+  /** Lazily resolves approved roots only when the transcript contains a Markdown image link. */
+  resolveApprovedLocalImageRoots?: () => Promise<readonly string[]>;
 };
 
 type TranscriptImageFetchResponse = {
@@ -58,14 +68,17 @@ type TranscriptImageFetchResponse = {
 export type TranscriptImageMaterializerDependencies = {
   fetch: (
     url: string,
-    init: { signal: AbortSignal },
+    init: { redirect: "error"; signal: AbortSignal },
   ) => Promise<TranscriptImageFetchResponse>;
   resolveRoot: (request: {
     backend: AppServerBackendKind;
     threadId: string;
   }) => string;
   mkdir: (dirPath: string, options: { recursive: true }) => Promise<unknown>;
-  resolveLocalImageLink: (sourcePath: string) => Promise<TranscriptImageFileResolution>;
+  resolveLocalImageLink: (
+    sourcePath: string,
+    options?: TranscriptImageProtocolOptions,
+  ) => Promise<TranscriptImageFileResolution>;
   writeFile: (filePath: string, data: Buffer) => Promise<unknown>;
 };
 
@@ -78,6 +91,13 @@ type MaterializedTranscriptImage = {
   extension: string;
   sha256: string;
 };
+
+type MaterializedMarkdownLinkedImage = {
+  sourceUrl: string;
+  url: string;
+};
+
+type ApprovedLocalImageRootResolver = () => Promise<readonly string[]>;
 
 const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies = {
   fetch: async (url, init) => await globalThis.fetch(url, init),
@@ -94,6 +114,24 @@ const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies =
   resolveLocalImageLink: resolveTranscriptImageFile,
   writeFile,
 };
+
+function createApprovedLocalImageRootResolver(
+  options: TranscriptImageMaterializationOptions,
+): ApprovedLocalImageRootResolver {
+  if (options.approvedLocalImageRoots) {
+    return async () => options.approvedLocalImageRoots ?? [];
+  }
+
+  let roots: Promise<readonly string[]> | undefined;
+  return async () => {
+    if (!roots) {
+      roots =
+        options.resolveApprovedLocalImageRoots?.().catch(() => []) ??
+        Promise.resolve([]);
+    }
+    return await roots;
+  };
+}
 
 export function toTranscriptImageProtocolUrl(src: string): string {
   return `pwragent-image://file/${encodeURIComponent(src)}`;
@@ -115,8 +153,10 @@ export function rewriteTranscriptImageUrlsForRenderer(
 export async function materializeTranscriptImageUrlsForRenderer(
   response: AppServerReadThreadResponse,
   dependencies: Partial<TranscriptImageMaterializerDependencies> = {},
+  options: TranscriptImageMaterializationOptions = {},
 ): Promise<AppServerReadThreadResponse> {
   const deps = { ...defaultMaterializerDependencies, ...dependencies };
+  const resolveApprovedLocalImageRoots = createApprovedLocalImageRootResolver(options);
   const materializedFileWrites = new Map<string, Promise<void>>();
   const fetchedLoopbackImages = new Map<
     string,
@@ -125,6 +165,10 @@ export async function materializeTranscriptImageUrlsForRenderer(
   const markdownLinkImageResolutions = new Map<
     string,
     Promise<TranscriptImageFileResolution>
+  >();
+  const materializedMarkdownLinkedImages = new Map<
+    string,
+    Promise<MaterializedMarkdownLinkedImage | undefined>
   >();
 
   return {
@@ -140,6 +184,8 @@ export async function materializeTranscriptImageUrlsForRenderer(
             materializedFileWrites,
             fetchedLoopbackImages,
             markdownLinkImageResolutions,
+            materializedMarkdownLinkedImages,
+            resolveApprovedLocalImageRoots,
           ),
         ),
       ),
@@ -152,6 +198,8 @@ export async function materializeTranscriptImageUrlsForRenderer(
             materializedFileWrites,
             fetchedLoopbackImages,
             markdownLinkImageResolutions,
+            materializedMarkdownLinkedImages,
+            resolveApprovedLocalImageRoots,
           ),
         ),
       ),
@@ -179,6 +227,11 @@ async function materializeTranscriptEntryImageUrls(
   materializedFileWrites: Map<string, Promise<void>>,
   fetchedLoopbackImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
   markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  materializedMarkdownLinkedImages: Map<
+    string,
+    Promise<MaterializedMarkdownLinkedImage | undefined>
+  >,
+  resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
 ): Promise<AppServerThreadEntry> {
   if (entry.type !== "message") {
     return entry;
@@ -191,6 +244,8 @@ async function materializeTranscriptEntryImageUrls(
     materializedFileWrites,
     fetchedLoopbackImages,
     markdownLinkImageResolutions,
+    materializedMarkdownLinkedImages,
+    resolveApprovedLocalImageRoots,
   )) as AppServerThreadMessageEntry;
 }
 
@@ -201,11 +256,20 @@ async function materializeTranscriptMessageImageUrls<T extends AppServerThreadMe
   materializedFileWrites: Map<string, Promise<void>>,
   fetchedLoopbackImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
   markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  materializedMarkdownLinkedImages: Map<
+    string,
+    Promise<MaterializedMarkdownLinkedImage | undefined>
+  >,
+  resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
 ): Promise<T> {
   const messageWithMarkdownLinkImages = await appendMarkdownLinkImageParts(
     message,
+    response,
     deps,
+    materializedFileWrites,
     markdownLinkImageResolutions,
+    materializedMarkdownLinkedImages,
+    resolveApprovedLocalImageRoots,
   );
   if (
     !messageWithMarkdownLinkImages.parts?.some(
@@ -332,7 +396,10 @@ async function fetchLoopbackSignedImageOnce(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS);
   try {
-    const response = await deps.fetch(url, { signal: controller.signal });
+    const response = await deps.fetch(url, {
+      redirect: "error",
+      signal: controller.signal,
+    });
     if (!response.ok) {
       return undefined;
     }
@@ -411,39 +478,17 @@ async function readFetchedTranscriptImageBuffer(
   return byteLength > 0 ? Buffer.concat(chunks, byteLength) : undefined;
 }
 
-function isPwrSnapSignedMediaUrl(value: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-
-  if (
-    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
-    || !isLoopbackHostname(parsed.hostname)
-    || parsed.pathname !== "/media"
-  ) {
-    return false;
-  }
-
-  return Boolean(parsed.searchParams.get("grant"));
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return (
-    normalized === "localhost"
-    || normalized === "127.0.0.1"
-    || normalized === "::1"
-    || normalized.endsWith(".localhost")
-  );
-}
-
 async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
   message: T,
+  response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
   markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  materializedMarkdownLinkedImages: Map<
+    string,
+    Promise<MaterializedMarkdownLinkedImage | undefined>
+  >,
+  resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
 ): Promise<T> {
   const textParts = message.parts?.filter(
     (part): part is Extract<AppServerThreadMessagePart, { type: "text" }> =>
@@ -465,25 +510,28 @@ async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
   const imageParts: AppServerThreadImagePart[] = [];
 
   for (const imageLink of imageLinks) {
-    const resolution = await resolveMarkdownLinkedImage(
+    const image = await materializeMarkdownLinkedImage(
       imageLink.sourcePath,
+      response,
       deps,
+      materializedFileWrites,
       markdownLinkImageResolutions,
+      materializedMarkdownLinkedImages,
+      resolveApprovedLocalImageRoots,
     );
-    if (!resolution.ok) {
+    if (!image) {
       continue;
     }
 
-    const sourceUrl = pathToFileURL(imageLink.sourcePath).toString();
-    if (existingSourceUrls.has(sourceUrl)) {
+    if (existingSourceUrls.has(image.sourceUrl)) {
       continue;
     }
-    existingSourceUrls.add(sourceUrl);
+    existingSourceUrls.add(image.sourceUrl);
     imageParts.push({
       type: "image",
-      url: toTranscriptImageProtocolUrl(pathToFileURL(resolution.path).toString()),
-      sourceUrl,
-      alt: imageLink.alt || path.basename(resolution.path),
+      url: image.url,
+      sourceUrl: image.sourceUrl,
+      alt: imageLink.alt || path.basename(imageLink.sourcePath),
     });
   }
 
@@ -497,17 +545,113 @@ async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
   };
 }
 
+async function materializeMarkdownLinkedImage(
+  sourcePath: string,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+  resolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  materializedImages: Map<string, Promise<MaterializedMarkdownLinkedImage | undefined>>,
+  resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
+): Promise<MaterializedMarkdownLinkedImage | undefined> {
+  const existing = materializedImages.get(sourcePath);
+  if (existing) {
+    return await existing;
+  }
+
+  const materialization = materializeMarkdownLinkedImageOnce(
+    sourcePath,
+    response,
+    deps,
+    materializedFileWrites,
+    resolutions,
+    resolveApprovedLocalImageRoots,
+  );
+  materializedImages.set(sourcePath, materialization);
+  return await materialization;
+}
+
+async function materializeMarkdownLinkedImageOnce(
+  sourcePath: string,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+  resolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
+): Promise<MaterializedMarkdownLinkedImage | undefined> {
+  const approvedLocalImageRoots = await resolveApprovedLocalImageRoots();
+  const resolution = await resolveMarkdownLinkedImage(
+    sourcePath,
+    deps,
+    resolutions,
+    approvedLocalImageRoots,
+  );
+  if (!resolution.ok) {
+    return undefined;
+  }
+
+  const image = await readMarkdownLinkedTranscriptImage(resolution);
+  if (!image) {
+    return undefined;
+  }
+
+  const sourceUrl = pathToFileURL(sourcePath).toString();
+  const imagePart = await materializeTranscriptImagePart(
+    { type: "image", url: sourceUrl, sourceUrl },
+    image,
+    response,
+    deps,
+    materializedFileWrites,
+  );
+  if (!isTranscriptImageProtocolUrl(imagePart.url)) {
+    return undefined;
+  }
+
+  return { sourceUrl, url: imagePart.url };
+}
+
+async function readMarkdownLinkedTranscriptImage(
+  resolution: Extract<TranscriptImageFileResolution, { ok: true }>,
+): Promise<MaterializedTranscriptImage | undefined> {
+  const extension = DATA_IMAGE_EXTENSIONS.get(resolution.mimeType);
+  if (!extension) {
+    return undefined;
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = await readFile(resolution.path);
+  } catch {
+    return undefined;
+  }
+  if (
+    buffer.byteLength === 0
+    || buffer.byteLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES
+  ) {
+    return undefined;
+  }
+
+  return {
+    buffer,
+    extension,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+  };
+}
+
 function resolveMarkdownLinkedImage(
   sourcePath: string,
   deps: TranscriptImageMaterializerDependencies,
   resolutions: Map<string, Promise<TranscriptImageFileResolution>>,
+  approvedLocalImageRoots: readonly string[] | undefined,
 ): Promise<TranscriptImageFileResolution> {
   const existing = resolutions.get(sourcePath);
   if (existing) {
     return existing;
   }
 
-  const resolution = deps.resolveLocalImageLink(sourcePath).catch(() => ({
+  const resolution = deps.resolveLocalImageLink(sourcePath, {
+    additionalAllowedRoots: approvedLocalImageRoots,
+  }).catch(() => ({
     ok: false as const,
     status: 500,
     message: "could not resolve Markdown-linked image",
@@ -644,6 +788,10 @@ function rewriteTranscriptMessagePartImageUrl(
 
 function isFileImageUrl(url: string): boolean {
   return url.startsWith("file://");
+}
+
+function isTranscriptImageProtocolUrl(url: string): boolean {
+  return url.startsWith(`${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}://file/`);
 }
 
 function isMaterializableImageUrl(url: string): boolean {
@@ -788,6 +936,12 @@ function collectTranscriptImageRoots(options?: TranscriptImageProtocolOptions): 
   roots.add(path.join(resolvePwragentRoot({ env: {}, homeDir }), "profiles"));
   roots.add(resolveDefaultCodexHome({ env, homeDir }));
   roots.add(resolveDefaultCodexHome({ env: {}, homeDir }));
+  for (const root of options?.additionalAllowedRoots ?? []) {
+    const trimmed = root.trim();
+    if (trimmed) {
+      roots.add(trimmed);
+    }
+  }
 
   return [...roots];
 }

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -39,7 +39,8 @@ const DATA_IMAGE_EXTENSIONS = new Map<string, string>([
 ]);
 
 const MARKDOWN_LINKED_IMAGE_PATTERN = /!?\[([^\]\r\n]*)\]\(\s*(?:<([^>\r\n]+)>|([^\s)]+))[^)]*\)/g;
-const MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES = 16 * 1024 * 1024;
+// PwrSnap links can point to full-resolution captures, not just UI-sized previews.
+const MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES = 64 * 1024 * 1024;
 const FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS = 10_000;
 
 export type TranscriptImageProtocolOptions = {

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -39,13 +39,26 @@ const DATA_IMAGE_EXTENSIONS = new Map<string, string>([
 ]);
 
 const MARKDOWN_LINKED_IMAGE_PATTERN = /!?\[([^\]\r\n]*)\]\(\s*(?:<([^>\r\n]+)>|([^\s)]+))[^)]*\)/g;
+const MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES = 16 * 1024 * 1024;
+const FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS = 10_000;
 
 export type TranscriptImageProtocolOptions = {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
 };
 
+type TranscriptImageFetchResponse = {
+  ok: boolean;
+  headers: { get: (name: string) => string | null };
+  body?: ReadableStream<Uint8Array> | null;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+};
+
 export type TranscriptImageMaterializerDependencies = {
+  fetch: (
+    url: string,
+    init: { signal: AbortSignal },
+  ) => Promise<TranscriptImageFetchResponse>;
   resolveRoot: (request: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -59,7 +72,14 @@ export type TranscriptImageFileResolution =
   | { ok: true; path: string; mimeType: string }
   | { ok: false; status: number; message: string };
 
+type MaterializedTranscriptImage = {
+  buffer: Buffer;
+  extension: string;
+  sha256: string;
+};
+
 const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies = {
+  fetch: async (url, init) => await globalThis.fetch(url, init),
   resolveRoot: ({ backend, threadId }) =>
     resolveActiveProfilePath(
       path.join(
@@ -97,6 +117,10 @@ export async function materializeTranscriptImageUrlsForRenderer(
 ): Promise<AppServerReadThreadResponse> {
   const deps = { ...defaultMaterializerDependencies, ...dependencies };
   const materializedFileWrites = new Map<string, Promise<void>>();
+  const fetchedLoopbackImages = new Map<
+    string,
+    Promise<MaterializedTranscriptImage | undefined>
+  >();
   const markdownLinkImageResolutions = new Map<
     string,
     Promise<TranscriptImageFileResolution>
@@ -113,6 +137,7 @@ export async function materializeTranscriptImageUrlsForRenderer(
             response,
             deps,
             materializedFileWrites,
+            fetchedLoopbackImages,
             markdownLinkImageResolutions,
           ),
         ),
@@ -124,6 +149,7 @@ export async function materializeTranscriptImageUrlsForRenderer(
             response,
             deps,
             materializedFileWrites,
+            fetchedLoopbackImages,
             markdownLinkImageResolutions,
           ),
         ),
@@ -150,6 +176,7 @@ async function materializeTranscriptEntryImageUrls(
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
   materializedFileWrites: Map<string, Promise<void>>,
+  fetchedLoopbackImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
   markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
 ): Promise<AppServerThreadEntry> {
   if (entry.type !== "message") {
@@ -161,6 +188,7 @@ async function materializeTranscriptEntryImageUrls(
     response,
     deps,
     materializedFileWrites,
+    fetchedLoopbackImages,
     markdownLinkImageResolutions,
   )) as AppServerThreadMessageEntry;
 }
@@ -170,6 +198,7 @@ async function materializeTranscriptMessageImageUrls<T extends AppServerThreadMe
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
   materializedFileWrites: Map<string, Promise<void>>,
+  fetchedLoopbackImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
   markdownLinkImageResolutions: Map<string, Promise<TranscriptImageFileResolution>>,
 ): Promise<T> {
   const messageWithMarkdownLinkImages = await appendMarkdownLinkImageParts(
@@ -194,6 +223,7 @@ async function materializeTranscriptMessageImageUrls<T extends AppServerThreadMe
           response,
           deps,
           materializedFileWrites,
+          fetchedLoopbackImages,
         ),
       ),
     ),
@@ -205,6 +235,7 @@ async function materializeTranscriptMessagePartImageUrl(
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
   materializedFileWrites: Map<string, Promise<void>>,
+  fetchedLoopbackImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
 ): Promise<AppServerThreadMessagePart> {
   if (part.type !== "image") {
     return part;
@@ -218,20 +249,51 @@ async function materializeTranscriptMessagePartImageUrl(
   }
 
   const dataImage = parseSupportedImageDataUrl(part.url);
-  if (!dataImage) {
+  if (dataImage) {
+    return await materializeTranscriptImagePart(
+      part,
+      dataImage,
+      response,
+      deps,
+      materializedFileWrites,
+    );
+  }
+
+  const fetchedImage = await fetchLoopbackSignedImage(
+    part.url,
+    deps,
+    fetchedLoopbackImages,
+  );
+  if (!fetchedImage) {
     return part;
   }
 
+  return await materializeTranscriptImagePart(
+    part,
+    fetchedImage,
+    response,
+    deps,
+    materializedFileWrites,
+  );
+}
+
+async function materializeTranscriptImagePart(
+  part: AppServerThreadImagePart,
+  image: MaterializedTranscriptImage,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+): Promise<AppServerThreadImagePart> {
   const root = deps.resolveRoot({
     backend: response.backend,
     threadId: response.threadId,
   });
   try {
     await deps.mkdir(root, { recursive: true });
-    const filePath = path.join(root, `${dataImage.sha256}.${dataImage.extension}`);
+    const filePath = path.join(root, `${image.sha256}.${image.extension}`);
     let writePromise = materializedFileWrites.get(filePath);
     if (!writePromise) {
-      writePromise = deps.writeFile(filePath, dataImage.buffer).then(() => undefined);
+      writePromise = deps.writeFile(filePath, image.buffer).then(() => undefined);
       materializedFileWrites.set(filePath, writePromise);
     }
     await writePromise;
@@ -243,6 +305,138 @@ async function materializeTranscriptMessagePartImageUrl(
   } catch {
     return part;
   }
+}
+
+async function fetchLoopbackSignedImage(
+  url: string,
+  deps: TranscriptImageMaterializerDependencies,
+  fetchedImages: Map<string, Promise<MaterializedTranscriptImage | undefined>>,
+): Promise<MaterializedTranscriptImage | undefined> {
+  if (!isPwrSnapSignedMediaUrl(url)) {
+    return undefined;
+  }
+
+  let fetchPromise = fetchedImages.get(url);
+  if (!fetchPromise) {
+    fetchPromise = fetchLoopbackSignedImageOnce(url, deps);
+    fetchedImages.set(url, fetchPromise);
+  }
+  return await fetchPromise;
+}
+
+async function fetchLoopbackSignedImageOnce(
+  url: string,
+  deps: TranscriptImageMaterializerDependencies,
+): Promise<MaterializedTranscriptImage | undefined> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCHED_TRANSCRIPT_IMAGE_TIMEOUT_MS);
+  try {
+    const response = await deps.fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const declaredLength = Number(response.headers.get("content-length"));
+    if (
+      Number.isFinite(declaredLength)
+      && declaredLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES
+    ) {
+      return undefined;
+    }
+
+    const mimeType = response.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    const extension = mimeType ? DATA_IMAGE_EXTENSIONS.get(mimeType) : undefined;
+    if (!extension) {
+      return undefined;
+    }
+
+    const buffer = await readFetchedTranscriptImageBuffer(response, controller);
+    if (!buffer) {
+      return undefined;
+    }
+
+    return {
+      buffer,
+      extension,
+      sha256: createHash("sha256").update(buffer).digest("hex"),
+    };
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readFetchedTranscriptImageBuffer(
+  response: TranscriptImageFetchResponse,
+  controller: AbortController,
+): Promise<Buffer | undefined> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength === 0 || buffer.byteLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES) {
+      return undefined;
+    }
+    return buffer;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      byteLength += value.byteLength;
+      if (byteLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES) {
+        controller.abort();
+        return undefined;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return byteLength > 0 ? Buffer.concat(chunks, byteLength) : undefined;
+}
+
+function isPwrSnapSignedMediaUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+    || !isLoopbackHostname(parsed.hostname)
+    || parsed.pathname !== "/media"
+  ) {
+    return false;
+  }
+
+  return Boolean(parsed.searchParams.get("grant"));
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost"
+    || normalized === "127.0.0.1"
+    || normalized === "::1"
+    || normalized.endsWith(".localhost")
+  );
 }
 
 async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
@@ -452,7 +646,11 @@ function isFileImageUrl(url: string): boolean {
 }
 
 function isMaterializableImageUrl(url: string): boolean {
-  return isFileImageUrl(url) || url.startsWith("data:image/");
+  return (
+    isFileImageUrl(url)
+    || url.startsWith("data:image/")
+    || isPwrSnapSignedMediaUrl(url)
+  );
 }
 
 export function installTranscriptImageProtocol(): void {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -2,6 +2,7 @@ import {
   isThreadUrl,
   PWRAGENT_URL_SCHEME,
   type AppServerSkillSummary,
+  type AppServerThreadImagePart,
   type DesktopApplicationsSnapshot,
   type MarkdownFileViewerContext,
 } from "@pwragent/shared";
@@ -57,6 +58,8 @@ type ThreadMarkdownProps = {
     "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
   >;
   fileViewerContext?: MarkdownFileViewerContext;
+  imageParts?: AppServerThreadImagePart[];
+  onOpenImage?: (image: AppServerThreadImagePart) => void;
   skills?: AppServerSkillSummary[];
   text: string;
   variant?: "message" | "summary";
@@ -229,6 +232,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
         const skillPath = localTarget?.path;
         const label = extractTextContent(anchorProps.children).trim();
+        const linkedImage = findMarkdownLinkedImagePart(props.imageParts, localTarget);
         const source = sourceForNode(markdownText, anchorProps.node);
 
         if (isImplicitBareAutolink({ href, label, source })) {
@@ -266,6 +270,22 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         const pullRequest = resolvePullRequestHref(href, pullRequestLinks);
         if (pullRequest) {
           return <PullRequestLinkChip pr={pullRequest} />;
+        }
+
+        if (linkedImage && props.onOpenImage) {
+          return (
+            <a
+              className="transcript-message__link"
+              href={linkedImage.url}
+              onClick={(event) => {
+                event.preventDefault();
+                props.onOpenImage?.(linkedImage);
+              }}
+              title="Open image in PwrAgent"
+            >
+              {anchorProps.children}
+            </a>
+          );
         }
 
         if (label.startsWith("@") && localTarget) {
@@ -515,6 +535,8 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       openLocalFileLink,
       openSkillMarkdownInEditor,
       props.desktopApi,
+      props.imageParts,
+      props.onOpenImage,
       pullRequestLinks,
       skillsByPath,
       threadLinks,
@@ -945,6 +967,23 @@ function localFileTargetFromHref(
   }
 
   return undefined;
+}
+
+function findMarkdownLinkedImagePart(
+  imageParts: AppServerThreadImagePart[] | undefined,
+  target: LocalFileTarget | undefined,
+): AppServerThreadImagePart | undefined {
+  if (!target) {
+    return undefined;
+  }
+
+  return imageParts?.find((imagePart) => {
+    if (!imagePart.sourceUrl) {
+      return false;
+    }
+
+    return localFileTargetFromHref(imagePart.sourceUrl)?.path === target.path;
+  });
 }
 
 function isMarkdownFilePath(filePath: string): boolean {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -60,6 +60,9 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
     () => buildMessageCopyText(props.message, contentParts),
     [contentParts, props.message]
   );
+  const imageParts = contentParts.filter(
+    (part): part is AppServerThreadImagePart => part.type === "image",
+  );
   const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
   const [monitorExpanded, setMonitorExpanded] = useState(false);
   const [monitorDetailsOpen, setMonitorDetailsOpen] = useState(false);
@@ -192,6 +195,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
                   applications: props.applications,
                   desktopApi: props.desktopApi,
                   fileViewerContext: props.fileViewerContext,
+                  imageParts,
                   onOpenImage: props.onOpenImage,
                   skills: props.skills,
                 }),
@@ -264,6 +268,7 @@ export const TranscriptMessage = memo(function TranscriptMessage(props: Transcri
               applications: props.applications,
               desktopApi: props.desktopApi,
               fileViewerContext: props.fileViewerContext,
+              imageParts,
               onOpenImage: props.onOpenImage,
               skills: props.skills,
             })}
@@ -496,6 +501,7 @@ function renderMessageSegment(params: {
     "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
   >;
   fileViewerContext?: MarkdownFileViewerContext;
+  imageParts?: AppServerThreadImagePart[];
   segment: MessagePartSegment;
   index: number;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
@@ -526,6 +532,8 @@ function renderMessageSegment(params: {
       className="transcript-message__text-block"
       desktopApi={params.desktopApi}
       fileViewerContext={params.fileViewerContext}
+      imageParts={params.imageParts}
+      onOpenImage={params.onOpenImage}
       skills={params.skills}
       text={params.segment.type === "table" ? params.segment.text : params.segment.part.text}
     />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -122,6 +122,58 @@ describe("ThreadMarkdown", () => {
     });
   });
 
+  it("opens Markdown-linked images in PwrAgent instead of the configured editor", () => {
+    const onOpenImage = vi.fn();
+    const openApplication = vi.fn(async () => ({ opened: true as const }));
+    const sourceUrl = "file:///Users/huntharo/.codex/worktrees/pwrgit/build/dmg-background.png";
+    const imagePart = {
+      type: "image" as const,
+      url: `pwragent-image://file/${encodeURIComponent(sourceUrl)}`,
+      sourceUrl,
+      alt: "dmg-background.png",
+    };
+
+    render(
+      <ThreadMarkdown
+        applications={{
+          editors: [
+            {
+              id: "vscode",
+              kind: "editor",
+              name: "VS Code",
+              source: "application",
+              appPath: "/Applications/Visual Studio Code.app",
+              canOpenWorkspace: true,
+            },
+          ],
+          terminals: [],
+          preferredEditorId: { value: "vscode", source: "config" },
+          preferredTerminalId: { value: "", source: "default" },
+          gh: {
+            path: { value: "", source: "default" },
+            discovery: { candidates: [] },
+          },
+          git: {
+            discovery: { candidates: [] },
+          },
+        }}
+        desktopApi={{ openApplication }}
+        imageParts={[imagePart]}
+        onOpenImage={onOpenImage}
+        text={"The branded DMG background is at [dmg-background.png](/Users/huntharo/.codex/worktrees/pwrgit/build/dmg-background.png)."}
+      />
+    );
+
+    const link = screen.getByRole("link", { name: "dmg-background.png" });
+    expect(link).toHaveAttribute("href", imagePart.url);
+    expect(link).toHaveAttribute("title", "Open image in PwrAgent");
+
+    fireEvent.click(link);
+
+    expect(onOpenImage).toHaveBeenCalledWith(imagePart);
+    expect(openApplication).not.toHaveBeenCalled();
+  });
+
   it("opens markdown file links in a document modal and keeps the editor icon separate", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
     const openMarkdownFileViewer = vi.fn(async () => ({ opened: true as const }));

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2050,12 +2050,17 @@ describe("ThreadView", () => {
             type: "message",
             id: "message-image-1",
             role: "user",
-            text: "",
+            text: "Open [Transcript screenshot](/Users/huntharo/.codex/worktrees/pwrsnap/latest.png).",
             parts: [
+              {
+                type: "text",
+                text: "Open [Transcript screenshot](/Users/huntharo/.codex/worktrees/pwrsnap/latest.png).",
+              },
               {
                 type: "image",
                 url: dataUrl,
-                alt: "Transcript screenshot"
+                alt: "Transcript screenshot",
+                sourceUrl: "file:///Users/huntharo/.codex/worktrees/pwrsnap/latest.png",
               }
             ]
           }
@@ -2066,7 +2071,7 @@ describe("ThreadView", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand transcript image 1" }));
+    fireEvent.click(screen.getByRole("button", { name: "Expand transcript image 2" }));
 
     const dialog = screen.getByRole("dialog", { name: "Expanded image" });
     expect(dialog).toBeInTheDocument();
@@ -2080,6 +2085,10 @@ describe("ThreadView", () => {
     expect(
       screen.queryByRole("dialog", { name: "Expanded image" })
     ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: "Transcript screenshot" }));
+
+    expect(screen.getByRole("dialog", { name: "Expanded image" })).toBeInTheDocument();
   });
 
   it("clears an expanded transcript image when the selected thread changes", () => {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -423,6 +423,12 @@ export type AppServerThreadImagePart = {
   type: "image";
   url: string;
   alt?: string;
+  /**
+   * Canonical local source URL when this image was discovered from a Markdown
+   * link. The renderer uses it to make the original link open the same image
+   * in PwrAgent rather than delegating it to an external editor.
+   */
+  sourceUrl?: string;
 };
 
 export type AppServerThreadMessagePart =


### PR DESCRIPTION
## Summary

- I make safe local raster Markdown links open in PwrAgent's existing lightbox and appear in a thumbnail gallery beneath their transcript message.
- I recover assistant image output from PwrSnap's typed MCP `resource_link` media delivery, retain the structured signed-URL fallback, and keep legacy `read_mcp_resource` image blobs working.
- I fetch each signed localhost image in the main process and persist it under the owning thread, so both the transcript and lightbox use an app-owned `pwragent-image://` URL rather than an expiring bearer URL. Full-resolution PwrSnap captures may be up to 64 MiB.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx packages/shared/src/__tests__/renderer-payload-boundary.test.ts` (198 passing tests).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (0 errors; 140 existing warnings).
- I ran `pnpm lint:boundaries`.
- I ran `pnpm lint:codex-storage`.

## Notes

- PwrSnap's [media-delivery change](https://github.com/pwrdrvr/PwrSnap/pull/346) now sends a direct typed resource link with no inline image bytes. The link identifies the exact full asset; it is not a URL parameter that can request a higher-resolution variant.
