### PR TITLE
fix(desktop): add non-terminal decline approval

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts
@@ -308,7 +308,13 @@ describe("buildApprovalIntent", () => {
         response: { decision: structuredDecision },
       }),
       expect.objectContaining({
+        decision: "decline",
+        fallbackText: "3",
+        response: { decision: "decline" },
+      }),
+      expect.objectContaining({
         decision: "cancel",
+        fallbackText: "4",
       }),
     ]);
     expect(intent.body).toContain(
@@ -353,7 +359,12 @@ describe("buildApprovalIntent", () => {
         description: "pnpm lint",
         response: { decision: secondDecision },
       }),
-      expect.objectContaining({ decision: "cancel" }),
+      expect.objectContaining({
+        decision: "decline",
+        fallbackText: "4",
+        response: { decision: "decline" },
+      }),
+      expect.objectContaining({ decision: "cancel", fallbackText: "5" }),
     ]);
     expect(intent.body).toContain("Persistent prefixes:");
     expect(intent.body).toContain(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -3472,7 +3472,7 @@ describe("ThreadView", () => {
     ).toBeInTheDocument();
   });
 
-  it("maps command approval actions to native decision values and dismisses the approval card", async () => {
+  it("submits a non-terminal decline for an incomplete Codex approval list", async () => {
     const submitServerRequest = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-2",
@@ -3483,7 +3483,7 @@ describe("ThreadView", () => {
       params: {
         threadId: "thread-2",
         requestId: "req-1",
-        availableDecisions: ["accept", "decline", "cancel"],
+        availableDecisions: ["accept", "cancel"],
         command: "npm view dive",
       },
     };
@@ -3644,7 +3644,7 @@ describe("ThreadView", () => {
 
     expect(screen.getByRole("group", { name: "Pending approval" })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Approve Once" }));
+    fireEvent.click(screen.getByRole("button", { name: "Decline" }));
 
     await waitFor(() => {
       expect(submitServerRequest).toHaveBeenCalledWith({
@@ -3652,7 +3652,7 @@ describe("ThreadView", () => {
         threadId: "thread-2",
         turnId: undefined,
         requestId: "req-1",
-        response: { decision: "accept" },
+        response: { decision: "decline" },
       });
     });
 
@@ -3661,7 +3661,7 @@ describe("ThreadView", () => {
         screen.queryByRole("group", { name: "Pending approval" })
       ).not.toBeInTheDocument();
     });
-    expect(clearPendingRequest).toHaveBeenCalledWith("req-1", "Thinking");
+    expect(clearPendingRequest).toHaveBeenCalledWith("req-1", undefined);
   });
 
   it("submits pending questionnaire answers with the request_user_input response shape", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3430,6 +3430,7 @@ describe("TranscriptList", () => {
     expect(action.querySelector(".transcript-request__action-detail")).toHaveTextContent(
       "python -m unittest package.tests.test_first package.tests.test_second"
     );
+    expect(screen.getByRole("button", { name: "Decline" })).toBeInTheDocument();
   });
 
   it("derives Kimi approval commands from prompt text when command is a shell title", () => {

--- a/packages/shared/src/__tests__/pending-request-response.test.ts
+++ b/packages/shared/src/__tests__/pending-request-response.test.ts
@@ -231,7 +231,7 @@ describe("buildPendingRequestResponse", () => {
     });
   });
 
-  it("exposes structured execpolicy amendment decisions", () => {
+  it("adds a non-terminal decline to structured Codex command approvals", () => {
     const structuredDecision = {
       acceptWithExecpolicyAmendment: {
         execpolicy_amendment: ["pnpm", "test"],
@@ -259,11 +259,43 @@ describe("buildPendingRequestResponse", () => {
         style: "secondary",
       }),
       expect.objectContaining({
+        decision: "decline",
+        fallbackText: "3",
+        response: { decision: "decline" },
+      }),
+      expect.objectContaining({
         decision: "cancel",
+        fallbackText: "4",
       }),
     ]);
     expect(buildPendingRequestResponse(request, actions[1]!)).toEqual({
       decision: structuredDecision,
+    });
+    expect(buildPendingRequestResponse(request, actions[2]!)).toEqual({
+      decision: "decline",
+    });
+  });
+
+  it("adds a non-terminal decline to advertised Codex file-change approvals", () => {
+    const request = createRequest({
+      method: "item/fileChange/requestApproval",
+      params: {
+        threadId: "thread-1",
+        requestId: "request-1",
+        availableDecisions: ["accept", "cancel"],
+      },
+    });
+
+    const actions = buildPendingRequestActions(request);
+
+    expect(actions.map((action) => action.decision)).toEqual([
+      "accept",
+      "decline",
+      "cancel",
+    ]);
+    expect(actions.map((action) => action.fallbackText)).toEqual(["1", "2", "3"]);
+    expect(buildPendingRequestResponse(request, actions[1]!)).toEqual({
+      decision: "decline",
     });
   });
 
@@ -348,6 +380,10 @@ describe("buildPendingRequestResponse", () => {
         decision: "apply_network_policy_amendment",
         label: "Block api.example.com",
         style: "danger",
+      }),
+      expect.objectContaining({
+        decision: "decline",
+        response: { decision: "decline" },
       }),
     ]);
   });

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -420,10 +420,56 @@ export function buildPendingRequestActions(
     )
     .filter((entry): entry is PendingRequestAction => Boolean(entry));
   if (provided?.length) {
-    return provided;
+    return ensureCodexDeclineAction(request, provided);
   }
 
   return defaultPendingRequestActions(request);
+}
+
+function ensureCodexDeclineAction(
+  request: AppServerPendingRequestNotification,
+  actions: PendingRequestAction[],
+): PendingRequestAction[] {
+  if (
+    !isCodexCommandOrFileApproval(request)
+    || actions.some((action) => action.decision === "decline")
+  ) {
+    return actions;
+  }
+
+  // Codex accepts `decline` for native command and file approvals even when
+  // the advertised choices only include allow variants and `cancel`.
+  const declineAction = buildAction({
+    decision: "decline",
+    fallbackText: String(actions.length + 1),
+    id: "approval:decline",
+    label: "Decline",
+    responseDecision: "decline",
+    style: "danger",
+  });
+  const cancelIndex = actions.findIndex((action) => action.decision === "cancel");
+  const actionsWithDecline = cancelIndex < 0
+    ? [...actions, declineAction]
+    : [
+        ...actions.slice(0, cancelIndex),
+        declineAction,
+        ...actions.slice(cancelIndex),
+      ];
+
+  return actionsWithDecline.map((action, index) =>
+    /^\d+$/.test(action.fallbackText)
+      ? { ...action, fallbackText: String(index + 1) }
+      : action,
+  );
+}
+
+function isCodexCommandOrFileApproval(
+  request: AppServerPendingRequestNotification,
+): boolean {
+  return (
+    request.method === "item/commandExecution/requestApproval"
+    || request.method === "item/fileChange/requestApproval"
+  );
 }
 
 function selectAvailableAction(


### PR DESCRIPTION
## Summary

- I added a non-terminal **Decline** action to native Codex command and file approval prompts when an advertised action list omits it.
- I place Decline before Cancel Turn and keep numeric text-reply shortcuts in order across desktop and messaging surfaces.
- I added coverage for the structured command-prefix request that reproduced the issue.

## Verification

- I ran `pnpm test packages/shared/src/__tests__/pending-request-response.test.ts apps/desktop/src/main/__tests__/messaging-approval-renderer.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx` (476 tests passed).
- I ran `pnpm lint:eslint` (0 errors; existing warnings only), `pnpm typecheck`, and `pnpm lint:boundaries`.

## Notes

- Codex distinguishes `decline` (deny this command and continue the turn) from `cancel` (deny it and interrupt the turn).
