### PR TITLE
fix(desktop): restore PR monitor control

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -24,6 +24,14 @@ const mockAppServerLog = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
+const resolveGitHubRepoForDirectory = vi.hoisted(() =>
+  vi.fn(
+    async (): Promise<
+      { host: string; owner: string; repo: string } | undefined
+    > => undefined,
+  ),
+);
+
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const listThreads = vi.fn(async (request?: {
   archived?: boolean;
@@ -580,6 +588,16 @@ vi.mock("../pr-status/pr-detection", () => ({
   detectPullRequestsForThread,
 }));
 
+vi.mock("../pr-status/git-remote", async () => {
+  const actual = await vi.importActual<typeof import("../pr-status/git-remote")>(
+    "../pr-status/git-remote",
+  );
+  return {
+    ...actual,
+    resolveGitHubRepoForDirectory,
+  };
+});
+
 describe("app server ipc", () => {
   beforeEach(() => {
     handlers.clear();
@@ -655,6 +673,8 @@ describe("app server ipc", () => {
     fetchPullRequestByUrl.mockResolvedValue(undefined);
     detectPullRequestsForThread.mockReset();
     detectPullRequestsForThread.mockResolvedValue([]);
+    resolveGitHubRepoForDirectory.mockReset();
+    resolveGitHubRepoForDirectory.mockResolvedValue(undefined);
     mockAppServerLog.debug.mockClear();
     mockAppServerLog.error.mockClear();
     mockAppServerLog.info.mockClear();
@@ -867,6 +887,48 @@ describe("app server ipc", () => {
         backend: "codex",
         executionMode: "default",
       },
+    });
+  });
+
+  it("publishes the primary repository resolved from a worktree to the composer", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const thread = {
+      id: "thread-1",
+      title: "Clipboard fallback",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [
+        {
+          id: "directory:/repo/PwrAgent",
+          kind: "worktree" as const,
+          label: "PwrAgent",
+          path: "/repo/PwrAgent",
+          worktreePath: "/repo/.worktrees/clipboard-fallback",
+        },
+      ],
+      updatedAt: 2000,
+    };
+    listThreads.mockResolvedValueOnce([thread] as never);
+    resolveGitHubRepoForDirectory.mockResolvedValueOnce({
+      host: "github.com",
+      owner: "pwrdrvr",
+      repo: "PwrAgent",
+    });
+
+    registerAppServerIpcHandlers();
+    const response = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(resolveGitHubRepoForDirectory).toHaveBeenCalledWith(
+      "/repo/.worktrees/clipboard-fallback",
+    );
+    expect(response).toMatchObject({
+      threads: [
+        {
+          id: "thread-1",
+          primaryGitRepository: "github.com/pwrdrvr/pwragent",
+        },
+      ],
     });
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -932,6 +932,83 @@ describe("app server ipc", () => {
     });
   });
 
+  it("invalidates unchanged snapshots when primary repository resolution recovers", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    const thread = {
+      id: "thread-1",
+      title: "Clipboard fallback",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [
+        {
+          id: "directory:/repo/PwrAgent",
+          kind: "worktree" as const,
+          label: "PwrAgent",
+          path: "/repo/PwrAgent",
+          worktreePath: "/repo/.worktrees/clipboard-fallback",
+        },
+      ],
+      updatedAt: 2_000,
+    };
+    const snapshot = (fetchedAt: number, unchanged: boolean) => ({
+      backend: "all" as const,
+      fetchedAt,
+      unchanged,
+      threads: [thread],
+      inboxThreadKeys: ["codex:thread-1"],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    });
+    listThreads
+      .mockResolvedValueOnce([thread] as never)
+      .mockResolvedValueOnce([thread] as never)
+      .mockResolvedValueOnce([thread] as never);
+    reconcileNavigationSnapshot
+      .mockResolvedValueOnce(snapshot(1_234, false))
+      .mockResolvedValueOnce(snapshot(5_678, true))
+      .mockResolvedValueOnce(snapshot(9_012, true));
+    resolveGitHubRepoForDirectory
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        host: "github.com",
+        owner: "pwrdrvr",
+        repo: "PwrAgent",
+      })
+      .mockResolvedValueOnce({
+        host: "github.com",
+        owner: "pwrdrvr",
+        repo: "PwrAgent",
+      });
+
+    registerAppServerIpcHandlers();
+    const first = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    const recovered = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    const stable = await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+
+    expect(first).toMatchObject({
+      unchanged: false,
+      threads: [{ id: "thread-1" }],
+    });
+    expect(recovered).toMatchObject({
+      unchanged: false,
+      threads: [{
+        id: "thread-1",
+        primaryGitRepository: "github.com/pwrdrvr/pwragent",
+      }],
+    });
+    expect(stable).toMatchObject({
+      unchanged: true,
+      threads: [{
+        id: "thread-1",
+        primaryGitRepository: "github.com/pwrdrvr/pwragent",
+      }],
+    });
+  });
+
   it("uses one active recent page for lightweight navigation refreshes", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -936,6 +936,14 @@ class DesktopAppServerService {
       prs: PrSummary[];
     }
   >();
+  /**
+   * This enrichment follows overlay snapshot hashing, so retain the last value
+   * sent to the renderer and invalidate when repository resolution changes.
+   */
+  private readonly publishedPrimaryGitRepositoriesByThreadKey = new Map<
+    string,
+    string | undefined
+  >();
   private prDiscoveryTimer: NodeJS.Timeout | undefined;
   /** Per-thread last discovery branch-lookup time, driving the slow rotation. */
   private readonly prDiscoveryLastRefreshedAt = new Map<string, number>();
@@ -1350,11 +1358,18 @@ class DesktopAppServerService {
     await this.loadPrLookupRegistry();
     this.seedPrStatusRegistryFromThreads(snapshot.threads);
     const canonicalSnapshot = this.applyCanonicalPrStatuses(snapshot.threads);
+    const replaceThreadPrAttachments =
+      backend === "all" && !request.filter?.trim() && !activeRecentRefresh;
     await this.rememberThreadPrAttachments(canonicalSnapshot.threads, {
-      replace: backend === "all" && !request.filter?.trim() && !activeRecentRefresh,
+      replace: replaceThreadPrAttachments,
     });
     const threadsWithPrimaryGitRepositories =
       this.applyPrimaryGitRepositories(canonicalSnapshot.threads);
+    const primaryGitRepositoriesChanged =
+      this.rememberPublishedPrimaryGitRepositories(
+        threadsWithPrimaryGitRepositories,
+        { replace: replaceThreadPrAttachments },
+      );
     void this.getPrAutoDispatchCoordinator().resume();
     await this.loadDirectoryGitStatusCache();
     for (const directory of snapshot.directories) {
@@ -1405,7 +1420,10 @@ class DesktopAppServerService {
       threads: threadsWithWorkingState,
       directories,
       unchanged:
-        snapshot.unchanged && directoriesUnchanged && !canonicalSnapshot.changed,
+        snapshot.unchanged
+        && directoriesUnchanged
+        && !canonicalSnapshot.changed
+        && !primaryGitRepositoriesChanged,
     };
   }
 
@@ -1579,6 +1597,39 @@ class DesktopAppServerService {
         ? { ...thread, primaryGitRepository }
         : thread;
     });
+  }
+
+  private rememberPublishedPrimaryGitRepositories(
+    threads: NavigationSnapshot["threads"],
+    options: { replace: boolean },
+  ): boolean {
+    const liveThreadKeys = new Set<string>();
+    let changed = false;
+    for (const thread of threads) {
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const primaryGitRepository = thread.primaryGitRepository;
+      liveThreadKeys.add(threadKey);
+      if (
+        !this.publishedPrimaryGitRepositoriesByThreadKey.has(threadKey)
+        || this.publishedPrimaryGitRepositoriesByThreadKey.get(threadKey) !==
+          primaryGitRepository
+      ) {
+        changed = true;
+        this.publishedPrimaryGitRepositoriesByThreadKey.set(
+          threadKey,
+          primaryGitRepository,
+        );
+      }
+    }
+    if (options.replace) {
+      for (const threadKey of this.publishedPrimaryGitRepositoriesByThreadKey.keys()) {
+        if (!liveThreadKeys.has(threadKey)) {
+          changed = true;
+          this.publishedPrimaryGitRepositoriesByThreadKey.delete(threadKey);
+        }
+      }
+    }
+    return changed;
   }
 
   private async syncThreadPrAutoDispatchCandidates(params: {
@@ -5015,6 +5066,7 @@ class DesktopAppServerService {
     this.prAutoDispatchCoordinator = undefined;
     this.prStatusWatchCoordinator = undefined;
     this.attachedPrsByThreadKey.clear();
+    this.publishedPrimaryGitRepositoriesByThreadKey.clear();
     this.pendingNavigationSnapshots.clear();
     this.pendingThreadPullRequestRefreshes.clear();
     this.pendingEditCommitResolves.clear();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1353,6 +1353,8 @@ class DesktopAppServerService {
     await this.rememberThreadPrAttachments(canonicalSnapshot.threads, {
       replace: backend === "all" && !request.filter?.trim() && !activeRecentRefresh,
     });
+    const threadsWithPrimaryGitRepositories =
+      this.applyPrimaryGitRepositories(canonicalSnapshot.threads);
     void this.getPrAutoDispatchCoordinator().resume();
     await this.loadDirectoryGitStatusCache();
     for (const directory of snapshot.directories) {
@@ -1389,9 +1391,10 @@ class DesktopAppServerService {
       canonicalSnapshot.threads,
       detachedPrsByThreadKey,
     );
-    const threadsWithWorkingState = canonicalSnapshot.threads.map((thread) =>
-      this.applyCachedWorktreeWorkingState(thread),
-    );
+    const threadsWithWorkingState =
+      threadsWithPrimaryGitRepositories.map((thread) =>
+        this.applyCachedWorktreeWorkingState(thread),
+      );
     this.startWorktreeWorkingStateRefresh({
       automatic: true,
       worktreePaths: this.collectThreadWorktreePaths(canonicalSnapshot.threads),
@@ -1563,6 +1566,19 @@ class DesktopAppServerService {
       },
     );
     await this.syncThreadPrAutoDispatchCandidates(params);
+  }
+
+  private applyPrimaryGitRepositories(
+    threads: NavigationSnapshot["threads"],
+  ): NavigationSnapshot["threads"] {
+    return threads.map((thread) => {
+      const primaryGitRepository = this.attachedPrsByThreadKey.get(
+        buildThreadIdentityKey(thread.source, thread.id),
+      )?.primaryRepoKey;
+      return primaryGitRepository
+        ? { ...thread, primaryGitRepository }
+        : thread;
+    });
   }
 
   private async syncThreadPrAutoDispatchCandidates(params: {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6888,7 +6888,7 @@ export function Composer(props: ComposerProps) {
   );
   const threadWorkspace = props.thread ? getThreadWorkspace(props.thread) : undefined;
   const showPrAutoDispatchToggle = Boolean(
-    normalizeGitOriginUrl(props.thread?.gitOriginUrl),
+    props.thread && getPrimaryWorkspaceRepository(props.thread),
   );
   const hasAttachedPullRequest = props.thread
     ? hasPrimaryWorkspacePullRequest(props.thread)
@@ -9982,11 +9982,20 @@ function getThreadWorkspace(thread: NavigationThreadSummary): ThreadWorkspace | 
 function hasPrimaryWorkspacePullRequest(
   thread: NavigationThreadSummary,
 ): boolean {
-  const primaryRepository = normalizeGitOriginUrl(thread.gitOriginUrl);
+  const primaryRepository = getPrimaryWorkspaceRepository(thread);
   if (!primaryRepository) return false;
   return (thread.prs ?? []).some((pr) =>
     normalizeGitOriginUrl(`${pr.provider}/${pr.org}/${pr.repo}`)
       === primaryRepository,
+  );
+}
+
+function getPrimaryWorkspaceRepository(
+  thread: NavigationThreadSummary,
+): string | undefined {
+  return (
+    normalizeGitOriginUrl(thread.primaryGitRepository)
+    ?? normalizeGitOriginUrl(thread.gitOriginUrl)
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -624,6 +624,48 @@ describe("Composer", () => {
     );
   });
 
+  it("shows Auto-fix PR when main resolved the primary repository for a worktree", () => {
+    render(
+      <Composer
+        backgroundPrPollingEnabled
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Fix CI",
+          titleSource: "explicit",
+          source: "codex",
+          primaryGitRepository: "github.com/pwrdrvr/pwragent",
+          linkedDirectories: [
+            {
+              id: "directory-1",
+              kind: "worktree",
+              label: "PwrAgent",
+              path: "/repo/PwrAgent",
+              worktreePath: "/repo/.worktrees/fix-ci",
+            },
+          ],
+          inbox: { inInbox: false },
+          prs: [
+            {
+              provider: "github.com",
+              number: 1128,
+              org: "pwrdrvr",
+              repo: "PwrAgent",
+              state: "passing",
+              url: "https://github.com/pwrdrvr/PwrAgent/pull/1128",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toHaveAttribute(
+      "data-tooltip",
+      "Auto-fix PR — handle new CI failures or merge conflicts",
+    );
+  });
+
   it("treats PRs from secondary linked repositories as informational", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7284,6 +7284,54 @@ describe("useThreadNavigation", () => {
     expect(getNavigationSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles a primary workspace repository resolved after an earlier refresh", async () => {
+    const snapshotState: { primaryGitRepository?: string } = {};
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-1"],
+      threads: [{
+        id: "thread-1",
+        title: "First thread",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        linkedDirectories: [],
+        ...(snapshotState.primaryGitRepository
+          ? { primaryGitRepository: snapshotState.primaryGitRepository }
+          : {}),
+        inbox: { inInbox: true, reason: "new-thread" as const },
+        // Remote resolution can change without the app-server thread record.
+        updatedAt: 1_000,
+      }],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.id).toBe("thread-1");
+    });
+    expect(result.current.selectedThread?.primaryGitRepository).toBeUndefined();
+
+    snapshotState.primaryGitRepository = "github.com/pwrdrvr/pwragent";
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.selectedThread?.primaryGitRepository).toBe(
+      "github.com/pwrdrvr/pwragent",
+    );
+  });
+
   it("preserves the current thread model when patching non-model settings", async () => {
     const getNavigationSnapshot = vi.fn(async () => ({
       backend: "all" as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -703,6 +703,7 @@ function threadSummariesEqual(
     left.threadStatus === right.threadStatus &&
     left.gitBranch === right.gitBranch &&
     left.observedGitBranch === right.observedGitBranch &&
+    left.primaryGitRepository === right.primaryGitRepository &&
     // Working state is probed on its own cadence (background refresh +
     // post-turn invalidation), independent of `updatedAt` — like PRs and
     // messaging bindings below. Without this check the reconciler would

--- a/packages/agent-core/src/__tests__/navigation-state.test.ts
+++ b/packages/agent-core/src/__tests__/navigation-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type {
   AppServerThreadSummary,
   AutomationThreadSummary,
+  NavigationThreadSummary,
   PrSummary,
 } from "@pwragent/shared";
 
@@ -111,6 +112,31 @@ describe("navigation execution mode authority", () => {
     });
 
     expect(thread?.executionMode).toBe("default");
+  });
+});
+
+describe("navigation primary repository", () => {
+  it("includes the primary workspace repository in the snapshot hash", () => {
+    const threadWithoutPrimaryRepository: NavigationThreadSummary = {
+      ...buildThread(),
+      inbox: { inInbox: false },
+    };
+    const threadWithPrimaryRepository: NavigationThreadSummary = {
+      ...threadWithoutPrimaryRepository,
+      primaryGitRepository: "github.com/pwrdrvr/pwragent",
+    };
+
+    expect(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithoutPrimaryRepository],
+      }),
+    ).not.toBe(
+      buildNavigationSnapshotHash({
+        backend: "codex",
+        threads: [threadWithPrimaryRepository],
+      }),
+    );
   });
 });
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -52,6 +52,11 @@ export type ThreadAgentMetadata = {
 
 export type NavigationThreadSummary = AppServerThreadSummary & {
   inbox: ThreadInboxState;
+  /**
+   * Normalized host/owner/repository identity resolved from the thread's
+   * primary workspace by the desktop main process.
+   */
+  primaryGitRepository?: string;
   /** Automatically dispatch bounded repair turns for newly failing/conflicting attached PRs. */
   prAutoDispatchEnabled?: boolean;
   /** Durable, cancellable PR repair waiting for its main-process send time. */

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -347,6 +347,7 @@ export function buildNavigationSnapshotHash(params: {
       updatedAt: thread.updatedAt ?? null,
       gitBranch: thread.gitBranch ?? null,
       gitOriginUrl: thread.gitOriginUrl ?? null,
+      primaryGitRepository: thread.primaryGitRepository ?? null,
       observedGitBranch: thread.observedGitBranch ?? null,
       retainedBranchDriftPairs: (thread.retainedBranchDriftPairs ?? []).map((pair) => ({
         expectedBranch: pair.expectedBranch,


### PR DESCRIPTION
## Summary

- restore the Auto-fix PR / CI-monitor composer control for Git worktrees whose Codex thread summary omits `gitOriginUrl`
- publish the main process's authoritative primary GitHub repository resolution in the navigation snapshot
- use that resolved repository for composer visibility and attached-PR matching
- keep fallback non-Git local directories hidden

## Root cause

The main process already resolves a GitHub repository from the primary worktree path for polling and dispatch. The renderer separately required the raw `gitOriginUrl` supplied by Codex. Many live worktree threads omit that raw field, so the composer hid the control even while the PR refresh log showed a successfully monitored attached PR.

## Validation

- regression test added first: failed before the fix because the control was absent
- focused composer Vitest: 225 tests passed
- focused app-server IPC Vitest: 72 tests passed
- full Vitest workspace: 405 files passed, 1 skipped; 5,504 tests passed, 3 skipped
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:sql`
- `pnpm lint:codex-storage`
- `git diff --check`
