### PR TITLE
fix(desktop): align new thread launchpad navigation

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -646,9 +646,11 @@ test("directory launchpad opens without an environment picker when no environmen
       .getByRole("button", { name: "Open new thread launchpad for NoEnvRepo" })
       .click();
 
+    const header = app.window.locator(".thread-header");
     await expect(
-      app.window.getByRole("heading", { level: 2, name: "NoEnvRepo" }),
+      header.getByRole("heading", { level: 2, name: "New thread" }),
     ).toBeVisible();
+    await expect(header.getByText("NoEnvRepo", { exact: true })).toBeVisible();
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
     await expect(
       app.window.getByRole("button", { name: "Environment", exact: true }),

--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -164,9 +164,11 @@ async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElect
     .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
     .click();
 
+  const header = app.window.locator(".thread-header");
   await expect(
-    app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    header.getByRole("heading", { level: 2, name: "New thread" }),
   ).toBeVisible();
+  await expect(header.getByText("FixtureRepo", { exact: true })).toBeVisible();
 }
 
 async function openExistingThread(app: Awaited<ReturnType<typeof launchElectronApp>>) {

--- a/apps/desktop/e2e/directory-launchpad-skills.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-skills.spec.ts
@@ -228,9 +228,11 @@ async function openDirectoryLaunchpad(app: Awaited<ReturnType<typeof launchElect
     .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
     .click();
 
+  const header = app.window.locator(".thread-header");
   await expect(
-    app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
+    header.getByRole("heading", { level: 2, name: "New thread" }),
   ).toBeVisible();
+  await expect(header.getByText("FixtureRepo", { exact: true })).toBeVisible();
 }
 
 async function typeSkillChip(

--- a/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
+++ b/apps/desktop/e2e/directory-launchpad-workspace.spec.ts
@@ -646,6 +646,17 @@ function readOverlayState(homeRoot: string): {
   }
 }
 
+async function expectDirectoryLaunchpadHeader(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+  projectName: string,
+): Promise<void> {
+  const header = app.window.locator(".thread-header");
+  await expect(
+    header.getByRole("heading", { level: 2, name: "New thread" }),
+  ).toBeVisible();
+  await expect(header.getByText(projectName, { exact: true })).toBeVisible();
+}
+
 test("directory launchpad can switch from local checkout to a new worktree", async () => {
   const fixture = await createDirectoryLaunchpadFixture();
   const app = await launchElectronApp({
@@ -658,9 +669,7 @@ test("directory launchpad can switch from local checkout to a new worktree", asy
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
 
     const settings = app.window.getByLabel("New thread settings");
     const workspaceMode = settings.getByLabel("Workspace mode");
@@ -703,9 +712,7 @@ test("directory launchpad does not show workspace application buttons before a t
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
     await expect(app.window.getByRole("textbox", { name: "New thread" })).toBeVisible();
     await expect(app.window.getByRole("button", { name: "VS Code" })).toHaveCount(0);
     await expect(app.window.getByRole("button", { name: "Ghostty" })).toHaveCount(0);
@@ -735,9 +742,7 @@ test("new-thread picker hydrates git status for a newly added directory", async 
     await app.window.getByRole("button", { name: /^(Project:|Choose a project)/ }).click();
     await app.window.getByRole("button", { name: /Add directory/ }).click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "PickedRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "PickedRepo");
 
     const settings = app.window.getByLabel("New thread settings");
     const workspaceMode = settings.getByLabel("Workspace mode");
@@ -809,9 +814,7 @@ test("directory launchpad starts a local thread from an unborn git HEAD", async 
       .getByRole("button", { name: "Open new thread launchpad for PwrTester" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "PwrTester" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "PwrTester");
 
     const directoryKey = `directory:${fixture.repoDir}`;
     await app.window.evaluate(async (key) => {
@@ -860,9 +863,7 @@ test("opening a directory launchpad persists directory identity for future draft
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
 
     const rootDir = path.dirname(fixture.fixturePath);
     const repoDir = path.join(rootDir, "FixtureRepo");
@@ -900,9 +901,7 @@ test("directory launchpad draft save does not leak the directory key into projec
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
 
     await app.window
       .getByRole("textbox", { name: "New thread" })
@@ -921,9 +920,7 @@ test("directory launchpad draft save does not leak the directory key into projec
         prompt: "Keep the project identity stable",
       });
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
     await expect(app.window.getByText(/^directory:/)).toHaveCount(0);
     await expect(app.window.getByText("FixtureRepo").first()).toBeVisible();
   } finally {
@@ -957,9 +954,7 @@ test("directory launchpad repairs stale drafts that saved the internal directory
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
 
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
     await expect(app.window.getByText(/^directory:/)).toHaveCount(0);
 
     await expect
@@ -1013,9 +1008,7 @@ test("directory launchpad keeps full access as the sticky default after user cha
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for OtherRepo" })
       .click();
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "OtherRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "OtherRepo");
     await expect(settings.getByLabel("Access mode")).toHaveAttribute(
       "data-value",
       "full-access",
@@ -1094,9 +1087,7 @@ test("directory launchpad keeps new worktree as the sticky default after startin
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
 
     await expect(settings.getByLabel("Workspace mode")).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");
@@ -1284,9 +1275,7 @@ test("directory launchpad applies new worktree sticky defaults to stale empty dr
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for OtherRepo" })
       .click();
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "OtherRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "OtherRepo");
     const otherWorkspaceMode = settings.getByLabel("Workspace mode");
     await otherWorkspaceMode.click();
     await expect(app.window.getByRole("option", { name: "New worktree" })).toHaveCount(1);
@@ -1296,9 +1285,7 @@ test("directory launchpad applies new worktree sticky defaults to stale empty dr
     await app.window
       .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
       .click();
-    await expect(
-      app.window.getByRole("heading", { level: 2, name: "FixtureRepo" }),
-    ).toBeVisible();
+    await expectDirectoryLaunchpadHeader(app, "FixtureRepo");
 
     await expect(settings.getByLabel("Workspace mode")).toHaveAttribute("data-value", "worktree");
     await expect(settings.getByLabel("Base branch")).toHaveAttribute("data-value", "main");

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1218,8 +1218,10 @@ function DesktopAppShell(props: {
     onLoadOlder: session.loadOlder,
     onLiveTranscriptEntry: session.upsertLiveTranscriptEntry,
     onCancelLaunchpad: (directoryKey) => {
-      navigation.discardLaunchpad(directoryKey);
-      history.goBack();
+      const restoredSourceThread = navigation.discardLaunchpad(directoryKey);
+      if (!restoredSourceThread) {
+        history.goBack();
+      }
     },
     // The composer's 5th argument is `extraDirectoryPaths` (draft
     // `@`-references); the hook's 5th is `parentThreadId` (resolved from

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1217,7 +1217,10 @@ function DesktopAppShell(props: {
       : undefined,
     onLoadOlder: session.loadOlder,
     onLiveTranscriptEntry: session.upsertLiveTranscriptEntry,
-    onCancelLaunchpad: navigation.discardLaunchpad,
+    onCancelLaunchpad: (directoryKey) => {
+      navigation.discardLaunchpad(directoryKey);
+      history.goBack();
+    },
     // The composer's 5th argument is `extraDirectoryPaths` (draft
     // `@`-references); the hook's 5th is `parentThreadId` (resolved from
     // the launchpad draft internally), so map positions explicitly.

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1608,6 +1608,9 @@ describe("App", () => {
     expect(
       await screen.findByRole("heading", { level: 2, name: "Investigate Grok thread" })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Investigate Grok thread" }),
+    ).toHaveAttribute("aria-pressed", "true");
     expect(screen.getAllByText(/Grok/).length).toBeGreaterThan(0);
     await waitFor(() => {
       expect(screen.getByRole("region", { name: "Transcript" })).toHaveTextContent(
@@ -3486,6 +3489,12 @@ describe("App", () => {
     );
     await clickButton("Open new thread launchpad for PwrAgent");
     await screen.findByRole("heading", { level: 2, name: "PwrAgent" });
+    expect(
+      screen.getByRole("button", { name: "First project thread" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: "Second project thread" }),
+    ).toHaveAttribute("aria-pressed", "false");
 
     const composer = screen.getByRole("textbox", { name: "New thread" });
     pasteComposerText(composer, "Keep this configured project draft.");
@@ -3511,14 +3520,13 @@ describe("App", () => {
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledTimes(1);
 
     await clickButton("Cancel");
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Back" })).toBeEnabled();
-    });
-    await clickButton("Back");
     await screen.findByRole("heading", {
       level: 2,
       name: "First project thread",
     });
+    expect(
+      screen.getByRole("button", { name: "First project thread" }),
+    ).toHaveAttribute("aria-pressed", "true");
   });
 
   it("renames the selected thread from the sidebar actions menu", async () => {

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1232,7 +1232,7 @@ describe("App", () => {
       "heading",
       {
         level: 2,
-        name: "PwrAgent",
+        name: "New thread",
       },
       { timeout: 5_000 },
     );
@@ -3488,7 +3488,7 @@ describe("App", () => {
       screen.getByRole("tab", { name: /^Directories/ }),
     );
     await clickButton("Open new thread launchpad for PwrAgent");
-    await screen.findByRole("heading", { level: 2, name: "PwrAgent" });
+    await screen.findByRole("heading", { level: 2, name: "New thread" });
     expect(
       screen.getByRole("button", { name: "First project thread" }),
     ).toHaveAttribute("aria-pressed", "false");
@@ -3512,7 +3512,7 @@ describe("App", () => {
     });
     await clickButton("Back");
 
-    await screen.findByRole("heading", { level: 2, name: "PwrAgent" });
+    await screen.findByRole("heading", { level: 2, name: "New thread" });
     expect(
       getComposerValueHost(screen.getByRole("textbox", { name: "New thread" })),
     ).toHaveAttribute("data-value", "Keep this configured project draft.");

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3301,15 +3301,24 @@ describe("App", () => {
       createdAt: 1,
       updatedAt: 1,
     };
-    const ensureDirectoryLaunchpad = vi.fn(async () => ({
-      launchpad,
-      defaults: {
-        backend: "codex" as const,
-        executionMode: "default" as const,
+    const ensureDirectoryLaunchpad = vi.fn(
+      async ({ directoryKey: ensuredDirectoryKey }: { directoryKey: string }) => {
+        launchpad = {
+          ...launchpad,
+          directoryKey: ensuredDirectoryKey,
+        };
+        return {
+          launchpad,
+          defaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        };
       },
-    }));
+    );
     const updateDirectoryLaunchpad = vi.fn(
       async ({
+        directoryKey: updatedDirectoryKey,
         patch,
       }: {
         directoryKey: string;
@@ -3317,6 +3326,7 @@ describe("App", () => {
       }) => {
         launchpad = {
           ...launchpad,
+          directoryKey: updatedDirectoryKey,
           ...patch,
           updatedAt: launchpad.updatedAt + 1,
         };
@@ -3526,6 +3536,32 @@ describe("App", () => {
     });
     expect(
       screen.getByRole("button", { name: "First project thread" }),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    // Opening a sub-thread composer from an unselected row must remember that
+    // row as its source. Cancel returns there directly instead of consuming
+    // history and restoring the unrelated thread that was previously open.
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Second project thread" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Sub-thread in Local" }),
+    );
+    await screen.findByRole("heading", { level: 2, name: "New thread" });
+    expect(
+      screen.getByRole("button", { name: "First project thread" }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", { name: "Second project thread" }),
+    ).toHaveAttribute("aria-pressed", "false");
+
+    await clickButton("Cancel");
+    await screen.findByRole("heading", {
+      level: 2,
+      name: "Second project thread",
+    });
+    expect(
+      screen.getByRole("button", { name: "Second project thread" }),
     ).toHaveAttribute("aria-pressed", "true");
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -354,8 +354,10 @@ export function Sidebar(props: SidebarProps) {
 
   // A direct navigation change (history, search, a thread link, etc.) starts a
   // fresh selection. Modified clicks deliberately do not navigate, so they can
-  // build a batch without making the detail pane jump around.
-  useEffect(() => {
+  // build a batch without making the detail pane jump around. Keep this in a
+  // layout effect so a launchpad cannot paint once with the previous thread's
+  // local batch-selection highlight still visible.
+  useLayoutEffect(() => {
     if (selectedItemKey === previousSelectedItemKeyRef.current) {
       return;
     }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -110,7 +110,8 @@ type ThreadContextPanelProps = {
     usd: boolean;
   };
   threadPricingSummaryEnabled?: boolean;
-  thread: NavigationThreadSummary;
+  /** Absent on the new-thread launchpad, where only provider context applies. */
+  thread?: NavigationThreadSummary;
   worktreeArchiveError?: string;
   onRestoreWorktree?: (
     thread: NavigationThreadSummary,
@@ -180,12 +181,15 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const outsideRailSinceRef = useRef<number | undefined>(undefined);
   const threadPricingSummaryEnabled = props.threadPricingSummaryEnabled ?? true;
 
-  const activeTab =
-    props.activeTab === "pricing" && !threadPricingSummaryEnabled
+  const activeTab = !props.thread
+    ? "providers"
+    : props.activeTab === "pricing" && !threadPricingSummaryEnabled
       ? "info"
       : props.activeTab;
-  const visibleTabs = CONTEXT_TABS.filter(
-    (tab) => tab.id !== "pricing" || threadPricingSummaryEnabled,
+  const visibleTabs = CONTEXT_TABS.filter((tab) =>
+    props.thread
+      ? tab.id !== "pricing" || threadPricingSummaryEnabled
+      : tab.id === "providers",
   );
   const topTabs = visibleTabs.filter((tab) => !tab.bottom);
   const bottomTabs = visibleTabs.filter((tab) => tab.bottom);
@@ -502,7 +506,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   return (
     <aside
       ref={railRef}
-      aria-label="Thread context"
+      aria-label={props.thread ? "Thread context" : "New thread context"}
       className={`context-rail${open ? " is-open" : " is-collapsed"}${
         pinned ? " is-pinned" : ""
       }${resizing ? " is-resizing" : ""}`}
@@ -681,6 +685,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   function renderActivePanel() {
     switch (activeTab) {
       case "info":
+        if (!props.thread) return null;
         return (
           <ThreadInfoPanel
             thread={props.thread}
@@ -693,6 +698,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "edits":
+        if (!props.thread) return null;
         return (
           <EditsPanel
             groups={props.editedFileGroups ?? []}
@@ -708,6 +714,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "pricing":
+        if (!props.thread) return null;
         return (
           <PricingPanel
             activeTurnId={props.activeTurnId}
@@ -719,6 +726,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "actions":
+        if (!props.thread) return null;
         return (
           <ActionRunsPanel
             dock={props.actionRunsDock ?? "above"}
@@ -735,6 +743,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "subagents":
+        if (!props.thread) return null;
         return (
           <SubAgentsPanel
             pricingDisplayOptions={props.pricingDisplayOptions}
@@ -743,6 +752,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "automations":
+        if (!props.thread) return null;
         return (
           <ThreadAutomationsPanel
             desktopApi={props.desktopApi}
@@ -751,6 +761,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "prs":
+        if (!props.thread) return null;
         return (
           <PullRequestsPanel
             desktopApi={props.desktopApi}
@@ -759,6 +770,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           />
         );
       case "projects":
+        if (!props.thread) return null;
         return (
           <LinkedProjectsPanel
             desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -18,7 +18,10 @@ type ThreadPlaceholderLayoutControls = {
 };
 
 type ThreadPlaceholderHeaderProps = {
+  backendLabel?: string;
+  contextLabel?: string;
   desktopApi?: DesktopApi;
+  projectLabel?: string;
   title: string;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
   /**
@@ -64,7 +67,30 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
         {props.history ? <HistoryNavButtons {...props.history} /> : null}
         <div className="thread-header__main">
           <div className="thread-header__eyebrow-row">
-            <h2 className="thread-header__compact-title">{props.title}</h2>
+            <div className="thread-header__breadcrumb">
+              {props.projectLabel ? (
+                <>
+                  <span
+                    className="thread-header__eyebrow"
+                    title={props.projectLabel}
+                  >
+                    {props.projectLabel}
+                  </span>
+                  <span aria-hidden="true" className="thread-header__separator">
+                    ›
+                  </span>
+                </>
+              ) : null}
+              <h2 className="thread-header__compact-title">{props.title}</h2>
+            </div>
+            {props.backendLabel ? (
+              <span className="chip chip--backend">{props.backendLabel}</span>
+            ) : null}
+            {props.contextLabel ? (
+              <span className="thread-row__chip" title={props.contextLabel}>
+                {props.contextLabel}
+              </span>
+            ) : null}
           </div>
         </div>
         <div className="thread-header__chrome">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -58,12 +58,10 @@ import {
   THREAD_HISTORY_PAGE_LIMIT,
 } from "../../lib/thread-history-limits";
 import { formatBackendLabel } from "../../lib/backend-label";
-import { isSameWorktreeSubthreadLaunchpad } from "../../lib/subthread-launchpads";
 import { resolvePreferredEditor } from "../../lib/preferred-application";
 import { Composer } from "../composer/Composer";
 import type { ComposerDraftStore } from "../composer/useComposerDraftStore";
 import type { AppNoticeToastNotice } from "../notifications/AppNoticeToast";
-import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { ThreadContextPanel } from "./ThreadContextPanel";
 import {
   DEFAULT_CONTEXT_TAB,
@@ -2477,48 +2475,65 @@ export function ThreadView(props: ThreadViewProps) {
 
   if (pendingForkEnvironmentSetup) {
     return (
-      <section className="thread-view thread-view--launchpad">
-        <header className="thread-header thread-header--launchpad">
-          <div className="thread-header__main thread-header__main--launchpad">
-            <div className="thread-header__eyebrow-row">
-              <p className="eyebrow">Forking thread</p>
-              <span className="chip chip--backend">
-                {formatBackendLabel(pendingForkEnvironmentSetup.backend, props.backends)}
-              </span>
-            </div>
-            <h2 className="thread-header__title">
-              {pendingForkEnvironmentSetup.directoryLabel}
-            </h2>
-          </div>
+      <section
+        className="thread-view thread-view--launchpad"
+        style={
+          {
+            "--context-rail-width": `${contextRailWidth}px`,
+          } as CSSProperties
+        }
+      >
+        <ThreadPlaceholderHeader
+          backendLabel={formatBackendLabel(
+            pendingForkEnvironmentSetup.backend,
+            props.backends,
+          )}
+          desktopApi={props.desktopApi}
+          projectLabel={pendingForkEnvironmentSetup.directoryLabel}
+          title="Forking thread"
+          onOpenMessagingActivity={props.onOpenMessagingActivity}
+          layout={{
+            sidebarOpen: !sidebarHidden,
+            railOpen: contextRailPinned,
+            onToggleSidebar,
+            onToggleRail: () => onContextRailPinnedChange(!contextRailPinned),
+          }}
+          masthead={props.mastheadActions}
+          history={props.historyNav}
+        />
 
-          <div className="thread-header__launchpad-aside">
-            <div className="thread-header__stats">
-              <div>
-                <span className="thread-header__stat-label">Workspace</span>
-                <strong>New worktree</strong>
-              </div>
-              <div>
-                <span className="thread-header__stat-label">Environment</span>
-                <strong>{pendingForkEnvironmentSetup.environmentName}</strong>
-              </div>
+        <div
+          className={`thread-view__layout${
+            contextRailPinned ? " has-pinned-context-rail" : ""
+          }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
+        >
+          <div className="thread-view__primary">
+            <div className="thread-view__launchpad-composer">
+              <LaunchpadEnvironmentSetupPending
+                command={
+                  launchpadSetupProgress?.command ??
+                  pendingForkEnvironmentSetup.command
+                }
+                cwd={launchpadSetupProgress?.cwd ?? pendingForkEnvironmentSetup.cwd}
+                directoryLabel={pendingForkEnvironmentSetup.directoryLabel}
+                environmentName={
+                  launchpadSetupProgress?.environmentName ??
+                  pendingForkEnvironmentSetup.environmentName
+                }
+                progress={launchpadSetupProgress}
+              />
             </div>
-            <MessagingStatusBar
-              desktopApi={props.desktopApi}
-              onOpenActivity={props.onOpenMessagingActivity}
-            />
           </div>
-        </header>
-
-        <div className="thread-view__launchpad-composer">
-          <LaunchpadEnvironmentSetupPending
-            command={launchpadSetupProgress?.command ?? pendingForkEnvironmentSetup.command}
-            cwd={launchpadSetupProgress?.cwd ?? pendingForkEnvironmentSetup.cwd}
-            directoryLabel={pendingForkEnvironmentSetup.directoryLabel}
-            environmentName={
-              launchpadSetupProgress?.environmentName ??
-              pendingForkEnvironmentSetup.environmentName
-            }
-            progress={launchpadSetupProgress}
+          <ThreadContextPanel
+            activeTab={activeContextTab}
+            backendError={props.backendError}
+            backends={props.backends}
+            desktopApi={props.desktopApi}
+            onActiveTabChange={onActiveContextTabChange}
+            onResizingChange={setContextRailResizing}
+            onWidthChange={setContextRailWidth}
+            width={contextRailWidth}
+            pinned={contextRailPinned}
           />
         </div>
       </section>
@@ -2559,49 +2574,6 @@ export function ThreadView(props: ThreadViewProps) {
     const launchpadBackend = props.backends.find(
       (backend) => backend.kind === selectedLaunchpad.backend
     );
-    const syncLabel = formatDirectorySync(props.selectedDirectory);
-    const sameWorktreeSubthread = isSameWorktreeSubthreadLaunchpad(
-      selectedLaunchpad.directoryKey,
-    );
-    const launchpadIsSubthread = Boolean(selectedLaunchpad.parentThreadId);
-    const launchpadCurrentBranch =
-      props.selectedDirectory.gitStatus?.currentBranch ?? selectedLaunchpad.branchName;
-    const workspaceLabel =
-      props.selectedDirectory.kind === "workspace"
-        ? "Workspace"
-        : sameWorktreeSubthread
-          ? "Same worktree"
-          : selectedLaunchpad.workMode === "worktree"
-            ? "New worktree"
-            : "Local checkout";
-    const launchpadTitle =
-      props.selectedDirectory.kind === "workspace"
-        ? "New thread"
-        : selectedLaunchpad.directoryLabel;
-    const launchpadBranchLabel =
-      selectedLaunchpad.workMode === "worktree"
-        ? selectedLaunchpad.branchName ??
-          props.selectedDirectory.gitStatus?.currentBranch ??
-          "Pick one"
-        : launchpadCurrentBranch ?? "Not attached";
-    const launchpadBranchDetailLabel =
-      selectedLaunchpad.workMode === "worktree" ? "Base branch" : "Current branch";
-    const launchpadBranchDetailValue =
-      selectedLaunchpad.workMode === "worktree"
-        ? launchpadBranchLabel
-        : launchpadCurrentBranch ??
-          (props.selectedDirectory.gitStatus?.syncState === "status-unavailable"
-            ? "Unavailable"
-            : "Not a Git repo");
-    const launchpadStatusValue =
-      launchpadIsSubthread
-        ? "Starts empty"
-        : syncLabel ?? "Directory context only";
-    const launchpadDirectoryStatusValue =
-      syncLabel ??
-      (sameWorktreeSubthread && selectedLaunchpad.branchName
-        ? "Git worktree"
-        : "Directory context only");
     const selectedLaunchpadCodexEnvironment =
       selectedLaunchpad.codexEnvironmentOptions?.find(
         (environment) => environment.id === selectedLaunchpad.codexEnvironmentId,
@@ -2641,167 +2613,145 @@ export function ThreadView(props: ThreadViewProps) {
     };
 
     return (
-      <section className="thread-view thread-view--launchpad">
-        <header className="thread-header thread-header--launchpad">
-          <div className="thread-header__main thread-header__main--launchpad">
-            <div className="thread-header__eyebrow-row">
-              <p className="eyebrow">New thread</p>
-              <span className="chip chip--backend">
-                {formatBackendLabel(selectedLaunchpad.backend, props.backends)}
-              </span>
-            </div>
-            <h2 className="thread-header__title">{launchpadTitle}</h2>
-          </div>
-
-          <div className="thread-header__launchpad-aside">
-            <div className="thread-header__stats">
-              <div>
-                <span className="thread-header__stat-label">Workspace</span>
-                <strong>{workspaceLabel}</strong>
-              </div>
-              <div>
-                <span className="thread-header__stat-label">Branch</span>
-                <strong>{launchpadBranchLabel}</strong>
-              </div>
-            </div>
-            <MessagingStatusBar
-              desktopApi={props.desktopApi}
-              onOpenActivity={props.onOpenMessagingActivity}
-            />
-          </div>
-        </header>
-
-        <div className="launchpad-panel launchpad-panel--compact">
-          <div className="launchpad-panel__summary">
-            <div>
-              <span className="launchpad-panel__label">Project</span>
-              <strong>{selectedLaunchpad.directoryLabel}</strong>
-            </div>
-            <div>
-              <span className="launchpad-panel__label">Threads</span>
-              <strong>
-                {props.selectedDirectory.threadKeys.length} thread
-                {props.selectedDirectory.threadKeys.length === 1 ? "" : "s"}
-              </strong>
-            </div>
-            {launchpadIsSubthread ? (
-              <div>
-                <span className="launchpad-panel__label">Grouped under</span>
-                <strong
-                  title={selectedLaunchpad.parentThreadTitle ?? selectedLaunchpad.parentThreadId}
-                >
-                  {selectedLaunchpad.parentThreadTitle ?? selectedLaunchpad.parentThreadId}
-                </strong>
-              </div>
-            ) : null}
-            <div>
-              <span className="launchpad-panel__label">
-                {launchpadIsSubthread ? "History" : "Status"}
-              </span>
-              <strong>{launchpadStatusValue}</strong>
-            </div>
-          </div>
-
-          <dl className="launchpad-grid">
-            <div>
-              <dt>Path</dt>
-              <dd>{props.selectedDirectory.path ?? "Not recorded"}</dd>
-            </div>
-            <div>
-              <dt>{launchpadBranchDetailLabel}</dt>
-              <dd>{launchpadBranchDetailValue}</dd>
-            </div>
-            <div>
-              <dt>Upstream</dt>
-              <dd>{props.selectedDirectory.gitStatus?.upstreamBranch ?? "Not tracking"}</dd>
-            </div>
-            <div>
-              <dt>Status</dt>
-              <dd>{launchpadDirectoryStatusValue}</dd>
-            </div>
-          </dl>
-        </div>
-
-        <div className="thread-view__launchpad-composer">
-          {launchpadMaterializing && launchpadMaterializeError ? (
-            <LaunchpadMaterializeFailure
-              directoryLabel={selectedLaunchpad.directoryLabel}
-              error={launchpadMaterializeError}
-              onClose={() => {
-                setLaunchpadMaterializing(false);
-                setLaunchpadMaterializeError(undefined);
-              }}
-            />
-          ) : launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
-            <LaunchpadEnvironmentSetupPending
-              command={
-                launchpadSetupProgress?.command ??
-                selectedLaunchpadCodexEnvironment?.setupScript
-              }
-              cwd={launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath}
-              directoryLabel={selectedLaunchpad.directoryLabel}
-              environmentName={
-                launchpadSetupProgress?.environmentName ??
-                selectedLaunchpadCodexEnvironment?.name
-              }
-              progress={launchpadSetupProgress}
-            />
-          ) : launchpadMaterializing ? (
-            <section
-              className="transcript-panel transcript-panel--pending"
-              aria-label="Preparing transcript"
-            >
-              <div className="launchpad-pending">
-                <p className="eyebrow">Preparing transcript</p>
-                <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
-                <p>Your prompt was sent. The transcript will appear here when the thread is ready.</p>
-              </div>
-            </section>
-          ) : (
-            <Composer
-              backends={props.backends}
-              applications={props.applications}
-              codexFastAllowed={props.codexFastAllowed}
-              providerModelDefaults={props.providerModelDefaults}
-              desktopApi={props.desktopApi}
-              onShowNotice={props.onShowNotice}
-              onProviderSelected={props.onProviderSelected}
-              composerImplementation={props.composerImplementation}
-              draftStore={props.composerDraftStore}
-              directory={props.selectedDirectory}
-              directories={props.directories}
-              disabled={launchpadBackend ? !launchpadBackend.available : false}
-              unavailableReason={launchpadBackend?.unavailableReason}
-              launchpad={selectedLaunchpad}
-              launchpadError={props.launchpadError}
-              pastedImageMaxPatches={props.pastedImageMaxPatches}
-              pdfAnalysisEnabled={props.pdfAnalysisEnabled}
-              fullAccessRiskWarningDismissed={
-                props.fullAccessRiskWarningDismissed
-              }
-              onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
-              onDismissFullAccessRiskWarning={
-                props.onDismissFullAccessRiskWarning
-              }
-              onMaterializeLaunchpad={handleMaterializeLaunchpad}
-              onCancelLaunchpad={props.onCancelLaunchpad}
-              onUpdateLaunchpad={props.onUpdateLaunchpad}
-              onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
-              onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
-              onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
-              onPickAndAttachDirectoryToThread={
-                props.onPickAndAttachDirectoryToThread
-              }
-              onPickDirectoryForReference={props.onPickDirectoryForReference}
-              onClearPickDirectoryError={props.onClearPickDirectoryError}
-              pickDirectoryError={props.pickDirectoryError}
-              pickingDirectory={props.pickingDirectory}
-              skillError={props.skillError}
-              skillLoading={props.skillLoading}
-              providerCommands={props.providerCommands ?? []}
-              skills={props.skills}
-            />
+      <section
+        className="thread-view thread-view--launchpad"
+        style={
+          {
+            "--context-rail-width": `${contextRailWidth}px`,
+          } as CSSProperties
+        }
+      >
+        <ThreadPlaceholderHeader
+          backendLabel={formatBackendLabel(
+            selectedLaunchpad.backend,
+            props.backends,
           )}
+          desktopApi={props.desktopApi}
+          contextLabel={
+            selectedLaunchpad.parentThreadTitle || selectedLaunchpad.parentThreadId
+              ? `Grouped under ${
+                  selectedLaunchpad.parentThreadTitle ??
+                  selectedLaunchpad.parentThreadId
+                }`
+              : undefined
+          }
+          projectLabel={selectedLaunchpad.directoryLabel}
+          title="New thread"
+          onOpenMessagingActivity={props.onOpenMessagingActivity}
+          layout={{
+            sidebarOpen: !sidebarHidden,
+            railOpen: contextRailPinned,
+            onToggleSidebar,
+            onToggleRail: () => onContextRailPinnedChange(!contextRailPinned),
+          }}
+          masthead={props.mastheadActions}
+          history={props.historyNav}
+        />
+
+        <div
+          className={`thread-view__layout${
+            contextRailPinned ? " has-pinned-context-rail" : ""
+          }${contextRailResizing ? " is-resizing-context-rail" : ""}`}
+        >
+          <div className="thread-view__primary">
+            <div className="thread-view__launchpad-composer">
+              {launchpadMaterializing && launchpadMaterializeError ? (
+                <LaunchpadMaterializeFailure
+                  directoryLabel={selectedLaunchpad.directoryLabel}
+                  error={launchpadMaterializeError}
+                  onClose={() => {
+                    setLaunchpadMaterializing(false);
+                    setLaunchpadMaterializeError(undefined);
+                  }}
+                />
+              ) : launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
+                <LaunchpadEnvironmentSetupPending
+                  command={
+                    launchpadSetupProgress?.command ??
+                    selectedLaunchpadCodexEnvironment?.setupScript
+                  }
+                  cwd={
+                    launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath
+                  }
+                  directoryLabel={selectedLaunchpad.directoryLabel}
+                  environmentName={
+                    launchpadSetupProgress?.environmentName ??
+                    selectedLaunchpadCodexEnvironment?.name
+                  }
+                  progress={launchpadSetupProgress}
+                />
+              ) : launchpadMaterializing ? (
+                <section
+                  className="transcript-panel transcript-panel--pending"
+                  aria-label="Preparing transcript"
+                >
+                  <div className="launchpad-pending">
+                    <p className="eyebrow">Preparing transcript</p>
+                    <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
+                    <p>
+                      Your prompt was sent. The transcript will appear here when
+                      the thread is ready.
+                    </p>
+                  </div>
+                </section>
+              ) : (
+                <Composer
+                  backends={props.backends}
+                  applications={props.applications}
+                  codexFastAllowed={props.codexFastAllowed}
+                  providerModelDefaults={props.providerModelDefaults}
+                  desktopApi={props.desktopApi}
+                  onShowNotice={props.onShowNotice}
+                  onProviderSelected={props.onProviderSelected}
+                  composerImplementation={props.composerImplementation}
+                  draftStore={props.composerDraftStore}
+                  directory={props.selectedDirectory}
+                  directories={props.directories}
+                  disabled={launchpadBackend ? !launchpadBackend.available : false}
+                  unavailableReason={launchpadBackend?.unavailableReason}
+                  launchpad={selectedLaunchpad}
+                  launchpadError={props.launchpadError}
+                  pastedImageMaxPatches={props.pastedImageMaxPatches}
+                  pdfAnalysisEnabled={props.pdfAnalysisEnabled}
+                  fullAccessRiskWarningDismissed={
+                    props.fullAccessRiskWarningDismissed
+                  }
+                  onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+                  onDismissFullAccessRiskWarning={
+                    props.onDismissFullAccessRiskWarning
+                  }
+                  onMaterializeLaunchpad={handleMaterializeLaunchpad}
+                  onCancelLaunchpad={props.onCancelLaunchpad}
+                  onUpdateLaunchpad={props.onUpdateLaunchpad}
+                  onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
+                  onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
+                  onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
+                  onPickAndAttachDirectoryToThread={
+                    props.onPickAndAttachDirectoryToThread
+                  }
+                  onPickDirectoryForReference={props.onPickDirectoryForReference}
+                  onClearPickDirectoryError={props.onClearPickDirectoryError}
+                  pickDirectoryError={props.pickDirectoryError}
+                  pickingDirectory={props.pickingDirectory}
+                  skillError={props.skillError}
+                  skillLoading={props.skillLoading}
+                  providerCommands={props.providerCommands ?? []}
+                  skills={props.skills}
+                />
+              )}
+            </div>
+          </div>
+          <ThreadContextPanel
+            activeTab={activeContextTab}
+            backendError={props.backendError}
+            backends={props.backends}
+            desktopApi={props.desktopApi}
+            onActiveTabChange={onActiveContextTabChange}
+            onResizingChange={setContextRailResizing}
+            onWidthChange={setContextRailWidth}
+            width={contextRailWidth}
+            pinned={contextRailPinned}
+          />
         </div>
       </section>
     );
@@ -3305,34 +3255,6 @@ export function ThreadView(props: ThreadViewProps) {
 
     </section>
   );
-}
-
-function formatDirectorySync(directory: NavigationDirectorySummary): string | undefined {
-  const status = directory.gitStatus;
-  if (!status) {
-    return undefined;
-  }
-
-  if (status.syncState === "in-sync") {
-    return "Up to date";
-  }
-  if (status.syncState === "ahead") {
-    return `${status.ahead ?? 0} ahead`;
-  }
-  if (status.syncState === "behind") {
-    return `${status.behind ?? 0} behind`;
-  }
-  if (status.syncState === "diverged") {
-    return `${status.ahead ?? 0} ahead · ${status.behind ?? 0} behind`;
-  }
-  if (status.syncState === "untracked") {
-    return "No upstream";
-  }
-  if (status.syncState === "status-unavailable") {
-    return "Status unavailable";
-  }
-
-  return undefined;
 }
 
 function threadDirectoryPaths(thread: NavigationThreadSummary): string[] {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1317,7 +1317,7 @@ describe("ThreadView", () => {
     expect(closeIntegratedTerminal).not.toHaveBeenCalled();
   });
 
-  it("renders launchpad header chips and messaging status icons", async () => {
+  it("renders launchpads with standard navigation chrome and no summary card", async () => {
     const statuses = [
       {
         changedAt: 1000,
@@ -1404,6 +1404,12 @@ describe("ThreadView", () => {
         }}
         loading={false}
         loadingMore={false}
+        historyNav={{
+          canGoBack: true,
+          canGoForward: false,
+          onBack: vi.fn(),
+          onForward: vi.fn(),
+        }}
         messageCount={2}
         selectedDirectory={selectedDirectory}
         selectedLaunchpad={selectedLaunchpad}
@@ -1414,12 +1420,21 @@ describe("ThreadView", () => {
       />
     );
 
-    const header = document.querySelector(".thread-header--launchpad");
+    const header = document.querySelector(".thread-header--placeholder");
     expect(header).not.toBeNull();
+    expect(within(header as HTMLElement).getByText("PwrAgnt")).toBeInTheDocument();
     expect(within(header as HTMLElement).getByText("New thread")).toBeInTheDocument();
     expect(within(header as HTMLElement).getByText("Codex app server")).toBeInTheDocument();
+    expect(within(header as HTMLElement).getByRole("button", { name: "Back" }))
+      .toBeEnabled();
+    expect(within(header as HTMLElement).getByRole("button", { name: "Forward" }))
+      .toBeDisabled();
     // Access mode is shown only in the composer now, not the header.
     expect(within(header as HTMLElement).queryByText("Full Access")).toBeNull();
+    expect(document.querySelector(".launchpad-panel")).toBeNull();
+    expect(screen.getByLabelText("New thread context")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "AI provider info" })).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Edits" })).not.toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByLabelText(/Telegram: Enabled/)).toBeInTheDocument();
     });
@@ -1559,7 +1574,8 @@ describe("ThreadView", () => {
       screen.getByRole("heading", { name: "Running environment setup" }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Setup command")).toHaveTextContent("pnpm install");
-    expect(screen.getByText("New worktree")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Forking thread" })).toBeInTheDocument();
+    expect(screen.getByLabelText("New thread context")).toBeInTheDocument();
 
     act(() => {
       setupProgress({
@@ -1705,11 +1721,10 @@ describe("ThreadView", () => {
       />
     );
 
-    expect(screen.getByText("Grouped under")).toBeInTheDocument();
-    expect(screen.getByText("Issue 193 Markdown attachments")).toBeInTheDocument();
-    expect(screen.getByText("History")).toBeInTheDocument();
-    expect(screen.getByText("Starts empty")).toBeInTheDocument();
-    expect(screen.getByText("Base branch")).toBeInTheDocument();
+    expect(
+      screen.getByText("Grouped under Issue 193 Markdown attachments"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "New thread" })).toBeInTheDocument();
     expect(screen.getAllByText("main").length).toBeGreaterThan(0);
     expect(screen.queryByText("Not a Git repo")).not.toBeInTheDocument();
   });
@@ -1757,15 +1772,11 @@ describe("ThreadView", () => {
       />
     );
 
-    expect(screen.getByText("Workspace").nextElementSibling).toHaveTextContent(
-      "Same worktree",
-    );
-    expect(screen.getByText("Current branch").nextElementSibling).toHaveTextContent(
-      "feat/messaging-artifact-delivery",
-    );
-    expect(screen.getByText("Status").nextElementSibling).toHaveTextContent(
-      "Git worktree",
-    );
+    expect(screen.getByText("Same worktree")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "New thread" })).toBeInTheDocument();
+    expect(screen.getByText("Grouped under Issue 193 Markdown attachments"))
+      .toBeInTheDocument();
+    expect(document.querySelector(".launchpad-panel")).not.toBeInTheDocument();
     expect(screen.queryByText("Local checkout")).not.toBeInTheDocument();
     expect(screen.queryByText("Not a Git repo")).not.toBeInTheDocument();
   });
@@ -1880,10 +1891,15 @@ describe("ThreadView", () => {
       />
     );
 
+    const composerTextbox = screen.getByRole("textbox", { name: "New thread" });
+    const composer = composerTextbox.closest(".composer");
+    expect(composer).not.toBeNull();
     expect(
-      await screen.findByText("ACP agent authentication required")
+      await within(composer as HTMLElement).findByText(
+        "ACP agent authentication required",
+      ),
     ).toHaveClass("composer__meta--error");
-    expect(screen.getByRole("textbox", { name: "New thread" })).toHaveAttribute(
+    expect(composerTextbox).toHaveAttribute(
       "contenteditable",
       "false",
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5498,8 +5498,11 @@ describe("useThreadNavigation", () => {
       "subthread:codex:thread-parent:local",
     );
 
+    let restoredSourceThread = false;
     await act(async () => {
-      result.current.discardLaunchpad("subthread:codex:thread-parent:local");
+      restoredSourceThread = result.current.discardLaunchpad(
+        "subthread:codex:thread-parent:local",
+      );
     });
 
     // A sub-thread launchpad has no registeredAt, so cancel drops the whole
@@ -5507,6 +5510,7 @@ describe("useThreadNavigation", () => {
     expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({
       directoryKey: "subthread:codex:thread-parent:local",
     });
+    expect(restoredSourceThread).toBe(true);
     expect(result.current.selectedLaunchpad).toBeUndefined();
   });
 
@@ -5595,8 +5599,11 @@ describe("useThreadNavigation", () => {
       "subthread:codex:thread-parent:local",
     );
 
+    let restoredSourceThread = false;
     await act(async () => {
-      result.current.discardLaunchpad("subthread:codex:thread-parent:local");
+      restoredSourceThread = result.current.discardLaunchpad(
+        "subthread:codex:thread-parent:local",
+      );
     });
 
     // Cancel must still resolve the launchpad (from localLaunchpads via the
@@ -5605,6 +5612,7 @@ describe("useThreadNavigation", () => {
     expect(resetDirectoryLaunchpad).toHaveBeenCalledWith({
       directoryKey: "subthread:codex:thread-parent:local",
     });
+    expect(restoredSourceThread).toBe(true);
     expect(result.current.selectedItemKey).toBe("codex:thread-parent");
   });
 
@@ -5672,8 +5680,11 @@ describe("useThreadNavigation", () => {
       ).toBe(true);
     });
 
+    let restoredSourceThread = true;
     await act(async () => {
-      result.current.discardLaunchpad("directory:/repo/app");
+      restoredSourceThread = result.current.discardLaunchpad(
+        "directory:/repo/app",
+      );
     });
 
     // Registered directory: keep the row, wipe only the composed message.
@@ -5682,6 +5693,7 @@ describe("useThreadNavigation", () => {
       patch: { prompt: "", imageAttachments: [], editorDocument: undefined },
     });
     expect(resetDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(restoredSourceThread).toBe(false);
     expect(
       result.current.directories.some(
         (directory) => directory.key === "directory:/repo/app",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2298,7 +2298,8 @@ export function useThreadNavigation(
     parent: NavigationThreadSummary,
     mode?: ThreadWorkspaceMode,
   ) => Promise<void>;
-  discardLaunchpad: (directoryKey: string) => void;
+  /** Returns true when cancellation restores a sub-thread source selection. */
+  discardLaunchpad: (directoryKey: string) => boolean;
   forkThread: (
     parent: NavigationThreadSummary,
     mode: ThreadWorkspaceMode,
@@ -5271,7 +5272,7 @@ export function useThreadNavigation(
    * thread"). Drops the draft and, for a sub-thread composer, returns the
    * selection to the source card the user invoked it from.
    */
-  const discardLaunchpad = useCallback((directoryKey: string): void => {
+  const discardLaunchpad = useCallback((directoryKey: string): boolean => {
     // Read from the merged `directories` memo, not the raw snapshot: the
     // main-process snapshot deliberately omits sub-thread launchpads, so after
     // an authoritative refresh they exist only in `localLaunchpads`. Sourcing
@@ -5283,6 +5284,7 @@ export function useThreadNavigation(
     )?.launchpad;
     const sourceThreadId = launchpad?.sourceThreadId;
     const sourceBackend = launchpad?.backend;
+    const restoresSourceThread = Boolean(sourceThreadId && sourceBackend);
     // An explicitly-registered directory (user added it, or it already holds
     // threads) must stay in the Directories list — Cancel only discards its
     // un-submitted message. Everything else (sub-thread launchpads, transient
@@ -5335,6 +5337,7 @@ export function useThreadNavigation(
         ?.resetDirectoryLaunchpad?.({ directoryKey })
         .catch(handleDiscardError);
     }
+    return restoresSourceThread;
   }, [desktopApi, directories]);
 
   const archiveThread = useCallback(

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -383,21 +383,9 @@ describe("Tangerine Terminal theme contract", () => {
     expect(titleButtonRule).not.toMatch(/(?:^|\n)\s*width:\s*100%;/);
   });
 
-  it("keeps launchpad header chips content-sized and aligned with the eyebrow", () => {
-    const launchpadHeaderRule = extractRuleBody(css, ".thread-header--launchpad");
-    const launchpadAsideRule = extractRuleBody(css, ".thread-header__launchpad-aside");
-    const eyebrowRule = extractRuleBody(css, ".thread-header__eyebrow-row > .eyebrow");
-
-    expect(launchpadHeaderRule).toContain("align-items: flex-start;");
-    expect(launchpadAsideRule).toContain("align-items: flex-start;");
-    expect(eyebrowRule).toContain("height: 24px;");
-    expect(eyebrowRule).toContain("margin: 0 2px 0 0;");
-    expect(css).toMatch(
-      /\.thread-header--launchpad \.thread-header__eyebrow-row > \.thread-row__chip\s*\{[\s\S]*?max-width:\s*100%;[\s\S]*?\}/
-    );
-    expect(css).toMatch(
-      /\.thread-header--launchpad \.messaging-status-bar\s*\{[\s\S]*?padding-top:\s*0;[\s\S]*?padding-bottom:\s*0;[\s\S]*?\}/
-    );
+  it("uses the standard thread chrome instead of legacy launchpad chrome", () => {
+    expect(css).not.toContain(".thread-header--launchpad");
+    expect(css).not.toContain(".launchpad-panel");
   });
 
   it("keeps launchpad setup output from shrinking the header summary", () => {
@@ -406,9 +394,6 @@ describe("Tangerine Terminal theme contract", () => {
       ".thread-view__launchpad-composer:has(.transcript-panel--setup)"
     );
 
-    expect(css).toMatch(
-      /\.thread-view--launchpad > \.thread-header,\s*\.thread-view--launchpad > \.launchpad-panel\s*\{[\s\S]*?flex:\s*0 0 auto;[\s\S]*?\}/
-    );
     expect(setupComposerRule).toContain("flex: 1 1 0;");
     expect(setupComposerRule).toContain("min-height: 0;");
   });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1072,9 +1072,6 @@ textarea,
      compact title's top at y=18.5 — exactly where the brand sits in
      the sidebar masthead. Result: title, brand, and messaging pills
      all share the same vertical centerline.
-     The launchpad variant (`.thread-header--launchpad`) overrides
-     align-items back to flex-start since it has its own taller
-     stacked layout.
      The header is now a column: a single top row (breadcrumb + chips on
      the left, layout toggles + MessagingStatusBar on the right) with any
      directory/branch warnings stacked beneath it. Keeping MSG in the top
@@ -3653,7 +3650,6 @@ textarea,
 .thread-row__time,
 .directory-group__count,
 .context-list__meta,
-.thread-header__stat-label,
 .transcript-message__time {
   color: var(--text-muted);
   font-size: 12px;
@@ -8589,16 +8585,6 @@ textarea,
   color: var(--danger-text);
 }
 
-.thread-view--launchpad {
-  gap: 12px;
-  padding: 0 24px 16px 24px;
-}
-
-.thread-view--launchpad > .thread-header,
-.thread-view--launchpad > .launchpad-panel {
-  flex: 0 0 auto;
-}
-
 .thread-view__launchpad-composer {
   display: flex;
   flex: 0 0 auto;
@@ -8620,9 +8606,7 @@ textarea,
 
 /* The launchpad surface doesn't have a transcript above the composer,
    so the composer's `border-top` (issue #240) would render as a
-   floating divider line with empty space above it. The launchpad-panel
-   above the composer is its own visually-framed card; no divider line
-   needed between it and the composer. */
+   floating divider line with empty space above it. */
 .thread-view__launchpad-composer > .composer {
   border-top: 0;
 }
@@ -8630,32 +8614,6 @@ textarea,
 .thread-header__title {
   font-size: 40px;
   font-weight: 700;
-}
-
-.thread-header--launchpad {
-  /* The launchpad header keeps its own row layout (title column +
-     aside), so opt back out of the base header's column stacking. */
-  flex-direction: row;
-  align-items: flex-start;
-  padding-left: 0;
-  padding-right: 0;
-}
-
-.thread-header__main--launchpad {
-  flex: 1 1 auto;
-}
-
-.thread-header__launchpad-aside {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: flex-start;
-  gap: 16px;
-  min-width: max-content;
-}
-
-.thread-header--launchpad .messaging-status-bar {
-  padding-top: 0;
-  padding-bottom: 0;
 }
 
 .environment-setup-choice {
@@ -8795,10 +8753,6 @@ textarea,
   gap: 8px;
 }
 
-.thread-header--launchpad .thread-header__title {
-  font-size: 34px;
-}
-
 .thread-header__eyebrow-row {
   display: flex;
   align-items: center;
@@ -8893,14 +8847,6 @@ textarea,
   max-width: min(26ch, 28%);
 }
 
-.thread-header--launchpad .thread-header__eyebrow-row {
-  flex-wrap: wrap;
-}
-
-.thread-header--launchpad .thread-header__eyebrow-row > .thread-row__chip {
-  max-width: 100%;
-}
-
 .thread-header__warning {
   max-width: min(72vw, 760px);
   margin: 10px 0 0;
@@ -8917,18 +8863,6 @@ textarea,
   color: var(--accent-bright);
   font-family: var(--font-mono);
   overflow-wrap: anywhere;
-}
-
-.thread-header__stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(104px, 1fr));
-  gap: 12px;
-}
-
-.thread-header__stats strong {
-  display: block;
-  margin-top: 4px;
-  font-size: 14px;
 }
 
 .thread-view__layout {
@@ -9081,81 +9015,6 @@ textarea,
 .transcript-panel,
 .composer {
   background: transparent;
-}
-
-.launchpad-panel {
-  border: 1px solid var(--border-subtle);
-  border-radius: 8px;
-  background: var(--bg-panel);
-}
-
-.launchpad-panel--compact {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.9fr) minmax(0, 1.6fr);
-  align-items: stretch;
-}
-
-.launchpad-panel__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 16px 16px 12px;
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.launchpad-panel__header p {
-  margin: 4px 0 0;
-  color: var(--text-secondary);
-  font-size: 14px;
-  line-height: 1.45;
-}
-
-.launchpad-panel__summary {
-  display: grid;
-  gap: 10px;
-  padding: 14px 16px;
-  border-right: 1px solid var(--border-subtle);
-}
-
-.launchpad-panel__summary strong {
-  display: block;
-  margin-top: 3px;
-  overflow: hidden;
-  color: var(--text-primary);
-  font-size: 14px;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.launchpad-panel__label {
-  display: block;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-}
-
-.launchpad-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px 14px;
-  padding: 14px 16px;
-}
-
-.launchpad-grid dt {
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 500;
-}
-
-.launchpad-grid dd {
-  margin: 4px 0 0;
-  color: var(--text-primary);
-  font-size: 14px;
-  line-height: 1.45;
-  word-break: break-word;
 }
 
 .transcript-panel {
@@ -18499,20 +18358,6 @@ a.transcript-message__messaging-origin:focus-visible {
     bottom: 16px;
   }
 
-  .launchpad-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .launchpad-panel--compact {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .launchpad-panel__summary {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    border-right: 0;
-    border-bottom: 1px solid var(--border-subtle);
-  }
-
   /* No rail overrides at narrow widths. The rail is anchored to
      `.thread-view__layout` (position: absolute) and its width is the
      sidebar-aware `--context-rail-effective`, which already shrinks the
@@ -18556,18 +18401,6 @@ a.transcript-message__messaging-origin:focus-visible {
 
   .thread-header__title {
     font-size: 32px;
-  }
-
-  .thread-header--launchpad {
-    align-items: flex-start;
-  }
-
-  .thread-header--launchpad .thread-header__title {
-    font-size: 30px;
-  }
-
-  .launchpad-panel__summary {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .composer__review-options {


### PR DESCRIPTION
## What changed

- treat the new-thread launchpad as its own browser-style navigation state
- clear the previously selected thread highlight before the launchpad paints
- make Cancel consume the existing Back history entry and restore the prior thread
- keep Start Thread selecting the newly materialized thread
- render the launchpad with the standard thread title bar, including Back/Forward, layout controls, messaging status, and a `Project › New thread` breadcrumb
- retain the right context rail on the launchpad with provider context, without leaking thread-specific panels from the previous thread
- remove the duplicate launchpad project/workspace/branch summary card
- add regression coverage for selection, cancellation, materialization, standard chrome, and restored launchpad history

## Why

The launchpad is a first-class navigation state. Keeping the old thread selected in the sidebar made the draft look associated with the wrong project, while replacing the normal thread chrome removed familiar Back/Forward and layout controls. The launchpad also repeated project, checkout, and branch information that is already available in the breadcrumb and composer.

## Validation

- `pnpm test apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx` (118 tests)
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx` (122 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`
