### PR TITLE
fix(composer): hydrate attachment capabilities

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -738,9 +738,9 @@ describe("app server ipc", () => {
   it("identifies explicitly selected extensionless PDFs by their magic bytes", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-pdf-ipc-"));
     const pdfPath = path.join(root, "Jeep");
-    const textPath = path.join(root, "notes.txt");
+    const nonPdfPath = path.join(root, "notes.pdf");
     await writeFile(pdfPath, "%PDF-1.7\n");
-    await writeFile(textPath, "not a PDF");
+    await writeFile(nonPdfPath, "not a PDF");
     try {
       const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
       const { NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL } = await import(
@@ -750,9 +750,12 @@ describe("app server ipc", () => {
 
       await expect(
         handlers.get(NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL)?.({}, {
-          paths: [pdfPath, textPath],
+          paths: [pdfPath, nonPdfPath],
         }),
-      ).resolves.toEqual({ pdfPaths: [pdfPath] });
+      ).resolves.toEqual({
+        filePaths: [pdfPath, nonPdfPath],
+        pdfPaths: [pdfPath],
+      });
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,7 +1,8 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -71,6 +72,10 @@ import type {
   AgentToolMcpRegistration,
   AgentToolMcpServerLike,
 } from "../agent-tools/agent-tool-mcp-server";
+
+const jeepStickerPageFixture = fileURLToPath(
+  new URL("./fixtures/pdf/jeep-sticker-page-size.pdf", import.meta.url),
+);
 
 const mainLoggerMock = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -7288,6 +7293,63 @@ script = "echo setup"
 
     await registry.close();
     expect(pdfMcp.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the single-page PDF preparation fallback for an extensionless Composer reference", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-registry-pdf-"));
+    const pdfPath = path.join(root, "Jeep");
+    await copyFile(jeepStickerPageFixture, pdfPath);
+    const codexClient = new MockBackendClient({ threads: [] });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            messagingPdfToolCatalogVersion:
+              PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
+          },
+        },
+      }),
+      resolvePdfAnalysisEnabled: () => true,
+    });
+
+    try {
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [
+          { type: "text", text: "Compare [@Jeep](~/Downloads/Jeep)" },
+          { type: "localFile", name: "Jeep", path: pdfPath },
+        ],
+      });
+
+      expect(codexClient.lastStartTurnParams?.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining(
+              "PwrAgent rendered PDF attachment `Jeep` into 1 page image",
+            ),
+            type: "text",
+          }),
+          {
+            type: "localImage",
+            name: "Jeep-page-1.png",
+            path: expect.stringMatching(/Jeep-page-1\.png$/u),
+          },
+        ]),
+      );
+      expect(codexClient.lastStartTurnParams?.input).not.toContainEqual(
+        expect.objectContaining({ type: "localFile", path: pdfPath }),
+      );
+    } finally {
+      await registry.close();
+      await rm(root, { force: true, recursive: true });
+    }
   });
 
   it("passes Agent dynamic tools when starting Agent Codex threads", async () => {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -351,7 +351,11 @@ function classifyReferencePaths(
 const PDF_MAGIC = Buffer.from("%PDF-");
 const MAX_PDF_REFERENCE_PATHS = 20;
 
-function inspectPdfReferencePaths(paths: string[]): string[] {
+function inspectPdfReferencePaths(paths: string[]): {
+  filePaths: string[];
+  pdfPaths: string[];
+} {
+  const filePaths: string[] = [];
   const pdfPaths: string[] = [];
   const candidates = [...new Set(paths.filter((candidate) => candidate.trim()))]
     .slice(0, MAX_PDF_REFERENCE_PATHS);
@@ -359,6 +363,10 @@ function inspectPdfReferencePaths(paths: string[]): string[] {
     let descriptor: number | undefined;
     try {
       descriptor = fs.openSync(candidate, "r");
+      if (!fs.fstatSync(descriptor).isFile()) {
+        continue;
+      }
+      filePaths.push(candidate);
       const header = Buffer.alloc(PDF_MAGIC.byteLength);
       const bytesRead = fs.readSync(descriptor, header, 0, header.byteLength, 0);
       if (bytesRead === PDF_MAGIC.byteLength && header.equals(PDF_MAGIC)) {
@@ -372,7 +380,7 @@ function inspectPdfReferencePaths(paths: string[]): string[] {
       }
     }
   }
-  return pdfPaths;
+  return { filePaths, pdfPaths };
 }
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -5993,9 +6001,8 @@ export function registerAppServerIpcHandlers(): void {
     async (
       _event,
       request: InspectPdfReferencePathsRequest,
-    ): Promise<InspectPdfReferencePathsResponse> => ({
-      pdfPaths: inspectPdfReferencePaths(request.paths ?? []),
-    }),
+    ): Promise<InspectPdfReferencePathsResponse> =>
+      inspectPdfReferencePaths(request.paths ?? []),
   );
   ipcMain.removeHandler(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL);
   ipcMain.handle(

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4,6 +4,7 @@ import {
   type DragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type Ref,
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -338,6 +339,25 @@ type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
 type ComposerFileAttachment = NavigationLaunchpadFileAttachment;
 
+type ComposerReferenceInspection = {
+  filePaths: string[];
+  pdfPaths: string[];
+};
+
+type ComposerReferencePathInspection = {
+  isFile: boolean;
+  isPdf: boolean;
+};
+
+const EMPTY_COMPOSER_REFERENCE_INSPECTION: ComposerReferenceInspection = {
+  filePaths: [],
+  pdfPaths: [],
+};
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return value instanceof Promise;
+}
+
 /**
  * Maximum number of image attachments allowed on a single message. No
  * provider currently advertises its own per-message image limit, so this is
@@ -395,6 +415,12 @@ type QueuedTurnDraft = {
 
 type PendingSteerDraft = QueuedTurnDraft & {
   status: "pending" | "steering";
+};
+
+type ComposerTurnPayload = {
+  displayText: string;
+  imageParts: AppServerThreadImagePart[];
+  input: AppServerTurnInputItem[];
 };
 
 type DeletedSkillTokenHistoryEntry = {
@@ -1343,19 +1369,57 @@ function appendFileReferenceMarkdown(
 }
 
 /**
+ * Paths carried by an explicit Composer reference. We intentionally do not
+ * scan arbitrary text for filesystem-looking values: a tray attachment or an
+ * `@` reference token is the user action that authorizes local inspection.
+ */
+function listExplicitComposerReferencePaths(
+  fileRefs: ComposerFileAttachment[],
+  skillTokens: ComposerSkillToken[],
+): string[] {
+  const paths = new Set<string>();
+  const add = (rawPath: string | undefined): void => {
+    const filePath = rawPath?.trim();
+    if (
+      filePath
+      && (
+        filePath.startsWith("/")
+        || filePath.startsWith("\\\\")
+        || /^[A-Za-z]:[\\/]/u.test(filePath)
+      )
+    ) {
+      paths.add(filePath);
+    }
+  };
+
+  for (const fileRef of fileRefs) {
+    add(fileRef.path);
+  }
+  for (const token of skillTokens) {
+    if (token.kind === "file" || token.kind === "directory") {
+      add(token.path);
+    }
+  }
+  return [...paths].sort();
+}
+
+/**
  * Keep the normal markdown reference visible in the transcript, while also
  * preserving the explicit user selection for main-process document handling.
- * Do not derive these from free-form draft text: only the file tray and `@`
- * file tokens grant PwrAgent permission to inspect a local path.
+ * File-tray entries and file chips are known local files; a hydrated generic
+ * `@` chip joins them only after the bounded main-process inspection confirms
+ * it is a regular file.
  */
 function buildLocalFileInputs(
   fileRefs: ComposerFileAttachment[],
   skillTokens: ComposerSkillToken[],
+  inspectedFilePaths: Iterable<string> = [],
 ): Extract<AppServerTurnInputItem, { type: "localFile" }>[] {
   const inputsByPath = new Map<
     string,
     Extract<AppServerTurnInputItem, { type: "localFile" }>
   >();
+  const inspectedPaths = new Set(inspectedFilePaths);
   const add = (name: string | undefined, rawPath: string | undefined): void => {
     const filePath = rawPath?.trim();
     if (!filePath || inputsByPath.has(filePath)) {
@@ -1373,11 +1437,42 @@ function buildLocalFileInputs(
     add(fileRef.label, fileRef.path);
   }
   for (const token of skillTokens) {
-    if (token.kind === "file") {
+    if (
+      token.kind === "file"
+      || (token.kind === "directory" && inspectedPaths.has(token.path ?? ""))
+    ) {
       add(token.name, token.path);
     }
   }
   return [...inputsByPath.values()];
+}
+
+function mergeDerivedLocalFileInputs(
+  existingInput: AppServerTurnInputItem[] | undefined,
+  derivedInput: AppServerTurnInputItem[],
+): AppServerTurnInputItem[] {
+  if (!existingInput?.length) {
+    return derivedInput;
+  }
+
+  const localFilePaths = new Set<string>();
+  const merged = existingInput.filter((item) => {
+    if (item.type !== "localFile") {
+      return true;
+    }
+    if (localFilePaths.has(item.path)) {
+      return false;
+    }
+    localFilePaths.add(item.path);
+    return true;
+  });
+  for (const item of derivedInput) {
+    if (item.type === "localFile" && !localFilePaths.has(item.path)) {
+      localFilePaths.add(item.path);
+      merged.push(item);
+    }
+  }
+  return merged;
 }
 
 function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
@@ -1463,9 +1558,10 @@ function hydrateComposerDraft(
         // Serialized paths are percent-encoded tilde form; the token
         // carries the decoded absolute path so send-time attach can use
         // it directly. File-reference chips serialize to the same
-        // `[@label](~/path)` form, so a restored file chip degrades to a
-        // directory-kind chip here — acceptable: the outgoing text is
-        // identical either way.
+        // `[@label](~/path)` form, so restored Markdown starts as a
+        // generic reference chip. The bounded main-process inspection
+        // upgrades regular files to `kind: "file"` without ever scanning
+        // free-form typed paths.
         skillTokens.push(
           createComposerDirectoryToken(
             {
@@ -2596,6 +2692,9 @@ export function Composer(props: ComposerProps) {
   const latestLaunchpadRef =
     useRef<NavigationLaunchpadDraft | undefined>(props.launchpad);
   latestLaunchpadRef.current = props.launchpad;
+  const desktopApiRef = useRef(props.desktopApi);
+  desktopApiRef.current = props.desktopApi;
+  const referenceInspector = props.desktopApi?.inspectPdfReferencePaths;
   const pendingProgrammaticComposerChangeRef =
     useRef<PendingProgrammaticComposerChange | undefined>(undefined);
   const composerScopeKey = props.launchpad
@@ -2726,6 +2825,9 @@ export function Composer(props: ComposerProps) {
     savedInitialQueuedTurns ?? []
   );
   const queuedAutoReleaseAttemptIdRef = useRef<string | undefined>(undefined);
+  const queueCurrentDraftInFlightRef = useRef(false);
+  const pendingSteerCreationInFlightRef = useRef(false);
+  const turnPayloadPreparationInFlightRef = useRef(false);
   const serverQueuedTurnEntryIdsRef = useRef(new Map<string, string>());
   const [serverQueuedTurnEntryId, setServerQueuedTurnEntryIdState] =
     useState<string>();
@@ -2790,7 +2892,12 @@ export function Composer(props: ComposerProps) {
   const [skillTokens, setSkillTokens] = useState<ComposerSkillToken[]>(
     latestDraftSnapshotRef.current.snapshot.skillTokens
   );
-  const [pdfReferencePaths, setPdfReferencePaths] = useState<string[]>([]);
+  const referenceInspectionCacheRef = useRef(
+    new Map<string, ComposerReferencePathInspection>(),
+  );
+  const referenceInspectionInFlightRef = useRef(new Map<string, Promise<void>>());
+  const [inspectedPdfReferencePaths, setInspectedPdfReferencePaths] =
+    useState<string[]>([]);
   const [composerSelectionRequest, setComposerSelectionRequest] = useState<{
     id: string;
     index: number;
@@ -2917,47 +3024,164 @@ export function Composer(props: ComposerProps) {
     () => serializeDraftWithSkillTokens(draft, skillTokens),
     [draft, skillTokens]
   );
-  const explicitFileReferencePaths = useMemo(
+  const canonicalReferenceTokens = useMemo(
+    () => hydrateComposerDraft(canonicalDraft, props.skills, threadLinks).skillTokens,
+    [canonicalDraft, props.skills, threadLinks],
+  );
+  const explicitReferencePaths = useMemo(
     () =>
-      buildLocalFileInputs(fileAttachments, skillTokens)
-        .map((input) => input.path)
-        .sort(),
-    [fileAttachments, skillTokens],
+      listExplicitComposerReferencePaths(fileAttachments, [
+        ...skillTokens,
+        ...canonicalReferenceTokens,
+      ]),
+    [canonicalReferenceTokens, fileAttachments, skillTokens],
+  );
+  const explicitReferencePathsKey = explicitReferencePaths.join("\u0000");
+  const explicitReferenceTokenKey = useMemo(
+    () =>
+      [...skillTokens, ...canonicalReferenceTokens]
+        .filter(
+          (token) => token.kind === "file" || token.kind === "directory",
+        )
+        .map(
+          (token) =>
+            [token.kind, token.name, token.path ?? ""].join("\u0001"),
+        )
+        .sort()
+        .join("\u0000"),
+    [canonicalReferenceTokens, skillTokens],
+  );
+  const explicitReferencePathsRef = useRef(explicitReferencePaths);
+  explicitReferencePathsRef.current = explicitReferencePaths;
+  // Only the main-process magic-byte check identifies a PDF. In particular,
+  // a regular file named `.pdf` must not opt into PDF preparation by suffix.
+  const pdfReferencePaths = inspectedPdfReferencePaths;
+  const inspectExplicitReferencePaths = useCallback(
+    (
+      paths: string[],
+    ): ComposerReferenceInspection | Promise<ComposerReferenceInspection> => {
+      const candidates = [...new Set(
+        paths
+          .map((path) => path.trim())
+          .filter(Boolean),
+      )].sort();
+      if (candidates.length === 0) {
+        return EMPTY_COMPOSER_REFERENCE_INSPECTION;
+      }
+
+      const cache = referenceInspectionCacheRef.current;
+      const inFlight = referenceInspectionInFlightRef.current;
+      const inspector = desktopApiRef.current?.inspectPdfReferencePaths;
+      const pathsToInspect: string[] = [];
+      for (const candidate of candidates) {
+        if (!cache.has(candidate) && !inFlight.has(candidate)) {
+          pathsToInspect.push(candidate);
+        }
+      }
+
+      if (inspector && pathsToInspect.length > 0) {
+        const requestedPaths = [...pathsToInspect];
+        const requestedPathSet = new Set(requestedPaths);
+        const inspection = Promise.resolve()
+          .then(async () => await inspector({ paths: requestedPaths }))
+          .then((response) => {
+            // `pdfPaths` is necessarily a file subset. Accepting it here also
+            // keeps a renderer/main pair from adjacent app builds graceful
+            // while the richer `filePaths` response rolls out.
+            const returnedFilePaths = new Set(
+              [
+                ...(response.filePaths ?? []),
+                ...response.pdfPaths,
+              ].filter((path) => requestedPathSet.has(path)),
+            );
+            const returnedPdfPaths = new Set(
+              response.pdfPaths.filter((path) => requestedPathSet.has(path)),
+            );
+            for (const path of requestedPaths) {
+              cache.set(path, {
+                isFile: returnedFilePaths.has(path),
+                isPdf: returnedPdfPaths.has(path),
+              });
+            }
+          })
+          .catch(() => {
+            for (const path of requestedPaths) {
+              cache.set(path, { isFile: false, isPdf: false });
+            }
+          })
+          .finally(() => {
+            for (const path of requestedPaths) {
+              if (inFlight.get(path) === inspection) {
+                inFlight.delete(path);
+              }
+            }
+          });
+        for (const path of requestedPaths) {
+          inFlight.set(path, inspection);
+        }
+      }
+
+      const pendingInspections = [
+        ...new Set(
+          candidates
+            .map((path) => inFlight.get(path))
+            .filter((inspection): inspection is Promise<void> => Boolean(inspection)),
+        ),
+      ];
+      const readCachedInspection = (): ComposerReferenceInspection => ({
+        filePaths: candidates.filter((path) => cache.get(path)?.isFile),
+        pdfPaths: candidates.filter((path) => cache.get(path)?.isPdf),
+      });
+      return pendingInspections.length > 0
+        ? Promise.all(pendingInspections).then(readCachedInspection)
+        : readCachedInspection();
+    },
+    [],
   );
   useEffect(() => {
-    const extensionPdfPaths = explicitFileReferencePaths.filter((filePath) =>
-      /\.pdf$/iu.test(filePath),
-    );
-    if (explicitFileReferencePaths.length === 0) {
-      setPdfReferencePaths([]);
-      return;
-    }
-    if (!props.desktopApi?.inspectPdfReferencePaths) {
-      setPdfReferencePaths(extensionPdfPaths);
+    if (!explicitReferencePathsKey) {
+      setInspectedPdfReferencePaths([]);
       return;
     }
 
+    setInspectedPdfReferencePaths([]);
     let cancelled = false;
-    void props.desktopApi.inspectPdfReferencePaths({
-      paths: explicitFileReferencePaths,
-    }).then(
-      ({ pdfPaths }) => {
-        if (!cancelled) {
-          setPdfReferencePaths([
-            ...new Set([...extensionPdfPaths, ...pdfPaths]),
-          ]);
-        }
-      },
-      () => {
-        if (!cancelled) {
-          setPdfReferencePaths(extensionPdfPaths);
-        }
-      },
-    );
+    void Promise.resolve(
+      inspectExplicitReferencePaths(explicitReferencePathsRef.current),
+    ).then((inspection) => {
+      if (cancelled) {
+        return;
+      }
+      setInspectedPdfReferencePaths(inspection.pdfPaths);
+      if (inspection.filePaths.length === 0) {
+        return;
+      }
+      const filePaths = new Set(inspection.filePaths);
+      setSkillTokens((current) => {
+        let changed = false;
+        const next = current.map((token) => {
+          if (
+            token.kind !== "directory"
+            || !token.path
+            || !filePaths.has(token.path)
+          ) {
+            return token;
+          }
+          changed = true;
+          return { ...token, kind: "file" as const };
+        });
+        return changed ? next : current;
+      });
+    });
     return () => {
       cancelled = true;
     };
-  }, [explicitFileReferencePaths, props.desktopApi]);
+  }, [
+    explicitReferencePathsKey,
+    explicitReferenceTokenKey,
+    inspectExplicitReferencePaths,
+    referenceInspector,
+  ]);
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
   const queuedTurn = queuedTurns[0];
@@ -4116,6 +4340,10 @@ export function Composer(props: ComposerProps) {
     if (skillTokens.length === 0 && draft.includes("](")) {
       const hydrated = hydrateComposerDraft(draft, props.skills, threadLinks);
       if (hydrated.skillTokens.length > 0) {
+        // The paste update retained a rich document without mention nodes.
+        // Let the controlled editor rebuild it from the hydrated tokens so
+        // the visual chips and canonical draft remain in lockstep.
+        setEditorDocument(undefined);
         setDraft(hydrated.draft);
         setSkillTokens(hydrated.skillTokens);
       }
@@ -4944,41 +5172,77 @@ export function Composer(props: ComposerProps) {
     attachments: ComposerImageAttachment[],
     fileRefs: ComposerFileAttachment[],
     fileSkillTokens: ComposerSkillToken[] = [],
-  ): {
-    displayText: string;
-    imageParts: AppServerThreadImagePart[];
-    input: AppServerTurnInputItem[];
-  } => {
-    const turnSkills = listMentionedSkills(textDraft, props.skills);
-    // File-reference pills ride the outgoing text as `[@label](~/path)`
-    // markdown appended after the typed draft — part of BOTH the display
-    // text and the text input item, so the agent and the transcript see
-    // the same message.
-    const displayText = appendFileReferenceMarkdown(
-      hydrateSkillLabelsWithMarkdown(textDraft.trim(), turnSkills),
-      fileRefs,
-    );
-    const imageParts = attachments.map((attachment, index) => ({
-      type: "image" as const,
-      url: attachment.url,
-      alt: formatPastedImageAlt(attachment, index),
-    }));
-    const input: AppServerTurnInputItem[] = [
-      ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
-      ...attachments.map((attachment) => ({
-        type: "image" as const,
-        name: attachment.name,
-        url: attachment.url,
-      })),
-      ...buildLocalFileInputs(fileRefs, fileSkillTokens),
+  ): ComposerTurnPayload | Promise<ComposerTurnPayload> => {
+    // Text-only pasted/restored `[@label](path)` links do not have a prior
+    // in-memory token, so hydrate their explicit reference form here too.
+    // This keeps a fast Start/Send from bypassing the same inspection that
+    // normally runs as the Composer paints its chips.
+    const hydratedReferenceTokens = hydrateComposerDraft(
+      textDraft,
+      props.skills,
+      threadLinks,
+    ).skillTokens;
+    const localReferenceTokens = [
+      ...fileSkillTokens,
+      ...hydratedReferenceTokens,
     ];
+    const inspection = inspectExplicitReferencePaths(
+      listExplicitComposerReferencePaths(fileRefs, localReferenceTokens),
+    );
+    const build = (
+      resolvedInspection: ComposerReferenceInspection,
+    ): ComposerTurnPayload => {
+      const turnSkills = listMentionedSkills(textDraft, props.skills);
+      // File-reference pills ride the outgoing text as `[@label](~/path)`
+      // markdown appended after the typed draft — part of BOTH the display
+      // text and the text input item, so the agent and the transcript see
+      // the same message.
+      const displayText = appendFileReferenceMarkdown(
+        hydrateSkillLabelsWithMarkdown(textDraft.trim(), turnSkills),
+        fileRefs,
+      );
+      const imageParts = attachments.map((attachment, index) => ({
+        type: "image" as const,
+        url: attachment.url,
+        alt: formatPastedImageAlt(attachment, index),
+      }));
+      const input: AppServerTurnInputItem[] = [
+        ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
+        ...attachments.map((attachment) => ({
+          type: "image" as const,
+          name: attachment.name,
+          url: attachment.url,
+        })),
+        ...buildLocalFileInputs(
+          fileRefs,
+          localReferenceTokens,
+          resolvedInspection.filePaths,
+        ),
+      ];
 
-    return { displayText, imageParts, input };
+      return { displayText, imageParts, input };
+    };
+    return isPromiseLike(inspection) ? inspection.then(build) : build(inspection);
+  };
+
+  const buildQueuedTurnPayload = (
+    queued: QueuedTurnDraft,
+  ): ComposerTurnPayload | Promise<ComposerTurnPayload> => {
+    const payload = buildTurnPayload(
+      queued.text,
+      queued.imageAttachments,
+      queued.fileAttachments,
+    );
+    const merge = (derived: ComposerTurnPayload): ComposerTurnPayload => ({
+      ...derived,
+      input: mergeDerivedLocalFileInputs(queued.input, derived.input),
+    });
+    return isPromiseLike(payload) ? payload.then(merge) : merge(payload);
   };
 
   const sendThreadTurn = async (
     queued?: QueuedTurnDraft,
-    options?: { queueClaimed?: boolean },
+    options?: { payload?: ComposerTurnPayload; queueClaimed?: boolean },
   ): Promise<void> => {
     if (!props.thread || !props.desktopApi?.startTurn) {
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
@@ -4988,21 +5252,19 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const builtPayload = queued
-      ? buildTurnPayload(
-          queued.text,
-          queued.imageAttachments,
-          queued.fileAttachments ?? [],
-        )
-      : buildTurnPayload(
-          canonicalDraft,
-          imageAttachments,
-          fileAttachments,
-          skillTokens,
-        );
-    const payload = queued?.input?.length
-      ? { ...builtPayload, input: queued.input }
-      : builtPayload;
+    const payloadOrPromise =
+      options?.payload
+      ?? (queued
+        ? buildQueuedTurnPayload(queued)
+        : buildTurnPayload(
+            canonicalDraft,
+            imageAttachments,
+            fileAttachments,
+            skillTokens,
+          ));
+    const payload = isPromiseLike(payloadOrPromise)
+      ? await payloadOrPromise
+      : payloadOrPromise;
     if (payload.input.length === 0 || props.disabled) {
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
@@ -5222,48 +5484,66 @@ export function Composer(props: ComposerProps) {
     setPendingSteer(undefined);
   }, [activeTurnId, pendingSteer, props.launchpad, queuedTurn]);
 
-  const queueCurrentDraft = (options?: { scheduledSendAt?: number }): void => {
+  const queueCurrentDraft = (
+    options?: { scheduledSendAt?: number },
+  ): Promise<void> | undefined => {
     if (
-      !hasComposerContent &&
-      imageAttachments.length === 0 &&
-      fileAttachments.length === 0
+      queueCurrentDraftInFlightRef.current
+      || (
+        !hasComposerContent
+        && imageAttachments.length === 0
+        && fileAttachments.length === 0
+      )
     ) {
       return;
     }
 
+    queueCurrentDraftInFlightRef.current = true;
+    const complete = (payload: ComposerTurnPayload): void => {
+      try {
+        if (payload.input.length === 0) {
+          return;
+        }
+
+        enqueueQueuedTurn({
+          id: createQueuedTurnId(),
+          input: payload.input,
+          text: canonicalDraft,
+          imageAttachments,
+          fileAttachments,
+          ...(options?.scheduledSendAt
+            ? { scheduledSendAt: options.scheduledSendAt }
+            : {}),
+        });
+        recordComposerDraftHistory(
+          composerScopeKey,
+          latestDraftSnapshotRef.current.snapshot,
+          "unsent",
+        );
+        clearComposerDraftSnapshot(composerScopeKey);
+        clearComposerDraft();
+        setImageAttachments([]);
+        setFileAttachments([]);
+        setScheduledDraftSendAt(undefined);
+        setScheduleArmed(true);
+        setReviewConfig(undefined);
+        setSendError(undefined);
+      } finally {
+        queueCurrentDraftInFlightRef.current = false;
+      }
+    };
     const payload = buildTurnPayload(
       canonicalDraft,
       imageAttachments,
       fileAttachments,
       skillTokens,
     );
-    if (payload.input.length === 0) {
-      return;
+    if (isPromiseLike(payload)) {
+      return payload.then(complete, () => {
+        queueCurrentDraftInFlightRef.current = false;
+      });
     }
-
-    enqueueQueuedTurn({
-      id: createQueuedTurnId(),
-      input: payload.input,
-      text: canonicalDraft,
-      imageAttachments,
-      fileAttachments,
-      ...(options?.scheduledSendAt
-        ? { scheduledSendAt: options.scheduledSendAt }
-        : {}),
-    });
-    recordComposerDraftHistory(
-      composerScopeKey,
-      latestDraftSnapshotRef.current.snapshot,
-      "unsent",
-    );
-    clearComposerDraftSnapshot(composerScopeKey);
-    clearComposerDraft();
-    setImageAttachments([]);
-    setFileAttachments([]);
-    setScheduledDraftSendAt(undefined);
-    setScheduleArmed(true);
-    setReviewConfig(undefined);
-    setSendError(undefined);
+    complete(payload);
   };
 
   const queueReviewCommand = (
@@ -5347,7 +5627,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    queueCurrentDraft({ scheduledSendAt });
+    void queueCurrentDraft({ scheduledSendAt });
   };
 
   const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
@@ -5361,24 +5641,10 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const payload = pending.input?.length
-      ? {
-          displayText: appendFileReferenceMarkdown(
-            pending.text,
-            pending.fileAttachments,
-          ),
-          imageParts: pending.imageAttachments.map((attachment, index) => ({
-            type: "image" as const,
-            url: attachment.url,
-            alt: formatPastedImageAlt(attachment, index),
-          })),
-          input: pending.input,
-        }
-      : buildTurnPayload(
-          pending.text,
-          pending.imageAttachments,
-          pending.fileAttachments,
-        );
+    const payloadOrPromise = buildQueuedTurnPayload(pending);
+    const payload = isPromiseLike(payloadOrPromise)
+      ? await payloadOrPromise
+      : payloadOrPromise;
     if (
       payload.input.length === 0 ||
       props.disabled ||
@@ -5445,84 +5711,113 @@ export function Composer(props: ComposerProps) {
     }
   };
 
-  const createPendingSteer = (pending: QueuedTurnDraft): boolean => {
+  const createPendingSteer = (
+    pending: QueuedTurnDraft,
+  ): boolean | Promise<boolean> => {
     const turnId = activeTurnIdRef.current;
-    if (!props.thread || !turnId || !props.desktopApi?.steerTurn || !supportsSteering) {
+    if (pendingSteerCreationInFlightRef.current) {
+      return false;
+    }
+    if (
+      !props.thread
+      || !turnId
+      || !props.desktopApi?.steerTurn
+      || !supportsSteering
+    ) {
       setSendError("Steering is not available for this model.");
       return false;
     }
 
-    const payload = pending.input?.length
-      ? { input: pending.input }
-      : buildTurnPayload(
-          pending.text,
-          pending.imageAttachments,
-          pending.fileAttachments,
-        );
-    if (payload.input.length === 0 || props.disabled || pendingSteer) {
-      return false;
-    }
+    pendingSteerCreationInFlightRef.current = true;
+    const inputOrPayload = buildQueuedTurnPayload(pending);
+    const complete = (input: AppServerTurnInputItem[]): boolean => {
+      try {
+        if (input.length === 0 || props.disabled || pendingSteer) {
+          return false;
+        }
 
-    setSendError(undefined);
-    setPendingSteer({
-      id: pending.id,
-      input: payload.input,
-      text: pending.text,
-      imageAttachments: pending.imageAttachments,
-      fileAttachments: pending.fileAttachments,
-      status: "pending",
-    });
-    recordComposerDraftHistory(
-      composerScopeKey,
-      latestDraftSnapshotRef.current.snapshot,
-      "unsent",
-    );
-    clearComposerDraftSnapshot(composerScopeKey);
-    clearComposerDraft();
-    setImageAttachments([]);
-    setFileAttachments([]);
-    setReviewConfig(undefined);
-    return true;
+        setSendError(undefined);
+        setPendingSteer({
+          id: pending.id,
+          input,
+          text: pending.text,
+          imageAttachments: pending.imageAttachments,
+          fileAttachments: pending.fileAttachments,
+          status: "pending",
+        });
+        recordComposerDraftHistory(
+          composerScopeKey,
+          latestDraftSnapshotRef.current.snapshot,
+          "unsent",
+        );
+        clearComposerDraftSnapshot(composerScopeKey);
+        clearComposerDraft();
+        setImageAttachments([]);
+        setFileAttachments([]);
+        setReviewConfig(undefined);
+        return true;
+      } finally {
+        pendingSteerCreationInFlightRef.current = false;
+      }
+    };
+    if (isPromiseLike(inputOrPayload)) {
+      return inputOrPayload.then(
+        (payload) => complete(payload.input),
+        () => {
+          pendingSteerCreationInFlightRef.current = false;
+          return false;
+        },
+      );
+    }
+    return complete(inputOrPayload.input);
   };
 
-  const steerCurrentDraft = (): void => {
+  const steerCurrentDraft = (): Promise<void> | undefined => {
     if (!props.thread || !activeTurnIdRef.current || !props.desktopApi?.steerTurn) {
-      queueCurrentDraft();
+      void queueCurrentDraft();
       setSendError("Steering is not available for this backend.");
       return;
     }
     if (!supportsSteering) {
-      queueCurrentDraft();
+      void queueCurrentDraft();
       setSendError("Steering is not available for this model.");
       return;
     }
 
-    createPendingSteer({
+    const created = createPendingSteer({
       id: createQueuedTurnId(),
-      input: buildTurnPayload(
-        canonicalDraft,
-        imageAttachments,
-        fileAttachments,
-        skillTokens,
-      ).input,
       text: canonicalDraft,
       imageAttachments,
       fileAttachments,
     });
+    return isPromiseLike(created)
+      ? created.then(() => undefined)
+      : undefined;
   };
 
   const steerQueuedTurn = (queued: QueuedTurnDraft): void => {
-    if (!createPendingSteer(queued)) {
-      return;
-    }
-    removeQueuedTurn(queued);
-    if (activeTurnIdRef.current) {
-      void submitPendingSteer(queued);
+    const continueSteering = (created: boolean): void => {
+      if (!created) {
+        return;
+      }
+      removeQueuedTurn(queued);
+      if (activeTurnIdRef.current) {
+        void submitPendingSteer(queued);
+      }
+    };
+    const created = createPendingSteer(queued);
+    if (isPromiseLike(created)) {
+      void created.then(continueSteering);
+    } else {
+      continueSteering(created);
     }
   };
 
   const submitTurn = async (mode: "default" | "steer" = "default"): Promise<void> => {
     const reviewCommand = parsedReviewCommand;
+    if (turnPayloadPreparationInFlightRef.current) {
+      return;
+    }
     if (
       reviewCommand &&
       sendingRef.current &&
@@ -5537,7 +5832,10 @@ export function Composer(props: ComposerProps) {
 
     if (shouldQueueThreadSubmit()) {
       if (activeTurnIdRef.current && mode === "steer") {
-        steerCurrentDraft();
+        const steering = steerCurrentDraft();
+        if (steering) {
+          await steering;
+        }
       } else if (reviewCommand && isBareReviewCommand) {
         setReviewConfig(
           reviewConfig ??
@@ -5570,11 +5868,14 @@ export function Composer(props: ComposerProps) {
             : undefined,
         );
       } else {
-        queueCurrentDraft(
+        const queued = queueCurrentDraft(
           effectiveScheduledSendAt
             ? { scheduledSendAt: effectiveScheduledSendAt }
             : undefined,
         );
+        if (queued) {
+          await queued;
+        }
       }
       return;
     }
@@ -5608,7 +5909,12 @@ export function Composer(props: ComposerProps) {
     }
 
     if (effectiveScheduledSendAt) {
-      queueCurrentDraft({ scheduledSendAt: effectiveScheduledSendAt });
+      const queued = queueCurrentDraft({
+        scheduledSendAt: effectiveScheduledSendAt,
+      });
+      if (queued) {
+        await queued;
+      }
       return;
     }
 
@@ -5616,12 +5922,28 @@ export function Composer(props: ComposerProps) {
     // pending time so the toggle doesn't reappear after the immediate send.
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
-    const payload = buildTurnPayload(
+    const payloadOrPromise = buildTurnPayload(
       canonicalDraft,
       imageAttachments,
       fileAttachments,
       skillTokens,
     );
+    let payload: ComposerTurnPayload;
+    if (isPromiseLike(payloadOrPromise)) {
+      turnPayloadPreparationInFlightRef.current = true;
+      updateSending(true);
+      try {
+        payload = await payloadOrPromise;
+      } catch (error) {
+        updateSending(false);
+        setSendError(error instanceof Error ? error.message : String(error));
+        return;
+      } finally {
+        turnPayloadPreparationInFlightRef.current = false;
+      }
+    } else {
+      payload = payloadOrPromise;
+    }
     const collaborationMode = planModeEnabled && supportsPlanMode
       ? ({
           mode: "plan",
@@ -5632,6 +5954,7 @@ export function Composer(props: ComposerProps) {
       : undefined;
 
     if (payload.input.length === 0 || props.disabled) {
+      updateSending(false);
       return;
     }
 
@@ -5680,7 +6003,7 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    await sendThreadTurn();
+    await sendThreadTurn(undefined, { payload });
   };
 
   const stopTurn = async (): Promise<void> => {
@@ -5794,7 +6117,7 @@ export function Composer(props: ComposerProps) {
     }
 
     if (shouldQueueThreadSubmit()) {
-      queueCurrentDraft();
+      void queueCurrentDraft();
       return;
     }
 

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1815,6 +1815,7 @@ function getContentSignature(params: {
     value: params.value,
     tokens: params.skillTokens.map((token) => ({
       index: token.index,
+      kind: token.kind,
       name: token.name,
       path: token.path,
     })),

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5492,6 +5492,71 @@ describe("Composer", () => {
     });
   });
 
+  it("hydrates a restored queued PDF reference before releasing it", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const draftStore = createComposerDraftStore();
+      draftStore.setQueuedTurn("thread:codex:thread-1", {
+        id: "queued-jeep",
+        input: [{ type: "text", text: "Compare [@Jeep](~/Downloads/Jeep)" }],
+        text: "Compare [@Jeep](~/Downloads/Jeep)",
+        imageAttachments: [],
+        fileAttachments: [],
+      });
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: ["/Users/huntharo/Downloads/Jeep"],
+        pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
+      }));
+      const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: "turn-2",
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            inspectPdfReferencePaths,
+            onAgentEvent: () => () => undefined,
+            startTurn,
+          }}
+          disabled={false}
+          draftStore={draftStore}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Queued window sticker",
+            titleSource: "explicit",
+            source: "codex",
+            executionMode: "default",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              { type: "text", text: "Compare [@Jeep](~/Downloads/Jeep)" },
+              {
+                type: "localFile",
+                name: "Jeep",
+                path: "/Users/huntharo/Downloads/Jeep",
+              },
+            ],
+          }),
+        );
+      });
+      expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("lets pending steers be edited before they are injected", async () => {
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -5549,6 +5614,88 @@ describe("Composer", () => {
     expect(textarea).toHaveValue("Revise the plan");
     expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
     expect(steerTurn).not.toHaveBeenCalled();
+  });
+
+  it("hydrates local PDF references when queued and steer drafts return to Composer", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const draftStore = createComposerDraftStore();
+      draftStore.setQueuedTurn("thread:codex:thread-1", {
+        id: "queued-jeep",
+        input: [{ type: "text", text: "Compare [@QueuedJeep](~/Downloads/Jeep)" }],
+        text: "Compare [@QueuedJeep](~/Downloads/Jeep)",
+        imageAttachments: [],
+        fileAttachments: [],
+      });
+      draftStore.setPendingSteer("thread:codex:thread-1", {
+        id: "steer-jeep",
+        input: [{ type: "text", text: "Compare [@SteerJeep](~/Downloads/Jeep)" }],
+        text: "Compare [@SteerJeep](~/Downloads/Jeep)",
+        imageAttachments: [],
+        fileAttachments: [],
+      });
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: ["/Users/huntharo/Downloads/Jeep"],
+        pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
+      }));
+
+      render(
+        <Composer
+          activeTurnId="turn-1"
+          desktopApi={{
+            inspectPdfReferencePaths,
+            onAgentEvent: () => () => undefined,
+          }}
+          disabled={false}
+          draftStore={draftStore}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Steerable thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      fireEvent.click(
+        within(screen.getByLabelText("Queued message")).getByRole("button", {
+          name: "Edit",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(inspectPdfReferencePaths).toHaveBeenCalledWith({
+          paths: ["/Users/huntharo/Downloads/Jeep"],
+        });
+        expect(
+          within(screen.getByTestId("composer-tiptap-input"))
+            .getByText("@QueuedJeep")
+            .closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+      });
+
+      fireEvent.click(
+        within(screen.getByLabelText("Pending steer message")).getByRole("button", {
+          name: "Edit",
+        }),
+      );
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId("composer-tiptap-input"))
+            .getByText("@SteerJeep")
+            .closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+      });
+      expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
   });
 
   it("does not acknowledge matching steer text before the steer is sent", async () => {
@@ -14663,6 +14810,7 @@ describe("Composer", () => {
       "/Users/huntharo";
     try {
       const inspectPdfReferencePaths = vi.fn(async ({ paths }: { paths: string[] }) => ({
+        filePaths: paths,
         pdfPaths: paths,
       }));
       const jeepFile = new File(["%PDF-1.7"], "Jeep", {
@@ -14708,6 +14856,374 @@ describe("Composer", () => {
         });
       });
       expect(await screen.findByText(/PDF analysis is on\./)).toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("does not infer PDF analysis from a reference filename suffix", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: ["/Users/huntharo/Downloads/not-a-pdf.pdf"],
+        pdfPaths: [],
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            inspectPdfReferencePaths,
+            onAgentEvent: () => () => undefined,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      fireEvent.paste(screen.getByRole("textbox", { name: "Reply" }), {
+        clipboardData: {
+          files: [],
+          getData: (type: string) =>
+            type === "text/plain"
+              ? "Compare [@not-a-pdf.pdf](~/Downloads/not-a-pdf.pdf)"
+              : "",
+          items: [],
+          types: ["text/plain"],
+        },
+      });
+
+      await waitFor(() => {
+        expect(inspectPdfReferencePaths).toHaveBeenCalledWith({
+          paths: ["/Users/huntharo/Downloads/not-a-pdf.pdf"],
+        });
+        expect(
+          within(screen.getByTestId("composer-tiptap-input"))
+            .getByText("@not-a-pdf.pdf")
+            .closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+      });
+      expect(screen.queryByText(/PDF analysis is on\./)).not.toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("hydrates pasted local PDF references before Send without duplicate attachments", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const referencedPaths = [
+        "/Users/huntharo/Downloads/Jeep",
+        "/Users/huntharo/Downloads/JeepRubicon.pdf",
+      ];
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: referencedPaths,
+        pdfPaths: referencedPaths,
+      }));
+      const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: "turn-1",
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            inspectPdfReferencePaths,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      const pastedText = [
+        "Help me compare these two Jeeps. What are the key feature differences and cost drivers?",
+        "",
+        "[@JeepRubicon.pdf](~/Downloads/JeepRubicon.pdf) [@Jeep](~/Downloads/Jeep)",
+      ].join("\n");
+      const textbox = screen.getByRole("textbox", { name: "Reply" });
+      fireEvent.paste(textbox, {
+        clipboardData: {
+          files: [],
+          getData: (type: string) => type === "text/plain" ? pastedText : "",
+          items: [],
+          types: ["text/plain"],
+        },
+      });
+
+      await waitFor(() => {
+        expect(inspectPdfReferencePaths).toHaveBeenCalledWith({
+          paths: referencedPaths,
+        });
+      });
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(
+          within(richInput)
+            .getByText("@JeepRubicon.pdf")
+            .closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+        expect(
+          within(richInput).getByText("@Jeep").closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+      });
+      expect(
+        await screen.findByText(/PDF analysis is on\./),
+      ).toBeInTheDocument();
+
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            backend: "codex",
+            threadId: "thread-1",
+          }),
+        );
+      });
+      const request = startTurn.mock.calls[0]?.[0];
+      const localFiles = request?.input.filter(
+        (item: { type: string }) => item.type === "localFile",
+      );
+      expect(localFiles).toEqual([
+        {
+          type: "localFile",
+          name: "JeepRubicon.pdf",
+          path: "/Users/huntharo/Downloads/JeepRubicon.pdf",
+        },
+        {
+          type: "localFile",
+          name: "Jeep",
+          path: "/Users/huntharo/Downloads/Jeep",
+        },
+      ]);
+      expect(request?.input[0]).toEqual({
+        type: "text",
+        text: pastedText,
+      });
+      expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("shares a pending pasted-reference inspection with an immediate Send", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const inspection = createDeferred<{
+        filePaths: string[];
+        pdfPaths: string[];
+      }>();
+      const inspectPdfReferencePaths = vi.fn(() => inspection.promise);
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            inspectPdfReferencePaths,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      const textbox = screen.getByRole("textbox", { name: "Reply" });
+      fireEvent.paste(textbox, {
+        clipboardData: {
+          files: [],
+          getData: (type: string) =>
+            type === "text/plain" ? "Compare [@Jeep](~/Downloads/Jeep)" : "",
+          items: [],
+          types: ["text/plain"],
+        },
+      });
+
+      await waitFor(() => {
+        expect(inspectPdfReferencePaths).toHaveBeenCalledWith({
+          paths: ["/Users/huntharo/Downloads/Jeep"],
+        });
+      });
+      const form = screen.getByTestId("composer-tiptap-input").closest("form");
+      fireEvent.submit(form!);
+      fireEvent.submit(form!);
+      await flushReactUpdates();
+      expect(startTurn).not.toHaveBeenCalled();
+      expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        inspection.resolve({
+          filePaths: ["/Users/huntharo/Downloads/Jeep"],
+          pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
+        });
+        await inspection.promise;
+      });
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              { type: "text", text: "Compare [@Jeep](~/Downloads/Jeep)" },
+              {
+                type: "localFile",
+                name: "Jeep",
+                path: "/Users/huntharo/Downloads/Jeep",
+              },
+            ],
+          }),
+        );
+      });
+      expect(startTurn).toHaveBeenCalledTimes(1);
+      expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("does not inspect a plain typed filesystem path", async () => {
+    const inspectPdfReferencePaths = vi.fn(async () => ({
+      filePaths: [],
+      pdfPaths: [],
+    }));
+
+    render(
+      <Composer
+        desktopApi={{
+          inspectPdfReferencePaths,
+          onAgentEvent: () => () => undefined,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Compare window stickers",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Reply" }), {
+      target: { value: "Compare /Users/huntharo/Downloads/Jeep" },
+    });
+    await flushReactUpdates();
+
+    expect(inspectPdfReferencePaths).not.toHaveBeenCalled();
+  });
+
+  it("hydrates a restored extensionless PDF reference before sending", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const draftStore = createComposerDraftStore();
+      draftStore.set("thread:codex:thread-1", {
+        draft: "Compare [@Jeep](~/Downloads/Jeep)",
+        editorDocument: undefined,
+        imageAttachments: [],
+        fileAttachments: [],
+        skillTokens: [],
+      });
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: ["/Users/huntharo/Downloads/Jeep"],
+        pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
+      }));
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            inspectPdfReferencePaths,
+            startTurn,
+          }}
+          disabled={false}
+          draftStore={draftStore}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(inspectPdfReferencePaths).toHaveBeenCalledWith({
+          paths: ["/Users/huntharo/Downloads/Jeep"],
+        });
+      });
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      await waitFor(() => {
+        expect(
+          within(richInput).getByText("@Jeep").closest("[data-mention-kind]"),
+        ).toHaveAttribute("data-mention-kind", "file");
+      });
+      expect(
+        await screen.findByText(/PDF analysis is on\./),
+      ).toBeInTheDocument();
+
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              { type: "text", text: "Compare [@Jeep](~/Downloads/Jeep)" },
+              {
+                type: "localFile",
+                name: "Jeep",
+                path: "/Users/huntharo/Downloads/Jeep",
+              },
+            ],
+          }),
+        );
+      });
     } finally {
       delete (window as unknown as { __pwragentHomeDir?: string })
         .__pwragentHomeDir;

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -738,6 +738,9 @@ export type InspectPdfReferencePathsRequest = {
 };
 
 export type InspectPdfReferencePathsResponse = {
+  /** Explicit reference paths that resolved to regular files. */
+  filePaths: string[];
+  /** The regular-file subset whose first bytes are `%PDF-`. */
   pdfPaths: string[];
 };
 


### PR DESCRIPTION
## Summary

I unified Composer handling of explicit local attachment/reference tokens so drag/drop, the file picker, pasted `@`/Markdown references, restored drafts, queued turns, and pending steers use the same bounded inspection path.

I classify regular files and PDFs in the main process with the `%PDF-` magic bytes. That recognizes extensionless Finder files, avoids treating a non-PDF merely named `.pdf` as a PDF, upgrades hydrated local-reference chips to file chips, and exposes the PDF-analysis state before Start/Send.

I also make send-time hydration await the shared inspection result, preventing a quick Start from passing a pasted PDF through as a raw local-file input. Derived local-file inputs are deduplicated while preserving pre-existing queued attachment metadata.

## Root cause

PR #691 only derived `localFile` inputs from file-tray attachments and in-memory file tokens. Serialized `[@label](~/path)` references hydrate initially as generic directory tokens, so pasted/restored references neither received capability inspection nor reached the PDF turn-preparation path.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/pdf-turn-input-preparation.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the repository's existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
