### PR TITLE
fix(desktop): review stacked PRs against their base

### DIFF
--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -19,6 +19,8 @@ function node(overrides: Partial<GraphqlPrNode> = {}): GraphqlPrNode {
     state: "OPEN",
     isDraft: false,
     mergeable: "MERGEABLE",
+    baseRefName: "agent/github-pr-auto-fix-settings",
+    headRefName: "agent/pr-auto-dispatch-budget",
     headRepository: { name: "PwrAgent" },
     headRepositoryOwner: { login: "pwrdrvr" },
     commits: {
@@ -72,6 +74,8 @@ describe("buildBatchedPrQuery", () => {
     expect(query).toContain("pullRequest(number: $p0)");
     expect(query).toContain("pullRequest(number: $p1)");
     expect(query.match(/repository\(/g)).toHaveLength(2);
+    expect(query).toContain("baseRefName");
+    expect(query).toContain("headRefName");
     expect(query).toContain("contexts(first: 100)");
     expect(query).toContain("pageInfo { hasNextPage endCursor }");
   });
@@ -168,6 +172,8 @@ describe("mapGraphqlPrNode", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       title: "Add polling",
+      baseRefName: "agent/github-pr-auto-fix-settings",
+      headRefName: "agent/pr-auto-dispatch-budget",
       state: "passing",
       checkState: "passing",
       lifecycleState: "open",

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -27,6 +27,7 @@ function rawMergedPr() {
       { oid: "a".repeat(40) },
       { oid: "b".repeat(40) },
     ],
+    baseRefName: "agent/github-pr-auto-fix-settings",
     headRefName: "feat/desktop-thread-reactions-and-pr-chips",
     headRepository: { name: "PwrAgent" },
     headRepositoryOwner: { login: "pwrdrvr" },
@@ -49,6 +50,8 @@ describe("parseGhPrPayload", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       title: "Retain thread pull request history",
+      baseRefName: "agent/github-pr-auto-fix-settings",
+      headRefName: "feat/desktop-thread-reactions-and-pr-chips",
       state: "passing",
       checkState: "passing",
       lifecycleState: "merged",
@@ -609,6 +612,8 @@ describe("GithubPrFetcher", () => {
           org: "pwrdrvr",
           repo: "PwrAgent",
           title: "Retain thread pull request history",
+          baseRefName: "agent/github-pr-auto-fix-settings",
+          headRefName: "feat/desktop-thread-reactions-and-pr-chips",
           state: "passing",
           checkState: "passing",
           lifecycleState: "merged",
@@ -633,6 +638,8 @@ describe("GithubPrFetcher", () => {
         "5",
       ]);
       expect(args[args.indexOf("--json") + 1]).toContain("title");
+      expect(args[args.indexOf("--json") + 1]).toContain("baseRefName");
+      expect(args[args.indexOf("--json") + 1]).toContain("headRefName");
     });
 
     it("returns [] on subprocess failure", async () => {
@@ -660,6 +667,8 @@ describe("GithubPrFetcher", () => {
         org: "pwrdrvr",
         repo: "PwrAgent",
         title: "Retain thread pull request history",
+        baseRefName: "agent/github-pr-auto-fix-settings",
+        headRefName: "feat/desktop-thread-reactions-and-pr-chips",
         state: "passing",
         checkState: "passing",
         lifecycleState: "merged",

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -628,6 +628,18 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
   } else {
     delete normalized.headSha;
   }
+  const baseRefName = pr.baseRefName?.trim();
+  if (baseRefName) {
+    normalized.baseRefName = baseRefName;
+  } else {
+    delete normalized.baseRefName;
+  }
+  const headRefName = pr.headRefName?.trim();
+  if (headRefName) {
+    normalized.headRefName = headRefName;
+  } else {
+    delete normalized.headRefName;
+  }
   return normalized;
 }
 
@@ -739,6 +751,8 @@ function prSummariesEqual(left: PrSummary[], right: PrSummary[]): boolean {
       candidate.lifecycleState === pr.lifecycleState &&
       candidate.reviewState === pr.reviewState &&
       candidate.mergeState === pr.mergeState &&
+      candidate.baseRefName === pr.baseRefName &&
+      candidate.headRefName === pr.headRefName &&
       candidate.headSha === pr.headSha &&
       JSON.stringify(candidate.commitShas ?? []) === JSON.stringify(pr.commitShas ?? []) &&
       candidate.url === pr.url

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -98,6 +98,8 @@ fragment PrStatus on PullRequest {
   state
   isDraft
   mergeable
+  baseRefName
+  headRefName
   headRepository { name }
   headRepositoryOwner { login }
   commits(last: 1) {
@@ -152,6 +154,8 @@ export type GraphqlPrNode = {
   state: string;
   isDraft: boolean;
   mergeable?: string | null;
+  baseRefName?: string | null;
+  headRefName?: string | null;
   headRepository?: { name?: string | null } | null;
   headRepositoryOwner?: { login?: string | null } | null;
   commits?: {
@@ -364,6 +368,8 @@ export function mapGraphqlPrNode(
     org: node.headRepositoryOwner?.login ?? "",
     repo: node.headRepository?.name ?? "",
     ...(node.title?.trim() ? { title: node.title.trim() } : {}),
+    ...(node.baseRefName?.trim() ? { baseRefName: node.baseRefName.trim() } : {}),
+    ...(node.headRefName?.trim() ? { headRefName: node.headRefName.trim() } : {}),
     state: checkState,
     checkState,
     ...(checksStillRunning ? { checksStillRunning: true } : {}),

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -40,6 +40,7 @@ const GH_FIELDS = [
   "mergeStateStatus",
   "mergedAt",
   "commits",
+  "baseRefName",
   "headRefName",
   "headRepository",
   "headRepositoryOwner",

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -37,6 +37,7 @@ export type GhPrPayload = {
   mergeStateStatus?: string | null;
   mergedAt: string | null;
   commits?: { oid?: string | null }[] | null;
+  baseRefName?: string | null;
   headRefName: string;
   headRepository: { name?: string } | null;
   headRepositoryOwner: { login?: string } | null;
@@ -67,6 +68,8 @@ export function parseGhPrPayload(row: GhPrPayload): PrSummary {
     org: row.headRepositoryOwner?.login ?? "",
     repo: row.headRepository?.name ?? "",
     ...(row.title?.trim() ? { title: row.title.trim() } : {}),
+    ...(row.baseRefName?.trim() ? { baseRefName: row.baseRefName.trim() } : {}),
+    ...(row.headRefName?.trim() ? { headRefName: row.headRefName.trim() } : {}),
     state: checkState,
     checkState,
     ...(checksStillRunning ? { checksStillRunning: true } : {}),

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -208,6 +208,18 @@ function normalizePrSummary(pr: PrSummary): PrSummary {
   } else {
     delete normalized.headSha;
   }
+  const baseRefName = pr.baseRefName?.trim();
+  if (baseRefName) {
+    normalized.baseRefName = baseRefName;
+  } else {
+    delete normalized.baseRefName;
+  }
+  const headRefName = pr.headRefName?.trim();
+  if (headRefName) {
+    normalized.headRefName = headRefName;
+  } else {
+    delete normalized.headRefName;
+  }
   return normalized;
 }
 

--- a/packages/shared/src/__tests__/review-branches.test.ts
+++ b/packages/shared/src/__tests__/review-branches.test.ts
@@ -1,6 +1,55 @@
 import { describe, expect, it } from "vitest";
-import type { NavigationThreadSummary } from "../contracts/navigation";
-import { findPreferredReviewWorkspaceCwd } from "../review-branches";
+import type { NavigationThreadSummary, PrSummary } from "../contracts/navigation";
+import {
+  buildReviewBranchOptions,
+  findPreferredReviewWorkspaceCwd,
+} from "../review-branches";
+
+describe("buildReviewBranchOptions", () => {
+  it("prefers an open PR's target branch over the conventional Git base", () => {
+    expect(
+      buildReviewBranchOptions({
+        thread: {
+          gitBranch: "agent/pr-auto-dispatch-budget",
+          observedGitBranch: "agent/pr-auto-dispatch-budget",
+          prs: [
+            pullRequest({
+              baseRefName: "agent/github-pr-auto-fix-settings",
+              headRefName: "agent/pr-auto-dispatch-budget",
+            }),
+          ],
+        } as NavigationThreadSummary,
+      }),
+    ).toEqual([
+      "agent/github-pr-auto-fix-settings",
+      "main",
+    ]);
+  });
+
+  it("does not select an unrelated open PR when several are attached", () => {
+    expect(
+      buildReviewBranchOptions({
+        thread: {
+          gitBranch: "agent/pr-auto-dispatch-budget",
+          prs: [
+            pullRequest({
+              baseRefName: "agent/github-pr-auto-fix-settings",
+              headRefName: "agent/pr-auto-dispatch-budget",
+            }),
+            pullRequest({
+              number: 1144,
+              baseRefName: "main",
+              headRefName: "agent/other-work",
+            }),
+          ],
+        } as NavigationThreadSummary,
+      }),
+    ).toEqual([
+      "agent/github-pr-auto-fix-settings",
+      "main",
+    ]);
+  });
+});
 
 describe("findPreferredReviewWorkspaceCwd", () => {
   it("selects the changed primary project from multiple linked workspaces", () => {
@@ -82,6 +131,19 @@ function reviewThread(
         worktreePath: "/worktrees/app",
       },
     ],
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    provider: "github.com",
+    number: 1143,
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    state: "passing",
+    lifecycleState: "open",
+    url: "https://github.com/pwrdrvr/PwrAgent/pull/1143",
     ...overrides,
   };
 }

--- a/packages/shared/src/__tests__/review-branches.test.ts
+++ b/packages/shared/src/__tests__/review-branches.test.ts
@@ -49,6 +49,39 @@ describe("buildReviewBranchOptions", () => {
       "main",
     ]);
   });
+
+  it("uses a remote-only stacked PR target branch", () => {
+    const options = buildReviewBranchOptions({
+      directory: {
+        key: "directory:app",
+        kind: "directory",
+        label: "App",
+        path: "/repo/app",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        gitStatus: {
+          currentBranch: "agent/pr-auto-dispatch-budget",
+          branches: ["agent/pr-auto-dispatch-budget"],
+          baseBranches: [
+            "origin/agent/github-pr-auto-fix-settings",
+            "origin/main",
+          ],
+        },
+      },
+      thread: {
+        gitBranch: "agent/pr-auto-dispatch-budget",
+        prs: [
+          pullRequest({
+            baseRefName: "agent/github-pr-auto-fix-settings",
+            headRefName: "agent/pr-auto-dispatch-budget",
+          }),
+        ],
+      } as NavigationThreadSummary,
+    });
+
+    expect(options[0]).toBe("origin/agent/github-pr-auto-fix-settings");
+    expect(options).not.toContain("agent/github-pr-auto-fix-settings");
+  });
 });
 
 describe("findPreferredReviewWorkspaceCwd", () => {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -254,6 +254,13 @@ export type PrSummary = {
   /** Last observed pull request title, when the provider returns one. */
   title?: string;
   /**
+   * Branch the PR is proposing to merge into. Used to default a review to the
+   * PR's actual target, including stacked pull requests.
+   */
+  baseRefName?: string;
+  /** Branch containing the PR changes, when the provider returns one. */
+  headRefName?: string;
+  /**
    * Deprecated compatibility alias for `checkState`. New writers keep this
    * check-only so review/lifecycle/mergeability never collide with checks.
    */

--- a/packages/shared/src/review-branches.ts
+++ b/packages/shared/src/review-branches.ts
@@ -123,6 +123,21 @@ export function buildReviewBranchOptions(params: {
     }
   };
 
+  const openPrs = (params.thread?.prs ?? []).filter(
+    (pr) => pr.lifecycleState === "open" && Boolean(pr.baseRefName?.trim()),
+  );
+  const pullRequestForCurrentBranch = openPrs.find(
+    (pr) => pr.headRefName && isCurrentBranch(pr.headRefName),
+  );
+  const soleOpenPullRequest = openPrs.length === 1 ? openPrs[0] : undefined;
+
+  // A PR target is more specific than Git's conventional-base heuristic. In
+  // particular, it prevents stacked PR reviews from re-reviewing their parent
+  // branch's commits as though they were changes against main.
+  pushInferredBaseBranch(
+    pullRequestForCurrentBranch?.baseRefName
+    ?? soleOpenPullRequest?.baseRefName,
+  );
   pushInferredBaseBranch(params.thread?.gitWorkingState?.baseBranch);
   pushDirectoryDefault();
   for (const branch of REVIEW_PREFERRED_BASE_BRANCHES) {

--- a/packages/shared/src/review-branches.ts
+++ b/packages/shared/src/review-branches.ts
@@ -115,6 +115,7 @@ export function buildReviewBranchOptions(params: {
       pushIfKnown(`origin/${value}`);
       pushIfKnown(value);
     } else {
+      pushIfKnown(`origin/${value}`);
       pushIfKnown(value);
     }
 


### PR DESCRIPTION
## Summary

- carry GitHub PR head and base ref names through PwrAgent status metadata
- default `/review` to the matching open PR's target branch
- preserve the existing inferred-base fallback when there is no unambiguous open PR

## Root cause

Review defaults only consulted Git's conventional-base heuristic, which resolved stacked PRs against `main` and included parent-branch commits.

## Impact

Stacked pull requests now review only the commits introduced above their PR base, avoiding redundant parent reviews and unsafe parent-branch rewrite suggestions.

## Validation

- `pnpm test packages/shared/src/__tests__/review-branches.test.ts apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts apps/desktop/src/main/__tests__/github-graphql-client.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/overlay-store-prs.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
