### PR TITLE
feat(composer): preview explicit PDF attachments

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ArchiveWorktreeRequest,
@@ -756,6 +757,60 @@ describe("app server ipc", () => {
         filePaths: [pdfPath, nonPdfPath],
         pdfPaths: [pdfPath],
       });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("renders and revalidates an explicit Composer PDF preview without caching it main-side", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-pdf-preview-ipc-"));
+    const pdfPath = path.join(root, "Jeep");
+    const nonPdfPath = path.join(root, "notes.pdf");
+    const fixture = await readFile(
+      fileURLToPath(
+        new URL("./fixtures/pdf/jeep-sticker-page-size.pdf", import.meta.url),
+      ),
+    );
+    await writeFile(pdfPath, fixture);
+    await writeFile(nonPdfPath, "not a PDF");
+    try {
+      const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+      const { NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL } = await import(
+        "../../shared/ipc"
+      );
+      registerAppServerIpcHandlers();
+
+      const handler = handlers.get(NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL);
+      expect(handler).toBeDefined();
+      const initial = await handler!({}, { path: pdfPath });
+      expect(initial).toMatchObject({
+        dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        fileIdentity: expect.any(String),
+        pageCount: 1,
+        unchanged: false,
+      });
+      const initialIdentity = (initial as { fileIdentity: string }).fileIdentity;
+
+      await expect(
+        handler!({}, { knownFileIdentity: initialIdentity, path: pdfPath }),
+      ).resolves.toEqual({
+        fileIdentity: initialIdentity,
+        unchanged: true,
+      });
+
+      await writeFile(pdfPath, Buffer.concat([fixture, Buffer.from("\n% preview mutation\n")]));
+      const changed = await handler!({}, {
+        knownFileIdentity: initialIdentity,
+        path: pdfPath,
+      });
+      expect(changed).toMatchObject({
+        dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        unchanged: false,
+      });
+      expect((changed as { fileIdentity: string }).fileIdentity).not.toBe(initialIdentity);
+      await expect(handler!({}, { path: nonPdfPath })).rejects.toThrow(
+        "no longer a PDF",
+      );
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/apps/desktop/src/main/__tests__/composer-pdf-preview.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-pdf-preview.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE,
+  calculateComposerPdfPreviewDimensions,
+  renderComposerPdfPreview,
+} from "../pdf/composer-pdf-preview";
+
+const jeepStickerPageFixture = fileURLToPath(
+  new URL("./fixtures/pdf/jeep-sticker-page-size.pdf", import.meta.url),
+);
+
+describe("Composer PDF preview renderer", () => {
+  it("caps the first-page thumbnail independently of model image profiles", () => {
+    expect(
+      calculateComposerPdfPreviewDimensions({
+        height: 792,
+        width: 1224,
+      }),
+    ).toEqual({ height: 311, width: COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE });
+  });
+
+  it("renders just page one into a small local PNG data URL", async () => {
+    const preview = await renderComposerPdfPreview({
+      data: await readFile(jeepStickerPageFixture),
+    });
+
+    expect(preview).toMatchObject({
+      dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+      pageCount: 1,
+      width: COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE,
+    });
+    expect(preview.height).toBeLessThan(COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE);
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -63,6 +63,8 @@ import {
   type PickReferenceFromDiskResponse,
   type InspectPdfReferencePathsRequest,
   type InspectPdfReferencePathsResponse,
+  type RenderComposerPdfPreviewRequest,
+  type RenderComposerPdfPreviewResponse,
   type RecordRecentFileReferencesRequest,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
@@ -198,6 +200,7 @@ import {
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
   NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL,
+  NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
@@ -207,6 +210,7 @@ import {
   NAVIGATION_UPDATE_DIRECTORY_LAUNCHPAD_CHANNEL,
 } from "../../shared/ipc";
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
+import { renderComposerPdfPreview } from "../pdf/composer-pdf-preview";
 import { getMainLogger } from "../log";
 import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindings-snapshot";
 import { getDesktopAutomationService } from "../automations/desktop-automation-service";
@@ -350,6 +354,7 @@ function classifyReferencePaths(
 
 const PDF_MAGIC = Buffer.from("%PDF-");
 const MAX_PDF_REFERENCE_PATHS = 20;
+const MAX_COMPOSER_PDF_PREVIEW_FILE_BYTES = 64 * 1024 * 1024;
 
 function inspectPdfReferencePaths(paths: string[]): {
   filePaths: string[];
@@ -381,6 +386,87 @@ function inspectPdfReferencePaths(paths: string[]): {
     }
   }
   return { filePaths, pdfPaths };
+}
+
+/**
+ * Read one explicitly referenced PDF from a stable descriptor. The preview
+ * endpoint rechecks the magic bytes itself so a path swapped after Composer's
+ * earlier inspection cannot become an arbitrary local-file renderer.
+ */
+function readComposerPdfPreviewFile(filePath: string): {
+  data: Buffer;
+  fileIdentity: string;
+} {
+  const candidate = filePath.trim();
+  if (!candidate || !path.isAbsolute(candidate)) {
+    throw new Error("Select a local PDF before opening its preview.");
+  }
+
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(candidate, "r");
+    const before = fs.fstatSync(descriptor);
+    if (!before.isFile()) {
+      throw new Error("The selected PDF is no longer a regular file.");
+    }
+    if (before.size > MAX_COMPOSER_PDF_PREVIEW_FILE_BYTES) {
+      throw new Error("This PDF is too large to preview locally.");
+    }
+
+    const header = Buffer.alloc(PDF_MAGIC.byteLength);
+    const bytesRead = fs.readSync(descriptor, header, 0, header.byteLength, 0);
+    if (bytesRead !== PDF_MAGIC.byteLength || !header.equals(PDF_MAGIC)) {
+      throw new Error("The selected file is no longer a PDF.");
+    }
+
+    // The header read uses an explicit position, leaving the descriptor at
+    // offset zero. Reading through that descriptor avoids a path-level
+    // time-of-check/time-of-use gap while pdfjs consumes the document.
+    const data = fs.readFileSync(descriptor);
+    const after = fs.fstatSync(descriptor);
+    const fileIdentity = composerPdfPreviewFileIdentity(before);
+    if (
+      data.byteLength !== after.size
+      || fileIdentity !== composerPdfPreviewFileIdentity(after)
+    ) {
+      throw new Error("The selected PDF changed while its preview was loading.");
+    }
+    return { data, fileIdentity };
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error("The selected PDF could not be read.", { cause: error });
+  } finally {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+  }
+}
+
+function composerPdfPreviewFileIdentity(stats: {
+  ctimeMs: number;
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  size: number;
+}): string {
+  return [stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs].join(":");
+}
+
+async function renderExplicitComposerPdfPreview(
+  request: RenderComposerPdfPreviewRequest,
+): Promise<RenderComposerPdfPreviewResponse> {
+  const file = readComposerPdfPreviewFile(request.path);
+  if (request.knownFileIdentity === file.fileIdentity) {
+    return { fileIdentity: file.fileIdentity, unchanged: true };
+  }
+
+  return {
+    ...(await renderComposerPdfPreview({ data: file.data })),
+    fileIdentity: file.fileIdentity,
+    unchanged: false,
+  };
 }
 
 function logDebug(event: string, payload: Record<string, unknown>): void {
@@ -6004,6 +6090,15 @@ export function registerAppServerIpcHandlers(): void {
     ): Promise<InspectPdfReferencePathsResponse> =>
       inspectPdfReferencePaths(request.paths ?? []),
   );
+  ipcMain.removeHandler(NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
+    async (
+      _event,
+      request: RenderComposerPdfPreviewRequest,
+    ): Promise<RenderComposerPdfPreviewResponse> =>
+      await renderExplicitComposerPdfPreview(request),
+  );
   ipcMain.removeHandler(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL);
   ipcMain.handle(
     NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
@@ -6089,6 +6184,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();

--- a/apps/desktop/src/main/pdf/composer-pdf-preview.ts
+++ b/apps/desktop/src/main/pdf/composer-pdf-preview.ts
@@ -1,0 +1,103 @@
+import { createCanvas } from "@napi-rs/canvas";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
+
+/**
+ * The Composer preview is deliberately much smaller than any image sent to a
+ * model. Its only job is to make an explicitly attached PDF recognizable in
+ * the local UI and readable in the local lightbox.
+ */
+export const COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE = 480;
+export const COMPOSER_PDF_PREVIEW_MAX_ENCODED_BYTES = 2 * 1024 * 1024;
+
+export type ComposerPdfPreview = {
+  dataUrl: string;
+  height: number;
+  pageCount: number;
+  width: number;
+};
+
+const require = createRequire(import.meta.url);
+const wasmUrl = pathToFileURL(
+  `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
+).href;
+
+/**
+ * Render page one for the Composer only. This module intentionally does not
+ * import the turn-time PDF renderer or its model-input budgets: no result
+ * produced here is eligible for an agent turn.
+ */
+export async function renderComposerPdfPreview(params: {
+  data: Uint8Array;
+}): Promise<ComposerPdfPreview> {
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(params.data),
+    verbosity: pdfjs.VerbosityLevel.ERRORS,
+    wasmUrl,
+  });
+  try {
+    const document = await loadingTask.promise;
+    if (document.numPages < 1) {
+      throw new Error("PDF has no renderable pages.");
+    }
+    const page = await document.getPage(1);
+    try {
+      const sourceViewport = page.getViewport({ scale: 1 });
+      const dimensions = calculateComposerPdfPreviewDimensions({
+        height: sourceViewport.height,
+        width: sourceViewport.width,
+      });
+      const viewport = page.getViewport({
+        scale: dimensions.width / sourceViewport.width,
+      });
+      const canvas = createCanvas(dimensions.width, dimensions.height);
+      const canvasContext = canvas.getContext("2d");
+
+      await page.render({
+        canvas: canvas as unknown as HTMLCanvasElement,
+        canvasContext: canvasContext as unknown as CanvasRenderingContext2D,
+        viewport,
+      }).promise;
+      const encoded = await canvas.encode("png");
+      if (encoded.byteLength > COMPOSER_PDF_PREVIEW_MAX_ENCODED_BYTES) {
+        throw new Error("PDF preview is too detailed to display safely.");
+      }
+
+      return {
+        dataUrl: `data:image/png;base64,${encoded.toString("base64")}`,
+        height: dimensions.height,
+        pageCount: document.numPages,
+        width: dimensions.width,
+      };
+    } finally {
+      page.cleanup();
+    }
+  } finally {
+    await loadingTask.destroy();
+  }
+}
+
+export function calculateComposerPdfPreviewDimensions(params: {
+  height: number;
+  width: number;
+}): { height: number; width: number } {
+  if (
+    !Number.isFinite(params.width)
+    || !Number.isFinite(params.height)
+    || params.width <= 0
+    || params.height <= 0
+  ) {
+    throw new Error("PDF page has invalid dimensions.");
+  }
+
+  const scale = Math.min(
+    1,
+    COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE / Math.max(params.width, params.height),
+  );
+  return {
+    height: Math.max(1, Math.round(params.height * scale)),
+    width: Math.max(1, Math.round(params.width * scale)),
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -146,6 +146,8 @@ import type {
   PickReferenceFromDiskResponse,
   InspectPdfReferencePathsRequest,
   InspectPdfReferencePathsResponse,
+  RenderComposerPdfPreviewRequest,
+  RenderComposerPdfPreviewResponse,
   ListRecentFileReferencesResponse,
   RecordRecentFileReferencesRequest,
   DetachThreadPullRequestRequest,
@@ -422,6 +424,7 @@ import {
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
   NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL,
+  NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
@@ -1353,6 +1356,13 @@ const desktopApi = Object.freeze({
   ): Promise<InspectPdfReferencePathsResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL,
+      request,
+    ),
+  renderComposerPdfPreview: async (
+    request: RenderComposerPdfPreviewRequest,
+  ): Promise<RenderComposerPdfPreviewResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
       request,
     ),
   listRecentFileReferences: async (): Promise<ListRecentFileReferencesResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -37,6 +37,7 @@ import type {
   NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
+  RenderComposerPdfPreviewResponse,
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
@@ -347,6 +348,22 @@ type ComposerReferenceInspection = {
 type ComposerReferencePathInspection = {
   isFile: boolean;
   isPdf: boolean;
+};
+
+type ComposerPdfPreview = Extract<
+  RenderComposerPdfPreviewResponse,
+  { unchanged: false }
+>;
+
+type ComposerPdfPreviewState =
+  | { status: "loading" }
+  | { message: string; status: "error" }
+  | { preview: ComposerPdfPreview; refreshing: boolean; status: "ready" };
+
+type ComposerPdfReference = {
+  attachmentId?: string;
+  label: string;
+  path: string;
 };
 
 const EMPTY_COMPOSER_REFERENCE_INSPECTION: ComposerReferenceInspection = {
@@ -1401,6 +1418,35 @@ function listExplicitComposerReferencePaths(
     }
   }
   return [...paths].sort();
+}
+
+function listComposerPdfReferences(params: {
+  fileAttachments: ComposerFileAttachment[];
+  pdfPaths: string[];
+  skillTokens: ComposerSkillToken[];
+}): ComposerPdfReference[] {
+  const attachmentByPath = new Map(
+    params.fileAttachments.map((attachment) => [attachment.path, attachment]),
+  );
+  const labelByPath = new Map<string, string>();
+  for (const token of params.skillTokens) {
+    if (
+      (token.kind === "file" || token.kind === "directory")
+      && token.path
+      && !labelByPath.has(token.path)
+    ) {
+      labelByPath.set(token.path, token.name);
+    }
+  }
+
+  return params.pdfPaths.map((path) => {
+    const attachment = attachmentByPath.get(path);
+    return {
+      ...(attachment ? { attachmentId: attachment.id } : {}),
+      label: attachment?.label ?? labelByPath.get(path) ?? fileLabelFromPath(path),
+      path,
+    };
+  });
 }
 
 /**
@@ -2898,6 +2944,19 @@ export function Composer(props: ComposerProps) {
   const referenceInspectionInFlightRef = useRef(new Map<string, Promise<void>>());
   const [inspectedPdfReferencePaths, setInspectedPdfReferencePaths] =
     useState<string[]>([]);
+  // Preview pages are intentionally renderer-only state. Draft snapshots keep
+  // only paths, and turn payload construction never reads this map.
+  const [composerPdfPreviewStates, setComposerPdfPreviewStates] = useState(
+    () => new Map<string, ComposerPdfPreviewState>(),
+  );
+  const composerPdfPreviewStatesRef = useRef(composerPdfPreviewStates);
+  composerPdfPreviewStatesRef.current = composerPdfPreviewStates;
+  const composerPdfPreviewRequestIdsRef = useRef(new Map<string, number>());
+  const [pdfPreviewLightbox, setPdfPreviewLightbox] = useState<{
+    label: string;
+    path: string;
+    preview: ComposerPdfPreview;
+  }>();
   const [composerSelectionRequest, setComposerSelectionRequest] = useState<{
     id: string;
     index: number;
@@ -3055,7 +3114,10 @@ export function Composer(props: ComposerProps) {
   explicitReferencePathsRef.current = explicitReferencePaths;
   // Only the main-process magic-byte check identifies a PDF. In particular,
   // a regular file named `.pdf` must not opt into PDF preparation by suffix.
-  const pdfReferencePaths = inspectedPdfReferencePaths;
+  const pdfReferencePaths = useMemo(() => {
+    const explicitPaths = new Set(explicitReferencePaths);
+    return inspectedPdfReferencePaths.filter((path) => explicitPaths.has(path));
+  }, [explicitReferencePaths, inspectedPdfReferencePaths]);
   const inspectExplicitReferencePaths = useCallback(
     (
       paths: string[],
@@ -3144,7 +3206,14 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    setInspectedPdfReferencePaths([]);
+    // Keep already-confirmed paths that remain explicit while a restored,
+    // queued, or steer draft rehydrates its chips. That lets the ephemeral
+    // preview state revalidate its file identity instead of flashing away
+    // during a token-only rewrite; removed paths are filtered synchronously
+    // by `pdfReferencePaths` above.
+    setInspectedPdfReferencePaths((current) =>
+      current.filter((path) => explicitReferencePathsRef.current.includes(path)),
+    );
     let cancelled = false;
     void Promise.resolve(
       inspectExplicitReferencePaths(explicitReferencePathsRef.current),
@@ -3182,6 +3251,191 @@ export function Composer(props: ComposerProps) {
     inspectExplicitReferencePaths,
     referenceInspector,
   ]);
+  const pdfReferencePathsRef = useRef(pdfReferencePaths);
+  pdfReferencePathsRef.current = pdfReferencePaths;
+  const pdfReferencePathSetRef = useRef(new Set<string>());
+  pdfReferencePathSetRef.current = new Set(pdfReferencePaths);
+  const pdfPreviewReferences = useMemo(
+    () =>
+      listComposerPdfReferences({
+        fileAttachments,
+        pdfPaths: pdfReferencePaths,
+        skillTokens: [...skillTokens, ...canonicalReferenceTokens],
+      }),
+    [canonicalReferenceTokens, fileAttachments, pdfReferencePaths, skillTokens],
+  );
+  const pdfPreviewPathsKey = pdfPreviewReferences
+    .map((reference) => reference.path)
+    .join("\u0000");
+  const pdfPreviewHydrationKey = useMemo(
+    () =>
+      [
+        composerScopeKey,
+        ...fileAttachments.map((attachment) =>
+          [attachment.id, attachment.label, attachment.path].join("\u0001"),
+        ),
+        ...skillTokens
+          .filter(
+            (token) => token.kind === "file" || token.kind === "directory",
+          )
+          .map((token) =>
+            [token.id, token.index, token.kind, token.path ?? ""].join("\u0001"),
+          ),
+      ]
+        .sort()
+        .join("\u0000"),
+    [composerScopeKey, fileAttachments, skillTokens],
+  );
+  const updateComposerPdfPreviewState = useCallback(
+    (path: string, state: ComposerPdfPreviewState | undefined): void => {
+      const next = new Map(composerPdfPreviewStatesRef.current);
+      if (state) {
+        next.set(path, state);
+      } else {
+        next.delete(path);
+      }
+      composerPdfPreviewStatesRef.current = next;
+      setComposerPdfPreviewStates(next);
+    },
+    [],
+  );
+  const requestComposerPdfPreview = useCallback(
+    async (path: string): Promise<void> => {
+      if (!pdfReferencePathSetRef.current.has(path)) {
+        return;
+      }
+
+      const current = composerPdfPreviewStatesRef.current.get(path);
+      if (
+        current?.status === "loading"
+        || (current?.status === "ready" && current.refreshing)
+      ) {
+        return;
+      }
+
+      const requestId =
+        (composerPdfPreviewRequestIdsRef.current.get(path) ?? 0) + 1;
+      composerPdfPreviewRequestIdsRef.current.set(path, requestId);
+      updateComposerPdfPreviewState(
+        path,
+        current?.status === "ready"
+          ? { ...current, refreshing: true }
+          : { status: "loading" },
+      );
+
+      const renderer = desktopApiRef.current?.renderComposerPdfPreview;
+      if (!renderer) {
+        updateComposerPdfPreviewState(path, {
+          message: "Preview unavailable",
+          status: "error",
+        });
+        return;
+      }
+
+      try {
+        const response = await renderer({
+          ...(current?.status === "ready"
+            ? { knownFileIdentity: current.preview.fileIdentity }
+            : {}),
+          path,
+        });
+        if (
+          composerPdfPreviewRequestIdsRef.current.get(path) !== requestId
+          || !pdfReferencePathSetRef.current.has(path)
+        ) {
+          return;
+        }
+
+        if (response.unchanged) {
+          if (current?.status === "ready") {
+            updateComposerPdfPreviewState(path, {
+              ...current,
+              refreshing: false,
+            });
+          } else {
+            updateComposerPdfPreviewState(path, {
+              message: "Preview unavailable",
+              status: "error",
+            });
+          }
+          return;
+        }
+
+        updateComposerPdfPreviewState(path, {
+          preview: response,
+          refreshing: false,
+          status: "ready",
+        });
+      } catch {
+        if (
+          composerPdfPreviewRequestIdsRef.current.get(path) === requestId
+          && pdfReferencePathSetRef.current.has(path)
+        ) {
+          updateComposerPdfPreviewState(path, {
+            message: "Preview unavailable",
+            status: "error",
+          });
+        }
+      }
+    },
+    [updateComposerPdfPreviewState],
+  );
+  useEffect(() => {
+    const allowedPaths = new Set(pdfReferencePaths);
+    const current = composerPdfPreviewStatesRef.current;
+    const next = new Map(
+      [...current].filter(([path]) => allowedPaths.has(path)),
+    );
+    if (next.size !== current.size) {
+      composerPdfPreviewStatesRef.current = next;
+      setComposerPdfPreviewStates(next);
+    }
+    setPdfPreviewLightbox((lightbox) =>
+      lightbox && !allowedPaths.has(lightbox.path) ? undefined : lightbox,
+    );
+  }, [pdfPreviewPathsKey, pdfReferencePaths]);
+  useEffect(() => {
+    if (props.pdfAnalysisEnabled === false || pdfPreviewPathsKey.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      for (const path of pdfReferencePathsRef.current) {
+        if (cancelled) {
+          return;
+        }
+        await requestComposerPdfPreview(path);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    pdfPreviewHydrationKey,
+    pdfPreviewPathsKey,
+    props.pdfAnalysisEnabled,
+    requestComposerPdfPreview,
+  ]);
+  useEffect(() => {
+    if (props.pdfAnalysisEnabled === false || pdfPreviewPathsKey.length === 0) {
+      return;
+    }
+
+    // A PDF can change in another app while PwrAgent is unfocused. Main compares
+    // the opaque file identity before retaining this renderer-only raster.
+    const revalidate = (): void => {
+      void (async () => {
+        for (const path of pdfReferencePathsRef.current) {
+          await requestComposerPdfPreview(path);
+        }
+      })();
+    };
+    window.addEventListener("focus", revalidate);
+    return () => {
+      window.removeEventListener("focus", revalidate);
+    };
+  }, [pdfPreviewPathsKey, props.pdfAnalysisEnabled, requestComposerPdfPreview]);
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
   const queuedTurn = queuedTurns[0];
@@ -8040,11 +8294,30 @@ export function Composer(props: ComposerProps) {
         document.body,
       )
     : null;
+  const pdfPreviewPathSet = new Set(
+    pdfPreviewReferences.map((reference) => reference.path),
+  );
+  const visibleFileAttachments = fileAttachments.filter(
+    (attachment) => !pdfPreviewPathSet.has(attachment.path),
+  );
+  const hasVisibleAttachments =
+    imageAttachments.length > 0
+    || visibleFileAttachments.length > 0
+    || pdfPreviewReferences.length > 0;
   const imageLightbox = lightboxAttachment ? (
     <ImageLightbox
       src={lightboxAttachment.url}
       alt={formatPastedImageAlt(lightboxAttachment, 0)}
       onClose={() => setLightboxAttachment(undefined)}
+    />
+  ) : null;
+  const pdfPreviewLightboxNode = pdfPreviewLightbox ? (
+    <ImageLightbox
+      alt={`Page 1 preview of ${pdfPreviewLightbox.label}`}
+      caption={`${pdfPreviewLightbox.label} · Page 1 of ${pdfPreviewLightbox.preview.pageCount}`}
+      dialogLabel={`PDF preview: ${pdfPreviewLightbox.label}`}
+      src={pdfPreviewLightbox.preview.dataUrl}
+      onClose={() => setPdfPreviewLightbox(undefined)}
     />
   ) : null;
   const workspaceHandoffDialog =
@@ -8488,10 +8761,14 @@ export function Composer(props: ComposerProps) {
         );
       })}
 
-      {imageAttachments.length > 0 || fileAttachments.length > 0 ? (
+      {hasVisibleAttachments ? (
         <div
           className="composer__attachments"
-          aria-label={fileAttachments.length > 0 ? "Attachments" : "Pasted images"}
+          aria-label={
+            visibleFileAttachments.length > 0 || pdfPreviewReferences.length > 0
+              ? "Attachments"
+              : "Pasted images"
+          }
         >
           {imageAttachments.map((attachment, index) => {
             const dimensions = formatImageDimensions(
@@ -8537,7 +8814,113 @@ export function Composer(props: ComposerProps) {
               </div>
             );
           })}
-          {fileAttachments.map((attachment) => (
+          {pdfPreviewReferences.map((reference) => {
+            const previewState = composerPdfPreviewStates.get(reference.path);
+            const preview =
+              previewState?.status === "ready" ? previewState.preview : undefined;
+            const previewActionLabel =
+              previewState?.status === "error" ? "Retry preview" : "Preview";
+            return (
+              <div
+                className="composer__attachment composer__attachment--pdf"
+                key={reference.path}
+              >
+                <div className="composer__attachment-thumb">
+                  {preview ? (
+                    <button
+                      aria-label={`Expand PDF preview for ${reference.label}`}
+                      className="composer__attachment-open"
+                      type="button"
+                      onClick={() => {
+                        setPdfPreviewLightbox({
+                          label: reference.label,
+                          path: reference.path,
+                          preview,
+                        });
+                      }}
+                    >
+                      <img
+                        className="composer__attachment-preview composer__attachment-preview--pdf"
+                        src={preview.dataUrl}
+                        alt={`Page 1 preview of ${reference.label}`}
+                      />
+                    </button>
+                  ) : (
+                    <div
+                      aria-live="polite"
+                      className={[
+                        "composer__pdf-preview-placeholder",
+                        previewState?.status !== "loading" ? "has-action" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      role="status"
+                    >
+                      {previewState?.status === "loading" ? (
+                        <span
+                          aria-hidden="true"
+                          className="composer__pdf-preview-spinner"
+                        />
+                      ) : (
+                        <FileCodeIcon size={22} aria-hidden="true" />
+                      )}
+                      <span className="composer__pdf-preview-placeholder-label">
+                        {previewState?.status === "loading"
+                          ? "Loading preview"
+                          : previewState?.status === "error"
+                            ? previewState.message
+                            : "PDF"}
+                      </span>
+                      {previewState?.status !== "loading" ? (
+                        <button
+                          className="composer__pdf-preview-action"
+                          type="button"
+                          onClick={() => {
+                            void requestComposerPdfPreview(reference.path);
+                          }}
+                        >
+                          {previewActionLabel}
+                        </button>
+                      ) : null}
+                    </div>
+                  )}
+                  {reference.attachmentId ? (
+                    <button
+                      aria-label={`Remove ${reference.label}`}
+                      className="composer__attachment-remove"
+                      type="button"
+                      onClick={() => {
+                        removeFileAttachment(reference.attachmentId!);
+                      }}
+                    >
+                      <CloseIcon size={12} aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+                <div className="composer__attachment-chips">
+                  {preview ? (
+                    <>
+                      <span className="composer__attachment-chip">
+                        Page 1 of {preview.pageCount}
+                      </span>
+                      <span className="composer__attachment-chip">
+                        {formatImageDimensions(preview.width, preview.height)}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="composer__attachment-chip">PDF</span>
+                  )}
+                </div>
+                <span
+                  className="composer__pdf-preview-label tooltip-target"
+                  data-tooltip={buildFileReferenceTooltip(reference.path)}
+                >
+                  {reference.label}
+                </span>
+              </div>
+            );
+          })}
+          {visibleFileAttachments.map((attachment) => (
             <span
               className="composer__file-attachment tooltip-target"
               data-tooltip={buildFileReferenceTooltip(attachment.path)}
@@ -9868,6 +10251,7 @@ export function Composer(props: ComposerProps) {
       </form>
       {fullAccessRiskDialog}
       {imageLightbox}
+      {pdfPreviewLightboxNode}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -5616,7 +5616,7 @@ describe("Composer", () => {
     expect(steerTurn).not.toHaveBeenCalled();
   });
 
-  it("hydrates local PDF references when queued and steer drafts return to Composer", async () => {
+  it("rehydrates local PDF previews when queued and steer drafts return to Composer", async () => {
     (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
       "/Users/huntharo";
     try {
@@ -5639,6 +5639,20 @@ describe("Composer", () => {
         filePaths: ["/Users/huntharo/Downloads/Jeep"],
         pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
       }));
+      const renderComposerPdfPreview = vi
+        .fn()
+        .mockResolvedValueOnce({
+          dataUrl: "data:image/png;base64,UEZERg==",
+          fileIdentity: "queued-pdf-v1",
+          height: 480,
+          pageCount: 1,
+          unchanged: false as const,
+          width: 360,
+        })
+        .mockResolvedValueOnce({
+          fileIdentity: "queued-pdf-v1",
+          unchanged: true as const,
+        });
 
       render(
         <Composer
@@ -5646,6 +5660,7 @@ describe("Composer", () => {
           desktopApi={{
             inspectPdfReferencePaths,
             onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
           }}
           disabled={false}
           draftStore={draftStore}
@@ -5677,6 +5692,11 @@ describe("Composer", () => {
             .closest("[data-mention-kind]"),
         ).toHaveAttribute("data-mention-kind", "file");
       });
+      await waitFor(() => {
+        expect(renderComposerPdfPreview).toHaveBeenCalledWith({
+          path: "/Users/huntharo/Downloads/Jeep",
+        });
+      });
 
       fireEvent.click(
         within(screen.getByLabelText("Pending steer message")).getByRole("button", {
@@ -5690,6 +5710,12 @@ describe("Composer", () => {
             .getByText("@SteerJeep")
             .closest("[data-mention-kind]"),
         ).toHaveAttribute("data-mention-kind", "file");
+      });
+      await waitFor(() => {
+        expect(renderComposerPdfPreview).toHaveBeenLastCalledWith({
+          knownFileIdentity: "queued-pdf-v1",
+          path: "/Users/huntharo/Downloads/Jeep",
+        });
       });
       expect(inspectPdfReferencePaths).toHaveBeenCalledTimes(1);
     } finally {
@@ -14862,6 +14888,259 @@ describe("Composer", () => {
     }
   });
 
+  it("shows an explicit PDF's local first-page preview without adding it to the turn", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pdfPath = "/Users/huntharo/Downloads/Jeep";
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: [pdfPath],
+        pdfPaths: [pdfPath],
+      }));
+      const renderComposerPdfPreview = vi
+        .fn()
+        .mockResolvedValueOnce({
+          dataUrl: "data:image/png;base64,UEZERg==",
+          fileIdentity: "pdf-v1",
+          height: 480,
+          pageCount: 7,
+          unchanged: false as const,
+          width: 360,
+        })
+        .mockResolvedValueOnce({
+          fileIdentity: "pdf-v1",
+          unchanged: true as const,
+        });
+      const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: "turn-1",
+      }));
+      const jeepFile = new File(["%PDF-1.7"], "Jeep", {
+        type: "application/octet-stream",
+      });
+
+      render(
+        <Composer
+          desktopApi={{
+            getPathForFile: () => pdfPath,
+            inspectPdfReferencePaths,
+            onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText("Reply"), {
+        target: { value: "Compare the first page" },
+      });
+      fireEvent.drop(screen.getByLabelText("Reply"), {
+        dataTransfer: {
+          files: [],
+          items: [
+            {
+              kind: "file",
+              type: "application/octet-stream",
+              getAsFile: () => jeepFile,
+            },
+          ],
+        },
+      });
+
+      expect(
+        await screen.findByAltText("Page 1 preview of Jeep"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Page 1 of 7")).toBeInTheDocument();
+      expect(renderComposerPdfPreview).toHaveBeenCalledWith({ path: pdfPath });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Expand PDF preview for Jeep" }),
+      );
+      const dialog = screen.getByRole("dialog", { name: "PDF preview: Jeep" });
+      expect(within(dialog).getByText("Jeep · Page 1 of 7")).toBeInTheDocument();
+
+      fireEvent.focus(window);
+      await waitFor(() => {
+        expect(renderComposerPdfPreview).toHaveBeenLastCalledWith({
+          knownFileIdentity: "pdf-v1",
+          path: pdfPath,
+        });
+      });
+
+      await clickButton("Send");
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [
+            {
+              type: "text",
+              text: "Compare the first page\n\n[@Jeep](~/Downloads/Jeep)",
+            },
+            {
+              type: "localFile",
+              name: "Jeep",
+              path: pdfPath,
+            },
+          ],
+        });
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("does not auto-render a PDF preview while PDF analysis is off", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pdfPath = "/Users/huntharo/Downloads/Jeep";
+      const inspectPdfReferencePaths = vi.fn(async () => ({
+        filePaths: [pdfPath],
+        pdfPaths: [pdfPath],
+      }));
+      const renderComposerPdfPreview = vi.fn(async () => ({
+        dataUrl: "data:image/png;base64,UEZERg==",
+        fileIdentity: "pdf-v1",
+        height: 480,
+        pageCount: 1,
+        unchanged: false as const,
+        width: 360,
+      }));
+      const jeepFile = new File(["%PDF-1.7"], "Jeep", {
+        type: "application/octet-stream",
+      });
+
+      render(
+        <Composer
+          desktopApi={{
+            getPathForFile: () => pdfPath,
+            inspectPdfReferencePaths,
+            onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
+          }}
+          disabled={false}
+          pdfAnalysisEnabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      fireEvent.drop(screen.getByLabelText("Reply"), {
+        dataTransfer: {
+          files: [],
+          items: [
+            {
+              kind: "file",
+              type: "application/octet-stream",
+              getAsFile: () => jeepFile,
+            },
+          ],
+        },
+      });
+
+      expect(await screen.findByRole("button", { name: "Preview" })).toBeInTheDocument();
+      expect(renderComposerPdfPreview).not.toHaveBeenCalled();
+
+      await clickButton("Preview");
+      await waitFor(() => {
+        expect(renderComposerPdfPreview).toHaveBeenCalledWith({ path: pdfPath });
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("shows PDF preview loading and retry states when local rendering fails", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pdfPath = "/Users/huntharo/Downloads/Jeep";
+      const preview = createDeferred<{
+        dataUrl: string;
+        fileIdentity: string;
+        height: number;
+        pageCount: number;
+        unchanged: false;
+        width: number;
+      }>();
+      const renderComposerPdfPreview = vi.fn(() => preview.promise);
+      const jeepFile = new File(["%PDF-1.7"], "Jeep", {
+        type: "application/octet-stream",
+      });
+
+      render(
+        <Composer
+          desktopApi={{
+            getPathForFile: () => pdfPath,
+            inspectPdfReferencePaths: async () => ({
+              filePaths: [pdfPath],
+              pdfPaths: [pdfPath],
+            }),
+            onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      fireEvent.drop(screen.getByLabelText("Reply"), {
+        dataTransfer: {
+          files: [],
+          items: [
+            {
+              kind: "file",
+              type: "application/octet-stream",
+              getAsFile: () => jeepFile,
+            },
+          ],
+        },
+      });
+
+      expect(await screen.findByText("Loading preview")).toBeInTheDocument();
+      await act(async () => {
+        preview.reject(new Error("PDF is damaged"));
+        await preview.promise.catch(() => undefined);
+      });
+      expect(
+        await screen.findByText("Preview unavailable"),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Retry preview" })).toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("does not infer PDF analysis from a reference filename suffix", async () => {
     (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
       "/Users/huntharo";
@@ -15122,12 +15401,14 @@ describe("Composer", () => {
       filePaths: [],
       pdfPaths: [],
     }));
+    const renderComposerPdfPreview = vi.fn();
 
     render(
       <Composer
         desktopApi={{
           inspectPdfReferencePaths,
           onAgentEvent: () => () => undefined,
+          renderComposerPdfPreview,
         }}
         disabled={false}
         skills={[]}
@@ -15148,6 +15429,7 @@ describe("Composer", () => {
     await flushReactUpdates();
 
     expect(inspectPdfReferencePaths).not.toHaveBeenCalled();
+    expect(renderComposerPdfPreview).not.toHaveBeenCalled();
   });
 
   it("hydrates a restored extensionless PDF reference before sending", async () => {
@@ -15166,6 +15448,14 @@ describe("Composer", () => {
         filePaths: ["/Users/huntharo/Downloads/Jeep"],
         pdfPaths: ["/Users/huntharo/Downloads/Jeep"],
       }));
+      const renderComposerPdfPreview = vi.fn(async () => ({
+        dataUrl: "data:image/png;base64,UEZERg==",
+        fileIdentity: "restored-pdf-v1",
+        height: 480,
+        pageCount: 1,
+        unchanged: false as const,
+        width: 360,
+      }));
       const startTurn = vi.fn(async () => ({
         backend: "codex" as const,
         threadId: "thread-1",
@@ -15177,6 +15467,7 @@ describe("Composer", () => {
           desktopApi={{
             onAgentEvent: () => () => undefined,
             inspectPdfReferencePaths,
+            renderComposerPdfPreview,
             startTurn,
           }}
           disabled={false}
@@ -15207,6 +15498,11 @@ describe("Composer", () => {
       expect(
         await screen.findByText(/PDF analysis is on\./),
       ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(renderComposerPdfPreview).toHaveBeenCalledWith({
+          path: "/Users/huntharo/Downloads/Jeep",
+        });
+      });
 
       await clickButton("Send");
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { type ReactNode, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { CloseIcon } from "../../icons";
 import { TranscriptImage } from "./TranscriptImage";
@@ -7,17 +7,27 @@ type ImageLightboxProps = {
   /** Image source — a data URL or any resolvable URL. */
   src: string;
   alt: string;
+  /** Optional visible local-image metadata, such as a PDF page count. */
+  caption?: ReactNode;
+  /** More specific accessible name for callers that expand a non-photo image. */
+  dialogLabel?: string;
   onClose: () => void;
 };
 
 /**
- * The single full-size image viewer used everywhere an image expands —
- * pasted composer attachments and sent transcript images alike. Portaled to
- * `<body>` so it escapes any clipping/stacking ancestor; closes on the scrim,
- * the accent close cookie, or Escape. `TranscriptImage` resolves embedded data
- * URLs to object URLs, so both image sources render the same way.
+ * The single full-size local-raster viewer used for pasted Composer attachments,
+ * Composer PDF page previews, and sent transcript images. Portaled to `<body>`
+ * so it escapes any clipping/stacking ancestor; closes on the scrim, the
+ * accent close cookie, or Escape. `TranscriptImage` resolves embedded data URLs
+ * to object URLs, so both image sources render the same way.
  */
-export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
+export function ImageLightbox({
+  src,
+  alt,
+  caption,
+  dialogLabel = "Expanded image",
+  onClose,
+}: ImageLightboxProps) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -40,7 +50,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       className="image-lightbox"
       role="dialog"
       aria-modal="true"
-      aria-label="Expanded image"
+      aria-label={dialogLabel}
       onClick={onClose}
     >
       <div
@@ -58,6 +68,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
           <CloseIcon size={18} aria-hidden="true" />
         </button>
         <TranscriptImage className="image-lightbox__image" src={src} alt={alt} />
+        {caption ? <p className="image-lightbox__caption">{caption}</p> : null}
       </div>
     </div>,
     document.body,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -149,6 +149,8 @@ import type {
   PickReferenceFromDiskResponse,
   InspectPdfReferencePathsRequest,
   InspectPdfReferencePathsResponse,
+  RenderComposerPdfPreviewRequest,
+  RenderComposerPdfPreviewResponse,
   ListRecentFileReferencesResponse,
   RecordRecentFileReferencesRequest,
   DetachThreadPullRequestRequest,
@@ -759,6 +761,10 @@ export type DesktopApi = {
   inspectPdfReferencePaths?: (
     request: InspectPdfReferencePathsRequest,
   ) => Promise<InspectPdfReferencePathsResponse>;
+  /** Render an explicitly referenced PDF's low-resolution local Composer preview. */
+  renderComposerPdfPreview?: (
+    request: RenderComposerPdfPreviewRequest,
+  ) => Promise<RenderComposerPdfPreviewResponse>;
   /** Recently referenced files for the reference picker's Files tab. */
   listRecentFileReferences?: () => Promise<ListRecentFileReferencesResponse>;
   /** Fire-and-forget record of freshly committed file references. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15730,6 +15730,76 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--bg-panel-hover);
 }
 
+.composer__attachment-preview--pdf {
+  object-fit: contain;
+}
+
+.composer__pdf-preview-placeholder {
+  display: flex;
+  width: 88px;
+  height: 88px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-hover);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.composer__pdf-preview-placeholder-label {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 11px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+}
+
+.composer__pdf-preview-placeholder.has-action {
+  flex-direction: column;
+  gap: 5px;
+}
+
+.composer__pdf-preview-action {
+  min-height: 22px;
+  padding: 2px 6px;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.composer__pdf-preview-action:hover,
+.composer__pdf-preview-action:focus-visible {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.composer__pdf-preview-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: composer-action-button-spin 0.8s linear infinite;
+}
+
+.composer__pdf-preview-label {
+  display: block;
+  max-width: 88px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Solid filled circle (not a translucent scrim) so the X stays legible over
    any underlying image. Pinned to the thumbnail's top-right corner. */
 .composer__attachment-remove {
@@ -15776,9 +15846,9 @@ a.transcript-message__messaging-origin:focus-visible {
   white-space: nowrap;
 }
 
-/* The single full-size image viewer (`ImageLightbox`) — used for both pasted
-   composer attachments and sent transcript images. Click the scrim, the close
-   cookie, or Escape to dismiss. */
+/* The single full-size local-raster viewer (`ImageLightbox`) — used for pasted
+   Composer attachments, Composer PDF page previews, and sent transcript
+   images. Click the scrim, the close cookie, or Escape to dismiss. */
 .image-lightbox {
   position: fixed;
   inset: 0;
@@ -15797,6 +15867,7 @@ a.transcript-message__messaging-origin:focus-visible {
 .image-lightbox__content {
   position: relative;
   display: flex;
+  flex-direction: column;
   max-width: min(100%, 1100px);
   cursor: default;
 }
@@ -15843,6 +15914,13 @@ a.transcript-message__messaging-origin:focus-visible {
   border-radius: 8px;
   background: var(--bg-panel);
   object-fit: contain;
+}
+
+.image-lightbox__caption {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: center;
 }
 
 .composer__setup {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -257,6 +257,8 @@ export const NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL =
   "navigation:pick-reference-from-disk";
 export const NAVIGATION_INSPECT_PDF_REFERENCE_PATHS_CHANNEL =
   "navigation:inspect-pdf-reference-paths";
+export const NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL =
+  "navigation:render-composer-pdf-preview";
 /**
  * Recently referenced files for the reference picker's Files tab —
  * `list` reads the persisted most-recent-first list; `record` is a

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -745,6 +745,35 @@ export type InspectPdfReferencePathsResponse = {
 };
 
 /**
+ * Request a local, low-resolution Composer preview after a reference has
+ * already been explicitly selected. `knownFileIdentity` is an opaque,
+ * in-memory cache key: main revalidates it before deciding whether a new
+ * raster is needed.
+ */
+export type RenderComposerPdfPreviewRequest = {
+  knownFileIdentity?: string;
+  path: string;
+};
+
+/**
+ * UI-only local PDF preview. The image data must not be persisted in a
+ * Composer draft or forwarded as a turn input.
+ */
+export type RenderComposerPdfPreviewResponse =
+  | {
+      fileIdentity: string;
+      unchanged: true;
+    }
+  | {
+      dataUrl: string;
+      fileIdentity: string;
+      height: number;
+      pageCount: number;
+      unchanged: false;
+      width: number;
+    };
+
+/**
  * Recently referenced files for the composer's reference picker. The main
  * process persists a small most-recent-first list of paths (capped,
  * deduped by path) and computes each label from the path's basename.


### PR DESCRIPTION
## Summary

- I added an isolated, low-resolution main-process renderer for page-one previews of explicitly inspected Composer PDFs.
- I added ephemeral Composer thumbnail cards with page metadata, an accessible local lightbox, loading/error/retry states, and identity-aware draft hydration and focus revalidation.
- I kept preview rasters out of Composer drafts and turn input, and automatic preview generation respects the PDF analysis setting.

## Verification

- I ran the focused Composer, PDF preview IPC, renderer, and lightbox tests (320 passing tests).
- I ran `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, `pnpm lint:codex-storage`, and `pnpm lint:colors`.
- I verified the committed diff with `git diff --check` and confirmed the checkpoint commit is SSH-signed.

## Notes

- I added no replay E2E fixture: focused Composer and main-process tests cover the new explicit-reference gating, local preview lifecycle, lightbox, disabled-analysis behavior, and turn-input isolation.
- This draft is stacked on `fix/composer-attachment-capability-hydration` (PR #1142).
