### PR TITLE
feat(desktop): add GitHub PR auto-fix settings

### DIFF
--- a/apps/desktop/e2e/transcript-command-output.spec.ts
+++ b/apps/desktop/e2e/transcript-command-output.spec.ts
@@ -13,7 +13,10 @@ test("captured command output is inspectable from transcript work", async () => 
     ),
     windowSize: {
       width: 1280,
-      height: 900,
+      // This command-output interaction does not depend on viewport height.
+      // Keep it below Linux CI's observed 873px content cap so the shared
+      // launcher can assert the requested viewport exactly.
+      height: 860,
     },
   });
 

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -291,6 +291,7 @@ const publishLocalEvent = vi.fn(async () => undefined);
 const setThreadPullRequestStatusToolHandler = vi.fn();
 const setThreadPullRequestWatchToolHandler = vi.fn();
 const setThreadPrAutoDispatchHandler = vi.fn();
+const setThreadPrAutoDispatchBatch = vi.fn(async () => undefined);
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
   directoryKey: string;
   directoryKind: string;
@@ -606,6 +607,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setThreadPullRequestStatusToolHandler,
     setThreadPullRequestWatchToolHandler,
     setThreadPrAutoDispatchHandler,
+    setThreadPrAutoDispatchBatch,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
     rememberCompleteNavigationSnapshot,
@@ -672,6 +674,7 @@ describe("app server ipc", () => {
     setThreadPullRequestStatusToolHandler.mockClear();
     setThreadPullRequestWatchToolHandler.mockClear();
     setThreadPrAutoDispatchHandler.mockClear();
+    setThreadPrAutoDispatchBatch.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
     registerDirectoryFromDiskService.mockClear();
@@ -736,6 +739,7 @@ describe("app server ipc", () => {
 
     expect(setThreadPrAutoDispatchHandler).toHaveBeenCalledWith({
       preferenceChanged: expect.any(Function),
+      preferencesChanged: expect.any(Function),
       cancelPending: expect.any(Function),
       sendPendingNow: expect.any(Function),
       inspect: expect.any(Function),
@@ -743,6 +747,117 @@ describe("app server ipc", () => {
     expect(setThreadPullRequestWatchToolHandler).toHaveBeenCalledWith(
       expect.any(Function),
     );
+  });
+
+  it("targets only existing threads with an open primary attached PR", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const {
+      NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
+    } = await import("../../shared/ipc");
+    const primaryPr = githubPr({
+      number: 42,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      title: "Primary PR",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/42",
+    });
+    const informationalPr = githubPr({
+      number: 43,
+      org: "other",
+      repo: "repo",
+      state: "failing",
+      title: "Informational PR",
+      url: "https://github.com/other/repo/pull/43",
+    });
+    const closedPr = githubPr({
+      number: 44,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "closed",
+      title: "Closed PR",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/44",
+    });
+    const threads = [
+      {
+        id: "thread-primary-disabled",
+        title: "Primary disabled",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        gitOriginUrl: "git@github.com:pwrdrvr/PwrAgent.git",
+        linkedDirectories: [],
+        prs: [primaryPr],
+        prAutoDispatchEnabled: false,
+        updatedAt: 2_000,
+      },
+      {
+        id: "thread-primary-enabled",
+        title: "Primary enabled",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        gitOriginUrl: "git@github.com:pwrdrvr/PwrAgent.git",
+        linkedDirectories: [],
+        prs: [primaryPr],
+        prAutoDispatchEnabled: true,
+        updatedAt: 1_900,
+      },
+      {
+        id: "thread-informational",
+        title: "Informational",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        gitOriginUrl: "git@github.com:pwrdrvr/PwrAgent.git",
+        linkedDirectories: [],
+        prs: [informationalPr],
+        prAutoDispatchEnabled: false,
+        updatedAt: 1_800,
+      },
+      {
+        id: "thread-closed",
+        title: "Closed",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        gitOriginUrl: "git@github.com:pwrdrvr/PwrAgent.git",
+        linkedDirectories: [],
+        prs: [closedPr],
+        prAutoDispatchEnabled: false,
+        updatedAt: 1_700,
+      },
+    ];
+    listThreads.mockResolvedValueOnce(threads as never);
+    listThreads.mockResolvedValueOnce(threads as never);
+
+    registerAppServerIpcHandlers();
+
+    await expect(
+      handlers.get(NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL)?.(
+        {},
+        { enabled: true, dryRun: true },
+      ),
+    ).resolves.toEqual({
+      enabled: true,
+      eligibleThreadCount: 2,
+      updatedThreadCount: 1,
+    });
+    expect(setThreadPrAutoDispatchBatch).not.toHaveBeenCalled();
+
+    await expect(
+      handlers.get(NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL)?.(
+        {},
+        { enabled: true },
+      ),
+    ).resolves.toEqual({
+      enabled: true,
+      eligibleThreadCount: 2,
+      updatedThreadCount: 1,
+    });
+    expect(setThreadPrAutoDispatchBatch).toHaveBeenCalledWith([
+      {
+        backend: "codex",
+        threadId: "thread-primary-disabled",
+        enabled: true,
+      },
+    ]);
   });
 
   it("does not advertise Auto-fix as active without a primary Git repository", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -29,9 +29,19 @@ const prAutomationSettings = vi.hoisted(() => {
     backgroundPrPollingEnabled: true,
     prAutoDispatchAllowed: true,
   };
+  const configWrittenListeners = new Set<() => void>();
   return {
     state,
-    onConfigWritten: vi.fn(() => () => undefined),
+    onConfigWritten: vi.fn((listener: () => void) => {
+      configWrittenListeners.add(listener);
+      return () => configWrittenListeners.delete(listener);
+    }),
+    emitConfigWritten: () => {
+      for (const listener of configWrittenListeners) {
+        listener();
+      }
+    },
+    resetConfigWrittenListeners: () => configWrittenListeners.clear(),
     readSettings: vi.fn(async () => ({
       git: {
         backgroundPrPolling: {
@@ -630,6 +640,7 @@ describe("app server ipc", () => {
   beforeEach(() => {
     prAutomationSettings.state.backgroundPrPollingEnabled = true;
     prAutomationSettings.state.prAutoDispatchAllowed = true;
+    prAutomationSettings.resetConfigWrittenListeners();
     prAutomationSettings.onConfigWritten.mockClear();
     prAutomationSettings.readSettings.mockClear();
     handlers.clear();
@@ -815,6 +826,75 @@ describe("app server ipc", () => {
       backend: "codex",
       threadId: "thread-1",
       enabled: true,
+    });
+    expect(scheduleThreadPrAutoDispatch).not.toHaveBeenCalled();
+  });
+
+  it("does not let a stale settings read re-enable Auto-fix PR", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    let resolveStaleRead:
+      | ((settings: {
+          git: {
+            backgroundPrPolling: { value: boolean };
+            prAutoDispatchAllowed: { value: boolean };
+          };
+        }) => void)
+      | undefined;
+    prAutomationSettings.readSettings.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveStaleRead = resolve;
+      }),
+    );
+    getThreadOverlayState.mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prAutoDispatchEnabled: true,
+    });
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    await vi.waitFor(() => {
+      expect(prAutomationSettings.readSettings).toHaveBeenCalledTimes(1);
+    });
+    expect(resolveStaleRead).toEqual(expect.any(Function));
+
+    prAutomationSettings.state.prAutoDispatchAllowed = false;
+    prAutomationSettings.emitConfigWritten();
+    await vi.waitFor(() => {
+      expect(prAutomationSettings.readSettings).toHaveBeenCalledTimes(2);
+    });
+
+    const autoDispatchHandlers = setThreadPrAutoDispatchHandler.mock.calls.at(-1)?.[0];
+    expect(autoDispatchHandlers).toBeDefined();
+    await vi.waitFor(async () => {
+      const status = await autoDispatchHandlers?.inspect({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+      expect(status).toMatchObject({
+        backgroundPollingEnabled: true,
+        autoFixAllowed: false,
+      });
+    });
+
+    resolveStaleRead?.({
+      git: {
+        backgroundPrPolling: { value: true },
+        prAutoDispatchAllowed: { value: true },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const status = await autoDispatchHandlers?.inspect({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(status).toMatchObject({
+      backgroundPollingEnabled: true,
+      autoFixAllowed: false,
     });
     expect(scheduleThreadPrAutoDispatch).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -24,6 +24,27 @@ const mockAppServerLog = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
+const prAutomationSettings = vi.hoisted(() => {
+  const state = {
+    backgroundPrPollingEnabled: true,
+    prAutoDispatchAllowed: true,
+  };
+  return {
+    state,
+    onConfigWritten: vi.fn(() => () => undefined),
+    readSettings: vi.fn(async () => ({
+      git: {
+        backgroundPrPolling: {
+          value: state.backgroundPrPollingEnabled,
+        },
+        prAutoDispatchAllowed: {
+          value: state.prAutoDispatchAllowed,
+        },
+      },
+    })),
+  };
+});
+
 const resolveGitHubRepoForDirectory = vi.hoisted(() =>
   vi.fn(
     async (): Promise<
@@ -500,6 +521,13 @@ vi.mock("../log", () => ({
   getMainLogger: vi.fn(() => mockAppServerLog),
 }));
 
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: () => ({
+    onConfigWritten: prAutomationSettings.onConfigWritten,
+    readSettings: prAutomationSettings.readSettings,
+  }),
+}));
+
 vi.mock("../app-server/desktop-overlay-store", () => ({
   getDesktopOverlayStore: () => ({
     reconcileNavigationSnapshot,
@@ -600,6 +628,10 @@ vi.mock("../pr-status/git-remote", async () => {
 
 describe("app server ipc", () => {
   beforeEach(() => {
+    prAutomationSettings.state.backgroundPrPollingEnabled = true;
+    prAutomationSettings.state.prAutoDispatchAllowed = true;
+    prAutomationSettings.onConfigWritten.mockClear();
+    prAutomationSettings.readSettings.mockClear();
     handlers.clear();
     archiveThread.mockClear();
     restoreThread.mockClear();
@@ -741,11 +773,50 @@ describe("app server ipc", () => {
       });
       expect(status).toMatchObject({
         backgroundPollingEnabled: true,
+        autoFixAllowed: true,
         autoFixEnabled: true,
         autoFixActive: false,
         guidance: expect.stringContaining("no GitHub primary workspace"),
       });
     });
+  });
+
+  it("keeps Auto-fix PR disabled globally without overwriting its thread setting", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
+    prAutomationSettings.state.prAutoDispatchAllowed = false;
+    getThreadOverlayState.mockResolvedValue({
+      backend: "codex",
+      threadId: "thread-1",
+      executionMode: "default",
+      extraLinkedDirectories: [],
+      prAutoDispatchEnabled: true,
+    });
+
+    registerAppServerIpcHandlers();
+    await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+    const autoDispatchHandlers = setThreadPrAutoDispatchHandler.mock.calls.at(-1)?.[0];
+    expect(autoDispatchHandlers).toBeDefined();
+    await vi.waitFor(async () => {
+      const status = await autoDispatchHandlers?.inspect({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+      expect(status).toMatchObject({
+        backgroundPollingEnabled: true,
+        autoFixAllowed: false,
+        autoFixEnabled: true,
+        autoFixActive: false,
+        guidance: expect.stringContaining("disabled globally"),
+      });
+    });
+
+    await autoDispatchHandlers?.preferenceChanged({
+      backend: "codex",
+      threadId: "thread-1",
+      enabled: true,
+    });
+    expect(scheduleThreadPrAutoDispatch).not.toHaveBeenCalled();
   });
 
   it("keeps a new PR watch pending when the cached outcome is stale", async () => {
@@ -4357,6 +4428,7 @@ describe("app server ipc", () => {
           directoryPaths: ["/repo/wt"],
           prAutomation: {
             backgroundPollingEnabled: false,
+            autoFixAllowed: false,
             autoFixEnabled: false,
             autoFixActive: false,
           },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2203,6 +2203,47 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("coalesces bulk Auto-fix PR preferences before coordinator evaluation", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const preferenceChanged = vi.fn(async () => undefined);
+    const preferencesChanged = vi.fn(async () => undefined);
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+    });
+    registry.setThreadPrAutoDispatchHandler({
+      preferenceChanged,
+      preferencesChanged,
+      cancelPending: vi.fn(async () => true),
+      sendPendingNow: vi.fn(async () => true),
+    });
+
+    try {
+      await registry.setThreadPrAutoDispatchBatch([
+        { backend: "codex", threadId: "thread-1", enabled: true },
+        { backend: "codex", threadId: "thread-2", enabled: true },
+      ]);
+
+      expect(preferenceChanged).not.toHaveBeenCalled();
+      expect(preferencesChanged).toHaveBeenCalledTimes(1);
+      expect(preferencesChanged).toHaveBeenCalledWith([
+        { backend: "codex", threadId: "thread-1", enabled: true },
+        { backend: "codex", threadId: "thread-2", enabled: true },
+      ]);
+      await expect(overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      })).resolves.toMatchObject({ prAutoDispatchEnabled: true });
+      await expect(overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-2",
+      })).resolves.toMatchObject({ prAutoDispatchEnabled: true });
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("routes structured generation to the configured Codex backend", async () => {
     const codexClient = new MockBackendClient({ threads: [] });
     const generateStructuredObject = vi.fn(async () => ({
@@ -2305,6 +2346,50 @@ describe("DesktopBackendRegistry", () => {
       ).toBe(false);
     } finally {
       await Promise.all([defaultRegistry.close(), disabledRegistry.close()]);
+    }
+  });
+
+  it("saves the launchpad Auto-fix PR choice through materialization", async () => {
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/start"] },
+      }),
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+      createScratchProjectDirectory: async () => "/tmp/pwragent-launchpad-test",
+      resolveDefaultPrAutoDispatchEnabled: () => false,
+    });
+
+    try {
+      const created = await registry.ensureDirectoryLaunchpad({
+        directoryKey: "workspace:/tmp/pwragent-launchpad-test",
+        directoryKind: "workspace",
+        directoryLabel: "Workspaces",
+      });
+      expect(created.launchpad.prAutoDispatchEnabled).toBe(false);
+
+      const updated = await registry.updateDirectoryLaunchpad({
+        directoryKey: created.launchpad.directoryKey,
+        patch: { prAutoDispatchEnabled: true },
+        stickySettingsChanged: true,
+      });
+      expect(updated.launchpad.prAutoDispatchEnabled).toBe(true);
+
+      const materialized = await registry.materializeDirectoryLaunchpad({
+        directoryKey: updated.launchpad.directoryKey,
+        launchpad: updated.launchpad,
+      });
+      expect(
+        (await overlayStore.getThreadOverlayState({
+          backend: materialized.backend,
+          threadId: materialized.threadId,
+        }))?.prAutoDispatchEnabled,
+      ).toBe(true);
+    } finally {
+      await registry.close();
     }
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2266,6 +2266,48 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("seeds Auto-fix PR for new threads from the configured default", async () => {
+    const defaultOverlayStore = createOverlayStoreMock();
+    const defaultRegistry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: defaultOverlayStore,
+    });
+    const disabledOverlayStore = createOverlayStoreMock();
+    const disabledRegistry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: disabledOverlayStore,
+      resolveDefaultPrAutoDispatchEnabled: () => false,
+    });
+
+    try {
+      await defaultRegistry.startThread({
+        backend: "codex",
+        cwd: process.cwd(),
+      });
+      expect(
+        (await defaultOverlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }))?.prAutoDispatchEnabled,
+      ).toBe(true);
+
+      await disabledRegistry.startThread({
+        backend: "codex",
+        cwd: process.cwd(),
+      });
+      expect(
+        (await disabledOverlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }))?.prAutoDispatchEnabled,
+      ).toBe(false);
+    } finally {
+      await Promise.all([defaultRegistry.close(), disabledRegistry.close()]);
+    }
+  });
+
   it("does not resolve the Grok API key while AgentCore-Grok is disabled", async () => {
     const previous = process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK;
     process.env.PWRAGENT_EXPERIMENTAL_AGENT_CORE_GROK = "0";
@@ -10477,6 +10519,7 @@ command = "pnpm grok"
       reasoningEffort: "high",
       serviceTier: "priority",
       fastMode: true,
+      prAutoDispatchEnabled: true,
     });
 
     await registry.close();
@@ -24702,6 +24745,7 @@ script = "printf setup"
       sendPendingNow: vi.fn(async () => false),
       inspect: vi.fn(async () => ({
         backgroundPollingEnabled: true,
+        autoFixAllowed: true,
         autoFixEnabled: true,
         autoFixActive: true,
         guidance: "End the turn and let PwrAgent watch CI.",
@@ -24742,6 +24786,7 @@ script = "printf setup"
       status: "idle",
       prAutomation: {
         backgroundPollingEnabled: true,
+        autoFixAllowed: true,
         autoFixEnabled: true,
         autoFixActive: true,
       },
@@ -26022,6 +26067,7 @@ script = "printf setup"
           directoryPaths: args.directoryPaths ?? ["/repo"],
           prAutomation: {
             backgroundPollingEnabled: true,
+            autoFixAllowed: true,
             autoFixEnabled: true,
             autoFixActive: true,
             guidance: "End the turn and let PwrAgent watch the PR.",
@@ -26110,6 +26156,7 @@ script = "printf setup"
           directoryPaths: args.directoryPaths ?? [],
           prAutomation: {
             backgroundPollingEnabled: true,
+            autoFixAllowed: true,
             autoFixEnabled: false,
             autoFixActive: false,
             guidance: "Use a one-shot PR watch.",
@@ -26185,6 +26232,7 @@ script = "printf setup"
           coveredByAutoFix: ["failure" as const],
           prAutomation: {
             backgroundPollingEnabled: true,
+            autoFixAllowed: true,
             autoFixEnabled: true,
             autoFixActive: true,
             guidance: "End the turn.",

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -219,6 +219,28 @@ describe("desktopSettingsPatchToEdits — Git", () => {
     ]);
   });
 
+  it("writes the GitHub PR automation controls", () => {
+    expect(
+      desktopSettingsPatchToEdits({
+        git: {
+          prAutoDispatchAllowed: false,
+          defaultPrAutoDispatchEnabled: false,
+        },
+      }),
+    ).toEqual([
+      {
+        op: "set",
+        path: ["git", "pr_auto_dispatch_allowed"],
+        value: false,
+      },
+      {
+        op: "set",
+        path: ["git", "default_pr_auto_dispatch_enabled"],
+        value: false,
+      },
+    ]);
+  });
+
   it("preserves and mirrors a recognized experimental polling key", () => {
     const edits = desktopSettingsPatchToEdits(
       {

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1880,6 +1880,48 @@ describe("DesktopSettingsService", () => {
     expect(contents).not.toContain("[experimental]");
   });
 
+  it("defaults GitHub PR automation to on and persists its global choices", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const service = new DesktopSettingsService({
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const initial = await service.readSettings();
+    expect(initial.git.prAutoDispatchAllowed).toEqual({
+      value: true,
+      source: "default",
+    });
+    expect(initial.git.defaultPrAutoDispatchEnabled).toEqual({
+      value: true,
+      source: "default",
+    });
+    expect(service.resolveDefaultPrAutoDispatchEnabled()).toBe(true);
+
+    await service.writeConfigPatch({
+      git: {
+        prAutoDispatchAllowed: false,
+        defaultPrAutoDispatchEnabled: false,
+      },
+    });
+
+    const updated = await service.readSettings();
+    expect(updated.git.prAutoDispatchAllowed).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(updated.git.defaultPrAutoDispatchEnabled).toEqual({
+      value: false,
+      source: "config",
+    });
+    expect(service.resolveDefaultPrAutoDispatchEnabled()).toBe(false);
+    const contents = fs.readFileSync(configPath, "utf8");
+    expect(contents).toContain("pr_auto_dispatch_allowed = false");
+    expect(contents).toContain("default_pr_auto_dispatch_enabled = false");
+  });
+
   it("reads the canonical Git background PR polling key", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1477,6 +1477,9 @@ type ThreadPullRequestWatchToolHandler = (
 
 type ThreadPrAutoDispatchHandler = {
   preferenceChanged: (request: SetThreadPrAutoDispatchRequest) => Promise<void>;
+  preferencesChanged?: (
+    requests: SetThreadPrAutoDispatchRequest[],
+  ) => Promise<void>;
   cancelPending: (request: CancelThreadPrAutoDispatchRequest) => Promise<boolean>;
   sendPendingNow: (
     request: SendThreadPrAutoDispatchNowRequest,
@@ -4496,11 +4499,17 @@ function resolveCodexEnvironmentSelection(
 }
 
 async function resetLaunchpadAfterMaterialize(params: {
+  defaultPrAutoDispatchEnabled: boolean;
   defaults: NavigationLaunchpadDefaults;
   launchpad: NavigationLaunchpadDraft;
   overlayStore: OverlayStoreLike;
 }): Promise<void> {
-  const { defaults, launchpad, overlayStore } = params;
+  const {
+    defaultPrAutoDispatchEnabled,
+    defaults,
+    launchpad,
+    overlayStore,
+  } = params;
   await overlayStore.resetDirectoryLaunchpad({
     directoryKey: launchpad.directoryKey,
   });
@@ -4521,6 +4530,7 @@ async function resetLaunchpadAfterMaterialize(params: {
     reasoningEffort: defaults.reasoningEffort,
     serviceTier: defaults.serviceTier,
     fastMode: defaults.fastMode,
+    prAutoDispatchEnabled: defaultPrAutoDispatchEnabled,
     prompt: "",
     workMode: defaultLaunchpadWorkMode(launchpad, defaults),
     branchName: launchpad.branchName,
@@ -9090,6 +9100,7 @@ export class DesktopBackendRegistry {
     branchName?: string;
     requiredWorkMode?: NavigationLaunchpadDraft["workMode"];
     parentThreadId?: string;
+    prAutoDispatchEnabled?: boolean;
     codexEnvironmentRuntime?: CodexThreadEnvironmentRuntime;
     linkedDirectories?: LinkedDirectorySummary[];
   }): Promise<StartThreadResponse> {
@@ -9103,6 +9114,7 @@ export class DesktopBackendRegistry {
       branchName,
       requiredWorkMode,
       parentThreadId,
+      prAutoDispatchEnabled,
       ...request
     } = params;
     const modelSettings = await this.resolveModelSettings(backend, request);
@@ -9345,7 +9357,8 @@ export class DesktopBackendRegistry {
     await this.overlayStore.setThreadPrAutoDispatchEnabled({
       backend,
       threadId: result.threadId,
-      enabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
+      enabled:
+        prAutoDispatchEnabled ?? this.resolveDefaultPrAutoDispatchEnabledFn(),
     });
     if (request.agent) {
       await this.overlayStore.setThreadAgent({
@@ -12215,23 +12228,51 @@ export class DesktopBackendRegistry {
   async setThreadPrAutoDispatch(
     params: SetThreadPrAutoDispatchRequest,
   ): Promise<SetThreadPrAutoDispatchResponse> {
-    await this.overlayStore.setThreadPrAutoDispatchEnabled({
-      backend: params.backend,
-      threadId: params.threadId,
-      enabled: params.enabled,
-    });
-    await this.emit({
-      backend: params.backend,
-      notification: {
-        method: "thread/prAutoDispatch/updated",
-        params: {
-          threadId: params.threadId,
-          enabled: params.enabled,
-        },
-      },
-    });
-    await this.threadPrAutoDispatchHandler?.preferenceChanged(params);
+    await this.setThreadPrAutoDispatchBatch([params]);
     return params;
+  }
+
+  /**
+   * Apply several operator-initiated Auto-fix preferences before asking the
+   * PR coordinator to evaluate them. This prevents a bulk settings action
+   * from refreshing or scheduling the same attached PR once per thread.
+   */
+  async setThreadPrAutoDispatchBatch(
+    requests: SetThreadPrAutoDispatchRequest[],
+  ): Promise<void> {
+    if (requests.length === 0) {
+      return;
+    }
+
+    for (const request of requests) {
+      await this.overlayStore.setThreadPrAutoDispatchEnabled({
+        backend: request.backend,
+        threadId: request.threadId,
+        enabled: request.enabled,
+      });
+      await this.emit({
+        backend: request.backend,
+        notification: {
+          method: "thread/prAutoDispatch/updated",
+          params: {
+            threadId: request.threadId,
+            enabled: request.enabled,
+          },
+        },
+      });
+    }
+
+    if (requests.length === 1) {
+      await this.threadPrAutoDispatchHandler?.preferenceChanged(requests[0]!);
+      return;
+    }
+    if (this.threadPrAutoDispatchHandler?.preferencesChanged) {
+      await this.threadPrAutoDispatchHandler.preferencesChanged(requests);
+      return;
+    }
+    for (const request of requests) {
+      await this.threadPrAutoDispatchHandler?.preferenceChanged(request);
+    }
   }
 
   async cancelThreadPrAutoDispatch(
@@ -13062,6 +13103,7 @@ export class DesktopBackendRegistry {
           fastMode: defaults.fastMode,
           acpRuntime: defaults.acpRuntime,
           providerSettings: defaults.providerSettings,
+          prAutoDispatchEnabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
           workMode: defaultLaunchpadWorkMode(request, defaults),
           branchName: existing.branchName ?? request.currentBranch,
           parentThreadId: requestParentThreadId,
@@ -13126,6 +13168,7 @@ export class DesktopBackendRegistry {
       fastMode: defaults.fastMode,
       acpRuntime: defaults.acpRuntime,
       providerSettings: defaults.providerSettings,
+      prAutoDispatchEnabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
       prompt: "",
       registeredAt: request.registeredAt,
       workMode: defaultLaunchpadWorkMode(request, defaults),
@@ -13903,6 +13946,8 @@ export class DesktopBackendRegistry {
       reasoningEffort: launchpad.reasoningEffort,
       serviceTier: launchpad.serviceTier,
       fastMode: launchpad.backend === "codex" ? launchpad.fastMode : undefined,
+      prAutoDispatchEnabled:
+        launchpad.prAutoDispatchEnabled ?? this.resolveDefaultPrAutoDispatchEnabledFn(),
       acpRuntime: launchpad.acpRuntime,
       codexEnvironmentRuntime,
       directoryKey: launchpad.directoryKey,
@@ -14010,6 +14055,7 @@ export class DesktopBackendRegistry {
     }
 
     await resetLaunchpadAfterMaterialize({
+      defaultPrAutoDispatchEnabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
       defaults: await this.resolveLaunchpadDefaults(
         await this.overlayStore.getLaunchpadDefaults(),
         launchpad.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -219,6 +219,7 @@ import {
   DEFAULT_TASK_MONITOR_POLL_INTERVAL_SECONDS,
   DEFAULT_TASK_MONITOR_REASONING_EFFORT,
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
+  DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
   type CompleteMonitoringToolArgs,
   type CreateMonitorDelegationToolArgs,
   type InjectMonitorProgressToolArgs,
@@ -6062,6 +6063,7 @@ export class DesktopBackendRegistry {
   private readonly isCodexBootstrapDeferredFn: () => boolean;
   private readonly resolveCodexDefaultModeRequestUserInputFn: () => boolean;
   private readonly resolveManagedReviewEnabledFn: () => boolean;
+  private readonly resolveDefaultPrAutoDispatchEnabledFn: () => boolean;
   private readonly resolveProviderModelDefaultsFn: () => Record<
     string,
     DesktopProviderModelDefaults
@@ -6111,6 +6113,7 @@ export class DesktopBackendRegistry {
     isBootstrapMode?: () => boolean;
     resolveCodexDefaultModeRequestUserInput?: () => boolean;
     resolveManagedReviewEnabled?: () => boolean;
+    resolveDefaultPrAutoDispatchEnabled?: () => boolean;
     resolveProviderModelDefaults?: () => Record<
       string,
       DesktopProviderModelDefaults
@@ -6195,6 +6198,24 @@ export class DesktopBackendRegistry {
             },
           );
           return false;
+        }
+      });
+    this.resolveDefaultPrAutoDispatchEnabledFn =
+      options?.resolveDefaultPrAutoDispatchEnabled ??
+      (() => {
+        try {
+          return (
+            settingsService?.resolveDefaultPrAutoDispatchEnabled()
+            ?? DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS
+          );
+        } catch (error) {
+          backendRegistryLog.warn(
+            "failed to resolve default Auto-fix PR setting",
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS;
         }
       });
     this.resolveProviderModelDefaultsFn =
@@ -9321,6 +9342,11 @@ export class DesktopBackendRegistry {
         branch: gitBranch,
       });
     }
+    await this.overlayStore.setThreadPrAutoDispatchEnabled({
+      backend,
+      threadId: result.threadId,
+      enabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
+    });
     if (request.agent) {
       await this.overlayStore.setThreadAgent({
         backend,
@@ -9600,6 +9626,11 @@ export class DesktopBackendRegistry {
         backend,
         threadId: result.threadId,
         executionMode,
+      });
+      await this.overlayStore.setThreadPrAutoDispatchEnabled({
+        backend,
+        threadId: result.threadId,
+        enabled: this.resolveDefaultPrAutoDispatchEnabledFn(),
       });
       const currentMigration =
         this.resolveProviderThreadModelMigrationsFn()[backend];

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -128,6 +128,7 @@ import {
 } from "@pwragent/shared";
 import {
   DEFAULT_BACKGROUND_PR_POLLING,
+  DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
   DEFAULT_PULL_REQUEST_PROVIDER,
   buildPullRequestStatusKey,
   buildThreadIdentityKey,
@@ -925,6 +926,7 @@ class DesktopAppServerService {
   private prGraphqlClient: GithubGraphqlPrClient | undefined;
   private prPollingScheduler: PrPollingScheduler | undefined;
   private backgroundPrPollingEnabled = false;
+  private prAutoDispatchAllowed = false;
   private prAutoDispatchCoordinator: PrAutoDispatchCoordinator | undefined;
   private prStatusWatchCoordinator: PrStatusWatchCoordinator | undefined;
   /** Visible thread→PR attachments plus the primary workspace's repository. */
@@ -2746,7 +2748,7 @@ class DesktopAppServerService {
     const waitingForPr = hasPrimaryRepo && primaryPrs.length === 0;
     const autoFixActive =
       autoFixEnabled
-      && this.backgroundPrPollingEnabled
+      && this.isPrAutoDispatchAvailable()
       && (waitingForPr || ownsAttachedPr);
     const watches = await this.getOverlayStore().listActiveThreadPrStatusWatches(
       params,
@@ -2757,15 +2759,20 @@ class DesktopAppServerService {
       ? "Auto-fix PR is active. Do not poll CI and do not create a monitor thread for this PR. End the turn; PwrAgent will start a repair turn on a CI failure or merge conflict. Use watch_thread_pull_request before ending when the thread should also wake on successful completion."
       : autoFixEnabled
         ? this.backgroundPrPollingEnabled
-          ? hasPrimaryRepo
-            ? "Auto-fix PR is enabled, but an older eligible thread owns monitoring for this PR. Do not poll CI or create another monitor; the elected thread receives the PR event."
-            : "Auto-fix PR is enabled, but this thread has no GitHub primary workspace. PwrAgent cannot monitor PR automation for it; check the PR directly until the thread is attached to a Git workspace."
+          ? this.prAutoDispatchAllowed
+            ? hasPrimaryRepo
+              ? "Auto-fix PR is enabled, but an older eligible thread owns monitoring for this PR. Do not poll CI or create another monitor; the elected thread receives the PR event."
+              : "Auto-fix PR is enabled, but this thread has no GitHub primary workspace. PwrAgent cannot monitor PR automation for it; check the PR directly until the thread is attached to a Git workspace."
+            : "Auto-fix PR is saved but disabled globally in Git settings. Do not assume PwrAgent will wake this thread until automatic PR repair is allowed again."
           : "Auto-fix PR is saved but paused because background PR polling is off. Do not assume PwrAgent will wake this thread until polling is enabled."
         : this.backgroundPrPollingEnabled
-          ? "Background PR polling is active, but Auto-fix PR is off for this thread. Use watch_thread_pull_request for a bounded one-shot success/failure notification instead of polling or creating a monitor thread."
+          ? this.prAutoDispatchAllowed
+            ? "Background PR polling is active, but Auto-fix PR is off for this thread. Use watch_thread_pull_request for a bounded one-shot success/failure notification instead of polling or creating a monitor thread."
+            : "Background PR polling is active, but automatic PR repair is disabled globally in Git settings. Use watch_thread_pull_request for a bounded one-shot success/failure notification instead of polling or creating a monitor thread."
           : "Background PR polling and Auto-fix PR are off. PwrAgent will not wake this thread for PR status changes.";
     return {
       backgroundPollingEnabled: this.backgroundPrPollingEnabled,
+      autoFixAllowed: this.prAutoDispatchAllowed,
       autoFixEnabled,
       autoFixActive,
       ...(overlay?.prAutoDispatchPending
@@ -3817,20 +3824,14 @@ class DesktopAppServerService {
   }
 
   /**
-   * Start or stop the background poller to match the experimental setting.
-   *
-   * Called on every navigation snapshot, so toggling the setting takes effect
-   * without an app restart. With the flag off nothing is scheduled and PR chips
-   * behave exactly as they did before the poller existed.
-   */
-  /**
-   * Start or stop the background PR poller to match the experimental flag.
-   * Public + idempotent: called on every navigation snapshot AND the moment the
-   * setting is written, so toggling takes effect without a restart.
+   * Start or stop background PR polling and automatic repair dispatch to match
+   * the Git settings. Public + idempotent: called on every navigation snapshot
+   * and after every settings write, so both gates take effect without a restart.
    */
   syncPrPollingSchedulerState(): void {
     void (async () => {
-      let enabled = DEFAULT_BACKGROUND_PR_POLLING;
+      let backgroundPollingEnabled = DEFAULT_BACKGROUND_PR_POLLING;
+      let prAutoDispatchAllowed = DEFAULT_PR_AUTO_DISPATCH_ALLOWED;
       try {
         const settingsService = getDesktopSettingsService();
         // Subscribe lazily on the first sync (which the first navigation
@@ -3841,30 +3842,42 @@ class DesktopAppServerService {
           this.prPollingSettingsUnsubscribe = settingsService.onConfigWritten(
             () => {
               // Pause dispatch pessimistically while the new snapshot is read.
-              // This closes the settings-write race for the global kill switch.
+              // This closes settings-write races for both global kill switches.
               this.backgroundPrPollingEnabled = false;
+              this.prAutoDispatchAllowed = false;
+              this.prAutoDispatchCoordinator?.pause();
               this.syncPrPollingSchedulerState();
             },
           );
         }
         const settings = await settingsService.readSettings();
-        enabled = settings.git.backgroundPrPolling.value;
+        backgroundPollingEnabled = settings.git.backgroundPrPolling.value;
+        prAutoDispatchAllowed = settings.git.prAutoDispatchAllowed.value;
       } catch (error) {
-        appServerLog.warn("failed to read background PR polling setting", {
+        appServerLog.warn("failed to read GitHub PR automation settings", {
           error: error instanceof Error ? error.message : String(error),
         });
       }
 
-      this.backgroundPrPollingEnabled = enabled;
+      this.backgroundPrPollingEnabled = backgroundPollingEnabled;
+      this.prAutoDispatchAllowed = prAutoDispatchAllowed;
 
-      if (!enabled) {
+      if (!backgroundPollingEnabled) {
         this.prAutoDispatchCoordinator?.pause();
         this.stopPrPollingScheduler();
         return;
       }
       this.ensurePrPollingSchedulerStarted();
+      if (!this.isPrAutoDispatchAvailable()) {
+        this.prAutoDispatchCoordinator?.pause();
+        return;
+      }
       void this.getPrAutoDispatchCoordinator().resume();
     })();
+  }
+
+  private isPrAutoDispatchAvailable(): boolean {
+    return this.backgroundPrPollingEnabled && this.prAutoDispatchAllowed;
   }
 
   private stopPrPollingScheduler(): void {
@@ -4149,7 +4162,7 @@ class DesktopAppServerService {
             pr,
             threadKeys,
             observedAt,
-            backgroundPollingEnabled: this.backgroundPrPollingEnabled,
+            backgroundPollingEnabled: this.isPrAutoDispatchAvailable(),
             operatorInitiated,
           })
         : [];
@@ -4190,7 +4203,7 @@ class DesktopAppServerService {
       );
       await coordinator.cancelAllPendingForThread(request);
       await this.syncThreadPrAutoDispatchCandidates(request);
-      if (this.backgroundPrPollingEnabled && previouslyEligiblePrs.length > 0) {
+      if (this.isPrAutoDispatchAvailable() && previouslyEligiblePrs.length > 0) {
         await this.handlePrAutoDispatchSnapshots(
           previouslyEligiblePrs,
           this.nextPrObservationTimestamp(),
@@ -4204,7 +4217,7 @@ class DesktopAppServerService {
     const prs = this.canonicalizePrs(overlay?.prs ?? []);
     await this.rememberThreadPrAttachmentUpdate({ ...request, prs });
     await coordinator.resetForOperator(request);
-    if (!this.backgroundPrPollingEnabled) return;
+    if (!this.isPrAutoDispatchAvailable()) return;
     const primaryPrs = this.primaryAttachedPrsForThread({ ...request, prs });
     await this.handlePrAutoDispatchSnapshots(
       primaryPrs,
@@ -5049,6 +5062,7 @@ class DesktopAppServerService {
     this.prPollingScheduler?.stop();
     this.prPollingScheduler = undefined;
     this.backgroundPrPollingEnabled = false;
+    this.prAutoDispatchAllowed = false;
     if (this.prDiscoveryTimer) {
       clearInterval(this.prDiscoveryTimer);
       this.prDiscoveryTimer = undefined;
@@ -5113,7 +5127,7 @@ class DesktopAppServerService {
       this.prAutoDispatchCoordinator = new PrAutoDispatchCoordinator({
         store: this.getOverlayStore(),
         registry: getDesktopBackendRegistry(),
-        isBackgroundPollingEnabled: () => this.backgroundPrPollingEnabled,
+        isBackgroundPollingEnabled: () => this.isPrAutoDispatchAvailable(),
         getCurrentPr: (prKey) => this.prStatusRegistry.get(prKey)?.pr,
         refreshPendingPrs: async (pending) =>
           await this.refreshPendingPrAutoDispatches(pending),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -37,6 +37,8 @@ import {
   type CancelThreadPrAutoDispatchRequest,
   type SendThreadPrAutoDispatchNowRequest,
   type SetThreadPrAutoDispatchRequest,
+  type SetEligibleThreadsPrAutoDispatchRequest,
+  type SetEligibleThreadsPrAutoDispatchResponse,
   type ThreadSearchRequest,
   type ThreadSearchResponse,
   type PersistThreadUsageActivityRequest,
@@ -187,6 +189,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
@@ -3622,11 +3625,14 @@ class DesktopAppServerService {
     }
   }
 
-  /** Resolve only visible attachments; detached lookup history never qualifies. */
+  /** Resolve only primary visible attachments; detached and informational links never qualify. */
   private findThreadKeysForPrKey(prKey: string): string[] {
     const threadKeys: string[] = [];
     for (const [threadKey, attachment] of this.attachedPrsByThreadKey) {
-      if (attachment.prs.some((pr) => getPrStatusKey(pr) === prKey)) {
+      if (attachment.prs.some((pr) =>
+        getPrStatusKey(pr) === prKey
+        && pullRequestMatchesRepositoryKey(pr, attachment.primaryRepoKey)
+      )) {
         threadKeys.push(threadKey);
       }
     }
@@ -4133,7 +4139,9 @@ class DesktopAppServerService {
     this.prPollBackendByKey.clear();
 
     for (const [threadKey, attachment] of this.attachedPrsByThreadKey) {
-      for (const pr of attachment.prs) {
+      for (const pr of attachment.prs.filter((candidate) =>
+        pullRequestMatchesRepositoryKey(candidate, attachment.primaryRepoKey)
+      )) {
         const prKey = getPrStatusKey(pr);
         const latest = this.prStatusRegistry.get(prKey)?.pr ?? pr;
         if (isTerminalPullRequest(latest)) continue;
@@ -4200,49 +4208,85 @@ class DesktopAppServerService {
   async handleThreadPrAutoDispatchPreference(
     request: SetThreadPrAutoDispatchRequest,
   ): Promise<void> {
-    const coordinator = this.getPrAutoDispatchCoordinator();
-    if (!request.enabled) {
-      const attachment = this.attachedPrsByThreadKey.get(
-        buildThreadIdentityKey(request.backend, request.threadId),
-      );
-      const previouslyEligiblePrs = (attachment?.prs ?? []).filter((pr) =>
-        pullRequestMatchesRepositoryKey(pr, attachment?.primaryRepoKey),
-      );
-      await coordinator.cancelAllPendingForThread(request);
-      await this.syncThreadPrAutoDispatchCandidates(request);
-      if (this.isPrAutoDispatchAvailable() && previouslyEligiblePrs.length > 0) {
-        await this.handlePrAutoDispatchSnapshots(
-          previouslyEligiblePrs,
-          this.nextPrObservationTimestamp(),
-          true,
-        );
-      }
+    await this.handleThreadPrAutoDispatchPreferences([request]);
+  }
+
+  /**
+   * Coalesce an operator's bulk preference change before reading provider
+   * state. Several threads can attach the same PR; evaluating the final
+   * candidate set once keeps the first eligible thread authoritative and
+   * avoids a GraphQL request per thread.
+   */
+  async handleThreadPrAutoDispatchPreferences(
+    requests: SetThreadPrAutoDispatchRequest[],
+  ): Promise<void> {
+    if (requests.length === 0) {
       return;
     }
 
-    const overlay = await this.getOverlayStore().getThreadOverlayState(request);
-    const prs = this.canonicalizePrs(overlay?.prs ?? []);
-    await this.rememberThreadPrAttachmentUpdate({ ...request, prs });
-    await coordinator.resetForOperator(request);
-    if (!this.isPrAutoDispatchAvailable()) return;
-    const primaryPrs = this.primaryAttachedPrsForThread({ ...request, prs });
+    const coordinator = this.getPrAutoDispatchCoordinator();
+    const disabledRequests = requests.filter((request) => !request.enabled);
+    const enabledRequests = requests.filter((request) => request.enabled);
+
+    const previouslyEligiblePrs: PrSummary[] = [];
+    for (const request of disabledRequests) {
+      const attachment = this.attachedPrsByThreadKey.get(
+        buildThreadIdentityKey(request.backend, request.threadId),
+      );
+      previouslyEligiblePrs.push(
+        ...(attachment?.prs ?? []).filter((pr) =>
+          pullRequestMatchesRepositoryKey(pr, attachment?.primaryRepoKey),
+        ),
+      );
+      await coordinator.cancelAllPendingForThread(request);
+      await this.syncThreadPrAutoDispatchCandidates(request);
+    }
+    if (this.isPrAutoDispatchAvailable() && previouslyEligiblePrs.length > 0) {
+      await this.handlePrAutoDispatchSnapshots(
+        dedupePrsByStatusKey(previouslyEligiblePrs),
+        this.nextPrObservationTimestamp(),
+        true,
+      );
+    }
+
+    if (enabledRequests.length === 0) {
+      return;
+    }
+
+    const primaryPrs: PrSummary[] = [];
+    for (const request of enabledRequests) {
+      const overlay = await this.getOverlayStore().getThreadOverlayState(request);
+      const prs = this.canonicalizePrs(overlay?.prs ?? []);
+      await this.rememberThreadPrAttachmentUpdate({ ...request, prs });
+      await coordinator.resetForOperator(request);
+      primaryPrs.push(...this.primaryAttachedPrsForThread({ ...request, prs }));
+    }
+    if (!this.isPrAutoDispatchAvailable()) {
+      return;
+    }
+
+    const uniquePrimaryPrs = dedupePrsByStatusKey(primaryPrs);
     await this.handlePrAutoDispatchSnapshots(
-      primaryPrs,
+      uniquePrimaryPrs,
       this.nextPrObservationTimestamp(),
       true,
     );
 
     const refs = [
       ...new Map(
-        primaryPrs.flatMap((pr) => {
+        uniquePrimaryPrs.flatMap((pr) => {
           const ref = parsePrRefFromUrl(pr.url);
           return ref ? [[`${ref.owner}/${ref.repo}#${ref.number}`, ref] as const] : [];
         }),
       ).values(),
     ];
-    if (refs.length === 0) return;
+    if (refs.length === 0) {
+      return;
+    }
     const refreshed = await this.getPrGraphqlClient().fetchPullRequests(refs);
-    if (refreshed.length === 0) return;
+    if (refreshed.length === 0) {
+      return;
+    }
     const fetchedAt = this.nextPrObservationTimestamp();
     const changed = this.rememberPrStatuses(
       refreshed,
@@ -4251,7 +4295,7 @@ class DesktopAppServerService {
     );
     await this.writePrStatusesToCache(refreshed, fetchedAt);
     await this.publishPullRequestStatusUpdates({
-      backend: request.backend,
+      backend: enabledRequests[0]!.backend,
       prs: changed,
     });
     await this.handlePrAutoDispatchSnapshots(
@@ -4259,6 +4303,50 @@ class DesktopAppServerService {
       fetchedAt,
       true,
     );
+  }
+
+  /**
+   * The Settings bulk action refreshes the complete attachment view before it
+   * decides which saved preferences to change. Detached and informational PR
+   * links are never eligible because primary-workspace matching happens here
+   * in the main process.
+   */
+  async setEligibleThreadsPrAutoDispatch(
+    request: SetEligibleThreadsPrAutoDispatchRequest,
+  ): Promise<SetEligibleThreadsPrAutoDispatchResponse> {
+    const snapshot = await this.getNavigationSnapshot({
+      backend: "all",
+      refreshMode: "full",
+    });
+    const eligibleThreads = snapshot.threads.filter((thread) => {
+      const attachment = this.attachedPrsByThreadKey.get(
+        buildThreadIdentityKey(thread.source, thread.id),
+      );
+      return Boolean(
+        attachment?.primaryRepoKey
+        && attachment.prs.some((pr) =>
+          pullRequestMatchesRepositoryKey(pr, attachment.primaryRepoKey)
+          && !isTerminalPullRequest(pr)
+        ),
+      );
+    });
+    const updates = eligibleThreads
+      .filter((thread) => thread.prAutoDispatchEnabled !== request.enabled)
+      .map((thread) => ({
+        backend: thread.source,
+        threadId: thread.id,
+        enabled: request.enabled,
+      }));
+
+    if (!request.dryRun && updates.length > 0) {
+      await getDesktopBackendRegistry().setThreadPrAutoDispatchBatch(updates);
+    }
+
+    return {
+      enabled: request.enabled,
+      eligibleThreadCount: eligibleThreads.length,
+      updatedThreadCount: updates.length,
+    };
   }
 
   async cancelThreadPrAutoDispatch(
@@ -5358,6 +5446,8 @@ export function registerAppServerIpcHandlers(): void {
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler({
     preferenceChanged: async (request) =>
       await appServerService.handleThreadPrAutoDispatchPreference(request),
+    preferencesChanged: async (requests) =>
+      await appServerService.handleThreadPrAutoDispatchPreferences(requests),
     cancelPending: async (request) =>
       await appServerService.cancelThreadPrAutoDispatch(request),
     sendPendingNow: async (request) =>
@@ -5803,6 +5893,16 @@ export function registerAppServerIpcHandlers(): void {
       return await appServerService.updateDirectoryLaunchpad(request);
     },
   );
+  ipcMain.removeHandler(NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
+    async (
+      _event,
+      request: SetEligibleThreadsPrAutoDispatchRequest,
+    ): Promise<SetEligibleThreadsPrAutoDispatchResponse> => {
+      return await appServerService.setEligibleThreadsPrAutoDispatch(request);
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.handle(
     NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -5927,6 +6027,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_GET_GH_STATUS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -951,6 +951,8 @@ class DesktopAppServerService {
   private readonly prDiscoveryLastRefreshedAt = new Map<string, number>();
   /** Set once we subscribe to settings writes for live flag re-sync. */
   private prPollingSettingsUnsubscribe: (() => void) | undefined;
+  /** Monotonically increases so an older settings read cannot overwrite a newer one. */
+  private prPollingSettingsSyncGeneration = 0;
   /**
    * Threads the operator currently has selected / on screen, pushed from the
    * renderer. Drives the poller's fast tier — main cannot infer selection.
@@ -3829,6 +3831,7 @@ class DesktopAppServerService {
    * and after every settings write, so both gates take effect without a restart.
    */
   syncPrPollingSchedulerState(): void {
+    const settingsSyncGeneration = ++this.prPollingSettingsSyncGeneration;
     void (async () => {
       let backgroundPollingEnabled = DEFAULT_BACKGROUND_PR_POLLING;
       let prAutoDispatchAllowed = DEFAULT_PR_AUTO_DISPATCH_ALLOWED;
@@ -3857,6 +3860,10 @@ class DesktopAppServerService {
         appServerLog.warn("failed to read GitHub PR automation settings", {
           error: error instanceof Error ? error.message : String(error),
         });
+      }
+
+      if (settingsSyncGeneration !== this.prPollingSettingsSyncGeneration) {
+        return;
       }
 
       this.backgroundPrPollingEnabled = backgroundPollingEnabled;
@@ -5061,6 +5068,7 @@ class DesktopAppServerService {
     this.prFetcher = undefined;
     this.prPollingScheduler?.stop();
     this.prPollingScheduler = undefined;
+    this.prPollingSettingsSyncGeneration += 1;
     this.backgroundPrPollingEnabled = false;
     this.prAutoDispatchAllowed = false;
     if (this.prDiscoveryTimer) {

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -244,6 +244,8 @@ export type DesktopSettingsConfig = {
   };
   git?: {
     backgroundPrPolling?: boolean;
+    prAutoDispatchAllowed?: boolean;
+    defaultPrAutoDispatchEnabled?: boolean;
   };
   applications?: {
     editor?: {
@@ -1321,6 +1323,18 @@ export function desktopSettingsPatchToEdits(
     }
     set(["git", "background_pr_polling"], patch.git.backgroundPrPolling);
   }
+  if (patch.git?.prAutoDispatchAllowed !== undefined) {
+    set(
+      ["git", "pr_auto_dispatch_allowed"],
+      patch.git.prAutoDispatchAllowed,
+    );
+  }
+  if (patch.git?.defaultPrAutoDispatchEnabled !== undefined) {
+    set(
+      ["git", "default_pr_auto_dispatch_enabled"],
+      patch.git.defaultPrAutoDispatchEnabled,
+    );
+  }
 
   if (patch.applications?.editor?.preferredId !== undefined) {
     set(["applications", "editor", "preferred_id"], patch.applications.editor.preferredId);
@@ -1648,6 +1662,10 @@ function normalizeDesktopConfig(
       backgroundPrPolling:
         readBoolean(git?.background_pr_polling)
         ?? readBoolean(experimental?.background_pr_polling),
+      prAutoDispatchAllowed: readBoolean(git?.pr_auto_dispatch_allowed),
+      defaultPrAutoDispatchEnabled: readBoolean(
+        git?.default_pr_auto_dispatch_enabled,
+      ),
     },
     applications: {
       editor: {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -31,6 +31,8 @@ import type {
 import { execFile } from "node:child_process";
 import {
   DEFAULT_BACKGROUND_PR_POLLING,
+  DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
   DESKTOP_APPEARANCE_DENSITY_DEFAULT,
   DESKTOP_APPEARANCE_THEME_DEFAULT,
   DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
@@ -1010,6 +1012,14 @@ export class DesktopSettingsService {
           config.git?.backgroundPrPolling,
           DEFAULT_BACKGROUND_PR_POLLING,
         ),
+        prAutoDispatchAllowed: this.resolveConfigBoolean(
+          config.git?.prAutoDispatchAllowed,
+          DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+        ),
+        defaultPrAutoDispatchEnabled: this.resolveConfigBoolean(
+          config.git?.defaultPrAutoDispatchEnabled,
+          DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
+        ),
       },
       worktrees: this.resolveWorktrees(config.worktrees?.storage),
     };
@@ -1146,6 +1156,13 @@ export class DesktopSettingsService {
     return this.resolveConfigBoolean(
       this.readConfig().config.experimental?.managedReview,
       false,
+    ).value;
+  }
+
+  resolveDefaultPrAutoDispatchEnabled(): boolean {
+    return this.resolveConfigBoolean(
+      this.readConfig().config.git?.defaultPrAutoDispatchEnabled,
+      DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
     ).value;
   }
 

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -44,6 +44,8 @@ import type {
   SetThreadModelSettingsResponse,
   SetThreadPrAutoDispatchRequest,
   SetThreadPrAutoDispatchResponse,
+  SetEligibleThreadsPrAutoDispatchRequest,
+  SetEligibleThreadsPrAutoDispatchResponse,
   CancelThreadPrAutoDispatchRequest,
   CancelThreadPrAutoDispatchResponse,
   SendThreadPrAutoDispatchNowRequest,
@@ -433,6 +435,7 @@ import {
   NAVIGATION_SET_THREAD_AGENT_CHANNEL,
   NAVIGATION_SET_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
+  NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
   NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL,
@@ -1304,6 +1307,13 @@ const desktopApi = Object.freeze({
     request: UpdateDirectoryLaunchpadRequest,
   ): Promise<UpdateDirectoryLaunchpadResponse> =>
     await ipcRenderer.invoke(NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL, request),
+  setEligibleThreadsPrAutoDispatch: async (
+    request: SetEligibleThreadsPrAutoDispatchRequest,
+  ): Promise<SetEligibleThreadsPrAutoDispatchResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
+      request,
+    ),
   resetDirectoryLaunchpad: async (
     request: ResetDirectoryLaunchpadRequest,
   ): Promise<ResetDirectoryLaunchpadResponse> =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import {
   buildThreadIdentityKey,
   DEFAULT_BACKGROUND_PR_POLLING,
+  DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
   parseThreadIdentityKey,
   type AppServerBackendKind,
   type DesktopBootInfo,
@@ -1080,6 +1081,11 @@ function DesktopAppShell(props: {
       settings.snapshot
         ? settings.snapshot.git?.backgroundPrPolling?.value
           ?? DEFAULT_BACKGROUND_PR_POLLING
+        : false,
+    prAutoDispatchAllowed:
+      settings.snapshot
+        ? settings.snapshot.git?.prAutoDispatchAllowed?.value
+          ?? DEFAULT_PR_AUTO_DISPATCH_ALLOWED
         : false,
     pickDirectoryError: navigation.pickDirectoryError,
     pickingDirectory: navigation.pickingDirectory,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -590,6 +590,8 @@ describe("App", () => {
       },
       git: {
         backgroundPrPolling: { value: true, source: "default" },
+        prAutoDispatchAllowed: { value: true, source: "default" },
+        defaultPrAutoDispatchEnabled: { value: true, source: "default" },
       },
       applications: {
         editors: [],

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -139,6 +139,7 @@ type ComposerProps = {
   applications?: DesktopApplicationsSnapshot;
   codexFastAllowed?: boolean;
   backgroundPrPollingEnabled?: boolean;
+  prAutoDispatchAllowed?: boolean;
   providerModelDefaults?: Record<string, DesktopProviderModelDefaults>;
   desktopApi?: DesktopApi;
   /**
@@ -6644,6 +6645,9 @@ export function Composer(props: ComposerProps) {
   const currentSettings = props.launchpad ?? props.thread;
   const backgroundPrPollingEnabled =
     props.backgroundPrPollingEnabled ?? true;
+  const prAutoDispatchAllowed = props.prAutoDispatchAllowed ?? true;
+  const prAutoDispatchAvailable =
+    backgroundPrPollingEnabled && prAutoDispatchAllowed;
   const modelOptions = backend?.launchpadOptions?.models ?? [];
   const selectedModelOption =
     modelOptions.find((option) => option.id === currentSettings?.model) ??
@@ -6895,9 +6899,11 @@ export function Composer(props: ComposerProps) {
     : false;
   const prAutoDispatchTooltip = !backgroundPrPollingEnabled
     ? "Auto-fix PR paused — turn on background PR polling in Settings"
-    : hasAttachedPullRequest
-      ? "Auto-fix PR — handle new CI failures or merge conflicts"
-      : "Auto-fix PR — starts when a PR for this workspace is linked";
+    : !prAutoDispatchAllowed
+      ? "Auto-fix PR disabled globally — allow it in Git settings"
+      : hasAttachedPullRequest
+        ? "Auto-fix PR — handle new CI failures or merge conflicts"
+        : "Auto-fix PR — starts when a PR for this workspace is linked";
   const workspaceOpenPath = getComposerWorkspaceOpenPath({
     directory: props.directory,
     launchpad: props.launchpad,
@@ -7764,10 +7770,12 @@ export function Composer(props: ComposerProps) {
             <span className="composer__queued-label">
               {!backgroundPrPollingEnabled
                 ? "Auto-fix PR paused"
-                : `Auto-fix PR in ${formatScheduledSendCountdown(
-                    prAutoDispatchPending.scheduledAt,
-                    scheduleNow,
-                  )}`}
+                : !prAutoDispatchAllowed
+                  ? "Auto-fix PR disabled"
+                  : `Auto-fix PR in ${formatScheduledSendCountdown(
+                      prAutoDispatchPending.scheduledAt,
+                      scheduleNow,
+                    )}`}
             </span>
             <span className="composer__queued-text">
               #{prAutoDispatchPending.prNumber} · {prAutoDispatchPending.eventKinds
@@ -7785,7 +7793,7 @@ export function Composer(props: ComposerProps) {
               className="composer__secondary-action"
               type="button"
               disabled={
-                !backgroundPrPollingEnabled
+                !prAutoDispatchAvailable
                 || !props.onSendThreadPrAutoDispatchNow
               }
               onClick={() => {
@@ -8816,9 +8824,9 @@ export function Composer(props: ComposerProps) {
               aria-label="Auto-fix PR"
               aria-pressed={Boolean(props.thread.prAutoDispatchEnabled)}
               data-tooltip={prAutoDispatchTooltip}
-              disabled={!backgroundPrPollingEnabled}
+              disabled={!prAutoDispatchAvailable}
               onClick={() => {
-                if (!backgroundPrPollingEnabled) return;
+                if (!prAutoDispatchAvailable) return;
                 void props.onSetThreadPrAutoDispatch?.(
                   !props.thread?.prAutoDispatchEnabled,
                 );

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -529,6 +529,22 @@ describe("Composer", () => {
       "data-tooltip",
       expect.stringContaining("paused"),
     );
+
+    rerender(
+      <Composer
+        backgroundPrPollingEnabled
+        prAutoDispatchAllowed={false}
+        disabled={false}
+        onSetThreadPrAutoDispatch={onSetThreadPrAutoDispatch}
+        skills={[]}
+        thread={thread}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Auto-fix PR" })).toHaveAttribute(
+      "data-tooltip",
+      expect.stringContaining("globally"),
+    );
   });
 
   it("hides Auto-fix PR when the thread is not backed by a Git repository", () => {

--- a/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   DEFAULT_BACKGROUND_PR_POLLING,
+  DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
   type DesktopGitDiscoveryCandidate,
   type DesktopGhDiscoveryCandidate,
   type DesktopSettingsSnapshot,
@@ -26,17 +28,35 @@ const DEFAULT_BACKGROUND_PR_POLLING_VALUE = {
   source: "default" as const,
 };
 
+const DEFAULT_PR_AUTO_DISPATCH_ALLOWED_VALUE = {
+  value: DEFAULT_PR_AUTO_DISPATCH_ALLOWED,
+  source: "default" as const,
+};
+
+const DEFAULT_PR_AUTO_DISPATCH_ENABLED_VALUE = {
+  value: DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
+  source: "default" as const,
+};
+
 export function GitSettings(props: {
   desktopApi?: DesktopApi;
   saving: boolean;
   snapshot: DesktopSettingsSnapshot;
   onBackgroundPrPollingChange: (enabled: boolean) => Promise<void>;
+  onPrAutoDispatchAllowedChange: (enabled: boolean) => Promise<void>;
+  onDefaultPrAutoDispatchEnabledChange: (enabled: boolean) => Promise<void>;
   onRefresh: () => Promise<void>;
   onSaveGhPath: (path: string) => Promise<void>;
 }) {
   const backgroundPrPolling =
     props.snapshot.git?.backgroundPrPolling ??
     DEFAULT_BACKGROUND_PR_POLLING_VALUE;
+  const prAutoDispatchAllowed =
+    props.snapshot.git?.prAutoDispatchAllowed ??
+    DEFAULT_PR_AUTO_DISPATCH_ALLOWED_VALUE;
+  const defaultPrAutoDispatchEnabled =
+    props.snapshot.git?.defaultPrAutoDispatchEnabled ??
+    DEFAULT_PR_AUTO_DISPATCH_ENABLED_VALUE;
 
   return (
     <SettingsSectionStack paneId="git" aria-label="Git settings">
@@ -77,6 +97,58 @@ export function GitSettings(props: {
                 label="Enable background pull request status"
                 onChange={(enabled) => {
                   void props.onBackgroundPrPollingChange(enabled);
+                }}
+              />
+            }
+          />
+        </div>
+      </SettingsSection>
+      <SettingsSection
+        eyebrow="GitHub"
+        title="Pull request automation"
+        description="Control whether PwrAgent can schedule a bounded repair turn for a linked pull request that fails CI or becomes conflicted."
+        chip={prAutoDispatchAllowed.value ? "Allowed" : "Off"}
+        chipKind={prAutoDispatchAllowed.value ? "ok" : "default"}
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Allow Auto-fix PR"
+            sub={
+              backgroundPrPolling.value
+                ? "When enabled, a thread with Auto-fix PR on can receive one bounded repair turn for a newly failing or conflicting pull request."
+                : "Turn on background pull request status above before allowing automatic PR repairs."
+            }
+            source={sourceBadge(prAutoDispatchAllowed)}
+            control={
+              <SettingsSwitch
+                checked={prAutoDispatchAllowed.value}
+                disabled={props.saving || !backgroundPrPolling.value}
+                label="Allow Auto-fix PR"
+                onChange={(enabled) => {
+                  void props.onPrAutoDispatchAllowedChange(enabled);
+                }}
+              />
+            }
+          />
+          <SettingsField
+            label="Enable Auto-fix PR for new threads"
+            sub={
+              backgroundPrPolling.value && prAutoDispatchAllowed.value
+                ? "New threads and launchpads start with Auto-fix PR on. Existing threads keep their saved choice."
+                : "This default is available when background pull request status and Auto-fix PR are allowed."
+            }
+            source={sourceBadge(defaultPrAutoDispatchEnabled)}
+            control={
+              <SettingsSwitch
+                checked={defaultPrAutoDispatchEnabled.value}
+                disabled={
+                  props.saving
+                  || !backgroundPrPolling.value
+                  || !prAutoDispatchAllowed.value
+                }
+                label="Enable Auto-fix PR for new threads"
+                onChange={(enabled) => {
+                  void props.onDefaultPrAutoDispatchEnabledChange(enabled);
                 }}
               />
             }

--- a/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GitSettings.tsx
@@ -57,6 +57,131 @@ export function GitSettings(props: {
   const defaultPrAutoDispatchEnabled =
     props.snapshot.git?.defaultPrAutoDispatchEnabled ??
     DEFAULT_PR_AUTO_DISPATCH_ENABLED_VALUE;
+  const [pendingLaunchpadApply, setPendingLaunchpadApply] = useState<{
+    directoryKeys: string[];
+    enabled: boolean;
+  }>();
+  const [pendingThreadEnable, setPendingThreadEnable] = useState<{
+    eligibleThreadCount: number;
+    updatedThreadCount: number;
+  }>();
+  const [checkingThreadEnable, setCheckingThreadEnable] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [bulkStatus, setBulkStatus] = useState<string | undefined>();
+  const automationAvailable =
+    backgroundPrPolling.value && prAutoDispatchAllowed.value;
+  const hasPendingBulkAction = Boolean(
+    pendingLaunchpadApply || pendingThreadEnable,
+  );
+  const actionsDisabled = props.saving || applying || !automationAvailable;
+
+  const previewLaunchpadApply = async (): Promise<void> => {
+    if (!props.desktopApi?.getNavigationSnapshot) {
+      setBulkStatus("Launchpad updates are unavailable in this build.");
+      return;
+    }
+    try {
+      const navigation = await props.desktopApi.getNavigationSnapshot();
+      const directoryKeys = navigation.directories
+        .filter((directory) => Boolean(directory.launchpad))
+        .map((directory) => directory.key);
+      if (directoryKeys.length === 0) {
+        setBulkStatus("No launchpads are available to update.");
+        return;
+      }
+      setBulkStatus(undefined);
+      setPendingThreadEnable(undefined);
+      setPendingLaunchpadApply({
+        directoryKeys,
+        enabled: defaultPrAutoDispatchEnabled.value,
+      });
+    } catch (error) {
+      setBulkStatus(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const applyToLaunchpads = async (): Promise<void> => {
+    if (!pendingLaunchpadApply || !props.desktopApi?.updateDirectoryLaunchpad) {
+      return;
+    }
+    setApplying(true);
+    try {
+      for (const directoryKey of pendingLaunchpadApply.directoryKeys) {
+        await props.desktopApi.updateDirectoryLaunchpad({
+          directoryKey,
+          patch: { prAutoDispatchEnabled: pendingLaunchpadApply.enabled },
+          stickySettingsChanged: true,
+        });
+      }
+      setBulkStatus(
+        `${pendingLaunchpadApply.enabled ? "Enabled" : "Turned off"} Auto-fix PR for ${pendingLaunchpadApply.directoryKeys.length} launchpad${
+          pendingLaunchpadApply.directoryKeys.length === 1 ? "" : "s"
+        }. Existing threads were not changed.`,
+      );
+      setPendingLaunchpadApply(undefined);
+    } catch (error) {
+      setBulkStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const previewExistingThreadEnable = async (): Promise<void> => {
+    if (!props.desktopApi?.setEligibleThreadsPrAutoDispatch) {
+      setBulkStatus("Existing thread updates are unavailable in this build.");
+      return;
+    }
+    setCheckingThreadEnable(true);
+    try {
+      const response = await props.desktopApi.setEligibleThreadsPrAutoDispatch({
+        enabled: true,
+        dryRun: true,
+      });
+      if (response.eligibleThreadCount === 0) {
+        setBulkStatus("No existing threads have an open PR attached to their primary workspace.");
+        return;
+      }
+      if (response.updatedThreadCount === 0) {
+        setBulkStatus(
+          `Auto-fix PR is already enabled for all ${response.eligibleThreadCount} eligible existing thread${
+            response.eligibleThreadCount === 1 ? "" : "s"
+          }.`,
+        );
+        return;
+      }
+      setBulkStatus(undefined);
+      setPendingLaunchpadApply(undefined);
+      setPendingThreadEnable(response);
+    } catch (error) {
+      setBulkStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setCheckingThreadEnable(false);
+    }
+  };
+
+  const enableExistingThreads = async (): Promise<void> => {
+    if (!pendingThreadEnable || !props.desktopApi?.setEligibleThreadsPrAutoDispatch) {
+      return;
+    }
+    setApplying(true);
+    try {
+      const response = await props.desktopApi.setEligibleThreadsPrAutoDispatch({
+        enabled: true,
+      });
+      setBulkStatus(
+        response.updatedThreadCount > 0
+          ? `Enabled Auto-fix PR for ${response.updatedThreadCount} existing thread${
+              response.updatedThreadCount === 1 ? "" : "s"
+            } with a primary attached pull request.`
+          : "No existing thread preferences needed updating.",
+      );
+      setPendingThreadEnable(undefined);
+    } catch (error) {
+      setBulkStatus(error instanceof Error ? error.message : String(error));
+    } finally {
+      setApplying(false);
+    }
+  };
 
   return (
     <SettingsSectionStack paneId="git" aria-label="Git settings">
@@ -131,31 +256,142 @@ export function GitSettings(props: {
             }
           />
           <SettingsField
-            label="Enable Auto-fix PR for new threads"
+            label="Enable Auto-fix PR for new threads and launchpads"
             sub={
               backgroundPrPolling.value && prAutoDispatchAllowed.value
-                ? "New threads and launchpads start with Auto-fix PR on. Existing threads keep their saved choice."
+                ? "New threads and launchpads start with this choice. Existing launchpads and threads keep their saved choice."
                 : "This default is available when background pull request status and Auto-fix PR are allowed."
             }
             source={sourceBadge(defaultPrAutoDispatchEnabled)}
             control={
-              <SettingsSwitch
-                checked={defaultPrAutoDispatchEnabled.value}
-                disabled={
-                  props.saving
-                  || !backgroundPrPolling.value
-                  || !prAutoDispatchAllowed.value
-                }
-                label="Enable Auto-fix PR for new threads"
-                onChange={(enabled) => {
-                  void props.onDefaultPrAutoDispatchEnabledChange(enabled);
-                }}
-              />
+              <>
+                <SettingsSwitch
+                  checked={defaultPrAutoDispatchEnabled.value}
+                  disabled={actionsDisabled || checkingThreadEnable || hasPendingBulkAction}
+                  label="Enable Auto-fix PR for new threads and launchpads"
+                  onChange={(enabled) => {
+                    void props.onDefaultPrAutoDispatchEnabledChange(enabled);
+                  }}
+                />
+                {pendingLaunchpadApply ? (
+                  <GitActionConfirmation
+                    applying={applying}
+                    confirmLabel="Apply"
+                    label={`Apply to ${pendingLaunchpadApply.directoryKeys.length} launchpad${
+                      pendingLaunchpadApply.directoryKeys.length === 1 ? "" : "s"
+                    }?`}
+                    sub="This saves the selected Auto-fix PR choice for each launchpad. Existing threads stay unchanged."
+                    onCancel={() => setPendingLaunchpadApply(undefined)}
+                    onConfirm={() => void applyToLaunchpads()}
+                  />
+                ) : (
+                  <div className="settings-inline-actions">
+                    <button
+                      className="button button--secondary"
+                      disabled={
+                        actionsDisabled
+                        || hasPendingBulkAction
+                        || !props.desktopApi?.getNavigationSnapshot
+                        || !props.desktopApi?.updateDirectoryLaunchpad
+                      }
+                      type="button"
+                      onClick={() => void previewLaunchpadApply()}
+                    >
+                      Apply to launchpads
+                    </button>
+                  </div>
+                )}
+              </>
+            }
+          />
+          <SettingsField
+            label="Enable Auto-fix PR for existing threads"
+            sub={
+              automationAvailable
+                ? "Enable it only for threads with an open pull request attached to their primary workspace. Informational and detached PR links are left alone."
+                : "This bulk action is available when background pull request status and Auto-fix PR are allowed."
+            }
+            control={
+              <>
+                {pendingThreadEnable ? (
+                  <GitActionConfirmation
+                    applying={applying}
+                    confirmLabel="Enable"
+                    label={`Enable Auto-fix PR for ${pendingThreadEnable.updatedThreadCount} existing thread${
+                      pendingThreadEnable.updatedThreadCount === 1 ? "" : "s"
+                    }?`}
+                    sub={`Only ${pendingThreadEnable.eligibleThreadCount} thread${
+                      pendingThreadEnable.eligibleThreadCount === 1 ? " has" : "s have"
+                    } an eligible primary attached PR. Other saved thread choices stay unchanged.`}
+                    onCancel={() => setPendingThreadEnable(undefined)}
+                    onConfirm={() => void enableExistingThreads()}
+                  />
+                ) : (
+                  <div className="settings-inline-actions">
+                    <button
+                      className="button button--secondary"
+                      disabled={
+                        actionsDisabled
+                        || checkingThreadEnable
+                        || hasPendingBulkAction
+                        || !props.desktopApi?.setEligibleThreadsPrAutoDispatch
+                      }
+                      type="button"
+                      onClick={() => void previewExistingThreadEnable()}
+                    >
+                      {checkingThreadEnable
+                        ? "Checking…"
+                        : "Enable existing PR threads…"}
+                    </button>
+                  </div>
+                )}
+                {bulkStatus ? (
+                  <p className="settings-empty" role="status">
+                    {bulkStatus}
+                  </p>
+                ) : null}
+              </>
             }
           />
         </div>
       </SettingsSection>
     </SettingsSectionStack>
+  );
+}
+
+function GitActionConfirmation(props: {
+  applying: boolean;
+  confirmLabel: string;
+  label: string;
+  sub: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div aria-live="polite" className="settings-action-confirmation">
+      <div className="settings-action-confirmation__copy">
+        <strong>{props.label}</strong>
+        <span>{props.sub}</span>
+      </div>
+      <div className="settings-inline-actions">
+        <button
+          className="button button--primary"
+          disabled={props.applying}
+          type="button"
+          onClick={props.onConfirm}
+        >
+          {props.applying ? "Updating…" : props.confirmLabel}
+        </button>
+        <button
+          className="button button--ghost"
+          disabled={props.applying}
+          type="button"
+          onClick={props.onCancel}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -658,6 +658,16 @@ function SettingsSectionBody(props: {
             git: { backgroundPrPolling: enabled },
           });
         }}
+        onPrAutoDispatchAllowedChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            git: { prAutoDispatchAllowed: enabled },
+          });
+        }}
+        onDefaultPrAutoDispatchEnabledChange={async (enabled: boolean) => {
+          await props.settings.writeConfig({
+            git: { defaultPrAutoDispatchEnabled: enabled },
+          });
+        }}
         onRefresh={props.settings.refresh}
         onSaveGhPath={async (path) => {
           await props.settings.writeConfig({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -4094,7 +4094,7 @@ describe("SettingsScreen", () => {
       name: "Allow Auto-fix PR",
     });
     const defaultAutoFix = screen.getByRole("switch", {
-      name: "Enable Auto-fix PR for new threads",
+      name: "Enable Auto-fix PR for new threads and launchpads",
     });
     expect(allowAutoFix).toHaveAttribute("aria-checked", "true");
     expect(defaultAutoFix).toHaveAttribute("aria-checked", "true");
@@ -4135,9 +4135,146 @@ describe("SettingsScreen", () => {
     ).toBeDisabled();
     expect(
       screen.getByRole("switch", {
-        name: "Enable Auto-fix PR for new threads",
+        name: "Enable Auto-fix PR for new threads and launchpads",
       }),
     ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Apply to launchpads" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Enable existing PR threads…" }),
+    ).toBeDisabled();
+  });
+
+  it("applies Auto-fix PR defaults to launchpads and eligible existing threads", async () => {
+    const settings = createSettingsState();
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 1_000,
+      unchanged: false,
+      directories: [
+        {
+          key: "directory:/repo-a",
+          kind: "directory" as const,
+          label: "Repo A",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey: "directory:/repo-a",
+            directoryKind: "directory" as const,
+            directoryLabel: "Repo A",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            workMode: "local" as const,
+            prompt: "",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+        {
+          key: "directory:/repo-b",
+          kind: "directory" as const,
+          label: "Repo B",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          launchpad: {
+            directoryKey: "directory:/repo-b",
+            directoryKind: "directory" as const,
+            directoryLabel: "Repo B",
+            backend: "codex" as const,
+            executionMode: "default" as const,
+            workMode: "local" as const,
+            prompt: "",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        },
+      ],
+      inboxThreadKeys: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+      threads: [],
+    }));
+    const updateDirectoryLaunchpad = vi.fn(async (request) => ({
+      launchpad: {
+        directoryKey: request.directoryKey,
+        directoryKind: "directory" as const,
+        directoryLabel: request.directoryKey,
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        workMode: "local" as const,
+        prompt: "",
+        prAutoDispatchEnabled: request.patch.prAutoDispatchEnabled,
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const setEligibleThreadsPrAutoDispatch = vi.fn(async (request) => ({
+      enabled: request.enabled,
+      eligibleThreadCount: 3,
+      updatedThreadCount: request.dryRun ? 2 : 2,
+    }));
+    const desktopApi = {
+      getNavigationSnapshot,
+      updateDirectoryLaunchpad,
+      setEligibleThreadsPrAutoDispatch,
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        initialSection="git"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply to launchpads" }));
+    expect(await screen.findByText("Apply to 2 launchpads?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await waitFor(() => {
+      expect(updateDirectoryLaunchpad).toHaveBeenCalledTimes(2);
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenNthCalledWith(1, {
+      directoryKey: "directory:/repo-a",
+      patch: { prAutoDispatchEnabled: true },
+      stickySettingsChanged: true,
+    });
+    expect(updateDirectoryLaunchpad).toHaveBeenNthCalledWith(2, {
+      directoryKey: "directory:/repo-b",
+      patch: { prAutoDispatchEnabled: true },
+      stickySettingsChanged: true,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Enable existing PR threads…" }),
+    );
+    await waitFor(() => {
+      expect(setEligibleThreadsPrAutoDispatch).toHaveBeenCalledWith({
+        enabled: true,
+        dryRun: true,
+      });
+    });
+    expect(
+      await screen.findByText("Enable Auto-fix PR for 2 existing threads?"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Enable" }));
+    await waitFor(() => {
+      expect(setEligibleThreadsPrAutoDispatch).toHaveBeenLastCalledWith({
+        enabled: true,
+      });
+    });
+    expect(
+      screen.getByText(
+        "Enabled Auto-fix PR for 2 existing threads with a primary attached pull request.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -345,6 +345,8 @@ function createSnapshot(
     },
     git: {
       backgroundPrPolling: { value: true, source: "default" },
+      prAutoDispatchAllowed: { value: true, source: "default" },
+      defaultPrAutoDispatchEnabled: { value: true, source: "default" },
     },
     applications: {
       editors: [
@@ -4076,6 +4078,66 @@ describe("SettingsScreen", () => {
       await screen.findByText(/Update available: v1.0.0-beta.8/),
     ).toBeInTheDocument();
     expect(desktopApi.readAppUpdateStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("configures GitHub Auto-fix PR and gates it on background PR status", async () => {
+    const settings = createSettingsState();
+    render(
+      <SettingsScreen
+        initialSection="git"
+        settings={settings}
+        onClose={() => undefined}
+      />,
+    );
+
+    const allowAutoFix = screen.getByRole("switch", {
+      name: "Allow Auto-fix PR",
+    });
+    const defaultAutoFix = screen.getByRole("switch", {
+      name: "Enable Auto-fix PR for new threads",
+    });
+    expect(allowAutoFix).toHaveAttribute("aria-checked", "true");
+    expect(defaultAutoFix).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(allowAutoFix);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        git: { prAutoDispatchAllowed: false },
+      });
+    });
+    fireEvent.click(defaultAutoFix);
+    await waitFor(() => {
+      expect(settings.writeConfig).toHaveBeenCalledWith({
+        git: { defaultPrAutoDispatchEnabled: false },
+      });
+    });
+
+    const baseSnapshot = createSnapshot();
+    const backgroundOffSettings = createSettingsState(
+      createSnapshot({
+        git: {
+          ...baseSnapshot.git,
+          backgroundPrPolling: { value: false, source: "config" },
+        },
+      }),
+    );
+    cleanup();
+    render(
+      <SettingsScreen
+        initialSection="git"
+        settings={backgroundOffSettings}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("switch", { name: "Allow Auto-fix PR" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("switch", {
+        name: "Enable Auto-fix PR for new threads",
+      }),
+    ).toBeDisabled();
   });
 
   it("blocks settings edits when the config file cannot be parsed", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -768,6 +768,7 @@ export type ThreadViewProps = {
   suppressBranchDriftDialog?: boolean;
   fullAccessRiskWarningDismissed?: boolean;
   backgroundPrPollingEnabled?: boolean;
+  prAutoDispatchAllowed?: boolean;
   /**
    * Project-directory picker (issue #223) — surfaced in the launchpad
    * composer when no thread is selected yet. Rendering happens inside
@@ -3034,6 +3035,7 @@ export function ThreadView(props: ThreadViewProps) {
             onCancelThreadPrAutoDispatch={props.onCancelThreadPrAutoDispatch}
             onSendThreadPrAutoDispatchNow={props.onSendThreadPrAutoDispatchNow}
             backgroundPrPollingEnabled={props.backgroundPrPollingEnabled}
+            prAutoDispatchAllowed={props.prAutoDispatchAllowed}
             onAttachDirectoryReferences={props.onAttachDirectoryReferences}
             onPickDirectoryForReference={props.onPickDirectoryForReference}
             pendingRequestActive={Boolean(props.pendingRequest)}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -103,6 +103,8 @@ import type {
   SetThreadPinResponse,
   SetThreadPrAutoDispatchRequest,
   SetThreadPrAutoDispatchResponse,
+  SetEligibleThreadsPrAutoDispatchRequest,
+  SetEligibleThreadsPrAutoDispatchResponse,
   CancelThreadPrAutoDispatchRequest,
   CancelThreadPrAutoDispatchResponse,
   SendThreadPrAutoDispatchNowRequest,
@@ -712,6 +714,9 @@ export type DesktopApi = {
   updateDirectoryLaunchpad?: (
     request: UpdateDirectoryLaunchpadRequest
   ) => Promise<UpdateDirectoryLaunchpadResponse>;
+  setEligibleThreadsPrAutoDispatch?: (
+    request: SetEligibleThreadsPrAutoDispatchRequest,
+  ) => Promise<SetEligibleThreadsPrAutoDispatchResponse>;
   resetDirectoryLaunchpad?: (
     request: ResetDirectoryLaunchpadRequest
   ) => Promise<ResetDirectoryLaunchpadResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -222,6 +222,8 @@ export const NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:ensure-directory-launchpad";
 export const NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:update-directory-launchpad";
+export const NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL =
+  "navigation:set-eligible-threads-pr-auto-dispatch";
 export const NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL =
   "navigation:reset-directory-launchpad";
 /**

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -326,6 +326,8 @@ describe("desktop settings contracts", () => {
       },
       git: {
         backgroundPrPolling: { value: true, source: "default" },
+        prAutoDispatchAllowed: { value: true, source: "default" },
+        defaultPrAutoDispatchEnabled: { value: true, source: "default" },
       },
       applications: {
         editors: [],

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -372,6 +372,26 @@ export type SetThreadPrAutoDispatchRequest = {
 
 export type SetThreadPrAutoDispatchResponse = SetThreadPrAutoDispatchRequest;
 
+/**
+ * Applies an Auto-fix PR preference only to existing threads that have an
+ * open pull request attached to their primary GitHub workspace. The main
+ * process resolves eligibility so detached and informational PR links never
+ * become automation targets.
+ */
+export type SetEligibleThreadsPrAutoDispatchRequest = {
+  enabled: boolean;
+  /** Preview the authoritative target set without changing any thread. */
+  dryRun?: boolean;
+};
+
+export type SetEligibleThreadsPrAutoDispatchResponse = {
+  enabled: boolean;
+  /** Threads with an eligible primary attached PR at the time of the request. */
+  eligibleThreadCount: number;
+  /** Threads whose saved preference was actually changed. */
+  updatedThreadCount: number;
+};
+
 export type CancelThreadPrAutoDispatchRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;
@@ -540,6 +560,7 @@ export type UpdateDirectoryLaunchpadRequest = {
       | "serviceTier"
       | "fastMode"
       | "acpRuntime"
+      | "prAutoDispatchEnabled"
       | "messagingToolUpdateMode"
       | "workMode"
       | "branchName"

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -565,6 +565,12 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
   settingsTouchedAt?: number;
   /** Explicit messaging `/new` override for this project. */
   messagingToolUpdateMode?: MessagingToolUpdateMode;
+  /**
+   * Saved Auto-fix PR choice for this launchpad. New launchpads seed this from
+   * the profile default so a later profile-default change does not silently
+   * rewrite a launchpad the operator has already configured.
+   */
+  prAutoDispatchEnabled?: boolean;
   workMode: LaunchpadWorkMode;
   branchName?: string;
   parentThreadId?: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1280,7 +1280,7 @@ export type ThreadOverlayState = {
   modelSettingsManuallyUpdatedAt?: number;
   serviceTier?: string;
   fastMode?: boolean;
-  /** Saved operator preference; the global background-polling flag gates its effect. */
+  /** Saved operator preference; global PR polling and Auto-fix gates control its effect. */
   prAutoDispatchEnabled?: boolean;
   /** Joined from the durable dispatch table for navigation; never stored in overlay JSON. */
   prAutoDispatchPending?: ThreadPrAutoDispatchPending;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -27,6 +27,19 @@ export const DESKTOP_WORKTREE_STORAGE_DEFAULT: DesktopWorktreeStorageLocation =
  */
 export const DEFAULT_BACKGROUND_PR_POLLING = true;
 
+/**
+ * Automatic pull-request repair is available by default whenever background
+ * PR monitoring is enabled. An explicit false value is a separate operator
+ * kill switch that preserves each thread's saved preference.
+ */
+export const DEFAULT_PR_AUTO_DISPATCH_ALLOWED = true;
+
+/**
+ * New ordinary threads and launchpads start with Auto-fix PR enabled by
+ * default. Existing threads retain their saved per-thread preference.
+ */
+export const DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS = true;
+
 export const DESKTOP_UPDATE_CHANNELS = ["latest", "prerelease"] as const;
 
 export type DesktopUpdateChannel = (typeof DESKTOP_UPDATE_CHANNELS)[number];
@@ -760,6 +773,13 @@ export type DesktopSettingsSnapshot = {
      * pull requests.
      */
     backgroundPrPolling: DesktopSettingsValue<boolean>;
+    /**
+     * Global permission for automatic repair turns. Background PR monitoring
+     * remains the prerequisite kill switch for this behavior.
+     */
+    prAutoDispatchAllowed: DesktopSettingsValue<boolean>;
+    /** Default Auto-fix PR preference seeded only onto newly created threads. */
+    defaultPrAutoDispatchEnabled: DesktopSettingsValue<boolean>;
   };
   applications: DesktopApplicationsSnapshot;
   worktrees: {
@@ -935,6 +955,8 @@ export type DesktopSettingsConfigPatch = {
   };
   git?: {
     backgroundPrPolling?: boolean;
+    prAutoDispatchAllowed?: boolean;
+    defaultPrAutoDispatchEnabled?: boolean;
   };
   applications?: {
     editor?: {

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -218,6 +218,8 @@ export type CheckThreadPullRequestStatusResult =
 
 export type ThreadPullRequestAutomationStatus = {
   backgroundPollingEnabled: boolean;
+  /** Global Git setting that permits automatic PR repair turns. */
+  autoFixAllowed: boolean;
   autoFixEnabled: boolean;
   autoFixActive: boolean;
   autoFixPending?: ThreadPrAutoDispatchPending;


### PR DESCRIPTION
## Summary

- adds a GitHub Pull request automation section in Git settings
- gates global Auto-fix PR permission on background pull request status
- seeds new threads, forks, and directory-launchpad threads from a persisted Auto-fix default; both new global settings default on
- adds the established bulk-settings pattern: apply the selected default to every saved launchpad, or enable it for existing threads with an eligible primary attached PR
- keeps bulk eligibility, candidate synchronization, and shared-PR scheduling authoritative in the main process

## Behavior

- Background pull request status remains the master prerequisite. When it is off, automatic PR repair cannot be enabled or dispatched.
- Turning off Allow Auto-fix PR pauses automatic repair without changing any thread preference. Re-enabling it restores eligible saved preferences.
- The new-thread-and-launchpad default affects only newly created items. **Apply to launchpads** makes the selected choice explicit for existing launchpads.
- **Enable existing PR threads…** refreshes the authoritative attachment view, previews the count, and enables only non-terminal PRs attached to each thread's primary GitHub workspace. Detached and informational links remain unchanged.
- A bulk enable writes all preferences before one coalesced candidate evaluation, so a PR shared by several threads retains one durable elected monitoring thread rather than producing duplicate pollers or repair turns.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx`
- `pnpm typecheck`
- `pnpm lint:eslint` (pre-existing warnings only)
- `pnpm lint:boundaries`