### PR TITLE
fix(desktop): allow agents to cancel task monitors

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2125,16 +2125,16 @@ async function callRegistryMcpTool(params: {
   args: Record<string, unknown>;
 }) {
   const internal = params.registry as unknown as {
-    handleCreateMonitorAgentRequest(
-      request: TaskMonitorRequest<"create_monitor_delegation">,
-    ): Promise<TaskMonitorResponse<"create_monitor_delegation">>;
+    handleAgentTaskMonitorRequest(
+      request: TaskMonitorRequest,
+    ): Promise<TaskMonitorResponse>;
     threadOrchestrationHandler: (
       request: PwrAgentThreadOrchestrationRequest,
     ) => Promise<PwrAgentThreadOrchestrationResponse>;
   };
   const catalogs = resolveAgentToolCatalogs({
     taskMonitorHandler: async (request) =>
-      await internal.handleCreateMonitorAgentRequest(request),
+      await internal.handleAgentTaskMonitorRequest(request),
     threadOrchestrationHandler: internal.threadOrchestrationHandler,
   });
   const router = catalogs
@@ -7199,6 +7199,7 @@ script = "echo setup"
       "send_message_to_thread",
       "start_review",
       "create_monitor_delegation",
+      "cancel_monitor_delegation",
     ]);
 
     await registry.close();
@@ -7382,6 +7383,7 @@ script = "echo setup"
       "list_automations",
       "get_automation_run_artifact",
       "create_monitor_delegation",
+      "cancel_monitor_delegation",
       "manage_pwragent",
       "search_threads",
       "read_thread",
@@ -10904,6 +10906,7 @@ command = "pnpm grok"
     });
     expectPwragentDynamicTools(codexClient.lastStartThreadParams?.dynamicTools, [
       "create_monitor_delegation",
+      "cancel_monitor_delegation",
     ]);
 
     await registry.close();
@@ -28504,6 +28507,177 @@ script = "printf setup"
     });
 
     unsubscribeEvents();
+    await registry.close();
+  });
+
+  it("lets only the active parent cancel a managed monitor without waking another turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      models: TEST_TASK_MONITOR_MODELS,
+      startThreadResult: { threadId: "monitor-thread" },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const delegationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_task_monitors",
+        tool: "create_monitor_delegation",
+        arguments: {
+          task: "Recover the runner after its current job finishes.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const monitorId = JSON.parse(
+      (delegationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ).monitorId as string;
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-2",
+          turnId: "turn-2",
+          turn: { id: "turn-2" },
+        },
+      },
+    });
+
+    const forbiddenResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-2",
+        turnId: "turn-2",
+        callId: "call-forbidden",
+        requestId: "call-forbidden",
+        namespace: "pwragent_task_monitors",
+        tool: "cancel_monitor_delegation",
+        arguments: { monitorId },
+      },
+    } as AppServerPendingRequestNotification);
+    expect(forbiddenResponse).toMatchObject({ success: false });
+    expect(codexClient.interruptTurnCallCount).toBe(0);
+
+    const cancellationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-cancel",
+        requestId: "call-cancel",
+        namespace: "pwragent_task_monitors",
+        tool: "cancel_monitor_delegation",
+        arguments: {
+          monitorId,
+          reason: "The monitor was targeting the wrong runner.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const cancellationPayload = JSON.parse(
+      (cancellationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ) as Record<string, unknown>;
+
+    expect(cancellationResponse).toMatchObject({ success: true });
+    expect(cancellationPayload).toMatchObject({
+      monitorId,
+      parentThreadId: "thread-1",
+      outcome: "cancelled",
+      completionSource: { type: "parent_cancel" },
+    });
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+    expect(codexClient.lastInterruptTurnParams).toEqual({
+      threadId: "monitor-thread",
+      turnId: "turn-1",
+    });
+    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(codexClient.injectedThreadItems).toHaveLength(1);
+    expect(codexClient.injectedThreadItems[0]).toMatchObject({
+      threadId: "thread-1",
+      items: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: expect.stringContaining(
+                "The monitor was targeting the wrong runner.",
+              ),
+            },
+          ],
+        },
+      ],
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      subAgents: [
+        {
+          completedAt: expect.any(Number),
+          completionSource: { type: "parent_cancel" },
+          lastMessage: "The monitor was targeting the wrong runner.",
+          monitorId,
+          outcome: "cancelled",
+          status: "cancelled",
+        },
+      ],
+    });
+
+    const repeatedResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-cancel-again",
+        requestId: "call-cancel-again",
+        namespace: "pwragent_task_monitors",
+        tool: "cancel_monitor_delegation",
+        arguments: { monitorId },
+      },
+    } as AppServerPendingRequestNotification);
+    expect(repeatedResponse).toMatchObject({ success: true });
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+    expect(codexClient.injectedThreadItems).toHaveLength(1);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "cancelled", output: [] },
+        },
+      },
+    });
+    expect(codexClient.startTurnCallCount).toBe(1);
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28542,7 +28542,7 @@ script = "printf setup"
         turnId: "turn-1",
         callId: "call-1",
         requestId: "call-1",
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         tool: "create_monitor_delegation",
         arguments: {
           task: "Recover the runner after its current job finishes.",
@@ -28553,6 +28553,20 @@ script = "printf setup"
       (delegationResponse as { contentItems: Array<{ text: string }> })
         .contentItems[0]?.text ?? "{}",
     ).monitorId as string;
+    const legacyCancellationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-cancel-legacy",
+        requestId: "call-cancel-legacy",
+        namespace: "pwragent_task_monitors",
+        tool: "cancel_monitor_delegation",
+        arguments: { monitorId },
+      },
+    } as AppServerPendingRequestNotification);
+    expect(legacyCancellationResponse).toMatchObject({ success: false });
+    expect(codexClient.interruptTurnCallCount).toBe(0);
     await registry.publishLocalEvent({
       backend: "codex",
       notification: {
@@ -28572,7 +28586,7 @@ script = "printf setup"
         turnId: "turn-2",
         callId: "call-forbidden",
         requestId: "call-forbidden",
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         tool: "cancel_monitor_delegation",
         arguments: { monitorId },
       },
@@ -28587,7 +28601,7 @@ script = "printf setup"
         turnId: "turn-1",
         callId: "call-cancel",
         requestId: "call-cancel",
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         tool: "cancel_monitor_delegation",
         arguments: {
           monitorId,
@@ -28606,7 +28620,7 @@ script = "printf setup"
         turnId: "turn-1",
         callId: "call-cancel-overlap",
         requestId: "call-cancel-overlap",
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         tool: "cancel_monitor_delegation",
         arguments: { monitorId },
       },
@@ -28744,7 +28758,7 @@ script = "printf setup"
         turnId: "turn-1",
         callId: "call-cancel-again",
         requestId: "call-cancel-again",
-        namespace: "pwragent_task_monitors",
+        namespace: "pwragent",
         tool: "cancel_monitor_delegation",
         arguments: { monitorId },
       },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28580,7 +28580,7 @@ script = "printf setup"
     expect(forbiddenResponse).toMatchObject({ success: false });
     expect(codexClient.interruptTurnCallCount).toBe(0);
 
-    const cancellationResponse = await codexClient.emitRequest({
+    const cancellationResponsePromise = codexClient.emitRequest({
       method: "item/tool/call",
       params: {
         threadId: "thread-1",
@@ -28595,12 +28595,100 @@ script = "printf setup"
         },
       },
     } as AppServerPendingRequestNotification);
+    await expectEventually(
+      async () => codexClient.interruptTurnCallCount,
+      1,
+    );
+    const overlappingResponsePromise = codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-cancel-overlap",
+        requestId: "call-cancel-overlap",
+        namespace: "pwragent_task_monitors",
+        tool: "cancel_monitor_delegation",
+        arguments: { monitorId },
+      },
+    } as AppServerPendingRequestNotification);
+    let cancellationSettled = false;
+    void cancellationResponsePromise.then(() => {
+      cancellationSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(codexClient.interruptTurnCallCount).toBe(1);
+    expect(cancellationSettled).toBe(false);
+    expect(codexClient.injectedThreadItems).toHaveLength(0);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      subAgents: [
+        {
+          lastMessage:
+            "Cancellation requested; waiting for the monitor turn to stop.",
+          monitorId,
+          status: "cancelling",
+        },
+      ],
+    });
+    const lateCompletionResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "monitor-thread",
+        turnId: "turn-1",
+        callId: "call-complete-late",
+        requestId: "call-complete-late",
+        namespace: "pwragent_task_monitors",
+        tool: "complete_monitoring",
+        arguments: {
+          monitorId,
+          outcome: "success",
+          summary: "The monitor finished while cancellation was pending.",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    expect(lateCompletionResponse).toMatchObject({ success: false });
+    expect(codexClient.injectedThreadItems).toHaveLength(0);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "some-other-turn",
+          turn: { id: "some-other-turn", status: "cancelled", output: [] },
+        },
+      },
+    });
+    expect(codexClient.injectedThreadItems).toHaveLength(0);
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "cancelled", output: [] },
+        },
+      },
+    });
+    const [cancellationResponse, overlappingResponse] = await Promise.all([
+      cancellationResponsePromise,
+      overlappingResponsePromise,
+    ]);
     const cancellationPayload = JSON.parse(
       (cancellationResponse as { contentItems: Array<{ text: string }> })
         .contentItems[0]?.text ?? "{}",
     ) as Record<string, unknown>;
 
     expect(cancellationResponse).toMatchObject({ success: true });
+    expect(overlappingResponse).toEqual(cancellationResponse);
     expect(cancellationPayload).toMatchObject({
       monitorId,
       parentThreadId: "thread-1",
@@ -28664,18 +28752,6 @@ script = "printf setup"
     expect(repeatedResponse).toMatchObject({ success: true });
     expect(codexClient.interruptTurnCallCount).toBe(1);
     expect(codexClient.injectedThreadItems).toHaveLength(1);
-
-    await registry.publishLocalEvent({
-      backend: "codex",
-      notification: {
-        method: "turn/cancelled",
-        params: {
-          threadId: "monitor-thread",
-          turnId: "turn-1",
-          turn: { id: "turn-1", status: "cancelled", output: [] },
-        },
-      },
-    });
     expect(codexClient.startTurnCallCount).toBe(1);
 
     await registry.close();

--- a/apps/desktop/src/main/agent-tools/AGENTS.md
+++ b/apps/desktop/src/main/agent-tools/AGENTS.md
@@ -17,3 +17,19 @@ shape as backwards-compatible API surfaces.
 - Envelope metadata such as `threadId`, `turnId`, and `callId` may be forwarded
   through `AgentToolCallContext`, but must not become required tool input.
 
+## Frozen Legacy Dynamic Namespaces
+
+Codex persists dynamic tool definitions when a thread is created. PwrAgent does
+not resend or refresh those definitions when starting later turns on an existing
+thread.
+
+- New threads receive only the unified `pwragent` dynamic namespace. Add new
+  tools there through the agent-tool catalog so both dynamic-tool and MCP
+  dispatch expose the same contract.
+- Deprecated namespaces are compatibility-only for threads that already have
+  their definitions persisted. They are never advertised to new threads and
+  cannot discover additive tool changes.
+- Keep the deprecated `pwragent_task_monitors` namespace frozen at its historical
+  operations: `create_monitor_delegation`, `inject_progress`, and
+  `complete_monitoring`. Do not add new operations or schemas to it; retain only
+  the dispatch needed for those existing threads.

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -3,7 +3,7 @@ import { resolveAgentToolCatalogs } from "../agent-tool-catalog-registry";
 import { buildPwrAgentTaskMonitorToolRouter } from "../pwragent-task-monitor-agent-tools";
 
 describe("PwrAgent task monitor agent tools", () => {
-  it("includes create_monitor_delegation in both parent transports", () => {
+  it("includes monitor creation and cancellation in both parent transports", () => {
     const catalogs = resolveAgentToolCatalogs({});
     const dynamicTools = catalogs
       .flatMap((catalog) => catalog.dynamicTools)
@@ -30,12 +30,14 @@ describe("PwrAgent task monitor agent tools", () => {
       "render_messaging_pdf_pages",
       "search_messaging_pdf_text",
     ]);
-    expect(dynamicTools).toHaveLength(25);
+    expect(dynamicTools).toHaveLength(26);
     expect(mcpTools).toEqual(
       dynamicTools.filter((tool) => !dynamicOnlyToolNames.has(tool.name)),
     );
     expect(mcpTools.map((tool) => tool.name))
       .toContain("create_monitor_delegation");
+    expect(mcpTools.map((tool) => tool.name))
+      .toContain("cancel_monitor_delegation");
     expect(mcpTools.map((tool) => tool.name))
       .toContain("start_review");
     expect(mcpTools.map((tool) => tool.name))
@@ -62,6 +64,15 @@ describe("PwrAgent task monitor agent tools", () => {
           ),
         },
       },
+    });
+    const cancelMonitorTool = mcpTools.find(
+      (tool) => tool.name === "cancel_monitor_delegation",
+    );
+    expect(cancelMonitorTool?.description).toContain(
+      "Use this instead of send_message_to_thread",
+    );
+    expect(cancelMonitorTool?.inputSchema).toMatchObject({
+      required: ["monitorId"],
     });
   });
 
@@ -155,6 +166,80 @@ describe("PwrAgent task monitor agent tools", () => {
         preferredModel: undefined,
         preferredReasoningEffort: undefined,
         finalHandoffPrompt: undefined,
+      },
+    });
+  });
+
+  it("dispatches dynamic and MCP monitor cancellation with matching context", async () => {
+    const handler = vi.fn(async () => ({
+      ok: true as const,
+      operation: "cancel_monitor_delegation" as const,
+      data: {
+        monitorId: "monitor-1",
+        parentThreadId: "thread-1",
+        injected: true as const,
+        outcome: "cancelled" as const,
+        completionSource: { type: "parent_cancel" as const },
+      },
+    }));
+    const router = buildPwrAgentTaskMonitorToolRouter(handler);
+
+    const dynamicResponse = await router.handleDynamicToolCall({
+      backend: "codex",
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "dynamic-call-1",
+        namespace: "pwragent",
+        tool: "cancel_monitor_delegation",
+        arguments: {
+          monitorId: "monitor-1",
+          reason: "Wrong runner was selected.",
+        },
+      },
+    });
+    const mcpResponse = await router.handleMcpToolCall({
+      backend: "codex",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      tool: "cancel_monitor_delegation",
+      args: {
+        monitorId: "monitor-1",
+        reason: "Wrong runner was selected.",
+      },
+    });
+
+    expect(dynamicResponse).toMatchObject({ success: true });
+    expect(mcpResponse).toMatchObject({
+      structuredContent: {
+        monitorId: "monitor-1",
+        outcome: "cancelled",
+      },
+    });
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, {
+      operation: "cancel_monitor_delegation",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        monitorId: "monitor-1",
+        reason: "Wrong runner was selected.",
+      },
+    });
+    expect(handler).toHaveBeenNthCalledWith(2, {
+      operation: "cancel_monitor_delegation",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        monitorId: "monitor-1",
+        reason: "Wrong runner was selected.",
       },
     });
   });

--- a/apps/desktop/src/main/agent-tools/pwragent-task-monitor-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-task-monitor-agent-tools.ts
@@ -1,4 +1,5 @@
 import type {
+  CancelMonitorDelegationToolArgs,
   CreateMonitorDelegationToolArgs,
   TaskMonitorRequest,
   TaskMonitorResponse,
@@ -40,15 +41,32 @@ export const TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA = {
   additionalProperties: false,
 } satisfies Record<string, unknown>;
 
+export const TASK_MONITOR_CANCEL_TOOL_DESCRIPTION =
+  "Cancel an active PwrAgent-managed monitor delegation immediately. Use the monitorId returned by create_monitor_delegation. This interrupts the monitor's active turn, records a cancelled result in the parent thread, and does not start or queue another parent turn. Use this instead of send_message_to_thread when a running monitor must stop.";
+
+export const TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    monitorId: { type: "string" },
+    reason: { type: "string" },
+  },
+  required: ["monitorId"],
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+type ParentTaskMonitorOperation =
+  | "create_monitor_delegation"
+  | "cancel_monitor_delegation";
+
 export type PwrAgentTaskMonitorHandler = (
-  request: TaskMonitorRequest<"create_monitor_delegation">,
+  request: TaskMonitorRequest,
 ) =>
-  | TaskMonitorResponse<"create_monitor_delegation">
-  | Promise<TaskMonitorResponse<"create_monitor_delegation">>;
+  | TaskMonitorResponse
+  | Promise<TaskMonitorResponse>;
 
 export function buildPwrAgentTaskMonitorToolDefinitions(
   handler: PwrAgentTaskMonitorHandler | undefined,
-): AgentToolDefinition<"create_monitor_delegation">[] {
+): AgentToolDefinition<ParentTaskMonitorOperation>[] {
   return [
     {
       namespace: PWRAGENT_TOOL_NAMESPACE,
@@ -72,6 +90,38 @@ export function buildPwrAgentTaskMonitorToolDefinitions(
         }
         const response = await handler({
           operation: "create_monitor_delegation",
+          context: {
+            backend: context.backend,
+            threadId: context.threadId,
+            turnId: context.turnId ?? "",
+          },
+          args: normalizedArgs,
+        });
+        return taskMonitorResponseToAgentToolResult(response);
+      },
+    },
+    {
+      namespace: PWRAGENT_TOOL_NAMESPACE,
+      name: "cancel_monitor_delegation",
+      description: TASK_MONITOR_CANCEL_TOOL_DESCRIPTION,
+      inputSchema: TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA,
+      deferLoading: false,
+      dispatch: async (args, context): Promise<AgentToolDispatchResult> => {
+        if (!handler) {
+          return agentToolFailure({
+            code: "internal_error",
+            message: "PwrAgent task monitor tools are not available.",
+          });
+        }
+        const normalizedArgs = normalizeCancelMonitorArgs(args);
+        if (!normalizedArgs) {
+          return agentToolFailure({
+            code: "invalid_arguments",
+            message: "cancel_monitor_delegation requires a non-empty monitorId string.",
+          });
+        }
+        const response = await handler({
+          operation: "cancel_monitor_delegation",
           context: {
             backend: context.backend,
             threadId: context.threadId,
@@ -114,8 +164,21 @@ function normalizeCreateMonitorArgs(
   };
 }
 
+function normalizeCancelMonitorArgs(
+  args: Record<string, unknown>,
+): CancelMonitorDelegationToolArgs | undefined {
+  const monitorId = readString(args.monitorId);
+  if (!monitorId) {
+    return undefined;
+  }
+  return {
+    monitorId,
+    reason: readString(args.reason),
+  };
+}
+
 function taskMonitorResponseToAgentToolResult(
-  response: TaskMonitorResponse<"create_monitor_delegation">,
+  response: TaskMonitorResponse,
 ): AgentToolDispatchResult {
   if (response.ok) {
     return agentToolSuccess(response.data);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -223,6 +223,7 @@ import {
   DEFAULT_TASK_MONITOR_STARTUP_TIMEOUT_SECONDS,
   DEFAULT_PR_AUTO_DISPATCH_ENABLED_FOR_NEW_THREADS,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
+  type CancelMonitorDelegationToolArgs,
   type CompleteMonitoringToolArgs,
   type CreateMonitorDelegationToolArgs,
   type InjectMonitorProgressToolArgs,
@@ -2362,6 +2363,7 @@ type TaskMonitorDelegationRecord = {
   pollIntervalSeconds: number;
   preferredModel: string;
   preferredReasoningEffort: string;
+  cancellationRequested?: boolean;
   recoveryAttempted?: boolean;
   staleInterruptAttempted?: boolean;
   startupTimeoutSeconds: number;
@@ -3018,7 +3020,9 @@ function formatTaskMonitorCompletionMessage(params: {
     `Outcome: ${params.outcome}`,
     params.completionSource?.type === "pwragent_fallback"
       ? "Completion source: PwrAgent fallback"
-      : undefined,
+      : params.completionSource?.type === "parent_cancel"
+        ? "Completion source: Parent cancellation"
+        : undefined,
     params.summary,
     params.details?.trim() ? `Details:\n${params.details.trim()}` : undefined,
   ]
@@ -3041,7 +3045,9 @@ function buildTaskMonitorFinalHandoffInput(params: {
     `Outcome: ${params.outcome}`,
     params.completionSource?.type === "pwragent_fallback"
       ? "Completion source: pwragent_fallback"
-      : undefined,
+      : params.completionSource?.type === "parent_cancel"
+        ? "Completion source: parent_cancel"
+        : undefined,
     `Summary: ${params.summary}`,
     params.details?.trim() ? `Details:\n${params.details.trim()}` : undefined,
     params.finalHandoffPrompt?.trim()
@@ -6423,7 +6429,7 @@ export class DesktopBackendRegistry {
                 automationInspectionHandler: this.automationInspectionHandler,
                 messagingHandler: this.messagingHandler,
                 taskMonitorHandler: async (request) =>
-                  await this.handleCreateMonitorAgentRequest(request),
+                  await this.handleAgentTaskMonitorRequest(request),
                 threadInspectionHandler: this.threadInspectionHandler,
                 threadOrchestrationHandler: this.threadOrchestrationHandler,
               }),
@@ -9388,7 +9394,7 @@ export class DesktopBackendRegistry {
       automationInspectionHandler: this.automationInspectionHandler,
       messagingHandler: this.messagingHandler,
       taskMonitorHandler: async (request) =>
-        await this.handleCreateMonitorAgentRequest(request),
+        await this.handleAgentTaskMonitorRequest(request),
       threadInspectionHandler: this.threadInspectionHandler,
       threadOrchestrationHandler: this.threadOrchestrationHandler,
     });
@@ -21789,6 +21795,12 @@ export class DesktopBackendRegistry {
         request.args as CreateMonitorDelegationToolArgs,
       );
     }
+    if (request.operation === "cancel_monitor_delegation") {
+      return await this.cancelTaskMonitorDelegation(
+        request.context,
+        request.args as CancelMonitorDelegationToolArgs,
+      );
+    }
     if (request.operation === "inject_progress") {
       return await this.injectTaskMonitorProgress(
         request.context.threadId,
@@ -21806,6 +21818,9 @@ export class DesktopBackendRegistry {
   ): Promise<TaskMonitorResponse> {
     if (request.operation === "create_monitor_delegation") {
       return await this.handleCreateMonitorAgentRequest(request);
+    }
+    if (request.operation === "cancel_monitor_delegation") {
+      return await this.handleCancelMonitorAgentRequest(request);
     }
     return await this.handleTaskMonitorRequest(request);
   }
@@ -21832,6 +21847,33 @@ export class DesktopBackendRegistry {
       );
     }
     return await this.createTaskMonitorDelegation(
+      request.context,
+      request.args,
+    );
+  }
+
+  private async handleCancelMonitorAgentRequest(
+    request: TaskMonitorRequest<"cancel_monitor_delegation">,
+  ): Promise<TaskMonitorResponse<"cancel_monitor_delegation">> {
+    if (
+      !this.isLiveDynamicToolCall(request.context.backend, {
+        threadId: request.context.threadId,
+        turnId: request.context.turnId,
+      })
+    ) {
+      backendRegistryLog.warn("rejecting task monitor cancellation tool call", {
+        backend: request.context.backend,
+        threadId: request.context.threadId,
+        tool: request.operation,
+        turnId: request.context.turnId,
+      });
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "forbidden",
+        "Task monitor cancellation must originate from an active parent turn.",
+      );
+    }
+    return await this.cancelTaskMonitorDelegation(
       request.context,
       request.args,
     );
@@ -21992,6 +22034,123 @@ export class DesktopBackendRegistry {
         monitorTurnId: startedMonitor.turnId,
         parentAgentGuidance,
         prompt,
+      },
+    };
+  }
+
+  private async cancelTaskMonitorDelegation(
+    context: TaskMonitorRequest<"cancel_monitor_delegation">["context"],
+    args: CancelMonitorDelegationToolArgs,
+  ): Promise<TaskMonitorResponse<"cancel_monitor_delegation">> {
+    const monitorId = args.monitorId?.trim();
+    if (!monitorId) {
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "invalid_arguments",
+        "monitorId is required.",
+      );
+    }
+
+    const record = this.taskMonitorDelegations.get(monitorId);
+    if (!record) {
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: context.backend,
+        threadId: context.threadId,
+      });
+      const completedCancellation = overlay?.subAgents?.find(
+        (subAgent) =>
+          subAgent.monitorId === monitorId
+          && subAgent.outcome === "cancelled"
+          && subAgent.completionSource?.type === "parent_cancel",
+      );
+      if (completedCancellation) {
+        return {
+          ok: true,
+          operation: "cancel_monitor_delegation",
+          data: {
+            monitorId,
+            parentThreadId: context.threadId,
+            injected: true,
+            outcome: "cancelled",
+            completionSource: { type: "parent_cancel" },
+            ...(completedCancellation.monitorUsage
+              ? { monitorUsage: completedCancellation.monitorUsage }
+              : {}),
+          },
+        };
+      }
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "not_found",
+        "Unknown, completed, or non-cancellable monitorId.",
+      );
+    }
+    if (
+      record.parentBackend !== context.backend
+      || record.parentThreadId !== context.threadId
+    ) {
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "forbidden",
+        "Only the parent thread that created a monitor may cancel it.",
+      );
+    }
+    if (!record.monitorThreadId || !record.monitorTurnId) {
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "internal_error",
+        "The monitor turn has not started and cannot be interrupted yet.",
+      );
+    }
+
+    record.cancellationRequested = true;
+    record.lastActivityAt = Date.now();
+    const executionMode = record.executionMode ?? "default";
+    try {
+      await this.getClient("codex", executionMode).interruptTurn({
+        threadId: record.monitorThreadId,
+        turnId: record.monitorTurnId,
+      });
+    } catch (error) {
+      record.cancellationRequested = false;
+      backendRegistryLog.error("failed to cancel task monitor", {
+        error: error instanceof Error ? error.message : String(error),
+        monitorId,
+        monitorThreadId: record.monitorThreadId,
+        monitorTurnId: record.monitorTurnId,
+        parentThreadId: record.parentThreadId,
+      });
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "internal_error",
+        `Failed to interrupt task monitor: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const summary =
+      args.reason?.trim()
+      || "Monitoring cancelled by the parent agent.";
+    const completionSource: TaskMonitorCompletionSource = {
+      type: "parent_cancel",
+    };
+    await this.finishTaskMonitorDelegation({
+      completionSource,
+      outcome: "cancelled",
+      record,
+      summary,
+      triggerParentTurn: false,
+    });
+
+    return {
+      ok: true,
+      operation: "cancel_monitor_delegation",
+      data: {
+        monitorId,
+        parentThreadId: record.parentThreadId,
+        injected: true,
+        outcome: "cancelled",
+        completionSource,
+        ...(record.latestUsage ? { monitorUsage: record.latestUsage } : {}),
       },
     };
   }
@@ -22373,6 +22532,10 @@ export class DesktopBackendRegistry {
         (!candidate.monitorTurnId || !turnId || candidate.monitorTurnId === turnId),
     );
     if (!record) {
+      return;
+    }
+
+    if (record.cancellationRequested) {
       return;
     }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -2345,6 +2345,16 @@ function readNotificationItemType(notification: AppServerNotification): string |
 const TASK_MONITOR_STALE_CHECK_INTERVAL_MS = 15_000;
 const TASK_MONITOR_STALE_GRACE_MS = 15_000;
 
+type TaskMonitorCancellationState = {
+  finalizing: boolean;
+  promise: Promise<TaskMonitorResponse<"cancel_monitor_delegation">>;
+  requestPersisted: Promise<void>;
+  resolve: (
+    response: TaskMonitorResponse<"cancel_monitor_delegation">,
+  ) => void;
+  summary: string;
+};
+
 type TaskMonitorDelegationRecord = {
   activeCommandCount: number;
   backend: "codex";
@@ -2363,7 +2373,8 @@ type TaskMonitorDelegationRecord = {
   pollIntervalSeconds: number;
   preferredModel: string;
   preferredReasoningEffort: string;
-  cancellationRequested?: boolean;
+  cancellation?: TaskMonitorCancellationState;
+  finalizationStarted?: boolean;
   recoveryAttempted?: boolean;
   staleInterruptAttempted?: boolean;
   startupTimeoutSeconds: number;
@@ -22095,6 +22106,16 @@ export class DesktopBackendRegistry {
         "Only the parent thread that created a monitor may cancel it.",
       );
     }
+    if (record.cancellation) {
+      return await record.cancellation.promise;
+    }
+    if (record.finalizationStarted) {
+      return taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "not_found",
+        "The monitor is already completing and can no longer be cancelled.",
+      );
+    }
     if (!record.monitorThreadId || !record.monitorTurnId) {
       return taskMonitorFailure(
         "cancel_monitor_delegation",
@@ -22103,16 +22124,52 @@ export class DesktopBackendRegistry {
       );
     }
 
-    record.cancellationRequested = true;
+    const summary =
+      args.reason?.trim()
+      || "Monitoring cancelled by the parent agent.";
+    let resolveCancellation!: TaskMonitorCancellationState["resolve"];
+    const cancellationPromise = new Promise<
+      TaskMonitorResponse<"cancel_monitor_delegation">
+    >((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const cancellation: TaskMonitorCancellationState = {
+      finalizing: false,
+      promise: cancellationPromise,
+      requestPersisted: Promise.resolve(),
+      resolve: resolveCancellation,
+      summary,
+    };
+    // Own cancellation before the first await so overlapping tool calls share
+    // one interrupt and one terminal completion.
+    record.cancellation = cancellation;
     record.lastActivityAt = Date.now();
     const executionMode = record.executionMode ?? "default";
+    cancellation.requestPersisted = this.persistTaskMonitorSubAgent(record, {
+      lastMessage: "Cancellation requested; waiting for the monitor turn to stop.",
+      status: "cancelling",
+    });
     try {
+      await cancellation.requestPersisted;
+      if (
+        cancellation.finalizing
+        || this.taskMonitorDelegations.get(monitorId) !== record
+      ) {
+        return await cancellation.promise;
+      }
       await this.getClient("codex", executionMode).interruptTurn({
         threadId: record.monitorThreadId,
         turnId: record.monitorTurnId,
       });
     } catch (error) {
-      record.cancellationRequested = false;
+      if (
+        record.cancellation !== cancellation
+        || cancellation.finalizing
+        || !this.taskMonitorDelegations.has(monitorId)
+      ) {
+        return await cancellation.promise;
+      }
+      record.cancellation = undefined;
       backendRegistryLog.error("failed to cancel task monitor", {
         error: error instanceof Error ? error.message : String(error),
         monitorId,
@@ -22120,39 +22177,75 @@ export class DesktopBackendRegistry {
         monitorTurnId: record.monitorTurnId,
         parentThreadId: record.parentThreadId,
       });
-      return taskMonitorFailure(
+      const failure = taskMonitorFailure(
         "cancel_monitor_delegation",
         "internal_error",
         `Failed to interrupt task monitor: ${error instanceof Error ? error.message : String(error)}`,
       );
+      cancellation.resolve(failure);
+      await this.persistTaskMonitorSubAgent(record, {
+        lastMessage: "Cancellation could not be requested; the monitor is still running.",
+        status: "running",
+      });
+      return failure;
     }
 
-    const summary =
-      args.reason?.trim()
-      || "Monitoring cancelled by the parent agent.";
+    return await cancellation.promise;
+  }
+
+  private async finalizeTaskMonitorCancellation(
+    record: TaskMonitorDelegationRecord,
+    terminalStatus: "completed" | "failed" | "cancelled",
+  ): Promise<void> {
+    const cancellation = record.cancellation;
+    if (!cancellation || cancellation.finalizing) {
+      return;
+    }
+    cancellation.finalizing = true;
     const completionSource: TaskMonitorCompletionSource = {
       type: "parent_cancel",
     };
-    await this.finishTaskMonitorDelegation({
-      completionSource,
-      outcome: "cancelled",
-      record,
-      summary,
-      triggerParentTurn: false,
-    });
-
-    return {
-      ok: true,
-      operation: "cancel_monitor_delegation",
-      data: {
-        monitorId,
-        parentThreadId: record.parentThreadId,
-        injected: true,
-        outcome: "cancelled",
+    try {
+      await cancellation.requestPersisted;
+      await this.finishTaskMonitorDelegation({
         completionSource,
-        ...(record.latestUsage ? { monitorUsage: record.latestUsage } : {}),
-      },
-    };
+        details: `Monitor turn reached terminal status: ${terminalStatus}.`,
+        outcome: "cancelled",
+        record,
+        summary: cancellation.summary,
+        triggerParentTurn: false,
+      });
+      cancellation.resolve({
+        ok: true,
+        operation: "cancel_monitor_delegation",
+        data: {
+          monitorId: record.monitorId,
+          parentThreadId: record.parentThreadId,
+          injected: true,
+          outcome: "cancelled",
+          completionSource,
+          ...(record.latestUsage ? { monitorUsage: record.latestUsage } : {}),
+        },
+      });
+    } catch (error) {
+      cancellation.finalizing = false;
+      if (this.taskMonitorDelegations.get(record.monitorId) === record) {
+        record.cancellation = undefined;
+      }
+      backendRegistryLog.error("failed to finalize task monitor cancellation", {
+        error: error instanceof Error ? error.message : String(error),
+        monitorId: record.monitorId,
+        monitorThreadId: record.monitorThreadId,
+        monitorTurnId: record.monitorTurnId,
+        parentThreadId: record.parentThreadId,
+        terminalStatus,
+      });
+      cancellation.resolve(taskMonitorFailure(
+        "cancel_monitor_delegation",
+        "internal_error",
+        `Monitor stopped, but cancellation could not be recorded: ${error instanceof Error ? error.message : String(error)}`,
+      ));
+    }
   }
 
   private async resolveTaskMonitorModelSettings(params: {
@@ -22373,20 +22466,48 @@ export class DesktopBackendRegistry {
     if (!bound.ok) {
       return taskMonitorFailure("complete_monitoring", bound.code, bound.message);
     }
+    if (bound.record.cancellation) {
+      return taskMonitorFailure(
+        "complete_monitoring",
+        "forbidden",
+        "The parent has requested cancellation; wait for the monitor turn to stop.",
+      );
+    }
+    if (bound.record.finalizationStarted) {
+      return taskMonitorFailure(
+        "complete_monitoring",
+        "forbidden",
+        "Monitor completion is already in progress.",
+      );
+    }
     const summary = args.summary?.trim();
     if (!summary) {
       return taskMonitorFailure("complete_monitoring", "invalid_arguments", "summary is required.");
     }
 
     bound.record.lastActivityAt = Date.now();
-    const parentTurn = await this.finishTaskMonitorDelegation({
-      completionSource: { type: "monitor_tool" },
-      details: args.details,
-      outcome: args.outcome,
-      record: bound.record,
-      summary,
-      triggerParentTurn: args.triggerParentTurn !== false,
-    });
+    bound.record.finalizationStarted = true;
+    let parentTurn:
+      | {
+          status: "started" | "queued";
+          turnId?: string;
+          queueEntryId?: string;
+          position?: number;
+        }
+      | undefined;
+    try {
+      parentTurn = await this.finishTaskMonitorDelegation({
+        completionSource: { type: "monitor_tool" },
+        details: args.details,
+        outcome: args.outcome,
+        record: bound.record,
+        summary,
+        triggerParentTurn: args.triggerParentTurn !== false,
+      });
+    } catch (error) {
+      bound.record.finalizationStarted = false;
+      throw error;
+    }
 
     return {
       ok: true,
@@ -22535,7 +22656,11 @@ export class DesktopBackendRegistry {
       return;
     }
 
-    if (record.cancellationRequested) {
+    if (record.cancellation) {
+      if (!turnId || !record.monitorTurnId || turnId !== record.monitorTurnId) {
+        return;
+      }
+      await this.finalizeTaskMonitorCancellation(record, terminalStatus);
       return;
     }
 
@@ -22557,6 +22682,9 @@ export class DesktopBackendRegistry {
   private async checkStaleTaskMonitors(now = Date.now()): Promise<void> {
     for (const record of Array.from(this.taskMonitorDelegations.values())) {
       if (!record.monitorThreadId || !record.monitorTurnId) {
+        continue;
+      }
+      if (record.cancellation) {
         continue;
       }
       if (record.activeCommandCount > 0) {

--- a/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
+++ b/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
@@ -1,5 +1,6 @@
 import type {
   AppServerBackendKind,
+  CancelMonitorDelegationToolArgs,
   CompleteMonitoringToolArgs,
   CreateMonitorDelegationToolArgs,
   InjectMonitorProgressToolArgs,
@@ -24,6 +25,8 @@ import type {
   DynamicToolSpec,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
+  TASK_MONITOR_CANCEL_TOOL_DESCRIPTION,
+  TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA,
   TASK_MONITOR_CREATE_TOOL_DESCRIPTION,
   TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA,
 } from "../agent-tools/pwragent-task-monitor-agent-tools.js";
@@ -40,6 +43,13 @@ export function buildTaskMonitorDynamicToolSpecs(
     name: "create_monitor_delegation",
     description: TASK_MONITOR_CREATE_TOOL_DESCRIPTION,
     inputSchema: TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA,
+    deferLoading: false,
+  };
+  const cancelTool: DynamicToolNamespaceTool = {
+    type: "function",
+    name: "cancel_monitor_delegation",
+    description: TASK_MONITOR_CANCEL_TOOL_DESCRIPTION,
+    inputSchema: TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA,
     deferLoading: false,
   };
   const monitorTools: DynamicToolNamespaceTool[] = [
@@ -88,10 +98,10 @@ export function buildTaskMonitorDynamicToolSpecs(
   ];
   const tools =
     role === "parent"
-      ? [createTool]
+      ? [createTool, cancelTool]
       : role === "monitor"
         ? monitorTools
-        : [createTool, ...monitorTools];
+        : [createTool, cancelTool, ...monitorTools];
   return [
     {
       type: "namespace",
@@ -366,6 +376,12 @@ function normalizeTaskMonitorToolArguments(
       preferredReasoningEffort: readString(args.preferredReasoningEffort),
       finalHandoffPrompt: readString(args.finalHandoffPrompt),
     } satisfies CreateMonitorDelegationToolArgs;
+  }
+  if (operation === "cancel_monitor_delegation") {
+    return {
+      monitorId: readString(args.monitorId) ?? "",
+      reason: readString(args.reason),
+    } satisfies CancelMonitorDelegationToolArgs;
   }
   if (operation === "inject_progress") {
     return {

--- a/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
+++ b/apps/desktop/src/main/app-server/task-monitor-codex-tools.ts
@@ -25,8 +25,6 @@ import type {
   DynamicToolSpec,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import {
-  TASK_MONITOR_CANCEL_TOOL_DESCRIPTION,
-  TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA,
   TASK_MONITOR_CREATE_TOOL_DESCRIPTION,
   TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA,
 } from "../agent-tools/pwragent-task-monitor-agent-tools.js";
@@ -34,6 +32,15 @@ import {
 export type TaskMonitorHandler = (
   request: TaskMonitorRequest,
 ) => TaskMonitorResponse | Promise<TaskMonitorResponse>;
+
+const LEGACY_TASK_MONITOR_OPERATION_NAMES = [
+  "create_monitor_delegation",
+  "inject_progress",
+  "complete_monitoring",
+] as const satisfies readonly TaskMonitorOperationName[];
+
+type LegacyTaskMonitorOperationName =
+  (typeof LEGACY_TASK_MONITOR_OPERATION_NAMES)[number];
 
 export function buildTaskMonitorDynamicToolSpecs(
   role: "parent" | "monitor" | "all" = "all",
@@ -43,13 +50,6 @@ export function buildTaskMonitorDynamicToolSpecs(
     name: "create_monitor_delegation",
     description: TASK_MONITOR_CREATE_TOOL_DESCRIPTION,
     inputSchema: TASK_MONITOR_CREATE_TOOL_INPUT_SCHEMA,
-    deferLoading: false,
-  };
-  const cancelTool: DynamicToolNamespaceTool = {
-    type: "function",
-    name: "cancel_monitor_delegation",
-    description: TASK_MONITOR_CANCEL_TOOL_DESCRIPTION,
-    inputSchema: TASK_MONITOR_CANCEL_TOOL_INPUT_SCHEMA,
     deferLoading: false,
   };
   const monitorTools: DynamicToolNamespaceTool[] = [
@@ -98,10 +98,10 @@ export function buildTaskMonitorDynamicToolSpecs(
   ];
   const tools =
     role === "parent"
-      ? [createTool, cancelTool]
+      ? [createTool]
       : role === "monitor"
         ? monitorTools
-        : [createTool, cancelTool, ...monitorTools];
+        : [createTool, ...monitorTools];
   return [
     {
       type: "namespace",
@@ -173,6 +173,15 @@ export async function handleTaskMonitorDynamicToolCall(params: {
       message: "Unsupported PwrAgent task monitor tool.",
     });
   }
+  if (
+    params.call.namespace === TASK_MONITOR_TOOL_NAMESPACE
+    && !isLegacyTaskMonitorOperationName(params.call.tool)
+  ) {
+    return buildTaskMonitorDynamicToolErrorResponse({
+      code: "unsupported_operation",
+      message: "Unsupported legacy PwrAgent task monitor tool.",
+    });
+  }
 
   const context: TaskMonitorContext = {
     backend: params.backend,
@@ -188,6 +197,14 @@ export async function handleTaskMonitorDynamicToolCall(params: {
     ),
   } as TaskMonitorRequest);
   return toDynamicToolResponse(response);
+}
+
+function isLegacyTaskMonitorOperationName(
+  value: string,
+): value is LegacyTaskMonitorOperationName {
+  return (
+    LEGACY_TASK_MONITOR_OPERATION_NAMES as readonly string[]
+  ).includes(value);
 }
 
 export function buildTaskMonitorDynamicToolErrorResponse(params: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-format.ts
@@ -23,6 +23,8 @@ export function subAgentTone(status: ThreadSubAgentStatus): RailChipTone {
   switch (status) {
     case "running":
       return "active";
+    case "cancelling":
+      return "warning";
     case "success":
       return "ok";
     case "blocked":
@@ -43,6 +45,8 @@ export function subAgentStatusLabel(status: ThreadSubAgentStatus): string {
       return "Pending";
     case "running":
       return "Running";
+    case "cancelling":
+      return "Cancelling";
     case "blocked":
       return "Blocked";
     case "failed":

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -168,6 +168,7 @@ export type NavigationThreadSummary = AppServerThreadSummary & {
 export type ThreadSubAgentStatus =
   | "pending"
   | "running"
+  | "cancelling"
   | "blocked"
   | "failed"
   | "success"

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -1,6 +1,9 @@
 import type { AppServerBackendKind, ThreadIdentifier } from "./normalized-app-server";
 
-/** @deprecated Use PWRAGENT_TOOL_NAMESPACE for advertised dynamic tools. */
+/**
+ * @deprecated Frozen compatibility namespace for persisted thread definitions.
+ * Use PWRAGENT_TOOL_NAMESPACE for all newly advertised dynamic tools.
+ */
 export const TASK_MONITOR_TOOL_NAMESPACE = "pwragent_task_monitors";
 
 export const DEFAULT_TASK_MONITOR_MODEL = "gpt-5.6-luna";

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -12,6 +12,7 @@ export const DEFAULT_TASK_MONITOR_HEARTBEAT_INTERVAL_SECONDS =
 
 export const TASK_MONITOR_OPERATION_NAMES = [
   "create_monitor_delegation",
+  "cancel_monitor_delegation",
   "inject_progress",
   "complete_monitoring",
 ] as const;
@@ -33,6 +34,11 @@ export type CreateMonitorDelegationToolArgs = {
   preferredModel?: string;
   preferredReasoningEffort?: string;
   finalHandoffPrompt?: string;
+};
+
+export type CancelMonitorDelegationToolArgs = {
+  monitorId: string;
+  reason?: string;
 };
 
 export type InjectMonitorProgressToolArgs = {
@@ -73,6 +79,9 @@ export type TaskMonitorCompletionSource =
       type: "monitor_tool";
     }
   | {
+      type: "parent_cancel";
+    }
+  | {
       type: "pwragent_fallback";
       reason: string;
       recoveryAttempted: boolean;
@@ -81,6 +90,7 @@ export type TaskMonitorCompletionSource =
 
 export type TaskMonitorToolArgsByOperation = {
   create_monitor_delegation: CreateMonitorDelegationToolArgs;
+  cancel_monitor_delegation: CancelMonitorDelegationToolArgs;
   inject_progress: InjectMonitorProgressToolArgs;
   complete_monitoring: CompleteMonitoringToolArgs;
 };
@@ -134,6 +144,7 @@ export type TaskMonitorCompletionData = TaskMonitorProgressData & {
 
 export type TaskMonitorToolDataByOperation = {
   create_monitor_delegation: TaskMonitorDelegationData;
+  cancel_monitor_delegation: TaskMonitorCompletionData;
   inject_progress: TaskMonitorProgressData;
   complete_monitoring: TaskMonitorCompletionData;
 };


### PR DESCRIPTION
## Summary

- expose `cancel_monitor_delegation` to parent agents through the unified `pwragent` catalog, shared by dynamic-tool and MCP dispatch
- interrupt the exact ephemeral monitor turn and persist a `parent_cancel` completion without waking or queueing another parent turn
- restrict cancellation to the creating parent thread and make repeated cancellation requests idempotent
- keep the deprecated `pwragent_task_monitors` namespace frozen for already-persisted threads; it does not advertise or accept cancellation

## Root cause

`send_message_to_thread` starts a new turn, so an agent trying to send an abort prompt to an active monitor received `turn_start_failed`. PwrAgent already had an internal watchdog-only monitor interrupt path, but no parent-callable cancellation primitive.

Dynamic tool definitions are persisted at thread creation and are not refreshed on later turns. New threads receive the unified `pwragent` namespace, while the deprecated task-monitor namespace exists only to serve its historical operations on older threads.

## Validation

- `pnpm test apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`