### PR TITLE
fix(desktop): coalesce PR lookup registry initialization

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2833,6 +2833,14 @@ describe("app server ipc", () => {
       state: "passing",
       lifecycleState: "merged",
     });
+    const firstStaleFetchedAt = Date.now() - 120_001;
+    const secondStaleFetchedAt = firstStaleFetchedAt + 1;
+    let releasePrLookupCache: (() => void) | undefined;
+    readPrLookupCache.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releasePrLookupCache = () => resolve({});
+      }),
+    );
     getThreadOverlayState
       .mockResolvedValueOnce({
         backend: "codex",
@@ -2840,7 +2848,7 @@ describe("app server ipc", () => {
         executionMode: "default",
         extraLinkedDirectories: [],
         prs: [firstStalePr],
-        prsFetchedAt: Date.now() - 120_000,
+        prsFetchedAt: firstStaleFetchedAt,
         prsRefreshKey: firstRequestKey,
       })
       .mockResolvedValueOnce({
@@ -2849,7 +2857,7 @@ describe("app server ipc", () => {
         executionMode: "default",
         extraLinkedDirectories: [],
         prs: [secondStalePr],
-        prsFetchedAt: Date.now() - 120_000,
+        prsFetchedAt: secondStaleFetchedAt,
         prsRefreshKey: secondRequestKey,
       });
     let resolveFetch: ((prs: PrSummary[]) => void) | undefined;
@@ -2868,7 +2876,16 @@ describe("app server ipc", () => {
 
     const handler = handlers.get(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL)!;
     const first = handler({}, firstRequest);
+    await vi.waitFor(() => {
+      expect(readPrLookupCache).toHaveBeenCalledOnce();
+    });
     const second = handler({}, secondRequest);
+    await vi.waitFor(() => {
+      expect(getThreadOverlayState).toHaveBeenCalledTimes(2);
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(isGhAvailable).not.toHaveBeenCalled();
+    releasePrLookupCache?.();
     await expect(Promise.all([first, second])).resolves.toEqual([
       {
         backend: "codex",

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1065,6 +1065,7 @@ class DesktopAppServerService {
   private prStatusRegistryLoaded = false;
   private prStatusRegistryLoadPromise: Promise<void> | undefined;
   private prLookupRegistryLoaded = false;
+  private prLookupRegistryLoadPromise: Promise<void> | undefined;
   private prGraphqlClient: GithubGraphqlPrClient | undefined;
   private prPollingScheduler: PrPollingScheduler | undefined;
   private backgroundPrPollingEnabled = false;
@@ -3838,11 +3839,23 @@ class DesktopAppServerService {
     if (this.prLookupRegistryLoaded) {
       return;
     }
-    this.prLookupRegistryLoaded = true;
-    const entries = await this.getOverlayStore().readPrLookupCache();
-    for (const entry of Object.values(entries)) {
-      this.rememberPrLookup(entry);
-      this.rememberPrStatuses(entry.prs, entry.fetchedAt, "pr-lookup-cache");
+    if (!this.prLookupRegistryLoadPromise) {
+      this.prLookupRegistryLoadPromise = (async () => {
+        const entries = await this.getOverlayStore().readPrLookupCache();
+        for (const entry of Object.values(entries)) {
+          this.rememberPrLookup(entry);
+          this.rememberPrStatuses(entry.prs, entry.fetchedAt, "pr-lookup-cache");
+        }
+        this.prLookupRegistryLoaded = true;
+      })();
+    }
+    const loadPromise = this.prLookupRegistryLoadPromise;
+    try {
+      await loadPromise;
+    } finally {
+      if (this.prLookupRegistryLoadPromise === loadPromise) {
+        this.prLookupRegistryLoadPromise = undefined;
+      }
     }
   }
 
@@ -5357,6 +5370,7 @@ class DesktopAppServerService {
     this.prStatusRegistryLoaded = false;
     this.prStatusRegistryLoadPromise = undefined;
     this.prLookupRegistryLoaded = false;
+    this.prLookupRegistryLoadPromise = undefined;
     this.pendingDirectoryGitStatusRefreshes.clear();
     this.pendingDirectoryGitStatusKeys.clear();
     this.previousDirectoriesByBackend.clear();


### PR DESCRIPTION
## Summary

- I coalesced desktop PR lookup-registry initialization behind a shared promise so concurrent refreshes cannot bypass an in-flight persisted-cache read.
- I reset the new initialization promise with the rest of the registry state during service disposal.
- I made the existing same-lookup subscriber test deterministic by holding the lookup-cache read open while two refreshes start with distinct stale-overlay timestamps, proving both callers wait without changing the intended subscriber behavior.
- This fixes an existing `main`-branch race independently discovered by the Test job on PR #1152; this branch does not modify or rebase PR #1152 or its branch.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts -t "refreshes retained PRs from all subscribers on a coalesced lookup"`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`

## Notes

- I based this independent fix branch on the latest `origin/main` rather than PR #1152.
