### PR TITLE
fix(desktop): await hot CPU profiler shutdown

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -109,9 +109,21 @@ function deferred<T = void>() {
 
 describe("RendererHotCpuProfiler", () => {
   const cleanups: Array<() => Promise<void>> = [];
+  const profilers: RendererHotCpuProfiler[] = [];
+
+  function createProfiler(
+    options: ConstructorParameters<typeof RendererHotCpuProfiler>[0],
+  ): RendererHotCpuProfiler {
+    const profiler = new RendererHotCpuProfiler(options);
+    profilers.push(profiler);
+    return profiler;
+  }
 
   afterEach(async () => {
     vi.useRealTimers();
+    await Promise.all(
+      profilers.splice(0).map((profiler) => profiler.stop("test-cleanup")),
+    );
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
   });
 
@@ -142,7 +154,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 101.5),
       createMetric(4, 103),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -257,7 +269,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 101.5),
       createMetric(4, 103),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -286,6 +298,91 @@ describe("RendererHotCpuProfiler", () => {
     profileWritten.resolve();
     await stopPromise;
     expect(stopResolved).toBe(true);
+  });
+
+  it("waits for an in-flight sample before allowing session cleanup", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS: "0",
+      PWRAGENT_HOT_CPU_PROFILING_THRESHOLD_PERCENT: "100",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      createdAt: new Date(2026, 5, 1, 15, 30, 0),
+      sessionId: "abc123",
+      versions: {
+        appVersion: "1.0.0",
+        electronVersion: "41.2.1",
+        chromeVersion: "146.0.0.0",
+        nodeVersion: "24.0.0",
+      },
+    });
+    expect(sessionResult.ok).toBe(true);
+    if (!sessionResult.ok) return;
+
+    vi.useFakeTimers();
+
+    const sampleWrite = deferred();
+    const originalAppendSample = sessionResult.session.appendSample;
+    sessionResult.session.appendSample = vi.fn(async (sample) => {
+      await sampleWrite.promise;
+      await originalAppendSample(sample);
+    });
+    const appendEvent = vi.spyOn(sessionResult.session, "appendEvent");
+    const { target } = createTarget();
+    const profiler = createProfiler({
+      config,
+      getAppMetrics: () => [createMetric(0, 100)],
+      session: sessionResult.session,
+      target,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await profiler.start();
+    vi.advanceTimersByTime(0);
+    expect(sessionResult.session.appendSample).toHaveBeenCalledTimes(1);
+
+    const stopPromise = profiler.stop("test-complete");
+    let concurrentStopResolved = false;
+    const concurrentStopPromise = profiler.stop("duplicate-stop").then(() => {
+      concurrentStopResolved = true;
+    });
+    await Promise.resolve();
+    const waitedForSample = !appendEvent.mock.calls.some(
+      ([event]) => event.type === "monitor-stopped",
+    );
+    const concurrentStopWaited = !concurrentStopResolved;
+    sampleWrite.resolve();
+    await Promise.all([stopPromise, concurrentStopPromise]);
+    expect(waitedForSample).toBe(true);
+    expect(concurrentStopWaited).toBe(true);
+    expect(
+      appendEvent.mock.calls.filter(([event]) => event.type === "monitor-stopped"),
+    ).toEqual([
+      [
+        expect.objectContaining({
+          detail: { reason: "test-complete" },
+        }),
+      ],
+    ]);
+
+    const appendSampleCalls = vi.mocked(sessionResult.session.appendSample).mock
+      .calls.length;
+    const appendEventCalls = appendEvent.mock.calls.length;
+    await workspace.cleanup();
+    await vi.advanceTimersByTimeAsync(config.intervalMs * 2);
+
+    expect(sessionResult.session.appendSample).toHaveBeenCalledTimes(appendSampleCalls);
+    expect(appendEvent).toHaveBeenCalledTimes(appendEventCalls);
+    await expect(fs.access(sessionResult.session.directoryPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("pauses process metric sampling while the renderer CPU profiler is active", async () => {
@@ -322,7 +419,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(0, 110),
     ];
     const getAppMetrics = vi.fn(() => [metrics.shift() ?? createMetric(0, 101)]);
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics,
       session: sessionResult.session,
@@ -414,7 +511,7 @@ describe("RendererHotCpuProfiler", () => {
 
     const { target } = createTarget();
     const getAppMetrics = vi.fn(() => [createMetric(0, 100)]);
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics,
       session: sessionResult.session,
@@ -463,7 +560,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(0, 100),
       createMetric(4, 101.2),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -528,7 +625,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(2, 100.4),
       createMetric(2, 100.8),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -599,7 +696,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 103),
     ];
     const getAppMetrics = vi.fn(() => [metrics.shift() ?? createMetric(0)]);
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics,
       onHeapSnapshotLimitReached,
@@ -725,7 +822,7 @@ describe("RendererHotCpuProfiler", () => {
       }
     });
     const onProfileWritten = vi.fn();
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [createMetric(89)],
       onProfileWritten,
@@ -834,7 +931,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 101.5),
       createMetric(4, 103),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -896,7 +993,7 @@ describe("RendererHotCpuProfiler", () => {
       createMetric(4, 101.5),
       createMetric(4, 103),
     ];
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [metrics.shift() ?? createMetric(0)],
       session: sessionResult.session,
@@ -970,7 +1067,7 @@ describe("RendererHotCpuProfiler", () => {
     vi.useFakeTimers();
 
     const { target, debuggerApi } = createTarget();
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [createMetric(89)],
       session: sessionResult.session,
@@ -1038,7 +1135,7 @@ describe("RendererHotCpuProfiler", () => {
 
       return {};
     });
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [createMetric(89)],
       session: sessionResult.session,
@@ -1112,7 +1209,7 @@ describe("RendererHotCpuProfiler", () => {
       return {};
     });
 
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = createProfiler({
       config,
       getAppMetrics: () => [createMetric(89)],
       session: sessionResult.session,

--- a/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/renderer-hot-cpu-profiler.ts
@@ -82,12 +82,14 @@ export class RendererHotCpuProfiler {
   private heapSnapshotLimitReached = false;
   private heapSnapshotsCaptured = 0;
   private heapSnapshotMidTimer: ReturnType<typeof setTimeout> | null = null;
+  private captureSamplePromise: Promise<void> | null = null;
   private intervalTimer: ReturnType<typeof setTimeout> | null = null;
   private lastProfileAtMs: number | null = null;
   private previousCumulativeCpuSeconds: number | null = null;
   private previousSampleAtMs: number | null = null;
   private profileDurationTimer: ReturnType<typeof setTimeout> | null = null;
   private profileCount = 0;
+  private shutdownPromise: Promise<void> | null = null;
   private stopProfilePromise: Promise<void> | null = null;
   private profiling = false;
   private samplingPausedForProfile = false;
@@ -148,17 +150,33 @@ export class RendererHotCpuProfiler {
   }
 
   async stop(reason = "stopped"): Promise<void> {
-    if (this.stopped) {
+    if (this.shutdownPromise) {
+      await this.shutdownPromise;
       return;
     }
 
     this.stopped = true;
+    this.shutdownPromise = this.stopInner(reason);
+    await this.shutdownPromise;
+  }
+
+  private async stopInner(reason: string): Promise<void> {
     if (this.intervalTimer) {
       clearTimeout(this.intervalTimer);
       this.intervalTimer = null;
     }
     this.clearProfileDurationTimer();
     this.clearHeapSnapshotMidTimer();
+
+    // Stop an already-started profile in parallel with its owning sample so a
+    // blocked heap snapshot cannot deadlock shutdown. Recheck after the sample
+    // settles in case it crossed into profiling while shutdown was starting.
+    const captureSamplePromise = this.captureSamplePromise;
+    const activeProfileStop =
+      this.profiling || this.stopProfilePromise
+        ? this.stopProfile(reason)
+        : null;
+    await Promise.all([captureSamplePromise, activeProfileStop]);
 
     if (this.profiling || this.stopProfilePromise) {
       await this.stopProfile(reason);
@@ -177,7 +195,23 @@ export class RendererHotCpuProfiler {
       return;
     }
 
-    this.intervalTimer = setTimeout(() => this.captureSample(), delayMs);
+    this.intervalTimer = setTimeout(() => {
+      const captureSamplePromise = this.captureSample();
+      this.captureSamplePromise = captureSamplePromise;
+      void captureSamplePromise.then(
+        () => {
+          if (this.captureSamplePromise === captureSamplePromise) {
+            this.captureSamplePromise = null;
+          }
+        },
+        (error) => {
+          if (this.captureSamplePromise === captureSamplePromise) {
+            this.captureSamplePromise = null;
+          }
+          this.logger.error("[pwragent:hot-cpu] sample task failed", error);
+        },
+      );
+    }, delayMs);
   }
 
   private async captureSample(): Promise<void> {
@@ -304,7 +338,11 @@ export class RendererHotCpuProfiler {
   }
 
   private shouldStartProfile(cpuPercent: number, capturedAt: string): boolean {
-    if (this.profiling || cpuPercent < this.triggerThresholdPercent()) {
+    if (
+      this.stopped
+      || this.profiling
+      || cpuPercent < this.triggerThresholdPercent()
+    ) {
       return false;
     }
 
@@ -338,6 +376,10 @@ export class RendererHotCpuProfiler {
     cpuPercent: number;
     pid: number;
   }): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
     if (this.target.debugger.isAttached()) {
       await this.session.appendEvent({
         capturedAt: options.capturedAt,
@@ -356,8 +398,15 @@ export class RendererHotCpuProfiler {
       this.debuggerAttached = true;
       this.target.debugger.on("detach", this.detachListener);
       await this.target.debugger.sendCommand("Profiler.enable");
+      if (this.stopped) {
+        this.detachDebugger();
+        return;
+      }
       await this.target.debugger.sendCommand("Profiler.start");
       this.profiling = true;
+      if (this.stopped) {
+        return;
+      }
       this.activeProfileHeapSnapshots = [];
       this.activeProfileTrigger = {
         triggerConsecutiveSamples: this.triggerConsecutiveSamples(),


### PR DESCRIPTION
## Summary

- retain ownership of the active renderer CPU sample and make `stop()` wait for it before completing
- share one shutdown promise across concurrent stop calls and prevent a sample from starting profiling after shutdown begins
- stop all profilers during test teardown before removing their temporary session roots
- add a deterministic regression test that blocks a sample write, verifies shutdown waits, removes the session directory, and confirms no later writes occur

## Root cause

The sampler timer launched `captureSample()` without retaining its promise. `stop()` cleared the next timer and waited for active profile shutdown, but it did not wait for a sample that was already awaiting an NDJSON write. A test could therefore complete and remove its temporary PwrAgent root while that sample resumed and attempted another session write. Windows exposed this timing window as repeated `ENOENT` failures against `events.ndjson`, after which the still-live sampler polluted later tests.

The regression test failed against the original implementation because `monitor-stopped` was emitted before the blocked sample write completed. It passes after shutdown owns and drains that sample.

## CI evidence

- [CI run 30829642799](https://github.com/pwrdrvr/PwrAgent/actions/runs/30829642799)
- [Windows (build + test) job 91740076593](https://github.com/pwrdrvr/PwrAgent/actions/runs/30829642799/job/91740076593)
- observed 8 failed profiler tests and 309 unhandled rejections, repeatedly rooted at `appendRecord` opening the removed temporary session's `events.ndjson`
- the supplied base `89908d003` previously passed main CI, so this PR is based directly on that `origin/main` commit and does not modify PR #1169

## Validation

- `pnpm test apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts` — 14 passed
- profiler test file repeated 20 consecutive times — all passed
- `pnpm typecheck` — passed
- `pnpm lint:eslint` — passed with 0 errors (existing repository warnings only)
- `pnpm lint:boundaries` — passed
- `pnpm build` — passed
