### PR TITLE
fix(desktop): preserve thread reading state

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1165,6 +1165,7 @@ function DesktopAppShell(props: {
     skills: skills.skills,
     transcriptEntries: session.entries,
     transcriptError: session.error,
+    expandedTranscriptActivityIds: session.expandedTranscriptActivityIds,
     expandedTranscriptWorkPhaseGroupIds:
       session.expandedTranscriptWorkPhaseGroupIds,
     renderedTranscriptEntryLimit: session.renderedTranscriptEntryLimit,
@@ -1291,6 +1292,8 @@ function DesktopAppShell(props: {
       : undefined,
     onRestoreWorktree: navigation.restoreWorktree,
     onTranscriptViewportChange: session.setViewport,
+    onExpandedTranscriptActivityIdsChange:
+      session.setExpandedTranscriptActivityIds,
     onExpandedTranscriptWorkPhaseGroupIdsChange:
       session.setExpandedTranscriptWorkPhaseGroupIds,
     onRenderedTranscriptEntryLimitChange:

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1165,6 +1165,9 @@ function DesktopAppShell(props: {
     skills: skills.skills,
     transcriptEntries: session.entries,
     transcriptError: session.error,
+    expandedTranscriptWorkPhaseGroupIds:
+      session.expandedTranscriptWorkPhaseGroupIds,
+    renderedTranscriptEntryLimit: session.renderedTranscriptEntryLimit,
     transcriptPagination: session.response?.replay.pagination,
     updatingExecutionMode: navigation.updatingThreadExecutionMode,
     worktreeArchiveError: navigation.worktreeArchiveError,
@@ -1288,6 +1291,10 @@ function DesktopAppShell(props: {
       : undefined,
     onRestoreWorktree: navigation.restoreWorktree,
     onTranscriptViewportChange: session.setViewport,
+    onExpandedTranscriptWorkPhaseGroupIdsChange:
+      session.setExpandedTranscriptWorkPhaseGroupIds,
+    onRenderedTranscriptEntryLimitChange:
+      session.setRenderedTranscriptEntryLimit,
     onUpdateLaunchpad: navigation.updateDirectoryLaunchpad,
     onUpdatePendingMcpInteraction: session.updatePendingMcpInteraction,
     onUpdatePendingUserInput: session.updatePendingUserInput,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -864,6 +864,7 @@ export type ThreadViewProps = {
   transcriptEntries: AppServerThreadEntry[];
   transcriptError?: string;
   /** Session-owned reading state; ThreadView may unmount while navigation resolves. */
+  expandedTranscriptActivityIds?: string[];
   expandedTranscriptWorkPhaseGroupIds?: string[];
   renderedTranscriptEntryLimit?: number;
   transcriptPagination?: AppServerThreadReplayPagination;
@@ -974,6 +975,7 @@ export type ThreadViewProps = {
     isGluedToBottom?: boolean;
     scrollTop: number;
   }) => void;
+  onExpandedTranscriptActivityIdsChange?: (activityIds: string[]) => void;
   onExpandedTranscriptWorkPhaseGroupIdsChange?: (groupIds: string[]) => void;
   onRenderedTranscriptEntryLimitChange?: (limit: number) => void;
   onUpdateLaunchpad?: (
@@ -2992,6 +2994,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingUserInput={props.pendingUserInput}
               pendingStatusText={props.pendingStatusText}
               runningTurnUsageText={props.runningTurnUsageText}
+              expandedActivityIds={props.expandedTranscriptActivityIds}
               expandedWorkPhaseGroupIds={
                 props.expandedTranscriptWorkPhaseGroupIds
               }
@@ -3004,6 +3007,9 @@ export function ThreadView(props: ThreadViewProps) {
               threadId={`${selectedThread!.source}:${selectedThread!.id}`}
               onLoadOlder={loadOlderTranscript}
               onOpenImage={setExpandedImage}
+              onExpandedActivityIdsChange={
+                props.onExpandedTranscriptActivityIdsChange
+              }
               onExpandedWorkPhaseGroupIdsChange={
                 props.onExpandedTranscriptWorkPhaseGroupIdsChange
               }

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -863,6 +863,9 @@ export type ThreadViewProps = {
   skills: AppServerSkillSummary[];
   transcriptEntries: AppServerThreadEntry[];
   transcriptError?: string;
+  /** Session-owned reading state; ThreadView may unmount while navigation resolves. */
+  expandedTranscriptWorkPhaseGroupIds?: string[];
+  renderedTranscriptEntryLimit?: number;
   transcriptPagination?: AppServerThreadReplayPagination;
   updatingExecutionMode?: ThreadExecutionMode;
   onActiveTurnIdChange?: (turnId?: string) => void;
@@ -971,6 +974,8 @@ export type ThreadViewProps = {
     isGluedToBottom?: boolean;
     scrollTop: number;
   }) => void;
+  onExpandedTranscriptWorkPhaseGroupIdsChange?: (groupIds: string[]) => void;
+  onRenderedTranscriptEntryLimitChange?: (limit: number) => void;
   onUpdateLaunchpad?: (
     directoryKey: string,
     patch: Partial<
@@ -1136,9 +1141,12 @@ export function ThreadView(props: ThreadViewProps) {
   const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
   const [contextRailResizing, setContextRailResizing] = useState(false);
   const [transcriptReglueRequestKey, setTranscriptReglueRequestKey] = useState(0);
-  const [transcriptEntryLimits, setTranscriptEntryLimits] = useState(
-    () => new Map<string, number>(),
-  );
+  // App supplies a session-owned limit in production. Keep a local fallback
+  // for isolated renderers/tests that intentionally omit the owner callbacks.
+  const [
+    uncontrolledTranscriptEntryLimits,
+    setUncontrolledTranscriptEntryLimits,
+  ] = useState(() => new Map<string, number>());
   const [pendingTranscriptTurnTarget, setPendingTranscriptTurnTarget] =
     useState<PendingTranscriptTurnTarget>();
   const transcriptTurnPageLoadsRef = useRef(0);
@@ -1290,7 +1298,8 @@ export function ThreadView(props: ThreadViewProps) {
     ? buildThreadIdentityKey(selectedThread.source, selectedThread.id)
     : undefined;
   const transcriptEntryLimit = selectedThreadKey
-    ? transcriptEntryLimits.get(selectedThreadKey)
+    ? props.renderedTranscriptEntryLimit
+      ?? uncontrolledTranscriptEntryLimits.get(selectedThreadKey)
       ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT
     : DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
   const visibleTranscriptEntries = useMemo(
@@ -1299,6 +1308,8 @@ export function ThreadView(props: ThreadViewProps) {
   );
   const transcriptEntryCount = props.transcriptEntries.length;
   const onLoadOlder = props.onLoadOlder;
+  const onRenderedTranscriptEntryLimitChange =
+    props.onRenderedTranscriptEntryLimitChange;
   const hiddenTranscriptEntryCount =
     transcriptEntryCount - visibleTranscriptEntries.length;
   const canLoadServerTranscriptHistory = Boolean(
@@ -1325,7 +1336,15 @@ export function ThreadView(props: ThreadViewProps) {
       if (!selectedThreadKey) {
         return;
       }
-      setTranscriptEntryLimits((current) => {
+      const nextLimit = Math.max(transcriptEntryLimit, minimumLimit);
+      if (nextLimit === transcriptEntryLimit) {
+        return;
+      }
+      if (onRenderedTranscriptEntryLimitChange) {
+        onRenderedTranscriptEntryLimitChange(nextLimit);
+        return;
+      }
+      setUncontrolledTranscriptEntryLimits((current) => {
         const currentLimit =
           current.get(selectedThreadKey)
           ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
@@ -1337,7 +1356,11 @@ export function ThreadView(props: ThreadViewProps) {
         return next;
       });
     },
-    [selectedThreadKey],
+    [
+      onRenderedTranscriptEntryLimitChange,
+      selectedThreadKey,
+      transcriptEntryLimit,
+    ],
   );
   const loadOlderTranscript = useCallback(async () => {
     if (hiddenTranscriptEntryCount > 0) {
@@ -2969,6 +2992,9 @@ export function ThreadView(props: ThreadViewProps) {
               pendingUserInput={props.pendingUserInput}
               pendingStatusText={props.pendingStatusText}
               runningTurnUsageText={props.runningTurnUsageText}
+              expandedWorkPhaseGroupIds={
+                props.expandedTranscriptWorkPhaseGroupIds
+              }
               restoredViewport={props.transcriptViewport}
               reglueRequestKey={transcriptReglueRequestKey}
               skills={props.skills}
@@ -2978,6 +3004,9 @@ export function ThreadView(props: ThreadViewProps) {
               threadId={`${selectedThread!.source}:${selectedThread!.id}`}
               onLoadOlder={loadOlderTranscript}
               onOpenImage={setExpandedImage}
+              onExpandedWorkPhaseGroupIdsChange={
+                props.onExpandedTranscriptWorkPhaseGroupIdsChange
+              }
               onRespondToPendingRequest={respondToPendingRequest}
               onPendingMcpInteractionChange={(state) => {
                 props.onUpdatePendingMcpInteraction?.(state.requestId, () => state);

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -20,14 +20,17 @@ type TranscriptActivityProps = {
     "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
   >;
   entry: AppServerThreadActivityEntry;
+  expanded?: boolean;
   fileViewerContext?: MarkdownFileViewerContext;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
+  onExpandedChange?: (expanded: boolean) => void;
   skills?: AppServerSkillSummary[];
 };
 
 export function TranscriptActivity(props: TranscriptActivityProps) {
   const detailsId = useId();
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false);
+  const isExpanded = props.expanded ?? uncontrolledExpanded;
   const [expandedDetailIds, setExpandedDetailIds] = useState(() => new Set<string>());
   const hasDetails = props.entry.details.length > 0;
   const directDetail = singleDirectDetail(props.entry);
@@ -49,7 +52,12 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
               aria-controls={detailsId}
               aria-expanded={isExpanded}
               onClick={() => {
-                setIsExpanded((current) => !current);
+                const nextExpanded = !isExpanded;
+                if (props.expanded !== undefined) {
+                  props.onExpandedChange?.(nextExpanded);
+                  return;
+                }
+                setUncontrolledExpanded(nextExpanded);
               }}
             >
               <span className="transcript-activity__chevron" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -81,6 +81,7 @@ type TranscriptListProps = {
   directoryPaths?: string[];
   entries: AppServerThreadEntry[];
   error?: string;
+  expandedWorkPhaseGroupIds?: string[];
   loading: boolean;
   loadingMore: boolean;
   pendingActivityEntry?: AppServerThreadActivityEntry;
@@ -106,6 +107,7 @@ type TranscriptListProps = {
   skills?: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
   onOpenImage?: (image: AppServerThreadImagePart) => void;
+  onExpandedWorkPhaseGroupIdsChange?: (groupIds: string[]) => void;
   onViewportChange?: (viewport?: TranscriptViewport) => void;
   onRespondToPendingRequest?: (action: PendingRequestAction) => Promise<void>;
   onPendingMcpInteractionChange?: (state: PendingMcpInteractionState) => void;
@@ -625,9 +627,22 @@ export function TranscriptList(props: TranscriptListProps) {
   // the post-mount `syncScrollState` corrects it for threads that
   // hydrate at a saved-scroll position other than the top.
   const [isAtTop, setIsAtTop] = useState(true);
-  const [expandedCommentaryGroupIds, setExpandedCommentaryGroupIds] = useState(
-    () => new Set<string>()
+  const [
+    uncontrolledExpandedCommentaryGroupIds,
+    setUncontrolledExpandedCommentaryGroupIds,
+  ] = useState(() => new Set<string>());
+  const controlledExpandedCommentaryGroupIds = useMemo(
+    () =>
+      props.expandedWorkPhaseGroupIds === undefined
+        ? undefined
+        : new Set(props.expandedWorkPhaseGroupIds),
+    [props.expandedWorkPhaseGroupIds]
   );
+  const expandedCommentaryGroupIds =
+    controlledExpandedCommentaryGroupIds
+    ?? uncontrolledExpandedCommentaryGroupIds;
+  const onExpandedWorkPhaseGroupIdsChange =
+    props.onExpandedWorkPhaseGroupIdsChange;
   const [renderNow, setRenderNow] = useState(() => Date.now());
   const canLoadOlder = Boolean(
     props.pagination?.supportsPagination && props.pagination.hasPreviousPage
@@ -826,8 +841,10 @@ export function TranscriptList(props: TranscriptListProps) {
     (props.pendingUserInput ? 1 : 0);
   const hasTranscriptContent = transcriptEntries.length > 0;
   useEffect(() => {
-    setExpandedCommentaryGroupIds(new Set());
-  }, [props.threadId]);
+    if (props.expandedWorkPhaseGroupIds === undefined) {
+      setUncontrolledExpandedCommentaryGroupIds(new Set());
+    }
+  }, [props.expandedWorkPhaseGroupIds, props.threadId]);
 
   useEffect(() => {
     if (!props.activeTurnId) {
@@ -865,7 +882,7 @@ export function TranscriptList(props: TranscriptListProps) {
   }, [props.activeTurnId, props.activeTurnStartedAt, transcriptEntries]);
 
   const toggleCommentaryGroup = useCallback((groupId: string) => {
-    setExpandedCommentaryGroupIds((current) => {
+    const toggle = (current: Set<string>): Set<string> => {
       const next = new Set(current);
       if (next.has(groupId)) {
         next.delete(groupId);
@@ -873,8 +890,20 @@ export function TranscriptList(props: TranscriptListProps) {
         next.add(groupId);
       }
       return next;
-    });
-  }, []);
+    };
+
+    if (controlledExpandedCommentaryGroupIds) {
+      onExpandedWorkPhaseGroupIdsChange?.([
+        ...toggle(controlledExpandedCommentaryGroupIds),
+      ]);
+      return;
+    }
+
+    setUncontrolledExpandedCommentaryGroupIds(toggle);
+  }, [
+    controlledExpandedCommentaryGroupIds,
+    onExpandedWorkPhaseGroupIdsChange,
+  ]);
 
   const captureSnapshot = useCallback((): ScrollSnapshot | undefined => {
     const container = scrollContainerRef.current;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -81,6 +81,7 @@ type TranscriptListProps = {
   directoryPaths?: string[];
   entries: AppServerThreadEntry[];
   error?: string;
+  expandedActivityIds?: string[];
   expandedWorkPhaseGroupIds?: string[];
   loading: boolean;
   loadingMore: boolean;
@@ -106,6 +107,7 @@ type TranscriptListProps = {
   fileViewerContext?: MarkdownFileViewerContext;
   skills?: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
+  onExpandedActivityIdsChange?: (activityIds: string[]) => void;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onExpandedWorkPhaseGroupIdsChange?: (groupIds: string[]) => void;
   onViewportChange?: (viewport?: TranscriptViewport) => void;
@@ -641,8 +643,16 @@ export function TranscriptList(props: TranscriptListProps) {
   const expandedCommentaryGroupIds =
     controlledExpandedCommentaryGroupIds
     ?? uncontrolledExpandedCommentaryGroupIds;
+  const controlledExpandedActivityIds = useMemo(
+    () =>
+      props.expandedActivityIds === undefined
+        ? undefined
+        : new Set(props.expandedActivityIds),
+    [props.expandedActivityIds]
+  );
   const onExpandedWorkPhaseGroupIdsChange =
     props.onExpandedWorkPhaseGroupIdsChange;
+  const onExpandedActivityIdsChange = props.onExpandedActivityIdsChange;
   const [renderNow, setRenderNow] = useState(() => Date.now());
   const canLoadOlder = Boolean(
     props.pagination?.supportsPagination && props.pagination.hasPreviousPage
@@ -904,6 +914,20 @@ export function TranscriptList(props: TranscriptListProps) {
     controlledExpandedCommentaryGroupIds,
     onExpandedWorkPhaseGroupIdsChange,
   ]);
+
+  const setActivityExpanded = useCallback((activityId: string, expanded: boolean) => {
+    if (!controlledExpandedActivityIds) {
+      return;
+    }
+
+    const next = new Set(controlledExpandedActivityIds);
+    if (expanded) {
+      next.add(activityId);
+    } else {
+      next.delete(activityId);
+    }
+    onExpandedActivityIdsChange?.([...next]);
+  }, [controlledExpandedActivityIds, onExpandedActivityIdsChange]);
 
   const captureSnapshot = useCallback((): ScrollSnapshot | undefined => {
     const container = scrollContainerRef.current;
@@ -1304,11 +1328,13 @@ export function TranscriptList(props: TranscriptListProps) {
                   desktopApi={props.desktopApi}
                   entries={item.entries}
                   expanded={expandedCommentaryGroupIds.has(item.id)}
+                  expandedActivityIds={controlledExpandedActivityIds}
                   fileViewerContext={props.fileViewerContext}
                   label={item.label}
                   parentThreadId={props.parentThreadId ?? ""}
                   skills={skills}
                   subAgents={props.subAgents}
+                  onActivityExpandedChange={setActivityExpanded}
                   onOpenImage={props.onOpenImage}
                   onToggle={() => {
                     toggleCommentaryGroup(item.id);
@@ -1319,7 +1345,11 @@ export function TranscriptList(props: TranscriptListProps) {
                   applications={props.applications}
                   desktopApi={props.desktopApi}
                   entry={item.entry}
+                  expanded={controlledExpandedActivityIds?.has(item.entry.id)}
                   fileViewerContext={props.fileViewerContext}
+                  onExpandedChange={(expanded) => {
+                    setActivityExpanded(item.entry.id, expanded);
+                  }}
                   onOpenImage={props.onOpenImage}
                   skills={skills}
                 />

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -25,11 +25,13 @@ type TranscriptWorkPhaseGroupProps = {
   >;
   entries: AppServerThreadEntry[];
   expanded: boolean;
+  expandedActivityIds?: ReadonlySet<string>;
   fileViewerContext?: MarkdownFileViewerContext;
   label: string;
   parentThreadId?: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
+  onActivityExpandedChange?: (activityId: string, expanded: boolean) => void;
   onOpenImage?: (image: AppServerThreadImagePart) => void;
   onToggle: () => void;
 };
@@ -74,7 +76,9 @@ export const TranscriptWorkPhaseGroup = memo(function TranscriptWorkPhaseGroup(
               directoryPaths: props.directoryPaths,
               desktopApi: props.desktopApi,
               entry,
+              expandedActivityIds: props.expandedActivityIds,
               fileViewerContext: props.fileViewerContext,
+              onActivityExpandedChange: props.onActivityExpandedChange,
               onOpenImage: props.onOpenImage,
               parentThreadId: props.parentThreadId ?? "",
               skills: props.skills,
@@ -124,7 +128,9 @@ function renderEntry(params: {
     "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
   >;
   entry: AppServerThreadEntry;
+  expandedActivityIds?: ReadonlySet<string>;
   fileViewerContext?: MarkdownFileViewerContext;
+  onActivityExpandedChange?: (activityId: string, expanded: boolean) => void;
   parentThreadId: string;
   skills: AppServerSkillSummary[];
   subAgents?: ThreadSubAgentSummary[];
@@ -137,7 +143,11 @@ function renderEntry(params: {
       applications={params.applications}
       desktopApi={params.desktopApi}
       entry={entry}
+      expanded={params.expandedActivityIds?.has(entry.id)}
       fileViewerContext={params.fileViewerContext}
+      onExpandedChange={(expanded) => {
+        params.onActivityExpandedChange?.(entry.id, expanded);
+      }}
       onOpenImage={params.onOpenImage}
       skills={params.skills}
     />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -650,28 +650,36 @@ describe("ThreadView", () => {
       },
     };
 
-    const { container } = render(
-      <ThreadView
-        addOptimisticUserMessage={(_text) => "optimistic-1"}
-        backends={[]}
-        clearPendingRequest={() => undefined}
-        composerDisabled={false}
-        desktopApi={{}}
-        loading={false}
-        loadingMore={false}
-        messageCount={entries.length}
-        onLoadOlder={loadOlder}
-        removeOptimisticMessage={(_id) => undefined}
-        selectedThread={selectedThread}
-        skills={[]}
-        transcriptEntries={entries}
-        transcriptPagination={{
-          supportsPagination: true,
-          hasPreviousPage: true,
-          previousCursor: "cursor-1",
-        }}
-      />,
-    );
+    function Harness() {
+      const [renderedTranscriptEntryLimit, setRenderedTranscriptEntryLimit] =
+        useState<number>();
+      return (
+        <ThreadView
+          addOptimisticUserMessage={(_text) => "optimistic-1"}
+          backends={[]}
+          clearPendingRequest={() => undefined}
+          composerDisabled={false}
+          desktopApi={{}}
+          loading={false}
+          loadingMore={false}
+          messageCount={entries.length}
+          onLoadOlder={loadOlder}
+          onRenderedTranscriptEntryLimitChange={setRenderedTranscriptEntryLimit}
+          removeOptimisticMessage={(_id) => undefined}
+          renderedTranscriptEntryLimit={renderedTranscriptEntryLimit}
+          selectedThread={selectedThread}
+          skills={[]}
+          transcriptEntries={entries}
+          transcriptPagination={{
+            supportsPagination: true,
+            hasPreviousPage: true,
+            previousCursor: "cursor-1",
+          }}
+        />
+      );
+    }
+
+    const { container } = render(<Harness />);
 
     expect(container.querySelectorAll(".transcript-message")).toHaveLength(40);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1446,6 +1446,78 @@ describe("TranscriptList", () => {
     expect(screen.getByText("Third commentary.")).toBeVisible();
   });
 
+  it("restores expanded work and the viewport after the transcript remounts", () => {
+    const entries = [
+      {
+        type: "message" as const,
+        id: "commentary-1",
+        role: "assistant" as const,
+        phase: "commentary" as const,
+        text: "First commentary.",
+      },
+      {
+        type: "message" as const,
+        id: "commentary-2",
+        role: "assistant" as const,
+        phase: "commentary" as const,
+        text: "Second commentary.",
+      },
+      {
+        type: "message" as const,
+        id: "commentary-3",
+        role: "assistant" as const,
+        phase: "commentary" as const,
+        text: "Third commentary.",
+      },
+      {
+        type: "message" as const,
+        id: "final-1",
+        role: "assistant" as const,
+        phase: "final" as const,
+        text: "Final answer.",
+      },
+    ];
+    const onExpandedWorkPhaseGroupIdsChange = vi.fn();
+    const firstRender = render(
+      <TranscriptList
+        entries={entries}
+        expandedWorkPhaseGroupIds={[]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onExpandedWorkPhaseGroupIdsChange={onExpandedWorkPhaseGroupIdsChange}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "3 previous messages" }));
+    const restoredGroupIds = onExpandedWorkPhaseGroupIdsChange.mock.calls[0]?.[0];
+    expect(restoredGroupIds).toHaveLength(1);
+
+    firstRender.unmount();
+    render(
+      <TranscriptList
+        entries={entries}
+        expandedWorkPhaseGroupIds={restoredGroupIds}
+        loading={false}
+        loadingMore={false}
+        restoredViewport={{
+          distanceFromBottom: 168,
+          isGluedToBottom: false,
+          scrollTop: 72,
+        }}
+        threadId="thread-1"
+        onExpandedWorkPhaseGroupIdsChange={onExpandedWorkPhaseGroupIdsChange}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "3 previous messages" }))
+      .toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("First commentary.")).toBeVisible();
+    expect(screen.getByRole("list").scrollTop).toBe(72);
+  });
+
   it("keeps all active commentary messages visible", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1981,6 +1981,53 @@ describe("TranscriptList", () => {
     expect(screen.queryByText("Read TranscriptActivity.tsx")).not.toBeInTheDocument();
   });
 
+  it("restores a session-owned activity disclosure after remount", () => {
+    const entry = {
+      type: "activity" as const,
+      id: "turn-usage-1",
+      summary: "Turn usage: 1,000 uncached in · 2,000 cached",
+      details: [
+        {
+          id: "usage-detail-1",
+          kind: "read" as const,
+          label: "Input: 3,000 tokens",
+        },
+      ],
+    };
+    const onExpandedActivityIdsChange = vi.fn();
+    const firstRender = render(
+      <TranscriptList
+        entries={[entry]}
+        expandedActivityIds={[]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onExpandedActivityIdsChange={onExpandedActivityIdsChange}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Turn usage/i }));
+    expect(onExpandedActivityIdsChange).toHaveBeenCalledWith(["turn-usage-1"]);
+
+    firstRender.unmount();
+    render(
+      <TranscriptList
+        entries={[entry]}
+        expandedActivityIds={["turn-usage-1"]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onExpandedActivityIdsChange={onExpandedActivityIdsChange}
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /Turn usage/i }))
+      .toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Input: 3,000 tokens")).toBeInTheDocument();
+  });
+
   it("renders pending same-turn work before a persisted final assistant reply", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -383,6 +383,7 @@ describe("useThreadSessionState", () => {
 
     await waitForThreadHydration(result);
     act(() => {
+      result.current.setExpandedTranscriptActivityIds(["turn-usage-1"]);
       result.current.setExpandedTranscriptWorkPhaseGroupIds(["work-group-1"]);
       result.current.setRenderedTranscriptEntryLimit(90);
       result.current.setViewport({
@@ -398,6 +399,9 @@ describe("useThreadSessionState", () => {
 
     await waitFor(() => {
       expect(result.current.response?.threadId).toBe("thread-1");
+      expect(result.current.expandedTranscriptActivityIds).toEqual([
+        "turn-usage-1",
+      ]);
       expect(result.current.expandedTranscriptWorkPhaseGroupIds).toEqual([
         "work-group-1",
       ]);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -348,6 +348,68 @@ describe("useThreadSessionState", () => {
     );
   });
 
+  it("retains transcript reading state across temporary view unmounts", async () => {
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: vi.fn(async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        threadStatus: "idle" as const,
+        replay: {
+          entries: [
+            messageEntry({
+              createdAt: 100,
+              id: `${threadId}-message`,
+              text: `History for ${threadId}`,
+            }),
+          ],
+          messages: [],
+          pagination: {
+            supportsPagination: true,
+            hasPreviousPage: false,
+          },
+        },
+      })),
+    };
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: buildThread({ id: threadId, updatedAt: 1_000 }),
+        }),
+      { initialProps: { threadId: "thread-1" } }
+    );
+
+    await waitForThreadHydration(result);
+    act(() => {
+      result.current.setExpandedTranscriptWorkPhaseGroupIds(["work-group-1"]);
+      result.current.setRenderedTranscriptEntryLimit(90);
+      result.current.setViewport({
+        distanceFromBottom: 480,
+        isGluedToBottom: false,
+        scrollTop: 720,
+      });
+    });
+
+    rerender({ threadId: "thread-2" });
+    await waitForThreadHydration(result, "thread-2");
+    rerender({ threadId: "thread-1" });
+
+    await waitFor(() => {
+      expect(result.current.response?.threadId).toBe("thread-1");
+      expect(result.current.expandedTranscriptWorkPhaseGroupIds).toEqual([
+        "work-group-1",
+      ]);
+      expect(result.current.renderedTranscriptEntryLimit).toBe(90);
+      expect(result.current.viewport).toEqual({
+        distanceFromBottom: 480,
+        isGluedToBottom: false,
+        scrollTop: 720,
+      });
+    });
+  });
+
   it("rehydrates the selected thread when the initial history limit changes", async () => {
     const readThread = vi.fn(async ({ backend, threadId }) => ({
       backend: backend ?? "codex",

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -53,6 +53,7 @@ import {
 import { THREAD_HISTORY_PAGE_LIMIT } from "./thread-history-limits";
 
 const MAX_VIEW_ONLY_THREADS = 10;
+const EMPTY_EXPANDED_TRANSCRIPT_WORK_PHASE_GROUP_IDS: string[] = [];
 const OWN_UPDATE_IDLE_GRACE_MS = 1_500;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
   "turn/requestApproval",
@@ -153,6 +154,10 @@ type ThreadSessionEntry = {
   pendingStatusText?: string;
   pendingTurnUsage?: TurnUsageAccumulator;
   response?: AppServerReadThreadResponse;
+  // Lightweight reading state belongs beside the bounded transcript cache.
+  // ThreadView is allowed to unmount while thread navigation resolves.
+  expandedTranscriptWorkPhaseGroupIds?: string[];
+  renderedTranscriptEntryLimit?: number;
   staleThinkingRecheckAt?: number;
   thinkingSinceAt?: number;
   viewport?: ThreadViewportState;
@@ -3421,6 +3426,7 @@ export function useThreadSessionState(params: {
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   entries: AppServerThreadEntry[];
   error?: string;
+  expandedTranscriptWorkPhaseGroupIds: string[];
   loading: boolean;
   loadingMore: boolean;
   loadOlder: () => Promise<void>;
@@ -3435,6 +3441,7 @@ export function useThreadSessionState(params: {
   approvalRequestThreadKeys: Record<string, boolean>;
   inputRequestThreadKeys: Record<string, boolean>;
   removeOptimisticMessage: (id: string) => void;
+  renderedTranscriptEntryLimit?: number;
   response?: AppServerReadThreadResponse;
   setActiveTurnId: (turnId?: string) => void;
   upsertLiveTranscriptEntry: (entry: AppServerThreadEntry) => void;
@@ -3447,6 +3454,8 @@ export function useThreadSessionState(params: {
     updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
   ) => void;
   setPendingStatusText: (status?: string) => void;
+  setExpandedTranscriptWorkPhaseGroupIds: (groupIds: string[]) => void;
+  setRenderedTranscriptEntryLimit: (limit: number) => void;
   threadBusy: boolean;
   thinkingThreadKeys: Record<string, boolean>;
   setViewport: (viewport?: ThreadViewportState) => void;
@@ -5395,6 +5404,56 @@ export function useThreadSessionState(params: {
     [threadKey, updateSession]
   );
 
+  const setExpandedTranscriptWorkPhaseGroupIds = useCallback(
+    (groupIds: string[]): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      const nextGroupIds = [...new Set(groupIds.filter(Boolean))];
+      updateSession(threadKey, (current) => {
+        const currentGroupIds = current.expandedTranscriptWorkPhaseGroupIds ?? [];
+        if (
+          currentGroupIds.length === nextGroupIds.length
+          && currentGroupIds.every(
+            (groupId, index) => groupId === nextGroupIds[index]
+          )
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          expandedTranscriptWorkPhaseGroupIds: nextGroupIds,
+          lastTouchedAt: Date.now(),
+        };
+      });
+    },
+    [threadKey, updateSession]
+  );
+
+  const setRenderedTranscriptEntryLimit = useCallback(
+    (limit: number): void => {
+      if (!threadKey || !Number.isFinite(limit)) {
+        return;
+      }
+
+      const nextLimit = Math.max(1, Math.floor(limit));
+      updateSession(threadKey, (current) => {
+        if (current.renderedTranscriptEntryLimit === nextLimit) {
+          return current;
+        }
+
+        return {
+          ...current,
+          lastTouchedAt: Date.now(),
+          renderedTranscriptEntryLimit: nextLimit,
+        };
+      });
+    },
+    [threadKey, updateSession]
+  );
+
   const visibleOptimisticEntries = useMemo(
     () =>
       pruneOptimisticEntries(
@@ -5495,13 +5554,19 @@ export function useThreadSessionState(params: {
     removeOptimisticMessage,
     response: selectedSession?.response,
     setActiveTurnId,
+    setExpandedTranscriptWorkPhaseGroupIds,
     upsertLiveTranscriptEntry,
     updatePendingUserInput,
     updatePendingMcpInteraction,
     setPendingStatusText,
+    setRenderedTranscriptEntryLimit,
     threadBusy,
     thinkingThreadKeys,
     setViewport,
     viewport: selectedSession?.viewport,
+    expandedTranscriptWorkPhaseGroupIds:
+      selectedSession?.expandedTranscriptWorkPhaseGroupIds
+      ?? EMPTY_EXPANDED_TRANSCRIPT_WORK_PHASE_GROUP_IDS,
+    renderedTranscriptEntryLimit: selectedSession?.renderedTranscriptEntryLimit,
   };
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -53,6 +53,7 @@ import {
 import { THREAD_HISTORY_PAGE_LIMIT } from "./thread-history-limits";
 
 const MAX_VIEW_ONLY_THREADS = 10;
+const EMPTY_EXPANDED_TRANSCRIPT_ACTIVITY_IDS: string[] = [];
 const EMPTY_EXPANDED_TRANSCRIPT_WORK_PHASE_GROUP_IDS: string[] = [];
 const OWN_UPDATE_IDLE_GRACE_MS = 1_500;
 const SUPPORTED_APPROVAL_REQUEST_METHODS = new Set([
@@ -156,6 +157,7 @@ type ThreadSessionEntry = {
   response?: AppServerReadThreadResponse;
   // Lightweight reading state belongs beside the bounded transcript cache.
   // ThreadView is allowed to unmount while thread navigation resolves.
+  expandedTranscriptActivityIds?: string[];
   expandedTranscriptWorkPhaseGroupIds?: string[];
   renderedTranscriptEntryLimit?: number;
   staleThinkingRecheckAt?: number;
@@ -3426,6 +3428,7 @@ export function useThreadSessionState(params: {
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
   entries: AppServerThreadEntry[];
   error?: string;
+  expandedTranscriptActivityIds: string[];
   expandedTranscriptWorkPhaseGroupIds: string[];
   loading: boolean;
   loadingMore: boolean;
@@ -3454,6 +3457,7 @@ export function useThreadSessionState(params: {
     updater: (state: PendingMcpInteractionState) => PendingMcpInteractionState
   ) => void;
   setPendingStatusText: (status?: string) => void;
+  setExpandedTranscriptActivityIds: (activityIds: string[]) => void;
   setExpandedTranscriptWorkPhaseGroupIds: (groupIds: string[]) => void;
   setRenderedTranscriptEntryLimit: (limit: number) => void;
   threadBusy: boolean;
@@ -5432,6 +5436,34 @@ export function useThreadSessionState(params: {
     [threadKey, updateSession]
   );
 
+  const setExpandedTranscriptActivityIds = useCallback(
+    (activityIds: string[]): void => {
+      if (!threadKey) {
+        return;
+      }
+
+      const nextActivityIds = [...new Set(activityIds.filter(Boolean))];
+      updateSession(threadKey, (current) => {
+        const currentActivityIds = current.expandedTranscriptActivityIds ?? [];
+        if (
+          currentActivityIds.length === nextActivityIds.length
+          && currentActivityIds.every(
+            (activityId, index) => activityId === nextActivityIds[index]
+          )
+        ) {
+          return current;
+        }
+
+        return {
+          ...current,
+          expandedTranscriptActivityIds: nextActivityIds,
+          lastTouchedAt: Date.now(),
+        };
+      });
+    },
+    [threadKey, updateSession]
+  );
+
   const setRenderedTranscriptEntryLimit = useCallback(
     (limit: number): void => {
       if (!threadKey || !Number.isFinite(limit)) {
@@ -5559,11 +5591,15 @@ export function useThreadSessionState(params: {
     updatePendingUserInput,
     updatePendingMcpInteraction,
     setPendingStatusText,
+    setExpandedTranscriptActivityIds,
     setRenderedTranscriptEntryLimit,
     threadBusy,
     thinkingThreadKeys,
     setViewport,
     viewport: selectedSession?.viewport,
+    expandedTranscriptActivityIds:
+      selectedSession?.expandedTranscriptActivityIds
+      ?? EMPTY_EXPANDED_TRANSCRIPT_ACTIVITY_IDS,
     expandedTranscriptWorkPhaseGroupIds:
       selectedSession?.expandedTranscriptWorkPhaseGroupIds
       ?? EMPTY_EXPANDED_TRANSCRIPT_WORK_PHASE_GROUP_IDS,


### PR DESCRIPTION
## Summary

- retain expanded transcript work groups in the bounded per-thread session cache
- retain each thread's rendered-history window so loaded older history survives navigation
- restore expanded content before applying the saved viewport, preventing Back navigation from clamping to the bottom

## Root cause

Thread transcript data and scroll coordinates were cached, but the expanded work-group state and rendered-history limit lived inside `ThreadView`. Navigation can temporarily unmount that view while resolving a thread. Returning through Back therefore rebuilt a shorter, fully collapsed transcript, and the saved scroll position clamped to its bottom.

## User impact

Returning to a recently viewed thread now restores the loaded history depth, expanded “More Work” sections, and reading position instead of dropping the reader at the newest message.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx` (225 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`
