### PR TITLE
feat(composer): preview explicit PDF attachments

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -27,6 +27,7 @@ Apache-2.0
 ~~~~~~~~~~
 - @zed-industries/agent-client-protocol@0.4.5 | https://github.com/zed-industries/agent-client-protocol
 - detect-libc@2.1.2 | https://github.com/lovell/detect-libc
+- pdfjs-dist@5.7.284 | https://github.com/mozilla/pdf.js
 - tunnel-agent@0.6.0 | https://github.com/mikeal/tunnel-agent
 
 BlueOak-1.0.0
@@ -68,6 +69,7 @@ MIT
 - @floating-ui/utils@0.2.12 | https://github.com/floating-ui/floating-ui
 - @hono/node-server@2.0.5 | https://github.com/honojs/node-server
 - @modelcontextprotocol/sdk@1.30.0 | https://github.com/modelcontextprotocol/typescript-sdk
+- @napi-rs/canvas@0.1.100 | https://github.com/Brooooooklyn/canvas
 - @octokit/endpoint@11.0.3 | github:octokit/endpoint.js
 - @octokit/graphql@9.0.3 | github:octokit/graphql.js
 - @octokit/openapi-types@27.0.0 | https://github.com/octokit/openapi-types.ts
@@ -452,6 +454,36 @@ Representative file: @modelcontextprotocol/sdk@1.30.0/LICENSE
 MIT License
 
 Copyright (c) 2024 Anthropic, PBC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+@napi-rs/canvas@0.1.100 (MIT)
+-----------------------------
+
+Applies to:
+- @napi-rs/canvas@0.1.100 (MIT)
+
+Representative file: @napi-rs/canvas@0.1.100/LICENSE
+
+MIT License
+
+Copyright (c) 2020 lynweklm@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -4799,6 +4831,191 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+pdfjs-dist@5.7.284 (Apache-2.0)
+-------------------------------
+
+Applies to:
+- pdfjs-dist@5.7.284 (Apache-2.0)
+
+Representative file: pdfjs-dist@5.7.284/LICENSE
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
 
 pkce-challenge@5.0.1 (MIT)
 --------------------------

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
+    "@napi-rs/canvas": "0.1.100",
     "@octokit/graphql": "^9.0.3",
     "@pwragent/messaging-interface": "workspace:*",
     "@pwragent/messaging-provider-discord": "workspace:*",
@@ -78,6 +79,7 @@
     "electron-updater": "6.8.9",
     "node-fetch": "2.7.0",
     "node-pty": "1.2.0-beta.14",
+    "pdfjs-dist": "5.7.284",
     "prosemirror-history": "^1.5.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/apps/desktop/src/main/__tests__/composer-pdf-preview.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-pdf-preview.test.ts
@@ -1,0 +1,123 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE,
+  calculateComposerPdfPreviewDimensions,
+  renderComposerPdfPreview,
+} from "../pdf/composer-pdf-preview";
+import { ComposerPdfPreviewReferences } from "../pdf/composer-pdf-preview-references";
+
+function createSinglePagePdf(): Buffer {
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> /Contents 4 0 R >>",
+    "<< /Length 0 >>\nstream\n\nendstream",
+  ];
+  let output = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  for (const [index, object] of objects.entries()) {
+    offsets.push(Buffer.byteLength(output));
+    output += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  }
+  const xrefOffset = Buffer.byteLength(output);
+  output += "xref\n0 5\n0000000000 65535 f \n";
+  for (const offset of offsets) {
+    output += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  output += `trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(output);
+}
+
+describe("Composer PDF preview", () => {
+  it("renders only page one into a small, local PNG", async () => {
+    expect(
+      calculateComposerPdfPreviewDimensions({ height: 792, width: 1224 }),
+    ).toEqual({ height: 311, width: COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE });
+
+    const preview = await renderComposerPdfPreview({
+      data: createSinglePagePdf(),
+    });
+
+    expect(preview).toMatchObject({
+      dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+      height: COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE,
+      pageCount: 1,
+    });
+    expect(preview.width).toBeLessThan(COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE);
+  });
+
+  it("renders only capabilities issued for explicit Composer PDF references", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-composer-pdf-"));
+    const pdfPath = path.join(root, "Jeep");
+    const textPath = path.join(root, "notes.pdf");
+    const previewReferences = new ComposerPdfPreviewReferences();
+    try {
+      await writeFile(pdfPath, createSinglePagePdf());
+      await writeFile(textPath, "not a PDF");
+
+      const inspected = previewReferences.inspect({
+        paths: [pdfPath, textPath],
+        scopeId: "thread:codex:thread-1",
+      });
+      expect(inspected.references).toHaveLength(1);
+      expect(inspected.references[0]).toMatchObject({ path: pdfPath });
+      const reference = inspected.references[0]!;
+
+      await expect(
+        previewReferences.render({
+          previewId: "not-an-authorized-reference",
+          scopeId: "thread:codex:thread-1",
+        }),
+      ).rejects.toThrow("no longer an active Composer reference");
+      await expect(
+        previewReferences.render({
+          previewId: reference.previewId,
+          scopeId: "thread:codex:other-thread",
+        }),
+      ).rejects.toThrow("no longer an active Composer reference");
+
+      const preview = await previewReferences.render({
+        previewId: reference.previewId,
+        scopeId: "thread:codex:thread-1",
+      });
+      expect(preview).toMatchObject({
+        dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+        fileIdentity: reference.fileIdentity,
+        unchanged: false,
+      });
+      await expect(
+        previewReferences.render({
+          knownFileIdentity: reference.fileIdentity,
+          previewId: reference.previewId,
+          scopeId: "thread:codex:thread-1",
+        }),
+      ).resolves.toEqual({
+        fileIdentity: reference.fileIdentity,
+        unchanged: true,
+      });
+
+      await writeFile(pdfPath, Buffer.concat([createSinglePagePdf(), Buffer.from("\n% changed\n")]));
+      await expect(
+        previewReferences.render({
+          previewId: reference.previewId,
+          scopeId: "thread:codex:thread-1",
+        }),
+      ).rejects.toThrow("selected PDF changed");
+
+      const revalidated = previewReferences.inspect({
+        paths: [pdfPath],
+        scopeId: "thread:codex:thread-1",
+      });
+      expect(revalidated.references[0]?.fileIdentity).not.toBe(
+        reference.fileIdentity,
+      );
+      expect(revalidated.references[0]?.previewId).not.toBe(reference.previewId);
+    } finally {
+      previewReferences.clear();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -61,7 +61,11 @@ import {
   type PickDirectoryFromDiskResponse,
   type PickFileFromDiskResponse,
   type PickReferenceFromDiskResponse,
+  type InspectComposerPdfReferencesRequest,
+  type InspectComposerPdfReferencesResponse,
   type RecordRecentFileReferencesRequest,
+  type RenderComposerPdfPreviewRequest,
+  type RenderComposerPdfPreviewResponse,
   type DetachThreadPullRequestRequest,
   type DetachThreadPullRequestResponse,
   type RefreshDirectoryGitStatusesRequest,
@@ -195,7 +199,9 @@ import {
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
+  NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL,
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
+  NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
   NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SET_BROWSE_MODE_CHANNEL,
@@ -206,6 +212,7 @@ import {
 import { FocusedDiffService } from "../diff-focus/focused-diff-service";
 import { getMainLogger } from "../log";
 import { buildMessagingBindingsByThreadKey } from "../messaging/messaging-bindings-snapshot";
+import { ComposerPdfPreviewReferences } from "../pdf/composer-pdf-preview-references";
 import { getDesktopAutomationService } from "../automations/desktop-automation-service";
 import { GithubPrFetcher } from "../pr-status/github-pr-fetcher";
 import { detectPullRequestsForThread } from "../pr-status/pr-detection";
@@ -5471,6 +5478,7 @@ const GIT_MUTATION_COMMAND =
   /(?:^|[;&|]\s*)git\s+(?:-{1,2}[\w-]+(?:[= ]\S+)?\s+)*(?:commit|merge|rebase|reset|revert|stash|checkout|switch|restore|cherry-pick|pull|push|am|apply|clean)\b/;
 
 const appServerService = new DesktopAppServerService();
+const composerPdfPreviewReferences = new ComposerPdfPreviewReferences();
 
 let unsubscribeWorkingStateEvents: (() => void) | undefined;
 
@@ -5996,6 +6004,24 @@ export function registerAppServerIpcHandlers(): void {
       );
     },
   );
+  ipcMain.removeHandler(NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL,
+    async (
+      _event,
+      request: InspectComposerPdfReferencesRequest,
+    ): Promise<InspectComposerPdfReferencesResponse> =>
+      composerPdfPreviewReferences.inspect(request),
+  );
+  ipcMain.removeHandler(NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
+    async (
+      _event,
+      request: RenderComposerPdfPreviewRequest,
+    ): Promise<RenderComposerPdfPreviewResponse> =>
+      await composerPdfPreviewReferences.render(request),
+  );
   ipcMain.removeHandler(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL);
   ipcMain.handle(
     NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL,
@@ -6080,6 +6106,8 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REGISTER_DIRECTORY_FROM_DISK_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
@@ -6089,6 +6117,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   getDesktopBackendRegistry().setThreadPullRequestCanonicalizer(undefined);
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(undefined);
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler(undefined);
+  composerPdfPreviewReferences.clear();
   await appServerService.close();
 }
 

--- a/apps/desktop/src/main/pdf/composer-pdf-preview-references.ts
+++ b/apps/desktop/src/main/pdf/composer-pdf-preview-references.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type {
+  ComposerPdfPreviewReference,
+  InspectComposerPdfReferencesRequest,
+  InspectComposerPdfReferencesResponse,
+  RenderComposerPdfPreviewRequest,
+  RenderComposerPdfPreviewResponse,
+} from "@pwragent/shared";
+import { renderComposerPdfPreview } from "./composer-pdf-preview";
+
+const PDF_MAGIC = Buffer.from("%PDF-");
+const MAX_COMPOSER_PDF_REFERENCE_PATHS = 20;
+const MAX_COMPOSER_PDF_PREVIEW_FILE_BYTES = 64 * 1024 * 1024;
+
+type ComposerPdfPreviewAuthorization = ComposerPdfPreviewReference;
+
+type FileIdentityStats = {
+  ctimeMs: number;
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  size: number;
+};
+
+function fileIdentity(stats: FileIdentityStats): string {
+  return [stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs].join(":");
+}
+
+function normalizeScopeId(scopeId: string): string {
+  const normalized = scopeId.trim();
+  if (!normalized || normalized.length > 512) {
+    throw new Error("Composer preview scope is invalid.");
+  }
+  return normalized;
+}
+
+function explicitLocalPaths(paths: string[]): string[] {
+  return [...new Set(
+    paths
+      .map((candidate) => candidate.trim())
+      .filter((candidate) => candidate && path.isAbsolute(candidate)),
+  )]
+    .sort()
+    .slice(0, MAX_COMPOSER_PDF_REFERENCE_PATHS);
+}
+
+function inspectPdfFile(filePath: string): { fileIdentity: string } | undefined {
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(filePath, "r");
+    const stats = fs.fstatSync(descriptor);
+    if (!stats.isFile()) {
+      return undefined;
+    }
+
+    const header = Buffer.alloc(PDF_MAGIC.byteLength);
+    const bytesRead = fs.readSync(descriptor, header, 0, header.byteLength, 0);
+    if (bytesRead !== PDF_MAGIC.byteLength || !header.equals(PDF_MAGIC)) {
+      return undefined;
+    }
+    return { fileIdentity: fileIdentity(stats) };
+  } catch {
+    return undefined;
+  } finally {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+  }
+}
+
+function readAuthorizedPdfFile(
+  authorization: ComposerPdfPreviewAuthorization,
+): { data: Buffer; fileIdentity: string } {
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(authorization.path, "r");
+    const before = fs.fstatSync(descriptor);
+    if (!before.isFile()) {
+      throw new Error("The selected PDF is no longer a regular file.");
+    }
+    if (before.size > MAX_COMPOSER_PDF_PREVIEW_FILE_BYTES) {
+      throw new Error("This PDF is too large to preview locally.");
+    }
+
+    const header = Buffer.alloc(PDF_MAGIC.byteLength);
+    const bytesRead = fs.readSync(descriptor, header, 0, header.byteLength, 0);
+    if (bytesRead !== PDF_MAGIC.byteLength || !header.equals(PDF_MAGIC)) {
+      throw new Error("The selected file is no longer a PDF.");
+    }
+
+    const currentFileIdentity = fileIdentity(before);
+    if (currentFileIdentity !== authorization.fileIdentity) {
+      throw new Error("The selected PDF changed. Use Preview again.");
+    }
+
+    // The header read uses an explicit offset, leaving this descriptor at zero.
+    // Reading through it closes the path-level TOCTOU gap while pdfjs renders.
+    const data = fs.readFileSync(descriptor);
+    const after = fs.fstatSync(descriptor);
+    if (
+      data.byteLength !== after.size
+      || currentFileIdentity !== fileIdentity(after)
+    ) {
+      throw new Error("The selected PDF changed while its preview was loading.");
+    }
+    return { data, fileIdentity: currentFileIdentity };
+  } finally {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+  }
+}
+
+/**
+ * Keeps only in-memory capabilities for PDFs the Composer explicitly named.
+ * Rendering accepts a capability, never a filesystem path, so a model-looking
+ * string typed into the editor cannot become a local PDF read or render.
+ */
+export class ComposerPdfPreviewReferences {
+  readonly #authorizationsByScope = new Map<
+    string,
+    Map<string, ComposerPdfPreviewAuthorization>
+  >();
+
+  inspect(
+    request: InspectComposerPdfReferencesRequest,
+  ): InspectComposerPdfReferencesResponse {
+    const scopeId = normalizeScopeId(request.scopeId);
+    const previous = this.#authorizationsByScope.get(scopeId);
+    const next = new Map<string, ComposerPdfPreviewAuthorization>();
+    const references: ComposerPdfPreviewReference[] = [];
+
+    for (const filePath of explicitLocalPaths(request.paths)) {
+      const inspected = inspectPdfFile(filePath);
+      if (!inspected) {
+        continue;
+      }
+      const reusable = [...(previous?.values() ?? [])].find(
+        (authorization) =>
+          authorization.path === filePath
+          && authorization.fileIdentity === inspected.fileIdentity,
+      );
+      const authorization: ComposerPdfPreviewAuthorization = reusable ?? {
+        fileIdentity: inspected.fileIdentity,
+        path: filePath,
+        previewId: randomUUID(),
+      };
+      next.set(authorization.previewId, authorization);
+      references.push(authorization);
+    }
+
+    if (next.size > 0) {
+      this.#authorizationsByScope.set(scopeId, next);
+    } else {
+      this.#authorizationsByScope.delete(scopeId);
+    }
+    return { references };
+  }
+
+  async render(
+    request: RenderComposerPdfPreviewRequest,
+  ): Promise<RenderComposerPdfPreviewResponse> {
+    const scopeId = normalizeScopeId(request.scopeId);
+    const authorization = this.#authorizationsByScope
+      .get(scopeId)
+      ?.get(request.previewId);
+    if (!authorization) {
+      throw new Error("This PDF is no longer an active Composer reference.");
+    }
+
+    const file = readAuthorizedPdfFile(authorization);
+    if (request.knownFileIdentity === file.fileIdentity) {
+      return { fileIdentity: file.fileIdentity, unchanged: true };
+    }
+
+    return {
+      ...(await renderComposerPdfPreview({ data: file.data })),
+      fileIdentity: file.fileIdentity,
+      unchanged: false,
+    };
+  }
+
+  clear(): void {
+    this.#authorizationsByScope.clear();
+  }
+}

--- a/apps/desktop/src/main/pdf/composer-pdf-preview.ts
+++ b/apps/desktop/src/main/pdf/composer-pdf-preview.ts
@@ -1,0 +1,100 @@
+import { createCanvas } from "@napi-rs/canvas";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
+
+/**
+ * The Composer preview is deliberately much smaller than any turn attachment.
+ * It is a local UI raster only: this module has no dependency on model-facing
+ * PDF page selection, turn input, or image-budget code.
+ */
+export const COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE = 480;
+export const COMPOSER_PDF_PREVIEW_MAX_ENCODED_BYTES = 2 * 1024 * 1024;
+
+export type ComposerPdfPreviewRaster = {
+  dataUrl: string;
+  height: number;
+  pageCount: number;
+  width: number;
+};
+
+const require = createRequire(import.meta.url);
+const wasmUrl = pathToFileURL(
+  `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
+).href;
+
+/** Render page one into a bounded, local-only PNG for Composer. */
+export async function renderComposerPdfPreview(params: {
+  data: Uint8Array;
+}): Promise<ComposerPdfPreviewRaster> {
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(params.data),
+    verbosity: pdfjs.VerbosityLevel.ERRORS,
+    wasmUrl,
+  });
+  try {
+    const document = await loadingTask.promise;
+    if (document.numPages < 1) {
+      throw new Error("PDF has no renderable pages.");
+    }
+
+    const page = await document.getPage(1);
+    try {
+      const sourceViewport = page.getViewport({ scale: 1 });
+      const dimensions = calculateComposerPdfPreviewDimensions({
+        height: sourceViewport.height,
+        width: sourceViewport.width,
+      });
+      const viewport = page.getViewport({
+        scale: dimensions.width / sourceViewport.width,
+      });
+      const canvas = createCanvas(dimensions.width, dimensions.height);
+      const canvasContext = canvas.getContext("2d");
+
+      await page.render({
+        canvas: canvas as unknown as HTMLCanvasElement,
+        canvasContext: canvasContext as unknown as CanvasRenderingContext2D,
+        viewport,
+      }).promise;
+      const encoded = await canvas.encode("png");
+      if (encoded.byteLength > COMPOSER_PDF_PREVIEW_MAX_ENCODED_BYTES) {
+        throw new Error("PDF preview is too detailed to display safely.");
+      }
+
+      return {
+        dataUrl: `data:image/png;base64,${encoded.toString("base64")}`,
+        height: dimensions.height,
+        pageCount: document.numPages,
+        width: dimensions.width,
+      };
+    } finally {
+      page.cleanup();
+    }
+  } finally {
+    await loadingTask.destroy();
+  }
+}
+
+export function calculateComposerPdfPreviewDimensions(params: {
+  height: number;
+  width: number;
+}): { height: number; width: number } {
+  if (
+    !Number.isFinite(params.width)
+    || !Number.isFinite(params.height)
+    || params.width <= 0
+    || params.height <= 0
+  ) {
+    throw new Error("PDF page has invalid dimensions.");
+  }
+
+  const scale = Math.min(
+    1,
+    COMPOSER_PDF_PREVIEW_MAX_LONG_EDGE / Math.max(params.width, params.height),
+  );
+  return {
+    height: Math.max(1, Math.round(params.height * scale)),
+    width: Math.max(1, Math.round(params.width * scale)),
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -144,8 +144,12 @@ import type {
   PickFileFromDiskResponse,
   PickGhCommandResponse,
   PickReferenceFromDiskResponse,
+  InspectComposerPdfReferencesRequest,
+  InspectComposerPdfReferencesResponse,
   ListRecentFileReferencesResponse,
   RecordRecentFileReferencesRequest,
+  RenderComposerPdfPreviewRequest,
+  RenderComposerPdfPreviewResponse,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
@@ -419,7 +423,9 @@ import {
   NAVIGATION_PICK_DIRECTORY_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL,
   NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL,
+  NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL,
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
+  NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
@@ -1345,6 +1351,20 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL),
   pickReferenceFromDisk: async (): Promise<PickReferenceFromDiskResponse> =>
     await ipcRenderer.invoke(NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL),
+  inspectComposerPdfReferences: async (
+    request: InspectComposerPdfReferencesRequest,
+  ): Promise<InspectComposerPdfReferencesResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL,
+      request,
+    ),
+  renderComposerPdfPreview: async (
+    request: RenderComposerPdfPreviewRequest,
+  ): Promise<RenderComposerPdfPreviewResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL,
+      request,
+    ),
   listRecentFileReferences: async (): Promise<ListRecentFileReferencesResponse> =>
     await ipcRenderer.invoke(NAVIGATION_LIST_RECENT_FILE_REFERENCES_CHANNEL),
   recordRecentFileReferences: async (

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4,6 +4,7 @@ import {
   type DragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type Ref,
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -36,6 +37,8 @@ import type {
   NavigationLaunchpadFileAttachment,
   NavigationLaunchpadImageAttachment,
   NavigationThreadSummary,
+  ComposerPdfPreviewReference,
+  RenderComposerPdfPreviewResponse,
   ThreadWorkspaceHandoffStrategy,
   ThreadExecutionMode,
 } from "@pwragent/shared";
@@ -336,6 +339,26 @@ type LocalHandoffStrategy = ThreadWorkspaceHandoffStrategy;
 type ComposerImageAttachment = NavigationLaunchpadImageAttachment;
 
 type ComposerFileAttachment = NavigationLaunchpadFileAttachment;
+
+type ComposerPdfPreview = Extract<
+  RenderComposerPdfPreviewResponse,
+  { unchanged: false }
+>;
+
+type ComposerPdfPreviewState =
+  | { previewId: string; status: "loading" }
+  | { message: string; previewId: string; status: "error" }
+  | { preview: ComposerPdfPreview; previewId: string; status: "ready" };
+
+type ComposerPdfReference = ComposerPdfPreviewReference & {
+  attachmentId?: string;
+  label: string;
+};
+
+type ComposerPdfReferenceSnapshot = {
+  references: ComposerPdfPreviewReference[];
+  scopeId: string;
+};
 
 /**
  * Maximum number of image attachments allowed on a single message. No
@@ -1339,6 +1362,69 @@ function appendFileReferenceMarkdown(
     )
     .join("\n");
   return text ? `${text}\n\n${referenceBlock}` : referenceBlock;
+}
+
+/**
+ * Local inspection is authorized only by a Composer attachment or an explicit
+ * `@` reference token. Do not scan ordinary typed text for path-shaped values.
+ */
+function listExplicitComposerReferencePaths(
+  fileRefs: ComposerFileAttachment[],
+  skillTokens: ComposerSkillToken[],
+): string[] {
+  const paths = new Set<string>();
+  const add = (rawPath: string | undefined): void => {
+    const filePath = rawPath?.trim();
+    if (
+      filePath
+      && (
+        filePath.startsWith("/")
+        || filePath.startsWith("\\\\")
+        || /^[A-Za-z]:[\\/]/u.test(filePath)
+      )
+    ) {
+      paths.add(filePath);
+    }
+  };
+
+  for (const fileRef of fileRefs) {
+    add(fileRef.path);
+  }
+  for (const token of skillTokens) {
+    if (token.kind === "file" || token.kind === "directory") {
+      add(token.path);
+    }
+  }
+  return [...paths].sort();
+}
+
+function listComposerPdfReferences(params: {
+  fileAttachments: ComposerFileAttachment[];
+  references: ComposerPdfPreviewReference[];
+  skillTokens: ComposerSkillToken[];
+}): ComposerPdfReference[] {
+  const attachmentByPath = new Map(
+    params.fileAttachments.map((attachment) => [attachment.path, attachment]),
+  );
+  const labelByPath = new Map<string, string>();
+  for (const token of params.skillTokens) {
+    if (
+      (token.kind === "file" || token.kind === "directory")
+      && token.path
+      && !labelByPath.has(token.path)
+    ) {
+      labelByPath.set(token.path, token.name);
+    }
+  }
+
+  return params.references.map((reference) => {
+    const attachment = attachmentByPath.get(reference.path);
+    return {
+      ...reference,
+      ...(attachment ? { attachmentId: attachment.id } : {}),
+      label: attachment?.label ?? labelByPath.get(reference.path) ?? fileLabelFromPath(reference.path),
+    };
+  });
 }
 
 function getComposerSkillTokensSignature(skillTokens: ComposerSkillToken[]): string {
@@ -2557,6 +2643,8 @@ export function Composer(props: ComposerProps) {
   const latestLaunchpadRef =
     useRef<NavigationLaunchpadDraft | undefined>(props.launchpad);
   latestLaunchpadRef.current = props.launchpad;
+  const desktopApiRef = useRef(props.desktopApi);
+  desktopApiRef.current = props.desktopApi;
   const pendingProgrammaticComposerChangeRef =
     useRef<PendingProgrammaticComposerChange | undefined>(undefined);
   const composerScopeKey = props.launchpad
@@ -2728,6 +2816,35 @@ export function Composer(props: ComposerProps) {
   const [fileAttachments, setFileAttachments] = useState<ComposerFileAttachment[]>(
     latestDraftSnapshotRef.current.snapshot.fileAttachments ?? []
   );
+  // Preview rasters live only in this component. Drafts, queued/steer snapshots,
+  // launchpads, and turn payloads retain their normal path-only references.
+  const [composerPdfReferenceSnapshot, setComposerPdfReferenceSnapshot] =
+    useState<ComposerPdfReferenceSnapshot>(() => ({
+      references: [],
+      scopeId: composerScopeKey,
+    }));
+  // Do not let a previous thread's in-memory capabilities or raster cards
+  // flash while this reusable Composer hydrates its next scope.
+  const composerPdfReferences = useMemo(
+    () =>
+      composerPdfReferenceSnapshot.scopeId === composerScopeKey
+        ? composerPdfReferenceSnapshot.references
+        : [],
+    [composerPdfReferenceSnapshot, composerScopeKey],
+  );
+  const [composerPdfPreviewStates, setComposerPdfPreviewStates] = useState(
+    () => new Map<string, ComposerPdfPreviewState>(),
+  );
+  const composerPdfPreviewStatesRef = useRef(composerPdfPreviewStates);
+  composerPdfPreviewStatesRef.current = composerPdfPreviewStates;
+  const composerPdfPreviewRequestIdsRef = useRef(new Map<string, number>());
+  const composerPdfReferenceInspectionIdRef = useRef(0);
+  const [pdfPreviewLightbox, setPdfPreviewLightbox] = useState<{
+    label: string;
+    path: string;
+    preview: ComposerPdfPreview;
+    scopeId: string;
+  }>();
   // Per-attachment content signature (`<size>:<hash>`) cache used to reject
   // exact-duplicate pastes. Computed lazily on first use and kept only in
   // memory — signatures are never part of the persisted draft snapshot.
@@ -2877,6 +2994,227 @@ export function Composer(props: ComposerProps) {
     () => serializeDraftWithSkillTokens(draft, skillTokens),
     [draft, skillTokens]
   );
+  // Restored markdown may not yet have a live Tiptap mention node. Parse only
+  // serialized `@` reference tokens here; ordinary typed path-like text never
+  // enters this set.
+  const canonicalReferenceTokens = useMemo(
+    () => hydrateComposerDraft(canonicalDraft, props.skills, threadLinks).skillTokens,
+    [canonicalDraft, props.skills, threadLinks],
+  );
+  const explicitComposerReferencePaths = useMemo(
+    () =>
+      listExplicitComposerReferencePaths(fileAttachments, [
+        ...skillTokens,
+        ...canonicalReferenceTokens,
+      ]),
+    [canonicalReferenceTokens, fileAttachments, skillTokens],
+  );
+  const explicitComposerReferencePathsKey = explicitComposerReferencePaths.join("\u0000");
+  const explicitComposerReferencePathsRef = useRef(explicitComposerReferencePaths);
+  explicitComposerReferencePathsRef.current = explicitComposerReferencePaths;
+  const refreshComposerPdfReferences = useCallback(async (): Promise<void> => {
+    if (activeComposerScopeKeyRef.current !== composerScopeKey) {
+      return;
+    }
+    const inspectionId = ++composerPdfReferenceInspectionIdRef.current;
+    const paths = explicitComposerReferencePathsRef.current;
+    const inspector = desktopApiRef.current?.inspectComposerPdfReferences;
+    if (!inspector || paths.length === 0) {
+      if (inspectionId === composerPdfReferenceInspectionIdRef.current) {
+        setComposerPdfReferenceSnapshot({
+          references: [],
+          scopeId: composerScopeKey,
+        });
+      }
+      return;
+    }
+
+    try {
+      const response = await inspector({
+        paths,
+        scopeId: composerScopeKey,
+      });
+      if (inspectionId !== composerPdfReferenceInspectionIdRef.current) {
+        return;
+      }
+      const allowedPaths = new Set(paths);
+      setComposerPdfReferenceSnapshot({
+        references: response.references.filter((reference) =>
+          allowedPaths.has(reference.path),
+        ),
+        scopeId: composerScopeKey,
+      });
+    } catch {
+      if (inspectionId === composerPdfReferenceInspectionIdRef.current) {
+        setComposerPdfReferenceSnapshot({
+          references: [],
+          scopeId: composerScopeKey,
+        });
+      }
+    }
+  }, [composerScopeKey]);
+  useEffect(() => {
+    void refreshComposerPdfReferences();
+  }, [explicitComposerReferencePathsKey, refreshComposerPdfReferences]);
+  useEffect(() => {
+    // A different app can replace a local file while PwrAgent is unfocused.
+    // Re-inspection invalidates any stale renderer-only raster without creating
+    // a new preview; rendering remains an explicit Preview action.
+    const revalidate = (): void => {
+      void refreshComposerPdfReferences();
+    };
+    window.addEventListener("focus", revalidate);
+    return () => {
+      window.removeEventListener("focus", revalidate);
+    };
+  }, [refreshComposerPdfReferences]);
+  const composerPdfReferenceKey = useMemo(
+    () =>
+      composerPdfReferences
+        .map((reference) =>
+          [reference.path, reference.fileIdentity, reference.previewId].join("\u0001"),
+        )
+        .sort()
+        .join("\u0000"),
+    [composerPdfReferences],
+  );
+  const composerPdfReferenceByPath = useMemo(
+    () => new Map(composerPdfReferences.map((reference) => [reference.path, reference])),
+    [composerPdfReferences],
+  );
+  const composerPdfReferenceByPathRef = useRef(composerPdfReferenceByPath);
+  composerPdfReferenceByPathRef.current = composerPdfReferenceByPath;
+  const pdfPreviewReferences = useMemo(
+    () =>
+      listComposerPdfReferences({
+        fileAttachments,
+        references: composerPdfReferences,
+        skillTokens: [...skillTokens, ...canonicalReferenceTokens],
+      }),
+    [canonicalReferenceTokens, composerPdfReferences, fileAttachments, skillTokens],
+  );
+  const updateComposerPdfPreviewState = useCallback(
+    (path: string, state: ComposerPdfPreviewState | undefined): void => {
+      const next = new Map(composerPdfPreviewStatesRef.current);
+      if (state) {
+        next.set(path, state);
+      } else {
+        next.delete(path);
+      }
+      composerPdfPreviewStatesRef.current = next;
+      setComposerPdfPreviewStates(next);
+    },
+    [],
+  );
+  const requestComposerPdfPreview = useCallback(
+    async (reference: ComposerPdfReference): Promise<void> => {
+      const current = composerPdfPreviewStatesRef.current.get(reference.path);
+      if (
+        current?.previewId === reference.previewId
+        && current.status === "loading"
+      ) {
+        return;
+      }
+
+      const requestId =
+        (composerPdfPreviewRequestIdsRef.current.get(reference.path) ?? 0) + 1;
+      composerPdfPreviewRequestIdsRef.current.set(reference.path, requestId);
+      updateComposerPdfPreviewState(reference.path, {
+        previewId: reference.previewId,
+        status: "loading",
+      });
+
+      const renderer = desktopApiRef.current?.renderComposerPdfPreview;
+      if (!renderer) {
+        updateComposerPdfPreviewState(reference.path, {
+          message: "Preview unavailable",
+          previewId: reference.previewId,
+          status: "error",
+        });
+        return;
+      }
+
+      try {
+        const response = await renderer({
+          ...(current?.status === "ready" && current.previewId === reference.previewId
+            ? { knownFileIdentity: current.preview.fileIdentity }
+            : {}),
+          previewId: reference.previewId,
+          scopeId: composerScopeKey,
+        });
+        const currentReference = composerPdfReferenceByPathRef.current.get(
+          reference.path,
+        );
+        if (
+          composerPdfPreviewRequestIdsRef.current.get(reference.path) !== requestId
+          || currentReference?.previewId !== reference.previewId
+        ) {
+          return;
+        }
+        if (response.unchanged) {
+          if (current?.status === "ready" && current.previewId === reference.previewId) {
+            updateComposerPdfPreviewState(reference.path, current);
+          } else {
+            updateComposerPdfPreviewState(reference.path, {
+              message: "Preview unavailable",
+              previewId: reference.previewId,
+              status: "error",
+            });
+          }
+          return;
+        }
+        updateComposerPdfPreviewState(reference.path, {
+          preview: response,
+          previewId: reference.previewId,
+          status: "ready",
+        });
+      } catch {
+        const currentReference = composerPdfReferenceByPathRef.current.get(
+          reference.path,
+        );
+        if (
+          composerPdfPreviewRequestIdsRef.current.get(reference.path) === requestId
+          && currentReference?.previewId === reference.previewId
+        ) {
+          updateComposerPdfPreviewState(reference.path, {
+            message: "Preview unavailable",
+            previewId: reference.previewId,
+            status: "error",
+          });
+        }
+      }
+    },
+    [composerScopeKey, updateComposerPdfPreviewState],
+  );
+  useEffect(() => {
+    const referencesByPath = new Map(
+      composerPdfReferences.map((reference) => [reference.path, reference]),
+    );
+    const current = composerPdfPreviewStatesRef.current;
+    const next = new Map(
+      [...current].filter(([path, state]) => {
+        const reference = referencesByPath.get(path);
+        return (
+          reference?.previewId === state.previewId
+          && (state.status !== "ready" || state.preview.fileIdentity === reference.fileIdentity)
+        );
+      }),
+    );
+    if (next.size !== current.size) {
+      composerPdfPreviewStatesRef.current = next;
+      setComposerPdfPreviewStates(next);
+    }
+    setPdfPreviewLightbox((lightbox) => {
+      const reference = lightbox && referencesByPath.get(lightbox.path);
+      return (
+        lightbox?.scopeId === composerScopeKey
+        && reference
+        && reference.fileIdentity === lightbox.preview.fileIdentity
+      )
+        ? lightbox
+        : undefined;
+    });
+  }, [composerPdfReferenceKey, composerPdfReferences, composerScopeKey]);
   const hasComposerContent =
     draft.trim().length > 0 || skillTokens.length > 0;
   const queuedTurn = queuedTurns[0];
@@ -3877,6 +4215,15 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
+    composerPdfReferenceInspectionIdRef.current += 1;
+    composerPdfPreviewRequestIdsRef.current.clear();
+    composerPdfPreviewStatesRef.current = new Map();
+    setComposerPdfReferenceSnapshot({
+      references: [],
+      scopeId: composerScopeKey,
+    });
+    setComposerPdfPreviewStates(composerPdfPreviewStatesRef.current);
+    setPdfPreviewLightbox(undefined);
     recoveryEligibilityVersionRef.current += 1;
     recoveryLookupSequenceRef.current += 1;
     const pendingRetarget = pendingDraftRetargetRef.current;
@@ -7598,6 +7945,29 @@ export function Composer(props: ComposerProps) {
       onClose={() => setLightboxAttachment(undefined)}
     />
   ) : null;
+  const pdfPreviewPathSet = new Set(
+    pdfPreviewReferences.map((reference) => reference.path),
+  );
+  const visibleFileAttachments = fileAttachments.filter(
+    (attachment) => !pdfPreviewPathSet.has(attachment.path),
+  );
+  const hasVisibleAttachments =
+    imageAttachments.length > 0
+    || visibleFileAttachments.length > 0
+    || pdfPreviewReferences.length > 0;
+  const activePdfPreviewLightbox =
+    pdfPreviewLightbox?.scopeId === composerScopeKey
+      ? pdfPreviewLightbox
+      : undefined;
+  const pdfPreviewLightboxNode = activePdfPreviewLightbox ? (
+    <ImageLightbox
+      alt={`Page 1 preview of ${activePdfPreviewLightbox.label}`}
+      caption={`${activePdfPreviewLightbox.label} · Page 1 of ${activePdfPreviewLightbox.preview.pageCount}`}
+      dialogLabel={`PDF preview: ${activePdfPreviewLightbox.label}`}
+      src={activePdfPreviewLightbox.preview.dataUrl}
+      onClose={() => setPdfPreviewLightbox(undefined)}
+    />
+  ) : null;
   const workspaceHandoffDialog =
     handoffDialog && threadWorkspace
       ? createPortal(
@@ -8039,10 +8409,14 @@ export function Composer(props: ComposerProps) {
         );
       })}
 
-      {imageAttachments.length > 0 || fileAttachments.length > 0 ? (
+      {hasVisibleAttachments ? (
         <div
           className="composer__attachments"
-          aria-label={fileAttachments.length > 0 ? "Attachments" : "Pasted images"}
+          aria-label={
+            visibleFileAttachments.length > 0 || pdfPreviewReferences.length > 0
+              ? "Attachments"
+              : "Pasted images"
+          }
         >
           {imageAttachments.map((attachment, index) => {
             const dimensions = formatImageDimensions(
@@ -8088,7 +8462,114 @@ export function Composer(props: ComposerProps) {
               </div>
             );
           })}
-          {fileAttachments.map((attachment) => (
+          {pdfPreviewReferences.map((reference) => {
+            const previewState = composerPdfPreviewStates.get(reference.path);
+            const preview =
+              previewState?.status === "ready" ? previewState.preview : undefined;
+            const previewActionLabel =
+              previewState?.status === "error" ? "Retry preview" : "Preview";
+            return (
+              <div
+                className="composer__attachment composer__attachment--pdf"
+                key={reference.path}
+              >
+                <div className="composer__attachment-thumb">
+                  {preview ? (
+                    <button
+                      aria-label={`Expand PDF preview for ${reference.label}`}
+                      className="composer__attachment-open"
+                      type="button"
+                      onClick={() => {
+                        setPdfPreviewLightbox({
+                          label: reference.label,
+                          path: reference.path,
+                          preview,
+                          scopeId: composerScopeKey,
+                        });
+                      }}
+                    >
+                      <img
+                        className="composer__attachment-preview composer__attachment-preview--pdf"
+                        src={preview.dataUrl}
+                        alt={`Page 1 preview of ${reference.label}`}
+                      />
+                    </button>
+                  ) : (
+                    <div
+                      aria-live="polite"
+                      className={[
+                        "composer__pdf-preview-placeholder",
+                        previewState?.status !== "loading" ? "has-action" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      role="status"
+                    >
+                      {previewState?.status === "loading" ? (
+                        <span
+                          aria-hidden="true"
+                          className="composer__pdf-preview-spinner"
+                        />
+                      ) : (
+                        <FileCodeIcon size={22} aria-hidden="true" />
+                      )}
+                      <span className="composer__pdf-preview-placeholder-label">
+                        {previewState?.status === "loading"
+                          ? "Loading preview"
+                          : previewState?.status === "error"
+                            ? previewState.message
+                            : "PDF"}
+                      </span>
+                      {previewState?.status !== "loading" ? (
+                        <button
+                          className="composer__pdf-preview-action"
+                          type="button"
+                          onClick={() => {
+                            void requestComposerPdfPreview(reference);
+                          }}
+                        >
+                          {previewActionLabel}
+                        </button>
+                      ) : null}
+                    </div>
+                  )}
+                  {reference.attachmentId ? (
+                    <button
+                      aria-label={`Remove ${reference.label}`}
+                      className="composer__attachment-remove"
+                      type="button"
+                      onClick={() => {
+                        removeFileAttachment(reference.attachmentId!);
+                      }}
+                    >
+                      <CloseIcon size={12} aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+                <div className="composer__attachment-chips">
+                  {preview ? (
+                    <>
+                      <span className="composer__attachment-chip">
+                        Page 1 of {preview.pageCount}
+                      </span>
+                      <span className="composer__attachment-chip">
+                        {formatImageDimensions(preview.width, preview.height)}
+                      </span>
+                    </>
+                  ) : (
+                    <span className="composer__attachment-chip">PDF</span>
+                  )}
+                </div>
+                <span
+                  className="composer__pdf-preview-label tooltip-target"
+                  data-tooltip={buildFileReferenceTooltip(reference.path)}
+                >
+                  {reference.label}
+                </span>
+              </div>
+            );
+          })}
+          {visibleFileAttachments.map((attachment) => (
             <span
               className="composer__file-attachment tooltip-target"
               data-tooltip={buildFileReferenceTooltip(attachment.path)}
@@ -9411,6 +9892,7 @@ export function Composer(props: ComposerProps) {
       </form>
       {fullAccessRiskDialog}
       {imageLightbox}
+      {pdfPreviewLightboxNode}
     </>
   );
 }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -14557,6 +14557,229 @@ describe("Composer", () => {
     }
   });
 
+  it("renders an explicit PDF only after Preview and keeps its raster out of the turn", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pdfPath = "/Users/huntharo/Downloads/Jeep";
+      const inspectComposerPdfReferences = vi.fn(async () => ({
+        references: [
+          {
+            fileIdentity: "jeep-v1",
+            path: pdfPath,
+            previewId: "preview-jeep-v1",
+          },
+        ],
+      }));
+      const renderComposerPdfPreview = vi.fn(async () => ({
+        dataUrl: "data:image/png;base64,UEZERg==",
+        fileIdentity: "jeep-v1",
+        height: 480,
+        pageCount: 7,
+        unchanged: false as const,
+        width: 360,
+      }));
+      const startTurn = vi.fn(async (_request: StartTurnRequest) => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+      const jeepFile = new File(["%PDF-1.7"], "Jeep", {
+        type: "application/octet-stream",
+      });
+
+      render(
+        <Composer
+          desktopApi={{
+            getPathForFile: () => pdfPath,
+            inspectComposerPdfReferences,
+            onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      const composer = screen.getByLabelText("Reply");
+      fireEvent.change(composer, { target: { value: "Compare the first page" } });
+      fireEvent.drop(composer, {
+        dataTransfer: {
+          files: [],
+          items: [
+            {
+              kind: "file",
+              type: "application/octet-stream",
+              getAsFile: () => jeepFile,
+            },
+          ],
+        },
+      });
+
+      expect(await screen.findByRole("button", { name: "Preview" })).toBeInTheDocument();
+      expect(renderComposerPdfPreview).not.toHaveBeenCalled();
+
+      await clickButton("Preview");
+      expect(
+        await screen.findByAltText("Page 1 preview of Jeep"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Page 1 of 7")).toBeInTheDocument();
+      expect(renderComposerPdfPreview).toHaveBeenCalledWith({
+        previewId: "preview-jeep-v1",
+        scopeId: "thread:codex:thread-1",
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Expand PDF preview for Jeep" }),
+      );
+      const dialog = screen.getByRole("dialog", { name: "PDF preview: Jeep" });
+      expect(within(dialog).getByText("Jeep · Page 1 of 7")).toBeInTheDocument();
+
+      await clickButton("Send");
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [
+              {
+                type: "text",
+                text: "Compare the first page\n\n[@Jeep](~/Downloads/Jeep)",
+              },
+            ],
+          }),
+        );
+      });
+      expect(JSON.stringify(startTurn.mock.calls[0]?.[0])).not.toContain(
+        "data:image/png",
+      );
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("invalidates a restored PDF raster on focus revalidation without auto-rendering", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const pdfPath = "/Users/huntharo/Downloads/Jeep";
+      const draftStore = createComposerDraftStore();
+      draftStore.set("thread:codex:thread-1", {
+        draft: "Compare [@Jeep](~/Downloads/Jeep)",
+        editorDocument: undefined,
+        fileAttachments: [],
+        imageAttachments: [],
+        skillTokens: [],
+      });
+      const inspectComposerPdfReferences = vi
+        .fn()
+        .mockResolvedValueOnce({
+          references: [
+            {
+              fileIdentity: "jeep-v1",
+              path: pdfPath,
+              previewId: "preview-jeep-v1",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          references: [
+            {
+              fileIdentity: "jeep-v2",
+              path: pdfPath,
+              previewId: "preview-jeep-v2",
+            },
+          ],
+        });
+      const renderComposerPdfPreview = vi.fn(async () => ({
+        dataUrl: "data:image/png;base64,UEZERg==",
+        fileIdentity: "jeep-v1",
+        height: 480,
+        pageCount: 1,
+        unchanged: false as const,
+        width: 360,
+      }));
+
+      render(
+        <Composer
+          desktopApi={{
+            inspectComposerPdfReferences,
+            onAgentEvent: () => () => undefined,
+            renderComposerPdfPreview,
+          }}
+          disabled={false}
+          draftStore={draftStore}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Compare window stickers",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />,
+      );
+
+      expect(await screen.findByRole("button", { name: "Preview" })).toBeInTheDocument();
+      await clickButton("Preview");
+      expect(
+        await screen.findByAltText("Page 1 preview of Jeep"),
+      ).toBeInTheDocument();
+
+      fireEvent.focus(window);
+      await waitFor(() => {
+        expect(inspectComposerPdfReferences).toHaveBeenCalledTimes(2);
+      });
+      await waitFor(() => {
+        expect(screen.queryByAltText("Page 1 preview of Jeep")).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
+      expect(renderComposerPdfPreview).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("does not inspect a filesystem-looking path typed as ordinary text", async () => {
+    const inspectComposerPdfReferences = vi.fn(async () => ({ references: [] }));
+
+    render(
+      <Composer
+        desktopApi={{
+          inspectComposerPdfReferences,
+          onAgentEvent: () => () => undefined,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Compare window stickers",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Read /Users/huntharo/Downloads/Jeep.pdf" },
+    });
+    await flushReactUpdates();
+
+    expect(inspectComposerPdfReferences).not.toHaveBeenCalled();
+  });
+
   it("sends a files-only draft as just the reference block", async () => {
     (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
       "/Users/huntharo";

--- a/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { type ReactNode, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { CloseIcon } from "../../icons";
 import { TranscriptImage } from "./TranscriptImage";
@@ -7,6 +7,10 @@ type ImageLightboxProps = {
   /** Image source — a data URL or any resolvable URL. */
   src: string;
   alt: string;
+  /** Optional visible local-image metadata, such as a PDF page count. */
+  caption?: ReactNode;
+  /** More specific accessible name for callers that expand a non-photo image. */
+  dialogLabel?: string;
   onClose: () => void;
 };
 
@@ -17,7 +21,13 @@ type ImageLightboxProps = {
  * the accent close cookie, or Escape. `TranscriptImage` resolves embedded data
  * URLs to object URLs, so both image sources render the same way.
  */
-export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
+export function ImageLightbox({
+  src,
+  alt,
+  caption,
+  dialogLabel = "Expanded image",
+  onClose,
+}: ImageLightboxProps) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -40,7 +50,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
       className="image-lightbox"
       role="dialog"
       aria-modal="true"
-      aria-label="Expanded image"
+      aria-label={dialogLabel}
       onClick={onClose}
     >
       <div
@@ -58,6 +68,7 @@ export function ImageLightbox({ src, alt, onClose }: ImageLightboxProps) {
           <CloseIcon size={18} aria-hidden="true" />
         </button>
         <TranscriptImage className="image-lightbox__image" src={src} alt={alt} />
+        {caption ? <p className="image-lightbox__caption">{caption}</p> : null}
       </div>
     </div>,
     document.body,

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -147,8 +147,12 @@ import type {
   PickDirectoryFromDiskResponse,
   PickFileFromDiskResponse,
   PickReferenceFromDiskResponse,
+  InspectComposerPdfReferencesRequest,
+  InspectComposerPdfReferencesResponse,
   ListRecentFileReferencesResponse,
   RecordRecentFileReferencesRequest,
+  RenderComposerPdfPreviewRequest,
+  RenderComposerPdfPreviewResponse,
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   RegisterDirectoryFromDiskRequest,
@@ -753,6 +757,14 @@ export type DesktopApi = {
    * tray and directories to reference chips.
    */
   pickReferenceFromDisk?: () => Promise<PickReferenceFromDiskResponse>;
+  /** Magic-byte inspection for explicit Composer attachments/reference tokens. */
+  inspectComposerPdfReferences?: (
+    request: InspectComposerPdfReferencesRequest,
+  ) => Promise<InspectComposerPdfReferencesResponse>;
+  /** Render a local PDF through an in-memory explicit-reference capability. */
+  renderComposerPdfPreview?: (
+    request: RenderComposerPdfPreviewRequest,
+  ) => Promise<RenderComposerPdfPreviewResponse>;
   /** Recently referenced files for the reference picker's Files tab. */
   listRecentFileReferences?: () => Promise<ListRecentFileReferencesResponse>;
   /** Fire-and-forget record of freshly committed file references. */

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15645,6 +15645,76 @@ a.transcript-message__messaging-origin:focus-visible {
   background: var(--bg-panel-hover);
 }
 
+.composer__attachment-preview--pdf {
+  object-fit: contain;
+}
+
+.composer__pdf-preview-placeholder {
+  display: flex;
+  width: 88px;
+  height: 88px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-hover);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.composer__pdf-preview-placeholder-label {
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 11px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+}
+
+.composer__pdf-preview-placeholder.has-action {
+  flex-direction: column;
+  gap: 5px;
+}
+
+.composer__pdf-preview-action {
+  min-height: 22px;
+  padding: 2px 6px;
+  border: 1px solid var(--accent-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.composer__pdf-preview-action:hover,
+.composer__pdf-preview-action:focus-visible {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.composer__pdf-preview-spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: composer-action-button-spin 0.8s linear infinite;
+}
+
+.composer__pdf-preview-label {
+  display: block;
+  max-width: 88px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Solid filled circle (not a translucent scrim) so the X stays legible over
    any underlying image. Pinned to the thumbnail's top-right corner. */
 .composer__attachment-remove {
@@ -15712,6 +15782,7 @@ a.transcript-message__messaging-origin:focus-visible {
 .image-lightbox__content {
   position: relative;
   display: flex;
+  flex-direction: column;
   max-width: min(100%, 1100px);
   cursor: default;
 }
@@ -15758,6 +15829,13 @@ a.transcript-message__messaging-origin:focus-visible {
   border-radius: 8px;
   background: var(--bg-panel);
   object-fit: contain;
+}
+
+.image-lightbox__caption {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: center;
 }
 
 .composer__setup {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -255,6 +255,11 @@ export const NAVIGATION_PICK_FILE_FROM_DISK_CHANNEL =
  */
 export const NAVIGATION_PICK_REFERENCE_FROM_DISK_CHANNEL =
   "navigation:pick-reference-from-disk";
+/** Local-only PDF preview bridge for explicit Composer references. */
+export const NAVIGATION_INSPECT_COMPOSER_PDF_REFERENCES_CHANNEL =
+  "navigation:inspect-composer-pdf-references";
+export const NAVIGATION_RENDER_COMPOSER_PDF_PREVIEW_CHANNEL =
+  "navigation:render-composer-pdf-preview";
 /**
  * Recently referenced files for the reference picker's Files tab —
  * `list` reads the persisted most-recent-first list; `record` is a

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -729,6 +729,61 @@ export type PickReferenceFromDiskResponse =
     };
 
 /**
+ * Ask main to identify PDF files from paths already carried by explicit
+ * Composer attachments or `@` reference tokens. The renderer must never pass
+ * a filesystem-looking value parsed from ordinary typed text.
+ */
+export type InspectComposerPdfReferencesRequest = {
+  /** Ephemeral identifier for one live Composer surface. */
+  scopeId: string;
+  /** Explicit attachment/reference paths currently visible in that Composer. */
+  paths: string[];
+};
+
+/**
+ * An in-memory capability for one explicit Composer PDF. It is invalidated
+ * when its path or observed file identity changes and is never persisted.
+ */
+export type ComposerPdfPreviewReference = {
+  fileIdentity: string;
+  path: string;
+  previewId: string;
+};
+
+export type InspectComposerPdfReferencesResponse = {
+  /** Only paths whose magic bytes identify a regular PDF. */
+  references: ComposerPdfPreviewReference[];
+};
+
+/**
+ * Render an explicitly authorized local PDF preview. There is deliberately no
+ * file path here: main resolves the path from the in-memory `previewId`.
+ */
+export type RenderComposerPdfPreviewRequest = {
+  knownFileIdentity?: string;
+  previewId: string;
+  scopeId: string;
+};
+
+/**
+ * A low-resolution, local-only first-page raster. Callers must keep this out
+ * of drafts, queued/steer snapshots, and model turn input.
+ */
+export type RenderComposerPdfPreviewResponse =
+  | {
+      fileIdentity: string;
+      unchanged: true;
+    }
+  | {
+      dataUrl: string;
+      fileIdentity: string;
+      height: number;
+      pageCount: number;
+      unchanged: false;
+      width: number;
+    };
+
+/**
  * Recently referenced files for the composer's reference picker. The main
  * process persists a small most-recent-first list of paths (capped,
  * deduped by path) and computes each label from the path's basename.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
         version: 1.30.0(zod@4.3.6)
+      '@napi-rs/canvas':
+        specifier: 0.1.100
+        version: 0.1.100
       '@octokit/graphql':
         specifier: ^9.0.3
         version: 9.0.3
@@ -150,6 +153,9 @@ importers:
       node-pty:
         specifier: 1.2.0-beta.14
         version: 1.2.0-beta.14
+      pdfjs-dist:
+        specifier: 5.7.284
+        version: 5.7.284
       prosemirror-history:
         specifier: ^1.5.0
         version: 1.5.0
@@ -899,6 +905,81 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3374,6 +3455,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -4931,6 +5016,53 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -7727,6 +7859,10 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   pe-library@0.4.1: {}
 

--- a/scripts/generate-third-party-licenses.mjs
+++ b/scripts/generate-third-party-licenses.mjs
@@ -191,6 +191,10 @@ function stableRecordKey(record) {
   return `${record.name}@${record.version}`;
 }
 
+export function isPlatformSpecificNapiCanvasPackage(name) {
+  return /^@napi-rs\/canvas-(?:android|darwin|linux|win32)-/u.test(name);
+}
+
 export function enrichRecord(record) {
   const packageJson = readPackageJson(record);
   const licensePath = findLicenseFile(record.packagePath);
@@ -236,7 +240,15 @@ function main() {
     }
   }
 
-  const records = Array.from(recordsByKey.values()).sort(compareRecords).map(enrichRecord);
+  // @napi-rs/canvas installs exactly one OS/architecture helper package. Its
+  // name changes with the host running this script, while the canonical
+  // @napi-rs/canvas package (which remains in this notice) carries the shared
+  // package license. Keeping the selected helper out of the generated notice
+  // makes this source-controlled disclosure deterministic across CI hosts.
+  const records = Array.from(recordsByKey.values())
+    .filter((record) => !isPlatformSpecificNapiCanvasPackage(record.name))
+    .sort(compareRecords)
+    .map(enrichRecord);
 
   const recordsByLicense = new Map();
   for (const record of records) {

--- a/scripts/generate-third-party-licenses.test.mjs
+++ b/scripts/generate-third-party-licenses.test.mjs
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   enrichRecord,
+  isPlatformSpecificNapiCanvasPackage,
   StaleInstallError,
 } from "./generate-third-party-licenses.mjs";
 
@@ -46,6 +47,20 @@ afterEach(() => {
 });
 
 describe("third-party license package enrichment", () => {
+  it("excludes only platform-selected @napi-rs/canvas helpers", () => {
+    expect(isPlatformSpecificNapiCanvasPackage("@napi-rs/canvas-darwin-arm64")).toBe(
+      true,
+    );
+    expect(isPlatformSpecificNapiCanvasPackage("@napi-rs/canvas-linux-x64-gnu")).toBe(
+      true,
+    );
+    expect(isPlatformSpecificNapiCanvasPackage("@napi-rs/canvas-win32-x64-msvc")).toBe(
+      true,
+    );
+    expect(isPlatformSpecificNapiCanvasPackage("@napi-rs/canvas")).toBe(false);
+    expect(isPlatformSpecificNapiCanvasPackage("pdfjs-dist")).toBe(false);
+  });
+
   it("rejects a license report without an installed package path", () => {
     const error = captureError(() => enrichRecord(createRecord(undefined)));
 


### PR DESCRIPTION
## Summary

- I added a manual Composer `Preview` action for PDFs explicitly added as file attachments or `@` reference tokens, with Page 1 metadata, loading/error feedback, and an accessible local lightbox.
- I added a capability-gated main-process PDF renderer that magic-byte-inspects only those explicit references, renders a bounded first-page PNG, and never accepts a renderer-supplied path at render time.
- I kept preview rasters renderer-local and ephemeral, revalidating capabilities when references hydrate or the app regains focus; no PDF-analysis setting or model PDF/input pipeline is included.
- I added the minimal cross-platform PDF/canvas dependencies and deterministic third-party-notice handling for the native canvas helper package.

## Verification

- I ran `pnpm test scripts/generate-third-party-licenses.test.mjs apps/desktop/src/main/__tests__/composer-pdf-preview.test.ts apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (238 tests passed).
- I ran `pnpm --filter @pwragent/shared typecheck`, `pnpm --filter @pwragent/desktop typecheck`, `pnpm lint:eslint`, `pnpm lint:colors`, `pnpm lint:codex-storage`, `pnpm licenses:check`, and `pnpm lint:boundaries`.
- I ran `pnpm build` and reran the focused Composer/main-process tests, desktop typecheck, and boundaries after rebasing onto current `origin/main`.

## Notes

- I intentionally kept this UI-only and manually invoked; the preview raster is not written into drafts, queued/steer snapshots, or model input.
