### PR TITLE
fix(tests): disable hardware video codecs in E2E — vmapple VideoToolbox kernel leak

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -173,7 +173,24 @@ export async function launchElectronApp(params: {
   }
 
   const electronApp = await electron.launch({
-    args: [path.resolve(fixtureDir, "../../out/main/index.js")],
+    args: [
+      path.resolve(fixtureDir, "../../out/main/index.js"),
+      // Hardware video codecs leak kernel objects inside a
+      // Virtualization.framework guest (the Tart macOS VMs): every
+      // VideoToolbox init creates an
+      // AppleVideoToolboxParavirtualizationUserClient that the vmapple
+      // paravirt driver never frees, even at process death. Chromium
+      // initializes them once per app launch, so a suite run leaks
+      // roughly one per spec. Past ~1.1k live clients the driver's
+      // IOService::newUserClient wedges, every new Electron helper
+      // hangs at birth in-kernel, and app teardown blocks ~6s per spec
+      // until the guest is rebooted. --disable-gpu and
+      // disableHardwareAcceleration() do NOT cover media codecs, so
+      // the codec switches have to be explicit. Harmless elsewhere:
+      // no spec plays video.
+      "--disable-accelerated-video-decode",
+      "--disable-accelerated-video-encode",
+    ],
     cwd: path.resolve(fixtureDir, "../.."),
     env,
   });


### PR DESCRIPTION
## What

Adds `--disable-accelerated-video-decode` / `--disable-accelerated-video-encode` to the desktop E2E fixture's Electron launch.

## Why

Every VideoToolbox initialization inside a Virtualization.framework guest leaks an `AppleVideoToolboxParavirtualizationUserClient` kernel object that the vmapple paravirt driver never frees — not even at process death. Chromium initializes the hardware video codecs once per app launch, and the fixture launches one Electron app per spec, so a suite run leaks roughly one kernel object per spec.

Past ~1.1k live clients the driver's `IOService::newUserClient` wedges: new Electron helpers hang **at birth** inside the kernel, app teardown then blocks in `wait4` on an unkillable helper, and every spec pays a ~6s forced teardown until the guest is rebooted. Same root cause and fix as PwrSnap [#366](https://github.com/pwrdrvr/PwrSnap/pull/366).

**`--disable-gpu` and `app.disableHardwareAcceleration()` do not cover media codecs** — this is the part that is easy to get wrong, and it is measured below against the pending macOS lane in #1146, which already sets both.

## Measured

Tart macOS dev VM, full suite (199 tests, `workers: 1`), guest rebooted before every run so the kernel table starts clean. `ioclasscount AppleVideoToolboxParavirtualizationUserClient` before/after:

| branch | `PWRAGENT_E2E_DISABLE_GPU` | before → after | delta | specs |
|---|---|---|---|---|
| `main` @ 89908d00 | unset | 2 → 176 | **+174** | 165 passed, 3 failed |
| `main` + this change | unset | 2 → 5 | **+3** | 164 passed, 4 failed¹ |
| #1146 (macOS lane) alone | `1` | 2 → 178 | **+176** | 170 passed, **0 failed** |
| #1146 + this change | `1` | 2 → 5 | **+3** | 170 passed, **0 failed** |

The third row is the important one: **#1146's `disableHardwareAcceleration()` + `--disable-gpu` gate does not reduce the leak at all** (+176 vs +174 unmitigated). Software rendering does not stop the GPU process from initializing hardware media codecs. Only the codec switches do.

At ~+176 per run a guest reaches the ~1.1k wedge threshold in about 6 suite runs; at +3 it takes about 370. Teardown telemetry stayed at baseline (3 forced closes out of 170) in both #1146 runs, and suite duration was unchanged (4.7m vs 4.8m).

¹ The 4th failure (`directory-launchpad-skills:439`) passed on two reruns of the same build, and re-running the failing specs twice on each of `main` and this branch produced byte-identical results — so this change is behaviorally neutral. Those `main` failures are fixed by #1146, which is why its rows are fully green.

## Relationship to #1146

#1146 adds the `macOS Desktop E2E (shared VM)` lane, the `PWRAGENT_E2E_DISABLE_GPU` gate, teardown hardening, and the VM-lab skill. It merges cleanly with this change and its suite is green in the VM — it is functionally ready.

But enabling it as-is would add ~176 kernel objects per PwrAgent job to a fleet where PwrSnap already contributes ~143 per job, roughly halving the runs-per-boot before the driver wedges — and both repos share those guests. This change should land with or before that lane is switched on.

**Placement note.** The switches go on the fixture's single Electron launch site rather than inside #1146's `PWRAGENT_E2E_DISABLE_GPU` block (where PwrSnap #366 put its equivalent). Deliberate: the first measurement above was a VM run *without* that env var, and it leaked +174 — anyone invoking Playwright directly in a guest, rather than through the lab script or CI, would still poison the shared VM. The switches cost nothing on Linux or on host macOS (no spec plays video), so scoping them to a VM-only flag would only add a way to miss the fix. Happy to move them under the gate if consolidating VM mitigations in one place is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)