### PR TITLE
fix(desktop): project canonical PR status in inspections

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -258,6 +258,7 @@ function emitRegistryEvent(event: unknown): void {
 }
 const publishLocalEvent = vi.fn(async () => undefined);
 const setThreadPullRequestStatusToolHandler = vi.fn();
+const setThreadPullRequestCanonicalizer = vi.fn();
 const setThreadPullRequestWatchToolHandler = vi.fn();
 const setThreadPrAutoDispatchHandler = vi.fn();
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
@@ -566,6 +567,7 @@ vi.mock("../app-server/backend-registry", () => ({
     onEvent,
     publishLocalEvent,
     setThreadPullRequestStatusToolHandler,
+    setThreadPullRequestCanonicalizer,
     setThreadPullRequestWatchToolHandler,
     setThreadPrAutoDispatchHandler,
     ensureDirectoryLaunchpad,
@@ -627,6 +629,7 @@ describe("app server ipc", () => {
     registryEventListeners.length = 0;
     publishLocalEvent.mockClear();
     setThreadPullRequestStatusToolHandler.mockClear();
+    setThreadPullRequestCanonicalizer.mockClear();
     setThreadPullRequestWatchToolHandler.mockClear();
     setThreadPrAutoDispatchHandler.mockClear();
     ensureDirectoryLaunchpad.mockClear();
@@ -700,6 +703,46 @@ describe("app server ipc", () => {
     expect(setThreadPullRequestWatchToolHandler).toHaveBeenCalledWith(
       expect.any(Function),
     );
+    expect(setThreadPullRequestCanonicalizer).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it("hydrates the thread inspection PR canonicalizer from durable cache", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const stalePr = githubPr({
+      number: 1132,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "passing",
+      lifecycleState: "open",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1132",
+    });
+    const mergedPr = githubPr({
+      ...stalePr,
+      lifecycleState: "merged",
+    });
+    readPrStatusCache.mockResolvedValueOnce({
+      "github.com/pwrdrvr/pwragent#1132": {
+        provider: "github.com",
+        prKey: "github.com/pwrdrvr/pwragent#1132",
+        fetchedAt: Date.now(),
+        pr: mergedPr,
+      },
+    });
+
+    registerAppServerIpcHandlers();
+
+    const canonicalize =
+      setThreadPullRequestCanonicalizer.mock.calls.at(-1)?.[0];
+    const [first, second] = await Promise.all([
+      canonicalize?.([stalePr]),
+      canonicalize?.([stalePr]),
+    ]);
+    expect(first).toEqual([mergedPr]);
+    expect(second).toEqual([mergedPr]);
+    expect(readPrStatusCache).toHaveBeenCalledTimes(1);
+    expect(publishLocalEvent).not.toHaveBeenCalled();
   });
 
   it("does not advertise Auto-fix as active without a primary Git repository", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24259,6 +24259,176 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("projects canonical PR status updates into both Agent inspection endpoints", async () => {
+    const stalePr = {
+      provider: "github.com",
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 1132,
+      title: "Fix agent inspection",
+      state: "passing" as const,
+      checkState: "passing" as const,
+      lifecycleState: "open" as const,
+      reviewState: "ready_for_review" as const,
+      mergeState: "mergeable" as const,
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1132",
+    };
+    const mergedPr = {
+      ...stalePr,
+      lifecycleState: "merged" as const,
+      mergeState: "unknown" as const,
+    };
+    const manualPr = {
+      ...stalePr,
+      repo: "PwrGit",
+      number: 77,
+      title: "Manual attachment",
+      url: "https://github.com/pwrdrvr/PwrGit/pull/77",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/read"] },
+      threads: [
+        {
+          id: "thread-1",
+          title: "Fix Agent PR status projection",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          updatedAt: 2_000,
+        },
+      ],
+      replay: {
+        entries: [],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+        threadStatus: "idle",
+      },
+    });
+    const search = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: 2_000,
+      filters: { backend: "all" as const, includeArchived: false },
+      contentMode: "metadata" as const,
+      semanticMode: "disabled" as const,
+      searchedScopes: ["metadata"] as const,
+      unavailableScopes: [],
+      results: [
+        {
+          backend: "codex" as const,
+          threadId: "thread-1",
+          identityKey: "codex:thread-1",
+          title: "Fix Agent PR status projection",
+          updatedAt: 2_000,
+          linkedDirectories: [],
+          source: "codex" as const,
+          score: 1,
+          confidence: "high" as const,
+          matchReasons: [{ kind: "metadata_match" as const }],
+          snippets: [],
+        },
+      ],
+      truncated: false,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:agent-thread": createAgentOverlay(),
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            executionMode: "default",
+            extraLinkedDirectories: [],
+            prs: [stalePr, manualPr],
+          },
+        },
+      }),
+      threadSearchService: { search } as unknown as ThreadSearchService,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "agent-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "pullRequest/status/updated",
+        params: {
+          prKey: "github.com/pwrdrvr/pwragent#1132",
+          pr: mergedPr,
+        },
+      },
+    });
+
+    const searchResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-search",
+        requestId: "call-search",
+        namespace: "pwragent",
+        tool: "search_threads",
+        arguments: {},
+      },
+    } as AppServerPendingRequestNotification);
+    const statusResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "agent-thread",
+        turnId: "turn-1",
+        callId: "call-status",
+        requestId: "call-status",
+        namespace: "pwragent",
+        tool: "get_thread_status",
+        arguments: {
+          backend: "codex",
+          threadId: "thread-1",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    const searchPayload = JSON.parse(
+      (searchResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    const statusPayload = JSON.parse(
+      (statusResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]!.text,
+    );
+    expect(searchPayload.threads[0].pullRequests[0]).toMatchObject({
+      number: 1132,
+      lifecycleState: "merged",
+    });
+    expect(searchPayload.threads[0].pullRequests[1]).toMatchObject({
+      number: 77,
+      lifecycleState: "open",
+    });
+    expect(statusPayload.thread.pullRequests[0]).toMatchObject({
+      number: 1132,
+      lifecycleState: "merged",
+    });
+    expect(statusPayload.thread.pullRequests[1]).toMatchObject({
+      number: 77,
+      lifecycleState: "open",
+    });
+
+    await registry.close();
+  });
+
   it("lists recent lightweight thread candidates for Agent thread search", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24259,7 +24259,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("projects canonical PR status updates into both Agent inspection endpoints", async () => {
+  it("projects canonical PR statuses into both Agent inspection endpoints", async () => {
     const stalePr = {
       provider: "github.com",
       org: "pwrdrvr",
@@ -24351,6 +24351,9 @@ script = "printf setup"
       }),
       threadSearchService: { search } as unknown as ThreadSearchService,
     });
+    registry.setThreadPullRequestCanonicalizer(async (prs) =>
+      prs.map((pr) => pr.number === mergedPr.number ? mergedPr : pr),
+    );
     await registry.publishLocalEvent({
       backend: "codex",
       notification: {
@@ -24362,17 +24365,6 @@ script = "printf setup"
         },
       },
     });
-    await registry.publishLocalEvent({
-      backend: "codex",
-      notification: {
-        method: "pullRequest/status/updated",
-        params: {
-          prKey: "github.com/pwrdrvr/pwragent#1132",
-          pr: mergedPr,
-        },
-      },
-    });
-
     const searchResponse = await codexClient.emitRequest({
       method: "item/tool/call",
       params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -202,7 +202,6 @@ import {
   type EnsureDirectoryLaunchpadResponse,
   applyCodexEnvironmentActionRunUpdate,
   buildPendingRequestResponse,
-  buildPullRequestStatusKey,
   buildThreadIdentityKey,
   insertSubthreadIdAfter,
   isAcpBackendId,
@@ -1470,6 +1469,10 @@ type ThreadTitleService = Pick<ThreadTitleGenerationService, "generateTitle"> & 
 type ThreadPullRequestStatusToolHandler = (
   args: CheckThreadPullRequestStatusToolArgs,
 ) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
+
+type ThreadPullRequestCanonicalizer = (
+  prs: PrSummary[],
+) => PrSummary[] | Promise<PrSummary[]>;
 
 type ThreadPullRequestWatchToolHandler = (
   args: WatchThreadPullRequestToolArgs,
@@ -5990,7 +5993,9 @@ export class DesktopBackendRegistry {
     | ThreadPullRequestWatchToolHandler
     | undefined;
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
-  private readonly canonicalPullRequestsByStatusKey = new Map<string, PrSummary>();
+  private threadPullRequestCanonicalizer:
+    | ThreadPullRequestCanonicalizer
+    | undefined;
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -6602,6 +6607,12 @@ export class DesktopBackendRegistry {
     handler: ThreadPullRequestStatusToolHandler | null | undefined,
   ): void {
     this.threadPullRequestStatusToolHandler = handler ?? undefined;
+  }
+
+  setThreadPullRequestCanonicalizer(
+    canonicalizer: ThreadPullRequestCanonicalizer | null | undefined,
+  ): void {
+    this.threadPullRequestCanonicalizer = canonicalizer ?? undefined;
   }
 
   setThreadPullRequestWatchToolHandler(
@@ -23225,7 +23236,7 @@ export class DesktopBackendRegistry {
         });
         return toThreadInspectionSummaryFromSearchResult(
           result,
-          this.projectCanonicalPullRequests(overlay),
+          await this.projectCanonicalPullRequests(overlay),
           messagingBindings,
         );
       }),
@@ -23255,31 +23266,21 @@ export class DesktopBackendRegistry {
             : undefined);
         return toThreadInspectionSummary(
           gitWorkingState ? { ...thread, gitWorkingState } : thread,
-          this.projectCanonicalPullRequests(overlay),
+          await this.projectCanonicalPullRequests(overlay),
           messagingBindings,
         );
       }),
     );
   }
 
-  private projectCanonicalPullRequests(
+  private async projectCanonicalPullRequests(
     overlay: ThreadOverlayState | undefined,
-  ): ThreadOverlayState | undefined {
-    if (!overlay?.prs?.length || this.canonicalPullRequestsByStatusKey.size === 0) {
+  ): Promise<ThreadOverlayState | undefined> {
+    if (!overlay?.prs?.length || !this.threadPullRequestCanonicalizer) {
       return overlay;
     }
-    let changed = false;
-    const prs = overlay.prs.map((pr) => {
-      const canonical = this.canonicalPullRequestsByStatusKey.get(
-        buildPullRequestStatusKey(pr),
-      );
-      if (!canonical) {
-        return pr;
-      }
-      changed = changed || canonical !== pr;
-      return canonical;
-    });
-    return changed ? { ...overlay, prs } : overlay;
+    const prs = await this.threadPullRequestCanonicalizer(overlay.prs);
+    return { ...overlay, prs };
   }
 
   private async getThreadInspectionMessagingBindings(params: {
@@ -23764,17 +23765,6 @@ export class DesktopBackendRegistry {
     event = await this.withThreadMessageOrigin(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);
-
-    if (event.notification.method === "pullRequest/status/updated") {
-      const { prKey, pr } = event.notification.params as {
-        prKey: string;
-        pr: PrSummary;
-      };
-      this.canonicalPullRequestsByStatusKey.set(
-        prKey,
-        pr,
-      );
-    }
 
     if (event.backend === "codex") {
       this.recordTaskMonitorActivity(event.notification);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -202,6 +202,7 @@ import {
   type EnsureDirectoryLaunchpadResponse,
   applyCodexEnvironmentActionRunUpdate,
   buildPendingRequestResponse,
+  buildPullRequestStatusKey,
   buildThreadIdentityKey,
   insertSubthreadIdAfter,
   isAcpBackendId,
@@ -5989,6 +5990,7 @@ export class DesktopBackendRegistry {
     | ThreadPullRequestWatchToolHandler
     | undefined;
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
+  private readonly canonicalPullRequestsByStatusKey = new Map<string, PrSummary>();
   private threadInspectionSearchService: ThreadSearchService | null | undefined;
   private readonly headlessAutomationTurns = new Map<
     string,
@@ -23223,7 +23225,7 @@ export class DesktopBackendRegistry {
         });
         return toThreadInspectionSummaryFromSearchResult(
           result,
-          overlay,
+          this.projectCanonicalPullRequests(overlay),
           messagingBindings,
         );
       }),
@@ -23253,11 +23255,31 @@ export class DesktopBackendRegistry {
             : undefined);
         return toThreadInspectionSummary(
           gitWorkingState ? { ...thread, gitWorkingState } : thread,
-          overlay,
+          this.projectCanonicalPullRequests(overlay),
           messagingBindings,
         );
       }),
     );
+  }
+
+  private projectCanonicalPullRequests(
+    overlay: ThreadOverlayState | undefined,
+  ): ThreadOverlayState | undefined {
+    if (!overlay?.prs?.length || this.canonicalPullRequestsByStatusKey.size === 0) {
+      return overlay;
+    }
+    let changed = false;
+    const prs = overlay.prs.map((pr) => {
+      const canonical = this.canonicalPullRequestsByStatusKey.get(
+        buildPullRequestStatusKey(pr),
+      );
+      if (!canonical) {
+        return pr;
+      }
+      changed = changed || canonical !== pr;
+      return canonical;
+    });
+    return changed ? { ...overlay, prs } : overlay;
   }
 
   private async getThreadInspectionMessagingBindings(params: {
@@ -23742,6 +23764,17 @@ export class DesktopBackendRegistry {
     event = await this.withThreadMessageOrigin(event);
     this.rememberFileChangeApprovalContext(event);
     event = this.withEmbeddedFileChangeApprovalContext(event);
+
+    if (event.notification.method === "pullRequest/status/updated") {
+      const { prKey, pr } = event.notification.params as {
+        prKey: string;
+        pr: PrSummary;
+      };
+      this.canonicalPullRequestsByStatusKey.set(
+        prKey,
+        pr,
+      );
+    }
 
     if (event.backend === "codex") {
       this.recordTaskMonitorActivity(event.notification);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -921,6 +921,7 @@ class DesktopAppServerService {
   private readonly prStatusTokenBucket = new PrStatusTokenBucket();
   private lastPrObservationTimestamp = 0;
   private prStatusRegistryLoaded = false;
+  private prStatusRegistryLoadPromise: Promise<void> | undefined;
   private prLookupRegistryLoaded = false;
   private prGraphqlClient: GithubGraphqlPrClient | undefined;
   private prPollingScheduler: PrPollingScheduler | undefined;
@@ -3650,10 +3651,22 @@ class DesktopAppServerService {
     if (this.prStatusRegistryLoaded) {
       return;
     }
-    this.prStatusRegistryLoaded = true;
-    const entries = await this.getOverlayStore().readPrStatusCache();
-    for (const entry of Object.values(entries)) {
-      this.rememberPrStatuses([entry.pr], entry.fetchedAt, "pr-status-cache");
+    if (!this.prStatusRegistryLoadPromise) {
+      this.prStatusRegistryLoadPromise = (async () => {
+        const entries = await this.getOverlayStore().readPrStatusCache();
+        for (const entry of Object.values(entries)) {
+          this.rememberPrStatuses([entry.pr], entry.fetchedAt, "pr-status-cache");
+        }
+        this.prStatusRegistryLoaded = true;
+      })();
+    }
+    const loadPromise = this.prStatusRegistryLoadPromise;
+    try {
+      await loadPromise;
+    } finally {
+      if (this.prStatusRegistryLoadPromise === loadPromise) {
+        this.prStatusRegistryLoadPromise = undefined;
+      }
     }
   }
 
@@ -3691,6 +3704,13 @@ class DesktopAppServerService {
       const normalized = normalizePrSummary(pr);
       return this.prStatusRegistry.get(getPrStatusKey(normalized))?.pr ?? normalized;
     });
+  }
+
+  async canonicalizeThreadInspectionPullRequests(
+    prs: PrSummary[],
+  ): Promise<PrSummary[]> {
+    await this.loadPrStatusRegistry();
+    return this.canonicalizePrs(prs);
   }
 
   private mergePrHistory(
@@ -5076,6 +5096,7 @@ class DesktopAppServerService {
     this.prLookupSubscribers.clear();
     this.pendingPrOverlayWrites.clear();
     this.prStatusRegistryLoaded = false;
+    this.prStatusRegistryLoadPromise = undefined;
     this.prLookupRegistryLoaded = false;
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
@@ -5329,6 +5350,10 @@ export function registerAppServerIpcHandlers(): void {
   });
   getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(
     async (args) => await appServerService.checkThreadPullRequestStatusForTool(args),
+  );
+  getDesktopBackendRegistry().setThreadPullRequestCanonicalizer(
+    async (prs) =>
+      await appServerService.canonicalizeThreadInspectionPullRequests(prs),
   );
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(
     async (args) => await appServerService.watchThreadPullRequestForTool(args),
@@ -5913,6 +5938,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
   getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(undefined);
+  getDesktopBackendRegistry().setThreadPullRequestCanonicalizer(undefined);
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(undefined);
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler(undefined);
   await appServerService.close();


### PR DESCRIPTION
## Summary

- I canonicalize Agent inspection PRs through the desktop service's existing `prStatusRegistry` instead of projecting stale overlay snapshots directly.
- I hydrate that registry from the durable PR-status cache before inspection, so both `search_threads` and `get_thread_status` remain correct after restart as well as after live polling updates.
- I leave attached/manual PRs unchanged when the canonical registry has no status for their identity.
- I added regression coverage for both inspection endpoints plus concurrent restart-time cache hydration.

## Verification

- I ran `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (420 tests passed).
- I ran `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (74 tests passed).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (no errors; existing warning baseline only).
- I ran `pnpm lint:boundaries`.
- I verified the checkpoint commit has a good SSH signature.

## Notes

- The root cause was that Agent inspection rebuilt PR summaries only from persisted thread overlays instead of consulting the canonical PR-status registry. An event-only projection fixed live transitions but missed already-cached statuses after restart.
- This change does not alter polling, overlay persistence, PR attachment, or renderer behavior.
