### PR TITLE
fix(desktop): improve tool activity details

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5242,6 +5242,57 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("does not use title arguments as labels for non-MCP dynamic tools", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-dynamic-tool-title", {
+      thread: {
+        turns: [
+          {
+            id: "turn-dynamic-tool-title",
+            status: "completed",
+            items: [
+              {
+                type: "dynamicToolCall",
+                id: "tool-handoff",
+                tool: "handoff_task",
+                arguments: {
+                  title: "Design Git remotes and branches UI",
+                  task: "Inspect the existing implementation",
+                },
+                status: "completed",
+                success: true,
+                durationMs: 50,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-dynamic-tool-title",
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        details: [
+          expect.objectContaining({
+            id: "tool-handoff",
+            label: "handoff_task (50ms)",
+          }),
+        ],
+      }),
+    ]);
+
+    await client.close();
+  });
+
   it("hydrates dynamic tool result images from persisted thread activity", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-pdf-tool-image", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5254,6 +5254,7 @@ describe("CodexAppServerClient", () => {
               {
                 type: "dynamicToolCall",
                 id: "tool-handoff",
+                namespace: "pwragent",
                 tool: "handoff_task",
                 arguments: {
                   title: "Design Git remotes and branches UI",
@@ -5290,8 +5291,10 @@ describe("CodexAppServerClient", () => {
             label: "Design Git remotes and branches UI (50ms)",
             command: expect.objectContaining({
               source: "tool",
-              rawCommand: "handoff_task",
-              displayCommand: expect.stringContaining("Inspect the existing implementation"),
+              rawCommand: "pwragent/handoff_task",
+              displayCommand: expect.stringMatching(
+                /pwragent\/handoff_task[\s\S]*Inspect the existing implementation/,
+              ),
               output: "Created delegated thread",
             }),
           }),

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5242,7 +5242,7 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
-  it("does not use title arguments as labels for non-MCP dynamic tools", async () => {
+  it("uses dynamic tool titles while preserving expandable tool identity", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-dynamic-tool-title", {
       thread: {
@@ -5262,6 +5262,9 @@ describe("CodexAppServerClient", () => {
                 status: "completed",
                 success: true,
                 durationMs: 50,
+                contentItems: [
+                  { type: "inputText", text: "Created delegated thread" },
+                ],
               },
             ],
           },
@@ -5284,7 +5287,13 @@ describe("CodexAppServerClient", () => {
         details: [
           expect.objectContaining({
             id: "tool-handoff",
-            label: "handoff_task (50ms)",
+            label: "Design Git remotes and branches UI (50ms)",
+            command: expect.objectContaining({
+              source: "tool",
+              rawCommand: "handoff_task",
+              displayCommand: expect.stringContaining("Inspect the existing implementation"),
+              output: "Created delegated thread",
+            }),
           }),
         ],
       }),

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5151,11 +5151,92 @@ describe("CodexAppServerClient", () => {
           {
             id: "tool-2",
             kind: "command",
-            label: "search_issues",
+            label: "Used MCP github/search_issues",
+            command: {
+              displayCommand: "github/search_issues",
+              rawCommand: "github/search_issues",
+              source: "tool",
+            },
             status: "in_progress"
           }
         ]
       }
+    ]);
+
+    await client.close();
+  });
+
+  it("uses MCP titles and preserves expandable invocations, output, and images", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-mcp-tool-details", {
+      thread: {
+        turns: [
+          {
+            id: "turn-mcp-tool-details",
+            status: "completed",
+            startedAt: 1_763_500_210,
+            items: [
+              {
+                type: "mcpToolCall",
+                id: "tool-node-repl",
+                server: "node_repl",
+                tool: "js",
+                arguments: {
+                  title: "Inspect PwrGit profile",
+                  code: "await sky.get_app_state();",
+                },
+                status: "completed",
+                result: {
+                  content: [
+                    { type: "text", text: "Visible application state" },
+                    { type: "image", mimeType: "image/png", data: "AQID" },
+                  ],
+                  structuredContent: {},
+                },
+                error: null,
+                durationMs: 1_170,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-mcp-tool-details",
+    });
+
+    expect(replay.entries).toEqual([
+      expect.objectContaining({
+        type: "activity",
+        summary: "Used 1 tool",
+        details: [
+          expect.objectContaining({
+            id: "tool-node-repl",
+            label: "Inspect PwrGit profile (1.2s)",
+            status: "completed",
+            command: expect.objectContaining({
+              source: "tool",
+              rawCommand: "node_repl/js",
+              durationMs: 1_170,
+              displayCommand: expect.stringContaining("await sky.get_app_state();"),
+              output: expect.stringContaining("Visible application state"),
+            }),
+            images: [
+              {
+                type: "image",
+                url: "data:image/png;base64,AQID",
+                alt: "node_repl/js result",
+              },
+            ],
+          }),
+        ],
+      }),
     ]);
 
     await client.close();

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -100,6 +100,12 @@ import {
 } from "../app-server/thread-directory-enricher";
 import { normalizeReviewDisplayText } from "../../shared/review-command";
 import {
+  formatMcpToolActivityTitle,
+  formatMcpToolIdentifier,
+  formatMcpToolInvocation,
+  formatMcpToolOutput,
+} from "../../shared/mcp-tool-activity";
+import {
   StdioJsonRpcTransport,
   type StdioJsonRpcTransportOptions,
 } from "./stdio-transport";
@@ -3618,6 +3624,42 @@ function extractMcpToolResultImagePartsFromReplayItem(
   );
 }
 
+function extractDirectMcpToolResultImageParts(
+  item: Record<string, unknown>,
+  toolName: string,
+): AppServerThreadImagePart[] {
+  const result = asRecord(item.result);
+  const content = Array.isArray(result?.content) ? result.content : [];
+  const identifier = formatMcpToolIdentifier(
+    pickString(item, ["server", "serverName", "server_name"]),
+    toolName,
+  );
+  return dedupeImageParts(content.flatMap((value): AppServerThreadImagePart[] => {
+    const block = asRecord(value);
+    const type = normalizeItemType(pickString(block ?? {}, ["type"]));
+    const mimeType = pickString(block ?? {}, ["mimeType", "mime_type"])
+      ?.trim()
+      .toLowerCase();
+    const data = pickString(block ?? {}, ["data"]);
+    if (
+      type !== "image"
+      || !mimeType
+      || !MCP_RESOURCE_IMAGE_MIME_TYPES.has(mimeType)
+      || !data
+      || data.length > MAX_MCP_RESOURCE_IMAGE_BASE64_CHARS
+      || data.length % 4 === 1
+      || !BASE64_IMAGE_BLOB_PATTERN.test(data)
+    ) {
+      return [];
+    }
+    return [{
+      type: "image",
+      url: `data:${mimeType};base64,${data}`,
+      alt: `${identifier} result`,
+    }];
+  }));
+}
+
 function buildMcpSignedImagePart(
   structuredContent: Record<string, unknown>,
 ): AppServerThreadImagePart | undefined {
@@ -3885,6 +3927,29 @@ function parseToolArguments(item: Record<string, unknown>): Record<string, unkno
     asRecord(item.input) ??
     undefined
   );
+}
+
+function buildMcpToolCommandDetail(params: {
+  item: Record<string, unknown>;
+  toolName: string;
+  elapsedMs: number | undefined;
+}): AppServerThreadCommandDetail {
+  const identifier = formatMcpToolIdentifier(
+    pickString(params.item, ["server", "serverName", "server_name"]),
+    params.toolName,
+  );
+  const args = parseToolArguments(params.item);
+  const output = formatMcpToolOutput({
+    error: params.item.error,
+    result: params.item.result,
+  });
+  return {
+    displayCommand: formatMcpToolInvocation(identifier, args),
+    rawCommand: identifier,
+    source: "tool",
+    ...(output ? { output } : {}),
+    ...(typeof params.elapsedMs === "number" ? { durationMs: params.elapsedMs } : {}),
+  };
 }
 
 function readActivityOutputText(item: Record<string, unknown>): string | undefined {
@@ -4175,19 +4240,38 @@ function summarizeActivityItems(
       const toolName =
         pickString(item, ["tool", "toolName", "tool_name", "name"]) ??
         (normalizedItemType === "websearch" ? "web search" : undefined);
-      const query = pickString(item, ["query"]);
+      const args = parseToolArguments(item);
+      const query =
+        pickString(item, ["query"]) ??
+        pickString(args ?? {}, ["query", "q"]);
+      const explicitTitle = pickString(args ?? {}, ["title"]);
+      const mcpCommandDetail =
+        normalizedItemType === "mcptoolcall" && toolName
+          ? buildMcpToolCommandDetail({ item, toolName, elapsedMs })
+          : undefined;
       const images =
         normalizedItemType === "dynamictoolcall"
           ? extractDynamicToolCallImageParts(item, toolName ?? "Tool")
+          : normalizedItemType === "mcptoolcall"
+            ? extractDirectMcpToolResultImageParts(item, toolName ?? "Tool")
           : [];
+      const label = explicitTitle
+        ? formatMcpToolActivityTitle(explicitTitle)
+        : normalizedItemType === "mcptoolcall" && toolName
+          ? `Used MCP ${formatMcpToolIdentifier(
+              pickString(item, ["server", "serverName", "server_name"]),
+              toolName,
+            )}`
+          : toolName ?? "Used tool";
       pushActivityDetail(details, {
         id: itemId,
         kind: normalizedItemType === "websearch" ? "read" : "command",
         label: [
-          appendElapsedLabel(toolName ?? "Used tool", elapsedMs),
+          appendElapsedLabel(label, elapsedMs),
           query ? `: ${query}` : "",
         ].join(""),
         ...(images.length > 0 ? { images } : {}),
+        ...(mcpCommandDetail ? { command: mcpCommandDetail } : {}),
         status: itemStatus
       });
     }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -100,11 +100,12 @@ import {
 } from "../app-server/thread-directory-enricher";
 import { normalizeReviewDisplayText } from "../../shared/review-command";
 import {
-  formatMcpToolActivityTitle,
-  formatMcpToolIdentifier,
-  formatMcpToolInvocation,
+  formatDynamicToolOutput,
   formatMcpToolOutput,
-} from "../../shared/mcp-tool-activity";
+  formatToolActivityTitle,
+  formatToolIdentifier,
+  formatToolInvocation,
+} from "../../shared/tool-activity";
 import {
   StdioJsonRpcTransport,
   type StdioJsonRpcTransportOptions,
@@ -3630,7 +3631,7 @@ function extractDirectMcpToolResultImageParts(
 ): AppServerThreadImagePart[] {
   const result = asRecord(item.result);
   const content = Array.isArray(result?.content) ? result.content : [];
-  const identifier = formatMcpToolIdentifier(
+  const identifier = formatToolIdentifier(
     pickString(item, ["server", "serverName", "server_name"]),
     toolName,
   );
@@ -3934,7 +3935,7 @@ function buildMcpToolCommandDetail(params: {
   toolName: string;
   elapsedMs: number | undefined;
 }): AppServerThreadCommandDetail {
-  const identifier = formatMcpToolIdentifier(
+  const identifier = formatToolIdentifier(
     pickString(params.item, ["server", "serverName", "server_name"]),
     params.toolName,
   );
@@ -3944,8 +3945,26 @@ function buildMcpToolCommandDetail(params: {
     result: params.item.result,
   });
   return {
-    displayCommand: formatMcpToolInvocation(identifier, args),
+    displayCommand: formatToolInvocation(identifier, args),
     rawCommand: identifier,
+    source: "tool",
+    ...(output ? { output } : {}),
+    ...(typeof params.elapsedMs === "number" ? { durationMs: params.elapsedMs } : {}),
+  };
+}
+
+function buildDynamicToolCommandDetail(params: {
+  item: Record<string, unknown>;
+  toolName: string;
+  elapsedMs: number | undefined;
+}): AppServerThreadCommandDetail {
+  const args = parseToolArguments(params.item);
+  const output = formatDynamicToolOutput(
+    params.item.contentItems ?? params.item.content_items,
+  );
+  return {
+    displayCommand: formatToolInvocation(params.toolName, args),
+    rawCommand: params.toolName,
     source: "tool",
     ...(output ? { output } : {}),
     ...(typeof params.elapsedMs === "number" ? { durationMs: params.elapsedMs } : {}),
@@ -4249,16 +4268,22 @@ function summarizeActivityItems(
         normalizedItemType === "mcptoolcall" && toolName
           ? buildMcpToolCommandDetail({ item, toolName, elapsedMs })
           : undefined;
+      const dynamicCommandDetail =
+        normalizedItemType === "dynamictoolcall" && explicitTitle && toolName
+          ? buildDynamicToolCommandDetail({ item, toolName, elapsedMs })
+          : undefined;
       const images =
         normalizedItemType === "dynamictoolcall"
           ? extractDynamicToolCallImageParts(item, toolName ?? "Tool")
           : normalizedItemType === "mcptoolcall"
             ? extractDirectMcpToolResultImageParts(item, toolName ?? "Tool")
           : [];
-      const label = normalizedItemType === "mcptoolcall" && explicitTitle
-        ? formatMcpToolActivityTitle(explicitTitle)
+      const label =
+        (normalizedItemType === "mcptoolcall" || normalizedItemType === "dynamictoolcall")
+        && explicitTitle
+        ? formatToolActivityTitle(explicitTitle)
         : normalizedItemType === "mcptoolcall" && toolName
-          ? `Used MCP ${formatMcpToolIdentifier(
+          ? `Used MCP ${formatToolIdentifier(
               pickString(item, ["server", "serverName", "server_name"]),
               toolName,
             )}`
@@ -4271,7 +4296,9 @@ function summarizeActivityItems(
           query ? `: ${query}` : "",
         ].join(""),
         ...(images.length > 0 ? { images } : {}),
-        ...(mcpCommandDetail ? { command: mcpCommandDetail } : {}),
+        ...(mcpCommandDetail || dynamicCommandDetail
+          ? { command: mcpCommandDetail ?? dynamicCommandDetail }
+          : {}),
         status: itemStatus
       });
     }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -4255,7 +4255,7 @@ function summarizeActivityItems(
           : normalizedItemType === "mcptoolcall"
             ? extractDirectMcpToolResultImageParts(item, toolName ?? "Tool")
           : [];
-      const label = explicitTitle
+      const label = normalizedItemType === "mcptoolcall" && explicitTitle
         ? formatMcpToolActivityTitle(explicitTitle)
         : normalizedItemType === "mcptoolcall" && toolName
           ? `Used MCP ${formatMcpToolIdentifier(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3958,13 +3958,17 @@ function buildDynamicToolCommandDetail(params: {
   toolName: string;
   elapsedMs: number | undefined;
 }): AppServerThreadCommandDetail {
+  const identifier = formatToolIdentifier(
+    pickString(params.item, ["namespace", "toolNamespace", "tool_namespace"]),
+    params.toolName,
+  );
   const args = parseToolArguments(params.item);
   const output = formatDynamicToolOutput(
     params.item.contentItems ?? params.item.content_items,
   );
   return {
-    displayCommand: formatToolInvocation(params.toolName, args),
-    rawCommand: params.toolName,
+    displayCommand: formatToolInvocation(identifier, args),
+    rawCommand: identifier,
     source: "tool",
     ...(output ? { output } : {}),
     ...(typeof params.elapsedMs === "number" ? { durationMs: params.elapsedMs } : {}),

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -264,6 +264,37 @@ describe("buildLiveToolDetails", () => {
     expect(details[0]?.label).not.toContain("Visible application state");
     expect(details[0]?.label).not.toContain("AQID");
   });
+
+  it("uses dynamic tool titles while preserving expandable tool identity", () => {
+    const details = buildLiveToolDetails({
+      type: "dynamicToolCall",
+      id: "tool-handoff",
+      tool: "handoff_task",
+      arguments: {
+        title: "Design Git remotes and branches UI",
+        task: "Inspect the existing implementation",
+      },
+      status: "completed",
+      success: true,
+      durationMs: 50,
+      contentItems: [
+        { type: "inputText", text: "Created delegated thread" },
+      ],
+    });
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        id: "tool-handoff",
+        label: "Design Git remotes and branches UI (50ms)",
+        command: expect.objectContaining({
+          source: "tool",
+          rawCommand: "handoff_task",
+          displayCommand: expect.stringContaining("Inspect the existing implementation"),
+          output: "Created delegated thread",
+        }),
+      }),
+    ]);
+  });
 });
 
 describe("appendCommandOutputDelta", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -269,6 +269,7 @@ describe("buildLiveToolDetails", () => {
     const details = buildLiveToolDetails({
       type: "dynamicToolCall",
       id: "tool-handoff",
+      namespace: "pwragent",
       tool: "handoff_task",
       arguments: {
         title: "Design Git remotes and branches UI",
@@ -288,8 +289,10 @@ describe("buildLiveToolDetails", () => {
         label: "Design Git remotes and branches UI (50ms)",
         command: expect.objectContaining({
           source: "tool",
-          rawCommand: "handoff_task",
-          displayCommand: expect.stringContaining("Inspect the existing implementation"),
+          rawCommand: "pwragent/handoff_task",
+          displayCommand: expect.stringMatching(
+            /pwragent\/handoff_task[\s\S]*Inspect the existing implementation/,
+          ),
           output: "Created delegated thread",
         }),
       }),

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -219,6 +219,51 @@ describe("buildLiveToolDetails", () => {
     ]);
     expect(details[0]?.label).not.toContain("AQID");
   });
+
+  it("uses MCP titles and builds expandable invocation details", () => {
+    const details = buildLiveToolDetails({
+      type: "mcpToolCall",
+      id: "tool-node-repl",
+      server: "node_repl",
+      tool: "js",
+      arguments: {
+        title: "Inspect PwrGit profile",
+        code: "await sky.get_app_state();",
+      },
+      status: "completed",
+      durationMs: 1_170,
+      result: {
+        content: [
+          { type: "text", text: "Visible application state" },
+          { type: "image", mimeType: "image/png", data: "AQID" },
+        ],
+        structuredContent: {},
+      },
+    });
+
+    expect(details).toEqual([
+      expect.objectContaining({
+        id: "tool-node-repl",
+        label: "Inspect PwrGit profile (1.2s)",
+        images: [
+          {
+            type: "image",
+            url: "data:image/png;base64,AQID",
+            alt: "node_repl/js result",
+          },
+        ],
+        command: expect.objectContaining({
+          source: "tool",
+          rawCommand: "node_repl/js",
+          durationMs: 1_170,
+          displayCommand: expect.stringContaining("await sky.get_app_state();"),
+          output: expect.stringContaining("Visible application state"),
+        }),
+      }),
+    ]);
+    expect(details[0]?.label).not.toContain("Visible application state");
+    expect(details[0]?.label).not.toContain("AQID");
+  });
 });
 
 describe("appendCommandOutputDelta", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -341,6 +341,31 @@ describe("mergeCommandDetail", () => {
       source: "shell",
     });
   });
+
+  it("keeps completed MCP invocations classified as tools", () => {
+    expect(
+      mergeCommandDetail(
+        {
+          displayCommand: "node_repl/js\n{\n  \"title\": \"Inspect profile\"\n}",
+          rawCommand: "node_repl/js",
+          source: "tool",
+        },
+        {
+          displayCommand: "node_repl/js\n{\n  \"title\": \"Inspect profile\"\n}",
+          rawCommand: "node_repl/js",
+          source: "tool",
+          output: "Visible application state",
+          durationMs: 1_170,
+        },
+      ),
+    ).toEqual({
+      displayCommand: "node_repl/js\n{\n  \"title\": \"Inspect profile\"\n}",
+      rawCommand: "node_repl/js",
+      source: "tool",
+      output: "Visible application state",
+      durationMs: 1_170,
+    });
+  });
 });
 
 describe("mergeActivityDetails", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -1149,9 +1149,11 @@ export function mergeCommandDetail(
     return undefined;
   }
   const source =
-    next?.rawCommand && existing?.source === "tool"
-      ? "shell"
-      : next?.source ?? existing?.source;
+    next?.source === "tool"
+      ? "tool"
+      : next?.rawCommand && existing?.source === "tool"
+        ? "shell"
+        : next?.source ?? existing?.source;
 
   return {
     displayCommand,

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -15,6 +15,12 @@ import {
   type AppServerThreadSubAgentCallDetail,
   type AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
+import {
+  formatMcpToolActivityTitle,
+  formatMcpToolIdentifier,
+  formatMcpToolInvocation,
+  formatMcpToolOutput,
+} from "../../../../shared/mcp-tool-activity";
 
 export const RENDERER_SEQUENCE_KEY = "__rendererSequence" as const;
 
@@ -186,27 +192,28 @@ function summarizeDynamicToolResult(item: Record<string, unknown>): string | und
   return summarizeToolOutput(text);
 }
 
-function summarizeMcpToolResult(item: Record<string, unknown>): string | undefined {
-  const error = summarizeJsonValue(item.error);
-  if (error) {
-    return error;
-  }
-  const result = readRecord(item.result);
-  if (!result) {
-    return undefined;
-  }
-  const structuredContent = summarizeJsonValue(
-    result.structuredContent ?? result.structured_content,
-  );
-  if (structuredContent) {
-    return structuredContent;
-  }
-  const text = (Array.isArray(result.content) ? result.content : [])
-    .map(readRecord)
-    .map((contentItem) => readString(contentItem, "text"))
-    .filter((value): value is string => Boolean(value))
-    .join(" ");
-  return summarizeToolOutput(text);
+function buildLiveMcpToolCommandDetail(
+  item: Record<string, unknown>,
+  toolName: string,
+  elapsedMs: number | undefined,
+): AppServerThreadCommandDetail {
+  const serverName =
+    readString(item, "server") ??
+    readString(item, "serverName") ??
+    readString(item, "server_name");
+  const identifier = formatMcpToolIdentifier(serverName, toolName);
+  const args = readRecord(item.arguments) ?? readRecord(item.input);
+  const output = formatMcpToolOutput({
+    error: item.error,
+    result: item.result,
+  });
+  return {
+    displayCommand: formatMcpToolInvocation(identifier, args),
+    rawCommand: identifier,
+    source: "tool",
+    ...(output ? { output } : {}),
+    ...(typeof elapsedMs === "number" ? { durationMs: elapsedMs } : {}),
+  };
 }
 
 function readCommandOutputText(item: Record<string, unknown>): string | undefined {
@@ -690,23 +697,6 @@ function summarizeToolOutput(text: string | undefined): string | undefined {
   return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
 }
 
-function summarizeJsonValue(value: unknown): string | undefined {
-  if (value == null) {
-    return undefined;
-  }
-  if (typeof value === "string") {
-    return summarizeToolOutput(value);
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  try {
-    return summarizeToolOutput(JSON.stringify(value));
-  } catch {
-    return undefined;
-  }
-}
-
 function formatLiveToolName(
   toolName: string,
   status: AppServerThreadActivityDetail["status"]
@@ -764,7 +754,14 @@ function buildLiveToolLabel(
   }
 
   if (itemType === "mcptoolcall") {
-    const serverName = readString(item, "server") ?? readString(item, "serverName");
+    const title = readToolArgument(item, "title");
+    if (title) {
+      return formatMcpToolActivityTitle(title);
+    }
+    const serverName =
+      readString(item, "server") ??
+      readString(item, "serverName") ??
+      readString(item, "server_name");
     return formatMcpToolName(serverName, toolName, status);
   }
 
@@ -1006,7 +1003,7 @@ export function buildLiveToolDetails(
   const query = readToolArgument(item, "query") ?? readToolArgument(item, "q");
   const preview =
     itemType === "mcptoolcall"
-      ? summarizeMcpToolResult(item)
+      ? undefined
       : itemType === "dynamictoolcall"
         ? summarizeDynamicToolResult(item)
       : summarizeToolOutput(readToolOutputText(item));
@@ -1026,6 +1023,8 @@ export function buildLiveToolDetails(
       ? buildLiveCommandDetail(item, command, elapsedMs)
       : itemType === "collabagenttoolcall"
         ? buildCollabAgentCommandDetail(item, toolName, readStringArray(item.receiverThreadIds))
+        : itemType === "mcptoolcall"
+          ? buildLiveMcpToolCommandDetail(item, toolName, elapsedMs)
         : undefined;
   const details: AppServerThreadActivityDetail[] = [
     {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -16,11 +16,12 @@ import {
   type AppServerThreadTurnMetadata,
 } from "@pwragent/shared";
 import {
-  formatMcpToolActivityTitle,
-  formatMcpToolIdentifier,
-  formatMcpToolInvocation,
+  formatDynamicToolOutput,
   formatMcpToolOutput,
-} from "../../../../shared/mcp-tool-activity";
+  formatToolActivityTitle,
+  formatToolIdentifier,
+  formatToolInvocation,
+} from "../../../../shared/tool-activity";
 
 export const RENDERER_SEQUENCE_KEY = "__rendererSequence" as const;
 
@@ -201,15 +202,31 @@ function buildLiveMcpToolCommandDetail(
     readString(item, "server") ??
     readString(item, "serverName") ??
     readString(item, "server_name");
-  const identifier = formatMcpToolIdentifier(serverName, toolName);
+  const identifier = formatToolIdentifier(serverName, toolName);
   const args = readRecord(item.arguments) ?? readRecord(item.input);
   const output = formatMcpToolOutput({
     error: item.error,
     result: item.result,
   });
   return {
-    displayCommand: formatMcpToolInvocation(identifier, args),
+    displayCommand: formatToolInvocation(identifier, args),
     rawCommand: identifier,
+    source: "tool",
+    ...(output ? { output } : {}),
+    ...(typeof elapsedMs === "number" ? { durationMs: elapsedMs } : {}),
+  };
+}
+
+function buildLiveDynamicToolCommandDetail(
+  item: Record<string, unknown>,
+  toolName: string,
+  elapsedMs: number | undefined,
+): AppServerThreadCommandDetail {
+  const args = readRecord(item.arguments) ?? readRecord(item.input);
+  const output = formatDynamicToolOutput(item.contentItems ?? item.content_items);
+  return {
+    displayCommand: formatToolInvocation(toolName, args),
+    rawCommand: toolName,
     source: "tool",
     ...(output ? { output } : {}),
     ...(typeof elapsedMs === "number" ? { durationMs: elapsedMs } : {}),
@@ -728,6 +745,11 @@ function buildLiveToolLabel(
   status: AppServerThreadActivityDetail["status"],
   toolName: string
 ): string {
+  const title = readToolArgument(item, "title");
+  if ((itemType === "mcptoolcall" || itemType === "dynamictoolcall") && title) {
+    return formatToolActivityTitle(title);
+  }
+
   if (itemType === "collabagenttoolcall") {
     return formatCollabAgentToolLabel({
       receiverThreadIds: readStringArray(item.receiverThreadIds),
@@ -754,10 +776,6 @@ function buildLiveToolLabel(
   }
 
   if (itemType === "mcptoolcall") {
-    const title = readToolArgument(item, "title");
-    if (title) {
-      return formatMcpToolActivityTitle(title);
-    }
     const serverName =
       readString(item, "server") ??
       readString(item, "serverName") ??
@@ -1000,10 +1018,13 @@ export function buildLiveToolDetails(
     readString(item, "name") ??
     (itemType === "websearch" ? "web search" : "tool");
   const status = normalizeItemStatus(item.status);
+  const title = readToolArgument(item, "title");
   const query = readToolArgument(item, "query") ?? readToolArgument(item, "q");
   const preview =
     itemType === "mcptoolcall"
       ? undefined
+      : itemType === "dynamictoolcall" && title
+        ? undefined
       : itemType === "dynamictoolcall"
         ? summarizeDynamicToolResult(item)
       : summarizeToolOutput(readToolOutputText(item));
@@ -1025,6 +1046,8 @@ export function buildLiveToolDetails(
         ? buildCollabAgentCommandDetail(item, toolName, readStringArray(item.receiverThreadIds))
         : itemType === "mcptoolcall"
           ? buildLiveMcpToolCommandDetail(item, toolName, elapsedMs)
+          : itemType === "dynamictoolcall" && title
+            ? buildLiveDynamicToolCommandDetail(item, toolName, elapsedMs)
         : undefined;
   const details: AppServerThreadActivityDetail[] = [
     {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -222,11 +222,16 @@ function buildLiveDynamicToolCommandDetail(
   toolName: string,
   elapsedMs: number | undefined,
 ): AppServerThreadCommandDetail {
+  const namespace =
+    readString(item, "namespace") ??
+    readString(item, "toolNamespace") ??
+    readString(item, "tool_namespace");
+  const identifier = formatToolIdentifier(namespace, toolName);
   const args = readRecord(item.arguments) ?? readRecord(item.input);
   const output = formatDynamicToolOutput(item.contentItems ?? item.content_items);
   return {
-    displayCommand: formatToolInvocation(toolName, args),
-    rawCommand: toolName,
+    displayCommand: formatToolInvocation(identifier, args),
+    rawCommand: identifier,
     source: "tool",
     ...(output ? { output } : {}),
     ...(typeof elapsedMs === "number" ? { durationMs: elapsedMs } : {}),

--- a/apps/desktop/src/shared/__tests__/tool-activity.test.ts
+++ b/apps/desktop/src/shared/__tests__/tool-activity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatMcpToolOutput } from "../tool-activity";
+
+describe("formatMcpToolOutput", () => {
+  it("replaces embedded image resource blobs with a compact placeholder", () => {
+    const blob = "AQID".repeat(10_000);
+
+    const output = formatMcpToolOutput({
+      error: null,
+      result: {
+        content: [
+          {
+            type: "resource",
+            resource: {
+              uri: "capture://overview",
+              mimeType: "image/png",
+              blob,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(output).toBe("[image/png image resource]");
+    expect(output).not.toContain(blob);
+  });
+});

--- a/apps/desktop/src/shared/mcp-tool-activity.ts
+++ b/apps/desktop/src/shared/mcp-tool-activity.ts
@@ -1,0 +1,112 @@
+import { truncateRendererPayloadString } from "@pwragent/shared";
+
+const TOOL_ACTIVITY_TITLE_MAX_CHARS = 160;
+
+export function formatMcpToolActivityTitle(value: string): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > TOOL_ACTIVITY_TITLE_MAX_CHARS
+    ? `${normalized.slice(0, TOOL_ACTIVITY_TITLE_MAX_CHARS - 3)}...`
+    : normalized;
+}
+
+export function formatMcpToolIdentifier(
+  serverName: string | undefined,
+  toolName: string,
+): string {
+  return serverName ? `${serverName}/${toolName}` : toolName;
+}
+
+export function formatMcpToolInvocation(
+  identifier: string,
+  args: Record<string, unknown> | undefined,
+): string {
+  if (!args || Object.keys(args).length === 0) {
+    return identifier;
+  }
+  try {
+    return truncateRendererPayloadString(
+      `${identifier}\n${JSON.stringify(args, null, 2)}`,
+      `${identifier} invocation`,
+    );
+  } catch {
+    return identifier;
+  }
+}
+
+export function formatMcpToolOutput(params: {
+  error: unknown;
+  result: unknown;
+}): string | undefined {
+  const parts: string[] = [];
+  const error = formatResultValue(params.error);
+  if (error) {
+    parts.push(`Error\n${error}`);
+  }
+
+  const result = asRecord(params.result);
+  const structuredContent = formatResultValue(
+    result?.structuredContent ?? result?.structured_content,
+  );
+  if (structuredContent) {
+    parts.push(`Structured result\n${structuredContent}`);
+  }
+
+  const content = Array.isArray(result?.content) ? result.content : [];
+  for (const value of content) {
+    const block = asRecord(value);
+    const blockType = readString(block, "type")?.replace(/[-_\s]/g, "").toLowerCase();
+    if (blockType === "image" || blockType === "audio") {
+      const mimeType = readString(block, "mimeType") ?? readString(block, "mime_type");
+      parts.push(`[${mimeType ?? blockType} ${blockType} result]`);
+      continue;
+    }
+    const text = readString(block, "text");
+    const formatted = text ?? formatResultValue(value);
+    if (formatted) {
+      parts.push(formatted);
+    }
+  }
+
+  if (parts.length === 0 && result) {
+    const fallback = formatResultValue(result);
+    if (fallback) {
+      parts.push(fallback);
+    }
+  }
+
+  const output = parts.join("\n\n");
+  return output
+    ? truncateRendererPayloadString(output, "MCP tool output")
+    : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function formatResultValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value.trim() || undefined;
+  }
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  try {
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized && serialized !== "{}" && serialized !== "[]"
+      ? serialized
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/desktop/src/shared/tool-activity.ts
+++ b/apps/desktop/src/shared/tool-activity.ts
@@ -10,10 +10,10 @@ export function formatToolActivityTitle(value: string): string {
 }
 
 export function formatToolIdentifier(
-  serverName: string | undefined,
+  qualifier: string | undefined,
   toolName: string,
 ): string {
-  return serverName ? `${serverName}/${toolName}` : toolName;
+  return qualifier ? `${qualifier}/${toolName}` : toolName;
 }
 
 export function formatToolInvocation(
@@ -58,6 +58,19 @@ export function formatMcpToolOutput(params: {
     if (blockType === "image" || blockType === "audio") {
       const mimeType = readString(block, "mimeType") ?? readString(block, "mime_type");
       parts.push(`[${mimeType ?? blockType} ${blockType} result]`);
+      continue;
+    }
+    const resource = asRecord(block?.resource);
+    const resourceMimeType =
+      readString(resource, "mimeType") ?? readString(resource, "mime_type");
+    const resourceBlob = resource?.blob;
+    if (
+      blockType === "resource"
+      && resourceMimeType?.toLowerCase().startsWith("image/")
+      && typeof resourceBlob === "string"
+      && resourceBlob.length > 0
+    ) {
+      parts.push(`[${resourceMimeType} image resource]`);
       continue;
     }
     const text = readString(block, "text");

--- a/apps/desktop/src/shared/tool-activity.ts
+++ b/apps/desktop/src/shared/tool-activity.ts
@@ -2,21 +2,21 @@ import { truncateRendererPayloadString } from "@pwragent/shared";
 
 const TOOL_ACTIVITY_TITLE_MAX_CHARS = 160;
 
-export function formatMcpToolActivityTitle(value: string): string {
+export function formatToolActivityTitle(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   return normalized.length > TOOL_ACTIVITY_TITLE_MAX_CHARS
     ? `${normalized.slice(0, TOOL_ACTIVITY_TITLE_MAX_CHARS - 3)}...`
     : normalized;
 }
 
-export function formatMcpToolIdentifier(
+export function formatToolIdentifier(
   serverName: string | undefined,
   toolName: string,
 ): string {
   return serverName ? `${serverName}/${toolName}` : toolName;
 }
 
-export function formatMcpToolInvocation(
+export function formatToolInvocation(
   identifier: string,
   args: Record<string, unknown> | undefined,
 ): string {
@@ -77,6 +77,30 @@ export function formatMcpToolOutput(params: {
   const output = parts.join("\n\n");
   return output
     ? truncateRendererPayloadString(output, "MCP tool output")
+    : undefined;
+}
+
+export function formatDynamicToolOutput(contentItems: unknown): string | undefined {
+  if (!Array.isArray(contentItems)) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const value of contentItems) {
+    const item = asRecord(value);
+    const itemType = readString(item, "type")?.replace(/[-_\s]/g, "").toLowerCase();
+    if (itemType === "inputimage") {
+      parts.push("[image result]");
+      continue;
+    }
+    const text = readString(item, "text");
+    const formatted = text ?? formatResultValue(value);
+    if (formatted) {
+      parts.push(formatted);
+    }
+  }
+  const output = parts.join("\n\n");
+  return output
+    ? truncateRendererPayloadString(output, "dynamic tool output")
     : undefined;
 }
 


### PR DESCRIPTION
## What changed

- Prefer human-readable `arguments.title` values for MCP and dynamic tool activity rows.
- Make MCP rows and title-bearing dynamic-tool rows expandable with fully qualified tool identity, formatted invocation arguments, duration/status, and bounded result or error output.
- Preserve MCP `server/tool` and dynamic `namespace/tool` identities in expandable details and copy actions.
- Keep live notifications and historical thread replay on the same formatting path.
- Preserve direct MCP image result blocks in historical activity details while replacing embedded image-resource blobs with compact placeholders before output serialization.
- Keep MCP invocations classified as tools across started-to-completed live updates.

## Why

Codex recorded the audited Computer Use calls as `node_repl/js` MCP calls with descriptive titles such as `Inspect PwrGit profile`, but historical replay rendered every row as bare `js`. Title-bearing dynamic tools such as `pwragent/handoff_task` had the same useful human context, but exposing it must not hide their fully qualified identity. Direct and embedded image results also needed replay parity without copying large base64 blobs into text output.

## User impact

Collapsed activity remains concise and human-readable. Expanding a titled tool row exposes canonical identity such as `node_repl/js` or `pwragent/handoff_task`, the actual invocation, copy controls, bounded output, and any returned images. Specialized web and image rows retain their existing purpose-built labels, and tools without titles remain unchanged.

## Validation

- `pnpm test apps/desktop/src/shared/__tests__/tool-activity.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts` (166 tests)
- `pnpm lint:eslint`
- scoped ESLint on all changed files
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm typecheck`
- `git diff --check`
