### PR TITLE
feat(desktop): mark selected directories read

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1430,6 +1430,9 @@ function DesktopAppShell(props: {
             requestAnimationFrame(() => revealSelectedThreadInList({ instant }));
           }}
           onArchiveThread={navigation.archiveThread}
+          onMarkThreadsSeen={
+            desktopApi?.markThreadSeen ? navigation.markThreadsSeen : undefined
+          }
           onRenameThread={navigation.renameThread}
           onSetThreadReaction={navigation.setThreadReaction}
           onSetThreadPin={navigation.setThreadPin}

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -62,6 +62,7 @@ type DirectoriesListProps = {
   directories: NavigationDirectorySummary[];
   revealSelectedThreadRequest?: number;
   selectedItemKey?: string;
+  selectedDirectoryKeys?: ReadonlySet<string>;
   selectedThreadKeys?: ReadonlySet<string>;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
@@ -81,6 +82,11 @@ type DirectoriesListProps = {
   onRevealSelectedThreadComplete?: (request: number) => void;
   onSelectThread: (
     thread: NavigationThreadSummary,
+    event: MouseEvent<HTMLButtonElement>,
+    selectionOrder: string[],
+  ) => void;
+  onSelectDirectory?: (
+    directory: NavigationDirectorySummary,
     event: MouseEvent<HTMLButtonElement>,
     selectionOrder: string[],
   ) => void;
@@ -330,6 +336,13 @@ export function DirectoriesList(props: DirectoriesListProps) {
   const unpinnedDirectories = useMemo(
     () => visibleDirectories.filter((directory) => !isPinnedDirectory(directory)),
     [visibleDirectories],
+  );
+  const directorySelectionOrder = useMemo(
+    () =>
+      [...pinnedDirectories, ...unpinnedDirectories].map(
+        (directory) => directory.key,
+      ),
+    [pinnedDirectories, unpinnedDirectories],
   );
   const directoryByKey = useMemo(
     () => new Map(visibleDirectories.map((directory) => [directory.key, directory])),
@@ -610,6 +623,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
 
     const selectedLaunchpad =
       props.selectedItemKey === buildLaunchpadSelectionKey(directory.key);
+    const selectedDirectory = selectedLaunchpad || Boolean(
+      props.selectedDirectoryKeys?.has(directory.key),
+    );
     const selectedThreadInDirectory = directory.threadKeys.includes(
       props.selectedItemKey ?? ""
     );
@@ -1080,11 +1096,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
           <button
             aria-label={directorySummaryLabel}
             aria-expanded={expanded}
+            aria-pressed={selectedDirectory}
             className={`thread-row thread-row--compact directory-row__summary${
-              selectedLaunchpad ? " is-selected" : ""
+              selectedDirectory ? " is-selected" : ""
             }`}
             type="button"
-            onClick={() => {
+            onClick={(event) => {
               // Suppress the synthetic post-drop click that the
               // browser fires on the element under the mouse when
               // a drag releases. The timestamp comparison expires
@@ -1094,6 +1111,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 Date.now() - lastDirectoryDragEndedAtRef.current <
                 POST_DRAG_CLICK_SUPPRESS_MS
               ) {
+                return;
+              }
+              props.onSelectDirectory?.(
+                directory,
+                event,
+                directorySelectionOrder,
+              );
+              if (event.metaKey || event.shiftKey) {
                 return;
               }
               setExpandedByKey((current) => ({

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -130,6 +130,7 @@ type SidebarProps = {
   onOpenSettings?: () => void;
   onOpenProfile?: (profile: string) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
+  onMarkThreadsSeen?: (threads: NavigationThreadSummary[]) => Promise<void>;
   onArchiveThread?: (
     thread: NavigationThreadSummary,
     options?: ArchiveThreadOptions,
@@ -232,6 +233,10 @@ function formatThreadCount(count: number): string {
   return `${count} ${count === 1 ? "Thread" : "Threads"}`;
 }
 
+function formatDirectoryCount(count: number): string {
+  return `${count} ${count === 1 ? "Directory" : "Directories"}`;
+}
+
 function uniqueContextMenuValues(
   values: Array<string | undefined>,
 ): string[] {
@@ -246,6 +251,7 @@ export function Sidebar(props: SidebarProps) {
   const selectionAnchorKeyRef = useRef<string | undefined>(
     props.selectedItemKey,
   );
+  const directorySelectionAnchorKeyRef = useRef<string | undefined>(undefined);
   const previousSelectedItemKeyRef = useRef<string | undefined>(
     props.selectedItemKey,
   );
@@ -255,6 +261,9 @@ export function Sidebar(props: SidebarProps) {
       props.selectedItemKey
         ? new Set([props.selectedItemKey])
         : new Set<string>(),
+  );
+  const [selectedDirectoryKeys, setSelectedDirectoryKeys] = useState<Set<string>>(
+    () => new Set<string>(),
   );
   const [contextMenu, setContextMenu] = useState<
     | {
@@ -268,9 +277,9 @@ export function Sidebar(props: SidebarProps) {
   >();
   /**
    * Directory context menu — parallel to `contextMenu` (the thread
-   * context menu) but only carries a "Pin Directory" / "Unpin
-   * Directory" action today. Kept as its own state instead of
-   * polymorphizing the thread menu because the thread menu has many
+   * context menu) but carries directory-specific actions such as
+   * marking contained threads read and pinning. Kept as its own state
+   * instead of polymorphizing the thread menu because the thread menu has many
    * thread-shaped actions (Rename / Archive / Copy / Unbind) that
    * don't make sense on directories. Plan 2026-05-09-002 Unit M.
    */
@@ -279,6 +288,7 @@ export function Sidebar(props: SidebarProps) {
         requestedPosition: ThreadContextMenuPosition;
         position?: { x: number; y: number };
         directory: NavigationDirectorySummary;
+        directories: NavigationDirectorySummary[];
       }
     | undefined
   >();
@@ -352,8 +362,12 @@ export function Sidebar(props: SidebarProps) {
 
     previousSelectedItemKeyRef.current = selectedItemKey;
     selectionAnchorKeyRef.current = selectedItemKey;
+    directorySelectionAnchorKeyRef.current = undefined;
     setSelectedThreadKeys(
       selectedItemKey ? new Set([selectedItemKey]) : new Set<string>(),
+    );
+    setSelectedDirectoryKeys((current) =>
+      current.size === 0 ? current : new Set<string>(),
     );
   }, [selectedItemKey]);
 
@@ -376,6 +390,42 @@ export function Sidebar(props: SidebarProps) {
       return next.size === current.size ? current : next;
     });
   }, [navigationThreads]);
+
+  // Directory refreshes can remove summary rows while the Directories lens
+  // remains mounted. Keep the separate directory selection scoped to rows that
+  // still exist, rather than letting a later context-menu action reach a stale
+  // project key.
+  useEffect(() => {
+    const availableDirectoryKeys = new Set(
+      props.directories.map((directory) => directory.key),
+    );
+    if (
+      !availableDirectoryKeys.has(directorySelectionAnchorKeyRef.current ?? "")
+    ) {
+      directorySelectionAnchorKeyRef.current = undefined;
+    }
+    setSelectedDirectoryKeys((current) => {
+      const next = new Set(
+        [...current].filter((directoryKey) =>
+          availableDirectoryKeys.has(directoryKey),
+        ),
+      );
+      return next.size === current.size ? current : next;
+    });
+  }, [props.directories]);
+
+  // Directory selection is a local batch operation, not navigation state. Do
+  // not carry its highlighted rows into a different lens where they are no
+  // longer actionable or visible.
+  useEffect(() => {
+    if (browseMode === "directories") {
+      return;
+    }
+    directorySelectionAnchorKeyRef.current = undefined;
+    setSelectedDirectoryKeys((current) =>
+      current.size === 0 ? current : new Set<string>(),
+    );
+  }, [browseMode]);
 
   const selectThreadFromList = (
     thread: NavigationThreadSummary,
@@ -425,6 +475,58 @@ export function Sidebar(props: SidebarProps) {
         next.delete(threadKey);
       } else {
         next.add(threadKey);
+      }
+      return next;
+    });
+  };
+
+  const selectDirectoryFromList = (
+    directory: NavigationDirectorySummary,
+    event: ReactMouseEvent<HTMLButtonElement>,
+    selectionOrder: string[],
+  ): void => {
+    const directoryKey = directory.key;
+
+    if (!event.metaKey && !event.shiftKey) {
+      directorySelectionAnchorKeyRef.current = directoryKey;
+      setSelectedDirectoryKeys(new Set([directoryKey]));
+      return;
+    }
+
+    if (event.shiftKey) {
+      const anchorKey = directorySelectionAnchorKeyRef.current;
+      const anchorIndex = anchorKey ? selectionOrder.indexOf(anchorKey) : -1;
+      const targetIndex = selectionOrder.indexOf(directoryKey);
+      if (anchorIndex < 0 || targetIndex < 0) {
+        directorySelectionAnchorKeyRef.current = directoryKey;
+        setSelectedDirectoryKeys((current) => {
+          const next = event.metaKey ? new Set(current) : new Set<string>();
+          next.add(directoryKey);
+          return next;
+        });
+        return;
+      }
+
+      const rangeStart = Math.min(anchorIndex, targetIndex);
+      const rangeEnd = Math.max(anchorIndex, targetIndex);
+      const range = selectionOrder.slice(rangeStart, rangeEnd + 1);
+      setSelectedDirectoryKeys((current) => {
+        const next = event.metaKey ? new Set(current) : new Set<string>();
+        for (const key of range) {
+          next.add(key);
+        }
+        return next;
+      });
+      return;
+    }
+
+    directorySelectionAnchorKeyRef.current = directoryKey;
+    setSelectedDirectoryKeys((current) => {
+      const next = new Set(current);
+      if (next.has(directoryKey)) {
+        next.delete(directoryKey);
+      } else {
+        next.add(directoryKey);
       }
       return next;
     });
@@ -680,6 +782,22 @@ export function Sidebar(props: SidebarProps) {
     return selectedThreads.length > 0 ? selectedThreads : [thread];
   };
 
+  const resolveDirectoryContextMenuDirectories = (
+    directory: NavigationDirectorySummary,
+  ): NavigationDirectorySummary[] => {
+    if (!selectedDirectoryKeys.has(directory.key)) {
+      directorySelectionAnchorKeyRef.current = directory.key;
+      setSelectedDirectoryKeys(new Set([directory.key]));
+      return [directory];
+    }
+
+    const selectedDirectories = props.directories.filter((candidate) =>
+      selectedDirectoryKeys.has(candidate.key),
+    );
+
+    return selectedDirectories.length > 0 ? selectedDirectories : [directory];
+  };
+
   const openThreadContextMenu = (
     thread: NavigationThreadSummary,
     position: ThreadContextMenuPosition
@@ -765,7 +883,11 @@ export function Sidebar(props: SidebarProps) {
   ): void => {
     setContextMenu(undefined);
     setRenameThread(undefined);
-    setDirectoryContextMenu({ requestedPosition: position, directory });
+    setDirectoryContextMenu({
+      requestedPosition: position,
+      directory,
+      directories: resolveDirectoryContextMenuDirectories(directory),
+    });
   };
 
   const togglePinDirectoryFromContextMenu = (
@@ -780,6 +902,26 @@ export function Sidebar(props: SidebarProps) {
   ): void => {
     setDirectoryContextMenu(undefined);
     props.onRemoveDirectory?.(directory);
+  };
+
+  const markSelectedDirectoryThreadsRead = (): void => {
+    if (!directoryContextMenu) {
+      return;
+    }
+
+    const directoryThreadKeys = new Set(
+      directoryContextMenu.directories.flatMap(
+        (directory) => directory.threadKeys,
+      ),
+    );
+    const unreadThreads = props.threads.filter(
+      (thread) =>
+        directoryThreadKeys.has(
+          buildThreadIdentityKey(thread.source, thread.id),
+        ) && thread.inbox.inInbox,
+    );
+    setDirectoryContextMenu(undefined);
+    void props.onMarkThreadsSeen?.(unreadThreads);
   };
 
   /**
@@ -1091,12 +1233,43 @@ export function Sidebar(props: SidebarProps) {
     contextMenuThreads.map((thread) => thread.gitBranch),
   );
 
+  const directoryContextMenuDirectories =
+    directoryContextMenu?.directories ?? [];
+  const directoryContextMenuIsBulk =
+    directoryContextMenuDirectories.length > 1;
+  const directoryMenuThreadKeys = new Set(
+    directoryContextMenuDirectories.flatMap(
+      (directory) => directory.threadKeys,
+    ),
+  );
+  const directoryMenuUnreadThreads = props.threads.filter(
+    (thread) =>
+      directoryMenuThreadKeys.has(
+        buildThreadIdentityKey(thread.source, thread.id),
+      ) && thread.inbox.inInbox,
+  );
+  const directoryMenuCanMarkRead = Boolean(
+    props.onMarkThreadsSeen && directoryMenuUnreadThreads.length > 0,
+  );
+  const directoryMenuCanPin = Boolean(
+    !directoryContextMenuIsBulk
+      && directoryContextMenu
+      && props.onSetDirectoryPin,
+  );
+  const directoryMenuCanRemove = Boolean(
+    !directoryContextMenuIsBulk
+      && props.onRemoveDirectory
+      && directoryContextMenu?.directory.kind === "directory"
+      && directoryContextMenu.directory.threadKeys.length === 0,
+  );
+
   // Same shape as the thread context menu's "Move" items, applied
   // to the directory context menu. Directory pinning is global so
   // a single sorted array drives both adjacency checks.
   const directoryMenuShowMoveItems = Boolean(
-    directoryContextMenu?.directory.pinnedRank &&
-      props.onReorderDirectoryPins,
+    !directoryContextMenuIsBulk
+      && directoryContextMenu?.directory.pinnedRank
+      && props.onReorderDirectoryPins,
   );
   const directoryMenuPinnedIndex = directoryContextMenu
     ? pinnedDirectoryKeysInOrder.indexOf(directoryContextMenu.directory.key)
@@ -1107,6 +1280,8 @@ export function Sidebar(props: SidebarProps) {
     directoryMenuShowMoveItems &&
     directoryMenuPinnedIndex >= 0 &&
     directoryMenuPinnedIndex < pinnedDirectoryKeysInOrder.length - 1;
+  const directoryMenuHasPinActions =
+    directoryMenuCanPin || directoryMenuShowMoveItems;
 
   return (
     <aside className="sidebar" aria-label="Threads">
@@ -1299,6 +1474,7 @@ export function Sidebar(props: SidebarProps) {
               directories={props.directories}
               revealSelectedThreadRequest={directoryRevealRequest}
               selectedItemKey={props.selectedItemKey}
+              selectedDirectoryKeys={selectedDirectoryKeys}
               selectedThreadKeys={selectedThreadKeys}
               thinkingThreadKeys={props.thinkingThreadKeys}
               threads={props.threads}
@@ -1318,9 +1494,12 @@ export function Sidebar(props: SidebarProps) {
                 props.onSetDirectoryThreadsCollapsed
               }
               onOpenDirectoryContextMenu={
-                props.onSetDirectoryPin ? openDirectoryContextMenu : undefined
+                props.onSetDirectoryPin || props.onMarkThreadsSeen
+                  ? openDirectoryContextMenu
+                  : undefined
               }
               onOpenPullRequestContextMenu={openPullRequestContextMenu}
+              onSelectDirectory={selectDirectoryFromList}
               onSelectThread={selectThreadFromList}
               onSetReaction={props.onSetThreadReaction}
               onSetThreadPin={props.onSetThreadPin}
@@ -1818,6 +1997,13 @@ export function Sidebar(props: SidebarProps) {
           ref={directoryContextMenuRef}
           className="thread-context-menu"
           role="menu"
+          aria-label={
+            directoryContextMenuIsBulk
+              ? `Actions for ${formatDirectoryCount(
+                  directoryContextMenuDirectories.length,
+                ).toLowerCase()} selected`
+              : undefined
+          }
           style={{
             left:
               directoryContextMenu.position?.x ??
@@ -1829,80 +2015,97 @@ export function Sidebar(props: SidebarProps) {
           }}
           onClick={(event) => event.stopPropagation()}
         >
-          <div className="thread-context-menu__section">
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() =>
-                togglePinDirectoryFromContextMenu(directoryContextMenu.directory)
-              }
-            >
-              {directoryContextMenu.directory.pinnedRank
-                ? "Unpin Directory"
-                : "Pin Directory"}
-            </button>
-            {directoryMenuShowMoveItems ? (
-              <>
+          {directoryMenuCanMarkRead ? (
+            <div className="thread-context-menu__section">
+              <button
+                role="menuitem"
+                type="button"
+                onClick={markSelectedDirectoryThreadsRead}
+              >
+                Mark Read
+              </button>
+            </div>
+          ) : null}
+          {directoryMenuCanMarkRead && directoryMenuHasPinActions ? (
+            <div className="thread-context-menu__separator" role="separator" />
+          ) : null}
+          {directoryMenuHasPinActions ? (
+            <div className="thread-context-menu__section">
+              {directoryMenuCanPin ? (
                 <button
                   role="menuitem"
                   type="button"
-                  aria-keyshortcuts="Meta+Shift+ArrowUp"
-                  disabled={!directoryMenuCanMoveUp}
                   onClick={() =>
-                    moveDirectoryFromContextMenu(
-                      directoryContextMenu.directory,
-                      "up",
-                    )
+                    togglePinDirectoryFromContextMenu(directoryContextMenu.directory)
                   }
                 >
-                  <span>Move Up</span>
-                  <span
-                    className="thread-context-menu__shortcut"
-                    aria-hidden="true"
+                  {directoryContextMenu.directory.pinnedRank
+                    ? "Unpin Directory"
+                    : "Pin Directory"}
+                </button>
+              ) : null}
+              {directoryMenuShowMoveItems ? (
+                <>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    aria-keyshortcuts="Meta+Shift+ArrowUp"
+                    disabled={!directoryMenuCanMoveUp}
+                    onClick={() =>
+                      moveDirectoryFromContextMenu(
+                        directoryContextMenu.directory,
+                        "up",
+                      )
+                    }
                   >
-                    {"⌘⇧↑"}
-                  </span>
-                </button>
-                <button
-                  role="menuitem"
-                  type="button"
-                  aria-keyshortcuts="Meta+Shift+ArrowDown"
-                  disabled={!directoryMenuCanMoveDown}
-                  onClick={() =>
-                    moveDirectoryFromContextMenu(
-                      directoryContextMenu.directory,
-                      "down",
-                    )
-                  }
-                >
-                  <span>Move Down</span>
-                  <span
-                    className="thread-context-menu__shortcut"
-                    aria-hidden="true"
+                    <span>Move Up</span>
+                    <span
+                      className="thread-context-menu__shortcut"
+                      aria-hidden="true"
+                    >
+                      {"⌘⇧↑"}
+                    </span>
+                  </button>
+                  <button
+                    role="menuitem"
+                    type="button"
+                    aria-keyshortcuts="Meta+Shift+ArrowDown"
+                    disabled={!directoryMenuCanMoveDown}
+                    onClick={() =>
+                      moveDirectoryFromContextMenu(
+                        directoryContextMenu.directory,
+                        "down",
+                      )
+                    }
                   >
-                    {"⌘⇧↓"}
-                  </span>
-                </button>
-              </>
-            ) : null}
-          </div>
-          {props.onRemoveDirectory
-            && directoryContextMenu.directory.kind === "directory"
-            && directoryContextMenu.directory.threadKeys.length === 0 ? (
-            <>
-              <div className="thread-context-menu__separator" role="separator" />
-              <div className="thread-context-menu__section">
-                <button
-                  role="menuitem"
-                  type="button"
-                  onClick={() =>
-                    removeDirectoryFromContextMenu(directoryContextMenu.directory)
-                  }
-                >
-                  Remove Directory
-                </button>
-              </div>
-            </>
+                    <span>Move Down</span>
+                    <span
+                      className="thread-context-menu__shortcut"
+                      aria-hidden="true"
+                    >
+                      {"⌘⇧↓"}
+                    </span>
+                  </button>
+                </>
+              ) : null}
+            </div>
+          ) : null}
+          {directoryMenuCanRemove
+            && (directoryMenuCanMarkRead || directoryMenuHasPinActions) ? (
+            <div className="thread-context-menu__separator" role="separator" />
+          ) : null}
+          {directoryMenuCanRemove ? (
+            <div className="thread-context-menu__section">
+              <button
+                role="menuitem"
+                type="button"
+                onClick={() =>
+                  removeDirectoryFromContextMenu(directoryContextMenu.directory)
+                }
+              >
+                Remove Directory
+              </button>
+            </div>
           ) : null}
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2254,6 +2254,140 @@ describe("Sidebar", () => {
     expect(secondButton).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("marks unread threads read across a Shift-selected range of collapsed directories", () => {
+    const onMarkThreadsSeen = vi.fn(async () => undefined);
+    const onSetDirectoryPin = vi.fn(async () => undefined);
+    const firstThread = {
+      ...sharedThread,
+      id: "thread-directory-first",
+      title: "Directory first unread thread",
+    };
+    const sharedUnreadThread = {
+      ...sharedThread,
+      id: "thread-directory-shared",
+      title: "Shared unread thread",
+    };
+    const lastThread = {
+      ...sharedThread,
+      id: "thread-directory-last",
+      title: "Directory last unread thread",
+    };
+    const alreadyReadThread = {
+      ...sharedThread,
+      id: "thread-directory-read",
+      title: "Already read thread",
+      inbox: {
+        inInbox: false,
+      },
+    };
+    const firstDirectory: NavigationDirectorySummary = {
+      key: "directory:/tmp/directory-first",
+      kind: "directory",
+      label: "Directory first",
+      path: "/tmp/directory-first",
+      threadKeys: [
+        `codex:${firstThread.id}`,
+        `codex:${sharedUnreadThread.id}`,
+      ],
+      needsAttentionCount: 2,
+      latestUpdatedAt: firstThread.updatedAt,
+    };
+    const middleDirectory: NavigationDirectorySummary = {
+      key: "directory:/tmp/directory-middle",
+      kind: "directory",
+      label: "Directory middle",
+      path: "/tmp/directory-middle",
+      threadKeys: [
+        `codex:${sharedUnreadThread.id}`,
+        `codex:${lastThread.id}`,
+      ],
+      needsAttentionCount: 2,
+      latestUpdatedAt: sharedUnreadThread.updatedAt,
+    };
+    const lastDirectory: NavigationDirectorySummary = {
+      key: "directory:/tmp/directory-last",
+      kind: "directory",
+      label: "Directory last",
+      path: "/tmp/directory-last",
+      threadKeys: [`codex:${alreadyReadThread.id}`],
+      needsAttentionCount: 0,
+      latestUpdatedAt: alreadyReadThread.updatedAt,
+    };
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        directories={[firstDirectory, middleDirectory, lastDirectory]}
+        inboxThreads={[
+          firstThread,
+          sharedUnreadThread,
+          lastThread,
+          alreadyReadThread,
+        ]}
+        loading={false}
+        threads={[
+          firstThread,
+          sharedUnreadThread,
+          lastThread,
+          alreadyReadThread,
+        ]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onMarkThreadsSeen={onMarkThreadsSeen}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onSetDirectoryPin={onSetDirectoryPin}
+      />,
+    );
+
+    const getDirectorySummary = (name: string): HTMLElement => {
+      const summary = screen
+        .getAllByRole("button", { name })
+        .find((button) => button.hasAttribute("aria-expanded"));
+      if (!summary) {
+        throw new Error(`Could not find ${name} directory summary`);
+      }
+      return summary;
+    };
+    const firstSummary = getDirectorySummary(
+      "Directory first, 2 threads to review",
+    );
+    const middleSummary = getDirectorySummary(
+      "Directory middle, 2 threads to review",
+    );
+    const lastSummary = getDirectorySummary("Directory last");
+
+    // Modified clicks leave the collapsed directory list stable while building
+    // a range. The shared thread appears in two selected directories but must
+    // be passed to the bulk action only once.
+    fireEvent.click(firstSummary, { metaKey: true });
+    fireEvent.click(lastSummary, { shiftKey: true });
+
+    expect(firstSummary).toHaveAttribute("aria-expanded", "false");
+    expect(middleSummary).toHaveAttribute("aria-expanded", "false");
+    expect(lastSummary).toHaveAttribute("aria-expanded", "false");
+    expect(firstSummary).toHaveAttribute("aria-pressed", "true");
+    expect(middleSummary).toHaveAttribute("aria-pressed", "true");
+    expect(lastSummary).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.contextMenu(middleSummary, { clientX: 48, clientY: 64 });
+    const menu = screen.getByRole("menu", {
+      name: "Actions for 3 directories selected",
+    });
+    expect(
+      within(menu).queryByRole("menuitem", { name: "Pin Directory" }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Mark Read" }));
+
+    expect(onMarkThreadsSeen).toHaveBeenCalledWith([
+      firstThread,
+      sharedUnreadThread,
+      lastThread,
+    ]);
+    expect(onSetDirectoryPin).not.toHaveBeenCalled();
+  });
+
   it("separates pinning, creation, management, and copy thread actions", () => {
     const forkBackends = backends.map((backend) =>
       backend.kind === "codex"

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -270,6 +270,138 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("marks each unread thread in a selected directory batch seen once", async () => {
+    const markThreadSeen = vi.fn(async (
+      request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0],
+    ) => ({
+      backend: request.backend ?? "codex",
+      threadId: request.threadId,
+      seenAt: Date.now(),
+      seenUpdatedAt: request.seenUpdatedAt,
+    }));
+    const firstThread = {
+      id: "thread-directory-first",
+      title: "First unread thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [],
+      inbox: {
+        inInbox: true,
+        reason: "new-thread" as const,
+      },
+      updatedAt: 1_000,
+    };
+    const sharedThread = {
+      ...firstThread,
+      id: "thread-directory-shared",
+      title: "Shared unread thread",
+      updatedAt: 2_000,
+    };
+    const lastThread = {
+      ...firstThread,
+      id: "thread-directory-last",
+      title: "Last unread thread",
+      updatedAt: 3_000,
+    };
+    const alreadyReadThread = {
+      ...firstThread,
+      id: "thread-directory-read",
+      title: "Already read thread",
+      inbox: {
+        inInbox: false,
+      },
+      updatedAt: 4_000,
+    };
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [
+        `codex:${firstThread.id}`,
+        `codex:${sharedThread.id}`,
+        `codex:${lastThread.id}`,
+      ],
+      threads: [firstThread, sharedThread, lastThread, alreadyReadThread],
+      directories: [
+        {
+          key: "directory:/tmp/first",
+          kind: "directory" as const,
+          label: "First directory",
+          path: "/tmp/first",
+          threadKeys: [
+            `codex:${firstThread.id}`,
+            `codex:${sharedThread.id}`,
+          ],
+          needsAttentionCount: 2,
+        },
+        {
+          key: "directory:/tmp/last",
+          kind: "directory" as const,
+          label: "Last directory",
+          path: "/tmp/last",
+          threadKeys: [
+            `codex:${sharedThread.id}`,
+            `codex:${lastThread.id}`,
+            `codex:${alreadyReadThread.id}`,
+          ],
+          needsAttentionCount: 2,
+        },
+      ],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(4);
+    });
+
+    await act(async () => {
+      await result.current.markThreadsSeen([
+        result.current.threads[0]!,
+        result.current.threads[1]!,
+        result.current.threads[1]!,
+        result.current.threads[2]!,
+        result.current.threads[3]!,
+      ]);
+    });
+
+    expect(markThreadSeen).toHaveBeenCalledTimes(3);
+    expect(markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: firstThread.id,
+      seenUpdatedAt: firstThread.updatedAt,
+    });
+    expect(markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: sharedThread.id,
+      seenUpdatedAt: sharedThread.updatedAt,
+    });
+    expect(markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: lastThread.id,
+      seenUpdatedAt: lastThread.updatedAt,
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.threads.map((thread) => thread.inbox.inInbox),
+      ).toEqual([false, false, false, false]);
+      expect(result.current.snapshot?.inboxThreadKeys).toEqual([]);
+      expect(
+        result.current.directories.map((directory) => directory.needsAttentionCount),
+      ).toEqual([0, 0]);
+    });
+  });
+
   it("refreshes selected thread directory git status on demand", async () => {
     const refreshDirectoryGitStatuses = vi.fn(async () => ({ scheduledCount: 1 }));
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1215,38 +1215,47 @@ function updateDirectoryThreadsCollapsedInSnapshot(
   return changed ? { ...snapshot, directories } : snapshot;
 }
 
-function markThreadSeenInSnapshot(
+function markThreadsSeenInSnapshot(
   snapshot: NavigationSnapshot | undefined,
-  params: {
+  params: Array<{
     backend: AppServerBackendKind;
     threadId: string;
     seenUpdatedAt?: number;
-  }
+  }>,
 ): NavigationSnapshot | undefined {
-  if (!snapshot) {
+  if (!snapshot || params.length === 0) {
     return snapshot;
   }
 
-  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  const seenUpdatedAtByThreadKey = new Map(
+    params.map((entry) => [
+      buildThreadIdentityKey(entry.backend, entry.threadId),
+      entry.seenUpdatedAt,
+    ]),
+  );
+  const markedThreadKeys = new Set<string>();
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
-    if (buildThreadIdentityKey(thread.source, thread.id) !== threadKey) {
+    const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+    if (!seenUpdatedAtByThreadKey.has(threadKey)) {
       return thread;
     }
+    const seenUpdatedAt = seenUpdatedAtByThreadKey.get(threadKey);
 
     if (
-      params.seenUpdatedAt !== undefined &&
+      seenUpdatedAt !== undefined &&
       thread.updatedAt !== undefined &&
-      thread.updatedAt > params.seenUpdatedAt
+      thread.updatedAt > seenUpdatedAt
     ) {
       return thread;
     }
 
-    if (!thread.inbox.inInbox && thread.inbox.lastSeenUpdatedAt === params.seenUpdatedAt) {
+    if (!thread.inbox.inInbox && thread.inbox.lastSeenUpdatedAt === seenUpdatedAt) {
       return thread;
     }
 
     changed = true;
+    markedThreadKeys.add(threadKey);
     return {
       ...thread,
       inbox: {
@@ -1254,7 +1263,7 @@ function markThreadSeenInSnapshot(
         inInbox: false,
         reason: undefined,
         lastSeenAt: Date.now(),
-        lastSeenUpdatedAt: params.seenUpdatedAt,
+        lastSeenUpdatedAt: seenUpdatedAt,
       },
     };
   });
@@ -1280,9 +1289,22 @@ function markThreadSeenInSnapshot(
         0
       ),
     })),
-    inboxThreadKeys: snapshot.inboxThreadKeys.filter((candidate) => candidate !== threadKey),
+    inboxThreadKeys: snapshot.inboxThreadKeys.filter(
+      (candidate) => !markedThreadKeys.has(candidate),
+    ),
     threads,
   };
+}
+
+function markThreadSeenInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    seenUpdatedAt?: number;
+  },
+): NavigationSnapshot | undefined {
+  return markThreadsSeenInSnapshot(snapshot, [params]);
 }
 
 function removeThreadFromSnapshot(
@@ -2385,6 +2407,7 @@ export function useThreadNavigation(
   ) => Promise<void>;
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
+  markThreadsSeen: (threads: NavigationThreadSummary[]) => Promise<void>;
   showThread: (params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -3975,6 +3998,83 @@ export function useThreadNavigation(
       setRetainedUnreadThread(thread);
     }
   }, [refreshThreadDirectoryGitStatuses, releaseRetainedUnreadThread]);
+
+  const markThreadsSeen = useCallback(
+    async (candidateThreads: NavigationThreadSummary[]): Promise<void> => {
+      if (!markThreadSeen) {
+        return;
+      }
+
+      const unreadThreadsByKey = new Map<string, NavigationThreadSummary>();
+      for (const thread of candidateThreads) {
+        if (!thread.inbox.inInbox) {
+          continue;
+        }
+        unreadThreadsByKey.set(
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread,
+        );
+      }
+      const unreadThreads = [...unreadThreadsByKey.values()];
+      if (unreadThreads.length === 0) {
+        return;
+      }
+
+      for (const thread of unreadThreads) {
+        submittedSeenUpdatedAtByThreadKeyRef.current.set(
+          buildThreadIdentityKey(thread.source, thread.id),
+          thread.updatedAt,
+        );
+      }
+
+      const results = await Promise.allSettled(
+        unreadThreads.map(async (thread) => {
+          await markThreadSeen({
+            backend: thread.source,
+            threadId: thread.id,
+            seenUpdatedAt: thread.updatedAt,
+          });
+          return thread;
+        }),
+      );
+      const markedThreads = results.flatMap((result) =>
+        result.status === "fulfilled" ? [result.value] : [],
+      );
+      if (!mountedRef.current || markedThreads.length === 0) {
+        return;
+      }
+
+      const markedThreadKeys = new Set(
+        markedThreads.map((thread) =>
+          buildThreadIdentityKey(thread.source, thread.id),
+        ),
+      );
+      const seenThreads = markedThreads.map((thread) => ({
+        backend: thread.source,
+        threadId: thread.id,
+        seenUpdatedAt: thread.updatedAt,
+      }));
+      setState((current) => ({
+        ...current,
+        response: markThreadsSeenInSnapshot(current.response, seenThreads),
+      }));
+      setRetainedUnreadThread((current) => {
+        if (
+          current
+          && markedThreadKeys.has(
+            buildThreadIdentityKey(current.source, current.id),
+          )
+        ) {
+          return undefined;
+        }
+        return current;
+      });
+      setPendingSeenThreadKey((current) =>
+        current && markedThreadKeys.has(current) ? undefined : current,
+      );
+    },
+    [markThreadSeen],
+  );
 
   const showThread = useCallback(
     async (params: {
@@ -6205,6 +6305,7 @@ export function useThreadNavigation(
     updateDirectoryLaunchpad,
     setBrowseMode: updateBrowseMode,
     selectThread,
+    markThreadsSeen,
     showThread,
     archiveThread,
     archiveWorktree,


### PR DESCRIPTION
## Summary

- I added Cmd-click, Shift-click, and Cmd+Shift-click selection for directory summaries without expanding modified rows.
- I added a selection-aware Mark Read action that marks each unread thread from the selected directories read once, including threads linked to more than one selected directory.
- I kept single-directory pin, reorder, and remove controls out of the group menu so it contains only actions that apply to the selected directories.

## Verification

- pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
- pnpm --filter @pwragent/desktop typecheck
- pnpm lint:eslint (0 errors; existing warnings only)
- pnpm lint:boundaries
- git diff --check

## Notes

- I based this branch on origin/main.
