### PR TITLE
feat(desktop): stop running sub-agents

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -4,6 +4,7 @@ import type {
   InterruptTurnRequest,
   ListBackendsRequest,
   MaterializeDirectoryLaunchpadRequest,
+  StopSubAgentRequest,
   StartReviewRequest,
   StartThreadRequest,
   StartTurnRequest,
@@ -56,6 +57,12 @@ const registry = {
     backend: request.backend,
     threadId: request.threadId,
     turnId: request.turnId,
+  })),
+  stopSubAgent: vi.fn(async (request: StopSubAgentRequest) => ({
+    backend: request.backend,
+    threadId: request.threadId,
+    monitorId: request.monitorId,
+    stoppedAt: 1,
   })),
   steerTurn: vi.fn(async (request: SteerTurnRequest) => ({
     backend: request.backend,
@@ -121,6 +128,7 @@ describe("agent ipc", () => {
     registry.submitTurn.mockClear();
     registry.startReview.mockClear();
     registry.interruptTurn.mockClear();
+    registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
     registry.materializeDirectoryLaunchpad.mockClear();
     registryListener = undefined;
@@ -138,6 +146,7 @@ describe("agent ipc", () => {
       AGENT_START_THREAD_CHANNEL,
       AGENT_START_REVIEW_CHANNEL,
       AGENT_START_TURN_CHANNEL,
+      AGENT_STOP_SUB_AGENT_CHANNEL,
       AGENT_STEER_TURN_CHANNEL,
       BACKEND_LIST_CHANNEL,
     } = await import("../../shared/ipc");
@@ -189,6 +198,18 @@ describe("agent ipc", () => {
       backend: "grok",
       threadId: "thread-1",
       turnId: "turn-1",
+    });
+    expect(
+      await handlers.get(AGENT_STOP_SUB_AGENT_CHANNEL)?.({}, {
+        backend: "codex",
+        threadId: "thread-1",
+        monitorId: "monitor-1",
+      }),
+    ).toEqual({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "monitor-1",
+      stoppedAt: 1,
     });
     expect(
       await handlers.get(AGENT_STEER_TURN_CHANNEL)?.({}, {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28684,6 +28684,176 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("stops active task monitors without starting recovery", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/interrupt"] },
+      models: TEST_TASK_MONITOR_MODELS,
+      startThreadResult: { threadId: "monitor-thread" },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+    const delegationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_task_monitors",
+        tool: "create_monitor_delegation",
+        arguments: {
+          task: "Watch an asynchronous task until it finishes.",
+          pollIntervalSeconds: 20,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const monitorId = JSON.parse(
+      (delegationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ).monitorId as string;
+
+    await expect(registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    })).resolves.toMatchObject({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    });
+
+    expect(codexClient.lastInterruptTurnParams).toMatchObject({
+      threadId: "monitor-thread",
+      turnId: "turn-1",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId,
+          status: "cancelled",
+          outcome: "cancelled",
+          lastMessage: "Stopped by user.",
+        }),
+      ],
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "cancelled", output: [] },
+        },
+      },
+    });
+
+    expect(codexClient.startTurnCallCount).toBe(1);
+    expect(codexClient.injectedThreadItems).toHaveLength(0);
+    await registry.close();
+  });
+
+  it("stops native Codex sub-agents using the child's active turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read", "turn/interrupt"] },
+      replay: {
+        entries: [
+          {
+            type: "activity",
+            id: "activity-1",
+            summary: "Working",
+            details: [],
+            turn: {
+              id: "child-turn",
+              status: "in_progress",
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "codex-native:child-thread",
+              task: "Investigate the issue",
+              status: "running",
+              createdAt: 1,
+              updatedAt: 1,
+              backend: "codex",
+              monitorThreadId: "child-thread",
+              monitorTurnId: "parent-turn",
+            },
+          ],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({}),
+      overlayStore,
+    });
+
+    await registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId: "codex-native:child-thread",
+    });
+
+    expect(codexClient.lastReadThreadParams).toMatchObject({
+      threadId: "child-thread",
+      includeTurns: true,
+    });
+    expect(codexClient.lastInterruptTurnParams).toMatchObject({
+      threadId: "child-thread",
+      turnId: "child-turn",
+    });
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "codex-native:child-thread",
+          status: "cancelled",
+          outcome: "cancelled",
+        }),
+      ],
+    });
+    await registry.close();
+  });
+
   it("interrupts stale active monitors before fallback completion", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -28774,6 +28774,114 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("stops a task monitor on its live recovery turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "turn/interrupt"] },
+      models: TEST_TASK_MONITOR_MODELS,
+      startThreadResult: { threadId: "monitor-thread" },
+      startTurnResults: [
+        { threadId: "monitor-thread", turnId: "monitor-turn-1" },
+        { threadId: "monitor-thread", turnId: "monitor-recovery-turn" },
+      ],
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+      }),
+      overlayStore,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "parent-turn",
+          turn: { id: "parent-turn" },
+        },
+      },
+    });
+    const delegationResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "parent-turn",
+        callId: "call-1",
+        requestId: "call-1",
+        namespace: "pwragent_task_monitors",
+        tool: "create_monitor_delegation",
+        arguments: {
+          task: "Watch an asynchronous task until it finishes.",
+          pollIntervalSeconds: 20,
+        },
+      },
+    } as AppServerPendingRequestNotification);
+    const monitorId = JSON.parse(
+      (delegationResponse as { contentItems: Array<{ text: string }> })
+        .contentItems[0]?.text ?? "{}",
+    ).monitorId as string;
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "monitor-turn-1",
+          turn: {
+            id: "monitor-turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+
+    await expect(overlayStore.getThreadOverlayState({
+      backend: "codex",
+      threadId: "thread-1",
+    })).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId,
+          monitorTurnId: "monitor-turn-1",
+          status: "running",
+        }),
+      ],
+    });
+
+    await registry.stopSubAgent({
+      backend: "codex",
+      threadId: "thread-1",
+      monitorId,
+    });
+
+    expect(codexClient.lastInterruptTurnParams).toEqual({
+      threadId: "monitor-thread",
+      turnId: "monitor-recovery-turn",
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/cancelled",
+        params: {
+          threadId: "monitor-thread",
+          turnId: "monitor-recovery-turn",
+          turn: {
+            id: "monitor-recovery-turn",
+            status: "cancelled",
+            output: [],
+          },
+        },
+      },
+    });
+
+    expect(codexClient.startTurnCallCount).toBe(2);
+    await registry.close();
+  });
+
   it("stops native Codex sub-agents using the child's active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read", "turn/interrupt"] },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -185,6 +185,8 @@ import {
   type StartReviewToolResult,
   type StartThreadRequest,
   type StartThreadResponse,
+  type StopSubAgentRequest,
+  type StopSubAgentResponse,
   type SubmitServerRequestRequest,
   type SubmitServerRequestResponse,
   type TrustCodexProjectRequest,
@@ -11448,6 +11450,125 @@ export class DesktopBackendRegistry {
       backend: params.backend,
       threadId: result.threadId,
       turnId: result.turnId,
+    };
+  }
+
+  async stopSubAgent(
+    params: StopSubAgentRequest,
+  ): Promise<StopSubAgentResponse> {
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    const subAgent = overlay?.subAgents?.find(
+      (candidate) => candidate.monitorId === params.monitorId,
+    );
+    if (!subAgent) {
+      throw new Error("Sub-agent was not found on this thread.");
+    }
+    if (subAgent.status !== "running") {
+      throw new Error("Sub-agent is no longer running.");
+    }
+    if (!subAgent.monitorThreadId || !subAgent.monitorTurnId) {
+      throw new Error("Sub-agent does not expose an active turn to stop.");
+    }
+
+    const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);
+    if (
+      taskMonitor
+      && taskMonitor.parentBackend === params.backend
+      && taskMonitor.parentThreadId === params.threadId
+    ) {
+      // A terminal notification from an interrupted monitor normally starts a
+      // recovery turn. Remove an intentionally stopped monitor first so the
+      // terminal handler cannot mistake this user action for a crash.
+      this.taskMonitorDelegations.delete(params.monitorId);
+      try {
+        await this.interruptTurn({
+          backend: taskMonitor.backend,
+          threadId: subAgent.monitorThreadId,
+          turnId: subAgent.monitorTurnId,
+        });
+      } catch (error) {
+        this.taskMonitorDelegations.set(params.monitorId, taskMonitor);
+        throw error;
+      }
+
+      const stoppedAt = Date.now();
+      await this.persistTaskMonitorSubAgent(taskMonitor, {
+        completedAt: stoppedAt,
+        lastMessage: "Stopped by user.",
+        outcome: "cancelled",
+        status: "cancelled",
+        updatedAt: stoppedAt,
+      });
+      return {
+        backend: params.backend,
+        threadId: params.threadId,
+        monitorId: params.monitorId,
+        stoppedAt,
+      };
+    }
+
+    let turnId = subAgent.monitorTurnId;
+    if (subAgent.monitorId.startsWith("codex-native:")) {
+      try {
+        const child = await this.readThread({
+          backend: "codex",
+          threadId: subAgent.monitorThreadId,
+          includeTurns: true,
+          viewOnly: true,
+        });
+        const activeEntry = [...child.replay.entries]
+          .reverse()
+          .find((entry) => entry.turn?.status === "in_progress");
+        turnId = activeEntry?.turn?.id ?? turnId;
+      } catch (error) {
+        backendRegistryLog.debug("native sub-agent active turn read failed", {
+          error: error instanceof Error ? error.message : String(error),
+          monitorId: subAgent.monitorId,
+          monitorThreadId: subAgent.monitorThreadId,
+        });
+      }
+    }
+
+    await this.interruptTurn({
+      backend: subAgent.backend ?? params.backend,
+      threadId: subAgent.monitorThreadId,
+      turnId,
+    });
+
+    const stoppedAt = Date.now();
+    await this.overlayStore.upsertThreadSubAgent({
+      backend: params.backend,
+      threadId: params.threadId,
+      subAgent: {
+        ...subAgent,
+        status: "cancelled",
+        outcome: "cancelled",
+        completedAt: stoppedAt,
+        updatedAt: stoppedAt,
+        lastMessage: "Stopped by user.",
+      },
+    });
+    if (subAgent.monitorId.startsWith("codex-native:")) {
+      this.clearCodexNativeSubAgentReconciliation(subAgent.monitorThreadId);
+    }
+    this.invalidateThreadListCache(params.backend);
+    await this.emit({
+      backend: params.backend,
+      notification: {
+        method: "thread/subAgents/updated",
+        params: {
+          threadId: params.threadId,
+        },
+      },
+    });
+    return {
+      backend: params.backend,
+      threadId: params.threadId,
+      monitorId: params.monitorId,
+      stoppedAt,
     };
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11469,25 +11469,24 @@ export class DesktopBackendRegistry {
     if (subAgent.status !== "running") {
       throw new Error("Sub-agent is no longer running.");
     }
-    if (!subAgent.monitorThreadId || !subAgent.monitorTurnId) {
-      throw new Error("Sub-agent does not expose an active turn to stop.");
-    }
-
     const taskMonitor = this.taskMonitorDelegations.get(params.monitorId);
     if (
       taskMonitor
       && taskMonitor.parentBackend === params.backend
       && taskMonitor.parentThreadId === params.threadId
     ) {
+      if (!taskMonitor.monitorThreadId || !taskMonitor.monitorTurnId) {
+        throw new Error("Sub-agent does not expose an active turn to stop.");
+      }
       // A terminal notification from an interrupted monitor normally starts a
       // recovery turn. Remove an intentionally stopped monitor first so the
       // terminal handler cannot mistake this user action for a crash.
       this.taskMonitorDelegations.delete(params.monitorId);
       try {
-        await this.interruptTurn({
-          backend: taskMonitor.backend,
-          threadId: subAgent.monitorThreadId,
-          turnId: subAgent.monitorTurnId,
+        const executionMode = taskMonitor.executionMode ?? "default";
+        await this.getClient("codex", executionMode).interruptTurn({
+          threadId: taskMonitor.monitorThreadId,
+          turnId: taskMonitor.monitorTurnId,
         });
       } catch (error) {
         this.taskMonitorDelegations.set(params.monitorId, taskMonitor);
@@ -11508,6 +11507,10 @@ export class DesktopBackendRegistry {
         monitorId: params.monitorId,
         stoppedAt,
       };
+    }
+
+    if (!subAgent.monitorThreadId || !subAgent.monitorTurnId) {
+      throw new Error("Sub-agent does not expose an active turn to stop.");
     }
 
     let turnId = subAgent.monitorTurnId;

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -17,6 +17,8 @@ import {
   type MaterializeDirectoryLaunchpadResponse,
   type InterruptTurnRequest,
   type InterruptTurnResponse,
+  type StopSubAgentRequest,
+  type StopSubAgentResponse,
   type LatestCodexConfigWarningResponse,
   type ListBackendsRequest,
   type ListBackendsResponse,
@@ -70,6 +72,7 @@ import {
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -526,6 +529,33 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);
+  ipcMain.handle(
+    AGENT_STOP_SUB_AGENT_CHANNEL,
+    async (
+      _event,
+      request: StopSubAgentRequest,
+    ): Promise<StopSubAgentResponse> => {
+      logDebug("stopSubAgent", {
+        backend: request.backend,
+        threadId: request.threadId,
+        monitorId: request.monitorId,
+      });
+
+      try {
+        return await registry.stopSubAgent(request);
+      } catch (error) {
+        appServerLog.error("stopSubAgent failed", {
+          backend: request.backend,
+          threadId: request.threadId,
+          monitorId: request.monitorId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  );
+
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_STEER_TURN_CHANNEL,
@@ -763,6 +793,7 @@ export function disposeAgentIpcHandlers(): void {
   ipcMain.removeHandler(AGENT_COMPACT_THREAD_CHANNEL);
   ipcMain.removeHandler(AGENT_START_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_INTERRUPT_TURN_CHANNEL);
+  ipcMain.removeHandler(AGENT_STOP_SUB_AGENT_CHANNEL);
   ipcMain.removeHandler(AGENT_STEER_TURN_CHANNEL);
   ipcMain.removeHandler(AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL);
   ipcMain.removeHandler(AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -19,6 +19,8 @@ import type {
   ForkThreadResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  StopSubAgentRequest,
+  StopSubAgentResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
   ListAutomationLoadIssuesResponse,
@@ -302,6 +304,7 @@ import {
   AGENT_CHECK_THREAD_BRANCH_DRIFT_CHANNEL,
   AGENT_COMPACT_THREAD_CHANNEL,
   AGENT_INTERRUPT_TURN_CHANNEL,
+  AGENT_STOP_SUB_AGENT_CHANNEL,
   AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
   AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL,
   AGENT_RETAIN_THREAD_BRANCH_DRIFT_CHANNEL,
@@ -1090,6 +1093,10 @@ const desktopApi = Object.freeze({
     request: InterruptTurnRequest
   ): Promise<InterruptTurnResponse> =>
     await ipcRenderer.invoke(AGENT_INTERRUPT_TURN_CHANNEL, request),
+  stopSubAgent: async (
+    request: StopSubAgentRequest,
+  ): Promise<StopSubAgentResponse> =>
+    await ipcRenderer.invoke(AGENT_STOP_SUB_AGENT_CHANNEL, request),
   steerTurn: async (
     request: SteerTurnRequest
   ): Promise<SteerTurnResponse> =>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -738,6 +738,8 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
       case "subagents":
         return (
           <SubAgentsPanel
+            desktopApi={props.desktopApi}
+            onRefreshNavigation={props.onRefreshNavigation}
             pricingDisplayOptions={props.pricingDisplayOptions}
             thread={props.thread}
             onDetailsModalOpenChange={handlePortaledInteractionChange}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -20,9 +20,12 @@ import {
   subAgentOriginSentence,
   subAgentUsageLabel,
 } from "./subagent-kind";
+import type { DesktopApi } from "../../../lib/desktop-api";
 
 type SubAgentsPanelProps = {
+  desktopApi?: DesktopApi;
   onDetailsModalOpenChange?: (open: boolean) => void;
+  onRefreshNavigation?: () => Promise<void>;
   pricingDisplayOptions?: PricingDisplayOptions;
   thread: NavigationThreadSummary;
 };
@@ -36,6 +39,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
     (subAgent) => !isTerminalSubAgent(subAgent),
   );
   const now = useNowWhileActive(hasRunningSubAgent);
+  const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set());
+  const [stopErrors, setStopErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     return () => onDetailsModalOpenChange?.(false);
@@ -49,6 +54,38 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const closeDetails = (): void => {
     setDetailsFor(null);
     onDetailsModalOpenChange?.(false);
+  };
+
+  const stopSubAgent = async (subAgent: ThreadSubAgentSummary): Promise<void> => {
+    if (!props.desktopApi?.stopSubAgent) {
+      return;
+    }
+    setStopErrors((current) => {
+      const next = { ...current };
+      delete next[subAgent.monitorId];
+      return next;
+    });
+    setStoppingIds((current) => new Set(current).add(subAgent.monitorId));
+    try {
+      await props.desktopApi.stopSubAgent({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        monitorId: subAgent.monitorId,
+      });
+      await props.onRefreshNavigation?.();
+    } catch (error) {
+      setStopErrors((current) => ({
+        ...current,
+        [subAgent.monitorId]:
+          error instanceof Error ? error.message : "Could not stop sub-agent.",
+      }));
+    } finally {
+      setStoppingIds((current) => {
+        const next = new Set(current);
+        next.delete(subAgent.monitorId);
+        return next;
+      });
+    }
   };
 
   return (
@@ -76,6 +113,12 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
               subAgent.lastMessage && subAgent.lastMessage !== originSentence
                 ? subAgent.lastMessage
                 : undefined;
+            const stopping = stoppingIds.has(subAgent.monitorId);
+            const canStop =
+              subAgent.status === "running"
+              && Boolean(subAgent.monitorThreadId)
+              && Boolean(subAgent.monitorTurnId)
+              && Boolean(props.desktopApi?.stopSubAgent);
             return (
               <li key={subAgent.monitorId} className="rail-card">
                 {/* Status on its own line so it never competes with the
@@ -125,13 +168,30 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                     })}
                   </p>
                 ) : null}
-                <button
-                  className="context-list__action"
-                  type="button"
-                  onClick={() => openDetails(subAgent)}
-                >
-                  Details
-                </button>
+                <div className="context-list__actions rail-card__actions">
+                  <button
+                    className="context-list__action rail-card__details-action"
+                    type="button"
+                    onClick={() => openDetails(subAgent)}
+                  >
+                    Details
+                  </button>
+                  {canStop ? (
+                    <button
+                      className="context-list__action context-list__action--danger"
+                      type="button"
+                      disabled={stopping}
+                      onClick={() => void stopSubAgent(subAgent)}
+                    >
+                      {stopping ? "Stopping…" : "Stop"}
+                    </button>
+                  ) : null}
+                </div>
+                {stopErrors[subAgent.monitorId] ? (
+                  <p className="rail-card__error" role="alert">
+                    {stopErrors[subAgent.monitorId]}
+                  </p>
+                ) : null}
               </li>
             );
           })}

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -1,0 +1,94 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import type { DesktopApi } from "../../../../lib/desktop-api";
+import { SubAgentsPanel } from "../SubAgentsPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+const thread: NavigationThreadSummary = {
+  id: "parent-thread",
+  title: "Parent thread",
+  titleSource: "explicit",
+  source: "codex",
+  linkedDirectories: [],
+  inbox: { inInbox: true },
+  subAgents: [
+    {
+      monitorId: "monitor-1",
+      task: "Watch the deployment",
+      status: "running",
+      createdAt: 1_800_000_000_000,
+      updatedAt: 1_800_000_000_000,
+      backend: "codex",
+      monitorThreadId: "monitor-thread",
+      monitorTurnId: "monitor-turn",
+    },
+    {
+      monitorId: "monitor-2",
+      task: "Finished work",
+      status: "success",
+      createdAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_100,
+      completedAt: 1_700_000_000_100,
+      backend: "codex",
+      monitorThreadId: "finished-thread",
+      monitorTurnId: "finished-turn",
+    },
+  ],
+};
+
+describe("SubAgentsPanel", () => {
+  it("stops a running sub-agent and refreshes navigation", async () => {
+    const stopSubAgent = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "parent-thread",
+      monitorId: "monitor-1",
+      stoppedAt: 1_800_000_000_100,
+    }));
+    const onRefreshNavigation = vi.fn(async () => undefined);
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        onRefreshNavigation={onRefreshNavigation}
+        thread={thread}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Stop" })).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    await waitFor(() => {
+      expect(stopSubAgent).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "parent-thread",
+        monitorId: "monitor-1",
+      });
+    });
+    expect(onRefreshNavigation).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the control available and reports an interruption failure", async () => {
+    const stopSubAgent = vi.fn(async () => {
+      throw new Error("Sub-agent is no longer running.");
+    });
+
+    render(
+      <SubAgentsPanel
+        desktopApi={{ stopSubAgent } as DesktopApi}
+        thread={thread}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(
+      await screen.findByRole("alert"),
+    ).toHaveTextContent("Sub-agent is no longer running.");
+    expect(screen.getByRole("button", { name: "Stop" })).toBeEnabled();
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -70,6 +70,8 @@ import type {
   HandoffThreadWorkspaceResponse,
   InterruptTurnRequest,
   InterruptTurnResponse,
+  StopSubAgentRequest,
+  StopSubAgentResponse,
   LatestCodexConfigWarningResponse,
   ListAutomationCardsRequest,
   ListAutomationCardsResponse,
@@ -472,6 +474,9 @@ export type DesktopApi = {
   interruptTurn?: (
     request: InterruptTurnRequest
   ) => Promise<InterruptTurnResponse>;
+  stopSubAgent?: (
+    request: StopSubAgentRequest,
+  ) => Promise<StopSubAgentResponse>;
   steerTurn?: (request: SteerTurnRequest) => Promise<SteerTurnResponse>;
   setThreadExecutionMode?: (
     request: SetThreadExecutionModeRequest

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13400,6 +13400,11 @@ a.transcript-message__messaging-origin:focus-visible {
   outline: none;
 }
 
+.context-list__action:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 .context-list__action--danger {
   border-color: var(--danger-border);
   color: var(--danger-text);
@@ -14677,6 +14682,23 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .rail-card__usage {
   color: var(--text-secondary);
+}
+
+.rail-card__actions {
+  width: 100%;
+  margin-top: 2px;
+}
+
+.rail-card__details-action {
+  flex: 1 1 auto;
+}
+
+.rail-card__error {
+  margin: 0;
+  color: var(--danger-text);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .pricing-usage-row {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -34,6 +34,7 @@ export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";
+export const AGENT_STOP_SUB_AGENT_CHANNEL = "agent:stop-sub-agent";
 export const AGENT_STEER_TURN_CHANNEL = "agent:steer-turn";
 export const AGENT_SET_THREAD_EXECUTION_MODE_CHANNEL = "agent:set-thread-execution-mode";
 export const AGENT_QUEUE_THREAD_EXECUTION_MODE_CHANNEL =

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -280,6 +280,19 @@ export type InterruptTurnResponse = {
   turnId: string;
 };
 
+export type StopSubAgentRequest = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  monitorId: string;
+};
+
+export type StopSubAgentResponse = {
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  monitorId: string;
+  stoppedAt: number;
+};
+
 export type CompactThreadRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;


### PR DESCRIPTION
## What changed

- adds a danger-styled **Stop** action to running sub-agent cards in the desktop context rail
- carries the action through the preload/IPC boundary to a parent-scoped backend operation
- interrupts managed task monitors without triggering their crash-recovery turn
- resolves the active child turn before interrupting native Codex sub-agents
- persists an intentional cancelled state and refreshes the navigation snapshot
- reports in-progress and error states on the card

## Why

Running sub-agents were visible in the Sub-agents panel but could only be inspected. Operators had no direct way to stop work that was no longer needed.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm lint:colors`
- focused Vitest coverage for the renderer control, IPC bridge, managed-monitor cancellation, and native Codex child-turn interruption
