### PR TITLE
fix(desktop): harden process lifecycle shutdown

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -1755,6 +1755,70 @@ describe("AcpBackendAdapter", () => {
 
     await adapter.close();
   });
+
+  it("bounds close while ACP initialization is pending", async () => {
+    vi.useFakeTimers();
+    try {
+      const backendId = "acp:gemini" as AcpBackendId;
+      const agent = buildInstalledAgent();
+      const initialize = vi.fn(() => new Promise<void>(() => undefined));
+      const dispose = vi.fn(async () => undefined);
+      const adapter = new AcpBackendAdapter({
+        acpAgentStore: {
+          getInstalledAgent: () => agent,
+          listInstalledAgents: () => [agent],
+          upsertInstalledAgent: vi.fn(),
+        },
+        captureStores: [],
+        closeTimeoutMs: 25,
+        createAcpClient: () => ({ initialize, dispose }) as never,
+        discoverLocalAcpAgents: async () => [],
+        emit: vi.fn(async () => undefined),
+        handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+      });
+
+      void adapter.getClient(backendId).catch(() => undefined);
+      await vi.waitFor(() => expect(initialize).toHaveBeenCalledOnce());
+      const close = adapter.close();
+      await vi.waitFor(() => expect(dispose).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(close).resolves.toBeUndefined();
+      await expect(adapter.getClient(backendId)).rejects.toThrow(
+        "ACP backend adapter is closed",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not create an ACP client when discovery finishes after close", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const agent = buildInstalledAgent();
+    let finishDiscovery:
+      | ((agents: AcpInstalledAgentRecord[]) => void)
+      | undefined;
+    const createAcpClient = vi.fn();
+    const adapter = new AcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient,
+      discoverLocalAcpAgents: () =>
+        new Promise((resolve) => {
+          finishDiscovery = resolve;
+        }),
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    const pendingClient = adapter.getClient(backendId);
+    await Promise.resolve();
+    await adapter.close();
+    finishDiscovery?.([agent]);
+
+    await expect(pendingClient).rejects.toThrow("ACP backend adapter is closed");
+    expect(createAcpClient).not.toHaveBeenCalled();
+  });
 });
 
 function buildInstalledAgent(): AcpInstalledAgentRecord {

--- a/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts
@@ -18,11 +18,15 @@ class MockAcpChildProcess extends EventEmitter {
   });
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
   killCalled = false;
 
-  kill(): void {
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
     this.killCalled = true;
+    this.signalCode = signal;
     this.emit("close");
+    return true;
   }
 }
 
@@ -256,5 +260,63 @@ describe("AcpStdioJsonRpcTransport", () => {
       result: { ok: true },
     });
     await transport.close();
+  });
+
+  it("prevents reconnect and late requests after close", async () => {
+    const child = new MockAcpChildProcess();
+    const spawn = vi.fn(() => child);
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor(),
+      spawn,
+    });
+
+    await transport.connect();
+    await transport.close();
+
+    await expect(transport.connect()).rejects.toThrow("transport is closed");
+    await expect(transport.request("session/new")).rejects.toThrow(
+      "transport is closed",
+    );
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up a child whose stdio pipes are unavailable", async () => {
+    const child = new MockAcpChildProcess();
+    Object.defineProperty(child, "stderr", { value: null });
+    const transport = new AcpStdioJsonRpcTransport({
+      launchDescriptor: createDescriptor(),
+      spawn: () => child,
+    });
+
+    await expect(transport.connect()).rejects.toThrow(
+      "ACP stdio pipes unavailable",
+    );
+    expect(child.killCalled).toBe(true);
+  });
+
+  it("waits for ACP exit and escalates when SIGTERM is resisted", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new MockAcpChildProcess();
+      child.kill = vi.fn(() => false);
+      const transport = new AcpStdioJsonRpcTransport({
+        launchDescriptor: createDescriptor(),
+        spawn: () => child,
+      });
+      await transport.connect();
+
+      const close = transport.close();
+      await Promise.resolve();
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+      child.signalCode = "SIGKILL";
+      child.emit("close");
+
+      await expect(close).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -24,6 +24,10 @@ const mockAppServerLog = vi.hoisted(() => ({
   info: vi.fn(),
   warn: vi.fn(),
 }));
+const backendRegistryLifecycle = vi.hoisted(() => ({
+  existing: true,
+  get: vi.fn(),
+}));
 
 const prAutoDispatchBudgetStatusSend = vi.hoisted(() => vi.fn());
 
@@ -646,9 +650,8 @@ vi.mock("../app-server/directory-registration-service", () => ({
   registerDirectoryFromDisk: registerDirectoryFromDiskService,
 }));
 
-vi.mock("../app-server/backend-registry", () => ({
-  disposeDesktopBackendRegistry: vi.fn(async () => undefined),
-  getDesktopBackendRegistry: () => ({
+vi.mock("../app-server/backend-registry", () => {
+  const registry = {
     archiveThread,
     restoreThread,
     archiveWorktree,
@@ -673,8 +676,15 @@ vi.mock("../app-server/backend-registry", () => ({
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
     rememberCompleteNavigationSnapshot,
-  }),
-}));
+  };
+  backendRegistryLifecycle.get.mockImplementation(() => registry);
+  return {
+    disposeDesktopBackendRegistry: vi.fn(async () => undefined),
+    getDesktopBackendRegistry: backendRegistryLifecycle.get,
+    getExistingDesktopBackendRegistry: () =>
+      backendRegistryLifecycle.existing ? registry : null,
+  };
+});
 
 vi.mock("../pr-status/github-pr-fetcher", () => ({
   GithubPrFetcher: vi.fn(function GithubPrFetcher() {
@@ -702,6 +712,8 @@ vi.mock("../pr-status/git-remote", async () => {
 
 describe("app server ipc", () => {
   beforeEach(() => {
+    backendRegistryLifecycle.existing = true;
+    backendRegistryLifecycle.get.mockClear();
     prAutomationSettings.state.backgroundPrPollingEnabled = true;
     prAutomationSettings.state.budgetPaused = false;
     prAutomationSettings.state.budgetPausedAt = 1_000;
@@ -802,6 +814,15 @@ describe("app server ipc", () => {
   afterEach(async () => {
     const { disposeAppServerIpcHandlers } = await import("../ipc/app-server");
     await disposeAppServerIpcHandlers();
+  });
+
+  it("does not construct a backend registry during disposal", async () => {
+    backendRegistryLifecycle.existing = false;
+    const { disposeAppServerIpcHandlers } = await import("../ipc/app-server");
+
+    await disposeAppServerIpcHandlers();
+
+    expect(backendRegistryLifecycle.get).not.toHaveBeenCalled();
   });
 
   it("identifies explicitly selected extensionless PDFs by their magic bytes", async () => {

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -67,8 +67,15 @@ vi.mock("../log", () => ({
 }));
 
 const markUpdateInstallInProgressMock = vi.fn();
+const markUpdateInstallUpdaterQuitReadyMock = vi.fn();
+const prepareForUpdateInstallMock = vi.fn<() => Promise<void>>(
+  async () => undefined,
+);
 vi.mock("../update-install-state", () => ({
   markUpdateInstallInProgress: () => markUpdateInstallInProgressMock(),
+  markUpdateInstallUpdaterQuitReady: () =>
+    markUpdateInstallUpdaterQuitReadyMock(),
+  prepareForUpdateInstall: () => prepareForUpdateInstallMock(),
 }));
 
 async function importAutoUpdater() {
@@ -104,6 +111,17 @@ function mockGitHubReleases(releases = [githubRelease("v1.0.0-beta.8")]): void {
     ok: true,
     json: async () => releases,
   });
+}
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
 }
 
 describe("auto updater", () => {
@@ -149,6 +167,9 @@ describe("auto updater", () => {
     autoUpdaterMock.on.mockClear();
     autoUpdaterMock.quitAndInstall.mockReset();
     markUpdateInstallInProgressMock.mockReset();
+    markUpdateInstallUpdaterQuitReadyMock.mockReset();
+    prepareForUpdateInstallMock.mockReset();
+    prepareForUpdateInstallMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -390,6 +411,9 @@ describe("auto updater", () => {
     autoUpdaterMock.quitAndInstall.mockImplementation(() => {
       callOrder.push("quitAndInstall");
     });
+    markUpdateInstallUpdaterQuitReadyMock.mockImplementation(() => {
+      callOrder.push("ready");
+    });
     const requestQuit = vi.fn(async (performQuit: () => void) => {
       performQuit();
       return true;
@@ -402,7 +426,36 @@ describe("auto updater", () => {
 
     await expect(install?.()).resolves.toEqual({ status: "restarting" });
     // The latch must be set before quitAndInstall so window-all-closed sees it.
-    expect(callOrder).toEqual(["mark", "quitAndInstall"]);
+    await vi.waitFor(() =>
+      expect(callOrder).toEqual(["mark", "ready", "quitAndInstall"]),
+    );
+  });
+
+  it("awaits shutdown preparation before handing quit ownership to the updater", async () => {
+    const preparation = createDeferred<void>();
+    prepareForUpdateInstallMock.mockReturnValueOnce(preparation.promise);
+    const updater = await importAutoUpdater();
+    const requestQuit = vi.fn(async (performQuit: () => void) => {
+      performQuit();
+      return true;
+    });
+
+    updater.initAutoUpdater();
+    updater.registerAppUpdateIpcHandlers({ requestQuit });
+    updateEventHandlers.get("update-downloaded")?.({ version: "1.0.0-beta.8" });
+    const install = ipcHandlers.get("app:install-update");
+
+    await expect(install?.()).resolves.toEqual({ status: "restarting" });
+    expect(markUpdateInstallInProgressMock).toHaveBeenCalledOnce();
+    expect(markUpdateInstallUpdaterQuitReadyMock).not.toHaveBeenCalled();
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+
+    preparation.resolve();
+    await vi.waitFor(() =>
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledOnce(),
+    );
+    expect(markUpdateInstallInProgressMock).toHaveBeenCalledOnce();
+    expect(markUpdateInstallUpdaterQuitReadyMock).toHaveBeenCalledOnce();
   });
 
   it("does not latch update-install-in-progress when quit is cancelled", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7769,7 +7769,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("waits for an in-flight repair and does not retry after registry close", async () => {
+  it("closes Codex while an in-flight repair drains and does not retry", async () => {
     const threadId = "thread-close-during-invalid-id-repair";
     const recoveryDelay = createDeferred<void>();
     const codexClient = new MockBackendClient({
@@ -7816,7 +7816,7 @@ script = "echo setup"
     });
     await Promise.resolve();
     expect(closeSettled).toBe(false);
-    expect(codexClient.closeCallCount).toBe(0);
+    expect(codexClient.closeCallCount).toBe(1);
 
     recoveryDelay.resolve();
     await closePromise;

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7769,7 +7769,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("closes Codex while an in-flight repair drains and does not retry", async () => {
+  it("drains an in-flight repair before the final Codex close", async () => {
     const threadId = "thread-close-during-invalid-id-repair";
     const recoveryDelay = createDeferred<void>();
     const codexClient = new MockBackendClient({
@@ -7816,7 +7816,7 @@ script = "echo setup"
     });
     await Promise.resolve();
     expect(closeSettled).toBe(false);
-    expect(codexClient.closeCallCount).toBe(1);
+    expect(codexClient.closeCallCount).toBe(0);
 
     recoveryDelay.resolve();
     await closePromise;

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -236,8 +236,13 @@ vi.mock("../auto-updater", () => ({
 }));
 
 const isUpdateInstallInProgressMock = vi.fn(() => false);
+const isUpdateInstallUpdaterQuitReadyMock = vi.fn(() => false);
+const setUpdateInstallPreparationHandlerMock = vi.fn();
 vi.mock("../update-install-state", () => ({
   isUpdateInstallInProgress: () => isUpdateInstallInProgressMock(),
+  isUpdateInstallUpdaterQuitReady: () =>
+    isUpdateInstallUpdaterQuitReadyMock(),
+  setUpdateInstallPreparationHandler: setUpdateInstallPreparationHandlerMock,
 }));
 
 vi.mock("../app-log-window", () => ({
@@ -496,6 +501,9 @@ describe("bootstrapApp", () => {
     isQuitAllowedMock.mockReturnValue(true);
     isUpdateInstallInProgressMock.mockReset();
     isUpdateInstallInProgressMock.mockReturnValue(false);
+    isUpdateInstallUpdaterQuitReadyMock.mockReset();
+    isUpdateInstallUpdaterQuitReadyMock.mockReturnValue(false);
+    setUpdateInstallPreparationHandlerMock.mockReset();
     mainLogInfoMock.mockReset();
     mainLogWarnMock.mockReset();
     mainLogErrorMock.mockReset();
@@ -764,12 +772,59 @@ describe("bootstrapApp", () => {
     // relaunch. If we answered that window-all-closed with our own app.quit()
     // we would race the native teardown and strand the app on the old version.
     isUpdateInstallInProgressMock.mockReturnValue(true);
+    isUpdateInstallUpdaterQuitReadyMock.mockReturnValue(true);
     requestQuitMock.mockClear();
 
     appEventHandlers.get("window-all-closed")?.();
     await flushMicrotasks();
 
     expect(requestQuitMock).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept the updater-owned before-quit event", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    isUpdateInstallInProgressMock.mockReturnValue(true);
+    isUpdateInstallUpdaterQuitReadyMock.mockReturnValue(true);
+    const event = { preventDefault: vi.fn() };
+    appEventHandlers.get("before-quit")?.(event);
+    await vi.waitFor(() =>
+      expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce(),
+    );
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(quitMock).not.toHaveBeenCalled();
+  });
+
+  it("holds before-quit while update shutdown preparation is pending", async () => {
+    let finishMessaging!: () => void;
+    startupProfilerInstance.start.mockResolvedValue();
+    disposeDesktopMessagingRuntimeMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishMessaging = resolve;
+      }),
+    );
+
+    await import("../index");
+    await flushMicrotasks();
+
+    isUpdateInstallInProgressMock.mockReturnValue(true);
+    isUpdateInstallUpdaterQuitReadyMock.mockReturnValue(false);
+    const event = { preventDefault: vi.fn() };
+    appEventHandlers.get("before-quit")?.(event);
+    await flushMicrotasks();
+
+    expect(event.preventDefault).toHaveBeenCalledOnce();
+    expect(quitMock).not.toHaveBeenCalled();
+
+    finishMessaging();
+    await vi.waitFor(() =>
+      expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce(),
+    );
+    expect(quitMock).not.toHaveBeenCalled();
   });
 
   it("creates a main window when a profile focus request arrives without one", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -1070,20 +1070,17 @@ describe("bootstrapApp", () => {
     expect(createMainWindowMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps ipc handlers registered until Electron reaches will-quit", async () => {
+  it("awaits async resource disposal before completing quit", async () => {
     startupProfilerInstance.start.mockResolvedValue();
 
     await import("../index");
     await flushMicrotasks();
 
-    appEventHandlers.get("before-quit")?.();
+    const event = { preventDefault: vi.fn() };
+    appEventHandlers.get("before-quit")?.(event);
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
 
-    expect(disposeComposerDraftIpcHandlersMock).not.toHaveBeenCalled();
-    expect(disposeIntegratedTerminalIpcHandlersMock).not.toHaveBeenCalled();
-    expect(disposeSettingsIpcHandlersMock).not.toHaveBeenCalled();
-
-    appEventHandlers.get("will-quit")?.();
-
+    expect(event.preventDefault).toHaveBeenCalledOnce();
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeSettingsIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -1092,6 +1089,52 @@ describe("bootstrapApp", () => {
       disposeAppStateMock.mock.invocationCallOrder[0],
     );
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(disposeAppStateMock).toHaveBeenCalledTimes(1);
+    expect(quitMock).toHaveBeenCalledTimes(1);
+
+    appEventHandlers.get("before-quit")?.(event);
+    await flushMicrotasks();
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses one quit barrier while messaging and app-server teardown settle", async () => {
+    let finishMessaging!: () => void;
+    let finishAppServer!: () => void;
+    disposeDesktopMessagingRuntimeMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishMessaging = resolve;
+      }),
+    );
+    disposeAppServerIpcHandlersMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishAppServer = resolve;
+      }),
+    );
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+
+    const event = { preventDefault: vi.fn() };
+    appEventHandlers.get("before-quit")?.(event);
+    appEventHandlers.get("before-quit")?.(event);
+    await flushMicrotasks();
+
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledOnce();
+    expect(disposeAppServerIpcHandlersMock).not.toHaveBeenCalled();
+    expect(quitMock).not.toHaveBeenCalled();
+
+    finishMessaging();
+    await vi.waitFor(() =>
+      expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce(),
+    );
+    expect(quitMock).not.toHaveBeenCalled();
+
+    finishAppServer();
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledOnce());
+    expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledOnce();
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce();
   });
 
   it("handles messaging runtime disposal failures during shutdown", async () => {
@@ -1103,13 +1146,17 @@ describe("bootstrapApp", () => {
     await import("../index");
     await flushMicrotasks();
 
-    appEventHandlers.get("will-quit")?.();
-    await flushMicrotasks();
+    appEventHandlers.get("before-quit")?.({ preventDefault: vi.fn() });
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledOnce());
 
     expect(mainLogWarnMock).toHaveBeenCalledWith(
-      "messaging runtime disposal failed during shutdown",
-      { error: "adapter stop failed" },
+      "shutdown phase failed",
+      expect.objectContaining({
+        error: "adapter stop failed",
+        phase: "messaging",
+      }),
     );
+    expect(disposeAppServerIpcHandlersMock).toHaveBeenCalledOnce();
   });
 
   it("routes closing the last window through the shared quit flow", async () => {
@@ -1119,6 +1166,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     appEventHandlers.get("window-all-closed")?.();
+    await flushMicrotasks();
 
     expect(requestQuitMock).toHaveBeenCalledWith({
       source: "window-all-closed",
@@ -1127,6 +1175,7 @@ describe("bootstrapApp", () => {
 
   it("does not re-enter quit when the confirmation window closes after cancellation", async () => {
     let resolveQuit!: (didQuit: boolean) => void;
+    isQuitAllowedMock.mockReturnValue(false);
     requestQuitMock.mockReturnValue(
       new Promise<boolean>((resolve) => {
         resolveQuit = resolve;
@@ -1146,7 +1195,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
     appEventHandlers.get("activate")?.();
 
-    expect(createMainWindowMock).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(createMainWindowMock).toHaveBeenCalledTimes(2));
   });
 
   it("completes quit when all windows close after before-quit approves shutdown", async () => {
@@ -1164,6 +1213,7 @@ describe("bootstrapApp", () => {
     appEventHandlers.get("before-quit")?.(event);
     await flushMicrotasks();
     appEventHandlers.get("window-all-closed")?.();
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(requestQuitMock).toHaveBeenCalledWith({ source: "before-quit" });
@@ -1233,7 +1283,8 @@ describe("bootstrapApp", () => {
 
     expect(registerRuntimeIdentityIpcHandlersMock).not.toHaveBeenCalled();
 
-    appEventHandlers.get("will-quit")?.();
+    appEventHandlers.get("before-quit")?.({ preventDefault: vi.fn() });
+    await flushMicrotasks();
     expect(disposeApplicationIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeComposerDraftIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(disposeIntegratedTerminalIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -1257,6 +1308,7 @@ describe("bootstrapApp", () => {
     }
 
     expect(() => sigtermHandler("SIGTERM")).not.toThrow();
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
 
     expect(getRuntimeMessagingLeaseCoordinatorMock).not.toHaveBeenCalled();
     expect(messagingLeaseShutdownSyncMock).not.toHaveBeenCalled();
@@ -1277,6 +1329,7 @@ describe("bootstrapApp", () => {
     }
 
     sigtermHandler("SIGTERM");
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
 
     expect(messagingLeaseShutdownSyncMock).toHaveBeenCalledTimes(1);
     expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/process-tree.test.ts
+++ b/apps/desktop/src/main/__tests__/process-tree.test.ts
@@ -6,10 +6,9 @@ import { terminateOwnedProcessTree } from "../process-tree";
 const posixOnly = process.platform === "win32" ? it.skip : it;
 
 describe("terminateOwnedProcessTree", () => {
-  posixOnly("escalates and kills resistant descendants", async () => {
+  posixOnly("kills a resistant descendant after its group leader exits", async () => {
     const script = [
       'const { spawn } = require("node:child_process");',
-      'process.on("SIGTERM", () => undefined);',
       "const descendant = spawn(process.execPath, [\"-e\", \"process.on('SIGTERM', () => undefined); setInterval(() => undefined, 1000)\"], { stdio: \"ignore\" });",
       'process.stdout.write(String(descendant.pid) + "\\n");',
       "setInterval(() => undefined, 1000);",

--- a/apps/desktop/src/main/__tests__/process-tree.test.ts
+++ b/apps/desktop/src/main/__tests__/process-tree.test.ts
@@ -1,0 +1,40 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { describe, expect, it } from "vitest";
+import { terminateOwnedProcessTree } from "../process-tree";
+
+const posixOnly = process.platform === "win32" ? it.skip : it;
+
+describe("terminateOwnedProcessTree", () => {
+  posixOnly("escalates and kills resistant descendants", async () => {
+    const script = [
+      'const { spawn } = require("node:child_process");',
+      'process.on("SIGTERM", () => undefined);',
+      "const descendant = spawn(process.execPath, [\"-e\", \"process.on('SIGTERM', () => undefined); setInterval(() => undefined, 1000)\"], { stdio: \"ignore\" });",
+      'process.stdout.write(String(descendant.pid) + "\\n");',
+      "setInterval(() => undefined, 1000);",
+    ].join(" ");
+    const child = spawn(process.execPath, ["-e", script], {
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    try {
+      const [line] = await once(child.stdout!, "data");
+      const descendantPid = Number(String(line).trim());
+
+      await terminateOwnedProcessTree(child, {
+        gracefulTimeoutMs: 25,
+        forceTimeoutMs: 1_000,
+      });
+
+      expect(() => process.kill(child.pid!, 0)).toThrow();
+      expect(() => process.kill(descendantPid, 0)).toThrow();
+    } finally {
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {
+        // The expected path already terminated the entire process group.
+      }
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
+++ b/apps/desktop/src/main/__tests__/shutdown-barrier.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { createShutdownBarrier } from "../shutdown-barrier";
+
+describe("createShutdownBarrier", () => {
+  it("is idempotent and bounds phases by their deadlines", async () => {
+    vi.useFakeTimers();
+    try {
+      const logger = { info: vi.fn(), warn: vi.fn() };
+      const secondPhase = vi.fn(async () => undefined);
+      const runShutdown = createShutdownBarrier({
+        globalTimeoutMs: 100,
+        logger,
+        phases: [
+          {
+            name: "resistant",
+            timeoutMs: 40,
+            run: () => new Promise<void>(() => undefined),
+          },
+          {
+            name: "cleanup",
+            timeoutMs: 40,
+            run: secondPhase,
+          },
+        ],
+      });
+
+      const first = runShutdown("test");
+      const second = runShutdown("ignored-repeat");
+      expect(second).toBe(first);
+
+      await vi.advanceTimersByTimeAsync(40);
+      await expect(first).resolves.toMatchObject({
+        source: "test",
+        outcomes: [
+          { name: "resistant", outcome: "timed-out" },
+          { name: "cleanup", outcome: "completed" },
+        ],
+      });
+      expect(secondPhase).toHaveBeenCalledOnce();
+      expect(logger.warn).toHaveBeenCalledWith(
+        "shutdown phase timed-out",
+        expect.objectContaining({ phase: "resistant", timeoutMs: 40 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps a phase at the remaining global deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const runShutdown = createShutdownBarrier({
+        globalTimeoutMs: 30,
+        logger: { info: vi.fn(), warn: vi.fn() },
+        phases: [
+          {
+            name: "hung",
+            timeoutMs: 100,
+            run: () => new Promise<void>(() => undefined),
+          },
+          {
+            name: "too-late",
+            timeoutMs: 100,
+            run: vi.fn(),
+          },
+        ],
+      });
+
+      const shutdown = runShutdown("global-deadline");
+      await vi.advanceTimersByTimeAsync(30);
+
+      await expect(shutdown).resolves.toMatchObject({
+        durationMs: 30,
+        outcomes: [
+          { name: "hung", outcome: "timed-out" },
+          { name: "too-late", outcome: "skipped" },
+        ],
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -184,7 +184,7 @@ describe("StdioJsonRpcTransport", () => {
 
       await transport.connect();
       const closeResult = expect(transport.close()).rejects.toThrow(
-        "Codex app-server did not accept SIGKILL",
+        "child process tree did not accept SIGKILL",
       );
       await vi.advanceTimersByTimeAsync(10_000);
       await closeResult;
@@ -207,5 +207,59 @@ describe("StdioJsonRpcTransport", () => {
     expect(() =>
       transport.send(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
     ).toThrow("codex app server stdio not connected");
+  });
+
+  it("does not spawn after close cancels environment hydration", async () => {
+    let resolveEnv: ((env: NodeJS.ProcessEnv) => void) | undefined;
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      resolveEnv: () =>
+        new Promise((resolve) => {
+          resolveEnv = resolve;
+        }),
+    });
+
+    const connect = transport.connect();
+    await Promise.resolve();
+    await transport.close();
+    resolveEnv?.({ PATH: process.env.PATH ?? "" });
+
+    await expect(connect).rejects.toThrow("connection cancelled");
+    expect(resolveCodexCommandMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("cleans up a spawned child whose stdio pipes are unavailable", async () => {
+    const child = new MockCodexChildProcess();
+    Object.defineProperty(child, "stdout", { value: null });
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    await expect(transport.connect()).rejects.toThrow(
+      "codex app server stdio pipes unavailable",
+    );
+    expect(child.killCalled).toBe(true);
+  });
+
+  it("supports an intentional reconnect after close completes", async () => {
+    const firstChild = new MockCodexChildProcess();
+    const secondChild = new MockCodexChildProcess();
+    spawnMock
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(secondChild);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    await transport.connect();
+    await transport.close();
+    await transport.connect();
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    await transport.close();
   });
 });

--- a/apps/desktop/src/main/acp/acp-stdio-transport.ts
+++ b/apps/desktop/src/main/acp/acp-stdio-transport.ts
@@ -15,17 +15,21 @@ import {
 } from "@pwrdrvr/agent-transport";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 import { getMainLogger } from "../log.js";
+import {
+  terminateOwnedProcessTree,
+  type OwnedChildProcess,
+} from "../process-tree.js";
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60_000;
+const PROCESS_CLOSE_TIMEOUT_MS = 5_000;
+const PROCESS_FORCE_CLOSE_TIMEOUT_MS = 5_000;
 
 const acpTransportLog = getMainLogger("pwragent:acp-transport");
 
-type AcpStdioChildProcess = {
+type AcpStdioChildProcess = OwnedChildProcess & {
   stdin: Writable | null;
   stdout: Readable | null;
   stderr: Readable | null;
-  kill(): void;
-  on(event: string, listener: (...args: any[]) => void): unknown;
 };
 
 export type AcpStdioSpawn = (
@@ -80,6 +84,7 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
         id?: JsonRpcId,
       ) => Promise<unknown> | unknown)
     | undefined;
+  private closed = false;
 
   constructor(options: AcpStdioJsonRpcTransportOptions) {
     this.lineTransport = new AcpLineStdioTransport({
@@ -110,10 +115,12 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
   }
 
   async connect(): Promise<void> {
+    this.assertOpen();
     await this.connection.connect();
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     await this.connection.close();
   }
 
@@ -122,11 +129,13 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
     params?: Record<string, unknown>,
     timeoutMs?: number,
   ): Promise<unknown> {
+    this.assertOpen();
     await this.connection.connect();
     return await this.connection.request(method, params, timeoutMs);
   }
 
   async notify(method: string, params?: Record<string, unknown>): Promise<void> {
+    this.assertOpen();
     await this.connection.connect();
     await this.connection.notify(method, params);
   }
@@ -154,12 +163,21 @@ export class AcpStdioJsonRpcTransport implements AcpJsonRpcTransport {
       }
     };
   }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error("ACP stdio transport is closed");
+    }
+  }
 }
 
 class AcpLineStdioTransport implements JsonRpcTransport {
   private childProcess: AcpStdioChildProcess | null = null;
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
+  private closed = false;
+  private closePromise?: Promise<void>;
+  private lifecycleGeneration = 0;
 
   constructor(
     private readonly options: {
@@ -177,9 +195,13 @@ class AcpLineStdioTransport implements JsonRpcTransport {
   }
 
   async connect(): Promise<void> {
+    if (this.closed) {
+      throw new Error("ACP stdio transport is closed");
+    }
     if (this.childProcess) {
       return;
     }
+    const generation = ++this.lifecycleGeneration;
 
     const descriptor = normalizeAcpLaunchDescriptor(this.options.launchDescriptor);
     const env = buildPwrAgentChildProcessEnv(
@@ -199,13 +221,29 @@ class AcpLineStdioTransport implements JsonRpcTransport {
       stdio: ["pipe", "pipe", "pipe"],
       env,
       cwd: descriptor.cwd,
+      detached: process.platform !== "win32",
     });
 
-    if (!child.stdin || !child.stdout || !child.stderr) {
-      throw new Error("ACP stdio pipes unavailable");
+    if (this.closed || generation !== this.lifecycleGeneration) {
+      await terminateOwnedProcessTree(child, {
+        gracefulTimeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+        forceTimeoutMs: PROCESS_FORCE_CLOSE_TIMEOUT_MS,
+      });
+      throw new Error("ACP stdio transport is closed");
     }
 
     this.childProcess = child;
+
+    if (!child.stdin || !child.stdout || !child.stderr) {
+      await terminateOwnedProcessTree(child, {
+        gracefulTimeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+        forceTimeoutMs: PROCESS_FORCE_CLOSE_TIMEOUT_MS,
+      });
+      if (this.childProcess === child) {
+        this.childProcess = null;
+      }
+      throw new Error("ACP stdio pipes unavailable");
+    }
 
     const stdoutReader = readline.createInterface({ input: child.stdout });
     stdoutReader.on("line", (line: string) => {
@@ -214,21 +252,39 @@ class AcpLineStdioTransport implements JsonRpcTransport {
 
     child.stderr.on("data", () => undefined);
     child.on("error", (error: Error) => {
+      if (this.childProcess === child && child.pid === undefined) {
+        this.childProcess = null;
+      }
       this.closeHandler(error);
     });
     child.on("close", () => {
-      this.childProcess = null;
+      if (this.childProcess === child) {
+        this.childProcess = null;
+      }
       this.closeHandler();
     });
   }
 
   async close(): Promise<void> {
+    this.closed = true;
+    this.lifecycleGeneration += 1;
+    if (this.closePromise) {
+      return await this.closePromise;
+    }
     const child = this.childProcess;
-    this.childProcess = null;
     if (!child) {
       return;
     }
-    child.kill();
+    this.closePromise = terminateOwnedProcessTree(child, {
+      gracefulTimeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+      forceTimeoutMs: PROCESS_FORCE_CLOSE_TIMEOUT_MS,
+    }).finally(() => {
+      if (this.childProcess === child) {
+        this.childProcess = null;
+      }
+      this.closePromise = undefined;
+    });
+    return await this.closePromise;
   }
 
   send(message: string): void {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -103,6 +103,7 @@ export const ACP_LIVE_HANDOFF_UNSUPPORTED_ERROR =
 
 const acpBackendAdapterLog = getMainLogger("pwragent:acp-backend-adapter");
 const ACP_PROVIDER_STATUS_CACHE_TTL_MS = 60_000;
+const ACP_CLOSE_TIMEOUT_MS = 5_000;
 
 export type AcpRuntimeClient = Pick<
   AcpAgentClient,
@@ -133,6 +134,12 @@ export type AcpSessionStoreLike =
   Pick<AcpSessionStoreContract, "getSession" | "listSessions"> &
   Partial<Pick<AcpSessionStoreContract, "upsertSession">>;
 
+type AcpClientEntry = {
+  client: AcpRuntimeClient;
+  promise: Promise<AcpRuntimeClient>;
+  disposePromise?: Promise<void>;
+};
+
 type AcpLiveTurnUsage = {
   model?: string;
   tokenUsage: AcpTokenUsage;
@@ -159,6 +166,7 @@ export type AcpBackendAdapterOptions = {
   discoverLocalAcpAgents?: LocalAcpDiscovery;
   resolveLocalAcpDiscoveryEnv?: () => Promise<NodeJS.ProcessEnv>;
   isAcpAgentEnabled?: (registryId: string) => boolean;
+  closeTimeoutMs?: number;
   emit: (event: AgentEvent) => Promise<void>;
   handleServerRequest: (
     backend: AcpBackendId,
@@ -844,12 +852,14 @@ export class AcpBackendAdapter {
     backend: AcpBackendId,
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
-  private readonly acpClients = new Map<AcpBackendId, Promise<AcpRuntimeClient>>();
+  private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
   private readonly liveNotificationFingerprints = new Map<string, string>();
   private readonly providerStatuses = new Map<AcpBackendId, AcpProviderStatus>();
   private readonly providerStatusRefreshAttempts = new Map<AcpBackendId, number>();
   private readonly providerStatusRefreshes = new Map<AcpBackendId, Promise<void>>();
   private closed = false;
+  private closePromise?: Promise<void>;
+  private readonly closeTimeoutMs: number;
   private readonly liveTurnUsage = new Map<string, AcpLiveTurnUsage>();
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
 
@@ -859,6 +869,7 @@ export class AcpBackendAdapter {
     this.automationInspectionMcpCommand = options.automationInspectionMcpCommand;
     this.emit = options.emit;
     this.handleServerRequest = options.handleServerRequest;
+    this.closeTimeoutMs = options.closeTimeoutMs ?? ACP_CLOSE_TIMEOUT_MS;
     this.acpAgentStore =
       options.acpAgentStore === null
         ? undefined
@@ -943,7 +954,7 @@ export class AcpBackendAdapter {
   }
 
   private refreshProviderStatusInBackground(backend: AcpBackendId): void {
-    const clientPromise = this.acpClients.get(backend);
+    const clientPromise = this.acpClients.get(backend)?.promise;
     if (
       this.closed
       || !clientPromise
@@ -1087,7 +1098,9 @@ export class AcpBackendAdapter {
     sessionId: string,
   ): Promise<AppServerThreadReplay> {
     const session = this.getSession(backend, sessionId);
-    const cachedClient = await this.acpClients.get(backend)?.catch(() => undefined);
+    const cachedClient = await this.acpClients
+      .get(backend)
+      ?.promise.catch(() => undefined);
     if (cachedClient) {
       const replay = cachedClient.readReplay(sessionId);
       if (
@@ -1189,24 +1202,38 @@ export class AcpBackendAdapter {
   }
 
   async getClient(backend: AcpBackendId): Promise<AcpRuntimeClient> {
+    if (this.closed) {
+      throw new Error("ACP backend adapter is closed");
+    }
     const cached = this.acpClients.get(backend);
     if (cached) {
-      return await cached;
+      return await cached.promise;
     }
 
     const agent = await this.resolveInstalledAgent(backend);
-    const clientPromise = (async () => {
-      const client = this.createAcpClient(agent);
+    if (this.closed) {
+      throw new Error("ACP backend adapter is closed");
+    }
+    const client = this.createAcpClient(agent);
+    const entry: AcpClientEntry = {
+      client,
+      promise: Promise.resolve(client),
+    };
+    entry.promise = (async () => {
       await client.initialize();
+      if (this.closed) {
+        await this.disposeAcpClient(entry);
+        throw new Error("ACP backend adapter is closed");
+      }
       return client;
     })();
-    this.acpClients.set(backend, clientPromise);
-    clientPromise.catch(() => {
-      if (this.acpClients.get(backend) === clientPromise) {
+    this.acpClients.set(backend, entry);
+    entry.promise.catch(() => {
+      if (this.acpClients.get(backend) === entry) {
         this.acpClients.delete(backend);
       }
     });
-    return await clientPromise;
+    return await entry.promise;
   }
 
   private readRolloutReplay(
@@ -1454,21 +1481,75 @@ export class AcpBackendAdapter {
   }
 
   async close(): Promise<void> {
+    if (this.closePromise) {
+      return await this.closePromise;
+    }
     this.closed = true;
-    const acpClients = [...this.acpClients.values()];
+    const acpClients = [...this.acpClients.entries()];
     this.acpClients.clear();
     this.liveNotificationFingerprints.clear();
     this.providerStatuses.clear();
     this.providerStatusRefreshAttempts.clear();
     this.providerStatusRefreshes.clear();
     this.liveTurnUsage.clear();
-    await Promise.all(
-      acpClients.map(async (clientPromise) => {
-        const client = await clientPromise.catch(() => undefined);
-        await client?.dispose();
+    this.closePromise = this.closeResources(acpClients);
+    return await this.closePromise;
+  }
+
+  private async closeResources(
+    acpClients: Array<[AcpBackendId, AcpClientEntry]>,
+  ): Promise<void> {
+    const resources = [
+      ...acpClients.map(async ([backend, entry]) => {
+        const dispose = this.disposeAcpClient(entry);
+        const [, disposeResult] = await Promise.allSettled([
+          entry.promise,
+          dispose,
+        ]);
+        if (disposeResult.status === "rejected") {
+          throw disposeResult.reason;
+        }
+        acpBackendAdapterLog.info("acp_client_closed", { backend });
       }),
-    );
-    await this.agentToolMcpServer?.close();
+      Promise.resolve().then(() => this.agentToolMcpServer?.close()),
+    ];
+    const cleanup = Promise.allSettled(resources).then((results) => {
+      for (const [index, result] of results.entries()) {
+        if (result.status === "rejected") {
+          acpBackendAdapterLog.warn("acp_resource_close_failed", {
+            resource:
+              index < acpClients.length
+                ? acpClients[index]?.[0]
+                : "agent-tool-mcp",
+            error:
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason),
+          });
+        }
+      }
+    });
+    let timer: NodeJS.Timeout | undefined;
+    const timedOut = await Promise.race([
+      cleanup.then(() => false),
+      new Promise<true>((resolve) => {
+        timer = setTimeout(() => resolve(true), this.closeTimeoutMs);
+      }),
+    ]);
+    if (timer) {
+      clearTimeout(timer);
+    }
+    if (timedOut) {
+      acpBackendAdapterLog.warn("acp_close_timed_out", {
+        clientCount: acpClients.length,
+        timeoutMs: this.closeTimeoutMs,
+      });
+    }
+  }
+
+  private disposeAcpClient(entry: AcpClientEntry): Promise<void> {
+    entry.disposePromise ??= Promise.resolve().then(() => entry.client.dispose());
+    return entry.disposePromise;
   }
 
   private shouldEmitLiveToolNotification(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14556,15 +14556,35 @@ export class DesktopBackendRegistry {
       this.codexInvalidIdRecoveryBarrier = undefined;
     }
     const recoveryDrain = this.codexInvalidIdRecoveryDrain;
-    if (recoveryDrain) {
-      await recoveryDrain;
+    const resources = [
+      ...(recoveryDrain
+        ? [{ name: "codex-recovery", close: () => recoveryDrain }]
+        : []),
+      { name: "acp", close: () => this.acpBackend.close() },
+      { name: "pdf-mcp", close: () => this.pdfToolMcpServer?.close() },
+      { name: "codex", close: () => this.codexClient.close() },
+      { name: "grok", close: () => this.grokClient.close() },
+      ...this.captureStores.splice(0).map((store, index) => ({
+        name: `capture-${index}`,
+        close: () => store.close(),
+      })),
+    ];
+    const results = await Promise.allSettled(
+      resources.map((resource) => Promise.resolve().then(resource.close)),
+    );
+    const failures = results.flatMap((result, index) =>
+      result.status === "rejected"
+        ? [{ name: resources[index].name, reason: result.reason }]
+        : [],
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        `Desktop backend registry close failed: ${failures
+          .map((failure) => failure.name)
+          .join(", ")}`,
+      );
     }
-
-    await this.acpBackend.close();
-    await this.pdfToolMcpServer?.close();
-    await this.codexClient.close();
-    await this.grokClient.close();
-    await Promise.all(this.captureStores.splice(0).map(async (store) => await store.close()));
   }
 
   private async resolveModelSettings(
@@ -25690,6 +25710,10 @@ function truncateThreadInspectionTextWithFlag(
 }
 
 let registry: DesktopBackendRegistry | null = null;
+
+export function getExistingDesktopBackendRegistry(): DesktopBackendRegistry | null {
+  return registry;
+}
 
 export function getDesktopBackendRegistry(): DesktopBackendRegistry {
   if (!registry) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14557,12 +14557,21 @@ export class DesktopBackendRegistry {
     }
     const recoveryDrain = this.codexInvalidIdRecoveryDrain;
     const resources = [
-      ...(recoveryDrain
-        ? [{ name: "codex-recovery", close: () => recoveryDrain }]
-        : []),
       { name: "acp", close: () => this.acpBackend.close() },
       { name: "pdf-mcp", close: () => this.pdfToolMcpServer?.close() },
-      { name: "codex", close: () => this.codexClient.close() },
+      {
+        name: "codex",
+        close: async () => {
+          try {
+            await recoveryDrain;
+          } finally {
+            // Recovery may restart the transport before it observes that the
+            // registry closed. Always make the final Codex close happen after
+            // that drain so no retry-path child can escape shutdown.
+            await this.codexClient.close();
+          }
+        },
+      },
       { name: "grok", close: () => this.grokClient.close() },
       ...this.captureStores.splice(0).map((store, index) => ({
         name: `capture-${index}`,

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -17,7 +17,11 @@ import type {
 } from "../shared/app-metadata";
 import { getMainLogger } from "./log";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
-import { markUpdateInstallInProgress } from "./update-install-state";
+import {
+  markUpdateInstallInProgress,
+  markUpdateInstallUpdaterQuitReady,
+  prepareForUpdateInstall,
+} from "./update-install-state";
 
 const log = getMainLogger("pwragent:updater");
 const GITHUB_RELEASES_URL =
@@ -560,12 +564,26 @@ export async function installDownloadedAppUpdate(options?: {
   }
   try {
     log.info("installing downloaded update", { version });
+    let updateHandoffPromise: Promise<void> | undefined;
     const performQuit = (): void => {
-      // Hand the quit + relaunch to the native Squirrel.Mac updater. Latch first
-      // so the app's own window-all-closed / before-quit handlers don't race it
-      // with a competing app.quit() that would strand us on the old version.
+      // The accepted update is now irreversible. Latch immediately so a user
+      // closing the last window while teardown runs cannot start another quit.
       markUpdateInstallInProgress();
-      autoUpdater.quitAndInstall();
+      updateHandoffPromise ??= prepareForUpdateInstall()
+        .catch((error: unknown) => {
+          // Teardown is bounded and normally resolves with phase outcomes, but
+          // never strand an accepted update if an unexpected synchronous
+          // cleanup error escapes. The updater still owns the eventual quit.
+          log.warn("update-install preparation failed", {
+            message: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .then(() => {
+          // From this point onward the updater owns before-quit. Set the ready
+          // latch immediately before the synchronous native handoff.
+          markUpdateInstallUpdaterQuitReady();
+          autoUpdater.quitAndInstall();
+        });
     };
     if (options?.requestQuit) {
       const quitAccepted = await options.requestQuit(performQuit);

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -6,6 +6,7 @@ import readline from "node:readline";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
 import { getMainLogger } from "../log";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { terminateOwnedProcessTree } from "../process-tree";
 import {
   compareCodexCliVersions,
   resolveCodexCommand,
@@ -57,6 +58,8 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   private closeHandler: (error?: Error) => void = () => undefined;
   private closeRequested = false;
   private closePromise?: Promise<void>;
+  private connectPromise?: Promise<void>;
+  private lifecycleGeneration = 0;
   private droppedSendAfterCloseLogged = false;
 
   constructor(private readonly options: StdioJsonRpcTransportOptions) {}
@@ -73,21 +76,46 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     if (this.childProcess) {
       return;
     }
+    if (this.connectPromise && !this.closeRequested) {
+      return await this.connectPromise;
+    }
+    const generation = ++this.lifecycleGeneration;
     this.closeRequested = false;
     this.droppedSendAfterCloseLogged = false;
 
+    const connectPromise = this.connectForGeneration(generation);
+    this.connectPromise = connectPromise;
+    try {
+      await connectPromise;
+    } finally {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = undefined;
+      }
+    }
+  }
+
+  private assertCurrentGeneration(generation: number): void {
+    if (this.closeRequested || generation !== this.lifecycleGeneration) {
+      throw new Error("codex app server connection cancelled");
+    }
+  }
+
+  private async connectForGeneration(generation: number): Promise<void> {
     const resolvedEnv = this.options.resolveEnv
       ? await this.options.resolveEnv()
       : this.options.env ?? process.env;
+    this.assertCurrentGeneration(generation);
     const env = buildPwrAgentChildProcessEnv(resolvedEnv);
     const args = this.options.resolveArgs
       ? await this.options.resolveArgs(env)
       : this.options.args ?? [];
+    this.assertCurrentGeneration(generation);
     const commandEnv = buildPwrAgentChildProcessEnv(env);
     const command = await resolveCodexCommand({
       command: this.options.command,
       env: commandEnv,
     });
+    this.assertCurrentGeneration(generation);
     const childEnv = buildPwrAgentChildProcessEnv(commandEnv);
     codexTransportLog.info("launch app-server", {
       command: command.command,
@@ -98,13 +126,21 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     const child = spawn(command.command, ["app-server", ...args], {
       stdio: ["pipe", "pipe", "pipe"],
       env: childEnv,
+      detached: process.platform !== "win32",
     });
 
+    this.childProcess = child;
+
     if (!child.stdin || !child.stdout || !child.stderr) {
+      await terminateOwnedProcessTree(child, {
+        gracefulTimeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+        forceTimeoutMs: PROCESS_FORCE_CLOSE_TIMEOUT_MS,
+      });
+      if (this.childProcess === child) {
+        this.childProcess = null;
+      }
       throw new Error("codex app server stdio pipes unavailable");
     }
-
-    this.childProcess = child;
 
     const stdoutReader = readline.createInterface({ input: child.stdout });
     stdoutReader.on("line", (line: string) => {
@@ -154,6 +190,9 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       });
     });
     child.on("error", (error: Error) => {
+      if (this.childProcess === child && child.pid === undefined) {
+        this.childProcess = null;
+      }
       this.closeHandler(error);
     });
     child.on("close", () => {
@@ -166,6 +205,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
 
   async close(): Promise<void> {
     this.closeRequested = true;
+    this.lifecycleGeneration += 1;
     if (this.closePromise) {
       return await this.closePromise;
     }
@@ -173,74 +213,16 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     if (!child) {
       return;
     }
-    this.closePromise = new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let lastError: Error | undefined;
-      let forceExitTimer: NodeJS.Timeout | undefined;
-      const cleanup = (): void => {
-        clearTimeout(forceKillTimer);
-        if (forceExitTimer) {
-          clearTimeout(forceExitTimer);
-        }
-        child.removeListener("close", onClose);
-        child.removeListener("error", onError);
-      };
-      const onClose = (): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
+    this.closePromise = terminateOwnedProcessTree(child, {
+      gracefulTimeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+      forceTimeoutMs: PROCESS_FORCE_CLOSE_TIMEOUT_MS,
+    })
+      .finally(() => {
         if (this.childProcess === child) {
           this.childProcess = null;
         }
-        resolve();
-      };
-      const onError = (error: Error): void => {
-        // An error can mean the termination signal itself failed. It is not
-        // proof that the process exited, so keep waiting for `close` and let
-        // the force-kill deadline decide whether shutdown failed.
-        lastError = error;
-      };
-      const tryKill = (signal: NodeJS.Signals): void => {
-        try {
-          if (!child.kill(signal)) {
-            lastError = new Error(
-              `Codex app-server did not accept ${signal}`,
-            );
-          }
-        } catch (error) {
-          onError(error instanceof Error ? error : new Error(String(error)));
-        }
-      };
-      const forceKillTimer = setTimeout(() => {
-        tryKill("SIGKILL");
-        forceExitTimer = setTimeout(() => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          cleanup();
-          reject(
-            lastError
-            ?? new Error(
-              "Codex app-server did not exit after SIGKILL",
-            ),
-          );
-        }, PROCESS_FORCE_CLOSE_TIMEOUT_MS);
-        forceExitTimer.unref?.();
-      }, PROCESS_CLOSE_TIMEOUT_MS);
-      forceKillTimer.unref?.();
-      child.once("close", onClose);
-      child.on("error", onError);
-      if (child.exitCode !== null || child.signalCode !== null) {
-        onClose();
-        return;
-      }
-      tryKill("SIGTERM");
-    }).finally(() => {
-      this.closePromise = undefined;
-    });
+        this.closePromise = undefined;
+      });
     return await this.closePromise;
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -138,6 +138,7 @@ import {
 } from "./profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "./settings/desktop-secret-store";
 import { isUpdateInstallInProgress } from "./update-install-state";
+import { createShutdownBarrier } from "./shutdown-barrier";
 
 const APP_NAME = "PwrAgent";
 const APP_COPYRIGHT = "Copyright © 2026 PwrDrvr LLC.";
@@ -147,7 +148,12 @@ const isMac = process.platform === "darwin";
 const isDevelopment = process.env.NODE_ENV !== "production";
 const mainLog = getMainLogger("pwragent:main");
 const mainProcessStartedAt = Date.now();
+const MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS = 12_000;
+const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
+const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
 let mainProcessResourcesDisposed = false;
+let mainProcessShutdownComplete = false;
+let finalQuitPromise: Promise<void> | undefined;
 let quitInProgress = false;
 let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
 let startupCpuProfilerForNewWindows:
@@ -404,18 +410,52 @@ function disposeMainProcessResourcesSync(): void {
   if (isDevelopment) {
     disposeRuntimeIdentityIpcHandlers();
   }
-  void disposeMessagingStatusIpcHandlers();
   const runtimeMessagingLeaseCoordinator =
     getExistingRuntimeMessagingLeaseCoordinator() ??
     (isAppStateInitialized() ? getRuntimeMessagingLeaseCoordinator() : null);
   runtimeMessagingLeaseCoordinator?.shutdownSync();
-  void disposeDesktopMessagingRuntime().catch((error) => {
-    mainLog.warn("messaging runtime disposal failed during shutdown", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  });
-  void disposeAppServerIpcHandlers();
+}
+
+const runMainProcessShutdownBarrier = createShutdownBarrier({
+  globalTimeoutMs: MAIN_PROCESS_SHUTDOWN_TIMEOUT_MS,
+  logger: mainLog,
+  phases: [
+    {
+      name: "messaging",
+      timeoutMs: MESSAGING_SHUTDOWN_TIMEOUT_MS,
+      run: async () => {
+        await disposeMessagingStatusIpcHandlers();
+        await disposeDesktopMessagingRuntime();
+      },
+    },
+    {
+      name: "app-server",
+      timeoutMs: APP_SERVER_SHUTDOWN_TIMEOUT_MS,
+      run: disposeAppServerIpcHandlers,
+    },
+  ],
+});
+
+async function disposeMainProcessResources(source: string): Promise<void> {
+  disposeMainProcessResourcesSync();
+  await runMainProcessShutdownBarrier(source);
   disposeAppState();
+  mainProcessShutdownComplete = true;
+}
+
+function quitAfterResourceShutdown(source: string): void {
+  finalQuitPromise ??= disposeMainProcessResources(source)
+    .catch((error: unknown) => {
+      mainLog.warn("main process shutdown barrier failed", {
+        source,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    })
+    .finally(() => {
+      mainProcessShutdownComplete = true;
+      appQuitManager.allowImmediateQuit();
+      app.quit();
+    });
 }
 
 function beginQuitInProgress(source: string): void {
@@ -497,14 +537,14 @@ function installProcessShutdownHandlers(): void {
   const handleSignal = (signal: NodeJS.Signals): void => {
     mainLog.info("main process shutdown signal received", { signal });
     beginQuitInProgress(signal);
-    disposeMainProcessResourcesSync();
     appQuitManager.allowImmediateQuit();
-    app.quit();
+    quitAfterResourceShutdown(signal);
   };
   process.once("SIGTERM", handleSignal);
   process.once("SIGINT", handleSignal);
   process.once("exit", () => {
     disposeMainProcessResourcesSync();
+    disposeAppState();
   });
 }
 
@@ -917,6 +957,11 @@ export function bootstrapApp(): void {
     }
     if (quitInProgress) {
       if (appQuitManager.isQuitAllowed()) {
+        if (!mainProcessShutdownComplete) {
+          mainLog.info("starting resource shutdown after windows closed");
+          quitAfterResourceShutdown("window-all-closed");
+          return;
+        }
         mainLog.info("quitting after windows closed during shutdown");
         app.quit();
         return;
@@ -934,10 +979,15 @@ export function bootstrapApp(): void {
       return;
     }
     beginQuitInProgress("before-quit");
+    if (!mainProcessShutdownComplete) {
+      event?.preventDefault();
+      quitAfterResourceShutdown("before-quit");
+    }
   });
 
   app.on("will-quit", () => {
     disposeMainProcessResourcesSync();
+    disposeAppState();
   });
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -137,7 +137,11 @@ import {
   type ProfileFocusRequestWatcher,
 } from "./profile";
 import { SECRET_STORAGE_DISABLED_ENV } from "./settings/desktop-secret-store";
-import { isUpdateInstallInProgress } from "./update-install-state";
+import {
+  isUpdateInstallInProgress,
+  isUpdateInstallUpdaterQuitReady,
+  setUpdateInstallPreparationHandler,
+} from "./update-install-state";
 import { createShutdownBarrier } from "./shutdown-barrier";
 
 const APP_NAME = "PwrAgent";
@@ -153,6 +157,7 @@ const MESSAGING_SHUTDOWN_TIMEOUT_MS = 4_000;
 const APP_SERVER_SHUTDOWN_TIMEOUT_MS = 7_500;
 let mainProcessResourcesDisposed = false;
 let mainProcessShutdownComplete = false;
+let mainProcessShutdownPromise: Promise<void> | undefined;
 let finalQuitPromise: Promise<void> | undefined;
 let quitInProgress = false;
 let profileFocusRequestWatcher: ProfileFocusRequestWatcher | null = null;
@@ -437,10 +442,18 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
 });
 
 async function disposeMainProcessResources(source: string): Promise<void> {
-  disposeMainProcessResourcesSync();
-  await runMainProcessShutdownBarrier(source);
-  disposeAppState();
-  mainProcessShutdownComplete = true;
+  mainProcessShutdownPromise ??= (async () => {
+    disposeMainProcessResourcesSync();
+    await runMainProcessShutdownBarrier(source);
+    disposeAppState();
+    mainProcessShutdownComplete = true;
+  })();
+  await mainProcessShutdownPromise;
+}
+
+async function prepareForUpdateInstallShutdown(): Promise<void> {
+  beginQuitInProgress("update-install");
+  await disposeMainProcessResources("update-install");
 }
 
 function quitAfterResourceShutdown(source: string): void {
@@ -724,6 +737,7 @@ function rejectDevOnlyEnvVarsInProduction(): void {
 }
 
 export function bootstrapApp(): void {
+  setUpdateInstallPreparationHandler(prepareForUpdateInstallShutdown);
   rejectDevOnlyEnvVarsInProduction();
   app.setName(APP_NAME);
   app.setAboutPanelOptions({
@@ -973,6 +987,23 @@ export function bootstrapApp(): void {
   });
 
   app.on("before-quit", (event) => {
+    if (isUpdateInstallInProgress()) {
+      beginQuitInProgress("update-install");
+      if (!isUpdateInstallUpdaterQuitReady()) {
+        event?.preventDefault();
+      }
+      if (!mainProcessShutdownComplete) {
+        // Defensive fallback for a native/direct updater invocation that did
+        // not pass through installDownloadedAppUpdate. Never issue app.quit()
+        // here; preparation or Squirrel owns the next transition.
+        void prepareForUpdateInstallShutdown().catch((error: unknown) => {
+          mainLog.warn("update-install shutdown preparation failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+      return;
+    }
     if (!appQuitManager.isQuitAllowed()) {
       event?.preventDefault();
       beginQuitWithRelease("before-quit");

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -151,6 +151,7 @@ import {
 import { registerDirectoryFromDisk } from "../app-server/directory-registration-service";
 import {
   disposeDesktopBackendRegistry,
+  getExistingDesktopBackendRegistry,
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
@@ -6404,10 +6405,11 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL);
   unsubscribeWorkingStateEvents?.();
   unsubscribeWorkingStateEvents = undefined;
-  getDesktopBackendRegistry().setThreadPullRequestStatusToolHandler(undefined);
-  getDesktopBackendRegistry().setThreadPullRequestCanonicalizer(undefined);
-  getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(undefined);
-  getDesktopBackendRegistry().setThreadPrAutoDispatchHandler(undefined);
+  const registry = getExistingDesktopBackendRegistry();
+  registry?.setThreadPullRequestStatusToolHandler(undefined);
+  registry?.setThreadPullRequestCanonicalizer(undefined);
+  registry?.setThreadPullRequestWatchToolHandler(undefined);
+  registry?.setThreadPrAutoDispatchHandler(undefined);
   await appServerService.close();
 }
 

--- a/apps/desktop/src/main/process-tree.ts
+++ b/apps/desktop/src/main/process-tree.ts
@@ -23,6 +23,18 @@ function isExited(child: OwnedChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null;
 }
 
+function isOwnedProcessTreeAlive(child: OwnedChildProcess): boolean {
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code !== "ESRCH";
+    }
+  }
+  return !isExited(child);
+}
+
 function waitForExit(
   child: OwnedChildProcess,
   timeoutMs: number,
@@ -47,6 +59,39 @@ function waitForExit(
     if (isExited(child)) {
       finish(true);
     }
+  });
+}
+
+function waitForOwnedProcessTreeExit(
+  child: OwnedChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (process.platform === "win32" || !child.pid) {
+    return waitForExit(child, timeoutMs);
+  }
+  if (!isOwnedProcessTreeAlive(child)) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearInterval(pollTimer);
+      clearTimeout(deadlineTimer);
+      resolve(exited);
+    };
+    const pollTimer = setInterval(() => {
+      if (!isOwnedProcessTreeAlive(child)) {
+        finish(true);
+      }
+    }, Math.max(1, Math.min(25, timeoutMs)));
+    const deadlineTimer = setTimeout(
+      () => finish(!isOwnedProcessTreeAlive(child)),
+      timeoutMs,
+    );
   });
 }
 
@@ -102,7 +147,7 @@ export async function terminateOwnedProcessTree(
   child: OwnedChildProcess,
   options: ProcessTreeTerminationOptions,
 ): Promise<void> {
-  if (isExited(child)) {
+  if (!isOwnedProcessTreeAlive(child)) {
     return;
   }
   let lastError: Error | undefined;
@@ -118,7 +163,7 @@ export async function terminateOwnedProcessTree(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
     }
-    if (await waitForExit(child, options.gracefulTimeoutMs)) {
+    if (await waitForOwnedProcessTreeExit(child, options.gracefulTimeoutMs)) {
       return;
     }
     try {
@@ -128,7 +173,7 @@ export async function terminateOwnedProcessTree(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
     }
-    if (await waitForExit(child, options.forceTimeoutMs)) {
+    if (await waitForOwnedProcessTreeExit(child, options.forceTimeoutMs)) {
       return;
     }
     throw lastError ?? new Error("child process tree did not exit after SIGKILL");

--- a/apps/desktop/src/main/process-tree.ts
+++ b/apps/desktop/src/main/process-tree.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { buildPwrAgentChildProcessEnv } from "./child-process-env";
+
+export type OwnedChildProcess = {
+  pid?: number;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: "error", listener: (error: Error) => void): unknown;
+  on(event: "close", listener: () => void): unknown;
+  once(event: "close", listener: () => void): unknown;
+  removeListener(event: "close", listener: () => void): unknown;
+  removeListener(event: "error", listener: (error: Error) => void): unknown;
+};
+
+export type ProcessTreeTerminationOptions = {
+  gracefulTimeoutMs: number;
+  forceTimeoutMs: number;
+};
+
+function isExited(child: OwnedChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForExit(
+  child: OwnedChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (isExited(child)) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      child.removeListener("close", onClose);
+      resolve(exited);
+    };
+    const onClose = (): void => finish(true);
+    const timer = setTimeout(() => finish(isExited(child)), timeoutMs);
+    child.once("close", onClose);
+    if (isExited(child)) {
+      finish(true);
+    }
+  });
+}
+
+function terminateWindowsTree(
+  pid: number,
+  signal: NodeJS.Signals,
+): boolean {
+  const childEnv = buildPwrAgentChildProcessEnv(process.env);
+  const systemRoot = Object.entries(childEnv).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const taskkill = systemRoot
+    ? path.join(systemRoot, "System32", "taskkill.exe")
+    : "taskkill";
+  const args = ["/pid", String(pid), "/t"];
+  if (signal === "SIGKILL") {
+    args.push("/f");
+  }
+  return spawnSync(taskkill, args, {
+    env: childEnv,
+    stdio: "ignore",
+  }).status === 0;
+}
+
+function signalProcessTree(
+  child: OwnedChildProcess,
+  signal: NodeJS.Signals,
+): boolean {
+  if (child.pid) {
+    if (process.platform === "win32") {
+      if (terminateWindowsTree(child.pid, signal)) {
+        return true;
+      }
+    } else {
+      try {
+        process.kill(-child.pid, signal);
+        return true;
+      } catch {
+        // Fall back to the immediate child when the process group is already
+        // gone or could not be addressed. This also keeps mocked children
+        // useful in unit tests.
+      }
+    }
+  }
+  return child.kill(signal);
+}
+
+/**
+ * Stop a child that PwrAgent launched as the leader of its own POSIX process
+ * group (or a Windows process tree), wait for a graceful exit, then escalate.
+ */
+export async function terminateOwnedProcessTree(
+  child: OwnedChildProcess,
+  options: ProcessTreeTerminationOptions,
+): Promise<void> {
+  if (isExited(child)) {
+    return;
+  }
+  let lastError: Error | undefined;
+  const onError = (error: Error): void => {
+    lastError = error;
+  };
+  child.on("error", onError);
+  try {
+    try {
+      if (!signalProcessTree(child, "SIGTERM")) {
+        lastError = new Error("child process tree did not accept SIGTERM");
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+    if (await waitForExit(child, options.gracefulTimeoutMs)) {
+      return;
+    }
+    try {
+      if (!signalProcessTree(child, "SIGKILL")) {
+        lastError = new Error("child process tree did not accept SIGKILL");
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+    if (await waitForExit(child, options.forceTimeoutMs)) {
+      return;
+    }
+    throw lastError ?? new Error("child process tree did not exit after SIGKILL");
+  } finally {
+    child.removeListener("error", onError);
+  }
+}

--- a/apps/desktop/src/main/shutdown-barrier.ts
+++ b/apps/desktop/src/main/shutdown-barrier.ts
@@ -1,0 +1,130 @@
+export type ShutdownPhase = {
+  name: string;
+  timeoutMs: number;
+  run: () => Promise<void> | void;
+};
+
+export type ShutdownBarrierLogger = {
+  info(message: string, detail?: Record<string, unknown>): void;
+  warn(message: string, detail?: Record<string, unknown>): void;
+};
+
+export type ShutdownPhaseOutcome = {
+  name: string;
+  outcome: "completed" | "failed" | "timed-out" | "skipped";
+  durationMs: number;
+  error?: string;
+};
+
+export type ShutdownSummary = {
+  source: string;
+  durationMs: number;
+  outcomes: ShutdownPhaseOutcome[];
+};
+
+export function createShutdownBarrier(options: {
+  phases: ShutdownPhase[];
+  globalTimeoutMs: number;
+  logger: ShutdownBarrierLogger;
+  now?: () => number;
+}): (source: string) => Promise<ShutdownSummary> {
+  let shutdownPromise: Promise<ShutdownSummary> | undefined;
+  return (source) => {
+    shutdownPromise ??= runShutdownPhases({ ...options, source });
+    return shutdownPromise;
+  };
+}
+
+async function runShutdownPhases(options: {
+  phases: ShutdownPhase[];
+  globalTimeoutMs: number;
+  logger: ShutdownBarrierLogger;
+  now?: () => number;
+  source: string;
+}): Promise<ShutdownSummary> {
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  const deadline = startedAt + options.globalTimeoutMs;
+  const outcomes: ShutdownPhaseOutcome[] = [];
+  options.logger.info("shutdown barrier started", {
+    source: options.source,
+    globalTimeoutMs: options.globalTimeoutMs,
+  });
+
+  for (const phase of options.phases) {
+    const remainingMs = Math.max(0, deadline - now());
+    if (remainingMs === 0) {
+      const outcome: ShutdownPhaseOutcome = {
+        name: phase.name,
+        outcome: "skipped",
+        durationMs: 0,
+      };
+      outcomes.push(outcome);
+      options.logger.warn("shutdown phase skipped after global deadline", {
+        source: options.source,
+        phase: phase.name,
+      });
+      continue;
+    }
+
+    const phaseStartedAt = now();
+    const timeoutMs = Math.min(phase.timeoutMs, remainingMs);
+    const result = await runPhase(phase.run, timeoutMs);
+    const outcome: ShutdownPhaseOutcome = {
+      name: phase.name,
+      outcome: result.outcome,
+      durationMs: Math.max(0, now() - phaseStartedAt),
+      ...(result.error ? { error: result.error } : {}),
+    };
+    outcomes.push(outcome);
+    const detail = {
+      source: options.source,
+      phase: phase.name,
+      timeoutMs,
+      durationMs: outcome.durationMs,
+      ...(outcome.error ? { error: outcome.error } : {}),
+    };
+    if (outcome.outcome === "completed") {
+      options.logger.info("shutdown phase completed", detail);
+    } else {
+      options.logger.warn(`shutdown phase ${outcome.outcome}`, detail);
+    }
+  }
+
+  const summary = {
+    source: options.source,
+    durationMs: Math.max(0, now() - startedAt),
+    outcomes,
+  };
+  options.logger.info("shutdown barrier completed", summary);
+  return summary;
+}
+
+async function runPhase(
+  run: () => Promise<void> | void,
+  timeoutMs: number,
+): Promise<{
+  outcome: "completed" | "failed" | "timed-out";
+  error?: string;
+}> {
+  let timer: NodeJS.Timeout | undefined;
+  const operation = Promise.resolve()
+    .then(run)
+    .then(
+      () => ({ outcome: "completed" as const }),
+      (error: unknown) => ({
+        outcome: "failed" as const,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  const outcome = await Promise.race([
+    operation,
+    new Promise<{ outcome: "timed-out" }>((resolve) => {
+      timer = setTimeout(() => resolve({ outcome: "timed-out" }), timeoutMs);
+    }),
+  ]);
+  if (timer) {
+    clearTimeout(timer);
+  }
+  return outcome;
+}

--- a/apps/desktop/src/main/update-install-state.ts
+++ b/apps/desktop/src/main/update-install-state.ts
@@ -1,6 +1,8 @@
 /**
- * One-way latch that records when the app has handed control to the auto
- * updater's `quitAndInstall()` flow.
+ * One-way latches for an accepted auto-update restart. The first blocks any
+ * competing ordinary quit while bounded teardown runs; the second records the
+ * immediate native `quitAndInstall()` handoff, when before-quit must no longer
+ * be intercepted.
  *
  * On macOS, `autoUpdater.quitAndInstall()` (electron-updater's MacUpdater →
  * Electron's native Squirrel.Mac updater) closes every window first and only
@@ -11,16 +13,35 @@
  * OLD version — or fails to relaunch at all. See the update-install quit path
  * in `auto-updater.ts` and the `window-all-closed` handler in `index.ts`.
  *
- * Once the install is underway there is no valid path back to a running app, so
- * this latch is intentionally never reset: the process is on its way down and
- * the updater owns the quit + relaunch.
+ * Once preparation is underway there is no valid path back to a running app,
+ * so these latches are intentionally never reset.
  */
 let updateInstallInProgress = false;
+let updaterQuitReady = false;
+let prepareUpdateInstall: (() => Promise<void>) | undefined;
+
+export function setUpdateInstallPreparationHandler(
+  handler: (() => Promise<void>) | undefined,
+): void {
+  prepareUpdateInstall = handler;
+}
+
+export async function prepareForUpdateInstall(): Promise<void> {
+  await prepareUpdateInstall?.();
+}
 
 export function markUpdateInstallInProgress(): void {
   updateInstallInProgress = true;
 }
 
+export function markUpdateInstallUpdaterQuitReady(): void {
+  updaterQuitReady = true;
+}
+
 export function isUpdateInstallInProgress(): boolean {
   return updateInstallInProgress;
+}
+
+export function isUpdateInstallUpdaterQuitReady(): boolean {
+  return updaterQuitReady;
 }


### PR DESCRIPTION
## Summary

- replace fire-and-forget desktop teardown with one idempotent asynchronous quit barrier that awaits messaging and App Server phases under per-phase and global deadlines, logs timings/outcomes, and preserves confirmation and updater-driven quit behavior
- preserve Squirrel.Mac ownership by completing bounded teardown before `quitAndInstall()`, holding ordinary quits during preparation, and never intercepting the updater-owned `before-quit`
- make Codex and ACP stdio ownership close-aware: cancel stale connection generations, clean partial launches, create POSIX process groups, terminate Windows trees, wait for the full tree to exit, and escalate surviving descendants to forced termination
- prevent shutdown from constructing the backend registry, close unrelated backend resources concurrently while draining recovery before the final Codex close, and bound ACP initialization/client disposal during adapter close
- add focused regressions for repeat/bounded quit, updater handoff, shutdown-time registry construction, post-close spawn, reconnect, ACP late creation, pending initialization, leader-exit/resistant-descendant trees, escalation, and invalid-ID recovery shutdown

## Testing

- `pnpm test apps/desktop/src/main/__tests__/auto-updater.test.ts apps/desktop/src/main/__tests__/shutdown-barrier.test.ts apps/desktop/src/main/__tests__/process-tree.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts apps/desktop/src/main/__tests__/acp-stdio-transport.test.ts apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (620 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with the existing warning baseline; 0 errors)
- `pnpm lint:boundaries`

## Deferred

- Codex executable discovery TTL/caching, invalidation, and bounded stale refreshes in Settings/startup remain group 1 work
- Codex Environment setup/action login-shell and nvm hydration behavior is intentionally unchanged

## Design risk

- POSIX descendant termination is exercised with a real leader-exit/resistant-descendant process group on macOS; the equivalent Windows `taskkill /t` path follows the existing Codex Environment runtime pattern but was not executed on this host
- the app-level deadline deliberately permits quit to continue after a pathological teardown timeout; phase outcome logs retain the diagnosis, while normal Codex/ACP paths force-kill before that deadline
