### PR TITLE
fix(desktop): preserve transcript text selection

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -137,6 +137,9 @@ type SyncScrollStateOptions = {
 
 const BOTTOM_THRESHOLD_PX = 24;
 const LOAD_OLDER_THRESHOLD_PX = 160;
+// Callers that do not need skill links should not invalidate every memoized
+// transcript message on an unrelated live-turn render.
+const EMPTY_SKILLS: AppServerSkillSummary[] = [];
 
 type AutomationThreadTarget = {
   backend: "codex" | "grok";
@@ -601,7 +604,7 @@ function ApprovalDiffDisclosures(props: {
 }
 
 export function TranscriptList(props: TranscriptListProps) {
-  const skills = props.skills ?? [];
+  const skills = props.skills ?? EMPTY_SKILLS;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const snapshotRef = useRef<ScrollSnapshot | undefined>(undefined);

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -47,25 +47,39 @@ type TranscriptMessageProps = {
   onOpenImage?: (image: AppServerThreadImagePart) => void;
 };
 
+// Keep text-only markdown props referentially stable when protocol refreshes
+// replace an otherwise equivalent message object. ReactMarkdown treats a new
+// component map as new element types, which remounts selected text nodes.
+const EMPTY_IMAGE_PARTS: AppServerThreadImagePart[] = [];
+
 export const TranscriptMessage = memo(function TranscriptMessage(props: TranscriptMessageProps) {
   const threadLinks = useThreadLinks();
   const sourceThreadLink = props.message.origin?.sourceThread
     ? threadLinks?.resolve(props.message.origin.sourceThread)
     : undefined;
-  const contentParts =
-    props.message.parts && props.message.parts.length > 0
-      ? props.message.parts
-      : props.message.text
-        ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
-        : [];
+  const contentParts = useMemo(
+    () =>
+      props.message.parts && props.message.parts.length > 0
+        ? props.message.parts
+        : props.message.text
+          ? [{ type: "text", text: props.message.text } satisfies AppServerThreadMessagePart]
+          : [],
+    [props.message.parts, props.message.text],
+  );
   const messageCopyText = useMemo(
     () => buildMessageCopyText(props.message, contentParts),
     [contentParts, props.message]
   );
-  const imageParts = contentParts.filter(
-    (part): part is AppServerThreadImagePart => part.type === "image",
+  const imageParts = useMemo(() => {
+    const parts = contentParts.filter(
+      (part): part is AppServerThreadImagePart => part.type === "image",
+    );
+    return parts.length > 0 ? parts : EMPTY_IMAGE_PARTS;
+  }, [contentParts]);
+  const messageSegments = useMemo(
+    () => groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment),
+    [contentParts],
   );
-  const messageSegments = groupMessageParts(contentParts).flatMap(splitMarkdownTableSegment);
   const [monitorExpanded, setMonitorExpanded] = useState(false);
   const [monitorDetailsOpen, setMonitorDetailsOpen] = useState(false);
   const monitorOrigin = props.message.origin?.subAgent;

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -2759,6 +2759,67 @@ describe("TranscriptList", () => {
     expect(list.scrollTop).toBe(1120);
   });
 
+  it("preserves selected assistant text across equivalent live transcript refreshes", () => {
+    const stableSkills: [] = [];
+    const assistantMessage = {
+      type: "message" as const,
+      id: "assistant-selection-1",
+      role: "assistant" as const,
+      phase: "final" as const,
+      parts: [
+        {
+          type: "text" as const,
+          text: "Selected assistant text must remain selected while the turn keeps running."
+        }
+      ],
+      text: "Selected assistant text must remain selected while the turn keeps running."
+    };
+    const { rerender } = render(
+      <TranscriptList
+        entries={[assistantMessage]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        runningTurnUsageText="Usage so far: 100 uncached in"
+        skills={stableSkills}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const paragraph = screen.getByText(assistantMessage.text);
+    const selectedTextNode = paragraph.firstChild;
+    expect(selectedTextNode).toBeInstanceOf(Text);
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(paragraph);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    expect(selection?.toString()).toBe(assistantMessage.text);
+
+    rerender(
+      <TranscriptList
+        entries={[
+          {
+            ...assistantMessage,
+            parts: assistantMessage.parts.map((part) => ({ ...part }))
+          }
+        ]}
+        loading={false}
+        loadingMore={false}
+        pendingStatusText="Thinking"
+        runningTurnUsageText="Usage so far: 100 uncached in · 200 cached"
+        skills={stableSkills}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByText("Usage so far: 100 uncached in · 200 cached")).toBeVisible();
+    expect(screen.getByText(assistantMessage.text).firstChild).toBe(selectedTextNode);
+    expect(selection?.toString()).toBe(assistantMessage.text);
+  });
+
   it("keeps following after a new prompt is appended to a long bottom-pinned chat", () => {
     const entries = Array.from({ length: 32 }, (_, index) => ({
       type: "message" as const,


### PR DESCRIPTION
## Summary

- preserve transcript message DOM identity across equivalent live protocol refreshes
- keep empty skill and image-part props referentially stable so unrelated running-turn updates do not remount markdown
- add a regression test that selects assistant text, applies a deep-equivalent message refresh plus a usage-footer update, and verifies the browser selection and text node survive

## Root cause

Live transcript reconciliation can replace a message and its parts with equivalent objects. The renderer recreated derived arrays from those objects, invalidating the memoized markdown component map. ReactMarkdown then treated its renderer functions as new element types and remounted the paragraph/text subtree, which cleared native browser selection.

The fix stabilizes derived message content, segments, and empty image/skill collections. This lets equivalent refreshes reuse the existing markdown DOM while genuine content changes still render normally.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-links.test.tsx` — 122 tests passed
- `pnpm lint:eslint` — 0 errors (existing warnings only)
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
