### PR TITLE
feat(messaging): separate working update defaults

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -112,6 +112,10 @@ describe("DesktopSettingsService", () => {
       value: "show_more",
       source: "config",
     });
+    expect(snapshot.messaging.managerToolUpdateMode).toEqual({
+      value: "show_none",
+      source: "default",
+    });
     expect(snapshot.messaging.showStreamingOption).toEqual({
       value: true,
       source: "config",
@@ -767,6 +771,7 @@ describe("DesktopSettingsService", () => {
     await service.writeConfigPatch({
       messaging: {
         toolUpdateMode: "show_all",
+        managerToolUpdateMode: "show_more",
         showStreamingOption: true,
       },
     });
@@ -777,6 +782,7 @@ describe("DesktopSettingsService", () => {
     );
     expect(contents).toContain('chat_reply_composer = "custom-widget-chips"');
     expect(contents).toContain('tool_update_mode = "show_all"');
+    expect(contents).toContain('manager_tool_update_mode = "show_more"');
     expect(contents).toContain("show_streaming_option = true");
   });
 

--- a/apps/desktop/src/main/__tests__/messaging-config.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-config.test.ts
@@ -65,6 +65,7 @@ describe("desktop messaging config", () => {
       "fullAccessControls",
       "inputDebounceMs",
       "line",
+      "managerToolUpdateDefaultMode",
       "mattermost",
       "showStreamingOption",
       "slack",
@@ -245,6 +246,7 @@ describe("desktop messaging config", () => {
       },
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
+      managerToolUpdateDefaultMode: "show_none",
       telegram: {
         channel: "telegram",
         enabled: true,
@@ -500,6 +502,7 @@ describe("desktop messaging config", () => {
       enabled: true,
       inputDebounceMs: 500,
       toolUpdateDefaultMode: "show_some",
+      managerToolUpdateDefaultMode: "show_none",
       showStreamingOption: false,
       attachmentPolicy: {
         imageProfile: "medium",
@@ -915,6 +918,7 @@ describe("desktop messaging config", () => {
         authorizedActorCount: 2,
       },
       toolUpdateDefaultMode: "show_some",
+      managerToolUpdateDefaultMode: "show_none",
       inputDebounceMs: 500,
       discord: {
         channel: "discord",

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -7303,7 +7303,10 @@ describe("MessagingController", () => {
   });
 
   it("lets /new create an Agent thread and return to regular projects", async () => {
-    const harness = await createHarness();
+    const harness = await createHarness({
+      toolUpdateDefaultMode: (targetKind) =>
+        targetKind === "agent_thread" ? "show_more" : "show_less",
+    });
 
     await harness.controller.handleInboundEvent(buildCommandEvent("/new"));
     await harness.controller.handleInboundEvent(
@@ -7381,6 +7384,7 @@ describe("MessagingController", () => {
       backend: "codex",
       threadId: "new-thread-1",
       targetKind: "agent_thread",
+      preferences: expect.objectContaining({ toolUpdateMode: "show_more" }),
     });
   });
 
@@ -18314,7 +18318,9 @@ async function createHarness(options?: {
   startThread?: NonNullable<MessagingBackendBridge["startThread"]>;
   startTurn?: NonNullable<MessagingBackendBridge["startTurn"]>;
   submitReview?: NonNullable<MessagingBackendBridge["submitReview"]>;
-  toolUpdateDefaultMode?: MessagingToolUpdateMode;
+  toolUpdateDefaultMode?:
+    | MessagingToolUpdateMode
+    | ((targetKind: "thread" | "agent_thread") => MessagingToolUpdateMode);
   showStreamingOption?: boolean;
 }): Promise<{
   controller: MessagingController;

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1306,10 +1306,10 @@ describe("MessagingController", () => {
         parts: [expect.objectContaining({ text: "I found it." })],
       }),
     );
-    expect(JSON.stringify(harness.delivered)).not.toContain(
+    expect(JSON.stringify(harness.delivered)).toContain(
       "I am searching for the thread now.",
     );
-    expect(JSON.stringify(harness.delivered)).not.toContain("find the thread");
+    expect(JSON.stringify(harness.delivered)).toContain("find the thread");
   });
 
   it("routes an accepted every-message topic to its default Agent without binding it", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-routes-service.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-routes-service.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   clearDesktopMessagingDefaultAgent,
   listDesktopMessagingRoutes,
+  resetDesktopMessagingToolUpdateBindings,
   setDesktopMessagingDefaultAgent,
 } from "../messaging/messaging-routes-service";
 
@@ -132,6 +133,7 @@ function buildDependencies(options: {
     findObservedSurfaces: vi.fn(async () => options.observedSurfaces ?? []),
     getDefaultAgentAssignment: vi.fn(async (id: string) =>
       assignments.find((assignment) => assignment.id === id)),
+    upsertBinding: vi.fn(async (binding) => binding),
     upsertDefaultAgentAssignment: vi.fn(async (assignment) => assignment),
     revokeDefaultAgentAssignment: vi.fn(async ({ assignmentId, revokedAt }) => {
       const assignment = assignments.find((candidate) => candidate.id === assignmentId);
@@ -334,5 +336,57 @@ describe("messaging routes service", () => {
       assignmentId: "assignment-1",
       revokedAt: 4000,
     });
+  });
+
+  it("resets only the selected binding kind to inherit its profile default", async () => {
+    const developmentBinding = buildBinding({
+      preferences: {
+        model: "gpt-5.6",
+        toolUpdateMode: "show_all",
+        updatedAt: 1200,
+      },
+    });
+    const managerBinding = buildBinding({
+      id: "binding-manager",
+      targetKind: "agent_thread",
+      preferences: {
+        toolUpdateMode: "show_more",
+        updatedAt: 1300,
+      },
+    });
+    const dependencies = buildDependencies({
+      bindings: [developmentBinding, managerBinding],
+    });
+
+    await expect(
+      resetDesktopMessagingToolUpdateBindings(
+        { targetKind: "thread" },
+        { ...dependencies, now: () => 4000 },
+      ),
+    ).resolves.toEqual({ bindingCount: 1 });
+    expect(dependencies.store.upsertBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "binding-1",
+        preferences: { model: "gpt-5.6", updatedAt: 4000 },
+        updatedAt: 4000,
+      }),
+    );
+    expect(dependencies.store.upsertBinding).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "binding-manager" }),
+    );
+
+    await expect(
+      resetDesktopMessagingToolUpdateBindings(
+        { targetKind: "agent_thread" },
+        { ...dependencies, now: () => 5000 },
+      ),
+    ).resolves.toEqual({ bindingCount: 1 });
+    expect(dependencies.store.upsertBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "binding-manager",
+        preferences: undefined,
+        updatedAt: 5000,
+      }),
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -23,14 +23,14 @@ afterEach(() => {
 });
 
 describe("resolveMessagingToolUpdateMode", () => {
-  it("defaults Agent threads to None without overriding an explicit preference", () => {
+  it("uses the Agent default when available and preserves an explicit preference", () => {
     const agentBinding = {
       ...buildBinding(),
       targetKind: "agent_thread",
     } satisfies MessagingBindingRecord;
 
     expect(resolveMessagingToolUpdateMode(agentBinding, "show_all")).toBe(
-      "show_none",
+      "show_all",
     );
     expect(
       resolveMessagingToolUpdateMode(
@@ -44,6 +44,9 @@ describe("resolveMessagingToolUpdateMode", () => {
         "show_some",
       ),
     ).toBe("show_all");
+    expect(resolveMessagingToolUpdateMode(agentBinding, undefined)).toBe(
+      "show_none",
+    );
     expect(resolveMessagingToolUpdateMode(buildBinding(), "show_all")).toBe(
       "show_all",
     );

--- a/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts
@@ -58,6 +58,7 @@ const slackProviderMock = vi.hoisted(() => ({
 const messagingRoutesServiceMock = vi.hoisted(() => ({
   clearDesktopMessagingDefaultAgent: vi.fn(),
   listDesktopMessagingRoutes: vi.fn(),
+  resetDesktopMessagingToolUpdateBindings: vi.fn(),
   setDesktopMessagingDefaultAgent: vi.fn(),
 }));
 
@@ -157,6 +158,7 @@ describe("messaging status ipc", () => {
     slackProviderMock.resolveContact.mockReset();
     messagingRoutesServiceMock.clearDesktopMessagingDefaultAgent.mockReset();
     messagingRoutesServiceMock.listDesktopMessagingRoutes.mockReset();
+    messagingRoutesServiceMock.resetDesktopMessagingToolUpdateBindings.mockReset();
     messagingRoutesServiceMock.setDesktopMessagingDefaultAgent.mockReset();
   });
 
@@ -212,6 +214,38 @@ describe("messaging status ipc", () => {
       messagingRoutesServiceMock.setDesktopMessagingDefaultAgent,
     ).toHaveBeenCalledWith(setRequest);
     expect(runtimeMock.notifyBindingsChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it("resets selected bound Working Updates through IPC", async () => {
+    const { registerMessagingStatusIpcHandlers } = await import(
+      "../ipc/messaging-status"
+    );
+    const { MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL } = await import(
+      "../../shared/ipc"
+    );
+    messagingRoutesServiceMock.resetDesktopMessagingToolUpdateBindings
+      .mockResolvedValueOnce({ bindingCount: 2 })
+      .mockResolvedValueOnce({ bindingCount: 0 });
+
+    registerMessagingStatusIpcHandlers();
+
+    await expect(
+      handlers.get(MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL)?.(
+        {},
+        { targetKind: "thread" },
+      ),
+    ).resolves.toEqual({ bindingCount: 2 });
+    await expect(
+      handlers.get(MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL)?.(
+        {},
+        { targetKind: "agent_thread" },
+      ),
+    ).resolves.toEqual({ bindingCount: 0 });
+
+    expect(
+      messagingRoutesServiceMock.resetDesktopMessagingToolUpdateBindings,
+    ).toHaveBeenNthCalledWith(1, { targetKind: "thread" });
+    expect(runtimeMock.notifyBindingsChanged).toHaveBeenCalledTimes(1);
   });
 
   it("loads startup eligibility diagnostics when enabling messaging at runtime", async () => {

--- a/apps/desktop/src/main/ipc/messaging-status.ts
+++ b/apps/desktop/src/main/ipc/messaging-status.ts
@@ -24,6 +24,8 @@ import type {
   MessagingPlatformStatusEvent,
   RejectMessagingPairingRequest,
   RejectMessagingPairingResponse,
+  ResetMessagingToolUpdateBindingsRequest,
+  ResetMessagingToolUpdateBindingsResponse,
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   SetMessagingDefaultAgentRequest,
@@ -67,6 +69,7 @@ import {
   MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   MESSAGING_REJECT_PAIRING_CHANNEL,
+  MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL,
   MESSAGING_SET_ENABLED_CHANNEL,
   MESSAGING_SET_DEFAULT_AGENT_CHANNEL,
   MESSAGING_SHUTDOWN_RUNTIME_CHANNEL,
@@ -83,6 +86,7 @@ import { getDesktopMessagingStore } from "../messaging/desktop-messaging-store";
 import {
   clearDesktopMessagingDefaultAgent,
   listDesktopMessagingRoutes,
+  resetDesktopMessagingToolUpdateBindings,
   setDesktopMessagingDefaultAgent,
 } from "../messaging/messaging-routes-service";
 
@@ -762,6 +766,21 @@ export function registerMessagingStatusIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL);
+  ipcMain.handle(
+    MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL,
+    async (
+      _event,
+      request: ResetMessagingToolUpdateBindingsRequest,
+    ): Promise<ResetMessagingToolUpdateBindingsResponse> => {
+      const result = await resetDesktopMessagingToolUpdateBindings(request);
+      if (result.bindingCount > 0) {
+        runtime.notifyBindingsChanged();
+      }
+      return result;
+    },
+  );
+
   ipcMain.removeHandler(MESSAGING_LIST_ROUTES_CHANNEL);
   ipcMain.handle(
     MESSAGING_LIST_ROUTES_CHANNEL,
@@ -895,6 +914,7 @@ export async function disposeMessagingStatusIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(MESSAGING_APPROVE_PAIRING_CHANNEL);
   ipcMain.removeHandler(MESSAGING_REJECT_PAIRING_CHANNEL);
   ipcMain.removeHandler(MESSAGING_UNBIND_THREAD_CHANNEL);
+  ipcMain.removeHandler(MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL);
   ipcMain.removeHandler(MESSAGING_LIST_ROUTES_CHANNEL);
   ipcMain.removeHandler(MESSAGING_SET_DEFAULT_AGENT_CHANNEL);
   ipcMain.removeHandler(MESSAGING_CLEAR_DEFAULT_AGENT_CHANNEL);

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -38,6 +38,7 @@ import type {
   LinkedDirectorySummary,
   LaunchpadWorkMode,
   MaterializedDirectoryLaunchpadThread,
+  MessagingBindingTargetKind,
   MessagingToolUpdateMode,
   PwrAgentMessagingBoundThreadSummary,
   PwrAgentMessagingLocationSummary,
@@ -430,7 +431,9 @@ type MessagingControllerLogger = {
 
 type MessagingToolUpdateDefaultModeResolver =
   | MessagingToolUpdateMode
-  | (() => MessagingToolUpdateMode | Promise<MessagingToolUpdateMode>);
+  | ((
+    targetKind: MessagingBindingTargetKind,
+  ) => MessagingToolUpdateMode | Promise<MessagingToolUpdateMode>);
 
 type MessagingFullAccessControls = {
   allowEscalation: boolean;
@@ -6313,12 +6316,16 @@ export class MessagingController {
     session: MessagingBrowseSessionRecord,
     directory?: NavigationDirectorySummary,
   ): Promise<MessagingToolUpdateMode> {
-    return session.preferences?.toolUpdateMode
-      ?? (isNewAgentThreadLaunchAction(session.launchAction)
-        ? "show_none"
-        : undefined)
-      ?? directory?.launchpad?.messagingToolUpdateMode
-      ?? await this.resolveToolUpdateDefaultMode();
+    if (session.preferences?.toolUpdateMode) {
+      return session.preferences.toolUpdateMode;
+    }
+    if (isNewAgentThreadLaunchAction(session.launchAction)) {
+      return await this.resolveToolUpdateDefaultMode("agent_thread");
+    }
+    return (
+      directory?.launchpad?.messagingToolUpdateMode
+      ?? await this.resolveToolUpdateDefaultMode("thread")
+    );
   }
 
   private async loadNewThreadBackendChoices(
@@ -10068,7 +10075,7 @@ export class MessagingController {
   ): Promise<void> {
     const currentMode = resolveMessagingToolUpdateMode(
       binding,
-      await this.resolveToolUpdateDefaultMode(),
+      await this.resolveToolUpdateDefaultMode(binding.targetKind ?? "thread"),
     );
     await this.deliverAndStoreStatusSubmode(
       buildStatusToolUpdateModePickerIntent({
@@ -11743,19 +11750,23 @@ export class MessagingController {
     return await this.renderBindingStatus(retiredBinding, event, snapshot);
   }
 
-  private async resolveToolUpdateDefaultMode(): Promise<MessagingToolUpdateMode> {
+  private async resolveToolUpdateDefaultMode(
+    targetKind: MessagingBindingTargetKind = "thread",
+  ): Promise<MessagingToolUpdateMode> {
     const configured = this.options.toolUpdateDefaultMode;
     if (!configured) {
-      return "show_some";
+      return targetKind === "agent_thread" ? "show_none" : "show_some";
     }
 
     try {
-      return typeof configured === "function" ? await configured() : configured;
+      return typeof configured === "function"
+        ? await configured(targetKind)
+        : configured;
     } catch (error) {
       this.logger.debug?.("messaging tool update default resolution failed", {
         error: error instanceof Error ? error.message : String(error),
       });
-      return "show_some";
+      return targetKind === "agent_thread" ? "show_none" : "show_some";
     }
   }
 
@@ -11804,7 +11815,9 @@ export class MessagingController {
               binding,
               navigation,
             }),
-            toolUpdateMode: await this.resolveToolUpdateDefaultMode(),
+            toolUpdateMode: await this.resolveToolUpdateDefaultMode(
+              binding.targetKind ?? "thread",
+            ),
           }),
           actions: [],
           delivery: {
@@ -11907,7 +11920,9 @@ export class MessagingController {
         binding,
         navigation: snapshot,
       }),
-      toolUpdateMode: await this.resolveToolUpdateDefaultMode(),
+      toolUpdateMode: await this.resolveToolUpdateDefaultMode(
+        binding.targetKind ?? "thread",
+      ),
     });
     const result = await this.deliver(intent, binding, event);
     const latestBinding = await this.options.store.getBinding(binding.id);
@@ -13489,7 +13504,7 @@ export class MessagingController {
 
     const mode = resolveMessagingToolUpdateMode(
       binding,
-      await this.resolveToolUpdateDefaultMode(),
+      await this.resolveToolUpdateDefaultMode(binding.targetKind ?? "thread"),
     );
     const deliveries = this.toolUpdatePolicy.processActivity({
       activity,
@@ -13536,7 +13551,7 @@ export class MessagingController {
 
     const mode = resolveMessagingToolUpdateMode(
       binding,
-      await this.resolveToolUpdateDefaultMode(),
+      await this.resolveToolUpdateDefaultMode(binding.targetKind ?? "thread"),
     );
     const deliveries = this.toolUpdatePolicy.processActivity({
       activity,

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -735,8 +735,8 @@ export function resolveMessagingToolUpdateMode(
   defaultMode: MessagingToolUpdateMode | undefined,
 ): MessagingToolUpdateMode {
   return binding.preferences?.toolUpdateMode
-    ?? (binding.targetKind === "agent_thread" ? "show_none" : defaultMode)
-    ?? "show_some";
+    ?? defaultMode
+    ?? (binding.targetKind === "agent_thread" ? "show_none" : "show_some");
 }
 
 export function resolveMessagingResponseMode(

--- a/apps/desktop/src/main/messaging/messaging-config.ts
+++ b/apps/desktop/src/main/messaging/messaging-config.ts
@@ -176,6 +176,7 @@ export type DesktopMessagingConfig = {
   slack?: SlackMessagingConfig;
   telegram?: TelegramMessagingConfig;
   toolUpdateDefaultMode?: MessagingToolUpdateMode;
+  managerToolUpdateDefaultMode?: MessagingToolUpdateMode;
   showStreamingOption?: boolean;
 };
 
@@ -212,6 +213,7 @@ export const DESKTOP_MESSAGING_ROOT_CONFIG_FIELD_IMPACTS = {
   slack: "connection",
   telegram: "connection",
   toolUpdateDefaultMode: "irrelevant",
+  managerToolUpdateDefaultMode: "irrelevant",
   showStreamingOption: "irrelevant",
 } as const satisfies Record<
   keyof DesktopMessagingConfig,
@@ -551,6 +553,7 @@ export function loadDesktopMessagingConfig(
     },
     inputDebounceMs: readInputDebounceMsFromEnv(env) ?? 500,
     toolUpdateDefaultMode: "show_some",
+    managerToolUpdateDefaultMode: "show_none",
     ...(attachmentPolicy ? { attachmentPolicy } : {}),
     ...(telegramBotToken
       ? {
@@ -1132,6 +1135,8 @@ export async function loadDesktopMessagingConfigFromSettings(
     },
     inputDebounceMs: snapshot.messaging.inputDebounceMs.value,
     toolUpdateDefaultMode: snapshot.messaging.toolUpdateMode.value,
+    managerToolUpdateDefaultMode:
+      snapshot.messaging.managerToolUpdateMode.value,
     showStreamingOption: snapshot.messaging.showStreamingOption.value,
     attachmentPolicy,
     ...telegramConfig,
@@ -1221,6 +1226,8 @@ export function redactDesktopMessagingConfig(
         }
       : undefined,
     toolUpdateDefaultMode: config.toolUpdateDefaultMode ?? "show_some",
+    managerToolUpdateDefaultMode:
+      config.managerToolUpdateDefaultMode ?? "show_none",
     inputDebounceMs: config.inputDebounceMs ?? 500,
     discord: config.discord
       ? {

--- a/apps/desktop/src/main/messaging/messaging-routes-service.ts
+++ b/apps/desktop/src/main/messaging/messaging-routes-service.ts
@@ -12,6 +12,8 @@ import type {
   SetMessagingDefaultAgentResponse,
   ClearMessagingDefaultAgentRequest,
   ClearMessagingDefaultAgentResponse,
+  ResetMessagingToolUpdateBindingsRequest,
+  ResetMessagingToolUpdateBindingsResponse,
   ThreadAgentMetadata,
 } from "@pwragent/shared";
 import { normalizeMessagingBindingTargetKind } from "@pwragent/shared";
@@ -31,6 +33,7 @@ type MessagingRoutesStore = Pick<
   | "findObservedSurfaces"
   | "getDefaultAgentAssignment"
   | "revokeDefaultAgentAssignment"
+  | "upsertBinding"
   | "upsertDefaultAgentAssignment"
 >;
 
@@ -257,6 +260,48 @@ export async function clearDesktopMessagingDefaultAgent(
     assignmentId: request.assignmentId,
     cleared: Boolean(revoked?.revokedAt),
   };
+}
+
+/**
+ * Return active bindings of one thread kind to their profile-wide Working
+ * Updates default. The explicit per-binding preference is deliberately
+ * removed rather than overwritten so a later default change reaches these
+ * bindings too.
+ */
+export async function resetDesktopMessagingToolUpdateBindings(
+  request: ResetMessagingToolUpdateBindingsRequest,
+  dependencies: MessagingRoutesServiceDependencies = {},
+): Promise<ResetMessagingToolUpdateBindingsResponse> {
+  const store = dependencies.store ?? getDesktopMessagingStore();
+  const now = (dependencies.now ?? Date.now)();
+  const bindings = await store.findActiveBindings();
+  let bindingCount = 0;
+
+  for (const binding of bindings) {
+    if (
+      normalizeMessagingBindingTargetKind(binding.targetKind) !== request.targetKind
+      || binding.preferences?.toolUpdateMode === undefined
+    ) {
+      continue;
+    }
+
+    const {
+      toolUpdateMode: _toolUpdateMode,
+      updatedAt: _updatedAt,
+      ...preferences
+    } = binding.preferences;
+    await store.upsertBinding({
+      ...binding,
+      preferences:
+        Object.keys(preferences).length > 0
+          ? { ...preferences, updatedAt: now }
+          : undefined,
+      updatedAt: now,
+    });
+    bindingCount += 1;
+  }
+
+  return { bindingCount };
 }
 
 async function resolveEligibleAgents(params: {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1025,8 +1025,12 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
           adapter.channel,
           channel,
         ),
-      toolUpdateDefaultMode: async () =>
-        (await this.loadConfig()).toolUpdateDefaultMode ?? "show_some",
+      toolUpdateDefaultMode: async (targetKind) => {
+        const config = await this.loadConfig();
+        return targetKind === "agent_thread"
+          ? config.managerToolUpdateDefaultMode ?? "show_none"
+          : config.toolUpdateDefaultMode ?? "show_some";
+      },
       fullAccessControls: async () =>
         (await this.loadConfig()).fullAccessControls,
       onBindingChanged: () => this.broadcastBindingsChanged(),

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -140,6 +140,7 @@ export type DesktopSettingsConfig = {
     fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    managerToolUpdateMode?: MessagingToolUpdateMode;
     showStreamingOption?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;
@@ -899,6 +900,12 @@ export function desktopSettingsPatchToEdits(
   if (patch.messaging?.toolUpdateMode !== undefined) {
     set(["messaging", "tool_update_mode"], patch.messaging.toolUpdateMode);
   }
+  if (patch.messaging?.managerToolUpdateMode !== undefined) {
+    set(
+      ["messaging", "manager_tool_update_mode"],
+      patch.messaging.managerToolUpdateMode,
+    );
+  }
   if (patch.messaging?.showStreamingOption !== undefined) {
     set(["messaging", "show_streaming_option"], patch.messaging.showStreamingOption);
   }
@@ -1479,6 +1486,9 @@ function normalizeDesktopConfig(
       ),
       inputDebounceMs: readNumber(messaging?.input_debounce_ms),
       toolUpdateMode: readToolUpdateMode(messaging?.tool_update_mode),
+      managerToolUpdateMode: readToolUpdateMode(
+        messaging?.manager_tool_update_mode,
+      ),
       showStreamingOption: readBoolean(messaging?.show_streaming_option),
       attachments: {
         imageProfile: readImageProfile(attachments?.image_profile),
@@ -1800,6 +1810,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
   const allowFullAccessThreadResume = config.messaging?.allowFullAccessThreadResume;
   const fullAccessWarning = config.messaging?.fullAccessWarning;
   const toolUpdateMode = config.messaging?.toolUpdateMode;
+  const managerToolUpdateMode = config.messaging?.managerToolUpdateMode;
   const showStreamingOption = config.messaging?.showStreamingOption;
   if (
     enabled !== undefined ||
@@ -1808,6 +1819,7 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     fullAccessWarning !== undefined ||
     inputDebounceMs !== undefined ||
     toolUpdateMode !== undefined ||
+    managerToolUpdateMode !== undefined ||
     showStreamingOption !== undefined ||
     (attachments && hasDefinedValue(attachments))
     || (telegram && hasDefinedValue(telegram))
@@ -1838,6 +1850,9 @@ function pruneEmptyConfig(config: DesktopSettingsConfig): DesktopSettingsConfig 
     }
     if (toolUpdateMode !== undefined) {
       pruned.messaging.toolUpdateMode = toolUpdateMode;
+    }
+    if (managerToolUpdateMode !== undefined) {
+      pruned.messaging.managerToolUpdateMode = managerToolUpdateMode;
     }
     if (attachments && hasDefinedValue(attachments)) {
       pruned.messaging.attachments = attachments;

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -695,6 +695,10 @@ export class DesktopSettingsService {
         toolUpdateMode: this.resolveToolUpdateMode(
           config.messaging?.toolUpdateMode,
         ),
+        managerToolUpdateMode: this.resolveToolUpdateMode(
+          config.messaging?.managerToolUpdateMode,
+          "show_none",
+        ),
         showStreamingOption: this.resolveConfigBoolean(
           config.messaging?.showStreamingOption,
           false,
@@ -1953,9 +1957,10 @@ export class DesktopSettingsService {
 
   private resolveToolUpdateMode(
     configValue: MessagingToolUpdateMode | undefined,
+    defaultValue: MessagingToolUpdateMode = "show_some",
   ): DesktopSettingsValue<MessagingToolUpdateMode> {
     return {
-      value: configValue ?? "show_some",
+      value: configValue ?? defaultValue,
       source: configValue === undefined ? "default" : "config",
     };
   }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -132,6 +132,8 @@ import type {
   MessagingPairingEntry,
   RejectMessagingPairingRequest,
   RejectMessagingPairingResponse,
+  ResetMessagingToolUpdateBindingsRequest,
+  ResetMessagingToolUpdateBindingsResponse,
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   SetMessagingDefaultAgentRequest,
@@ -400,6 +402,7 @@ import {
   MESSAGING_PAIRING_CHANGED_EVENT_CHANNEL,
   MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL,
   MESSAGING_REJECT_PAIRING_CHANNEL,
+  MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL,
   MESSAGING_SET_ENABLED_CHANNEL,
   MESSAGING_SET_DEFAULT_AGENT_CHANNEL,
   MESSAGING_SHUTDOWN_RUNTIME_CHANNEL,
@@ -1510,6 +1513,13 @@ const desktopApi = Object.freeze({
     request: UnbindMessagingThreadRequest,
   ): Promise<UnbindMessagingThreadResponse> =>
     await ipcRenderer.invoke(MESSAGING_UNBIND_THREAD_CHANNEL, request),
+  resetMessagingToolUpdateBindings: async (
+    request: ResetMessagingToolUpdateBindingsRequest,
+  ): Promise<ResetMessagingToolUpdateBindingsResponse> =>
+    await ipcRenderer.invoke(
+      MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL,
+      request,
+    ),
   listMessagingRoutes: async (): Promise<ListMessagingRoutesResponse> =>
     await ipcRenderer.invoke(MESSAGING_LIST_ROUTES_CHANNEL),
   setMessagingDefaultAgent: async (

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -479,6 +479,7 @@ describe("App", () => {
         fullAccessWarning: { value: "dismissable", source: "default" },
         inputDebounceMs: { value: 500, source: "default" },
         toolUpdateMode: { value: "show_some", source: "default" },
+        managerToolUpdateMode: { value: "show_none", source: "default" },
         showStreamingOption: { value: false, source: "default" },
         telegram: {
           enabled: { value: false, source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -87,6 +87,9 @@ export function MessagingSettings(props: {
     value: string,
   ) => Promise<boolean>;
   onToolUpdateModeChange: (mode: MessagingToolUpdateMode) => Promise<void>;
+  onManagerToolUpdateModeChange: (
+    mode: MessagingToolUpdateMode,
+  ) => Promise<void>;
   onShowStreamingOptionChange: (enabled: boolean) => Promise<void>;
   onImageProfileChange: (profile: DesktopMessagingImageProfile) => Promise<void>;
   onInputDebounceMsChange: (value: number) => Promise<void>;
@@ -129,8 +132,18 @@ export function MessagingSettings(props: {
     props.snapshot.messaging.allowFullAccessThreadResume;
   const fullAccessWarning = props.snapshot.messaging.fullAccessWarning;
   const toolUpdateMode = props.snapshot.messaging.toolUpdateMode;
+  const managerToolUpdateMode = props.snapshot.messaging.managerToolUpdateMode;
   const showStreamingOption = props.snapshot.messaging.showStreamingOption;
   const inputDebounceMs = props.snapshot.messaging.inputDebounceMs;
+  const [pendingToolUpdateBindingReset, setPendingToolUpdateBindingReset] =
+    useState<{
+      bindingCount: number;
+      targetKind: "thread" | "agent_thread";
+    }>();
+  const [resettingToolUpdateBindings, setResettingToolUpdateBindings] =
+    useState(false);
+  const [toolUpdateBindingResetStatus, setToolUpdateBindingResetStatus] =
+    useState<string>();
   const [streamingNudgeProvider, setStreamingNudgeProvider] = useState<
     string | null
   >(null);
@@ -192,6 +205,68 @@ export function MessagingSettings(props: {
     props.snapshot,
   );
 
+  const previewToolUpdateBindingReset = async (
+    targetKind: "thread" | "agent_thread",
+  ): Promise<void> => {
+    if (
+      !props.desktopApi?.listMessagingRoutes
+      || !props.desktopApi.resetMessagingToolUpdateBindings
+    ) {
+      setToolUpdateBindingResetStatus(
+        "Working Updates cleanup is unavailable in this build.",
+      );
+      return;
+    }
+    setToolUpdateBindingResetStatus(undefined);
+    try {
+      const routes = await props.desktopApi.listMessagingRoutes();
+      const bindingCount = routes.bindings.filter(
+        (binding) => binding.target.kind === targetKind,
+      ).length;
+      if (bindingCount === 0) {
+        setToolUpdateBindingResetStatus(
+          `No bound ${toolUpdateTargetLabel(targetKind)} need cleanup.`,
+        );
+        return;
+      }
+      setPendingToolUpdateBindingReset({ bindingCount, targetKind });
+    } catch (error) {
+      setToolUpdateBindingResetStatus(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  };
+
+  const resetToolUpdateBindings = async (): Promise<void> => {
+    if (
+      !pendingToolUpdateBindingReset
+      || !props.desktopApi?.resetMessagingToolUpdateBindings
+    ) {
+      return;
+    }
+    setResettingToolUpdateBindings(true);
+    try {
+      const result = await props.desktopApi.resetMessagingToolUpdateBindings({
+        targetKind: pendingToolUpdateBindingReset.targetKind,
+      });
+      const targetLabel = toolUpdateTargetLabel(
+        pendingToolUpdateBindingReset.targetKind,
+      );
+      setToolUpdateBindingResetStatus(
+        result.bindingCount === 0
+          ? `All bound ${targetLabel} already use the profile default.`
+          : `Reset Working Updates for ${result.bindingCount} bound ${targetLabel}.`,
+      );
+      setPendingToolUpdateBindingReset(undefined);
+    } catch (error) {
+      setToolUpdateBindingResetStatus(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setResettingToolUpdateBindings(false);
+    }
+  };
+
   return (
     <MessagingRoutesProvider desktopApi={props.desktopApi}>
       <SettingsSectionStack paneId="messaging" aria-label="Messaging settings">
@@ -242,9 +317,25 @@ export function MessagingSettings(props: {
             }}
           />
           <SegmentedField
-            disabled={props.saving}
-            label="Working Updates"
-            sub="How much of the agent's in-progress work — tool activity and in-turn messages — is bridged. None sends only final answers and questions; higher settings send coalesced batches that respect platform rate limits."
+            actions={
+              <ToolUpdateBindingResetActions
+                applying={resettingToolUpdateBindings}
+                disabled={props.saving}
+                mode={toolUpdateMode.value}
+                pending={
+                  pendingToolUpdateBindingReset?.targetKind === "thread"
+                    ? pendingToolUpdateBindingReset
+                    : undefined
+                }
+                targetKind="thread"
+                onCancel={() => setPendingToolUpdateBindingReset(undefined)}
+                onConfirm={() => void resetToolUpdateBindings()}
+                onReset={() => void previewToolUpdateBindingReset("thread")}
+              />
+            }
+            disabled={props.saving || resettingToolUpdateBindings}
+            label="Development thread Working Updates"
+            sub="Default for new Development-thread bindings. Bound threads keep their own selection until you reset them to this default. None sends only final answers and questions; higher settings send coalesced batches that respect platform rate limits."
             options={TOOL_UPDATE_MODE_OPTIONS}
             source={sourceBadge(toolUpdateMode)}
             value={toolUpdateMode.value}
@@ -252,6 +343,36 @@ export function MessagingSettings(props: {
               void props.onToolUpdateModeChange(mode);
             }}
           />
+          <SegmentedField
+            actions={
+              <ToolUpdateBindingResetActions
+                applying={resettingToolUpdateBindings}
+                disabled={props.saving}
+                mode={managerToolUpdateMode.value}
+                pending={
+                  pendingToolUpdateBindingReset?.targetKind === "agent_thread"
+                    ? pendingToolUpdateBindingReset
+                    : undefined
+                }
+                targetKind="agent_thread"
+                onCancel={() => setPendingToolUpdateBindingReset(undefined)}
+                onConfirm={() => void resetToolUpdateBindings()}
+                onReset={() => void previewToolUpdateBindingReset("agent_thread")}
+              />
+            }
+            disabled={props.saving || resettingToolUpdateBindings}
+            label="Manager agent Working Updates"
+            sub="Default for new manager-agent bindings. Manager agents can stay quieter than Development threads; reset existing bound agents to make them follow this default."
+            options={TOOL_UPDATE_MODE_OPTIONS}
+            source={sourceBadge(managerToolUpdateMode)}
+            value={managerToolUpdateMode.value}
+            onChange={(mode) => {
+              void props.onManagerToolUpdateModeChange(mode);
+            }}
+          />
+          {toolUpdateBindingResetStatus ? (
+            <p className="settings-empty">{toolUpdateBindingResetStatus}</p>
+          ) : null}
           <NumberField
             disabled={props.saving}
             label="Input debounce"
@@ -1862,6 +1983,7 @@ function isLikelyWorkspaceUrl(value: string): boolean {
 }
 
 function SegmentedField<TValue extends string>(props: {
+  actions?: ReactNode;
   disabled?: boolean;
   label: string;
   sub?: ReactNode;
@@ -1876,30 +1998,110 @@ function SegmentedField<TValue extends string>(props: {
       sub={props.sub}
       source={props.source}
       control={
-        <div
-          className="settings-segmented"
-          role="radiogroup"
-          aria-label={props.label}
-        >
-          {props.options.map((option) => (
-            <button
-              key={option.value}
-              aria-checked={props.value === option.value}
-              className={`settings-segmented__button${
-                props.value === option.value ? " is-active" : ""
-              }`}
-              disabled={props.disabled}
-              role="radio"
-              type="button"
-              onClick={() => props.onChange(option.value)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
+        <>
+          <div
+            className="settings-segmented"
+            role="radiogroup"
+            aria-label={props.label}
+          >
+            {props.options.map((option) => (
+              <button
+                key={option.value}
+                aria-checked={props.value === option.value}
+                className={`settings-segmented__button${
+                  props.value === option.value ? " is-active" : ""
+                }`}
+                disabled={props.disabled}
+                role="radio"
+                type="button"
+                onClick={() => props.onChange(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          {props.actions}
+        </>
       }
     />
   );
+}
+
+function ToolUpdateBindingResetActions(props: {
+  applying: boolean;
+  disabled: boolean;
+  mode: MessagingToolUpdateMode;
+  pending?: {
+    bindingCount: number;
+    targetKind: "thread" | "agent_thread";
+  };
+  targetKind: "thread" | "agent_thread";
+  onCancel: () => void;
+  onConfirm: () => void;
+  onReset: () => void;
+}) {
+  const target = toolUpdateTargetLabel(props.targetKind);
+  if (props.pending) {
+    const bindingCount = props.pending.bindingCount;
+    return (
+      <div aria-live="polite" className="settings-action-confirmation">
+        <div className="settings-action-confirmation__copy">
+          <strong>
+            Reset {bindingCount} bound {target}{" "}
+            {bindingCount === 1 ? "binding" : "bindings"}?
+          </strong>
+          <span>
+            This clears each binding&apos;s explicit selection. They will use{" "}
+            {toolUpdateModeLabel(props.mode)} now and follow future default changes.
+          </span>
+        </div>
+        <div className="settings-inline-actions">
+          <button
+            className="button button--primary"
+            disabled={props.applying}
+            type="button"
+            onClick={props.onConfirm}
+          >
+            {props.applying ? "Resetting…" : "Reset bindings"}
+          </button>
+          <button
+            className="button button--ghost"
+            disabled={props.applying}
+            type="button"
+            onClick={props.onCancel}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-inline-actions">
+      <button
+        className="button button--secondary"
+        disabled={props.disabled}
+        type="button"
+        onClick={props.onReset}
+      >
+        Reset bound {target} bindings
+      </button>
+    </div>
+  );
+}
+
+function toolUpdateTargetLabel(
+  targetKind: "thread" | "agent_thread",
+): string {
+  return targetKind === "agent_thread"
+    ? "manager agent"
+    : "Development thread";
+}
+
+function toolUpdateModeLabel(mode: MessagingToolUpdateMode): string {
+  return TOOL_UPDATE_MODE_OPTIONS.find((option) => option.value === mode)?.label
+    ?? "the selected default";
 }
 
 function ToggleField(props: {

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -502,6 +502,13 @@ function SettingsSectionBody(props: {
             },
           });
         }}
+        onManagerToolUpdateModeChange={async (managerToolUpdateMode) => {
+          await props.settings.writeConfig({
+            messaging: {
+              managerToolUpdateMode,
+            },
+          });
+        }}
         onShowStreamingOptionChange={async (showStreamingOption) => {
           await props.settings.writeConfig({
             messaging: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -196,6 +196,7 @@ function createSnapshot(
       fullAccessWarning: { value: "dismissable", source: "default" },
       inputDebounceMs: { value: 500, source: "default" },
       toolUpdateMode: { value: "show_some", source: "default" },
+      managerToolUpdateMode: { value: "show_none", source: "default" },
       showStreamingOption: { value: false, source: "default" },
       telegram: {
         enabled: { value: false, source: "default" },
@@ -838,15 +839,38 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    expect(screen.getByRole("radio", { name: "Show Some" })).toHaveAttribute(
+    const developmentWorkingUpdates = screen.getByRole("radiogroup", {
+      name: "Development thread Working Updates",
+    });
+    expect(
+      within(developmentWorkingUpdates).getByRole("radio", { name: "Show Some" }),
+    ).toHaveAttribute(
       "aria-checked",
       "true",
     );
-    fireEvent.click(screen.getByRole("radio", { name: "Show All" }));
+    fireEvent.click(
+      within(developmentWorkingUpdates).getByRole("radio", { name: "Show All" }),
+    );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         messaging: {
           toolUpdateMode: "show_all",
+        },
+      });
+    });
+    const managerWorkingUpdates = screen.getByRole("radiogroup", {
+      name: "Manager agent Working Updates",
+    });
+    expect(
+      within(managerWorkingUpdates).getByRole("radio", { name: "Show None" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(
+      within(managerWorkingUpdates).getByRole("radio", { name: "Show More" }),
+    );
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        messaging: {
+          managerToolUpdateMode: "show_more",
         },
       });
     });
@@ -960,6 +984,88 @@ describe("SettingsScreen", () => {
       "page",
     );
   }, 15_000);
+
+  it("resets bound Working Updates separately for Development threads and manager agents", async () => {
+    const settings = createSettingsState();
+    const listMessagingRoutes = vi.fn(async () => ({
+      defaultAgents: [],
+      bindings: [
+        {
+          bindingId: "development-binding",
+          platform: "slack" as const,
+          conversation: { id: "C1", kind: "channel" as const },
+          target: {
+            backend: "codex" as const,
+            threadId: "thread-1",
+            label: "Development work",
+            kind: "thread" as const,
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          bindingId: "manager-binding",
+          platform: "slack" as const,
+          conversation: { id: "C2", kind: "channel" as const },
+          target: {
+            backend: "codex" as const,
+            threadId: "agent-1",
+            label: "Queue manager",
+            kind: "agent_thread" as const,
+          },
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      eligibleAgents: [],
+      observedSurfaces: [],
+    }));
+    const resetMessagingToolUpdateBindings = vi.fn(async () => ({
+      bindingCount: 1,
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{
+          listMessagingRoutes,
+          resetMessagingToolUpdateBindings,
+        }}
+        initialSection="messaging"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reset bound Development thread bindings",
+      }),
+    );
+    expect(
+      await screen.findByText("Reset 1 bound Development thread binding?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reset bindings" }));
+    await waitFor(() => {
+      expect(resetMessagingToolUpdateBindings).toHaveBeenCalledWith({
+        targetKind: "thread",
+      });
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Reset bound manager agent bindings",
+      }),
+    );
+    expect(
+      await screen.findByText("Reset 1 bound manager agent binding?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Reset bindings" }));
+    await waitFor(() => {
+      expect(resetMessagingToolUpdateBindings).toHaveBeenLastCalledWith({
+        targetKind: "agent_thread",
+      });
+    });
+  });
 
   it("saves the hot CPU heap snapshot limit when heap capture is armed", async () => {
     const baseSnapshot = createSnapshot();

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -136,6 +136,8 @@ import type {
   MessagingPlatformStatusEvent,
   RejectMessagingPairingRequest,
   RejectMessagingPairingResponse,
+  ResetMessagingToolUpdateBindingsRequest,
+  ResetMessagingToolUpdateBindingsResponse,
   SetMessagingEnabledRequest,
   SetMessagingEnabledResponse,
   SetMessagingDefaultAgentRequest,
@@ -819,6 +821,9 @@ export type DesktopApi = {
   unbindMessagingThread?: (
     request: UnbindMessagingThreadRequest,
   ) => Promise<UnbindMessagingThreadResponse>;
+  resetMessagingToolUpdateBindings?: (
+    request: ResetMessagingToolUpdateBindingsRequest,
+  ) => Promise<ResetMessagingToolUpdateBindingsResponse>;
   listMessagingRoutes?: () => Promise<ListMessagingRoutesResponse>;
   setMessagingDefaultAgent?: (
     request: SetMessagingDefaultAgentRequest,

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -124,6 +124,8 @@ export const MESSAGING_GET_PLATFORM_STATUSES_CHANNEL =
 export const MESSAGING_PLATFORM_STATUS_EVENT_CHANNEL =
   "messaging:platform-status-event";
 export const MESSAGING_UNBIND_THREAD_CHANNEL = "messaging:unbind-thread";
+export const MESSAGING_RESET_TOOL_UPDATE_BINDINGS_CHANNEL =
+  "messaging:reset-tool-update-bindings";
 export const MESSAGING_LIST_ROUTES_CHANNEL = "messaging:list-routes";
 export const MESSAGING_SET_DEFAULT_AGENT_CHANNEL =
   "messaging:set-default-agent";

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -153,6 +153,10 @@ describe("desktop settings contracts", () => {
           value: "show_some",
           source: "default",
         },
+        managerToolUpdateMode: {
+          value: "show_none",
+          source: "default",
+        },
         showStreamingOption: { value: false, source: "default" },
         attachments: {
           imageProfile: { value: "medium", source: "default" },

--- a/packages/shared/src/contracts/messaging.ts
+++ b/packages/shared/src/contracts/messaging.ts
@@ -264,6 +264,19 @@ export type UnbindMessagingThreadResponse = {
   bindingId: string;
 };
 
+/**
+ * Clear the per-binding Working Updates selection so bound conversations
+ * inherit the profile default for their thread kind again.
+ */
+export type ResetMessagingToolUpdateBindingsRequest = {
+  targetKind: MessagingBindingTargetKind;
+};
+
+export type ResetMessagingToolUpdateBindingsResponse = {
+  /** Number of active bindings whose explicit Working Updates selection cleared. */
+  bindingCount: number;
+};
+
 export type DesktopMessagingDefaultAgentScope =
   | {
       kind: "profile";

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -596,6 +596,7 @@ export type DesktopSettingsSnapshot = {
     fullAccessWarning: DesktopSettingsValue<DesktopMessagingFullAccessWarningGlobalPolicy>;
     inputDebounceMs: DesktopSettingsValue<number>;
     toolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
+    managerToolUpdateMode: DesktopSettingsValue<MessagingToolUpdateMode>;
     showStreamingOption: DesktopSettingsValue<boolean>;
     attachments: DesktopMessagingAttachmentSettingsSnapshot;
     telegram: {
@@ -831,6 +832,7 @@ export type DesktopSettingsConfigPatch = {
     fullAccessWarning?: DesktopMessagingFullAccessWarningGlobalPolicy;
     inputDebounceMs?: number;
     toolUpdateMode?: MessagingToolUpdateMode;
+    managerToolUpdateMode?: MessagingToolUpdateMode;
     showStreamingOption?: boolean;
     attachments?: {
       imageProfile?: DesktopMessagingImageProfile;


### PR DESCRIPTION
## Summary
- split Messaging Working Updates defaults between Development threads and manager agents
- add reset actions that clear active binding overrides so existing bound conversations inherit their selected default
- wire the new defaults through settings, runtime resolution, and messaging IPC

## Validation
- pnpm typecheck
- pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts apps/desktop/src/main/__tests__/messaging-routes-service.test.ts apps/desktop/src/main/__tests__/messaging-status-ipc.test.ts apps/desktop/src/main/__tests__/messaging-config.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx packages/shared/src/contracts/__tests__/settings.test.ts
- pnpm lint:eslint
- pnpm lint:boundaries
- pnpm lint:codex-storage
- pnpm lint:colors