### PR TITLE
fix(messaging): let /new create Agent threads

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -6967,6 +6967,95 @@ describe("MessagingController", () => {
       kind: "project_picker",
       fallbackText: expect.stringContaining("new PwrAgent thread"),
       prompt: expect.stringContaining("Choose a project"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:resume", label: "Resume" }),
+          expect.objectContaining({ id: "browse:mode:new-agent", label: "New Agent" }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
+      },
+    });
+  });
+
+  it("lets /new create an Agent thread and return to regular projects", async () => {
+    const harness = await createHarness();
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:new-agent",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("new PwrAgent Agent thread"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:new-thread", label: "Projects" }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:new-thread",
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("new PwrAgent thread"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:resume", label: "Resume" }),
+          expect.objectContaining({ id: "browse:mode:new-agent", label: "New Agent" }),
+        ]),
+      },
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:mode:new-agent",
+      }),
+    );
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      title: "Ready to start",
+      body: expect.stringContaining("Agent: Messaging Agent"),
+    });
+
+    await harness.controller.handleInboundEvent(buildTextEvent("Check the queue"));
+
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: {
+          name: "Messaging Agent",
+          instructions: expect.stringContaining("created from messaging"),
+        },
+      }),
+      expect.objectContaining({
+        onThreadMaterialized: expect.any(Function),
+      }),
+    );
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/new").channel),
+    ).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "new-thread-1",
+      targetKind: "agent_thread",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts
@@ -349,6 +349,11 @@ describe("messaging resume browser", () => {
       session: buildBrowseSession({
         launchAction: "start_new_thread",
         mode: "new_project",
+        returnTo: {
+          launchAction: "resume_thread",
+          mode: "recents",
+          pageIndex: 0,
+        },
       }),
     });
 
@@ -362,10 +367,16 @@ describe("messaging resume browser", () => {
             label: "PwrAgent",
           }),
         ],
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:resume", label: "Resume" }),
+          expect.objectContaining({ id: "browse:mode:new-agent", label: "New Agent" }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
       },
     });
     expect(intent.prompt).not.toContain("1. PwrAgent");
     expect(intent.fallbackText).toContain("1. PwrAgent");
+    expect(intent.fallbackText).toContain("resume, new agent, or cancel");
   });
 
   it("renders a Resume return action for new-thread pickers opened from resume", () => {
@@ -386,7 +397,7 @@ describe("messaging resume browser", () => {
 
     expect(intent).toMatchObject({
       kind: "project_picker",
-      fallbackText: expect.stringContaining("resume or cancel"),
+      fallbackText: expect.stringContaining("resume, new agent, or cancel"),
       page: {
         actions: expect.arrayContaining([
           expect.objectContaining({
@@ -398,6 +409,38 @@ describe("messaging resume browser", () => {
         ]),
       },
     });
+  });
+
+  it("renders Projects to return from Agent creation opened by /new", () => {
+    const intent = buildResumeIntent({
+      id: "intent-1",
+      createdAt: 1000,
+      navigation: buildNavigationSnapshot(),
+      session: buildBrowseSession({
+        launchAction: "start_new_agent_thread",
+        mode: "new_project",
+        returnTo: {
+          launchAction: "resume_thread",
+          mode: "recents",
+          pageIndex: 0,
+        },
+      }),
+    });
+
+    expect(intent).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("new PwrAgent Agent thread"),
+      fallbackText: expect.stringContaining("projects or cancel"),
+      page: {
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "browse:mode:new-thread", label: "Projects" }),
+          expect.objectContaining({ id: "browse:cancel" }),
+        ]),
+      },
+    });
+    expect(intent.page.actions).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "browse:mode:resume" })]),
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/telegram-adapter.test.ts
@@ -1737,6 +1737,10 @@ describe("TelegramAdapter", () => {
           description: "Resume or start a PwrAgent thread",
         },
         {
+          command: "agent",
+          description: "Choose or create a PwrAgent Agent",
+        },
+        {
           command: "new",
           description: "Start a new PwrAgent thread",
         },

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -5206,6 +5206,12 @@ export class MessagingController {
           (directory) => directory.path === parsed.cwd || directory.key === parsed.cwd,
         )
       : undefined;
+    const preferences = parsed.preferences
+      ? {
+          ...parsed.preferences,
+          updatedAt: this.now(),
+        }
+      : undefined;
     const session: MessagingBrowseSessionRecord = {
       id: this.newIntentId("browse"),
       allowedActorIds: [event.actor.platformUserId],
@@ -5219,13 +5225,17 @@ export class MessagingController {
       mode: selectedDirectory && parsed.mode === "recents" ? "project_threads" : parsed.mode,
       pageIndex: 0,
       pageSize: resumeBrowserPageSize(this.capabilityProfile),
-      preferences: parsed.preferences
+      preferences,
+      query: parsed.query,
+      returnTo: parsed.launchAction === "start_new_thread"
         ? {
-            ...parsed.preferences,
-            updatedAt: this.now(),
+            launchAction: "resume_thread",
+            mode: "recents",
+            pageIndex: 0,
+            preferences,
+            query: parsed.query,
           }
         : undefined,
-      query: parsed.query,
       selectedProject: selectedDirectory
         ? {
             directoryKey: selectedDirectory.key,
@@ -5599,6 +5609,56 @@ export class MessagingController {
           mode: "new_project",
           pageIndex: 0,
           returnTo: session.returnTo ?? resumeReturnTargetForSession(nextSession),
+          selectedProject: undefined,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:mode:new-agent") {
+      const selectedBackend = await this.resolveNewThreadBackendForSession(
+        {
+          launchpadBackend: navigation.launchpadDefaults.backend,
+          session: nextSession,
+        },
+        event,
+      );
+      if (!selectedBackend) {
+        return;
+      }
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          backend: selectedBackend.kind,
+          launchAction: "start_new_agent_thread",
+          mode: "new_project",
+          pageIndex: 0,
+          selectedProject: undefined,
+        },
+        navigation,
+        event,
+      );
+      return;
+    }
+    if (actionId === "browse:mode:new-thread") {
+      const selectedBackend = await this.resolveNewThreadBackendForSession(
+        {
+          launchpadBackend: navigation.launchpadDefaults.backend,
+          session: nextSession,
+        },
+        event,
+      );
+      if (!selectedBackend) {
+        return;
+      }
+      await this.renderResumeBrowser(
+        {
+          ...nextSession,
+          backend: selectedBackend.kind,
+          launchAction: "start_new_thread",
+          mode: "new_project",
+          pageIndex: 0,
           selectedProject: undefined,
         },
         navigation,

--- a/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-resume-browser.ts
@@ -509,6 +509,52 @@ function navigationActions(
     });
     return actions;
   }
+  if (session.mode === "new_project") {
+    if (session.launchAction === "start_new_thread") {
+      if (session.returnTo) {
+        actions.push({
+          id: "browse:mode:resume",
+          label: "Resume",
+          style: "navigation",
+          fallbackText: "resume",
+          layout: { row: FOOTER_ROW },
+        });
+      }
+      actions.push({
+        id: "browse:mode:new-agent",
+        label: "New Agent",
+        style: "secondary",
+        fallbackText: "new agent",
+        layout: { row: FOOTER_ROW },
+      });
+    } else if (session.launchAction === "start_new_agent_thread") {
+      if (session.returnTo?.mode === "recents") {
+        actions.push({
+          id: "browse:mode:new-thread",
+          label: "Projects",
+          style: "navigation",
+          fallbackText: "projects",
+          layout: { row: FOOTER_ROW },
+        });
+      } else if (session.returnTo) {
+        actions.push({
+          id: "browse:mode:resume",
+          label: "Resume",
+          style: "navigation",
+          fallbackText: "resume",
+          layout: { row: FOOTER_ROW },
+        });
+      }
+    }
+    actions.push({
+      id: "browse:cancel",
+      label: "Cancel",
+      style: "secondary",
+      fallbackText: "cancel",
+      layout: { row: FOOTER_ROW },
+    });
+    return actions;
+  }
   if (session.mode === "agents") {
     actions.push({
       id: "browse:mode:recents",
@@ -524,7 +570,7 @@ function navigationActions(
       fallbackText: "new",
       layout: { row: FOOTER_ROW },
     });
-  } else if (session.mode !== "projects" && session.mode !== "new_project") {
+  } else if (session.mode !== "projects") {
     actions.push({
       id: "browse:mode:projects",
       label: "Projects",
@@ -685,7 +731,20 @@ function projectPickerFallbackText(
     page.pageIndex > 0 ? "previous" : undefined,
     page.pageIndex < page.totalPages - 1 ? "next" : undefined,
     session.launchAction === "resume_thread" ? "recent" : undefined,
-    session.returnTo ? "resume" : undefined,
+    session.mode === "new_project" && session.launchAction === "start_new_thread"
+      ? session.returnTo
+        ? "resume"
+        : undefined
+      : session.mode === "new_project" &&
+          session.launchAction === "start_new_agent_thread" &&
+          session.returnTo?.mode === "recents"
+        ? "projects"
+        : session.returnTo
+          ? "resume"
+          : undefined,
+    session.mode === "new_project" && session.launchAction === "start_new_thread"
+      ? "new agent"
+      : undefined,
     "cancel",
   ].filter(Boolean);
   return [

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -165,7 +165,7 @@ describe("adaptGrammyBot", () => {
 });
 
 describe("TelegramAdapter callback persistence", () => {
-  it("registers Monitor with Telegram bot commands", async () => {
+  it("registers Agent and Monitor with Telegram bot commands", async () => {
     const grammyBot = createGrammyBot();
     const adapter = new TelegramAdapter({
       api: adaptGrammyBot(grammyBot).api,
@@ -184,6 +184,10 @@ describe("TelegramAdapter callback persistence", () => {
       {
         command: "resume",
         description: "Resume or start a PwrAgent thread",
+      },
+      {
+        command: "agent",
+        description: "Choose or create a PwrAgent Agent",
       },
       {
         command: "new",

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -674,6 +674,10 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           description: "Resume or start a PwrAgent thread",
         },
         {
+          command: "agent",
+          description: "Choose or create a PwrAgent Agent",
+        },
+        {
           command: "new",
           description: "Start a new PwrAgent thread",
         },


### PR DESCRIPTION
## Summary

- I gave direct `/new` project pickers the same escape hatches as the resume flow: Resume, New Agent, and Cancel.
- I added a New Agent transition that opens the existing Agent-aware project picker, then creates and binds an Agent thread after the first prompt.
- I added a Projects control on that Agent picker to return to ordinary new-thread project selection without losing the Resume route.
- I advertised the existing `/agent` flow in Telegram's native command menu, matching Discord's registered command surface.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts` (334 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm exec eslint apps/desktop/src/main/messaging/core/messaging-controller.ts apps/desktop/src/main/messaging/core/messaging-resume-browser.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-resume-browser.test.ts` (passes with four existing warnings)
- `pnpm lint:boundaries`
- `pnpm test packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts` (10 passed)
- `pnpm --filter @pwragent/messaging-provider-telegram typecheck`
- `pnpm lint` (passes; existing ESLint warnings only)

## Notes

- I verified the complete `/new` → New Agent → project → first prompt path creates an `agent_thread` binding in the focused controller test.
