### PR TITLE
fix(desktop): coordinate Codex discovery refresh

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodexDiscoverySnapshot } from "@pwrdrvr/codex-discovery";
+import { CodexDiscoveryCoordinator } from "../codex-discovery-coordinator";
+
+function selectedSnapshot(command: string): CodexDiscoverySnapshot {
+  return {
+    candidates: [
+      {
+        command,
+        executable: true,
+        selected: true,
+        source: "path",
+        version: "0.126.0",
+      },
+    ],
+    selectedCommand: command,
+    selectedSource: "path",
+  };
+}
+
+function notInstalledSnapshot(): CodexDiscoverySnapshot {
+  return { candidates: [] };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("CodexDiscoveryCoordinator", () => {
+  it("single-flights concurrent probes and waits for the hydrated environment", async () => {
+    const hydratedEnv = deferred<NodeJS.ProcessEnv>();
+    const discover = vi.fn(async () => selectedSnapshot("/nvm/bin/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      resolveEnv: () => hydratedEnv.promise,
+    });
+
+    const first = coordinator.discover();
+    const second = coordinator.discover();
+    await Promise.resolve();
+
+    expect(discover).not.toHaveBeenCalled();
+    hydratedEnv.resolve({ PATH: "/nvm/bin:/usr/bin", NVM_DIR: "/nvm" });
+
+    await expect(first).resolves.toEqual(selectedSnapshot("/nvm/bin/codex"));
+    await expect(second).resolves.toEqual(selectedSnapshot("/nvm/bin/codex"));
+    expect(discover).toHaveBeenCalledOnce();
+    expect(discover).toHaveBeenCalledWith({
+      configuredCommand: undefined,
+      env: { PATH: "/nvm/bin:/usr/bin", NVM_DIR: "/nvm" },
+    });
+  });
+
+  it("expires successful results and only serves them stale during a refresh", async () => {
+    let now = 0;
+    const refresh = deferred<CodexDiscoverySnapshot>();
+    const discover = vi.fn()
+      .mockResolvedValueOnce(selectedSnapshot("/old/codex"))
+      .mockReturnValueOnce(refresh.promise);
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      now: () => now,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+      staleSuccessTtlMs: 1_000,
+      successTtlMs: 100,
+    });
+
+    await coordinator.discover();
+    now = 100;
+    const freshProbe = coordinator.discover();
+    await Promise.resolve();
+
+    await expect(
+      coordinator.discover(undefined, { allowStaleSuccess: true }),
+    ).resolves.toEqual(selectedSnapshot("/old/codex"));
+    refresh.resolve(selectedSnapshot("/new/codex"));
+    await expect(freshProbe).resolves.toEqual(selectedSnapshot("/new/codex"));
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-probes not-installed results after their short TTL", async () => {
+    let now = 0;
+    const discover = vi.fn()
+      .mockResolvedValueOnce(notInstalledSnapshot())
+      .mockResolvedValueOnce(selectedSnapshot("/installed/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      notInstalledTtlMs: 15,
+      now: () => now,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+
+    await expect(coordinator.discover()).resolves.toEqual(notInstalledSnapshot());
+    now = 14;
+    await coordinator.discover();
+    expect(discover).toHaveBeenCalledOnce();
+
+    now = 15;
+    await expect(coordinator.discover()).resolves.toEqual(
+      selectedSnapshot("/installed/codex"),
+    );
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the latest hydrated PATH when an expired result is re-probed", async () => {
+    let now = 0;
+    let path = "/old/bin";
+    const discover = vi.fn(async (params?: { env?: NodeJS.ProcessEnv }) =>
+      selectedSnapshot(`${params?.env?.PATH}/codex`),
+    );
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      now: () => now,
+      resolveEnv: async () => ({ PATH: path }),
+      successTtlMs: 10,
+    });
+
+    await expect(coordinator.resolve()).resolves.toMatchObject({
+      command: "/old/bin/codex",
+    });
+    path = "/new/bin";
+    now = 10;
+    await expect(coordinator.resolve()).resolves.toMatchObject({
+      command: "/new/bin/codex",
+    });
+  });
+
+  it("bounds failed probes and recovers after the failure TTL", async () => {
+    let now = 0;
+    const failure = new Error("probe failed");
+    const discover = vi.fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(selectedSnapshot("/recovered/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      failureTtlMs: 5,
+      now: () => now,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+
+    await expect(coordinator.discover()).rejects.toBe(failure);
+    now = 4;
+    await expect(coordinator.discover()).rejects.toBe(failure);
+    expect(discover).toHaveBeenCalledOnce();
+
+    now = 5;
+    await expect(coordinator.discover()).resolves.toEqual(
+      selectedSnapshot("/recovered/codex"),
+    );
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces force refreshes and bypasses a fresh cache entry", async () => {
+    const discover = vi.fn()
+      .mockResolvedValueOnce(selectedSnapshot("/old/codex"))
+      .mockResolvedValueOnce(selectedSnapshot("/forced/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+    await coordinator.discover();
+
+    const [first, second] = await Promise.all([
+      coordinator.discover(undefined, { force: true }),
+      coordinator.discover(undefined, { force: true }),
+    ]);
+
+    expect(first).toEqual(selectedSnapshot("/forced/codex"));
+    expect(second).toEqual(first);
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates config-sensitive results and shares selection with launch", async () => {
+    const discover = vi.fn()
+      .mockResolvedValueOnce(selectedSnapshot("/configured/codex"))
+      .mockResolvedValueOnce(selectedSnapshot("/changed/codex"));
+    const coordinator = new CodexDiscoveryCoordinator({
+      discover,
+      resolveEnv: async () => ({ PATH: "/bin" }),
+    });
+
+    const settings = await coordinator.discover("codex-custom");
+    const launch = await coordinator.resolve("codex-custom");
+    expect(launch.command).toBe(settings.selectedCommand);
+    expect(discover).toHaveBeenCalledOnce();
+
+    coordinator.invalidate();
+    await expect(coordinator.resolve("codex-custom")).resolves.toMatchObject({
+      command: "/changed/codex",
+    });
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -24,6 +24,55 @@ function createTempRoot(): string {
 }
 
 describe("DesktopSettingsService", () => {
+  it("forces discovery refresh and invalidates command-setting writes", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const discover = vi.fn(async () => ({
+      candidates: [
+        {
+          command: "/opt/codex",
+          executable: true,
+          selected: true,
+          source: "config" as const,
+          version: "0.126.0",
+        },
+      ],
+      selectedCommand: "/opt/codex",
+      selectedSource: "config" as const,
+    }));
+    const invalidate = vi.fn();
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover,
+        invalidate,
+        resolve: vi.fn(async () => ({
+          command: "/opt/codex",
+          source: "config" as const,
+          version: "0.126.0",
+        })),
+      },
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    await service.readSettings();
+    await service.refreshCodexDiscovery();
+    expect(discover).toHaveBeenNthCalledWith(2, undefined, {
+      allowStaleSuccess: true,
+      force: true,
+    });
+
+    await service.writeConfigPatch({
+      models: { codex: { path: "/opt/codex" } },
+    });
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(discover).toHaveBeenLastCalledWith("/opt/codex", {
+      allowStaleSuccess: true,
+      force: false,
+    });
+  });
+
   it("loads TOML values from the desktop config path", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -247,9 +247,11 @@ describe("settings ipc", () => {
     } = await import("../ipc/settings");
     const {
       SETTINGS_READ_CHANNEL,
+      SETTINGS_REFRESH_CODEX_DISCOVERY_CHANNEL,
       SETTINGS_REPLACE_SECRET_CHANNEL,
       SETTINGS_WRITE_CONFIG_CHANNEL,
     } = await import("../../shared/ipc");
+    const refreshCodexDiscovery = vi.spyOn(service, "refreshCodexDiscovery");
 
     registerSettingsIpcHandlers(service);
 
@@ -268,6 +270,8 @@ describe("settings ipc", () => {
         },
       },
     });
+    await handlers.get(SETTINGS_REFRESH_CODEX_DISCOVERY_CHANNEL)?.({}, {});
+    expect(refreshCodexDiscovery).toHaveBeenCalledOnce();
 
     await handlers.get(SETTINGS_WRITE_CONFIG_CHANNEL)?.(
       {},
@@ -401,6 +405,9 @@ describe("settings ipc", () => {
 
   it("does not run the saved Codex path when discovery rejected it", async () => {
     const service = {
+      resolveCodexCommand: vi.fn(async () => {
+        throw new Error("Codex CLI is older than the minimum supported version");
+      }),
       readSettings: vi.fn(async () => ({
         models: {
           codex: {

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -262,4 +262,36 @@ describe("StdioJsonRpcTransport", () => {
     expect(spawnMock).toHaveBeenCalledTimes(2);
     await transport.close();
   });
+
+  it("uses the shared command resolver instead of probing discovery directly", async () => {
+    const firstChild = new MockCodexChildProcess();
+    const secondChild = new MockCodexChildProcess();
+    spawnMock
+      .mockReturnValueOnce(firstChild)
+      .mockReturnValueOnce(secondChild);
+    const sharedResolver = vi.fn(async () => ({
+      command: "/hydrated/bin/codex",
+      source: "path" as const,
+      version: "0.126.0",
+    }));
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { PATH: "/hydrated/bin:/usr/bin" },
+      resolveCommand: sharedResolver,
+    });
+
+    await transport.connect();
+    await transport.close();
+    await transport.connect();
+
+    expect(sharedResolver).toHaveBeenCalledTimes(2);
+    expect(resolveCodexCommandMock).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenNthCalledWith(
+      1,
+      "/hydrated/bin/codex",
+      ["app-server"],
+      expect.any(Object),
+    );
+    await transport.close();
+  });
 });

--- a/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-migration-service.test.ts
@@ -3,6 +3,7 @@ import type {
   AppServerThreadReplay,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
+import type { ResolvedCodexCommandCandidate } from "@pwrdrvr/codex-discovery";
 import type { CodexThreadMigrationMetadata } from "../codex-app-server/client";
 import { ThreadMigrationService } from "../app-server/thread-migration-service";
 
@@ -120,6 +121,11 @@ describe("ThreadMigrationService", () => {
 
   it("lists source threads through a captive CAS client without exposing rollout paths", async () => {
     let capturedEnv: NodeJS.ProcessEnv | undefined;
+    let capturedResolveCommand:
+      | ((params: { command: string; env: NodeJS.ProcessEnv }) => Promise<
+          ResolvedCodexCommandCandidate
+        >)
+      | undefined;
     const sourceClient = {
       listThreadsForMigration: vi.fn(async () => [makeSourceThread()]),
       readThread: vi.fn(),
@@ -132,10 +138,20 @@ describe("ThreadMigrationService", () => {
       settingsService: {
         readSettings: async () => makeSettingsSnapshot("work"),
         resolveCodexCommandPreference: () => "codex",
-        resolveCodexSpawnEnv: () => ({ PATH: "/bin" }),
+        resolveCodexCommand: async () => ({
+          command: "/nvm/bin/codex",
+          source: "path",
+          version: "0.126.0",
+        }),
+        resolveCodexSpawnEnv: () => ({ PATH: "/raw/bin" }),
+        resolveCodexSpawnEnvAsync: async () => ({
+          NVM_DIR: "/nvm",
+          PATH: "/nvm/bin:/usr/bin",
+        }),
       },
-      sourceClientFactory: ({ env }) => {
+      sourceClientFactory: ({ env, resolveCommand }) => {
         capturedEnv = env;
+        capturedResolveCommand = resolveCommand;
         return sourceClient;
       },
       now: () => 1234,
@@ -144,6 +160,13 @@ describe("ThreadMigrationService", () => {
     const response = await service.listSourceThreads({ sourceProfile: "" });
 
     expect(capturedEnv?.CODEX_HOME).toBe("/Users/alice/.codex");
+    expect(capturedEnv).toMatchObject({
+      NVM_DIR: "/nvm",
+      PATH: "/nvm/bin:/usr/bin",
+    });
+    await expect(
+      capturedResolveCommand?.({ command: "codex", env: capturedEnv ?? {} }),
+    ).resolves.toMatchObject({ command: "/nvm/bin/codex" });
     expect(response).toMatchObject({
       sourceProfile: "",
       fetchedAt: 1234,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6392,6 +6392,9 @@ export class DesktopBackendRegistry {
         resolveArgs: settingsService
           ? async (env) => buildCodexClientArgs(env)
           : undefined,
+        resolveCommand: settingsService
+          ? async () => await settingsService.resolveCodexCommand()
+          : undefined,
         resolveEnv: settingsService
           ? async () => await settingsService.resolveCodexSpawnEnvAsync()
           : undefined,

--- a/apps/desktop/src/main/app-server/thread-migration-service.ts
+++ b/apps/desktop/src/main/app-server/thread-migration-service.ts
@@ -31,6 +31,7 @@ import {
   discoverCodexAuthProfiles,
   resolveDefaultCodexHome,
   resolveCodexHomeForProfile,
+  type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
 import {
   CodexAppServerClient,
@@ -68,12 +69,19 @@ type ThreadMigrationServiceOptions = {
   settingsService?: Pick<
     DesktopSettingsService,
     "readSettings" | "resolveCodexCommandPreference" | "resolveCodexSpawnEnv"
-  >;
+  > & Partial<Pick<
+    DesktopSettingsService,
+    "resolveCodexCommand" | "resolveCodexSpawnEnvAsync"
+  >>;
   sourceClientFactory?: (params: {
     codexHome: string;
     command?: string;
     env: NodeJS.ProcessEnv;
     profile: string;
+    resolveCommand?: (params: {
+      command: string;
+      env: NodeJS.ProcessEnv;
+    }) => Promise<ResolvedCodexCommandCandidate>;
   }) => SourceMigrationClient;
   idFactory?: () => string;
   now?: () => number;
@@ -684,23 +692,31 @@ export class ThreadMigrationService {
     const codexHome =
       source?.codexHome ?? resolveCodexHome(sourceProfile, this.options);
     const settingsService = this.getSettingsService();
-    const baseEnv = settingsService.resolveCodexSpawnEnv();
+    const baseEnv = settingsService.resolveCodexSpawnEnvAsync
+      ? await settingsService.resolveCodexSpawnEnvAsync()
+      : settingsService.resolveCodexSpawnEnv();
     const env = {
       ...baseEnv,
       CODEX_HOME: codexHome,
     };
     const command = settingsService.resolveCodexCommandPreference();
+    const resolveCodexCommand = settingsService.resolveCodexCommand;
+    const resolveCommand = resolveCodexCommand
+      ? async () => await resolveCodexCommand.call(settingsService)
+      : undefined;
     const client =
       this.options.sourceClientFactory?.({
         codexHome,
         command,
         env,
         profile: sourceProfile,
+        resolveCommand,
       }) ??
       new CodexAppServerClient({
         args: buildCodexClientArgs(env),
         command,
         env,
+        resolveCommand,
       });
     this.sourceClients.set(sourceProfile, client);
     return client;
@@ -709,7 +725,10 @@ export class ThreadMigrationService {
   private getSettingsService(): Pick<
     DesktopSettingsService,
     "readSettings" | "resolveCodexCommandPreference" | "resolveCodexSpawnEnv"
-  > {
+  > & Partial<Pick<
+    DesktopSettingsService,
+    "resolveCodexCommand" | "resolveCodexSpawnEnvAsync"
+  >> {
     return this.options.settingsService ?? getDesktopSettingsService();
   }
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -99,7 +99,10 @@ import {
   type ThreadDirectoryEnrichment,
 } from "../app-server/thread-directory-enricher";
 import { normalizeReviewDisplayText } from "../../shared/review-command";
-import { StdioJsonRpcTransport } from "./stdio-transport";
+import {
+  StdioJsonRpcTransport,
+  type StdioJsonRpcTransportOptions,
+} from "./stdio-transport";
 import {
   isCodexInvalidResponseMessageIdError,
   repairCodexInvalidResponseMessageIds,
@@ -235,6 +238,7 @@ type CodexClientOptions = {
   args?: string[];
   env?: NodeJS.ProcessEnv;
   resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
+  resolveCommand?: StdioJsonRpcTransportOptions["resolveCommand"];
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
   directoryResolver?: (
     projectKey?: string
@@ -6643,6 +6647,7 @@ export class CodexAppServerClient {
         args: options.args ?? [],
         env: options.env,
         resolveArgs: options.resolveArgs,
+        resolveCommand: options.resolveCommand,
         resolveEnv: options.resolveEnv,
       }),
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -10,6 +10,7 @@ import { terminateOwnedProcessTree } from "../process-tree";
 import {
   compareCodexCliVersions,
   resolveCodexCommand,
+  type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
 
 const codexTransportLog = getMainLogger("pwragent:codex-transport");
@@ -30,6 +31,10 @@ export type StdioJsonRpcTransportOptions = {
   args?: string[];
   env?: NodeJS.ProcessEnv;
   resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
+  resolveCommand?: (params: {
+    command: string;
+    env: NodeJS.ProcessEnv;
+  }) => Promise<ResolvedCodexCommandCandidate>;
   resolveEnv?: () => Promise<NodeJS.ProcessEnv>;
 };
 
@@ -111,7 +116,9 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       : this.options.args ?? [];
     this.assertCurrentGeneration(generation);
     const commandEnv = buildPwrAgentChildProcessEnv(env);
-    const command = await resolveCodexCommand({
+    const command = await (
+      this.options.resolveCommand ?? resolveCodexCommand
+    )({
       command: this.options.command,
       env: commandEnv,
     });

--- a/apps/desktop/src/main/codex-discovery-coordinator.ts
+++ b/apps/desktop/src/main/codex-discovery-coordinator.ts
@@ -1,0 +1,233 @@
+import {
+  CodexCliNotInstalledError,
+  MINIMUM_CODEX_CLI_VERSION,
+  discoverCodexCommands,
+  type CodexDiscoverySnapshot,
+  type ResolvedCodexCommandCandidate,
+} from "@pwrdrvr/codex-discovery";
+
+export const CODEX_DISCOVERY_SUCCESS_TTL_MS = 5 * 60_000;
+export const CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS = 15_000;
+export const CODEX_DISCOVERY_FAILURE_TTL_MS = 5_000;
+export const CODEX_DISCOVERY_STALE_SUCCESS_TTL_MS = 30 * 60_000;
+
+type DiscoveryOutcome =
+  | {
+      kind: "snapshot";
+      snapshot: CodexDiscoverySnapshot;
+    }
+  | {
+      error: unknown;
+      kind: "failure";
+    };
+
+type DiscoveryCacheEntry = {
+  cachedAt: number;
+  outcome: DiscoveryOutcome;
+};
+
+type InFlightDiscovery = {
+  forced: boolean;
+  promise: Promise<CodexDiscoverySnapshot>;
+};
+
+export type CodexDiscoveryCoordinatorOptions = {
+  discover?: typeof discoverCodexCommands;
+  failureTtlMs?: number;
+  notInstalledTtlMs?: number;
+  now?: () => number;
+  resolveEnv: () => Promise<NodeJS.ProcessEnv>;
+  staleSuccessTtlMs?: number;
+  successTtlMs?: number;
+};
+
+export type CodexDiscoveryRequest = {
+  allowStaleSuccess?: boolean;
+  force?: boolean;
+};
+
+/**
+ * Owns executable discovery for every desktop Codex consumer.
+ *
+ * Real probes always await the desktop's hydrated login-shell environment.
+ * Settings may reuse a bounded stale success while another non-forced refresh
+ * is already checking the filesystem; launches never do, so a reconnect waits
+ * for the fresh result before spawning.
+ */
+export class CodexDiscoveryCoordinator {
+  private readonly cache = new Map<string, DiscoveryCacheEntry>();
+  private readonly discoverFn: typeof discoverCodexCommands;
+  private readonly failureTtlMs: number;
+  private readonly inFlight = new Map<string, InFlightDiscovery>();
+  private readonly notInstalledTtlMs: number;
+  private readonly now: () => number;
+  private readonly staleSuccessTtlMs: number;
+  private readonly successTtlMs: number;
+  private generation = 0;
+
+  constructor(private readonly options: CodexDiscoveryCoordinatorOptions) {
+    this.discoverFn = options.discover ?? discoverCodexCommands;
+    this.failureTtlMs =
+      options.failureTtlMs ?? CODEX_DISCOVERY_FAILURE_TTL_MS;
+    this.notInstalledTtlMs =
+      options.notInstalledTtlMs ?? CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS;
+    this.now = options.now ?? Date.now;
+    this.staleSuccessTtlMs =
+      options.staleSuccessTtlMs ?? CODEX_DISCOVERY_STALE_SUCCESS_TTL_MS;
+    this.successTtlMs =
+      options.successTtlMs ?? CODEX_DISCOVERY_SUCCESS_TTL_MS;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.cache.clear();
+  }
+
+  async discover(
+    configuredCommand?: string,
+    request: CodexDiscoveryRequest = {},
+  ): Promise<CodexDiscoverySnapshot> {
+    const key = configuredCommand?.trim() ?? "";
+    const active = this.inFlight.get(key);
+
+    if (request.force === true) {
+      if (active?.forced) {
+        return await active.promise;
+      }
+      this.invalidate();
+      if (active) {
+        try {
+          await active.promise;
+        } catch {
+          // The forced probe below supersedes the earlier result.
+        }
+        return await this.discover(configuredCommand, request);
+      }
+      return await this.startProbe(key, configuredCommand, true);
+    }
+
+    const cached = this.cache.get(key);
+    if (cached && this.isFresh(cached)) {
+      return this.readOutcome(cached.outcome);
+    }
+
+    if (active) {
+      if (
+        request.allowStaleSuccess === true
+        && cached
+        && this.isSafeStaleSuccess(cached)
+      ) {
+        return cached.outcome.kind === "snapshot"
+          ? cached.outcome.snapshot
+          : await active.promise;
+      }
+      return await active.promise;
+    }
+
+    return await this.startProbe(key, configuredCommand, false);
+  }
+
+  async resolve(
+    configuredCommand?: string,
+    request: Omit<CodexDiscoveryRequest, "allowStaleSuccess"> = {},
+  ): Promise<ResolvedCodexCommandCandidate> {
+    const snapshot = await this.discover(configuredCommand, {
+      ...request,
+      allowStaleSuccess: false,
+    });
+    const selected = snapshot.candidates.find((candidate) => candidate.selected);
+    if (selected) {
+      return {
+        command: selected.command,
+        source: selected.source,
+        version: selected.version,
+      };
+    }
+
+    const rejectedOldCodex = snapshot.candidates.find(
+      (candidate) => candidate.failureReason === "codex_too_old",
+    );
+    if (rejectedOldCodex) {
+      throw new Error(
+        `Codex CLI ${rejectedOldCodex.version ?? "unknown"} is older than `
+        + `the minimum supported version ${MINIMUM_CODEX_CLI_VERSION}: `
+        + rejectedOldCodex.command,
+      );
+    }
+    throw new CodexCliNotInstalledError();
+  }
+
+  private isFresh(entry: DiscoveryCacheEntry): boolean {
+    const age = this.now() - entry.cachedAt;
+    if (entry.outcome.kind === "failure") {
+      return age < this.failureTtlMs;
+    }
+    const ttlMs = entry.outcome.snapshot.selectedCommand
+      ? this.successTtlMs
+      : this.notInstalledTtlMs;
+    return age < ttlMs;
+  }
+
+  private isSafeStaleSuccess(entry: DiscoveryCacheEntry): boolean {
+    return (
+      entry.outcome.kind === "snapshot"
+      && Boolean(entry.outcome.snapshot.selectedCommand)
+      && this.now() - entry.cachedAt < this.staleSuccessTtlMs
+    );
+  }
+
+  private readOutcome(outcome: DiscoveryOutcome): CodexDiscoverySnapshot {
+    if (outcome.kind === "failure") {
+      throw outcome.error;
+    }
+    return outcome.snapshot;
+  }
+
+  private async startProbe(
+    key: string,
+    configuredCommand: string | undefined,
+    forced: boolean,
+  ): Promise<CodexDiscoverySnapshot> {
+    const existing = this.inFlight.get(key);
+    if (existing) {
+      return await existing.promise;
+    }
+
+    const generation = this.generation;
+    const promise = this.runProbe(configuredCommand, generation);
+    const active: InFlightDiscovery = { forced, promise };
+    this.inFlight.set(key, active);
+    try {
+      return await promise;
+    } finally {
+      if (this.inFlight.get(key) === active) {
+        this.inFlight.delete(key);
+      }
+    }
+  }
+
+  private async runProbe(
+    configuredCommand: string | undefined,
+    generation: number,
+  ): Promise<CodexDiscoverySnapshot> {
+    try {
+      const env = await this.options.resolveEnv();
+      const snapshot = await this.discoverFn({ configuredCommand, env });
+      if (generation === this.generation) {
+        this.cache.set(configuredCommand?.trim() ?? "", {
+          cachedAt: this.now(),
+          outcome: { kind: "snapshot", snapshot },
+        });
+      }
+      return snapshot;
+    } catch (error) {
+      if (generation === this.generation) {
+        this.cache.set(configuredCommand?.trim() ?? "", {
+          cachedAt: this.now(),
+          outcome: { error, kind: "failure" },
+        });
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -852,8 +852,11 @@ function getCredentialTester(
         resolveService().resolveLineChannelAccessTokenSync(),
       resolveGrokApiKey: () => resolveService().resolveGrokApiKey(),
       resolveCodexCommand: async () => {
-        const snapshot = await resolveService().readSettings();
-        return snapshot.models.codex.discovery.selectedCommand ?? undefined;
+        try {
+          return (await resolveService().resolveCodexCommand()).command;
+        } catch {
+          return undefined;
+        }
       },
       validateMessagingCredentials: (request) =>
         getDesktopMessagingRuntime().requestCredentialValidation(request),
@@ -990,7 +993,7 @@ export function registerSettingsIpcHandlers(
       _request?: RefreshDesktopCodexDiscoveryRequest,
     ): Promise<ReadDesktopSettingsResponse> => ({
       snapshot: applyRuntimeMessagingSnapshot(
-        await getService(service).readSettings(),
+        await getService(service).refreshCodexDiscovery(),
       ),
     }),
   );

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -146,10 +146,10 @@ import {
   readEnvString,
   readEnvWorktreeStorage,
 } from "./desktop-settings-env";
-import { discoverCodexCommands } from "@pwrdrvr/codex-discovery";
 import {
   discoverCodexAuthProfiles,
   resolveCodexHomeForProfile,
+  type ResolvedCodexCommandCandidate,
 } from "@pwrdrvr/codex-discovery";
 import { discoverDesktopApplications } from "./application-discovery";
 import { discoverGitCommands } from "./git-discovery";
@@ -164,6 +164,11 @@ import {
 // shape + the `resolveShellEnv` test seam; the kit takes an injected logger
 // (passed below) where the in-tree copy hardcoded `getMainLogger`.
 import { mergeLoginShellEnvIntoEnv } from "@pwrdrvr/agent-transport";
+import {
+  CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS,
+  CODEX_DISCOVERY_SUCCESS_TTL_MS,
+  CodexDiscoveryCoordinator,
+} from "../codex-discovery-coordinator";
 
 const LOGIN_SHELL_ENV_MARKER_START = "__PWRAGENT_LOGIN_SHELL_ENV_START__";
 const LOGIN_SHELL_ENV_MARKER_END = "__PWRAGENT_LOGIN_SHELL_ENV_END__";
@@ -199,6 +204,10 @@ function normalizeCodexProfilesSnapshot(
 }
 
 type DesktopSettingsServiceOptions = {
+  codexDiscoveryCoordinator?: Pick<
+    CodexDiscoveryCoordinator,
+    "discover" | "invalidate" | "resolve"
+  >;
   configPath?: string;
   defaultDeveloperMode?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -360,26 +369,22 @@ export class DesktopSettingsService {
   private readonly startupCodexHome?: string;
   private loggedObsoleteComposerConfig = false;
   private loggedObsoleteComposerEnv = false;
-  // Per-instance memoization for executable discovery. Each discovery is a
-  // pure function of `this.env` (fixed at construction), the filesystem, and a
-  // handful of config strings — so re-running them on every readSettings() just
-  // re-spawns the same probe child processes. That's wasteful everywhere and,
-  // on Windows where process spawn is far slower, multiple readSettings() calls
-  // in a single unit test could blow past the 5s test timeout. Caching is
-  // behavior-preserving: git/applications are config-independent (cached as a
-  // single promise), while codex/gh are keyed on the exact config input they
-  // consume, so a test that changes that input still triggers a fresh probe.
+  // Git/applications discovery remains process-lifetime memoized. Codex uses a
+  // bounded coordinator shared with app-server launch so Settings and launch
+  // cannot select different binaries.
   private gitDiscoveryPromise?: Promise<DesktopGitDiscoverySnapshot>;
   private applicationsDiscoveryPromise?: Promise<DesktopApplicationsSnapshot>;
-  private codexDiscoveryCache?: {
-    key: string;
-    promise: ReturnType<typeof discoverCodexCommands>;
-  };
+  private readonly codexDiscoveryCoordinator: Pick<
+    CodexDiscoveryCoordinator,
+    "discover" | "invalidate" | "resolve"
+  >;
   private ghDiscoveryCache?: {
     key: string;
     promise: ReturnType<typeof discoverGhCommands>;
   };
   private codexSpawnEnv?: NodeJS.ProcessEnv;
+  private codexSpawnEnvHydratedAt?: number;
+  private codexSpawnEnvHydrationSucceeded = false;
   private codexSpawnEnvHydrationPromise?: Promise<NodeJS.ProcessEnv>;
   private terminalSpawnEnv?: NodeJS.ProcessEnv;
   private terminalSpawnEnvHydrationPromise?: Promise<NodeJS.ProcessEnv>;
@@ -395,9 +400,17 @@ export class DesktopSettingsService {
       this.readConfig().config.models?.codex?.profile,
       { env: this.env },
     );
+    this.codexDiscoveryCoordinator =
+      options.codexDiscoveryCoordinator
+      ?? new CodexDiscoveryCoordinator({
+        now: this.now,
+        resolveEnv: async () => await this.resolveCodexSpawnEnvAsync(),
+      });
   }
 
-  async readSettings(): Promise<DesktopSettingsSnapshot> {
+  async readSettings(options: {
+    forceCodexDiscovery?: boolean;
+  } = {}): Promise<DesktopSettingsSnapshot> {
     const { config, error } = this.readConfig();
     const secretStorage = this.options.secretStore.describe();
 
@@ -471,8 +484,12 @@ export class DesktopSettingsService {
       undefined,
       secretStorage.available,
     );
-    const codexDiscovery = await this.discoverCodexCommandsCached(
-      config.models?.codex?.path,
+    const codexDiscovery = await this.codexDiscoveryCoordinator.discover(
+      this.resolveCodexCommandPreferenceFromConfig(config),
+      {
+        allowStaleSuccess: true,
+        force: options.forceCodexDiscovery === true,
+      },
     );
     const codexProfiles = normalizeCodexProfilesSnapshot(
       discoverCodexAuthProfiles({
@@ -1081,22 +1098,6 @@ export class DesktopSettingsService {
     return this.applicationsDiscoveryPromise;
   }
 
-  // codex/gh discovery depends on a single config string. Cache keyed on that
-  // string so repeated readSettings() with unchanged config skip the re-spawn,
-  // while a test that mutates the configured path re-probes (cache miss).
-  private discoverCodexCommandsCached(
-    configuredCommand: string | undefined,
-  ): ReturnType<typeof discoverCodexCommands> {
-    const key = configuredCommand ?? "";
-    if (this.codexDiscoveryCache?.key !== key) {
-      this.codexDiscoveryCache = {
-        key,
-        promise: discoverCodexCommands({ configuredCommand, env: this.env }),
-      };
-    }
-    return this.codexDiscoveryCache.promise;
-  }
-
   private discoverGhCommandsCached(
     configuredCommand: string | undefined,
   ): ReturnType<typeof discoverGhCommands> {
@@ -1256,6 +1257,9 @@ export class DesktopSettingsService {
       );
     }
     applyDesktopSettingsPatch(this.configPath, patch);
+    if (patch.models?.codex?.path !== undefined) {
+      this.codexDiscoveryCoordinator.invalidate();
+    }
     // Fan out appearance updates to every open window so aux surfaces
     // (changelog, app-log, license, messaging activity) re-apply their
     // <html data-*> attributes live instead of staying stuck on
@@ -1411,10 +1415,17 @@ export class DesktopSettingsService {
   }
 
   resolveCodexCommandPreference(): string | undefined {
-    return (
-      readEnvString(this.env, CODEX_COMMAND_ENV)
-      || this.readConfig().config.models?.codex?.path
-      || undefined
+    return this.resolveCodexCommandPreferenceFromConfig(this.readConfig().config);
+  }
+
+  async refreshCodexDiscovery(): Promise<DesktopSettingsSnapshot> {
+    this.codexSpawnEnvHydratedAt = undefined;
+    return await this.readSettings({ forceCodexDiscovery: true });
+  }
+
+  async resolveCodexCommand(): Promise<ResolvedCodexCommandCandidate> {
+    return await this.codexDiscoveryCoordinator.resolve(
+      this.resolveCodexCommandPreference(),
     );
   }
 
@@ -1462,10 +1473,22 @@ export class DesktopSettingsService {
     }
 
     const targetEnv = this.ensureBaseCodexSpawnEnv();
-    this.codexSpawnEnvHydrationPromise = resolveInteractiveLoginShellEnvAsync(this.env)
+    const hydrationTtlMs = this.codexSpawnEnvHydrationSucceeded
+      ? CODEX_DISCOVERY_SUCCESS_TTL_MS
+      : CODEX_DISCOVERY_NOT_INSTALLED_TTL_MS;
+    if (
+      this.codexSpawnEnvHydratedAt !== undefined
+      && this.now() - this.codexSpawnEnvHydratedAt < hydrationTtlMs
+    ) {
+      return targetEnv;
+    }
+
+    const hydrationPromise = resolveInteractiveLoginShellEnvAsync(this.env)
       .then((shellEnv) => {
         const logger = getMainLogger("pwragent:shell-environment");
         if (!shellEnv || Object.keys(shellEnv).length === 0) {
+          this.codexSpawnEnvHydratedAt = this.now();
+          this.codexSpawnEnvHydrationSucceeded = false;
           logger.warn("login-shell-env-merge-empty", {
             parentPathLength: this.env.PATH?.length ?? 0,
             parentShell: this.env.SHELL,
@@ -1485,10 +1508,18 @@ export class DesktopSettingsService {
         if (this.startupCodexHome) {
           targetEnv.CODEX_HOME = this.startupCodexHome;
         }
+        this.codexSpawnEnvHydratedAt = this.now();
+        this.codexSpawnEnvHydrationSucceeded = true;
         return targetEnv;
       });
-
-    return await this.codexSpawnEnvHydrationPromise;
+    this.codexSpawnEnvHydrationPromise = hydrationPromise;
+    try {
+      return await hydrationPromise;
+    } finally {
+      if (this.codexSpawnEnvHydrationPromise === hydrationPromise) {
+        this.codexSpawnEnvHydrationPromise = undefined;
+      }
+    }
   }
 
   async resolveTerminalSpawnEnvAsync(): Promise<NodeJS.ProcessEnv> {
@@ -1538,6 +1569,16 @@ export class DesktopSettingsService {
       buildPwrAgentChildProcessEnv(this.env),
     );
     return this.codexSpawnEnv;
+  }
+
+  private resolveCodexCommandPreferenceFromConfig(
+    config: DesktopSettingsConfig,
+  ): string | undefined {
+    return (
+      readEnvString(this.env, CODEX_COMMAND_ENV)
+      || config.models?.codex?.path
+      || undefined
+    );
   }
 
   private ensureBaseTerminalSpawnEnv(): NodeJS.ProcessEnv {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -1722,6 +1722,7 @@ function BackendRequirementsStep(props: {
     setRefreshing(true);
     try {
       await props.desktopApi.refreshCodexDiscovery({});
+      await props.settings.refresh();
     } catch (caught) {
        
       console.warn("Onboarding: refreshCodexDiscovery failed", caught);


### PR DESCRIPTION
## Summary

- add one PwrAgent-owned Codex executable discovery coordinator shared by Settings/status, credential checks, and Codex App Server launch
- run real probes against the hydrated desktop login-shell environment, including existing login-shell and nvm behavior
- single-flight concurrent probes and bound cache lifetimes for success, not-installed, and thrown-failure outcomes
- make the existing Codex discovery Refresh/Retry IPC force a real refresh and update onboarding state afterward
- invalidate discovery when the configured Codex command changes
- route live and migration Codex App Server clients through the shared resolver while preserving the generation-aware lifecycle seams from #1163
- make migration client creation await the hydrated environment instead of capturing the startup environment early

## Stack

This is the third and final PR in the discovery/hydration audit group and is intentionally stacked on `fix/desktop-process-lifecycle` / #1163.

**After #1163 merges, rebase this branch onto `main` and retarget this PR to `main`.**

## Cache policy

- selected executable: fresh for 5 minutes
- not installed / no selected executable: fresh for 15 seconds
- thrown discovery failure: fresh for 5 seconds
- successful stale snapshot: eligible for up to 30 minutes, but only for Settings/status while a non-forced refresh is already in flight
- launch resolution never accepts stale data; it joins the active refresh
- successful login-shell hydration is refreshed on the same 5-minute boundary; empty/failed hydration retries after 15 seconds

## Invalidation and recovery

Discovery is invalidated by:

- the explicit Settings/onboarding Codex Refresh action (forced probe)
- a `models.codex.path` settings write
- TTL expiry, which re-reads the hydrated PATH and filesystem/install state
- a changed configured-command cache key

A command-setting write still disposes the backend registry through the existing IPC flow. App Server reconnect/recovery resolves through the coordinator, avoiding repeated package probes inside the TTL while allowing PATH/install recovery after expiry or manual refresh.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/codex-discovery-coordinator.test.ts apps/desktop/src/main/__tests__/stdio-transport.test.ts apps/desktop/src/main/__tests__/thread-migration-service.test.ts apps/desktop/src/main/__tests__/desktop-settings-service.test.ts apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts` — 246 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — 0 errors; existing warning baseline remains
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

## Residual risks

- An already-running healthy App Server intentionally keeps its current executable until reconnect/disposal; TTL refresh affects subsequent resolution rather than replacing a live process.
- Without manual Refresh, a newly changed PATH may take up to 5 minutes to be observed. Not-installed and thrown-failure states recover faster (15 seconds and 5 seconds respectively).
- Settings may briefly display a bounded stale successful path while another refresh is in flight, but launch never consumes that stale result.

No agent-kit or PwrSnap changes are included.
