### PR TITLE
fix(desktop): recover ACP replay timestamps

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1360,7 +1360,7 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
-  it("persists local rollout history only when provider replay lacks timestamps", async () => {
+  it("retains fallback rollout history until provider replay is verified", async () => {
     for (const registryId of ["grok", "qwen", "kimi"] as const) {
       const backendId = `acp:${registryId}` as AcpBackendId;
       const appendUpdate = vi.fn();
@@ -1435,11 +1435,7 @@ describe("AcpBackendAdapter", () => {
         ).toBe(true);
       });
 
-      if (registryId === "kimi") {
-        expect(appendUpdate).toHaveBeenCalled();
-      } else {
-        expect(appendUpdate).not.toHaveBeenCalled();
-      }
+      expect(appendUpdate).toHaveBeenCalled();
       await adapter.close();
     }
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1157,6 +1157,104 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("does not make a thread newly active when session/load refreshes ACP runtime", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+      "session/load": {
+        models: {
+          currentModelId: "grok-4.5",
+          availableModels: [{ modelId: "grok-4.5" }],
+        },
+      },
+    });
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId,
+        sessionId: "session-1",
+        title: "Grok session",
+        cwd: "/repo",
+        createdAt: 900,
+        updatedAt: 950,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: [],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backend, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          const index = sessions.findIndex(
+            (session) => session.sessionId === metadata.sessionId,
+          );
+          sessions[index] = metadata;
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => ({
+        request: async (method, params, timeoutMs) => {
+          if (method === "session/load") {
+            transport.emitSessionUpdate("session-1", {
+              kind: "current_mode_update",
+              currentModeId: "yolo",
+            });
+          }
+          return await transport.request(method, params, timeoutMs);
+        },
+        notify: async (method, params) => await transport.notify(method, params),
+        close: async () => await transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+        onRequest: (listener) => transport.onRequest(listener),
+      }),
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const client = await adapter.getClient(backendId);
+    await client.loadSession(sessions[0]!);
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "session/load",
+    ]);
+
+    await vi.waitFor(() => {
+      expect(sessions[0]).toMatchObject({
+        acpRuntime: {
+          currentModelId: "grok-4.5",
+          currentModeId: "yolo",
+        },
+        updatedAt: 950,
+      });
+    });
+    await adapter.close();
+  });
+
   it("adds Grok billing metadata from an active ACP connection", async () => {
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport({
@@ -1645,6 +1743,128 @@ describe("AcpBackendAdapter", () => {
     // session/load is still invoked to resume the agent session, but its
     // bogus <session_context> replay is discarded in favor of the rollout.
     expect(loadSession).toHaveBeenCalled();
+
+    await adapter.close();
+  });
+
+  it("prefers session/load history observed through ACP notifications", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      runtimeCapabilities: {
+        schemaVersion: 1,
+        status: "discovered",
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    };
+    const session: AcpSessionMetadata = {
+      backendId,
+      sessionId: "session-1",
+      title: "Grok thread",
+      createdAt: 1000,
+      updatedAt: 1000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    };
+    const rolloutReplay = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "assistant:rollout",
+          role: "assistant" as const,
+          text: "Stale rollout reply",
+          createdAt: 1001,
+        },
+      ],
+      messages: [
+        {
+          id: "assistant:rollout",
+          role: "assistant" as const,
+          text: "Stale rollout reply",
+          createdAt: 1001,
+        },
+      ],
+      lastAssistantMessage: "Stale rollout reply",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle" as const,
+    };
+    const providerReplay = {
+      entries: [
+        {
+          type: "message" as const,
+          id: "assistant:provider",
+          role: "assistant" as const,
+          text: "Timestamped provider reply",
+          createdAt: 1002,
+        },
+      ],
+      messages: [
+        {
+          id: "assistant:provider",
+          role: "assistant" as const,
+          text: "Timestamped provider reply",
+          createdAt: 1002,
+        },
+      ],
+      lastAssistantMessage: "Timestamped provider reply",
+      pagination: {
+        supportsPagination: false,
+        hasPreviousPage: false,
+      },
+      threadStatus: "idle" as const,
+    };
+    const loadSession = vi.fn(async () => providerReplay);
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpRolloutStore: {
+        appendUpdate: vi.fn(),
+        readUpdates: vi.fn(() => []),
+        readReplay: vi.fn(() => rolloutReplay),
+      },
+      acpSessionStore: {
+        listSessions: () => [session],
+        getSession: () => session,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: () =>
+        ({
+          didSessionLoadReplayHistory: () => true,
+          dispose: vi.fn(async () => undefined),
+          initialize: vi.fn(async () => undefined),
+          loadSession,
+          readReplay: vi.fn(() => ({
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+            threadStatus: "idle",
+          })),
+          refreshSession: vi.fn(async () => undefined),
+        }) as never,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await expect(adapter.readReplay(backendId, "session-1")).resolves.toMatchObject({
+      lastAssistantMessage: "Timestamped provider reply",
+    });
+    expect(loadSession).toHaveBeenCalledOnce();
 
     await adapter.close();
   });

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1255,6 +1255,111 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("does not emit live tool notifications while replaying session/load history", async () => {
+    const backendId = "acp:grok" as AcpBackendId;
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    });
+    const events: AgentEvent[] = [];
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId,
+        sessionId: "session-1",
+        title: "Grok session",
+        cwd: "/repo",
+        createdAt: 900,
+        updatedAt: 950,
+        executionMode: "default",
+        status: "idle",
+        hasConversationHistory: true,
+      },
+    ];
+    const agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      backendId,
+      registryId: "grok",
+      name: "Grok",
+      launchDescriptor: {
+        backendId,
+        registryId: "grok",
+        distributionKind: "local",
+        command: "grok",
+        args: [],
+        env: {},
+      },
+    };
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: {
+        getInstalledAgent: () => agent,
+        listInstalledAgents: () => [agent],
+        upsertInstalledAgent: vi.fn(),
+      },
+      acpSessionStore: {
+        listSessions: () => sessions,
+        getSession: (_backend, sessionId) =>
+          sessions.find((session) => session.sessionId === sessionId),
+        upsertSession: (metadata) => {
+          sessions[0] = metadata;
+        },
+      },
+      captureStores: [],
+      createAcpTransport: () => ({
+        request: async (method, params, timeoutMs) => {
+          if (method === "session/load") {
+            transport.emitSessionUpdate("session-1", {
+              session_update: "tool_call",
+              tool_call_id: "tool-1",
+              title: "Read README.md",
+              kind: "read",
+              status: "in_progress",
+            });
+            transport.emitSessionUpdate("session-1", {
+              session_update: "tool_call_update",
+              tool_call_id: "tool-1",
+              title: "Read README.md",
+              kind: "read",
+              status: "completed",
+            });
+          }
+          return await transport.request(method, params, timeoutMs);
+        },
+        notify: async (method, params) => await transport.notify(method, params),
+        close: async () => await transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+        onRequest: (listener) => transport.onRequest(listener),
+      }),
+      emit: async (event) => {
+        events.push(event);
+      },
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const client = await adapter.getClient(backendId);
+    const replay = await client.loadSession(sessions[0]!);
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        id: "tool-1",
+        createdAt: expect.any(Number),
+        status: "completed",
+      }),
+    ]);
+    expect(
+      events.filter((event) =>
+        event.notification.method === "item/started"
+        || event.notification.method === "item/completed",
+      ),
+    ).toEqual([]);
+
+    await adapter.close();
+  });
+
   it("adds Grok billing metadata from an active ACP connection", async () => {
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1360,6 +1360,90 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("persists local rollout history only when provider replay lacks timestamps", async () => {
+    for (const registryId of ["grok", "qwen", "kimi"] as const) {
+      const backendId = `acp:${registryId}` as AcpBackendId;
+      const appendUpdate = vi.fn();
+      const transport = new FakeAcpAgentTransport();
+      const sessions: AcpSessionMetadata[] = [];
+      const agent: AcpInstalledAgentRecord = {
+        ...buildInstalledAgent(),
+        backendId,
+        registryId,
+        name: registryId,
+        launchDescriptor: {
+          backendId,
+          registryId,
+          distributionKind: "local",
+          command: registryId,
+          args: [],
+          env: {},
+        },
+      };
+      const adapter = new AcpBackendAdapter({
+        acpAgentStore: {
+          getInstalledAgent: () => agent,
+          listInstalledAgents: () => [agent],
+          upsertInstalledAgent: vi.fn(),
+        },
+        acpRolloutStore: {
+          appendUpdate,
+          readUpdates: vi.fn(() => []),
+          readReplay: vi.fn(() => ({
+            entries: [],
+            messages: [],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          })),
+        },
+        acpSessionStore: {
+          listSessions: () => sessions,
+          getSession: (_backend, sessionId) =>
+            sessions.find((session) => session.sessionId === sessionId),
+          upsertSession: (metadata) => {
+            const index = sessions.findIndex(
+              (session) => session.sessionId === metadata.sessionId,
+            );
+            if (index >= 0) {
+              sessions[index] = metadata;
+            } else {
+              sessions.push(metadata);
+            }
+          },
+        },
+        captureStores: [],
+        createAcpTransport: () => transport,
+        emit: vi.fn(async () => undefined),
+        handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      });
+
+      const client = await adapter.getClient(backendId);
+      const session = await client.startSession({
+        cwd: "/repo",
+        executionMode: "default",
+      });
+      client.startPrompt({
+        sessionId: session.sessionId,
+        prompt: "Tell me about this project",
+        turnId: "turn-1",
+      });
+      await vi.waitFor(() => {
+        expect(
+          transport.requests.some((request) => request.method === "session/prompt"),
+        ).toBe(true);
+      });
+
+      if (registryId === "kimi") {
+        expect(appendUpdate).toHaveBeenCalled();
+      } else {
+        expect(appendUpdate).not.toHaveBeenCalled();
+      }
+      await adapter.close();
+    }
+  });
+
   it("adds Grok billing metadata from an active ACP connection", async () => {
     const backendId = "acp:grok" as AcpBackendId;
     const transport = new FakeAcpAgentTransport({

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1919,7 +1919,7 @@ describe("AcpAgentClient", () => {
     ).toHaveLength(5);
   });
 
-  it("repairs a session activity timestamp from complete local rollout history", async () => {
+  it("preserves newer metadata activity over complete local rollout history", async () => {
     const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
     rolloutStore.appendUpdate({
       backendId: "acp:grok",
@@ -1979,10 +1979,15 @@ describe("AcpAgentClient", () => {
       title: "Grok session",
       cwd: "/repo",
       createdAt: 1000,
-      // Simulates the old session/load behavior marking the thread as freshly
-      // active even though the durable replay ended at 1201.
+      // A rename and runtime-option change legitimately happened after the
+      // last conversation event in the rollout.
       updatedAt: 2000,
       executionMode: "default",
+      titleSource: "explicit",
+      acpRuntime: {
+        currentModelId: "grok-4.5",
+        updatedAt: 2000,
+      },
       status: "idle",
       hasConversationHistory: true,
     });
@@ -1996,7 +2001,7 @@ describe("AcpAgentClient", () => {
       1100,
       1200,
     ]);
-    expect(store.getSession("acp:grok", "session-1")?.updatedAt).toBe(1201);
+    expect(store.getSession("acp:grok", "session-1")?.updatedAt).toBe(2000);
     expect(transport.requests.map((request) => request.method)).toEqual([
       "initialize",
       "session/load",
@@ -2120,9 +2125,24 @@ describe("AcpAgentClient", () => {
       { createdAt: 1_785_000_001_300, text: "Provider prompt" },
       { createdAt: 1_785_000_001_400, text: "Provider reply" },
     ]);
+    client.startPrompt({
+      sessionId: "session-1",
+      prompt: "Provider-owned follow-up",
+      turnId: "turn-2",
+    });
+    await vi.waitFor(() => {
+      expect(
+        transport.requests.filter(
+          (request) => request.method === "session/prompt",
+        ),
+      ).toHaveLength(1);
+    });
+    await vi.waitFor(() => {
+      expect(client.readReplay("session-1").threadStatus).toBe("idle");
+    });
     expect(client.didSessionLoadReplayHistory("session-1")).toBe(true);
     expect(store.getSession("acp:grok", "session-1")?.updatedAt).toBe(
-      1_785_000_001_401,
+      1_800_000_000_000,
     );
     expect(store.getSession("acp:grok", "session-1")?.status).toBe("idle");
     expect(
@@ -2389,7 +2409,7 @@ describe("AcpAgentClient", () => {
     ).toBeUndefined();
   });
 
-  it("does not write local rollout history when the ACP agent advertises session replay", async () => {
+  it("retains fallback history when advertised session replay returns no transcript", async () => {
     const rolloutStore = {
       appendUpdate: vi.fn(),
       readUpdates: vi.fn(() => []),
@@ -2417,32 +2437,41 @@ describe("AcpAgentClient", () => {
       transport,
       now: () => 1000,
     });
+    store.upsertSession({
+      backendId: "acp:kimi",
+      sessionId: "session-1",
+      title: "Kimi session",
+      cwd: "/repo",
+      createdAt: 900,
+      updatedAt: 900,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    });
 
     await client.initialize();
-    const session = await client.startSession({
-      cwd: "/repo",
-      executionMode: "default",
-    });
+    await client.loadSession(store.getSession("acp:kimi", "session-1")!);
     client.startPrompt({
-      sessionId: session.sessionId,
+      sessionId: "session-1",
       prompt: "hello",
       turnId: "turn-1",
     });
-    transport.emitSessionUpdate(session.sessionId, {
+    transport.emitSessionUpdate("session-1", {
       session_update: "agent_message_chunk",
       content: { type: "text", text: "Kimi says hi." },
     });
 
     await vi.waitFor(() => {
-      expect(client.readReplay(session.sessionId).lastAssistantMessage).toBe(
+      expect(client.readReplay("session-1").lastAssistantMessage).toBe(
         "Kimi says hi.",
       );
     });
     await vi.waitFor(() => {
-      expect(client.readReplay(session.sessionId).threadStatus).toBe("idle");
+      expect(client.readReplay("session-1").threadStatus).toBe("idle");
     });
 
-    expect(rolloutStore.appendUpdate).not.toHaveBeenCalled();
+    expect(client.didSessionLoadReplayHistory("session-1")).toBe(false);
+    expect(rolloutStore.appendUpdate).toHaveBeenCalled();
   });
 
   it("does not call session/load when the ACP agent says loading is unsupported", async () => {

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -1618,12 +1618,13 @@ describe("AcpAgentClient", () => {
   });
 
   it("stores available command updates as session metadata", async () => {
+    let now = 1000;
     const transport = new FakeAcpAgentTransport();
     const client = new AcpAgentClient({
       backendId: "acp:kimi",
       store,
       transport,
-      now: () => 1000,
+      now: () => now,
     });
 
     await client.initialize();
@@ -1633,6 +1634,7 @@ describe("AcpAgentClient", () => {
       title: "Kimi ACP",
     });
 
+    now = 2000;
     transport.emitSessionUpdate(session.sessionId, {
       sessionUpdate: "available_commands_update",
       availableCommands: [
@@ -1666,6 +1668,7 @@ describe("AcpAgentClient", () => {
     expect(readRawAcpSessionPayload("acp:kimi", "session-1")?.availableCommands).toEqual(
       store.getSession("acp:kimi", "session-1")?.availableCommands,
     );
+    expect(store.getSession("acp:kimi", "session-1")?.updatedAt).toBe(1000);
   });
 
   it("loads ACP transcript replay from provider session/load without storing it in the DB", async () => {
@@ -1985,9 +1988,9 @@ describe("AcpAgentClient", () => {
     });
 
     await client.initialize();
-    const replay = await client.loadSession(
-      store.getSession("acp:grok", "session-1")!,
-    );
+    const staleMetadata = store.getSession("acp:grok", "session-1")!;
+    const replay = await client.loadSession(staleMetadata);
+    await client.refreshSession(staleMetadata);
 
     expect(replay.messages.map((message) => message.createdAt)).toEqual([
       1100,

--- a/apps/desktop/src/main/__tests__/acp-client.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-client.test.ts
@@ -133,6 +133,38 @@ describe("AcpAgentClient", () => {
     expect(sessionUpdates).toEqual(["session-1"]);
   });
 
+  it("uses a provider update timestamp for persisted ACP activity", async () => {
+    const transport = new FakeAcpAgentTransport();
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      store,
+      transport,
+      now: () => 1_800_000_000_000,
+    });
+    store.upsertSession({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      title: "Grok session",
+      cwd: "/repo",
+      createdAt: 1_600_000_000_000,
+      updatedAt: 1_600_000_000_000,
+      executionMode: "default",
+      status: "idle",
+    });
+
+    await client.initialize();
+    transport.emitSessionUpdate("session-1", {
+      kind: "agent_message_chunk",
+      content: "This update has a provider timestamp.",
+      timestamp: 1_700_000_000,
+    });
+
+    expect(store.getSession("acp:grok", "session-1")).toMatchObject({
+      hasConversationHistory: true,
+      updatedAt: 1_700_000_000_000,
+    });
+  });
+
   it("records Kimi snake_case assistant chunks as active turn text", async () => {
     const promptResponse = createDeferred<unknown>();
     const transport = new FakeAcpAgentTransport({
@@ -1884,6 +1916,223 @@ describe("AcpAgentClient", () => {
     ).toHaveLength(5);
   });
 
+  it("repairs a session activity timestamp from complete local rollout history", async () => {
+    const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1100,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "Was this really sent now?",
+        turnId: "turn-1",
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1200,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "No, it was sent earlier." },
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1201,
+      update: {
+        session_update: "turn_finished",
+        turnId: "turn-1",
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1900,
+      update: {
+        kind: "provider_runtime_snapshot",
+        state: "ready",
+      },
+    });
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      rolloutStore,
+      store,
+      transport,
+      now: () => 2000,
+    });
+    store.upsertSession({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      title: "Grok session",
+      cwd: "/repo",
+      createdAt: 1000,
+      // Simulates the old session/load behavior marking the thread as freshly
+      // active even though the durable replay ended at 1201.
+      updatedAt: 2000,
+      executionMode: "default",
+      status: "idle",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const replay = await client.loadSession(
+      store.getSession("acp:grok", "session-1")!,
+    );
+
+    expect(replay.messages.map((message) => message.createdAt)).toEqual([
+      1100,
+      1200,
+    ]);
+    expect(store.getSession("acp:grok", "session-1")?.updatedAt).toBe(1201);
+    expect(transport.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "session/load",
+    ]);
+  });
+
+  it("uses timestamped Grok session/load notifications over a complete rollout", async () => {
+    const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1100,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "Old local prompt",
+        turnId: "turn-1",
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1200,
+      update: {
+        session_update: "agent_message_chunk",
+        content: { type: "text", text: "Old local reply" },
+      },
+    });
+    rolloutStore.appendUpdate({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      receivedAt: 1201,
+      update: {
+        session_update: "turn_finished",
+        turnId: "turn-1",
+      },
+    });
+    const transport = new FakeAcpAgentTransport({
+      initialize: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+        },
+      },
+    });
+    const client = new AcpAgentClient({
+      backendId: "acp:grok",
+      rolloutStore,
+      store,
+      transport: {
+        request: async (method, params) => {
+          const result = await transport.request(method, params);
+          if (method === "session/load") {
+            transport.emitSessionUpdate(
+              "session-1",
+              {
+                session_update: "user_message_chunk",
+                content: { type: "text", text: "Provider prompt" },
+              },
+              { agentTimestampMs: 1_785_000_001_300, isReplay: true },
+            );
+            transport.emitSessionUpdate(
+              "session-1",
+              {
+                session_update: "agent_message_chunk",
+                content: { type: "text", text: "Provider reply" },
+              },
+              { agentTimestampMs: 1_785_000_001_400, isReplay: true },
+            );
+            transport.emitSessionUpdate(
+              "session-1",
+              {
+                session_update: "turn_completed",
+                turnId: "turn-1",
+              },
+              { agentTimestampMs: 1_785_000_001_401, isReplay: true },
+            );
+          }
+          return result;
+        },
+        notify: (method, params) => transport.notify(method, params),
+        close: () => transport.close(),
+        onNotification: (listener) => transport.onNotification(listener),
+      },
+      now: () => 1_800_000_000_000,
+    });
+    store.upsertSession({
+      backendId: "acp:grok",
+      sessionId: "session-1",
+      title: "Grok session",
+      cwd: "/repo",
+      createdAt: 1_785_000_000_000,
+      updatedAt: 1_800_000_000_000,
+      executionMode: "default",
+      status: "active",
+      hasConversationHistory: true,
+    });
+
+    await client.initialize();
+    const replay = await client.loadSession(
+      store.getSession("acp:grok", "session-1")!,
+    );
+    const cachedReplay = await client.loadSession(
+      store.getSession("acp:grok", "session-1")!,
+    );
+
+    expect(
+      replay.messages.map((message) => ({
+        createdAt: message.createdAt,
+        text: message.text,
+      })),
+    ).toEqual([
+      { createdAt: 1_785_000_001_300, text: "Provider prompt" },
+      { createdAt: 1_785_000_001_400, text: "Provider reply" },
+    ]);
+    expect(
+      cachedReplay.messages.map((message) => ({
+        createdAt: message.createdAt,
+        text: message.text,
+      })),
+    ).toEqual([
+      { createdAt: 1_785_000_001_300, text: "Provider prompt" },
+      { createdAt: 1_785_000_001_400, text: "Provider reply" },
+    ]);
+    expect(client.didSessionLoadReplayHistory("session-1")).toBe(true);
+    expect(store.getSession("acp:grok", "session-1")?.updatedAt).toBe(
+      1_785_000_001_401,
+    );
+    expect(store.getSession("acp:grok", "session-1")?.status).toBe("idle");
+    expect(
+      rolloutStore.readUpdates({
+        backendId: "acp:grok",
+        sessionId: "session-1",
+      }),
+    ).toHaveLength(3);
+    expect(
+      transport.requests.filter((request) => request.method === "session/load"),
+    ).toHaveLength(1);
+  });
+
   it("merges provider session/load replay when local rollout history is incomplete", async () => {
     const rolloutStore = new AcpRolloutStore(path.join(tempDir, "rollouts"));
     rolloutStore.appendUpdate({
@@ -2896,6 +3145,13 @@ describe("AcpAgentClient", () => {
             notificationListener?.("session/update", {
               sessionId: "session-1",
               update: {
+                kind: "current_mode_update",
+                currentModeId: "yolo",
+              },
+            });
+            notificationListener?.("session/update", {
+              sessionId: "session-1",
+              update: {
                 sessionUpdate: "tool_call_update",
                 toolCallId: "update_topic_1",
                 kind: "think",
@@ -2951,7 +3207,11 @@ describe("AcpAgentClient", () => {
       "Loaded Project Research",
     );
     expect(store.getSession("acp:gemini", "session-1")).toMatchObject({
+      acpRuntime: {
+        currentModeId: "yolo",
+      },
       hasConversationHistory: true,
+      updatedAt: 950,
     });
     expect(
       readRawAcpSessionPayload("acp:gemini", "session-1")?.transcriptUpdates,

--- a/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-rollout-store.test.ts
@@ -69,7 +69,7 @@ describe("AcpRolloutStore", () => {
     expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(false);
   });
 
-  it("migrates legacy encoded backend rollout history before writing", () => {
+  it("recovers legacy encoded backend rollout history before writing", () => {
     const backendId = "acp:grok" as AcpBackendId;
     const legacyRolloutPath = path.join(
       tempDir,
@@ -110,7 +110,7 @@ describe("AcpRolloutStore", () => {
     ).toBe(true);
     expect(
       fs.existsSync(path.join(tempDir, ".backend-path-layout-v2")),
-    ).toBe(true);
+    ).toBe(false);
     expect(replay.messages.map((message) => message.text)).toEqual([
       "from the old path",
       "from the new path",
@@ -166,8 +166,81 @@ describe("AcpRolloutStore", () => {
         .messages.map((message) => message.text),
     ).toEqual(["3Agrok history"]);
     expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(true);
-    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(false);
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_3Agrok__current")),
+    ).toBe(true);
     expect(fs.existsSync(path.join(tempDir, "acp_3A3Agrok"))).toBe(false);
+  });
+
+  it("does not claim a legacy backend directory for a colliding current backend", () => {
+    const sessionId = "shared-session";
+    const legacyRolloutPath = path.join(
+      tempDir,
+      "acp_3Agrok",
+      sessionId,
+      "rollout.jsonl",
+    );
+    fs.mkdirSync(path.dirname(legacyRolloutPath), { recursive: true });
+    fs.writeFileSync(
+      legacyRolloutPath,
+      `${JSON.stringify({
+        type: "update",
+        receivedAt: 1000,
+        update: {
+          kind: "pwragent_user_prompt",
+          prompt: "grok history",
+          turnId: "turn-1",
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    const store = new AcpRolloutStore(tempDir);
+    const collidingBackendId = "acp:3Agrok" as AcpBackendId;
+
+    expect(
+      store.readReplay({
+        backendId: collidingBackendId,
+        sessionId,
+      }).messages,
+    ).toEqual([]);
+
+    store.appendUpdate({
+      backendId: collidingBackendId,
+      sessionId,
+      receivedAt: 1001,
+      update: {
+        kind: "pwragent_user_prompt",
+        prompt: "3Agrok history",
+        turnId: "turn-1",
+      },
+    });
+
+    expect(fs.existsSync(legacyRolloutPath)).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tempDir,
+          "acp_3Agrok__current",
+          sessionId,
+          "rollout.jsonl",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      store
+        .readReplay({
+          backendId: "acp:grok" as AcpBackendId,
+          sessionId,
+        })
+        .messages.map((message) => message.text),
+    ).toEqual(["grok history"]);
+    expect(
+      store
+        .readReplay({ backendId: collidingBackendId, sessionId })
+        .messages.map((message) => message.text),
+    ).toEqual(["3Agrok history"]);
   });
 
   it("does not remigrate new backend directories on later startups", () => {
@@ -191,19 +264,108 @@ describe("AcpRolloutStore", () => {
         .readReplay({ backendId, sessionId: "session-1" })
         .messages.map((message) => message.text),
     ).toEqual(["belongs to 3Agrok"]);
-    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_3Agrok__current")),
+    ).toBe(true);
     expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(false);
   });
 
-  it("refuses to overwrite an existing migration destination", () => {
-    fs.mkdirSync(path.join(tempDir, "acp_3Agrok"), { recursive: true });
-    fs.mkdirSync(path.join(tempDir, "acp_grok"), { recursive: true });
+  it("keeps a canonical session when an old build recreates its legacy duplicate", () => {
+    const sessionId = "session-1";
+    const writeRollout = (backendDirectory: string, prompt: string): void => {
+      const rolloutPath = path.join(
+        tempDir,
+        backendDirectory,
+        sessionId,
+        "rollout.jsonl",
+      );
+      fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+      fs.writeFileSync(
+        rolloutPath,
+        `${JSON.stringify({
+          type: "update",
+          receivedAt: 1000,
+          update: {
+            kind: "pwragent_user_prompt",
+            prompt,
+            turnId: "turn-1",
+          },
+        })}\n`,
+        "utf8",
+      );
+    };
+    writeRollout("acp_grok", "canonical history");
+    writeRollout("acp_3Agrok", "legacy duplicate");
 
-    expect(() => new AcpRolloutStore(tempDir)).toThrow(
-      /both paths exist/,
+    const store = new AcpRolloutStore(tempDir);
+
+    expect(
+      store
+        .readReplay({
+          backendId: "acp:grok" as AcpBackendId,
+          sessionId,
+        })
+        .messages.map((message) => message.text),
+    ).toEqual(["canonical history"]);
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_3Agrok", sessionId)),
+    ).toBe(true);
+  });
+
+  it("recovers a legacy session created after the old migration marker", () => {
+    const sessionId = "recreated-by-old-build";
+    const unrelatedCurrentRollout = path.join(
+      tempDir,
+      "acp_grok",
+      "already-migrated",
+      "rollout.jsonl",
     );
-    expect(fs.existsSync(path.join(tempDir, "acp_3Agrok"))).toBe(true);
-    expect(fs.existsSync(path.join(tempDir, "acp_grok"))).toBe(true);
+    const legacyRollout = path.join(
+      tempDir,
+      "acp_3Agrok",
+      sessionId,
+      "rollout.jsonl",
+    );
+    fs.mkdirSync(path.dirname(unrelatedCurrentRollout), { recursive: true });
+    fs.writeFileSync(unrelatedCurrentRollout, "", "utf8");
+    fs.mkdirSync(path.dirname(legacyRollout), { recursive: true });
+    fs.writeFileSync(
+      legacyRollout,
+      `${JSON.stringify({
+        type: "update",
+        receivedAt: 1000,
+        update: {
+          kind: "pwragent_user_prompt",
+          prompt: "written after migration",
+          turnId: "turn-1",
+        },
+      })}\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(tempDir, ".backend-path-layout-v2"),
+      "2\n",
+      "utf8",
+    );
+
+    const store = new AcpRolloutStore(tempDir);
+
+    expect(
+      store
+        .readReplay({
+          backendId: "acp:grok" as AcpBackendId,
+          sessionId,
+        })
+        .messages.map((message) => message.text),
+    ).toEqual(["written after migration"]);
+    expect(
+      fs.existsSync(
+        path.join(tempDir, "acp_grok", sessionId, "rollout.jsonl"),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tempDir, "acp_3Agrok", sessionId)),
+    ).toBe(false);
   });
 
   it("hides Qwen thought chunks when restoring rollout replay", () => {

--- a/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts
@@ -25,6 +25,59 @@ describe("AcpSessionReplayNormalizer", () => {
     expect(replay.lastAssistantMessage).toBe("Hello world");
   });
 
+  it("prefers a provider timestamp extension over local receipt time", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1_800_000_000_000,
+      update: {
+        kind: "agent_message_chunk",
+        content: "Recorded earlier by the provider.",
+        created_at: "2026-07-27T05:38:07.874Z",
+      },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({
+        createdAt: Date.parse("2026-07-27T05:38:07.874Z"),
+        role: "assistant",
+        text: "Recorded earlier by the provider.",
+      }),
+    ]);
+  });
+
+  it("reads Grok and Qwen timestamps from ACP update metadata", () => {
+    const normalizer = new AcpSessionReplayNormalizer();
+
+    normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1_800_000_000_000,
+      update: {
+        kind: "agent_message_chunk",
+        content: "Grok timestamp.",
+        _meta: { agentTimestampMs: 1_785_000_000_100 },
+      },
+    });
+    const replay = normalizer.apply({
+      sessionId: "session-1",
+      receivedAt: 1_800_000_000_000,
+      update: {
+        kind: "agent_message_chunk",
+        content: " Qwen timestamp.",
+        _meta: { timestamp: 1_785_000_000_200 },
+      },
+    });
+
+    expect(replay.messages).toEqual([
+      expect.objectContaining({
+        createdAt: 1_785_000_000_100,
+        role: "assistant",
+        text: "Grok timestamp. Qwen timestamp.",
+      }),
+    ]);
+  });
+
   it("drops Gemini's <session_context> boilerplate user_message_chunk", () => {
     // Gemini re-emits its <session_context> environment block (date/OS/workspace
     // /directory tree) as a user_message_chunk on session/load. It is agent

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -13,9 +13,11 @@ import type {
 } from "@pwragent/shared";
 import {
   AcpSessionReplayNormalizer,
+  isAcpUserBoilerplateMessage,
   isGrokTransientUpdateKind,
   readAcpContentText,
   readAcpTopicTitle,
+  readAcpUpdateTimestamp,
   shouldSurfaceAcpThoughtsAsMessages,
   type AcpSessionUpdate,
 } from "./acp-session-normalizer.js";
@@ -128,7 +130,17 @@ type AcpActiveTurn = {
 };
 
 type AcpSessionLoadState = {
+  lastTimestampedTranscriptAt?: number;
+  replayedTranscript: boolean;
   suppressTranscriptReplay: boolean;
+};
+
+type AcpSessionLoadReplay = {
+  lastTimestampedTranscriptAt?: number;
+};
+
+type AcpSessionMetadataUpdateOptions = {
+  touchActivity?: boolean;
 };
 
 type AcpSuppressedControlPrompt = {
@@ -140,6 +152,7 @@ type AcpSuppressedControlPrompt = {
 
 type AcpHydratedSessionHistory = {
   isComplete: boolean;
+  lastActivityAt?: number;
 };
 
 export type AcpAgentClientOptions = {
@@ -152,6 +165,7 @@ export type AcpAgentClientOptions = {
   now?: () => number;
   onSessionUpdate?: (event: {
     assistantMessageItemId?: string;
+    fromSessionLoad?: boolean;
     sessionId: string;
     replay: AppServerThreadReplay;
     title?: string;
@@ -164,11 +178,13 @@ export type AcpAgentClientOptions = {
     error: unknown;
   }) => Promise<void> | void;
   onRuntimeCapabilities?: (event: {
+    fromSessionLoad?: boolean;
     sessionId?: string;
     runtimeCapabilities: BackendAcpRuntimeCapabilities;
     runtimeState?: BackendAcpSessionRuntimeState;
   }) => Promise<void> | void;
   onSessionRuntimeStateChange?: (event: {
+    fromSessionLoad?: boolean;
     sessionId: string;
     runtimeState: BackendAcpSessionRuntimeState;
   }) => Promise<void> | void;
@@ -195,6 +211,7 @@ export class AcpAgentClient {
     AcpSuppressedControlPrompt
   >();
   private readonly loadingSessions = new Map<string, AcpSessionLoadState>();
+  private readonly sessionLoadReplays = new Map<string, AcpSessionLoadReplay>();
   private readonly agentSessionIdsByAppSessionId = new Map<string, string>();
   private readonly appSessionIdsByAgentSessionId = new Map<string, string>();
   private readonly now: () => number;
@@ -433,13 +450,60 @@ export class AcpAgentClient {
   }
 
   async loadSession(metadata: AcpSessionMetadata): Promise<AppServerThreadReplay> {
-    this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
+    const storedMetadata =
+      this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
+      metadata;
+    if (this.supportsSessionLoad() && this.isSessionLoaded(storedMetadata)) {
+      const replay = this.normalizers.get(metadata.sessionId)?.replay();
+      if (replay && (replay.entries.length > 0 || replay.messages.length > 0)) {
+        return this.replayForSessionMetadata(storedMetadata);
+      }
+    }
+    this.options.store.upsertSession(metadata);
     const localHistory = this.hydrateSessionFromHistory(metadata);
+    const fallbackNormalizer = this.normalizers.get(metadata.sessionId);
+    this.reconcileSessionActivityTimestamp(
+      metadata.sessionId,
+      localHistory,
+    );
+    const hydratedMetadata =
+      this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
+      metadata;
     if (this.supportsSessionLoad()) {
-      await this.ensureSession(metadata, {
-        suppressTranscriptReplay: localHistory.isComplete,
+      const protocolSessionId = this.protocolSessionIdFor(metadata.sessionId);
+      this.sessionLoadReplays.delete(protocolSessionId);
+      // Give session/load a clean normalizer only when the fallback already
+      // holds a complete transcript. An incomplete fallback still contributes
+      // timestamps that providers such as Kimi do not send, so it must merge
+      // with the incoming replay instead.
+      if (localHistory.isComplete) {
+        this.normalizers.delete(metadata.sessionId);
+      }
+      await this.ensureSession(hydratedMetadata, {
+        suppressTranscriptReplay: false,
       });
+      const sessionLoadReplay = this.sessionLoadReplays.get(protocolSessionId);
+      if (
+        sessionLoadReplay?.lastTimestampedTranscriptAt !== undefined ||
+        (!localHistory.isComplete && sessionLoadReplay)
+      ) {
+        if (sessionLoadReplay.lastTimestampedTranscriptAt !== undefined) {
+          this.reconcileSessionActivityTimestamp(metadata.sessionId, {
+            isComplete: true,
+            lastActivityAt: sessionLoadReplay.lastTimestampedTranscriptAt,
+          });
+        }
+        return this.replayForSessionMetadata(
+          this.options.store.getSession(
+            this.options.backendId,
+            metadata.sessionId,
+          ) ?? metadata,
+        );
+      }
+      if (fallbackNormalizer) {
+        this.normalizers.set(metadata.sessionId, fallbackNormalizer);
+      }
     }
     return this.replayForSessionMetadata(
       this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
@@ -460,12 +524,7 @@ export class AcpAgentClient {
     if (!this.supportsSessionLoad()) {
       return;
     }
-    const cwd = metadata.cwd ?? process.cwd();
-    const protocolSessionId = protocolSessionIdForMetadata(metadata);
-    if (
-      this.loadedSessionCwds.has(protocolSessionId) &&
-      this.loadedSessionCwds.get(protocolSessionId) === cwd
-    ) {
+    if (this.isSessionLoaded(metadata)) {
       return;
     }
     await this.loadSessionFromAgent(metadata, options);
@@ -737,10 +796,17 @@ export class AcpAgentClient {
     return this.normalizerFor(sessionId).replay();
   }
 
+  didSessionLoadReplayHistory(sessionId: string): boolean {
+    return this.sessionLoadReplays.has(this.protocolSessionIdFor(sessionId));
+  }
+
   private applySessionUpdate(params: Record<string, unknown>): void {
     const protocolSessionId =
       typeof params.sessionId === "string" ? params.sessionId : undefined;
-    const update = asRecord(params.update);
+    const update = withAcpSessionUpdateEnvelopeMetadata(
+      asRecord(params.update),
+      asRecord(params._meta),
+    );
     if (!protocolSessionId || !update) {
       return;
     }
@@ -775,36 +841,83 @@ export class AcpAgentClient {
     }
     const sessionId = this.appSessionIdFor(protocolSessionId);
     const receivedAt = this.now();
+    const activityAt = readAcpUpdateTimestamp(update) ?? receivedAt;
+    const loadState = this.loadingSessions.get(protocolSessionId);
+    const isExplicitSessionReplay = isAcpSessionReplayUpdate(update);
+    const fromSessionLoad = loadState !== undefined || isExplicitSessionReplay;
     const activeTurn = this.activeTurns.get(sessionId);
     const updateKind = readUpdateKind(update);
-    const runtimeState = acpSessionRuntimeStateFromUpdate(update, receivedAt);
+    if (isProviderTranscriptReplayUpdate(update)) {
+      if (loadState) {
+        loadState.replayedTranscript = true;
+        if (readAcpUpdateTimestamp(update) !== undefined) {
+          loadState.lastTimestampedTranscriptAt = Math.max(
+            loadState.lastTimestampedTranscriptAt ?? 0,
+            activityAt,
+          );
+        }
+      } else if (isExplicitSessionReplay) {
+        const existing = this.sessionLoadReplays.get(protocolSessionId);
+        this.sessionLoadReplays.set(protocolSessionId, {
+          ...(existing ?? {}),
+          ...(readAcpUpdateTimestamp(update) !== undefined
+            ? {
+                lastTimestampedTranscriptAt: Math.max(
+                  existing?.lastTimestampedTranscriptAt ?? 0,
+                  activityAt,
+                ),
+              }
+            : {}),
+        });
+      }
+    }
+    const runtimeState = acpSessionRuntimeStateFromUpdate(update, activityAt);
     if (runtimeState) {
-      this.updateSessionRuntimeState(sessionId, runtimeState);
+      this.updateSessionRuntimeState(sessionId, runtimeState, {
+        touchActivity: !fromSessionLoad,
+      });
       void Promise.resolve(
-        this.options.onSessionRuntimeStateChange?.({ sessionId, runtimeState }),
+        this.options.onSessionRuntimeStateChange?.({
+          ...(fromSessionLoad ? { fromSessionLoad: true } : {}),
+          sessionId,
+          runtimeState,
+        }),
       ).catch(() => undefined);
       return;
     }
-    const loadState = this.loadingSessions.get(protocolSessionId);
     if (loadState?.suppressTranscriptReplay && isTranscriptReplayUpdate(update)) {
       return;
     }
     if (updateKind === "available_commands_update") {
-      this.updateSessionAvailableCommands(sessionId, update, receivedAt);
+      this.updateSessionAvailableCommands(sessionId, update, activityAt, {
+        touchActivity: !fromSessionLoad,
+      });
     }
     if (updateKind === "turn_started") {
-      this.updateSessionStatus(sessionId, "active");
+      this.updateSessionStatus(sessionId, "active", activityAt, {
+        touchActivity: !fromSessionLoad,
+      });
     } else if (
       updateKind === "turn_finished" ||
-      updateKind === "pwragent_turn_failed"
+      updateKind === "pwragent_turn_failed" ||
+      (updateKind === "turn_completed" && activeTurn === undefined)
     ) {
-      this.updateSessionStatus(sessionId, "idle");
+      this.updateSessionStatus(sessionId, "idle", activityAt, {
+        touchActivity: !fromSessionLoad,
+      });
     }
-    const title = this.updateSessionTitleFromAcpUpdate(sessionId, update, receivedAt);
+    const title = this.updateSessionTitleFromAcpUpdate(
+      sessionId,
+      update,
+      activityAt,
+      { touchActivity: !fromSessionLoad },
+    );
     if (isConversationHistoryUpdate(update)) {
-      this.markSessionHasConversationHistory(sessionId, receivedAt);
+      this.markSessionHasConversationHistory(sessionId, activityAt, {
+        touchActivity: !fromSessionLoad,
+      });
     }
-    if (!loadState) {
+    if (!fromSessionLoad) {
       this.appendHistoryUpdate(sessionId, receivedAt, update);
     }
     const isAssistantTextUpdate =
@@ -842,6 +955,7 @@ export class AcpAgentClient {
     } satisfies AcpSessionUpdate);
     void this.notifySessionUpdate({
       assistantMessageItemId,
+      ...(fromSessionLoad ? { fromSessionLoad: true } : {}),
       sessionId,
       replay,
       title,
@@ -946,6 +1060,7 @@ export class AcpAgentClient {
       surfaceThoughtsAsMessages: this.surfaceThoughtsAsMessages,
     });
     let hasTranscriptHistory = false;
+    let lastActivityAt: number | undefined;
     const records = this.options.rolloutStore.readUpdates({
       backendId: this.options.backendId,
       sessionId: metadata.sessionId,
@@ -956,6 +1071,10 @@ export class AcpAgentClient {
       }
       if (isTranscriptReplayUpdate(record.update)) {
         hasTranscriptHistory = true;
+        lastActivityAt = Math.max(
+          lastActivityAt ?? 0,
+          readAcpUpdateTimestamp(record.update) ?? record.receivedAt,
+        );
       }
       normalizer.apply({
         sessionId: metadata.sessionId,
@@ -968,12 +1087,34 @@ export class AcpAgentClient {
     const hasReplay = replay.messages.length > 0 || replay.entries.length > 0;
     return {
       isComplete: (hasTranscriptHistory || hasReplay) && replay.threadStatus === "idle",
+      lastActivityAt,
     };
+  }
+
+  private reconcileSessionActivityTimestamp(
+    sessionId: string,
+    localHistory: AcpHydratedSessionHistory,
+  ): void {
+    if (!localHistory.isComplete || localHistory.lastActivityAt === undefined) {
+      return;
+    }
+    const metadata = this.options.store.getSession(this.options.backendId, sessionId);
+    if (!metadata || metadata.updatedAt === localHistory.lastActivityAt) {
+      return;
+    }
+    // A complete local rollout is the durable record of actual conversation
+    // activity. It repairs timestamps previously inflated by session/load
+    // hydration without turning metadata/config refreshes into unread events.
+    this.options.store.upsertSession({
+      ...metadata,
+      updatedAt: localHistory.lastActivityAt,
+    });
   }
 
   private markSessionHasConversationHistory(
     sessionId: string,
     receivedAt: number,
+    options: AcpSessionMetadataUpdateOptions = {},
   ): void {
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata || metadata.hasConversationHistory) {
@@ -982,7 +1123,10 @@ export class AcpAgentClient {
     this.options.store.upsertSession({
       ...metadata,
       hasConversationHistory: true,
-      updatedAt: Math.max(metadata.updatedAt, receivedAt),
+      updatedAt:
+        options.touchActivity === false
+          ? metadata.updatedAt
+          : Math.max(metadata.updatedAt, receivedAt),
     });
   }
 
@@ -990,6 +1134,7 @@ export class AcpAgentClient {
     sessionId: string,
     update: Record<string, unknown>,
     receivedAt: number,
+    options: AcpSessionMetadataUpdateOptions = {},
   ): void {
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata) {
@@ -1001,7 +1146,10 @@ export class AcpAgentClient {
         update,
         this.options.backendId,
       ),
-      updatedAt: Math.max(metadata.updatedAt, receivedAt),
+      updatedAt:
+        options.touchActivity === false
+          ? metadata.updatedAt
+          : Math.max(metadata.updatedAt, receivedAt),
     });
   }
 
@@ -1022,6 +1170,7 @@ export class AcpAgentClient {
   }
 
   private notifyRuntimeCapabilities(event: {
+    fromSessionLoad?: boolean;
     sessionId?: string;
     runtimeCapabilities?: BackendAcpRuntimeCapabilities;
     runtimeState?: BackendAcpSessionRuntimeState;
@@ -1031,6 +1180,7 @@ export class AcpAgentClient {
     }
     void Promise.resolve(
       this.options.onRuntimeCapabilities?.({
+        ...(event.fromSessionLoad ? { fromSessionLoad: true } : {}),
         sessionId: event.sessionId,
         runtimeCapabilities: event.runtimeCapabilities,
         runtimeState: event.runtimeState,
@@ -1041,6 +1191,7 @@ export class AcpAgentClient {
   private updateSessionRuntimeState(
     sessionId: string,
     runtimeState: BackendAcpSessionRuntimeState,
+    options: AcpSessionMetadataUpdateOptions = {},
   ): void {
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata) {
@@ -1049,12 +1200,16 @@ export class AcpAgentClient {
     this.options.store.upsertSession({
       ...metadata,
       acpRuntime: mergeAcpRuntimeState(metadata.acpRuntime, runtimeState),
-      updatedAt: Math.max(metadata.updatedAt, runtimeState.updatedAt ?? this.now()),
+      updatedAt:
+        options.touchActivity === false
+          ? metadata.updatedAt
+          : Math.max(metadata.updatedAt, runtimeState.updatedAt ?? this.now()),
     });
   }
 
   private async notifySessionUpdate(event: {
     assistantMessageItemId?: string;
+    fromSessionLoad?: boolean;
     sessionId: string;
     replay: AppServerThreadReplay;
     title?: string;
@@ -1079,9 +1234,11 @@ export class AcpAgentClient {
       cwd,
       sessionId: metadata.sessionId,
     });
-    this.loadingSessions.set(protocolSessionId, {
+    const loadState: AcpSessionLoadState = {
+      replayedTranscript: false,
       suppressTranscriptReplay: options.suppressTranscriptReplay === true,
-    });
+    };
+    this.loadingSessions.set(protocolSessionId, loadState);
     let result: unknown;
     try {
       result = await this.options.transport.request("session/load", {
@@ -1091,6 +1248,16 @@ export class AcpAgentClient {
       });
     } finally {
       this.loadingSessions.delete(protocolSessionId);
+      if (loadState.replayedTranscript) {
+        this.sessionLoadReplays.set(protocolSessionId, {
+          ...(loadState.lastTimestampedTranscriptAt !== undefined
+            ? {
+                lastTimestampedTranscriptAt:
+                  loadState.lastTimestampedTranscriptAt,
+              }
+            : {}),
+        });
+      }
     }
     const runtimeCapabilities = this.captureRuntimeCapabilities({
       source: "session-load",
@@ -1099,15 +1266,19 @@ export class AcpAgentClient {
     await Promise.resolve(mcpRegistration.bindThread?.(metadata.sessionId));
     const runtimeState = acpSessionRuntimeStateFromResponse(result, this.now());
     if (runtimeState) {
-      this.updateSessionRuntimeState(metadata.sessionId, runtimeState);
+      this.updateSessionRuntimeState(metadata.sessionId, runtimeState, {
+        touchActivity: false,
+      });
       void Promise.resolve(
         this.options.onSessionRuntimeStateChange?.({
+          fromSessionLoad: true,
           sessionId: metadata.sessionId,
           runtimeState,
         }),
       ).catch(() => undefined);
     }
     this.notifyRuntimeCapabilities({
+      fromSessionLoad: true,
       sessionId: metadata.sessionId,
       runtimeCapabilities,
       runtimeState,
@@ -1118,6 +1289,15 @@ export class AcpAgentClient {
 
   private supportsSessionLoad(): boolean {
     return acpRuntimeSupportsSessionLoad(this.runtimeCapabilities);
+  }
+
+  private isSessionLoaded(metadata: AcpSessionMetadata): boolean {
+    const cwd = metadata.cwd ?? process.cwd();
+    const protocolSessionId = protocolSessionIdForMetadata(metadata);
+    return (
+      this.loadedSessionCwds.has(protocolSessionId) &&
+      this.loadedSessionCwds.get(protocolSessionId) === cwd
+    );
   }
 
   private async buildMcpServers(params: {
@@ -1214,6 +1394,8 @@ export class AcpAgentClient {
   private updateSessionStatus(
     sessionId: string,
     status: AcpSessionMetadata["status"],
+    receivedAt = this.now(),
+    options: AcpSessionMetadataUpdateOptions = {},
   ): void {
     const metadata = this.options.store.getSession(this.options.backendId, sessionId);
     if (!metadata) {
@@ -1222,7 +1404,10 @@ export class AcpAgentClient {
     this.options.store.upsertSession({
       ...metadata,
       status,
-      updatedAt: Math.max(metadata.updatedAt, this.now()),
+      updatedAt:
+        options.touchActivity === false
+          ? metadata.updatedAt
+          : Math.max(metadata.updatedAt, receivedAt),
     });
   }
 
@@ -1230,6 +1415,7 @@ export class AcpAgentClient {
     sessionId: string,
     update: Record<string, unknown>,
     receivedAt: number,
+    options: AcpSessionMetadataUpdateOptions = {},
   ): string | undefined {
     const title = readAcpTopicTitle(update);
     if (!title) {
@@ -1251,7 +1437,10 @@ export class AcpAgentClient {
       ...metadata,
       title,
       titleSource: "derived",
-      updatedAt: Math.max(metadata.updatedAt, receivedAt),
+      updatedAt:
+        options.touchActivity === false
+          ? metadata.updatedAt
+          : Math.max(metadata.updatedAt, receivedAt),
     });
     return title;
   }
@@ -1280,10 +1469,44 @@ function protocolSessionIdForMetadata(metadata: AcpSessionMetadata): string {
   return metadata.agentSessionId ?? metadata.sessionId;
 }
 
+function withAcpSessionUpdateEnvelopeMetadata(
+  update: Record<string, unknown> | undefined,
+  envelopeMeta: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!update || !envelopeMeta) {
+    return update;
+  }
+  const updateMeta = asRecord(update._meta);
+  return {
+    ...update,
+    _meta: {
+      ...envelopeMeta,
+      ...updateMeta,
+    },
+  };
+}
+
 function readUpdateKind(update: Record<string, unknown>): string | undefined {
   const kind =
     update.sessionUpdate ?? update.session_update ?? update.kind ?? update.type;
   return typeof kind === "string" ? kind : undefined;
+}
+
+function isAcpSessionReplayUpdate(update: Record<string, unknown>): boolean {
+  const meta = asRecord(update._meta);
+  return meta?.isReplay === true || meta?.is_replay === true;
+}
+
+function isProviderTranscriptReplayUpdate(
+  update: Record<string, unknown>,
+): boolean {
+  if (!isTranscriptReplayUpdate(update)) {
+    return false;
+  }
+  return (
+    readUpdateKind(update) !== "user_message_chunk" ||
+    !isAcpUserBoilerplateMessage(readUpdateText(update))
+  );
 }
 
 function isConversationHistoryUpdate(update: Record<string, unknown>): boolean {
@@ -1305,6 +1528,7 @@ function isTranscriptReplayUpdate(update: Record<string, unknown>): boolean {
     kind === "tool_call_update" ||
     kind === "file" ||
     kind === "terminal" ||
+    kind === "turn_completed" ||
     kind === "turn_finished" ||
     kind === "pwragent_turn_failed"
   );

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -519,12 +519,12 @@ export class AcpAgentClient {
     metadata: AcpSessionMetadata,
     options: { suppressTranscriptReplay?: boolean } = {},
   ): Promise<void> {
-    this.options.store.upsertSession(metadata);
     this.rememberSessionIds(metadata);
-    if (!this.supportsSessionLoad()) {
+    if (this.supportsSessionLoad() && this.isSessionLoaded(metadata)) {
       return;
     }
-    if (this.isSessionLoaded(metadata)) {
+    this.options.store.upsertSession(metadata);
+    if (!this.supportsSessionLoad()) {
       return;
     }
     await this.loadSessionFromAgent(metadata, options);
@@ -890,7 +890,10 @@ export class AcpAgentClient {
     }
     if (updateKind === "available_commands_update") {
       this.updateSessionAvailableCommands(sessionId, update, activityAt, {
-        touchActivity: !fromSessionLoad,
+        // Providers refresh command capabilities during and immediately after
+        // session/load. Capability metadata is not conversation activity,
+        // even when a late notification no longer carries replay provenance.
+        touchActivity: false,
       });
     }
     if (updateKind === "turn_started") {

--- a/apps/desktop/src/main/acp/acp-client.ts
+++ b/apps/desktop/src/main/acp/acp-client.ts
@@ -22,7 +22,6 @@ import {
   type AcpSessionUpdate,
 } from "./acp-session-normalizer.js";
 import {
-  acpRuntimeSupportsSessionHistoryReplay,
   acpRuntimeSupportsSessionLoad,
   acpSessionRuntimeStateFromResponse,
   acpSessionRuntimeStateFromUpdate,
@@ -152,7 +151,6 @@ type AcpSuppressedControlPrompt = {
 
 type AcpHydratedSessionHistory = {
   isComplete: boolean;
-  lastActivityAt?: number;
 };
 
 export type AcpAgentClientOptions = {
@@ -463,10 +461,6 @@ export class AcpAgentClient {
     this.options.store.upsertSession(metadata);
     const localHistory = this.hydrateSessionFromHistory(metadata);
     const fallbackNormalizer = this.normalizers.get(metadata.sessionId);
-    this.reconcileSessionActivityTimestamp(
-      metadata.sessionId,
-      localHistory,
-    );
     const hydratedMetadata =
       this.options.store.getSession(this.options.backendId, metadata.sessionId) ??
       metadata;
@@ -488,12 +482,6 @@ export class AcpAgentClient {
         sessionLoadReplay?.lastTimestampedTranscriptAt !== undefined ||
         (!localHistory.isComplete && sessionLoadReplay)
       ) {
-        if (sessionLoadReplay.lastTimestampedTranscriptAt !== undefined) {
-          this.reconcileSessionActivityTimestamp(metadata.sessionId, {
-            isComplete: true,
-            lastActivityAt: sessionLoadReplay.lastTimestampedTranscriptAt,
-          });
-        }
         return this.replayForSessionMetadata(
           this.options.store.getSession(
             this.options.backendId,
@@ -1063,7 +1051,6 @@ export class AcpAgentClient {
       surfaceThoughtsAsMessages: this.surfaceThoughtsAsMessages,
     });
     let hasTranscriptHistory = false;
-    let lastActivityAt: number | undefined;
     const records = this.options.rolloutStore.readUpdates({
       backendId: this.options.backendId,
       sessionId: metadata.sessionId,
@@ -1074,10 +1061,6 @@ export class AcpAgentClient {
       }
       if (isTranscriptReplayUpdate(record.update)) {
         hasTranscriptHistory = true;
-        lastActivityAt = Math.max(
-          lastActivityAt ?? 0,
-          readAcpUpdateTimestamp(record.update) ?? record.receivedAt,
-        );
       }
       normalizer.apply({
         sessionId: metadata.sessionId,
@@ -1090,28 +1073,7 @@ export class AcpAgentClient {
     const hasReplay = replay.messages.length > 0 || replay.entries.length > 0;
     return {
       isComplete: (hasTranscriptHistory || hasReplay) && replay.threadStatus === "idle",
-      lastActivityAt,
     };
-  }
-
-  private reconcileSessionActivityTimestamp(
-    sessionId: string,
-    localHistory: AcpHydratedSessionHistory,
-  ): void {
-    if (!localHistory.isComplete || localHistory.lastActivityAt === undefined) {
-      return;
-    }
-    const metadata = this.options.store.getSession(this.options.backendId, sessionId);
-    if (!metadata || metadata.updatedAt === localHistory.lastActivityAt) {
-      return;
-    }
-    // A complete local rollout is the durable record of actual conversation
-    // activity. It repairs timestamps previously inflated by session/load
-    // hydration without turning metadata/config refreshes into unread events.
-    this.options.store.upsertSession({
-      ...metadata,
-      updatedAt: localHistory.lastActivityAt,
-    });
   }
 
   private markSessionHasConversationHistory(
@@ -1383,7 +1345,14 @@ export class AcpAgentClient {
     receivedAt: number,
     update: Record<string, unknown>,
   ): void {
-    if (acpRuntimeSupportsSessionHistoryReplay(this.runtimeCapabilities)) {
+    const verifiedReplay = this.sessionLoadReplays.get(
+      this.protocolSessionIdFor(sessionId),
+    );
+    // Keep a durable fallback until this exact session has successfully
+    // replayed timestamped provider history. An advertised capability alone
+    // cannot prove that session/load returned usable transcript history, and
+    // providers such as Kimi still need the local timestamps they omit.
+    if (verifiedReplay?.lastTimestampedTranscriptAt !== undefined) {
       return;
     }
     this.options.rolloutStore?.appendUpdate({

--- a/apps/desktop/src/main/acp/acp-rollout-store.ts
+++ b/apps/desktop/src/main/acp/acp-rollout-store.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
-  isAcpBackendId,
   type AcpBackendId,
   type AppServerThreadReplay,
 } from "@pwragent/shared";
@@ -35,10 +34,9 @@ type ChunkBuffer = {
 };
 
 const CHUNK_FLUSH_TEXT_LENGTH = 2_048;
-const LEGACY_BACKEND_PATH_PREFIX = "acp_3A";
-const CURRENT_BACKEND_PATH_PREFIX = "acp_";
-const PATH_LAYOUT_MIGRATION_MARKER = ".backend-path-layout-v2";
 const PWRAGENT_SYNTHETIC_UPDATE_META_KEY = "pwragentSynthetic";
+const LEGACY_BACKEND_PATH_PREFIX = "acp_3A";
+const COLLISION_SAFE_CURRENT_BACKEND_PATH_SUFFIX = "__current";
 
 export function isPwrAgentSyntheticAcpUpdate(
   update: Record<string, unknown>,
@@ -56,9 +54,7 @@ export class AcpRolloutStore {
   private readonly chunkBuffers = new Map<string, ChunkBuffer>();
   private readonly lastFingerprints = new Map<string, string>();
 
-  constructor(private readonly rootDir: string) {
-    migrateLegacyBackendDirectories(rootDir);
-  }
+  constructor(private readonly rootDir: string) {}
 
   appendUpdate(params: AcpRolloutStoreAppendParams): void {
     if (!shouldPersistUpdate(params.update)) {
@@ -186,12 +182,73 @@ export class AcpRolloutStore {
   }
 
   private rolloutPath(backendId: AcpBackendId, sessionId: string): string {
-    return path.join(
+    const rolloutPath = path.join(
       this.rootDir,
       encodeBackendPathSegment(backendId),
       encodePathSegment(sessionId),
       "rollout.jsonl",
     );
+    this.recoverLegacySession(backendId, sessionId, rolloutPath);
+    return rolloutPath;
+  }
+
+  /**
+   * Older desktop builds encoded `acp:grok` as `acp_3Agrok`; current builds
+   * use `acp_grok`. An older process can still recreate the old directory
+   * after a newer build has migrated it, so a one-time root marker cannot make
+   * the layout durable. Recover only the exact requested session instead.
+   *
+   * The canonical session directory always wins. This deliberately leaves a
+   * duplicate old-path session alone rather than merging or overwriting it.
+   */
+  private recoverLegacySession(
+    backendId: AcpBackendId,
+    sessionId: string,
+    currentRolloutPath: string,
+  ): void {
+    const currentSessionPath = path.dirname(currentRolloutPath);
+    if (fs.existsSync(currentSessionPath)) {
+      return;
+    }
+
+    const legacySessionPath = path.join(
+      this.rootDir,
+      encodePathSegment(backendId),
+      encodePathSegment(sessionId),
+    );
+    if (!fs.existsSync(legacySessionPath)) {
+      return;
+    }
+
+    fs.mkdirSync(path.dirname(currentSessionPath), { recursive: true });
+    try {
+      fs.renameSync(legacySessionPath, currentSessionPath);
+    } catch (error) {
+      // Another current build may have recovered this same session first.
+      if (
+        isErrnoException(error) &&
+        error.code === "ENOENT" &&
+        !fs.existsSync(legacySessionPath) &&
+        fs.existsSync(currentSessionPath)
+      ) {
+        return;
+      }
+      throw error;
+    }
+
+    try {
+      fs.rmdirSync(path.dirname(legacySessionPath));
+    } catch (error) {
+      // Keep a non-empty legacy backend directory for any other sessions an
+      // older app instance may still own. Its next current-build access will
+      // recover that session independently.
+      if (
+        !isErrnoException(error) ||
+        (error.code !== "ENOENT" && error.code !== "ENOTEMPTY")
+      ) {
+        throw error;
+      }
+    }
   }
 }
 
@@ -328,69 +385,13 @@ function encodePathSegment(value: string): string {
 }
 
 function encodeBackendPathSegment(value: AcpBackendId): string {
-  return value.replace(":", "_");
-}
-
-function migrateLegacyBackendDirectories(rootDir: string): void {
-  const markerPath = path.join(rootDir, PATH_LAYOUT_MIGRATION_MARKER);
-  if (fs.existsSync(markerPath)) {
-    return;
-  }
-
-  fs.mkdirSync(rootDir, { recursive: true });
-  const legacyDirectoryNames = fs
-    .readdirSync(rootDir, { withFileTypes: true })
-    .filter(
-      (entry) =>
-        entry.isDirectory() &&
-        entry.name.startsWith(LEGACY_BACKEND_PATH_PREFIX) &&
-        isAcpBackendId(
-          `acp:${entry.name.slice(LEGACY_BACKEND_PATH_PREFIX.length)}`,
-        ),
-    )
-    .map((entry) => entry.name)
-    .sort(
-      (left, right) =>
-        left.length - right.length || left.localeCompare(right),
-    );
-
-  for (const legacyDirectoryName of legacyDirectoryNames) {
-    const registryId = legacyDirectoryName.slice(
-      LEGACY_BACKEND_PATH_PREFIX.length,
-    );
-    const currentDirectoryName = `${CURRENT_BACKEND_PATH_PREFIX}${registryId}`;
-    const legacyPath = path.join(rootDir, legacyDirectoryName);
-    const currentPath = path.join(rootDir, currentDirectoryName);
-    if (!fs.existsSync(legacyPath)) {
-      continue;
-    }
-    if (fs.existsSync(currentPath)) {
-      throw new Error(
-        `Cannot migrate ACP rollout directory because both paths exist: ${legacyPath} and ${currentPath}`,
-      );
-    }
-    try {
-      fs.renameSync(legacyPath, currentPath);
-    } catch (error) {
-      if (
-        isErrnoException(error) &&
-        error.code === "ENOENT" &&
-        !fs.existsSync(legacyPath) &&
-        fs.existsSync(currentPath)
-      ) {
-        continue;
-      }
-      throw error;
-    }
-  }
-
-  try {
-    fs.writeFileSync(markerPath, "2\n", { encoding: "utf8", flag: "wx" });
-  } catch (error) {
-    if (!isErrnoException(error) || error.code !== "EEXIST") {
-      throw error;
-    }
-  }
+  const currentPathSegment = value.replace(":", "_");
+  // The old URL-style encoding makes `acp:grok` `acp_3Agrok`, which is also
+  // the readable encoding of a valid current backend ID, `acp:3Agrok`.
+  // Never let a current backend claim a directory that an old build can own.
+  return currentPathSegment.startsWith(LEGACY_BACKEND_PATH_PREFIX)
+    ? `${currentPathSegment}${COLLISION_SAFE_CURRENT_BACKEND_PATH_SUFFIX}`
+    : currentPathSegment;
 }
 
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {

--- a/apps/desktop/src/main/acp/acp-session-normalizer.ts
+++ b/apps/desktop/src/main/acp/acp-session-normalizer.ts
@@ -152,7 +152,8 @@ export class AcpSessionReplayNormalizer {
 
   apply(update: AcpSessionUpdate): AppServerThreadReplay {
     const kind = readKind(update.update);
-    const createdAt = update.receivedAt ?? Date.now();
+    const createdAt =
+      readAcpUpdateTimestamp(update.update) ?? update.receivedAt ?? Date.now();
     if (
       kind === "agent_thought_chunk" &&
       this.options.surfaceThoughtsAsMessages === false
@@ -606,6 +607,63 @@ export function readAcpTopicTitle(
   const fallbackMatch = /^Update topic to:\s*(.+)$/iu.exec(title);
   const topic = (quotedMatch?.[1] ?? fallbackMatch?.[1])?.trim();
   return topic || undefined;
+}
+
+/**
+ * ACP has no required per-update timestamp field, but several providers add
+ * one as an extension. Prefer it to local receipt time when it is a real Unix
+ * timestamp so a provider's historical session replay keeps its chronology.
+ */
+export function readAcpUpdateTimestamp(
+  update: Record<string, unknown>,
+): number | undefined {
+  for (const record of [update, asRecord(update._meta)]) {
+    if (!record) {
+      continue;
+    }
+    for (const key of [
+      "agentTimestampMs",
+      "agent_timestamp_ms",
+      "createdAt",
+      "created_at",
+      "occurredAt",
+      "occurred_at",
+      "timestamp",
+    ]) {
+      const timestamp = parseAcpUpdateTimestamp(record[key]);
+      if (timestamp !== undefined) {
+        return timestamp;
+      }
+    }
+  }
+  return undefined;
+}
+
+function parseAcpUpdateTimestamp(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return normalizeAcpUpdateTimestamp(value);
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return normalizeAcpUpdateTimestamp(numeric);
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function normalizeAcpUpdateTimestamp(value: number): number | undefined {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  // Seconds are common in CLI extension payloads; internally PwrAgent uses
+  // epoch milliseconds. Refuse small counters/durations that are not dates.
+  if (value >= 946_684_800 && value < 10_000_000_000) {
+    return Math.trunc(value * 1_000);
+  }
+  return value >= 946_684_800_000 ? Math.trunc(value) : undefined;
 }
 
 function readString(

--- a/apps/desktop/src/main/acp/testing/fake-acp-agent.ts
+++ b/apps/desktop/src/main/acp/testing/fake-acp-agent.ts
@@ -80,9 +80,17 @@ export class FakeAcpAgentTransport implements AcpJsonRpcTransport {
     this.closeCount += 1;
   }
 
-  emitSessionUpdate(sessionId: string, update: Record<string, unknown>): void {
+  emitSessionUpdate(
+    sessionId: string,
+    update: Record<string, unknown>,
+    envelopeMeta?: Record<string, unknown>,
+  ): void {
     for (const listener of this.listeners) {
-      listener("session/update", { sessionId, update });
+      listener("session/update", {
+        sessionId,
+        update,
+        ...(envelopeMeta ? { _meta: envelopeMeta } : {}),
+      });
     }
   }
 

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1765,13 +1765,15 @@ export class AcpBackendAdapter {
             });
           }
         }
-        const toolNotifications = acpToolUpdateNotifications({
-          threadId: sessionId,
-          turnId,
-          update,
-        }).filter((notification) =>
-          this.shouldEmitLiveToolNotification(agent.backendId, notification),
-        );
+        const toolNotifications = fromSessionLoad
+          ? []
+          : acpToolUpdateNotifications({
+              threadId: sessionId,
+              turnId,
+              update,
+            }).filter((notification) =>
+              this.shouldEmitLiveToolNotification(agent.backendId, notification),
+            );
         for (const notification of toolNotifications) {
           await this.emit({
             backend: agent.backendId,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -375,6 +375,14 @@ function acpRuntimeCapabilitiesForAgent(
   return agent.runtimeCapabilities;
 }
 
+function shouldPersistAcpRollout(agent: AcpInstalledAgentRecord): boolean {
+  // Grok and Qwen replay complete, timestamped transcripts from their own
+  // session stores. Keep reading legacy PwrAgent rollouts as a compatibility
+  // fallback, but do not duplicate new provider-owned history locally. Kimi
+  // still needs the local timestamps its session/load replay does not provide.
+  return agent.registryId !== "grok" && agent.registryId !== "qwen";
+}
+
 function normalizeInstalledAcpAgent(
   agent: AcpInstalledAgentRecord,
 ): AcpInstalledAgentRecord {
@@ -1623,7 +1631,9 @@ export class AcpBackendAdapter {
       backendId: agent.backendId,
       agentDisplayName: agent.name,
       initialRuntimeCapabilities: acpRuntimeCapabilitiesForAgent(agent),
-      rolloutStore: this.acpRolloutStore,
+      rolloutStore: shouldPersistAcpRollout(agent)
+        ? this.acpRolloutStore
+        : undefined,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport:
         this.createAcpTransport?.(agent) ??

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -120,7 +120,10 @@ export type AcpRuntimeClient = Pick<
   Partial<
     Pick<
       AcpAgentClient,
-      "readProviderStatus" | "sendControlPrompt" | "setRuntimeOption"
+      | "didSessionLoadReplayHistory"
+      | "readProviderStatus"
+      | "sendControlPrompt"
+      | "setRuntimeOption"
     >
   >;
 
@@ -195,6 +198,13 @@ export function readAcpUpdateText(
     return update.output_text;
   }
   return readAcpContentText(update.content);
+}
+
+function observedAcpSessionHistoryReplay(
+  client: AcpRuntimeClient,
+  sessionId: string,
+): boolean | undefined {
+  return client.didSessionLoadReplayHistory?.(sessionId);
 }
 
 export function readKimiYoloExecutionModeFromText(
@@ -1115,6 +1125,8 @@ export class AcpBackendAdapter {
           const replay = await cachedClient.loadSession(session);
           return this.providerReplayOrRolloutFallback({
             backend,
+            observedSessionHistoryReplay:
+              observedAcpSessionHistoryReplay(cachedClient, session.sessionId),
             replay,
             session,
           });
@@ -1184,6 +1196,8 @@ export class AcpBackendAdapter {
       });
       return this.providerReplayOrRolloutFallback({
         backend,
+        observedSessionHistoryReplay:
+          observedAcpSessionHistoryReplay(client, session.sessionId),
         replay,
         session,
       });
@@ -1292,23 +1306,22 @@ export class AcpBackendAdapter {
 
   private providerReplayOrRolloutFallback(params: {
     backend: AcpBackendId;
+    observedSessionHistoryReplay?: boolean;
     replay: AppServerThreadReplay;
     session: AcpSessionMetadata;
   }): AppServerThreadReplay {
     const { backend, replay, session } = params;
 
-    // For agents that do NOT replay their transcript on session/load (Gemini,
-    // Grok, Qwen — anything without sessionHistoryReplay), the provider
-    // "replay" is not the real history. Gemini in particular re-emits its
-    // <session_context> as a single user message on session/load, so the
-    // provider replay is non-empty but bogus — trusting it (entries > 0) used
-    // to drop the real conversation on reload. Our durable rollout captured
-    // every turn while the creating instance ran, so prefer it whenever it has
-    // entries. (We still call session/load above to resume the agent session
-    // for continuation; we just don't trust its replay as history here.)
-    const supportsHistoryReplay = acpRuntimeSupportsSessionHistoryReplay(
-      this.getInstalledAgent(backend)?.runtimeCapabilities,
-    );
+    // ACP agents commonly replay the transcript as session/update
+    // notifications during session/load rather than advertising
+    // sessionHistoryReplay. Prefer a replay that the client observed, but
+    // retain the advertised flag and rollout fallback for older providers and
+    // Gemini's non-transcript session_context bootstrap.
+    const supportsHistoryReplay =
+      params.observedSessionHistoryReplay === true ||
+      acpRuntimeSupportsSessionHistoryReplay(
+        this.getInstalledAgent(backend)?.runtimeCapabilities,
+      );
     if (!supportsHistoryReplay) {
       const rolloutReplay =
         this.acpRolloutStore?.readReplay({
@@ -1625,6 +1638,7 @@ export class AcpBackendAdapter {
         }),
       onSessionUpdate: async ({
         assistantMessageItemId,
+        fromSessionLoad,
         sessionId,
         replay,
         title,
@@ -1709,7 +1723,9 @@ export class AcpBackendAdapter {
             this.acpSessionStore?.upsertSession?.({
               ...metadata,
               executionMode: kimiYoloExecutionMode,
-              updatedAt: Math.max(metadata.updatedAt, Date.now()),
+              updatedAt: fromSessionLoad
+                ? metadata.updatedAt
+                : Math.max(metadata.updatedAt, Date.now()),
             });
             await this.emit({
               backend: agent.backendId,
@@ -1832,6 +1848,7 @@ export class AcpBackendAdapter {
         });
       },
       onRuntimeCapabilities: async ({
+        fromSessionLoad,
         runtimeCapabilities,
         runtimeState,
         sessionId,
@@ -1867,15 +1884,21 @@ export class AcpBackendAdapter {
                   ...(runtimeState.configValues ?? {}),
                 },
               },
-              updatedAt: Math.max(
-                metadata.updatedAt,
-                runtimeState.updatedAt ?? now,
-              ),
+              updatedAt: fromSessionLoad
+                ? metadata.updatedAt
+                : Math.max(
+                    metadata.updatedAt,
+                    runtimeState.updatedAt ?? now,
+                  ),
             });
           }
         }
       },
-      onSessionRuntimeStateChange: async ({ sessionId, runtimeState }) => {
+      onSessionRuntimeStateChange: async ({
+        fromSessionLoad,
+        sessionId,
+        runtimeState,
+      }) => {
         if (!this.acpSessionStore?.upsertSession) {
           return;
         }
@@ -1894,10 +1917,12 @@ export class AcpBackendAdapter {
         this.acpSessionStore.upsertSession({
           ...metadata,
           acpRuntime,
-          updatedAt: Math.max(
-            metadata.updatedAt,
-            runtimeState.updatedAt ?? Date.now(),
-          ),
+          updatedAt: fromSessionLoad
+            ? metadata.updatedAt
+            : Math.max(
+                metadata.updatedAt,
+                runtimeState.updatedAt ?? Date.now(),
+              ),
         });
         await this.emit({
           backend: agent.backendId,

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -375,14 +375,6 @@ function acpRuntimeCapabilitiesForAgent(
   return agent.runtimeCapabilities;
 }
 
-function shouldPersistAcpRollout(agent: AcpInstalledAgentRecord): boolean {
-  // Grok and Qwen replay complete, timestamped transcripts from their own
-  // session stores. Keep reading legacy PwrAgent rollouts as a compatibility
-  // fallback, but do not duplicate new provider-owned history locally. Kimi
-  // still needs the local timestamps its session/load replay does not provide.
-  return agent.registryId !== "grok" && agent.registryId !== "qwen";
-}
-
 function normalizeInstalledAcpAgent(
   agent: AcpInstalledAgentRecord,
 ): AcpInstalledAgentRecord {
@@ -1631,9 +1623,7 @@ export class AcpBackendAdapter {
       backendId: agent.backendId,
       agentDisplayName: agent.name,
       initialRuntimeCapabilities: acpRuntimeCapabilitiesForAgent(agent),
-      rolloutStore: shouldPersistAcpRollout(agent)
-        ? this.acpRolloutStore
-        : undefined,
+      rolloutStore: this.acpRolloutStore,
       store: this.acpSessionStore as AcpSessionStoreContract,
       transport:
         this.createAcpTransport?.(agent) ??


### PR DESCRIPTION
## Summary

- Recover the exact ACP rollout session from a legacy path even when an older build recreates it after migration; canonical history wins when both copies exist.
- Prefer transcript replay actually observed during `session/load`, even when the provider advertises only `loadSession: true`.
- Preserve Grok and Qwen provider timestamps, repair previously inflated activity time, and prevent load-time runtime/config notifications from creating unread activity.
- Keep an already-loaded provider replay in memory across repeated reads and derive repaired activity only from transcript/tool/turn events.

## Root cause

An older build could recreate `acp_3Agrok` after a current build had already migrated that directory. Current builds could then miss the intended history. Separately, ACP transcript replay arrives as `session/update` notifications during `session/load`; the providers do not advertise the separate `sessionHistoryReplay` capability, and PwrAgent ignored Grok envelope timestamps plus Qwen nested timestamps. Load-time metadata updates could therefore look like fresh user activity.

## Provider verification

A fresh-process harness created a session, sent two prompts, stopped the ACP process, and loaded the session in a new process.

- Grok 0.2.112 replayed both turns and supplied `_meta.agentTimestampMs`.
- Kimi Code 0.31.1, the current TypeScript/Node implementation, replayed both turns but supplied no per-message timestamps.
- Qwen 0.16.1 and 0.21.0 replayed both turns and supplied `update._meta.timestamp`.

Kimi provider content is therefore available after restart, while the existing local history remains useful only for preserving original message times when Kimi omits them.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/acp-client.test.ts apps/desktop/src/main/__tests__/acp-session-normalizer.test.ts apps/desktop/src/main/__tests__/acp-rollout-store.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts` — 141 tests
- `pnpm typecheck`
- ESLint with `--quiet`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`