### PR TITLE
fix(desktop): add transcript image gallery navigation

### DIFF
--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -444,6 +444,62 @@ describe("transcript image protocol", () => {
     await expect(readFile(materializedPath)).resolves.toEqual(Buffer.from([7, 8, 9]));
   });
 
+  it("snapshots Markdown image links from agent temporary directories", async () => {
+    const { materializeTranscriptImageUrlsForRenderer } = await import(
+      "../transcript-image-protocol"
+    );
+    const temporaryRoot = path.sep === "/" ? "/tmp" : os.tmpdir();
+    const agentTempDir = await mkdtemp(
+      path.join(temporaryRoot, "pwragent-markdown-image-")
+    );
+    const imagePath = path.join(agentTempDir, "pwrgit-ui-qa-overview.png");
+    const sourceUrl = pathToFileURL(imagePath).toString();
+    await writeFile(imagePath, Buffer.from([10, 11, 12]));
+
+    try {
+      const message = {
+        id: "message-temporary-image-link",
+        role: "assistant" as const,
+        text: `Open [Worktrees overview](${imagePath}).`,
+      };
+      const response = await materializeTranscriptImageUrlsForRenderer(
+        {
+          backend: "codex",
+          fetchedAt: 1,
+          threadId: "thread-temporary-image-link",
+          replay: {
+            entries: [{ type: "message", ...message }],
+            messages: [message],
+            pagination: {
+              supportsPagination: false,
+              hasPreviousPage: false,
+            },
+          },
+        },
+        {
+          resolveRoot: () => path.join(tempDir, "thread-images"),
+        },
+        {
+          includeTemporaryImageRoots: true,
+        },
+      );
+
+      expect(response.replay.messages[0]).toMatchObject({
+        parts: [
+          { type: "text", text: message.text },
+          {
+            type: "image",
+            url: expect.stringMatching(/^pwragent-image:\/\/file\//),
+            sourceUrl,
+            alt: "Worktrees overview",
+          },
+        ],
+      });
+    } finally {
+      await rm(agentTempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps data image URLs when materialization writes fail", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -462,38 +462,71 @@ describe("transcript image protocol", () => {
         role: "assistant" as const,
         text: `Open [Worktrees overview](${imagePath}).`,
       };
-      const response = await materializeTranscriptImageUrlsForRenderer(
-        {
-          backend: "codex",
-          fetchedAt: 1,
-          threadId: "thread-temporary-image-link",
-          replay: {
-            entries: [{ type: "message", ...message }],
-            messages: [message],
-            pagination: {
-              supportsPagination: false,
-              hasPreviousPage: false,
-            },
+      const rawResponse = {
+        backend: "codex" as const,
+        fetchedAt: 1,
+        threadId: "thread-temporary-image-link",
+        replay: {
+          entries: [{ type: "message" as const, ...message }],
+          messages: [message],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
           },
         },
-        {
-          resolveRoot: () => path.join(tempDir, "thread-images"),
-        },
-        {
-          includeTemporaryImageRoots: true,
-        },
+      };
+      const snapshotRoot = path.join(tempDir, "thread-images");
+      const dependencies = {
+        resolveRoot: () => snapshotRoot,
+      };
+      const options = {
+        includeTemporaryImageRoots: true,
+      };
+      const response = await materializeTranscriptImageUrlsForRenderer(
+        rawResponse,
+        dependencies,
+        options,
       );
 
+      const expectedImagePart = expect.objectContaining({
+        type: "image",
+        url: expect.stringMatching(/^pwragent-image:\/\/file\//),
+        sourceUrl,
+        alt: "Worktrees overview",
+      });
       expect(response.replay.messages[0]).toMatchObject({
         parts: [
           { type: "text", text: message.text },
-          {
-            type: "image",
-            url: expect.stringMatching(/^pwragent-image:\/\/file\//),
-            sourceUrl,
-            alt: "Worktrees overview",
-          },
+          expectedImagePart,
         ],
+      });
+      const firstImagePart = response.replay.messages[0]?.parts?.[1];
+      const firstSnapshotUrl = firstImagePart?.type === "image"
+        ? firstImagePart.url
+        : "";
+      const firstSnapshotPath = filePathFromProtocolUrl(firstSnapshotUrl);
+      expect(path.basename(firstSnapshotPath)).toMatch(/^markdown-[a-f0-9]{64}\.png$/);
+      await expect(readFile(firstSnapshotPath)).resolves.toEqual(Buffer.from([10, 11, 12]));
+
+      await rm(agentTempDir, { recursive: true, force: true });
+
+      const rehydrated = await materializeTranscriptImageUrlsForRenderer(
+        rawResponse,
+        dependencies,
+        options,
+      );
+
+      expect(rehydrated.replay.messages[0]).toMatchObject({
+        parts: [
+          { type: "text", text: message.text },
+          expectedImagePart,
+        ],
+      });
+      const rehydratedImagePart = rehydrated.replay.messages[0]?.parts?.[1];
+      expect(rehydratedImagePart).toMatchObject({
+        type: "image",
+        url: firstSnapshotUrl,
+        sourceUrl,
       });
     } finally {
       await rm(agentTempDir, { recursive: true, force: true });

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1303,6 +1303,7 @@ class DesktopAppServerService {
       response,
       {},
       {
+        includeTemporaryImageRoots: true,
         resolveApprovedLocalImageRoots: async () =>
           await registry.getThreadTranscriptImageRoots({
             backend,

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -522,6 +522,7 @@ async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
 
   for (const imageLink of imageLinks) {
     const image = await materializeMarkdownLinkedImage(
+      message.id,
       imageLink.sourcePath,
       response,
       deps,
@@ -557,6 +558,7 @@ async function appendMarkdownLinkImageParts<T extends AppServerThreadMessage>(
 }
 
 async function materializeMarkdownLinkedImage(
+  messageId: string,
   sourcePath: string,
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
@@ -565,12 +567,14 @@ async function materializeMarkdownLinkedImage(
   materializedImages: Map<string, Promise<MaterializedMarkdownLinkedImage | undefined>>,
   resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
 ): Promise<MaterializedMarkdownLinkedImage | undefined> {
-  const existing = materializedImages.get(sourcePath);
+  const associationKey = markdownLinkedImageAssociationKey(messageId, sourcePath);
+  const existing = materializedImages.get(associationKey);
   if (existing) {
     return await existing;
   }
 
   const materialization = materializeMarkdownLinkedImageOnce(
+    messageId,
     sourcePath,
     response,
     deps,
@@ -578,11 +582,12 @@ async function materializeMarkdownLinkedImage(
     resolutions,
     resolveApprovedLocalImageRoots,
   );
-  materializedImages.set(sourcePath, materialization);
+  materializedImages.set(associationKey, materialization);
   return await materialization;
 }
 
 async function materializeMarkdownLinkedImageOnce(
+  messageId: string,
   sourcePath: string,
   response: AppServerReadThreadResponse,
   deps: TranscriptImageMaterializerDependencies,
@@ -590,6 +595,18 @@ async function materializeMarkdownLinkedImageOnce(
   resolutions: Map<string, Promise<TranscriptImageFileResolution>>,
   resolveApprovedLocalImageRoots: ApprovedLocalImageRootResolver,
 ): Promise<MaterializedMarkdownLinkedImage | undefined> {
+  const sourceUrl = pathToFileURL(sourcePath).toString();
+  const cachedImage = await readCachedMarkdownLinkedImage(
+    messageId,
+    sourceUrl,
+    sourcePath,
+    response,
+    deps,
+  );
+  if (cachedImage) {
+    return cachedImage;
+  }
+
   const approvedLocalImageRoots = await resolveApprovedLocalImageRoots();
   const resolution = await resolveMarkdownLinkedImage(
     sourcePath,
@@ -606,19 +623,114 @@ async function materializeMarkdownLinkedImageOnce(
     return undefined;
   }
 
-  const sourceUrl = pathToFileURL(sourcePath).toString();
-  const imagePart = await materializeTranscriptImagePart(
-    { type: "image", url: sourceUrl, sourceUrl },
+  return await writeCachedMarkdownLinkedImage(
+    messageId,
+    sourceUrl,
     image,
     response,
     deps,
     materializedFileWrites,
   );
-  if (!isTranscriptImageProtocolUrl(imagePart.url)) {
+}
+
+async function readCachedMarkdownLinkedImage(
+  messageId: string,
+  sourceUrl: string,
+  sourcePath: string,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+): Promise<MaterializedMarkdownLinkedImage | undefined> {
+  const mimeType = mimeTypeForImagePath(sourcePath);
+  const extension = mimeType ? DATA_IMAGE_EXTENSIONS.get(mimeType) : undefined;
+  if (!extension) {
     return undefined;
   }
 
-  return { sourceUrl, url: imagePart.url };
+  const filePath = markdownLinkedImageCachePath(
+    messageId,
+    sourceUrl,
+    extension,
+    response,
+    deps,
+  );
+  try {
+    const fileStat = await stat(filePath);
+    if (
+      !fileStat.isFile()
+      || fileStat.size === 0
+      || fileStat.size > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES
+    ) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return {
+    sourceUrl,
+    url: toTranscriptImageProtocolUrl(pathToFileURL(filePath).toString()),
+  };
+}
+
+async function writeCachedMarkdownLinkedImage(
+  messageId: string,
+  sourceUrl: string,
+  image: MaterializedTranscriptImage,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+  materializedFileWrites: Map<string, Promise<void>>,
+): Promise<MaterializedMarkdownLinkedImage | undefined> {
+  const root = deps.resolveRoot({
+    backend: response.backend,
+    threadId: response.threadId,
+  });
+  const filePath = markdownLinkedImageCachePath(
+    messageId,
+    sourceUrl,
+    image.extension,
+    response,
+    deps,
+  );
+  try {
+    await deps.mkdir(root, { recursive: true });
+    let writePromise = materializedFileWrites.get(filePath);
+    if (!writePromise) {
+      writePromise = deps.writeFile(filePath, image.buffer).then(() => undefined);
+      materializedFileWrites.set(filePath, writePromise);
+    }
+    await writePromise;
+  } catch {
+    return undefined;
+  }
+
+  return {
+    sourceUrl,
+    url: toTranscriptImageProtocolUrl(pathToFileURL(filePath).toString()),
+  };
+}
+
+function markdownLinkedImageCachePath(
+  messageId: string,
+  sourceUrl: string,
+  extension: string,
+  response: AppServerReadThreadResponse,
+  deps: TranscriptImageMaterializerDependencies,
+): string {
+  const root = deps.resolveRoot({
+    backend: response.backend,
+    threadId: response.threadId,
+  });
+  const associationHash = createHash("sha256")
+    .update(markdownLinkedImageAssociationKey(messageId, sourceUrl))
+    .digest("hex");
+  return path.join(root, `markdown-${associationHash}.${extension}`);
+}
+
+function markdownLinkedImageAssociationKey(
+  messageId: string,
+  source: string,
+): string {
+  return `${messageId}\0${source}`;
 }
 
 async function readMarkdownLinkedTranscriptImage(
@@ -799,10 +911,6 @@ function rewriteTranscriptMessagePartImageUrl(
 
 function isFileImageUrl(url: string): boolean {
   return url.startsWith("file://");
-}
-
-function isTranscriptImageProtocolUrl(url: string): boolean {
-  return url.startsWith(`${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}://file/`);
 }
 
 function isMaterializableImageUrl(url: string): boolean {

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -54,6 +54,8 @@ export type TranscriptImageProtocolOptions = {
 export type TranscriptImageMaterializationOptions = {
   /** Linked project/worktree roots approved for this thread's Markdown image links. */
   approvedLocalImageRoots?: readonly string[];
+  /** Agent-authored screenshots commonly live in the OS temporary directories. */
+  includeTemporaryImageRoots?: boolean;
   /** Lazily resolves approved roots only when the transcript contains a Markdown image link. */
   resolveApprovedLocalImageRoots?: () => Promise<readonly string[]>;
 };
@@ -118,16 +120,25 @@ const defaultMaterializerDependencies: TranscriptImageMaterializerDependencies =
 function createApprovedLocalImageRootResolver(
   options: TranscriptImageMaterializationOptions,
 ): ApprovedLocalImageRootResolver {
-  if (options.approvedLocalImageRoots) {
-    return async () => options.approvedLocalImageRoots ?? [];
-  }
-
   let roots: Promise<readonly string[]> | undefined;
   return async () => {
     if (!roots) {
-      roots =
-        options.resolveApprovedLocalImageRoots?.().catch(() => []) ??
-        Promise.resolve([]);
+      roots = (async () => {
+        const configuredRoots = options.approvedLocalImageRoots
+          ?? await options.resolveApprovedLocalImageRoots?.().catch(() => [])
+          ?? [];
+        if (!options.includeTemporaryImageRoots) {
+          return configuredRoots;
+        }
+
+        const temporaryRoots = [os.tmpdir()];
+        // macOS agent/browser tools frequently return explicit `/tmp/...`
+        // paths even though Node's TMPDIR points at `/var/folders/...`.
+        if (path.sep === "/") {
+          temporaryRoots.push("/tmp");
+        }
+        return [...new Set([...configuredRoots, ...temporaryRoots])];
+      })();
     }
     return await roots;
   };

--- a/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { CloseIcon } from "../../icons";
+import { ChevronLeftIcon, ChevronRightIcon, CloseIcon } from "../../icons";
 import { TranscriptImage } from "./TranscriptImage";
 
 type ImageLightboxProps = {
@@ -11,27 +11,48 @@ type ImageLightboxProps = {
   caption?: ReactNode;
   /** More specific accessible name for callers that expand a non-photo image. */
   dialogLabel?: string;
+  /** One-based position within an optional image gallery. */
+  position?: number;
+  /** Total number of images in an optional gallery. */
+  total?: number;
   onClose: () => void;
+  onNext?: () => void;
+  onPrevious?: () => void;
 };
 
 /**
  * The single full-size local-raster viewer used for pasted Composer attachments,
  * Composer PDF page previews, and sent transcript images. Portaled to `<body>`
  * so it escapes any clipping/stacking ancestor; closes on the scrim, the
- * accent close cookie, or Escape. `TranscriptImage` resolves embedded data URLs
- * to object URLs, so both image sources render the same way.
+ * accent close cookie, or Escape. Transcript galleries add visible edge controls
+ * plus Left/Right Arrow navigation. `TranscriptImage` resolves embedded data
+ * URLs to object URLs, so both image sources render the same way.
  */
 export function ImageLightbox({
   src,
   alt,
   caption,
   dialogLabel = "Expanded image",
+  position,
+  total,
   onClose,
+  onNext,
+  onPrevious,
 }: ImageLightboxProps) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
+        return;
+      }
+      if (event.key === "ArrowLeft" && onPrevious) {
+        event.preventDefault();
+        onPrevious();
+        return;
+      }
+      if (event.key === "ArrowRight" && onNext) {
+        event.preventDefault();
+        onNext();
       }
     };
 
@@ -39,7 +60,7 @@ export function ImageLightbox({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [onClose]);
+  }, [onClose, onNext, onPrevious]);
 
   if (typeof document === "undefined") {
     return null;
@@ -53,6 +74,21 @@ export function ImageLightbox({
       aria-label={dialogLabel}
       onClick={onClose}
     >
+      {typeof total === "number" && total > 1 ? (
+        <button
+          type="button"
+          className="image-lightbox__nav image-lightbox__nav--previous"
+          aria-label="Previous image"
+          disabled={!onPrevious}
+          title="Previous image (Left Arrow)"
+          onClick={(event) => {
+            event.stopPropagation();
+            onPrevious?.();
+          }}
+        >
+          <ChevronLeftIcon size={22} aria-hidden="true" />
+        </button>
+      ) : null}
       <div
         className="image-lightbox__content"
         onClick={(event) => {
@@ -68,8 +104,28 @@ export function ImageLightbox({
           <CloseIcon size={18} aria-hidden="true" />
         </button>
         <TranscriptImage className="image-lightbox__image" src={src} alt={alt} />
+        {typeof position === "number" && typeof total === "number" && total > 1 ? (
+          <p className="image-lightbox__position" aria-live="polite">
+            <b>{position}</b> / {total}
+          </p>
+        ) : null}
         {caption ? <p className="image-lightbox__caption">{caption}</p> : null}
       </div>
+      {typeof total === "number" && total > 1 ? (
+        <button
+          type="button"
+          className="image-lightbox__nav image-lightbox__nav--next"
+          aria-label="Next image"
+          disabled={!onNext}
+          title="Next image (Right Arrow)"
+          onClick={(event) => {
+            event.stopPropagation();
+            onNext?.();
+          }}
+        >
+          <ChevronRightIcon size={22} aria-hidden="true" />
+        </button>
+      ) : null}
     </div>,
     document.body,
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -110,6 +110,64 @@ type LaunchpadEnvironmentSetupProgress = {
   status: "starting" | "running" | "completed" | "failed";
 };
 
+function collectThreadImageGallery(
+  entries: Array<AppServerThreadEntry | undefined>,
+): AppServerThreadImagePart[] {
+  const images: AppServerThreadImagePart[] = [];
+  const seenSourceUrls = new Set<string>();
+  const seenUrls = new Set<string>();
+
+  const appendImage = (image: AppServerThreadImagePart): void => {
+    if (
+      seenUrls.has(image.url)
+      || (image.sourceUrl ? seenSourceUrls.has(image.sourceUrl) : false)
+    ) {
+      return;
+    }
+    seenUrls.add(image.url);
+    if (image.sourceUrl) {
+      seenSourceUrls.add(image.sourceUrl);
+    }
+    images.push(image);
+  };
+
+  for (const entry of entries) {
+    if (entry?.type === "message") {
+      for (const part of entry.parts ?? []) {
+        if (part.type === "image") {
+          appendImage(part);
+        }
+      }
+      continue;
+    }
+
+    if (entry?.type === "activity") {
+      for (const detail of entry.details) {
+        for (const image of detail.images ?? []) {
+          appendImage(image);
+        }
+      }
+    }
+  }
+
+  return images;
+}
+
+function threadGalleryImageMatches(
+  candidate: AppServerThreadImagePart,
+  selected: AppServerThreadImagePart,
+): boolean {
+  return (
+    candidate === selected
+    || candidate.url === selected.url
+    || Boolean(
+      candidate.sourceUrl
+      && selected.sourceUrl
+      && candidate.sourceUrl === selected.sourceUrl,
+    )
+  );
+}
+
 const LazyIntegratedTerminal = lazy(async () => {
   const module = await import("./IntegratedTerminal");
   return { default: module.IntegratedTerminal };
@@ -1882,6 +1940,28 @@ export function ThreadView(props: ThreadViewProps) {
     pendingActivityEntry && activityHasFileDiff(pendingActivityEntry)
       ? pendingActivityEntry
       : undefined;
+  const threadImageGallery = useMemo(
+    () =>
+      collectThreadImageGallery([
+        ...props.transcriptEntries,
+        pendingTranscriptActivityEntry,
+        pendingProtocolActivityEntry,
+        pendingUsageActivityEntry,
+        props.pendingAssistantMessage,
+      ]),
+    [
+      pendingProtocolActivityEntry,
+      pendingTranscriptActivityEntry,
+      pendingUsageActivityEntry,
+      props.pendingAssistantMessage,
+      props.transcriptEntries,
+    ],
+  );
+  const expandedImageIndex = expandedImage
+    ? threadImageGallery.findIndex((image) =>
+        threadGalleryImageMatches(image, expandedImage)
+      )
+    : -1;
 
   // Accumulated edited files: persisted replay entries + deferred live
   // entries grouped per turn, cleared past a committed turn once the
@@ -3130,9 +3210,25 @@ export function ThreadView(props: ThreadViewProps) {
         <ImageLightbox
           src={expandedImage.url}
           alt={expandedImage.alt ?? "Expanded image"}
+          position={expandedImageIndex >= 0 ? expandedImageIndex + 1 : undefined}
+          total={expandedImageIndex >= 0 ? threadImageGallery.length : undefined}
           onClose={() => {
             setExpandedImage(undefined);
           }}
+          onNext={
+            expandedImageIndex >= 0 && expandedImageIndex < threadImageGallery.length - 1
+              ? () => {
+                  setExpandedImage(threadImageGallery[expandedImageIndex + 1]);
+                }
+              : undefined
+          }
+          onPrevious={
+            expandedImageIndex > 0
+              ? () => {
+                  setExpandedImage(threadImageGallery[expandedImageIndex - 1]);
+                }
+              : undefined
+          }
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ImageLightbox.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ImageLightbox.test.tsx
@@ -67,6 +67,63 @@ describe("ImageLightbox", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("navigates galleries with edge controls and the Left/Right Arrow keys", () => {
+    const onNext = vi.fn();
+    const onPrevious = vi.fn();
+    render(
+      <ImageLightbox
+        src="https://example.test/cat.png"
+        alt="A cat"
+        position={2}
+        total={3}
+        onClose={() => {}}
+        onNext={onNext}
+        onPrevious={onPrevious}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Expanded image" });
+    expect(dialog).toHaveTextContent("2 / 3");
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous image" }));
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    fireEvent.click(screen.getByRole("button", { name: "Next image" }));
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    expect(onPrevious).toHaveBeenCalledTimes(2);
+    expect(onNext).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows disabled gallery controls at the first and last image", () => {
+    const { rerender } = render(
+      <ImageLightbox
+        src="https://example.test/first.png"
+        alt="First"
+        position={1}
+        total={2}
+        onClose={() => {}}
+        onNext={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Previous image" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Next image" })).toBeEnabled();
+
+    rerender(
+      <ImageLightbox
+        src="https://example.test/last.png"
+        alt="Last"
+        position={2}
+        total={2}
+        onClose={() => {}}
+        onPrevious={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Previous image" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Next image" })).toBeDisabled();
+  });
+
   it("stops listening for Escape after unmount", () => {
     const onClose = vi.fn();
     const { unmount } = render(

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2091,6 +2091,129 @@ describe("ThreadView", () => {
     expect(screen.getByRole("dialog", { name: "Expanded image" })).toBeInTheDocument();
   });
 
+  it("navigates images across activity and message entries as one thread gallery", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[
+          {
+            kind: "codex",
+            label: "Codex app server",
+            available: true,
+            methods: ["thread/list", "thread/read", "turn/start", "skills/list"],
+            capabilities: {
+              listThreads: true,
+              createThread: false,
+              resumeThread: true,
+              renameThread: false,
+              readThread: true,
+              startTurn: true,
+              interruptTurn: false,
+              steerTurn: false,
+              transcriptPagination: true,
+              toolUse: false,
+              approvalRequests: false,
+              multiDirectoryThreads: true,
+            },
+            executionModes: [
+              {
+                mode: "default",
+                label: "Default Access",
+                available: true,
+                isDefault: true,
+              },
+            ],
+          },
+        ]}
+        composerDisabled={false}
+        desktopApi={{
+          startTurn: async () => ({
+            backend: "codex",
+            threadId: "thread-gallery",
+            turnId: "turn-1",
+          }),
+        }}
+        loading={false}
+        loadingMore={false}
+        messageCount={1}
+        selectedThread={{
+          id: "thread-gallery",
+          title: "Inspect image gallery",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: Date.now(),
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+          },
+        }}
+        skills={[]}
+        transcriptEntries={[
+          {
+            type: "activity",
+            id: "activity-images",
+            summary: "Explored 1 item",
+            details: [
+              {
+                id: "tool-images",
+                kind: "read",
+                label: "Screenshots",
+                images: [
+                  {
+                    type: "image",
+                    url: "https://example.test/overview.png",
+                    alt: "Overview",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "message",
+            id: "message-images",
+            role: "assistant",
+            text: "Two more screenshots.",
+            parts: [
+              { type: "text", text: "Two more screenshots." },
+              {
+                type: "image",
+                url: "https://example.test/branches.png",
+                alt: "Branches",
+              },
+              {
+                type: "image",
+                url: "https://example.test/remotes.png",
+                alt: "Remotes",
+              },
+            ],
+          },
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand tool result image 1" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Expanded image" });
+    expect(within(dialog).getByRole("img", { name: "Overview" })).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("1 / 3");
+    expect(screen.getByRole("button", { name: "Previous image" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next image" }));
+    expect(within(dialog).getByRole("img", { name: "Branches" })).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("2 / 3");
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(within(dialog).getByRole("img", { name: "Remotes" })).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("3 / 3");
+    expect(screen.getByRole("button", { name: "Next image" })).toBeDisabled();
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(within(dialog).getByRole("img", { name: "Branches" })).toBeInTheDocument();
+  });
+
   it("clears an expanded transcript image when the selected thread changes", () => {
     const viewProps = {
       addOptimisticUserMessage: (_text: string) => "optimistic-1",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15848,7 +15848,8 @@ a.transcript-message__messaging-origin:focus-visible {
 
 /* The single full-size local-raster viewer (`ImageLightbox`) — used for pasted
    Composer attachments, Composer PDF page previews, and sent transcript
-   images. Click the scrim, the close cookie, or Escape to dismiss. */
+   images. Click the scrim, the close cookie, or Escape to dismiss. Transcript
+   galleries add edge controls and a compact position indicator. */
 .image-lightbox {
   position: fixed;
   inset: 0;
@@ -15906,6 +15907,50 @@ a.transcript-message__messaging-origin:focus-visible {
   outline-offset: 2px;
 }
 
+.image-lightbox__nav {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--bg-panel-elevated) 92%, transparent);
+  color: var(--text-primary);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--shadow-base) 34%, transparent);
+  cursor: pointer;
+  transform: translateY(-50%);
+  -webkit-app-region: no-drag;
+}
+
+.image-lightbox__nav--previous {
+  left: 24px;
+}
+
+.image-lightbox__nav--next {
+  right: 24px;
+}
+
+.image-lightbox__nav:hover:not(:disabled) {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  color: var(--accent);
+}
+
+.image-lightbox__nav:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.image-lightbox__nav:disabled {
+  opacity: 0.32;
+  cursor: default;
+}
+
 .image-lightbox__image {
   display: block;
   max-width: min(100vw - 48px, 1100px);
@@ -15921,6 +15966,27 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-secondary);
   font-size: 13px;
   text-align: center;
+}
+
+.image-lightbox__position {
+  align-self: center;
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.image-lightbox__position b {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+@media (max-width: 760px) {
+  .image-lightbox__nav {
+    top: auto;
+    bottom: 24px;
+    transform: none;
+  }
 }
 
 .composer__setup {


### PR DESCRIPTION
## What changed

- snapshot Markdown-linked screenshots from agent temporary directories into the PwrAgent profile-owned transcript image cache
- treat activity/tool images and message images as one ordered thread gallery
- add visible previous/next controls, disabled end states, a position counter, and Left/Right Arrow navigation to the shared image lightbox
- keep Escape, backdrop, and close-button dismissal behavior intact

## Why

Assistant responses commonly link screenshots written to `/tmp`. The existing image-link materializer only approved linked worktree/profile roots, and macOS reports a separate per-user `TMPDIR`, so those links fell through to the generic local-file handler and opened VS Code. Even when images rendered as tool-result thumbnails, inspecting several required repeatedly closing and reopening the lightbox.

Temporary images are still copied through the bounded snapshot/materialization path into `state/thread-images`; the custom renderer protocol does not directly serve arbitrary temporary files.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/ImageLightbox.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx` (76 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (passes with existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:colors`
- `git diff --check`