### PR TITLE
feat(desktop): add Agent thread composer menu

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -10018,6 +10018,48 @@ command = "pnpm grok"
     await registry.close();
   });
 
+  it("keeps a selected Agent designation when reopening a blank launchpad", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+    await registry.updateDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      patch: {
+        agent: {
+          name: "PwrAgent Agent",
+          instructions: "Manage PwrAgent threads.",
+        },
+      },
+    });
+
+    const reopened = await registry.ensureDirectoryLaunchpad({
+      directoryKey: "directory:/repo-a",
+      directoryKind: "directory",
+      directoryLabel: "Repo A",
+      directoryPath: "/repo-a",
+    });
+
+    expect(reopened.launchpad.agent).toEqual({
+      name: "PwrAgent Agent",
+      instructions: "Manage PwrAgent threads.",
+    });
+
+    await registry.close();
+  });
+
   it("keeps workspace launchpads in workspace mode even when directory drafts prefer worktrees", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({
@@ -12171,7 +12213,7 @@ script = "printf setup-output"
     await registry.close();
   });
 
-  it("passes Agent metadata through materialized launchpad starts", async () => {
+  it("passes launchpad-selected Agent metadata through materialized starts", async () => {
     const overlayStore = createOverlayStoreMock();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/start"] },
@@ -12193,10 +12235,6 @@ script = "printf setup-output"
 
     const response = await registry.materializeDirectoryLaunchpad({
       directoryKey: "directory:/repo/app",
-      agent: {
-        name: "Messaging Agent",
-        instructions: "Keep shared messaging context.",
-      },
       launchpad: {
         directoryKey: "directory:/repo/app",
         directoryKind: "directory",
@@ -12204,6 +12242,10 @@ script = "printf setup-output"
         directoryPath: "/repo/app",
         backend: "codex",
         executionMode: "default",
+        agent: {
+          name: "PwrAgent Agent",
+          instructions: "Manage PwrAgent threads.",
+        },
         prompt: "",
         workMode: "local",
         createdAt: 1_000,
@@ -12218,8 +12260,8 @@ script = "printf setup-output"
       }),
     ).resolves.toMatchObject({
       agent: {
-        name: "Messaging Agent",
-        instructions: "Keep shared messaging context.",
+        name: "PwrAgent Agent",
+        instructions: "Manage PwrAgent threads.",
       },
     });
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -13865,7 +13865,7 @@ export class DesktopBackendRegistry {
     const startThreadResponse = await this.startThread({
       backend: launchpad.backend,
       executionMode: launchpad.executionMode,
-      agent: request.agent,
+      agent: request.agent ?? launchpad.agent,
       cwd: workspace.cwd,
       linkedDirectories,
       model: launchpad.model,

--- a/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationEditor.tsx
@@ -30,6 +30,10 @@ import {
   validateAutomationScheduleDefinition,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  canChangeExistingThreadAgentDesignation,
+} from "../../lib/agent-thread";
 import { copyText } from "../../lib/copy-text";
 import { HelpCircleIcon } from "../../icons";
 
@@ -667,8 +671,19 @@ export function AutomationEditor(props: AutomationEditorProps) {
   const threadOptions = useMemo(
     () =>
       (props.threads ?? [])
-        .filter((thread) => !thread.agent)
+        .filter(
+          (thread) =>
+            !thread.agent && canChangeExistingThreadAgentDesignation(thread),
+        )
         .map((thread) => buildAgentOption(thread)),
+    [props.threads],
+  );
+  const hasUnpromotableCodexThreads = useMemo(
+    () =>
+      (props.threads ?? []).some(
+        (thread) =>
+          !thread.agent && !canChangeExistingThreadAgentDesignation(thread),
+      ),
     [props.threads],
   );
   const visibleAgentOptions = useMemo(
@@ -1072,7 +1087,9 @@ export function AutomationEditor(props: AutomationEditorProps) {
                       ))
                     ) : (
                       <p className="automation-agent-picker__empty">
-                        No regular threads match.
+                        {threadOptions.length === 0 && hasUnpromotableCodexThreads
+                          ? CODEX_AGENT_THREAD_CREATION_NOTE
+                          : "No regular threads match."}
                       </p>
                     )}
                   </div>

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -5,6 +5,10 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import { buildThreadIdentityKey } from "@pwragent/shared";
+import {
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  canChangeExistingThreadAgentDesignation,
+} from "../../lib/agent-thread";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import {
@@ -64,6 +68,9 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
   };
 
   const promoteThreadToAgent = async (thread: NavigationThreadSummary) => {
+    if (!canChangeExistingThreadAgentDesignation(thread)) {
+      throw new Error(CODEX_AGENT_THREAD_CREATION_NOTE);
+    }
     if (!props.desktopApi?.setThreadAgent) {
       throw new Error("Desktop bridge is missing setThreadAgent().");
     }

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automation-editor.test.tsx
@@ -18,6 +18,7 @@ import type {
   ReadDesktopSettingsResponse,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { CODEX_AGENT_THREAD_CREATION_NOTE } from "../../../lib/agent-thread";
 import { AutomationEditor } from "../AutomationEditor";
 
 afterEach(() => {
@@ -959,7 +960,7 @@ describe("AutomationEditor", () => {
             id: "ordinary-thread",
             inbox: { inInbox: false },
             linkedDirectories: [],
-            source: "codex",
+            source: "acp:gemini",
             title: "Ordinary work",
             titleSource: "explicit",
             updatedAt: 1,
@@ -1093,14 +1094,39 @@ describe("AutomationEditor", () => {
     });
   });
 
+  it("does not offer existing Codex threads for Agent promotion", () => {
+    const ordinaryCodexThread = buildThread({
+      id: "ordinary-thread",
+      title: "Incident triage",
+    });
+
+    render(
+      <AutomationEditor
+        mode={{ kind: "create" }}
+        threads={[ordinaryCodexThread]}
+        onCancel={() => undefined}
+        onSubmit={vi.fn(async () => undefined)}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Agent"));
+    fireEvent.click(screen.getByRole("tab", { name: "Threads" }));
+
+    expect(screen.getByText(CODEX_AGENT_THREAD_CREATION_NOTE)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: /Incident triage/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("promotes a regular thread to an Agent and selects it", async () => {
     const onPromoteThread = vi.fn(async () => ({
-      backend: "codex" as const,
+      backend: "acp:gemini" as const,
       threadId: "ordinary-thread",
     }));
     const onSubmit = vi.fn(async () => undefined);
     const ordinaryThread = buildThread({
       id: "ordinary-thread",
+      source: "acp:gemini",
       title: "Incident triage",
     });
 
@@ -1134,7 +1160,7 @@ describe("AutomationEditor", () => {
     expect(onSubmit).toHaveBeenCalledWith({
       kind: "create",
       request: expect.objectContaining({
-        backend: "codex",
+        backend: "acp:gemini",
         threadId: "ordinary-thread",
       }),
     });

--- a/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/__tests__/automations-screen.test.tsx
@@ -8,6 +8,7 @@ import type {
   NavigationThreadSummary,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { CODEX_AGENT_THREAD_CREATION_NOTE } from "../../../lib/agent-thread";
 import { AutomationsScreen } from "../AutomationsScreen";
 
 const thread: NavigationThreadSummary = {
@@ -155,14 +156,19 @@ describe("AutomationsScreen", () => {
   });
 
   it("promotes a regular thread to an Agent before creating an automation", async () => {
+    const promotableThread: NavigationThreadSummary = {
+      ...ordinaryThread,
+      source: "acp:gemini",
+    };
     const promotedAutomation: AutomationDetail = {
       ...automation,
+      backend: "acp:gemini",
       id: "automation-promoted",
       threadId: "ordinary-thread",
     };
     const createAutomation = vi.fn(async () => ({ automation: promotedAutomation }));
     const setThreadAgent = vi.fn(async () => ({
-      backend: "codex" as const,
+      backend: "acp:gemini" as const,
       threadId: "ordinary-thread",
       agent: {
         name: "Slack Agent",
@@ -185,7 +191,7 @@ describe("AutomationsScreen", () => {
     render(
       <AutomationsScreen
         desktopApi={desktopApi}
-        threads={[thread, ordinaryThread]}
+        threads={[thread, promotableThread]}
         onClose={() => undefined}
         onRefreshNavigation={onRefreshNavigation}
       />,
@@ -204,7 +210,7 @@ describe("AutomationsScreen", () => {
     await waitFor(() => expect(setThreadAgent).toHaveBeenCalledTimes(1));
     expect(setThreadAgent).toHaveBeenCalledWith({
       agent: { name: "Slack helper" },
-      backend: "codex",
+      backend: "acp:gemini",
       threadId: "ordinary-thread",
     });
     expect(within(editor).getByLabelText("Agent")).toHaveTextContent("Slack Agent");
@@ -217,11 +223,39 @@ describe("AutomationsScreen", () => {
     await waitFor(() => expect(createAutomation).toHaveBeenCalledTimes(1));
     expect(createAutomation).toHaveBeenCalledWith(
       expect.objectContaining({
-        backend: "codex",
+        backend: "acp:gemini",
         threadId: "ordinary-thread",
       }),
     );
     expect(onRefreshNavigation).toHaveBeenCalled();
+  });
+
+  it("does not offer existing Codex threads for Agent promotion", async () => {
+    const setThreadAgent = vi.fn();
+    const desktopApi: DesktopApi = {
+      listAutomations: vi.fn(async () => ({ automations: [] })),
+      onAgentEvent: () => () => undefined,
+      setThreadAgent,
+    };
+
+    render(
+      <AutomationsScreen
+        desktopApi={desktopApi}
+        threads={[thread, ordinaryThread]}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "New Automation" }));
+    const editor = screen.getByLabelText("Name").closest("form") as HTMLElement;
+    fireEvent.click(within(editor).getByLabelText("Agent"));
+    fireEvent.click(within(editor).getByRole("tab", { name: "Threads" }));
+
+    expect(screen.getByText(CODEX_AGENT_THREAD_CREATION_NOTE)).toBeInTheDocument();
+    expect(
+      within(editor).queryByRole("option", { name: /Slack helper/ }),
+    ).not.toBeInTheDocument();
+    expect(setThreadAgent).not.toHaveBeenCalled();
   });
 
   it("shows rollout replay details for an automation run", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -56,6 +56,7 @@ import {
   FileCodeIcon,
   FolderIcon,
   LightningIcon,
+  MoreVerticalIcon,
   PlanIcon,
   PlayIcon,
   PlusIcon,
@@ -87,6 +88,12 @@ import {
 } from "../../lib/directory-references";
 import { expandTildePath } from "../../lib/tildify-path";
 import { normalizeImageFile } from "../../lib/image-normalization";
+import {
+  AGENT_THREAD_CAPABILITIES,
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  canChangeExistingThreadAgentDesignation,
+  createDesktopAgentThread,
+} from "../../lib/agent-thread";
 import {
   resolveThreadHref,
   resolveThreadIdText,
@@ -219,6 +226,7 @@ type ComposerProps = {
         | "directoryPath"
         | "imageAttachments"
         | "fileAttachments"
+        | "agent"
       >
     >,
     options?: { stickySettingsChanged?: boolean }
@@ -1672,6 +1680,78 @@ function ComposerDropdown(props: {
   );
 }
 
+function ComposerThreadOptionsMenu(props: {
+  agentThread: boolean;
+  disabled?: boolean;
+  existingCodexThread?: boolean;
+  onAgentThreadChange?: (agentThread: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const ref = useDismissableMenu<HTMLDivElement>(open, () => setOpen(false));
+  const agentThreadChangeDisabled =
+    props.disabled ||
+    props.existingCodexThread ||
+    !props.onAgentThreadChange;
+
+  return (
+    <div className="composer-thread-options" ref={ref}>
+      <button
+        aria-controls={open ? menuId : undefined}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Thread options"
+        className={`composer__toggle tooltip-target${
+          props.agentThread ? " is-active" : ""
+        }`}
+        // Omit the CSS tooltip while the menu is open so it does not cover
+        // the Agent explanation.
+        data-tooltip={open ? undefined : AGENT_THREAD_CAPABILITIES}
+        disabled={props.disabled}
+        type="button"
+        onClick={() => setOpen((current) => !current)}
+      >
+        <MoreVerticalIcon size={15} aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          aria-label="Thread options"
+          className="composer-dropdown__menu composer-thread-options__menu"
+          id={menuId}
+          role="menu"
+        >
+          <button
+            aria-checked={props.agentThread}
+            className="composer-dropdown__option composer-thread-options__option"
+            disabled={agentThreadChangeDisabled}
+            role="menuitemcheckbox"
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              props.onAgentThreadChange?.(!props.agentThread);
+            }}
+          >
+            <span aria-hidden="true" className="composer-dropdown__check">
+              {props.agentThread ? <CheckIcon size={13} /> : null}
+            </span>
+            <span className="composer-thread-options__copy">
+              <span className="composer-thread-options__label">Agent thread</span>
+              <span className="composer-thread-options__description">
+                {AGENT_THREAD_CAPABILITIES}
+              </span>
+              {props.existingCodexThread ? (
+                <span className="composer-thread-options__note">
+                  {CODEX_AGENT_THREAD_CREATION_NOTE}
+                </span>
+              ) : null}
+            </span>
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 type LaunchpadBranchOption = {
   name: string;
   /** Last commit time on the branch tip, in unix seconds. */
@@ -2631,6 +2711,8 @@ export function Composer(props: ComposerProps) {
     props.activeTurnId
   );
   const [sendError, setSendError] = useState<string>();
+  const [agentThreadError, setAgentThreadError] = useState<string>();
+  const [agentThreadSaving, setAgentThreadSaving] = useState(false);
   const [applicationOpenError, setApplicationOpenError] = useState<string>();
   const [threadEnvActionStarting, setThreadEnvActionStartingState] =
     useState<ThreadEnvActionStartingKey>();
@@ -2674,6 +2756,11 @@ export function Composer(props: ComposerProps) {
   const [activeSlashIndex, setActiveSlashIndex] = useState(0);
   const [activeDirectoryRefIndex, setActiveDirectoryRefIndex] = useState(0);
   const [dismissedAutocompleteKey, setDismissedAutocompleteKey] = useState<string>();
+
+  useEffect(() => {
+    setAgentThreadError(undefined);
+    setAgentThreadSaving(false);
+  }, [composerScopeKey]);
 
   const setThreadEnvActionStarting = (
     next: ThreadEnvActionStartingKey | undefined,
@@ -6399,6 +6486,50 @@ export function Composer(props: ComposerProps) {
     }, 0);
   };
 
+  const changeAgentThread = async (agentThread: boolean): Promise<void> => {
+    if (props.launchpad) {
+      if (!props.onUpdateLaunchpad) {
+        return;
+      }
+      setAgentThreadSaving(true);
+      setAgentThreadError(undefined);
+      try {
+        await props.onUpdateLaunchpad(props.launchpad.directoryKey, {
+          agent: agentThread ? createDesktopAgentThread() : undefined,
+        });
+      } catch (error) {
+        setAgentThreadError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setAgentThreadSaving(false);
+      }
+      return;
+    }
+
+    const thread = props.thread;
+    if (
+      !thread ||
+      !canChangeExistingThreadAgentDesignation(thread) ||
+      !props.desktopApi?.setThreadAgent
+    ) {
+      return;
+    }
+
+    setAgentThreadSaving(true);
+    setAgentThreadError(undefined);
+    try {
+      await props.desktopApi.setThreadAgent({
+        backend: thread.source,
+        threadId: thread.id,
+        agent: agentThread ? createDesktopAgentThread() : null,
+      });
+      await props.onRefreshNavigation?.();
+    } catch (error) {
+      setAgentThreadError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setAgentThreadSaving(false);
+    }
+  };
+
   useEffect(() => {
     const launchpad = props.launchpad;
     const backend = launchpad?.backend;
@@ -8897,6 +9028,29 @@ export function Composer(props: ComposerProps) {
               </button>
             </ReferencePicker>
           ) : null}
+          <ComposerThreadOptionsMenu
+            agentThread={Boolean(props.launchpad?.agent ?? props.thread?.agent)}
+            disabled={launchpadSubmitting || agentThreadSaving}
+            existingCodexThread={
+              props.thread !== undefined &&
+              !canChangeExistingThreadAgentDesignation(props.thread)
+            }
+            onAgentThreadChange={
+              props.launchpad
+                ? props.onUpdateLaunchpad
+                  ? (agentThread) => {
+                      void changeAgentThread(agentThread);
+                    }
+                  : undefined
+                : props.thread &&
+                    canChangeExistingThreadAgentDesignation(props.thread) &&
+                    props.desktopApi?.setThreadAgent
+                  ? (agentThread) => {
+                      void changeAgentThread(agentThread);
+                    }
+                  : undefined
+            }
+          />
         </div>
       ) : null}
 
@@ -8916,6 +9070,11 @@ export function Composer(props: ComposerProps) {
         />
       ) : null}
       {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
+      {agentThreadError ? (
+        <p className="composer__meta composer__meta--error" role="alert">
+          {agentThreadError}
+        </p>
+      ) : null}
       {applicationOpenError ? (
         <p className="composer__meta composer__meta--error">{applicationOpenError}</p>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1704,9 +1704,7 @@ function ComposerThreadOptionsMenu(props: {
         className={`composer__toggle tooltip-target${
           props.agentThread ? " is-active" : ""
         }`}
-        // Omit the CSS tooltip while the menu is open so it does not cover
-        // the Agent explanation.
-        data-tooltip={open ? undefined : AGENT_THREAD_CAPABILITIES}
+        data-tooltip={open ? undefined : "Thread options"}
         disabled={props.disabled}
         type="button"
         onClick={() => setOpen((current) => !current)}
@@ -1720,32 +1718,36 @@ function ComposerThreadOptionsMenu(props: {
           id={menuId}
           role="menu"
         >
-          <button
-            aria-checked={props.agentThread}
-            className="composer-dropdown__option composer-thread-options__option"
-            disabled={agentThreadChangeDisabled}
-            role="menuitemcheckbox"
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              props.onAgentThreadChange?.(!props.agentThread);
-            }}
+          <div
+            className="composer-thread-options__item tooltip-target"
+            data-tooltip={
+              props.existingCodexThread
+                ? CODEX_AGENT_THREAD_CREATION_NOTE
+                : AGENT_THREAD_CAPABILITIES
+            }
           >
-            <span aria-hidden="true" className="composer-dropdown__check">
-              {props.agentThread ? <CheckIcon size={13} /> : null}
-            </span>
-            <span className="composer-thread-options__copy">
+            <button
+              aria-checked={props.agentThread}
+              className="composer-dropdown__option composer-thread-options__option"
+              disabled={agentThreadChangeDisabled}
+              role="menuitemcheckbox"
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                props.onAgentThreadChange?.(!props.agentThread);
+              }}
+            >
               <span className="composer-thread-options__label">Agent thread</span>
-              <span className="composer-thread-options__description">
-                {AGENT_THREAD_CAPABILITIES}
+              <span
+                aria-hidden="true"
+                className={`composer-thread-options__toggle${
+                  props.agentThread ? " is-checked" : ""
+                }`}
+              >
+                <span className="composer-thread-options__toggle-thumb" />
               </span>
-              {props.existingCodexThread ? (
-                <span className="composer-thread-options__note">
-                  {CODEX_AGENT_THREAD_CREATION_NOTE}
-                </span>
-              ) : null}
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -16,6 +16,11 @@ import {
 import type { JSONContent } from "@tiptap/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import {
+  AGENT_THREAD_CAPABILITIES,
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  DEFAULT_DESKTOP_AGENT_THREAD,
+} from "../../../lib/agent-thread";
 import { normalizeImageFile } from "../../../lib/image-normalization";
 import { ThreadLinkProvider } from "../../../lib/thread-links";
 import { Composer } from "../Composer";
@@ -669,6 +674,128 @@ describe("Composer", () => {
       "data-tooltip",
       "Auto-fix PR — starts when a PR for this workspace is linked",
     );
+  });
+
+  it("places the Agent thread menu after the reference picker and persists its choice", async () => {
+    const onUpdateLaunchpad = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        desktopApi={{ pickFileFromDisk: vi.fn() }}
+        disabled={false}
+        launchpad={{
+          directoryKey: "directory:/repo",
+          directoryKind: "directory",
+          directoryLabel: "Repo",
+          directoryPath: "/repo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "local",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={onUpdateLaunchpad}
+        skills={[]}
+      />,
+    );
+
+    const addReference = screen.getByRole("button", { name: "Add reference" });
+    const threadOptions = screen.getByRole("button", { name: "Thread options" });
+    expect(
+      addReference.compareDocumentPosition(threadOptions) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(threadOptions).toHaveAttribute(
+      "data-tooltip",
+      AGENT_THREAD_CAPABILITIES,
+    );
+
+    fireEvent.click(threadOptions);
+    const agentThread = screen.getByRole("menuitemcheckbox", {
+      name: /Agent thread/,
+    });
+    expect(agentThread).toHaveAttribute("aria-checked", "false");
+    expect(agentThread).toHaveTextContent(AGENT_THREAD_CAPABILITIES);
+
+    await act(async () => {
+      fireEvent.click(agentThread);
+      await Promise.resolve();
+    });
+
+    expect(onUpdateLaunchpad).toHaveBeenCalledWith("directory:/repo", {
+      agent: DEFAULT_DESKTOP_AGENT_THREAD,
+    });
+  });
+
+  it("explains that an existing Codex thread cannot be converted into an Agent", () => {
+    const setThreadAgent = vi.fn();
+
+    render(
+      <Composer
+        desktopApi={{ setThreadAgent }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Existing Codex thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread options" }));
+    const agentThread = screen.getByRole("menuitemcheckbox", {
+      name: /Agent thread/,
+    });
+    expect(agentThread).toBeDisabled();
+    expect(agentThread).toHaveTextContent(CODEX_AGENT_THREAD_CREATION_NOTE);
+
+    fireEvent.click(agentThread);
+    expect(setThreadAgent).not.toHaveBeenCalled();
+  });
+
+  it("marks an existing non-Codex thread as an Agent from the composer menu", async () => {
+    const setThreadAgent = vi.fn(async () => ({
+      backend: "acp:gemini" as const,
+      threadId: "thread-1",
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+
+    render(
+      <Composer
+        desktopApi={{ setThreadAgent }}
+        disabled={false}
+        onRefreshNavigation={onRefreshNavigation}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Existing Gemini thread",
+          titleSource: "explicit",
+          source: "acp:gemini",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread options" }));
+    fireEvent.click(
+      screen.getByRole("menuitemcheckbox", { name: /Agent thread/ }),
+    );
+
+    await waitFor(() => {
+      expect(setThreadAgent).toHaveBeenCalledWith({
+        backend: "acp:gemini",
+        threadId: "thread-1",
+        agent: DEFAULT_DESKTOP_AGENT_THREAD,
+      });
+    });
+    expect(onRefreshNavigation).toHaveBeenCalledOnce();
   });
 
   it("shows a cancellable on-deck countdown for a scheduled PR repair", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -709,7 +709,7 @@ describe("Composer", () => {
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(threadOptions).toHaveAttribute(
       "data-tooltip",
-      AGENT_THREAD_CAPABILITIES,
+      "Thread options",
     );
 
     fireEvent.click(threadOptions);
@@ -717,7 +717,11 @@ describe("Composer", () => {
       name: /Agent thread/,
     });
     expect(agentThread).toHaveAttribute("aria-checked", "false");
-    expect(agentThread).toHaveTextContent(AGENT_THREAD_CAPABILITIES);
+    expect(agentThread).not.toHaveTextContent(AGENT_THREAD_CAPABILITIES);
+    expect(agentThread.parentElement).toHaveAttribute(
+      "data-tooltip",
+      AGENT_THREAD_CAPABILITIES,
+    );
 
     await act(async () => {
       fireEvent.click(agentThread);
@@ -753,7 +757,11 @@ describe("Composer", () => {
       name: /Agent thread/,
     });
     expect(agentThread).toBeDisabled();
-    expect(agentThread).toHaveTextContent(CODEX_AGENT_THREAD_CREATION_NOTE);
+    expect(agentThread).not.toHaveTextContent(CODEX_AGENT_THREAD_CREATION_NOTE);
+    expect(agentThread.parentElement).toHaveAttribute(
+      "data-tooltip",
+      CODEX_AGENT_THREAD_CREATION_NOTE,
+    );
 
     fireEvent.click(agentThread);
     expect(setThreadAgent).not.toHaveBeenCalled();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -930,6 +930,7 @@ export type ThreadViewProps = {
         | "directoryLabel"
         | "directoryPath"
         | "imageAttachments"
+        | "agent"
       >
     >,
     options?: { stickySettingsChanged?: boolean }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -20,6 +20,10 @@ import type {
 import { ThreadContextPanel } from "../ThreadContextPanel";
 import type { ContextTabId } from "../context-panels/context-tab";
 import { collectEditedFileGroups } from "../edited-file-groups";
+import {
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  DEFAULT_DESKTOP_AGENT_THREAD,
+} from "../../../lib/agent-thread";
 
 const HOVER_RAIL_REVEAL_DELAY_MS = 350;
 
@@ -2742,12 +2746,45 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByText(/Spark Weekly limit: 100% left/)).toBeInTheDocument();
   });
 
-  it("marks an ordinary thread as an Agent from the context panel", async () => {
+  it("explains that existing Codex threads cannot be converted into Agents", () => {
+    const setThreadAgent = vi.fn();
+
+    renderPanel({
+      desktopApi: { setThreadAgent },
+      pinned: true,
+    });
+
+    expect(screen.getByText(CODEX_AGENT_THREAD_CREATION_NOTE)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Mark as Agent" }),
+    ).not.toBeInTheDocument();
+    expect(setThreadAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps existing Codex Agent metadata read-only", () => {
+    renderPanel({
+      pinned: true,
+      thread: {
+        ...baseThread,
+        agent: {
+          name: "Existing Agent",
+          instructionLineCount: 0,
+          instructionsTooLong: false,
+          updatedAt: 1,
+        },
+      },
+    });
+
+    expect(screen.getByText(CODEX_AGENT_THREAD_CREATION_NOTE)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear" })).not.toBeInTheDocument();
+  });
+
+  it("marks an ordinary non-Codex thread as an Agent from the context panel", async () => {
     const setThreadAgent = vi.fn(async () => ({
-      backend: "codex" as const,
+      backend: "acp:gemini" as const,
       threadId: "thread-1",
       agent: {
-        name: "Thread",
+        name: DEFAULT_DESKTOP_AGENT_THREAD.name,
         instructionLineCount: 0,
         instructionsTooLong: false,
         updatedAt: 1,
@@ -2759,24 +2796,26 @@ describe("ThreadContextPanel", () => {
       desktopApi: { setThreadAgent },
       pinned: true,
       onRefreshNavigation,
+      thread: {
+        ...baseThread,
+        source: "acp:gemini",
+      },
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Mark as Agent" }));
 
     await waitFor(() => expect(setThreadAgent).toHaveBeenCalledTimes(1));
     expect(setThreadAgent).toHaveBeenCalledWith({
-      backend: "codex",
+      backend: "acp:gemini",
       threadId: "thread-1",
-      agent: {
-        name: "Thread",
-      },
+      agent: DEFAULT_DESKTOP_AGENT_THREAD,
     });
     expect(onRefreshNavigation).toHaveBeenCalledOnce();
   });
 
   it("clears Agent metadata from the context panel", async () => {
     const setThreadAgent = vi.fn(async () => ({
-      backend: "codex" as const,
+      backend: "acp:gemini" as const,
       threadId: "thread-1",
     }));
 
@@ -2785,6 +2824,7 @@ describe("ThreadContextPanel", () => {
       pinned: true,
       thread: {
         ...baseThread,
+        source: "acp:gemini",
         agent: {
           name: "Inbox Agent",
           instructionLineCount: 0,
@@ -2798,7 +2838,7 @@ describe("ThreadContextPanel", () => {
 
     await waitFor(() => expect(setThreadAgent).toHaveBeenCalledTimes(1));
     expect(setThreadAgent).toHaveBeenCalledWith({
-      backend: "codex",
+      backend: "acp:gemini",
       threadId: "thread-1",
       agent: null,
     });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -4,6 +4,11 @@ import type { DesktopApi } from "../../../lib/desktop-api";
 import { formatBackendLabel } from "../../../lib/backend-label";
 import { formatExecutionModeLabel } from "../../../lib/execution-mode";
 import {
+  CODEX_AGENT_THREAD_CREATION_NOTE,
+  canChangeExistingThreadAgentDesignation,
+  createDesktopAgentThread,
+} from "../../../lib/agent-thread";
+import {
   CopyValueButton,
   formatAgentInstructionSummary,
   formatTimestamp,
@@ -31,14 +36,19 @@ type ThreadInfoPanelProps = {
 export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
   const [agentSaving, setAgentSaving] = useState(false);
   const [agentError, setAgentError] = useState<string>();
+  const canChangeAgentDesignation = canChangeExistingThreadAgentDesignation(
+    props.thread,
+  );
 
   useEffect(() => {
     setAgentError(undefined);
     setAgentSaving(false);
   }, [props.thread.id, props.thread.source]);
 
-  const setThreadAgent = async (agent: { name: string } | null): Promise<void> => {
-    if (!props.desktopApi?.setThreadAgent) {
+  const setThreadAgent = async (
+    agent: { name: string; instructions?: string } | null,
+  ): Promise<void> => {
+    if (!canChangeAgentDesignation || !props.desktopApi?.setThreadAgent) {
       return;
     }
     setAgentSaving(true);
@@ -68,27 +78,40 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
               <p className="context-list__meta">
                 {formatAgentInstructionSummary(props.thread.agent.instructionLineCount)}
               </p>
+              {!canChangeAgentDesignation ? (
+                <p className="context-list__meta context-list__agent-note">
+                  {CODEX_AGENT_THREAD_CREATION_NOTE}
+                </p>
+              ) : null}
             </div>
-            <button
-              className="context-list__action"
-              disabled={agentSaving || !props.desktopApi?.setThreadAgent}
-              type="button"
-              onClick={() => void setThreadAgent(null)}
-            >
-              Clear
-            </button>
+            {canChangeAgentDesignation ? (
+              <button
+                className="context-list__action"
+                disabled={agentSaving || !props.desktopApi?.setThreadAgent}
+                type="button"
+                onClick={() => void setThreadAgent(null)}
+              >
+                Clear
+              </button>
+            ) : null}
           </div>
         ) : (
           <div className="context-list__item">
-            <p className="context-empty">Ordinary work thread</p>
-            <button
-              className="context-list__action"
-              disabled={agentSaving || !props.desktopApi?.setThreadAgent}
-              type="button"
-              onClick={() => void setThreadAgent({ name: props.thread.title })}
-            >
-              Mark as Agent
-            </button>
+            <p className="context-empty">
+              {canChangeAgentDesignation
+                ? "Ordinary work thread"
+                : CODEX_AGENT_THREAD_CREATION_NOTE}
+            </p>
+            {canChangeAgentDesignation ? (
+              <button
+                className="context-list__action"
+                disabled={agentSaving || !props.desktopApi?.setThreadAgent}
+                type="button"
+                onClick={() => void setThreadAgent(createDesktopAgentThread())}
+              >
+                Mark as Agent
+              </button>
+            ) : null}
           </div>
         )}
         {agentError ? (

--- a/apps/desktop/src/renderer/src/icons/MoreVerticalIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/MoreVerticalIcon.tsx
@@ -1,0 +1,11 @@
+import { resolveIconSvgProps, type IconProps } from "./icon-types";
+
+export function MoreVerticalIcon(props: IconProps) {
+  return (
+    <svg {...resolveIconSvgProps(props)}>
+      <circle cx="12" cy="5" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+      <circle cx="12" cy="19" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -11,6 +11,7 @@ import {
   FileCodeIcon,
   FolderIcon,
   MattermostIcon,
+  MoreVerticalIcon,
   NewThreadIcon,
   PinIcon,
   PopoutIcon,
@@ -42,6 +43,7 @@ const ALL_ICONS = [
   ["ChevronRightIcon", ChevronRightIcon],
   ["PinIcon", PinIcon],
   ["PopoutIcon", PopoutIcon],
+  ["MoreVerticalIcon", MoreVerticalIcon],
 ] as const;
 
 describe("icon library", () => {

--- a/apps/desktop/src/renderer/src/icons/index.ts
+++ b/apps/desktop/src/renderer/src/icons/index.ts
@@ -17,6 +17,7 @@ export { HelpCircleIcon } from "./HelpCircleIcon";
 export { InfoIcon } from "./InfoIcon";
 export { LightningIcon } from "./LightningIcon";
 export { MattermostIcon } from "./MattermostIcon";
+export { MoreVerticalIcon } from "./MoreVerticalIcon";
 export { LineIcon } from "./LineIcon";
 export { NewThreadIcon } from "./NewThreadIcon";
 export { PinIcon } from "./PinIcon";

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2363,6 +2363,10 @@ describe("useThreadNavigation", () => {
             directoryPath: "/Users/huntharo/github/PwrAgent",
             backend: "codex" as const,
             executionMode: "default" as const,
+            agent: {
+              name: "PwrAgent Agent",
+              instructions: "Manage PwrAgent threads.",
+            },
             prompt: "",
             workMode: "worktree" as const,
             branchName: "main",
@@ -2415,12 +2419,22 @@ describe("useThreadNavigation", () => {
       directoryKey: "directory:/Users/huntharo/github/PwrAgent",
       launchpad: expect.objectContaining({
         directoryKey: "directory:/Users/huntharo/github/PwrAgent",
+        agent: {
+          name: "PwrAgent Agent",
+          instructions: "Manage PwrAgent threads.",
+        },
       }),
       input: undefined,
       collaborationMode: undefined,
       reviewTarget: undefined,
     });
     expect(result.current.selectedThread?.id).toBe("thread-new");
+    expect(result.current.selectedThread?.title).toBe("PwrAgent Agent");
+    expect(result.current.selectedThread?.agent).toMatchObject({
+      name: "PwrAgent Agent",
+      instructionLineCount: 1,
+      instructionsTooLong: false,
+    });
     expect(result.current.selectedThread?.gitBranch).toBe("HEAD");
     expect(result.current.selectedThread?.observedGitBranch).toBe("HEAD");
     expect(result.current.directories[0]?.threadKeys).toEqual(["codex:thread-new"]);

--- a/apps/desktop/src/renderer/src/lib/agent-thread.ts
+++ b/apps/desktop/src/renderer/src/lib/agent-thread.ts
@@ -1,0 +1,30 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+
+export const DEFAULT_DESKTOP_AGENT_THREAD = {
+  name: "PwrAgent Agent",
+  instructions:
+    "You are a PwrAgent Agent thread. Use available PwrAgent tools to manage PwrAgent threads and attach them to messaging when relevant.",
+} as const;
+
+export const AGENT_THREAD_CAPABILITIES =
+  "Agent threads have elevated capabilities to manage PwrAgent threads and attach them to messaging. Ordinary threads do not.";
+
+export const CODEX_AGENT_THREAD_CREATION_NOTE =
+  "Existing Codex threads cannot be converted. Agent tools are registered only when the thread is created; create a new Agent thread instead.";
+
+export function createDesktopAgentThread(): {
+  name: string;
+  instructions: string;
+} {
+  return { ...DEFAULT_DESKTOP_AGENT_THREAD };
+}
+
+/**
+ * Codex receives its Agent tools through `thread/start`, so changing its
+ * overlay marker after startup would misrepresent what the thread can do.
+ */
+export function canChangeExistingThreadAgentDesignation(
+  thread: Pick<NavigationThreadSummary, "source">,
+): boolean {
+  return thread.source !== "codex";
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -24,6 +24,7 @@ import type {
   ThreadExecutionMode,
 } from "@pwragent/shared";
 import {
+  AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
   applyNavigationLaunchpadProviderSettingsPatch,
   buildAppendPinRank,
   buildPinnedRanks,
@@ -2092,11 +2093,16 @@ function buildOptimisticThreadFromLaunchpad(params: {
   const titlePrompt =
     params.optimisticUserMessage?.text?.trim() || params.launchpad.prompt.trim();
   const derivedTitle = shortenDerivedThreadTitle(titlePrompt);
+  const agentName = params.launchpad.agent?.name.trim();
+  const agentInstructions = params.launchpad.agent?.instructions?.trim();
+  const agentInstructionLineCount = agentInstructions
+    ? agentInstructions.split(/\r?\n/).length
+    : 0;
 
   return {
     id: params.threadId,
-    title: derivedTitle ?? "Untitled thread",
-    titleSource: derivedTitle ? "derived" : "fallback",
+    title: agentName || derivedTitle || "Untitled thread",
+    titleSource: agentName ? "explicit" : derivedTitle ? "derived" : "fallback",
     summary: titlePrompt || undefined,
     projectKey: params.launchpad.directoryPath,
     source: params.backend,
@@ -2105,6 +2111,18 @@ function buildOptimisticThreadFromLaunchpad(params: {
     reasoningEffort: params.launchpad.reasoningEffort,
     serviceTier: params.launchpad.serviceTier,
     fastMode: params.launchpad.fastMode,
+    ...(params.launchpad.agent
+      ? {
+          agent: {
+            name: params.launchpad.agent.name,
+            ...(agentInstructions ? { instructions: agentInstructions } : {}),
+            instructionLineCount: agentInstructionLineCount,
+            instructionsTooLong:
+              agentInstructionLineCount > AGENT_PERSONA_INSTRUCTIONS_LINE_GUIDANCE,
+            updatedAt: Date.now(),
+          },
+        }
+      : {}),
     parentThreadId: params.parentThreadId,
     pinnedRank: params.pinnedRank,
     acpRuntime: params.launchpad.acpRuntime,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16045,42 +16045,70 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .composer-thread-options__menu {
-  min-width: min(360px, calc(100vw - 32px));
+  right: 0;
+  left: auto;
+  min-width: min(204px, calc(100vw - 32px));
+  overflow: visible;
 }
 
 .composer-thread-options__option {
-  align-items: flex-start;
-}
-
-.composer-thread-options__copy {
-  display: flex;
-  min-width: 0;
-  flex: 1 1 auto;
-  flex-direction: column;
-  gap: 3px;
+  min-height: 34px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 10px;
 }
 
 .composer-thread-options__label {
   font-weight: 650;
 }
 
-.composer-thread-options__description,
-.composer-thread-options__note {
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 1.4;
+.composer-thread-options__toggle {
+  width: 28px;
+  height: 16px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
+  background: var(--bg-input);
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
 }
 
-.composer-thread-options__note {
-  margin-top: 3px;
-  color: var(--text-muted);
+.composer-thread-options__toggle-thumb {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition:
+    transform 120ms ease,
+    background 120ms ease;
 }
 
-.composer-thread-options__option:hover:not(:disabled)
-  .composer-thread-options__description,
-.composer-thread-options__option:focus-visible:not(:disabled)
-  .composer-thread-options__description {
-  color: inherit;
+.composer-thread-options__toggle.is-checked {
+  border-color: var(--accent-border);
+  background: var(--accent);
+}
+
+.composer-thread-options__toggle.is-checked
+  .composer-thread-options__toggle-thumb {
+  transform: translateX(12px);
+  background: var(--button-text);
+}
+
+.composer-thread-options__item.tooltip-target[data-tooltip]::after {
+  right: 0;
+  bottom: calc(100% + 8px);
+  left: auto;
+  z-index: 31;
+  transform: translateY(4px);
+}
+
+.composer-thread-options__item.tooltip-target[data-tooltip]:hover::after,
+.composer-thread-options__item.tooltip-target[data-tooltip]:focus-within::after {
+  transform: translateY(0);
 }
 
 /* ============================================================

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13280,6 +13280,10 @@ a.transcript-message__messaging-origin:focus-visible {
   margin: 3px 0 0;
 }
 
+.context-list__agent-note {
+  line-height: 1.4;
+}
+
 .context-list__label {
   display: inline-flex;
   align-items: center;
@@ -16033,6 +16037,50 @@ a.transcript-message__messaging-origin:focus-visible {
   height: 1px;
   margin: 6px 2px;
   background: var(--border-subtle);
+}
+
+.composer-thread-options {
+  position: relative;
+  display: inline-flex;
+}
+
+.composer-thread-options__menu {
+  min-width: min(360px, calc(100vw - 32px));
+}
+
+.composer-thread-options__option {
+  align-items: flex-start;
+}
+
+.composer-thread-options__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.composer-thread-options__label {
+  font-weight: 650;
+}
+
+.composer-thread-options__description,
+.composer-thread-options__note {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.composer-thread-options__note {
+  margin-top: 3px;
+  color: var(--text-muted);
+}
+
+.composer-thread-options__option:hover:not(:disabled)
+  .composer-thread-options__description,
+.composer-thread-options__option:focus-visible:not(:disabled)
+  .composer-thread-options__description {
+  color: inherit;
 }
 
 /* ============================================================

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -20,6 +20,7 @@ import type {
   DirectorySummaryKind,
   LaunchpadWorkMode,
   NavigationDirectoryGitStatus,
+  NavigationLaunchpadAgent,
   NavigationLaunchpadDraft,
   NavigationLaunchpadDefaults,
 } from "./navigation";
@@ -29,10 +30,7 @@ export type StartThreadRequest = {
   /**
    * When present, start the thread with Agent/persona metadata.
    */
-  agent?: {
-    name: string;
-    instructions?: string;
-  };
+  agent?: NavigationLaunchpadAgent;
   executionMode?: ThreadExecutionMode;
   cwd?: string;
   directoryKey?: string;
@@ -550,6 +548,7 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "codexEnvironmentActionId"
       | "directoryLabel"
       | "directoryPath"
+      | "agent"
     >
   >;
   stickySettingsChanged?: boolean;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -50,6 +50,15 @@ export type ThreadAgentMetadata = {
   updatedAt: number;
 };
 
+/**
+ * Agent metadata selected before a launchpad has materialized a thread.
+ * The overlay store normalizes this into `ThreadAgentMetadata` after start.
+ */
+export type NavigationLaunchpadAgent = Pick<
+  ThreadAgentMetadata,
+  "name" | "instructions"
+>;
+
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
   /** Automatically dispatch bounded repair turns for newly failing/conflicting attached PRs. */
@@ -555,6 +564,12 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   editorDocument?: Record<string, unknown>;
   imageAttachments?: NavigationLaunchpadImageAttachment[];
   fileAttachments?: NavigationLaunchpadFileAttachment[];
+  /**
+   * Creates the materialized thread as an Agent. This is launchpad-specific
+   * rather than a sticky provider default: ordinary threads remain the
+   * default for each new draft.
+   */
+  agent?: NavigationLaunchpadAgent;
   prompt: string;
   registeredAt?: number;
   settingsTouchedAt?: number;


### PR DESCRIPTION
## Summary

- I added a Thread options overflow menu immediately after the composer’s Add reference (`+`) button. Its Agent thread toggle persists on the current launchpad and forwards the selected Agent metadata through thread creation.
- I explain that Agent threads can manage PwrAgent threads and attach them to messaging. Existing Codex threads are read-only: their Agent capability has to be selected when the thread is created.
- I retained explicit Agent-designation controls for existing non-Codex threads and covered the composer, launchpad, context-panel, automation, and registry paths.

## Verification

- I ran the focused renderer suites (410 tests) and the complete backend-registry suite (418 tests).
- I ran `pnpm typecheck`, `pnpm lint:eslint` (0 errors; 139 existing warnings), `pnpm lint:boundaries`, `pnpm lint:colors`, and `pnpm lint:codex-storage`.

## Notes

- This work began on #1134 (`agent/new-picker-agent-flow`), which aligns `/new` and Telegram Agent creation. #1134 merged while I worked, so I rebased onto its `main` merge commit; this remains the separate desktop GUI path.
