### PR TITLE
feat(messaging): deliver final assistant images

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -255,6 +255,129 @@ describe("DesktopMessagingBackendBridge", () => {
     ]);
     expect(readThread).toHaveBeenCalledTimes(1);
   });
+
+  it("resolves the exact image-only assistant replay message by item id", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-1",
+      replay: {
+        entries: [],
+        messages: [
+          {
+            id: "other-empty-assistant",
+            role: "assistant",
+            text: "",
+            parts: [{ type: "image", url: "https://example.com/other.png" }],
+          },
+          {
+            id: "target-empty-assistant",
+            role: "assistant",
+            text: "",
+            parts: [{ type: "image", url: "https://example.com/target.png" }],
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const bridge = new DesktopMessagingBackendBridge({
+      getThreadTranscriptImageRoots: vi.fn(async () => []),
+      readThread: vi.fn(async () => response),
+    } as unknown as DesktopBackendRegistry);
+
+    await expect(bridge.resolveAssistantMessageImages({
+      backend: "codex",
+      itemId: "other-empty-assistant",
+      text: "",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    })).resolves.toEqual([
+      expect.objectContaining({
+        type: "image",
+        url: "https://example.com/other.png",
+      }),
+    ]);
+  });
+
+  it("does not reuse an older image-only message for an unrelated empty turn", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-1",
+      replay: {
+        entries: [
+          {
+            id: "older-image-only",
+            role: "assistant",
+            text: "",
+            type: "message",
+            turn: { id: "turn-older" },
+            parts: [{ type: "image", url: "https://example.com/older.png" }],
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const bridge = new DesktopMessagingBackendBridge({
+      getThreadTranscriptImageRoots: vi.fn(async () => []),
+      readThread: vi.fn(async () => response),
+    } as unknown as DesktopBackendRegistry);
+
+    await expect(bridge.resolveAssistantMessageImages({
+      backend: "codex",
+      text: "",
+      threadId: "thread-1",
+      turnId: "turn-current",
+    })).resolves.toEqual([]);
+  });
+
+  it("resolves an image-only assistant replay entry by turn id", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-1",
+      replay: {
+        entries: [
+          {
+            id: "current-image-only",
+            role: "assistant",
+            text: "",
+            type: "message",
+            turn: { id: "turn-current" },
+            parts: [{ type: "image", url: "https://example.com/current.png" }],
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const bridge = new DesktopMessagingBackendBridge({
+      getThreadTranscriptImageRoots: vi.fn(async () => []),
+      readThread: vi.fn(async () => response),
+    } as unknown as DesktopBackendRegistry);
+
+    await expect(bridge.resolveAssistantMessageImages({
+      backend: "codex",
+      text: "",
+      threadId: "thread-1",
+      turnId: "turn-current",
+    })).resolves.toEqual([
+      expect.objectContaining({
+        type: "image",
+        url: "https://example.com/current.png",
+      }),
+    ]);
+  });
 });
 
 function createBridge(replay: AppServerThreadReplay): DesktopMessagingBackendBridge {

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -191,6 +191,70 @@ describe("DesktopMessagingBackendBridge", () => {
       createdAt: 3_000,
     });
   });
+
+  it("resolves and shares final assistant images across messaging controllers", async () => {
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "thread-1",
+      replay: {
+        entries: [],
+        messages: [
+          {
+            id: "assistant-final",
+            role: "assistant",
+            text: "Final screenshot.",
+            parts: [
+              { type: "text", text: "Final screenshot." },
+              {
+                type: "image",
+                url: "https://example.com/final.png",
+                alt: "Final screenshot",
+              },
+            ],
+          },
+        ],
+        pagination: {
+          supportsPagination: false,
+          hasPreviousPage: false,
+        },
+      },
+    };
+    const readThread = vi.fn(async () => response);
+    const bridge = new DesktopMessagingBackendBridge({
+      getThreadTranscriptImageRoots: vi.fn(async () => []),
+      readThread,
+    } as unknown as DesktopBackendRegistry);
+    const request = {
+      backend: "codex" as const,
+      text: "Final screenshot.",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    };
+
+    await expect(Promise.all([
+      bridge.resolveAssistantMessageImages(request),
+      bridge.resolveAssistantMessageImages(request),
+    ])).resolves.toEqual([
+      [
+        {
+          type: "image",
+          url: "https://example.com/final.png",
+          alt: "Final screenshot",
+          source: "assistant",
+        },
+      ],
+      [
+        {
+          type: "image",
+          url: "https://example.com/final.png",
+          alt: "Final screenshot",
+          source: "assistant",
+        },
+      ],
+    ]);
+    expect(readThread).toHaveBeenCalledTimes(1);
+  });
 });
 
 function createBridge(replay: AppServerThreadReplay): DesktopMessagingBackendBridge {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11830,6 +11830,55 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("delivers resolved images for an image-only assistant completion", async () => {
+    const resolveAssistantMessageImages = vi.fn(async () => [{
+      type: "image" as const,
+      url: "data:image/png;base64,AQID",
+      alt: "Image-only result",
+      source: "assistant" as const,
+    }]);
+    const harness = await createHarness({ resolveAssistantMessageImages });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-image-only",
+            type: "agentMessage",
+            phase: "final",
+            text: "",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(resolveAssistantMessageImages).toHaveBeenCalledWith({
+      backend: "codex",
+      itemId: "assistant-image-only",
+      text: "",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          expect.objectContaining({
+            type: "image",
+            alt: "Image-only result",
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("posts resolved images after finalizing a streamed assistant response", async () => {
     const harness = await createHarness({
       streamingResponsesDefault: true,

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -11762,6 +11762,182 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("includes resolved assistant images in the final provider message", async () => {
+    const resolveAssistantMessageImages = vi.fn(async () => [
+      {
+        type: "image" as const,
+        url: "data:image/png;base64,AQID",
+        alt: "Worktrees overview",
+        source: "assistant" as const,
+        sourceUrl: "file:///tmp/worktrees.png",
+      },
+      {
+        type: "image" as const,
+        url: "https://example.com/remote.png",
+        alt: "Remote preview",
+        source: "assistant" as const,
+      },
+    ]);
+    const harness = await createHarness({ resolveAssistantMessageImages });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-message-1",
+            type: "agentMessage",
+            phase: "final",
+            text: "Screenshots attached.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(resolveAssistantMessageImages).toHaveBeenCalledWith({
+      backend: "codex",
+      itemId: "assistant-message-1",
+      text: "Screenshots attached.",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [
+          expect.objectContaining({
+            type: "text",
+            text: "Screenshots attached.",
+          }),
+          expect.objectContaining({
+            type: "image",
+            url: "data:image/png;base64,AQID",
+          }),
+          expect.objectContaining({
+            type: "image",
+            url: "https://example.com/remote.png",
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("posts resolved images after finalizing a streamed assistant response", async () => {
+    const harness = await createHarness({
+      streamingResponsesDefault: true,
+      resolveAssistantMessageImages: async () => [{
+        type: "image",
+        url: "data:image/png;base64,AQID",
+        alt: "Final screenshot",
+      }],
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-message-1",
+          delta: "Done.",
+          phase: "final",
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Done." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "stream_update",
+        stream: expect.objectContaining({ isFinal: true }),
+      }),
+      expect.objectContaining({
+        kind: "message",
+        role: "assistant",
+        parts: [expect.objectContaining({ type: "image" })],
+      }),
+    ]));
+  });
+
+  it("delivers images discovered on the terminal event after final text was deduped", async () => {
+    const resolveAssistantMessageImages = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        type: "image",
+        url: "data:image/png;base64,AQID",
+        alt: "Late replay image",
+      }]);
+    const harness = await createHarness({ resolveAssistantMessageImages });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-message-1",
+            type: "agentMessage",
+            phase: "final",
+            text: "Done.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Done." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(harness.delivered.filter((intent) => intent.kind === "message")).toEqual([
+      expect.objectContaining({
+        parts: [expect.objectContaining({ type: "text", text: "Done." })],
+      }),
+      expect.objectContaining({
+        parts: [expect.objectContaining({ type: "image", alt: "Late replay image" })],
+      }),
+    ]);
+  });
+
   it("falls back with a final assistant message per binding", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({
@@ -18597,6 +18773,9 @@ async function createHarness(options?: {
   readThreadLastAssistantReply?: NonNullable<
     MessagingBackendBridge["readThreadLastAssistantReply"]
   >;
+  resolveAssistantMessageImages?: NonNullable<
+    MessagingBackendBridge["resolveAssistantMessageImages"]
+  >;
   readActiveTurn?: NonNullable<MessagingBackendBridge["readActiveTurn"]>;
   setAcpSessionRuntimeOption?: NonNullable<
     MessagingBackendBridge["setAcpSessionRuntimeOption"]
@@ -18997,6 +19176,9 @@ async function createHarness(options?: {
     readThreadLastAssistantReply,
     readThreadLastAssistantMessage,
     readThreadStatus,
+    ...(options?.resolveAssistantMessageImages
+      ? { resolveAssistantMessageImages: options.resolveAssistantMessageImages }
+      : {}),
     recordMessagingBindingTransition,
     setAcpSessionRuntimeOption,
     setThreadExecutionMode,

--- a/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
+++ b/apps/desktop/src/main/__tests__/transcript-image-protocol.test.ts
@@ -533,6 +533,73 @@ describe("transcript image protocol", () => {
     }
   });
 
+  it("returns durable data images for messaging after temporary source cleanup", async () => {
+    const { materializeTranscriptMessageImagesForMessaging } = await import(
+      "../transcript-image-protocol"
+    );
+    const agentTempDir = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-messaging-image-")
+    );
+    const imagePath = path.join(agentTempDir, "final-overview.png");
+    const imageBytes = Buffer.from([20, 21, 22, 23]);
+    await writeFile(imagePath, imageBytes);
+
+    try {
+      const message = {
+        id: "assistant-final-image",
+        role: "assistant" as const,
+        text: `See [Final overview](${imagePath}).`,
+      };
+      const response = {
+        backend: "codex" as const,
+        fetchedAt: 1,
+        threadId: "thread-messaging-image",
+        replay: {
+          entries: [],
+          messages: [message],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      };
+      const dependencies = {
+        resolveRoot: () => path.join(tempDir, "thread-images"),
+      };
+      const options = {
+        includeTemporaryImageRoots: true,
+      };
+
+      const first = await materializeTranscriptMessageImagesForMessaging(
+        response,
+        message,
+        dependencies,
+        options,
+      );
+      expect(first).toEqual([
+        {
+          type: "image",
+          url: `data:image/png;base64,${imageBytes.toString("base64")}`,
+          sourceUrl: pathToFileURL(imagePath).toString(),
+          alt: "Final overview",
+        },
+      ]);
+
+      await rm(agentTempDir, { recursive: true, force: true });
+
+      await expect(
+        materializeTranscriptMessageImagesForMessaging(
+          response,
+          message,
+          dependencies,
+          options,
+        ),
+      ).resolves.toEqual(first);
+    } finally {
+      await rm(agentTempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps data image URLs when materialization writes fail", async () => {
     const { materializeTranscriptImageUrlsForRenderer } = await import(
       "../transcript-image-protocol"

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -51,6 +51,7 @@ import type {
   MessagingCapabilityProfile,
   MessagingClientRateLimitStrategy,
   MessagingInboundEvent,
+  MessagingImagePart,
   MessagingActorIdentity,
   MessagingAdapterState,
   MessagingAdapterAuthorizationUpdate,
@@ -148,6 +149,13 @@ export type MessagingBackendBridge = {
     backend: AppServerBackendKind;
     threadId: string;
   }): Promise<MessagingLastAssistantReply | undefined>;
+  resolveAssistantMessageImages?(request: {
+    backend: AppServerBackendKind;
+    itemId?: string;
+    text: string;
+    threadId: string;
+    turnId?: string;
+  }): Promise<MessagingImagePart[]>;
   handoffThreadWorkspace?(
     request: HandoffThreadWorkspaceRequest,
   ): Promise<HandoffThreadWorkspaceResponse>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1463,20 +1463,34 @@ export class MessagingController {
             activeTurn?.turnId,
           );
         }
-      } else if (
-        isTerminalTurnLifecycle(activeTurn)
-        && !assistantDelta
-        && !reviewTurnEvent
-      ) {
-        // Only flush buffered stream text on a genuine terminal event (e.g.
-        // turn/completed, idle) — never on an assistant delta. Deltas are
-        // mid-stream content owned by deliverAssistantStreamUpdate's buffer;
-        // when the turn lifecycle is already terminal but the backend keeps
-        // emitting deltas, letting each delta run the terminal flush re-posts
-        // the (growing) buffer as a brand-new message every time — the
-        // multi-message channel flood (and the budget starvation it caused).
-        await this.waitForAssistantStreamDeliveriesForEvent(event, binding);
-        await this.flushBufferedAssistantStreamsForTerminalEvent(event, binding);
+      } else {
+        if (
+          isFinalAssistantImageResolutionEvent(event)
+          && !reviewTurnEvent
+          && !isTaskMonitorProgressEvent(event)
+        ) {
+          const assistantImages = await this.resolveAssistantMessageImages(
+            "",
+            event,
+            binding,
+          );
+          await this.deliverAssistantImages(assistantImages, event, binding);
+        }
+        if (
+          isTerminalTurnLifecycle(activeTurn)
+          && !assistantDelta
+          && !reviewTurnEvent
+        ) {
+          // Only flush buffered stream text on a genuine terminal event (e.g.
+          // turn/completed, idle) — never on an assistant delta. Deltas are
+          // mid-stream content owned by deliverAssistantStreamUpdate's buffer;
+          // when the turn lifecycle is already terminal but the backend keeps
+          // emitting deltas, letting each delta run the terminal flush re-posts
+          // the (growing) buffer as a brand-new message every time — the
+          // multi-message channel flood (and the budget starvation it caused).
+          await this.waitForAssistantStreamDeliveriesForEvent(event, binding);
+          await this.flushBufferedAssistantStreamsForTerminalEvent(event, binding);
+        }
       }
 
       // Automation turns surface their own terminal output (incl. errors) via
@@ -16841,6 +16855,20 @@ function isNonFinalAssistantTextForBackendEvent(event: AgentEvent): boolean {
   }
   const phase = typeof params.item.phase === "string" ? params.item.phase : undefined;
   return Boolean(phase && phase !== "final" && phase !== "final_answer");
+}
+
+function isFinalAssistantImageResolutionEvent(event: AgentEvent): boolean {
+  if (event.notification.method === "turn/completed") {
+    return true;
+  }
+  if (event.notification.method !== "item/completed") {
+    return false;
+  }
+  const item = (event.notification.params as {
+    item?: { type?: unknown };
+  }).item;
+  return item?.type === "agentMessage"
+    && !isNonFinalAssistantTextForBackendEvent(event);
 }
 
 function isTaskMonitorProgressEvent(event: AgentEvent): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -72,6 +72,7 @@ import type {
   MessagingInboundEvent,
   MessagingInboundMediaEvent,
   MessagingInboundTextEvent,
+  MessagingImagePart,
   MessagingAdapterState,
   MessagingJsonValue,
   MessagingManagedConversationActionResult,
@@ -1426,6 +1427,11 @@ export class MessagingController {
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
         ) {
+          const assistantImages = await this.resolveAssistantMessageImages(
+            assistantText,
+            event,
+            binding,
+          );
           const deliveredFinalStream = await this.flushAssistantStreamForEvent(
             event,
             binding,
@@ -1433,8 +1439,14 @@ export class MessagingController {
           );
           if (deliveredFinalStream) {
             this.markAssistantMessageDelivered(event, binding, assistantText);
+            await this.deliverAssistantImages(assistantImages, event, binding);
           } else {
-            await this.deliverAssistantMessage(assistantText, event, binding);
+            await this.deliverAssistantMessage(
+              assistantText,
+              event,
+              binding,
+              assistantImages,
+            );
           }
         } else if (!automationTurnEvent) {
           // NON-final agentMessage completions (e.g. Codex "commentary" phases
@@ -5006,12 +5018,21 @@ export class MessagingController {
     text: string,
     event: AgentEvent,
     binding: MessagingBindingRecord,
+    images: MessagingImagePart[] = [],
   ): Promise<void> {
     if (!this.markAssistantMessageDelivered(event, binding, text)) {
+      await this.deliverAssistantImages(images, event, binding);
       return;
     }
+    if (images.length > 0) {
+      this.markAssistantMessageDelivered(
+        event,
+        binding,
+        assistantImageDeliverySignature(images),
+      );
+    }
     this.logger.debug?.(
-      `messaging assistant deliver thread=${binding.threadId} binding=${binding.id} chars=${text.length} preview="${compactLogPreview(text)}"`,
+      `messaging assistant deliver thread=${binding.threadId} binding=${binding.id} chars=${text.length} images=${images.length} preview="${compactLogPreview(text)}"`,
     );
 
     await this.deliver(
@@ -5027,10 +5048,69 @@ export class MessagingController {
             text,
             markdown: "markdown",
           },
+          ...images,
         ],
       },
       binding,
     );
+  }
+
+  private async deliverAssistantImages(
+    images: MessagingImagePart[],
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    if (images.length === 0) {
+      return;
+    }
+    if (
+      !this.markAssistantMessageDelivered(
+        event,
+        binding,
+        assistantImageDeliverySignature(images),
+      )
+    ) {
+      return;
+    }
+    await this.deliver(
+      {
+        id: this.newIntentId("assistant-images"),
+        kind: "message",
+        bindingId: binding.id,
+        createdAt: this.now(),
+        role: "assistant",
+        parts: images,
+      },
+      binding,
+    );
+  }
+
+  private async resolveAssistantMessageImages(
+    text: string,
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+  ): Promise<MessagingImagePart[]> {
+    const resolveImages = this.options.backend.resolveAssistantMessageImages;
+    if (!resolveImages) {
+      return [];
+    }
+    try {
+      const images = await resolveImages.call(this.options.backend, {
+        backend: binding.backend,
+        itemId: assistantItemIdForBackendEvent(event),
+        text,
+        threadId: binding.threadId,
+        turnId: turnIdForBackendEvent(event),
+      });
+      return selectAssistantImagesForCapability(images, this.capabilityProfile);
+    } catch (error) {
+      this.logger.debug?.("messaging assistant image resolution failed", {
+        backend: binding.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: binding.threadId,
+      });
+      return [];
+    }
   }
 
   /**
@@ -5101,6 +5181,26 @@ export class MessagingController {
       return;
     }
 
+    let images: MessagingImagePart[] = [];
+    if (this.options.backend.resolveAssistantMessageImages) {
+      try {
+        images = selectAssistantImagesForCapability(
+          await this.options.backend.resolveAssistantMessageImages({
+            backend: binding.backend,
+            text: trimmed,
+            threadId: binding.threadId,
+          }),
+          this.capabilityProfile,
+        );
+      } catch (error) {
+        this.logger.debug?.("messaging resume assistant image resolution failed", {
+          backend: binding.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: binding.threadId,
+        });
+      }
+    }
+
     await this.deliver(
       {
         id: this.newIntentId(
@@ -5122,6 +5222,7 @@ export class MessagingController {
             }),
             markdown: "markdown",
           },
+          ...images,
         ],
       },
       binding,
@@ -16377,6 +16478,72 @@ function turnIdForBackendEvent(event: AgentEvent): string | undefined {
     return params.turnId;
   }
   return typeof params.turn?.id === "string" ? params.turn.id : undefined;
+}
+
+function assistantItemIdForBackendEvent(event: AgentEvent): string | undefined {
+  if (
+    event.notification.method !== "item/started"
+    && event.notification.method !== "item/completed"
+  ) {
+    return undefined;
+  }
+  const item = (event.notification.params as {
+    item?: { id?: unknown; itemId?: unknown; item_id?: unknown };
+  }).item;
+  for (const value of [item?.id, item?.itemId, item?.item_id]) {
+    if (typeof value === "string" && value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function selectAssistantImagesForCapability(
+  images: readonly MessagingImagePart[],
+  capabilityProfile: MessagingCapabilityProfile,
+): MessagingImagePart[] {
+  const attachments = capabilityProfile.outboundAttachments;
+  if (!attachments) {
+    return [];
+  }
+  const selected: MessagingImagePart[] = [];
+  const seen = new Set<string>();
+  for (const image of images) {
+    if (seen.has(image.url)) {
+      continue;
+    }
+    if (image.url.startsWith("data:image/")) {
+      const sizeBytes = imageDataUrlSizeBytes(image.url);
+      if (
+        !attachments.supportsImageUpload
+        || sizeBytes === undefined
+        || sizeBytes > (attachments.maxUploadBytes ?? Infinity)
+      ) {
+        continue;
+      }
+    } else if (
+      !attachments.supportsRemoteImageUrl
+      || !/^https:\/\//iu.test(image.url)
+    ) {
+      continue;
+    }
+    seen.add(image.url);
+    selected.push(image);
+  }
+  return selected;
+}
+
+function imageDataUrlSizeBytes(url: string): number | undefined {
+  const payload = /^data:image\/[a-z0-9.+-]+;base64,([a-z0-9+/]+={0,2})$/iu.exec(url)?.[1];
+  if (!payload) {
+    return undefined;
+  }
+  const padding = payload.endsWith("==") ? 2 : payload.endsWith("=") ? 1 : 0;
+  return Math.floor(payload.length * 3 / 4) - padding;
+}
+
+function assistantImageDeliverySignature(images: readonly MessagingImagePart[]): string {
+  return `images:${images.map((image) => image.sourceUrl ?? image.url).join("\0")}`;
 }
 
 function automationTurnKey(params: {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -230,7 +230,12 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       limit: 20,
       threadId: request.threadId,
     });
-    const message = findAssistantMessageForText(response.replay, request.text) ?? {
+    const message = findAssistantMessageForText(
+      response.replay,
+      request.text,
+      request.itemId,
+      request.turnId,
+    ) ?? {
       id: request.itemId ?? `turn:${request.turnId ?? "unknown"}:assistant`,
       role: "assistant" as const,
       text: request.text,
@@ -394,8 +399,47 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
 function findAssistantMessageForText(
   replay: AppServerThreadReplay,
   text: string,
+  itemId?: string,
+  turnId?: string,
 ): AppServerThreadMessage | undefined {
+  if (itemId) {
+    for (let index = replay.messages.length - 1; index >= 0; index -= 1) {
+      const message = replay.messages[index];
+      if (message?.role === "assistant" && message.id === itemId) {
+        return message;
+      }
+    }
+    for (let index = replay.entries.length - 1; index >= 0; index -= 1) {
+      const entry = replay.entries[index];
+      if (
+        entry?.type === "message"
+        && entry.role === "assistant"
+        && entry.id === itemId
+      ) {
+        return entry;
+      }
+    }
+  }
   const expected = text.trim();
+  if (turnId) {
+    for (let index = replay.entries.length - 1; index >= 0; index -= 1) {
+      const entry = replay.entries[index];
+      if (
+        entry?.type === "message"
+        && entry.role === "assistant"
+        && entry.turn?.id === turnId
+        && entry.text.trim() === expected
+      ) {
+        return entry;
+      }
+    }
+  }
+  // Empty assistant messages need an item or turn identity. Falling back to a
+  // text-only match here could pick an unrelated image-only result from an
+  // earlier turn when the current terminal event produced no assistant output.
+  if (!expected && (itemId || turnId)) {
+    return undefined;
+  }
   for (let index = replay.messages.length - 1; index >= 0; index -= 1) {
     const message = replay.messages[index];
     if (message?.role === "assistant" && message.text.trim() === expected) {

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,7 +1,9 @@
+import { createHash } from "node:crypto";
 import type {
   AgentEvent,
   AppServerBackendKind,
   AppServerThreadMessageOrigin,
+  AppServerThreadMessage,
   AppServerThreadReplay,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
@@ -42,6 +44,7 @@ import type {
   UpdateDirectoryLaunchpadRequest,
   UpdateDirectoryLaunchpadResponse,
 } from "@pwragent/shared";
+import type { MessagingImagePart } from "@pwragent/messaging-interface";
 import type {
   MessagingBackendBridge,
   MessagingLastAssistantReply,
@@ -51,8 +54,14 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { resolveScratchProjectsRoots } from "../app-server/scratch-projects";
 import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot";
+import { materializeTranscriptMessageImagesForMessaging } from "../transcript-image-protocol";
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
+  private readonly assistantImageResolutions = new Map<
+    string,
+    Promise<MessagingImagePart[]>
+  >();
+
   constructor(
     private readonly registry: DesktopBackendRegistry = getDesktopBackendRegistry(),
   ) {}
@@ -170,6 +179,79 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       };
     }
     return undefined;
+  }
+
+  async resolveAssistantMessageImages(request: {
+    backend: AppServerBackendKind;
+    itemId?: string;
+    text: string;
+    threadId: string;
+    turnId?: string;
+  }): Promise<MessagingImagePart[]> {
+    const key = [
+      request.backend,
+      request.threadId,
+      request.turnId ?? "",
+      request.itemId ?? "",
+      createHash("sha256").update(request.text).digest("base64url"),
+    ].join("\0");
+    const existing = this.assistantImageResolutions.get(key);
+    if (existing) {
+      return await existing;
+    }
+
+    const resolution = this.resolveAssistantMessageImagesOnce(request);
+    this.assistantImageResolutions.set(key, resolution);
+    const expiry = setTimeout(() => {
+      if (this.assistantImageResolutions.get(key) === resolution) {
+        this.assistantImageResolutions.delete(key);
+      }
+    }, 5_000);
+    expiry.unref?.();
+    while (this.assistantImageResolutions.size > 64) {
+      const oldest = this.assistantImageResolutions.keys().next().value;
+      if (typeof oldest !== "string") {
+        break;
+      }
+      this.assistantImageResolutions.delete(oldest);
+    }
+    return await resolution;
+  }
+
+  private async resolveAssistantMessageImagesOnce(request: {
+    backend: AppServerBackendKind;
+    itemId?: string;
+    text: string;
+    threadId: string;
+    turnId?: string;
+  }): Promise<MessagingImagePart[]> {
+    const response = await this.registry.readThread({
+      backend: request.backend,
+      limit: 20,
+      threadId: request.threadId,
+    });
+    const message = findAssistantMessageForText(response.replay, request.text) ?? {
+      id: request.itemId ?? `turn:${request.turnId ?? "unknown"}:assistant`,
+      role: "assistant" as const,
+      text: request.text,
+    };
+    const roots = await this.registry.getThreadTranscriptImageRoots({
+      backend: request.backend,
+      threadId: request.threadId,
+    });
+    const parts = await materializeTranscriptMessageImagesForMessaging(
+      response,
+      message,
+      {},
+      {
+        approvedLocalImageRoots: roots,
+        includeTemporaryImageRoots: true,
+      },
+    );
+    return parts.map((part) => ({
+      ...part,
+      source: "assistant" as const,
+    }));
   }
 
   async handoffThreadWorkspace(
@@ -307,6 +389,30 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
   onEvent(listener: (event: AgentEvent) => void | Promise<void>): () => void {
     return this.registry.onEvent(listener);
   }
+}
+
+function findAssistantMessageForText(
+  replay: AppServerThreadReplay,
+  text: string,
+): AppServerThreadMessage | undefined {
+  const expected = text.trim();
+  for (let index = replay.messages.length - 1; index >= 0; index -= 1) {
+    const message = replay.messages[index];
+    if (message?.role === "assistant" && message.text.trim() === expected) {
+      return message;
+    }
+  }
+  for (let index = replay.entries.length - 1; index >= 0; index -= 1) {
+    const entry = replay.entries[index];
+    if (
+      entry?.type === "message"
+      && entry.role === "assistant"
+      && entry.text.trim() === expected
+    ) {
+      return entry;
+    }
+  }
+  return undefined;
 }
 
 function findLastAssistantMessageReply(

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -218,6 +218,105 @@ export async function materializeTranscriptImageUrlsForRenderer(
   };
 }
 
+/**
+ * Resolve the images belonging to one assistant message into provider-safe
+ * image parts. Local files, data images, and signed PwrSnap loopback URLs are
+ * first copied into the durable transcript cache, then returned as data URLs
+ * so messaging adapters never receive renderer-only `pwragent-image://` URLs.
+ * Ordinary remote URLs remain remote URLs for adapters that can embed them.
+ */
+export async function materializeTranscriptMessageImagesForMessaging(
+  response: AppServerReadThreadResponse,
+  message: AppServerThreadMessage,
+  dependencies: Partial<TranscriptImageMaterializerDependencies> = {},
+  options: TranscriptImageMaterializationOptions = {},
+): Promise<AppServerThreadImagePart[]> {
+  const scopedMessage = message.parts?.some((part) => part.type === "text")
+    ? message
+    : {
+        ...message,
+        parts: [
+          { type: "text" as const, text: message.text },
+          ...(message.parts ?? []),
+        ],
+      };
+  const scopedResponse: AppServerReadThreadResponse = {
+    ...response,
+    replay: {
+      ...response.replay,
+      entries: [],
+      messages: [scopedMessage],
+    },
+  };
+  const materialized = await materializeTranscriptImageUrlsForRenderer(
+    scopedResponse,
+    dependencies,
+    options,
+  );
+  const materializedMessage = materialized.replay.messages[0];
+  if (!materializedMessage) {
+    return [];
+  }
+
+  const approvedLocalImageRoots = await createApprovedLocalImageRootResolver(options)();
+  const imageParts = materializedMessage.parts?.filter(
+    (part): part is AppServerThreadImagePart => part.type === "image",
+  ) ?? [];
+  const output: AppServerThreadImagePart[] = [];
+  for (const part of imageParts) {
+    const providerUrl = await transcriptImageUrlForMessaging(
+      part.url,
+      approvedLocalImageRoots,
+    );
+    if (!providerUrl) {
+      continue;
+    }
+    output.push({
+      ...part,
+      url: providerUrl,
+    });
+  }
+  return output;
+}
+
+async function transcriptImageUrlForMessaging(
+  url: string,
+  approvedLocalImageRoots: readonly string[],
+): Promise<string | undefined> {
+  if (url.startsWith("data:image/") || /^https:\/\//iu.test(url)) {
+    return url;
+  }
+
+  const sourcePath = url.startsWith(`${TRANSCRIPT_IMAGE_PROTOCOL_SCHEME}://`)
+    ? decodeTranscriptImageProtocolRequest(url)
+    : isFileImageUrl(url)
+      ? localImageLinkPath(url)
+      : undefined;
+  if (!sourcePath) {
+    return undefined;
+  }
+
+  const resolution = await resolveTranscriptImageFile(sourcePath, {
+    additionalAllowedRoots: approvedLocalImageRoots,
+  });
+  if (!resolution.ok) {
+    return undefined;
+  }
+  let buffer: Buffer;
+  try {
+    buffer = await readFile(resolution.path);
+  } catch {
+    return undefined;
+  }
+  if (
+    buffer.byteLength === 0
+    || buffer.byteLength > MAX_FETCHED_TRANSCRIPT_IMAGE_BYTES
+  ) {
+    return undefined;
+  }
+  return `data:${resolution.mimeType};base64,${buffer.toString("base64")}`;
+}
+
 export function registerTranscriptImageProtocolScheme(): void {
   protocol.registerSchemesAsPrivileged([
     {

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -148,6 +148,16 @@ returns user-visible rejection reasons for unsupported or oversized files.
 Downloaded bytes and extracted file contents are not persisted in messaging
 state.
 
+For outbound final responses, desktop messaging core resolves structured
+assistant image parts and local Markdown image links before constructing the
+provider intent. Local files and signed loopback media are copied into the
+profile-owned transcript image cache and emitted as bounded data-image parts;
+ordinary HTTPS images remain remote-image parts. Providers consume only those
+generic parts and apply their declared capabilities. Telegram, Discord, Slack,
+Mattermost, and Feishu upload local image data. LINE can render HTTPS image
+parts but cannot accept local bytes, so local-only images degrade to the text
+response on LINE.
+
 ## Typing Activity
 
 `activity: "typing"` is a semantic lease signal from the messaging controller.

--- a/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
+++ b/packages/messaging/providers/discord/src/__tests__/discord-adapter.test.ts
@@ -410,6 +410,57 @@ describe("discord adapter", () => {
     );
   });
 
+  it("delivers every final image as an upload or remote embed", async () => {
+    const createMessage = vi.fn(async (channelId: string) => ({
+      channel_id: channelId,
+      id: "message-images",
+    }));
+    const adapter = new DiscordAdapter({
+      api: createApi({ createMessage }),
+      config: {
+        authorizedActorIds: [{ id: TEST_USER_ID, displayName: "" }],
+        botToken: "token",
+        channel: "discord",
+      },
+      now: () => 1234,
+    });
+
+    await adapter.deliver({
+      audit: discordAudit(),
+      createdAt: 1234,
+      id: "message-images",
+      kind: "message",
+      parts: [
+        { type: "text", text: "Rendered images" },
+        { type: "image", url: "data:image/png;base64,AQID" },
+        { type: "image", url: "data:image/jpeg;base64,BAUG" },
+        { type: "image", url: "https://example.com/one.png" },
+        { type: "image", url: "https://example.com/two.png" },
+      ],
+      role: "assistant",
+    });
+
+    expect(createMessage).toHaveBeenCalledWith(
+      "channel-1",
+      expect.objectContaining({
+        embeds: [
+          { image: { url: "https://example.com/one.png" } },
+          { image: { url: "https://example.com/two.png" } },
+        ],
+        files: [
+          {
+            data: new Uint8Array([1, 2, 3]),
+            name: "assistant-image.png",
+          },
+          {
+            data: new Uint8Array([4, 5, 6]),
+            name: "assistant-image-2.jpg",
+          },
+        ],
+      }),
+    );
+  });
+
   it("resolves persisted component handles after an adapter restart", async () => {
     const store = createCallbackHandleStore();
     let createdRequest: Parameters<DiscordApi["createMessage"]>[1] | undefined;

--- a/packages/messaging/providers/discord/src/discord-adapter.ts
+++ b/packages/messaging/providers/discord/src/discord-adapter.ts
@@ -25,6 +25,7 @@ import type {
   MessagingDeliveryResult,
   MessagingDeliveryScope,
   MessagingFilePart,
+  MessagingImagePart,
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
   MessagingRateLimitInfo,
@@ -488,9 +489,9 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         this.capabilityProfile,
       );
       await Promise.all(callbackHandleWrites);
-      const imageUpload = uploadableImagePart(intent);
-      const imageUrl = imageUpload ? undefined : this.firstImageUrl(intent);
-      const files = [...uploadableFileParts(intent), ...(imageUpload ? [imageUpload] : [])];
+      const imageUploads = uploadableImageParts(intent);
+      const imageUrls = this.remoteImageUrls(intent);
+      const files = [...uploadableFileParts(intent), ...imageUploads];
       const chunks = splitDiscordContent(
         (files.length > 0
           ? textForDiscordIntentWithoutUploads(intent)
@@ -503,7 +504,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         target.applicationId &&
         target.interactionToken &&
         chunks.length === 1 &&
-        !imageUrl &&
+        imageUrls.length === 0 &&
         files.length === 0
       ) {
         const message = await this.api.updateInteractionOriginalResponse(
@@ -528,7 +529,7 @@ export class DiscordAdapter implements DiscordProviderAdapter {
         intent.delivery?.mode === "update" &&
         target.messageId &&
         chunks.length === 1 &&
-        !imageUrl
+        imageUrls.length === 0
       ) {
         try {
           const message = await this.api.updateMessage(
@@ -566,14 +567,8 @@ export class DiscordAdapter implements DiscordProviderAdapter {
           components: index === chunks.length - 1 ? components : undefined,
           content: chunk,
           embeds:
-            index === chunks.length - 1 && imageUrl
-              ? [
-                  {
-                    image: {
-                      url: imageUrl,
-                    },
-                  },
-                ]
+            index === chunks.length - 1 && imageUrls.length > 0
+              ? imageUrls.map((url) => ({ image: { url } }))
               : undefined,
           files: index === chunks.length - 1 ? filesForDiscordRequest(files) : undefined,
         };
@@ -1415,12 +1410,16 @@ export class DiscordAdapter implements DiscordProviderAdapter {
     }
   }
 
-  private firstImageUrl(intent: MessagingSurfaceIntent): string | undefined {
+  private remoteImageUrls(intent: MessagingSurfaceIntent): string[] {
     if (intent.kind !== "message") {
-      return undefined;
+      return [];
     }
 
-    return intent.parts.find((part) => part.type === "image")?.url;
+    return intent.parts.flatMap((part) =>
+      part.type === "image" && !part.url.startsWith("data:image/")
+        ? [part.url]
+        : [],
+    ).slice(0, 10);
   }
 
   private async deliverActivity(
@@ -1869,28 +1868,30 @@ function uploadableFileParts(intent: MessagingSurfaceIntent): MessagingFilePart[
   );
 }
 
-function uploadableImagePart(intent: MessagingSurfaceIntent): MessagingFilePart | undefined {
+function uploadableImageParts(intent: MessagingSurfaceIntent): MessagingFilePart[] {
   if (intent.kind !== "message") {
-    return undefined;
+    return [];
   }
 
-  const url = intent.parts.find((part) => part.type === "image")?.url;
-  if (!url) {
-    return undefined;
-  }
-
-  const dataImage = parseDataImageUrl(url);
-  if (!dataImage) {
-    return undefined;
-  }
-
-  return {
-    data: dataImage.data,
-    mimeType: dataImage.mimeType,
-    name: dataImage.name,
-    sizeBytes: dataImage.data.byteLength,
-    type: "file",
-  };
+  return intent.parts.filter(
+    (part): part is MessagingImagePart => part.type === "image",
+  ).flatMap((part, index): MessagingFilePart[] => {
+    const dataImage = parseDataImageUrl(part.url);
+    if (!dataImage) {
+      return [];
+    }
+    const extension = dataImage.name.split(".").at(-1) ?? "png";
+    return [{
+      data: dataImage.data,
+      description: part.alt,
+      mimeType: dataImage.mimeType,
+      name: index === 0
+        ? `assistant-image.${extension}`
+        : `assistant-image-${index + 1}.${extension}`,
+      sizeBytes: dataImage.data.byteLength,
+      type: "file",
+    }];
+  }).slice(0, 10);
 }
 
 function textForDiscordIntentWithoutUploads(intent: MessagingSurfaceIntent): string {

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -295,6 +295,68 @@ describe("FeishuAdapter", () => {
     expect(spies.sent.length).toBeGreaterThan(1);
   });
 
+  it("splits long text with an uploaded image and attaches it to the final card", async () => {
+    const sent: Array<{
+      card?: {
+        elements: Array<{
+          alt?: { content?: string };
+          img_key?: string;
+          tag: string;
+          text?: { content?: string };
+        }>;
+      };
+      text?: string;
+    }> = [];
+    const uploaded: unknown[] = [];
+    const adapter = new FeishuAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ sent, uploaded }),
+      now: () => 1_700_000_000_000,
+    });
+    const longText = `${"This is a full sentence that keeps going. ".repeat(240)}END`;
+
+    await expect(adapter.deliver({
+      id: "assistant-message-with-image",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: longText, markdown: "markdown" },
+        { type: "image", url: "data:image/png;base64,AQID", alt: "Screenshot" },
+      ],
+      audit: {
+        actor: { platformUserId: "ou_user" },
+        bindingId: "binding-1",
+        channel: {
+          channel: "feishu",
+          conversation: { id: "ou_user", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    } satisfies MessagingSurfaceIntent)).resolves.toMatchObject({
+      channel: "feishu",
+      outcome: "presented",
+    });
+
+    expect(sent.length).toBeGreaterThan(1);
+    expect(uploaded).toHaveLength(1);
+    expect(
+      sent.slice(0, -1).flatMap((message) => message.card?.elements ?? [])
+        .some((element) => element.tag === "img"),
+    ).toBe(false);
+    expect(sent.at(-1)?.card?.elements).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        tag: "img",
+        img_key: "img_1",
+      }),
+    ]));
+    expect(
+      sent.at(-1)?.card?.elements.find((element) => element.tag === "div")
+        ?.text?.content,
+    ).toContain("END");
+  });
+
   it("sends interactive cards with persisted callback handles", async () => {
     const store = fakeStore();
     const spies: { sent: unknown[] } = { sent: [] };

--- a/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
+++ b/packages/messaging/providers/feishu/src/__tests__/feishu-adapter.test.ts
@@ -72,6 +72,7 @@ function encryptFeishuPayload(payload: unknown, encryptKey: string): string {
 function fakeApi(spies: {
   deleted?: string[];
   downloaded?: unknown[];
+  uploaded?: unknown[];
   sent?: unknown[];
   updated?: unknown[];
 }): FeishuApi {
@@ -88,6 +89,10 @@ function fakeApi(spies: {
       openId: "ou_bot",
       tenantKey: "tenant_1",
     }),
+    uploadImage: async (params) => {
+      spies.uploaded?.push(params);
+      return { imageKey: `img_${spies.uploaded?.length ?? 1}` };
+    },
     sendMessage: async (params) => {
       spies.sent?.push(params);
       return { messageId: "om_sent", chatId: params.receiveId };
@@ -116,6 +121,68 @@ describe("FeishuAdapter", () => {
     expect(adapter.clientRateLimitStrategy).toBe("direct");
     expect(adapter.capabilityProfile.actions?.maxActions).toBe(20);
     expect(adapter.capabilityProfile.text.markdownDialect).toBe("feishu-md");
+    expect(adapter.capabilityProfile.outboundAttachments?.supportsImageUpload).toBe(true);
+  });
+
+  it("uploads assistant images and renders them in an interactive card", async () => {
+    const spies: { sent: unknown[]; uploaded: unknown[] } = {
+      sent: [],
+      uploaded: [],
+    };
+    const adapter = new FeishuAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi(spies),
+      now: () => 1_700_000_000_000,
+    });
+
+    await adapter.deliver({
+      id: "assistant-images",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Final screenshot" },
+        {
+          type: "image",
+          url: "data:image/png;base64,AQID",
+          alt: "Worktrees overview",
+        },
+      ],
+      audit: {
+        actor: { platformUserId: "ou_user" },
+        channel: {
+          channel: "feishu",
+          conversation: { id: "ou_user", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    });
+
+    expect(spies.uploaded).toHaveLength(1);
+    expect(spies.uploaded[0]).toMatchObject({
+      mimeType: "image/png",
+      name: "assistant-image-2.png",
+    });
+    expect(Array.from((spies.uploaded[0] as { data: Uint8Array }).data)).toEqual([
+      1,
+      2,
+      3,
+    ]);
+    expect(spies.sent).toEqual([
+      expect.objectContaining({
+        card: expect.objectContaining({
+          elements: expect.arrayContaining([
+            {
+              tag: "img",
+              img_key: "img_1",
+              alt: { tag: "plain_text", content: "Worktrees overview" },
+            },
+          ]),
+        }),
+        text: undefined,
+      }),
+    ]);
   });
 
   function streamIntent(params: {
@@ -782,7 +849,10 @@ describe("FeishuAdapter", () => {
   });
 
   it("calls the Feishu message resource endpoint with type when downloading", async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
       const url = String(input);
       if (url.endsWith("/open-apis/auth/v3/tenant_access_token/internal")) {
         return new Response(JSON.stringify({
@@ -813,6 +883,45 @@ describe("FeishuAdapter", () => {
         headers: { authorization: "Bearer tenant-token" },
       },
     );
+  });
+
+  it("uploads message images through the Feishu image resource endpoint", async () => {
+    const fetchMock = vi.fn(async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      const url = String(input);
+      if (url.endsWith("/open-apis/auth/v3/tenant_access_token/internal")) {
+        return new Response(JSON.stringify({
+          code: 0,
+          expire: 3600,
+          tenant_access_token: "tenant-token",
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        code: 0,
+        data: { image_key: "img_uploaded" },
+      }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createFeishuApi(baseConfig).uploadImage({
+      data: new Uint8Array([1, 2, 3]),
+      mimeType: "image/png",
+      name: "assistant-image.png",
+    })).resolves.toEqual({ imageKey: "img_uploaded" });
+
+    const uploadCall = fetchMock.mock.calls[1];
+    expect(String(uploadCall?.[0])).toBe(
+      "https://open.feishu.cn/open-apis/im/v1/images",
+    );
+    const init = uploadCall?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ authorization: "Bearer tenant-token" });
+    expect(init.body).toBeInstanceOf(FormData);
+    const formData = init.body as FormData;
+    expect(formData.get("image_type")).toBe("message");
+    expect(formData.get("image")).toMatchObject({ size: 3, type: "image/png" });
   });
 
   it("decrypts encrypted webhook event envelopes", async () => {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -104,6 +104,11 @@ export type FeishuApi = {
     resourceType: FeishuMessageResourceType;
   }): Promise<Uint8Array>;
   getBotInfo(): Promise<FeishuBotInfo>;
+  uploadImage(params: {
+    data: Uint8Array;
+    mimeType: string;
+    name: string;
+  }): Promise<{ imageKey: string }>;
   sendMessage(params: FeishuSendMessageParams): Promise<FeishuSendMessageResult>;
   updateMessage(params: { card: FeishuInteractiveCard; messageId: string }): Promise<FeishuSendMessageResult>;
 };
@@ -300,9 +305,9 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       supportsDownload: true,
     },
     outboundAttachments: {
-      maxUploadBytes: 30 * 1024 * 1024,
+      maxUploadBytes: 10 * 1024 * 1024,
       supportsFileUpload: false,
-      supportsImageUpload: false,
+      supportsImageUpload: true,
       supportsRemoteImageUrl: false,
     },
   };
@@ -489,6 +494,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     }
 
     const rawText = textForFeishuIntent(intent);
+    const uploadedImages = await this.uploadOutboundImages(intent);
     const actions = actionsForFeishuIntent(intent);
     const callbackBuilder = this.buildCallbackValueBuilder({
       allowedActorIds: callbackAllowedActorIds(intent, this.authorizedActorIds[0] ?? ""),
@@ -509,6 +515,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
     if (
       intent.kind === "message" &&
       actionElements.length === 0 &&
+      uploadedImages.length === 0 &&
       intent.delivery?.mode !== "update"
     ) {
       const chunks = splitTextForDelivery(rawText, {
@@ -564,6 +571,7 @@ export class FeishuAdapter implements FeishuProviderAdapter {
 
     const card = buildFeishuCardForIntent({
       actionElements,
+      images: uploadedImages,
       intent,
       text: rawText,
     });
@@ -573,7 +581,8 @@ export class FeishuAdapter implements FeishuProviderAdapter {
         intent.delivery?.mode === "update" && target.messageId
           ? await this.api.updateMessage({ card, messageId: target.messageId })
           : undefined;
-      const shouldSendCard = shouldSendFeishuCard(intent, rawText, actionElements.length);
+      const shouldSendCard = uploadedImages.length > 0
+        || shouldSendFeishuCard(intent, rawText, actionElements.length);
       const result = updated ?? (await this.api.sendMessage({
         card: shouldSendCard ? card : undefined,
         receiveId: target.receiveId,
@@ -619,6 +628,42 @@ export class FeishuAdapter implements FeishuProviderAdapter {
         ...(rateLimit ? { rateLimit } : {}),
       };
     }
+  }
+
+  private async uploadOutboundImages(
+    intent: MessagingSurfaceIntent,
+  ): Promise<Array<{ alt: string; imageKey: string }>> {
+    if (intent.kind !== "message") {
+      return [];
+    }
+    const maxBytes = this.capabilityProfile.outboundAttachments?.maxUploadBytes ?? Infinity;
+    const output: Array<{ alt: string; imageKey: string }> = [];
+    for (const [index, part] of intent.parts.entries()) {
+      if (part.type !== "image") {
+        continue;
+      }
+      const image = parseFeishuDataImageUrl(part.url);
+      if (!image || image.data.byteLength > maxBytes) {
+        continue;
+      }
+      try {
+        const uploaded = await this.api.uploadImage({
+          data: image.data,
+          mimeType: image.mimeType,
+          name: `assistant-image-${index + 1}.${image.extension}`,
+        });
+        output.push({
+          alt: part.alt?.trim() || `Assistant image ${index + 1}`,
+          imageKey: uploaded.imageKey,
+        });
+      } catch (error) {
+        this.logger.warn?.("feishu outbound image upload failed", {
+          error: error instanceof Error ? error.message : String(error),
+          index,
+        });
+      }
+    }
+    return output;
   }
 
   async downloadAttachment(
@@ -1753,6 +1798,40 @@ class DirectFeishuApi implements FeishuApi {
     };
   }
 
+  async uploadImage(params: {
+    data: Uint8Array;
+    mimeType: string;
+    name: string;
+  }): Promise<{ imageKey: string }> {
+    const token = await this.getTenantAccessToken();
+    const formData = new FormData();
+    formData.append("image_type", "message");
+    const buffer = new ArrayBuffer(params.data.byteLength);
+    new Uint8Array(buffer).set(params.data);
+    formData.append(
+      "image",
+      new Blob([buffer], { type: params.mimeType }),
+      params.name,
+    );
+    const response = await fetch(`${this.baseUrl}/open-apis/im/v1/images`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    const text = await response.text();
+    let payload: { code?: number; data?: { image_key?: string }; msg?: string } = {};
+    try {
+      payload = text ? JSON.parse(text) : {};
+    } catch {
+      // Keep raw text below for error reporting.
+    }
+    const imageKey = payload.data?.image_key;
+    if (!response.ok || payload.code !== 0 || !imageKey) {
+      throw new Error(payload.msg || text || `Feishu image upload failed: ${response.status}`);
+    }
+    return { imageKey };
+  }
+
   async updateMessage(params: { card: FeishuInteractiveCard; messageId: string }): Promise<FeishuSendMessageResult> {
     const data = await this.request<{ message_id?: string }>(
       `/open-apis/im/v1/messages/${encodeURIComponent(params.messageId)}`,
@@ -2098,6 +2177,28 @@ function shouldSendFeishuCard(
     && part.markdown === "markdown"
     && containsMarkdownTable(part.text || text)
   );
+}
+
+function parseFeishuDataImageUrl(
+  url: string,
+): { data: Uint8Array; extension: string; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/iu.exec(url);
+  if (!match) {
+    return undefined;
+  }
+  const mimeType = match[1]?.toLowerCase();
+  const payload = match[2];
+  if (!mimeType || !payload) {
+    return undefined;
+  }
+  const extension = mimeType === "image/jpeg"
+    ? "jpg"
+    : mimeType.split("/")[1]?.replace(/[^a-z0-9]/giu, "") || "png";
+  return {
+    data: Buffer.from(payload, "base64"),
+    extension,
+    mimeType,
+  };
 }
 
 function containsMarkdownTable(text: string): boolean {

--- a/packages/messaging/providers/feishu/src/feishu-adapter.ts
+++ b/packages/messaging/providers/feishu/src/feishu-adapter.ts
@@ -41,6 +41,8 @@ import {
 import type { FeishuMessagingConfig } from "./feishu-config.ts";
 import {
   FEISHU_BUTTON_VALUE_LIMIT,
+  FEISHU_CARD_TEXT_LIMIT,
+  FEISHU_MESSAGE_TEXT_LIMIT,
   actionsForFeishuIntent,
   buildFeishuActionElements,
   buildFeishuCardForIntent,
@@ -61,9 +63,6 @@ const DEFAULT_CALLBACK_PORT = 47823;
 const DEFAULT_CALLBACK_HOST = "127.0.0.1";
 const FEISHU_SIGNED_VALUE_VERSION = 1;
 const FEISHU_WEBHOOK_BODY_LIMIT_BYTES = 2 * 1024 * 1024;
-// Feishu's per-message text limit (matches the capability profile). Longer
-// responses split onto multiple card messages instead of truncating.
-const FEISHU_MESSAGE_TEXT_LIMIT = 30_000;
 const FEISHU_INBOUND_DEDUP_TTL_MS = 10 * 60 * 1000;
 const FEISHU_INBOUND_DEDUP_MAX = 1_000;
 
@@ -509,26 +508,32 @@ export class FeishuAdapter implements FeishuProviderAdapter {
       layout: intent.actionLayout,
     });
 
-    // Long text-only messages: split into several card messages at clean
-    // boundaries so the per-message limit doesn't truncate the tail. Restricted
-    // to the simple assistant-response case — no buttons, not an in-place edit.
+    // Long assistant messages: split into several messages at clean boundaries
+    // so neither the card nor plain-text limit truncates the tail. Uploaded
+    // images are attached to the final chunk. Restricted to the simple
+    // assistant-response case — no buttons, not an in-place edit.
     if (
       intent.kind === "message" &&
       actionElements.length === 0 &&
-      uploadedImages.length === 0 &&
       intent.delivery?.mode !== "update"
     ) {
       const chunks = splitTextForDelivery(rawText, {
-        limit: FEISHU_MESSAGE_TEXT_LIMIT,
+        limit: uploadedImages.length > 0
+          ? FEISHU_CARD_TEXT_LIMIT
+          : FEISHU_MESSAGE_TEXT_LIMIT,
         measure: "chars",
       });
       if (chunks.length > 1) {
         let firstMessageId: string | undefined;
         try {
-          for (const chunk of chunks) {
-            const useCard = shouldSendFeishuCard(intent, chunk, 0);
+          for (const [index, chunk] of chunks.entries()) {
+            const images = index === chunks.length - 1 ? uploadedImages : [];
+            const useCard = images.length > 0
+              || shouldSendFeishuCard(intent, chunk, 0);
             const result = await this.api.sendMessage({
-              card: useCard ? buildFeishuCardForIntent({ intent, text: chunk }) : undefined,
+              card: useCard
+                ? buildFeishuCardForIntent({ images, intent, text: chunk })
+                : undefined,
               receiveId: target.receiveId,
               receiveIdType: target.receiveIdType,
               text: useCard ? undefined : clampFeishuMessage(chunk),

--- a/packages/messaging/providers/feishu/src/feishu-formatting.ts
+++ b/packages/messaging/providers/feishu/src/feishu-formatting.ts
@@ -30,6 +30,11 @@ export type FeishuCardElement =
       tag: "action";
       actions: FeishuButtonElement[];
       layout?: "bisected" | "flow";
+    }
+  | {
+      tag: "img";
+      img_key: string;
+      alt: { tag: "plain_text"; content: string };
     };
 
 export type FeishuButtonElement = {
@@ -125,6 +130,7 @@ export function buildFeishuActionElements(params: {
 
 export function buildFeishuCardForIntent(params: {
   actionElements?: FeishuCardElement[];
+  images?: Array<{ alt: string; imageKey: string }>;
   intent: MessagingSurfaceIntent;
   text: string;
 }): FeishuInteractiveCard {
@@ -145,6 +151,16 @@ export function buildFeishuCardForIntent(params: {
       text: {
         tag: "plain_text",
         content: `Progress: ${params.intent.value}/${params.intent.max ?? 100}`,
+      },
+    });
+  }
+  for (const image of params.images ?? []) {
+    elements.push({
+      tag: "img",
+      img_key: image.imageKey,
+      alt: {
+        tag: "plain_text",
+        content: image.alt,
       },
     });
   }

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -519,8 +519,13 @@ describe("MattermostAdapter — outbound deliver", () => {
         },
         {
           type: "image",
-          url: "https://example.com/remote.png",
-          alt: "Remote screenshot",
+          url: "https://example.com/remote-1.png",
+          alt: "Remote screenshot 1",
+        },
+        {
+          type: "image",
+          url: "https://example.com/remote-2.png",
+          alt: "Remote screenshot 2",
         },
       ],
       audit: {
@@ -541,7 +546,10 @@ describe("MattermostAdapter — outbound deliver", () => {
         props: {
           attachments: [
             expect.objectContaining({
-              image_url: "https://example.com/remote.png",
+              image_url: "https://example.com/remote-1.png",
+            }),
+            expect.objectContaining({
+              image_url: "https://example.com/remote-2.png",
             }),
           ],
         },
@@ -650,6 +658,51 @@ describe("MattermostAdapter — outbound deliver", () => {
     for (const post of spies.createdPosts) {
       expect(post.message.length).toBeLessThanOrEqual(16_383);
     }
+  });
+
+  it("splits long text with images and attaches them to the final post", async () => {
+    const spies = {
+      createdPosts: [] as CreatedPost[],
+      patchedPosts: [] as PatchedPost[],
+      uploadedFiles: [] as FormData[],
+    };
+    const adapter = makeAdapter(spies);
+    const longText = `${"This is a full sentence that keeps going. ".repeat(500)}END`;
+
+    const result = await adapter.deliver({
+      id: "intent-long-images",
+      kind: "message",
+      createdAt: 1_700_000_000_000,
+      parts: [
+        { type: "text", text: longText },
+        { type: "image", url: "data:image/png;base64,AQID", alt: "Local" },
+        { type: "image", url: "https://example.com/remote.png", alt: "Remote" },
+      ],
+      audit: {
+        channel: dmChannel("dm-1"),
+        actor: { platformUserId: "user-1" },
+      },
+    } as unknown as MessagingSurfaceIntent);
+
+    expect(result.outcome).toBe("presented");
+    expect(spies.createdPosts.length).toBeGreaterThan(1);
+    expect(spies.uploadedFiles).toHaveLength(1);
+    for (const post of spies.createdPosts.slice(0, -1)) {
+      expect(post.file_ids).toBeUndefined();
+      expect(post.props).toBeUndefined();
+      expect(post.message.length).toBeLessThanOrEqual(16_383);
+    }
+    expect(spies.createdPosts.at(-1)).toMatchObject({
+      file_ids: ["file-1"],
+      message: expect.stringContaining("END"),
+      props: {
+        attachments: [
+          expect.objectContaining({
+            image_url: "https://example.com/remote.png",
+          }),
+        ],
+      },
+    });
   });
 
   it("returns failed outcome when neither audit.channel nor opaque postId is present", async () => {

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -498,6 +498,57 @@ describe("MattermostAdapter — outbound deliver", () => {
     expect(spies.createdPosts[0].root_id).toBeUndefined();
   });
 
+  it("uploads data images and embeds remote images in Mattermost posts", async () => {
+    const spies = {
+      createdPosts: [] as CreatedPost[],
+      patchedPosts: [] as PatchedPost[],
+      uploadedFiles: [] as FormData[],
+    };
+    const adapter = makeAdapter(spies);
+
+    await adapter.deliver({
+      id: "intent-images",
+      kind: "message",
+      createdAt: 1_700_000_000_000,
+      parts: [
+        { type: "text", text: "Final screenshots" },
+        {
+          type: "image",
+          url: "data:image/png;base64,AQID",
+          alt: "Local screenshot",
+        },
+        {
+          type: "image",
+          url: "https://example.com/remote.png",
+          alt: "Remote screenshot",
+        },
+      ],
+      audit: {
+        channel: dmChannel("dm-1"),
+        actor: { platformUserId: "user-1" },
+      },
+    } as unknown as MessagingSurfaceIntent);
+
+    expect(spies.uploadedFiles).toHaveLength(1);
+    const uploaded = spies.uploadedFiles[0]?.get("files");
+    expect(uploaded).toBeInstanceOf(Blob);
+    expect(uploaded).toMatchObject({ size: 3, type: "image/png" });
+    expect(spies.createdPosts).toEqual([
+      expect.objectContaining({
+        channel_id: "dm-1",
+        file_ids: ["file-1"],
+        message: "Final screenshots",
+        props: {
+          attachments: [
+            expect.objectContaining({
+              image_url: "https://example.com/remote.png",
+            }),
+          ],
+        },
+      }),
+    ]);
+  });
+
   function makeStreamIntent(params: {
     id: string;
     text: string;

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -30,6 +30,8 @@ import type {
   MessagingInboundEvent,
   MessagingInboundRejectedListener,
   MessagingJsonValue,
+  MessagingFilePart,
+  MessagingImagePart,
   MessagingRejectedInboundEvent,
   MessagingReconnectInfo,
   MessagingSurfaceAction,
@@ -1730,8 +1732,17 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       layout: intent.actionLayout,
     });
 
-    const attachment: MattermostMessageAttachment | undefined = buttons
-      ? { actions: buttons }
+    const remoteImageUrl = intent.kind === "message"
+      ? intent.parts.find(
+          (part): part is MessagingImagePart =>
+            part.type === "image" && /^https:\/\//iu.test(part.url),
+        )?.url
+      : undefined;
+    const attachment: MattermostMessageAttachment | undefined = buttons || remoteImageUrl
+      ? {
+          ...(buttons ? { actions: buttons } : {}),
+          ...(remoteImageUrl ? { image_url: remoteImageUrl } : {}),
+        }
       : undefined;
 
     const fileIds = await this.uploadOutboundFiles({
@@ -1745,7 +1756,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     // response_url delivery — which is the assistant-response path.
     if (
       intent.kind === "message" &&
-      !buttons &&
+      !attachment &&
       fileIds.length === 0 &&
       !(target.existingPostId && target.canUpdate) &&
       !target.responseUrl
@@ -2405,10 +2416,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
     if (params.intent.kind !== "message") {
       return [];
     }
-    const fileParts = params.intent.parts.filter(
-      (part): part is import("@pwragent/messaging-interface").MessagingFilePart =>
-        part.type === "file",
-    );
+    const fileParts = mattermostUploadParts(params.intent);
     if (fileParts.length === 0) {
       return [];
     }
@@ -2576,6 +2584,54 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       void listener(event);
     }
   }
+}
+
+function mattermostUploadParts(intent: MessagingSurfaceIntent): MessagingFilePart[] {
+  if (intent.kind !== "message") {
+    return [];
+  }
+  return intent.parts.flatMap((part, index): MessagingFilePart[] => {
+    if (part.type === "file") {
+      return [part];
+    }
+    if (part.type !== "image") {
+      return [];
+    }
+    const image = parseMattermostDataImageUrl(part.url);
+    if (!image) {
+      return [];
+    }
+    return [{
+      data: image.data,
+      description: part.alt,
+      mimeType: image.mimeType,
+      name: `image-${index + 1}.${image.extension}`,
+      sizeBytes: image.data.byteLength,
+      type: "file",
+    }];
+  });
+}
+
+function parseMattermostDataImageUrl(
+  url: string,
+): { data: Uint8Array; extension: string; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/iu.exec(url);
+  if (!match) {
+    return undefined;
+  }
+  const mimeType = match[1]?.toLowerCase();
+  const payload = match[2];
+  if (!mimeType || !payload) {
+    return undefined;
+  }
+  const extension = mimeType === "image/jpeg"
+    ? "jpg"
+    : mimeType.split("/")[1]?.replace(/[^a-z0-9]/giu, "") || "png";
+  return {
+    data: Buffer.from(payload, "base64"),
+    extension,
+    mimeType,
+  };
 }
 
 /**

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -1732,32 +1732,31 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       layout: intent.actionLayout,
     });
 
-    const remoteImageUrl = intent.kind === "message"
-      ? intent.parts.find(
-          (part): part is MessagingImagePart =>
-            part.type === "image" && /^https:\/\//iu.test(part.url),
-        )?.url
-      : undefined;
-    const attachment: MattermostMessageAttachment | undefined = buttons || remoteImageUrl
-      ? {
-          ...(buttons ? { actions: buttons } : {}),
-          ...(remoteImageUrl ? { image_url: remoteImageUrl } : {}),
-        }
-      : undefined;
+    const remoteImageAttachments: MattermostMessageAttachment[] = intent.kind === "message"
+      ? intent.parts
+          .filter(
+            (part): part is MessagingImagePart =>
+              part.type === "image" && /^https:\/\//iu.test(part.url),
+          )
+          .map((part) => ({ image_url: part.url }))
+      : [];
+    const attachments: MattermostMessageAttachment[] = [
+      ...(buttons ? [{ actions: buttons }] : []),
+      ...remoteImageAttachments,
+    ];
 
     const fileIds = await this.uploadOutboundFiles({
       channelId: target.channelId,
       intent,
     });
 
-    // Long text-only messages: split into several posts at clean boundaries so
-    // the per-post limit doesn't truncate the tail. Restricted to the simple
-    // case — a plain message, no buttons/attachments, not an edit or a
-    // response_url delivery — which is the assistant-response path.
+    // Long assistant messages: split into several posts at clean boundaries so
+    // the per-post limit doesn't truncate the tail. Images and uploaded files
+    // are attached to the final chunk. Restricted to the simple case — no
+    // buttons, not an edit or a response_url delivery.
     if (
       intent.kind === "message" &&
-      !attachment &&
-      fileIds.length === 0 &&
+      !buttons &&
       !(target.existingPostId && target.canUpdate) &&
       !target.responseUrl
     ) {
@@ -1767,11 +1766,16 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       });
       if (chunks.length > 1) {
         let firstSurface: MessagingSurfaceRef | undefined;
-        for (const chunk of chunks) {
+        for (const [index, chunk] of chunks.entries()) {
+          const isLastChunk = index === chunks.length - 1;
           const created = await this.client.createPost({
             channel_id: target.channelId,
             message: chunk,
             ...(target.rootId ? { root_id: target.rootId } : {}),
+            ...(isLastChunk && fileIds.length > 0 ? { file_ids: fileIds } : {}),
+            ...(isLastChunk && attachments.length > 0
+              ? { props: { attachments } }
+              : {}),
           });
           firstSurface ??= surfaceRefForPost(created.id, target.channelId, target.rootId);
         }
@@ -1788,7 +1792,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       message: text || " ",
       ...(target.rootId ? { root_id: target.rootId } : {}),
       ...(fileIds.length > 0 ? { file_ids: fileIds } : {}),
-      ...(attachment ? { props: { attachments: [attachment] } } : {}),
+      ...(attachments.length > 0 ? { props: { attachments } } : {}),
     };
 
     if (target.existingPostId && target.canUpdate) {
@@ -1844,7 +1848,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       const recovered = await this.deliverViaResponseUrl({
         channelId: target.channelId,
         message: post.message,
-        attachment,
+        attachments,
         responseUrl: target.responseUrl,
         invokerUserId: target.responseUrlInvokerUserId,
       });
@@ -1945,7 +1949,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
   private async deliverViaResponseUrl(params: {
     channelId: string;
     message: string;
-    attachment: MattermostMessageAttachment | undefined;
+    attachments: MattermostMessageAttachment[];
     responseUrl: string;
     /**
      * Mattermost's response_url handler stamps the resulting post
@@ -1969,7 +1973,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       // from_webhook prop gives us a defensive filter in
       // `handlePostedEvent` even if the post-id dedup misses.
       ...(this.botUsername ? { username: this.botUsername } : {}),
-      ...(params.attachment ? { attachments: [params.attachment] } : {}),
+      ...(params.attachments.length > 0 ? { attachments: params.attachments } : {}),
     };
     const before = this.now();
     try {

--- a/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-formatting.ts
@@ -285,7 +285,7 @@ function renderContentPart(part: MessagingContentPart): string | undefined {
     return renderMarkdownPolicy(part.text, part.markdown ?? "plain");
   }
   if (part.type === "image") {
-    return part.alt ? part.alt : undefined;
+    return undefined;
   }
   return [part.name, part.description, part.url]
     .filter((value): value is string => Boolean(value))

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -645,6 +645,78 @@ describe("SlackAdapter", () => {
     });
   });
 
+  it("uploads data images and renders remote images as Slack blocks", async () => {
+    const posted: unknown[] = [];
+    const uploads: Array<{
+      channel: string;
+      data: Uint8Array;
+      filename: string;
+      mimeType?: string;
+      threadTs?: string;
+      title?: string;
+    }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: {
+        ...fakeApi({ posted }),
+        uploadFile: async (params) => {
+          uploads.push(params);
+        },
+      },
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await adapter.deliver({
+      id: "message-images",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Final screenshots" },
+        {
+          type: "image",
+          url: "data:image/png;base64,AQID",
+          alt: "Local screenshot",
+        },
+        {
+          type: "image",
+          url: "https://example.com/remote.png",
+          alt: "Remote screenshot",
+        },
+      ],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        channel: {
+          channel: "slack",
+          conversation: { id: "D012ABCDEF0", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    });
+
+    expect(posted).toEqual([
+      expect.objectContaining({
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: "image",
+            image_url: "https://example.com/remote.png",
+            alt_text: "Remote screenshot",
+          }),
+        ]),
+      }),
+    ]);
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]).toMatchObject({
+      channel: "D012ABCDEF0",
+      filename: "image-2.png",
+      mimeType: "image/png",
+      title: "Local screenshot",
+    });
+    expect(Array.from(uploads[0]?.data ?? [])).toEqual([1, 2, 3]);
+  });
+
   it("delivers interactive status cards as Block Kit messages", async () => {
     const store = fakeStore();
     const spies: { posted: unknown[] } = { posted: [] };

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -2980,6 +2980,66 @@ describe("SlackAdapter", () => {
     }
   });
 
+  it("splits long Markdown with images and attaches them to the final post", async () => {
+    const posted: Array<{
+      blocks?: Array<{ image_url?: string; text?: string; type: string }>;
+      channel: string;
+      text?: string;
+    }> = [];
+    const uploads: Array<{ threadTs?: string }> = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: {
+        ...fakeApi({ posted }),
+        uploadFile: async (params) => {
+          uploads.push(params);
+        },
+      },
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const longText = `${"This is a full sentence that keeps going. ".repeat(320)}END`;
+
+    await expect(adapter.deliver({
+      id: "assistant-message-with-images",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: longText, markdown: "markdown" },
+        { type: "image", url: "https://example.com/remote.png", alt: "Remote" },
+        { type: "image", url: "data:image/png;base64,AQID", alt: "Local" },
+      ],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: { id: "D012ABCDEF0", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    } satisfies MessagingSurfaceIntent)).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "presented",
+    });
+
+    expect(posted.length).toBeGreaterThan(1);
+    expect(posted.at(-1)?.blocks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "image",
+        image_url: "https://example.com/remote.png",
+      }),
+    ]));
+    expect(
+      posted.slice(0, -1).flatMap((post) => post.blocks ?? [])
+        .some((block) => block.type === "image"),
+    ).toBe(false);
+    expect(posted.at(-1)?.blocks?.[0]?.text).toContain("END");
+    expect(uploads).toHaveLength(1);
+  });
+
   it("keeps oversized Markdown tables renderable across native Markdown posts", async () => {
     const posted: Array<{
       blocks?: Array<{ text?: string; type: string }>;

--- a/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-formatting.test.ts
@@ -90,6 +90,24 @@ describe("Slack formatting", () => {
     ]);
   });
 
+  it("clamps remote image alt text to Slack's plain-text limit", () => {
+    const alt = "a".repeat(2_500);
+    const intent: MessagingSurfaceIntent = {
+      id: "remote-image",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [{ type: "image", url: "https://example.com/image.png", alt }],
+    };
+
+    const [block] = buildSlackBlocksForIntent({ intent, text: "" });
+    expect(block).toMatchObject({
+      type: "image",
+      alt_text: `${"a".repeat(1_999)}…`,
+      title: expect.objectContaining({ text: `${"a".repeat(1_999)}…` }),
+    });
+  });
+
   it("splits legacy text by its escaped mrkdwn length", () => {
     const text = "<".repeat(3_000);
     const intent: MessagingSurfaceIntent = {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -564,7 +564,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       intent.kind === "message" &&
       (actionBlocks?.length ?? 0) === 0 &&
       intent.delivery?.mode !== "update" &&
-      !intent.parts.some((part) => part.type === "file")
+      !intent.parts.some((part) => part.type === "file" || part.type === "image")
     ) {
       const chunks = splitSlackTextForDelivery(intent, rawText);
       if (chunks.length > 1) {
@@ -2076,15 +2076,25 @@ export class SlackAdapter implements SlackProviderAdapter {
     threadTs?: string;
   }): Promise<void> {
     if (!this.api.uploadFile || params.intent.kind !== "message") return;
-    for (const part of params.intent.parts) {
-      if (part.type !== "file" || !part.data) continue;
+    for (const [index, part] of params.intent.parts.entries()) {
+      const image = part.type === "image" ? parseSlackDataImageUrl(part.url) : undefined;
+      if (part.type !== "file" && !image) continue;
+      const data = part.type === "file" ? part.data : image?.data;
+      if (!data) continue;
+      const filename = part.type === "file"
+        ? part.name
+        : `image-${index + 1}.${image?.extension ?? "png"}`;
       await this.api.uploadFile({
         channel: params.channelId,
-        data: part.data,
-        filename: part.name,
-        mimeType: part.mimeType,
+        data,
+        filename,
+        mimeType: part.type === "file" ? part.mimeType : image?.mimeType,
         threadTs: params.threadTs,
-        title: part.description ?? part.name,
+        title: part.type === "file"
+          ? part.description ?? part.name
+          : "alt" in part
+            ? part.alt ?? filename
+            : filename,
       });
     }
   }
@@ -2539,6 +2549,28 @@ function kindForSlackMime(mimeType: string | undefined): MessagingAttachmentDesc
   if (mimeType.startsWith("audio/")) return "audio";
   if (mimeType.startsWith("video/")) return "video";
   return "file";
+}
+
+function parseSlackDataImageUrl(
+  url: string,
+): { data: Uint8Array; extension: string; mimeType: string } | undefined {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/]+={0,2})$/iu.exec(url);
+  if (!match) {
+    return undefined;
+  }
+  const mimeType = match[1]?.toLowerCase();
+  const payload = match[2];
+  if (!mimeType || !payload) {
+    return undefined;
+  }
+  const extension = mimeType === "image/jpeg"
+    ? "jpg"
+    : mimeType.split("/")[1]?.replace(/[^a-z0-9]/giu, "") || "png";
+  return {
+    data: Buffer.from(payload, "base64"),
+    extension,
+    mimeType,
+  };
 }
 
 function normalizeSlackConversationTitle(value: string | undefined): string | undefined {

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -555,16 +555,16 @@ export class SlackAdapter implements SlackProviderAdapter {
       capabilityProfile: this.capabilityProfile,
       layout: intent.actionLayout,
     });
-    // Long text-only messages: split into several posts at clean boundaries so
+    // Long assistant messages: split into several posts at clean boundaries so
     // neither a 12,000-char standard-Markdown block nor a legacy 3,000-char
-    // section block truncates the tail. Restricted to the simple case — a
-    // message with no buttons, attachments, or in-place edit — which is exactly
-    // the assistant-response path.
+    // section block truncates the tail. Images are attached to the final chunk;
+    // file attachments and interactive/update surfaces retain the single-post
+    // path because their placement and update semantics are more specialized.
     if (
       intent.kind === "message" &&
       (actionBlocks?.length ?? 0) === 0 &&
       intent.delivery?.mode !== "update" &&
-      !intent.parts.some((part) => part.type === "file" || part.type === "image")
+      !intent.parts.some((part) => part.type === "file")
     ) {
       const chunks = splitSlackTextForDelivery(intent, rawText);
       if (chunks.length > 1) {
@@ -1122,10 +1122,11 @@ export class SlackAdapter implements SlackProviderAdapter {
   }
 
   /**
-   * Post a long text-only message as several Slack messages, one per chunk, so
+   * Post a long message as several Slack messages, one per chunk, so
    * the content is never truncated at the 3000-char section-block limit. The
-   * chunks are already boundary-split by the caller. Returns the first message
-   * as the surface (mirrors a single-post delivery).
+   * chunks are already boundary-split by the caller. Remote image blocks and
+   * uploaded data images are associated with the final chunk. Returns the first
+   * message as the surface (mirrors a single-post delivery).
    */
   private async deliverChunkedTextMessage(params: {
     intent: Extract<MessagingSurfaceIntent, { kind: "message" }>;
@@ -1134,9 +1135,17 @@ export class SlackAdapter implements SlackProviderAdapter {
   }): Promise<MessagingDeliveryResult> {
     let firstSurface: MessagingSurfaceRef | undefined;
     let deliveredAny = false;
+    let lastTs: string | undefined;
     try {
-      for (const chunk of params.chunks) {
-        const blocks = buildSlackBlocksForIntent({ intent: params.intent, text: chunk });
+      for (const [index, chunk] of params.chunks.entries()) {
+        const isLastChunk = index === params.chunks.length - 1;
+        const chunkIntent = isLastChunk
+          ? params.intent
+          : {
+              ...params.intent,
+              parts: params.intent.parts.filter((part) => part.type !== "image"),
+            };
+        const blocks = buildSlackBlocksForIntent({ intent: chunkIntent, text: chunk });
         const result = await this.api.postMessage({
           channel: params.target.channelId,
           text: clampSlackMessage(markdownToSlackMrkdwn(chunk)) || "PwrAgent",
@@ -1147,6 +1156,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         });
         deliveredAny = true;
         const ts = result.ts;
+        lastTs = ts ?? lastTs;
         if (ts && !firstSurface) {
           firstSurface = {
             channel: this.channel,
@@ -1161,6 +1171,11 @@ export class SlackAdapter implements SlackProviderAdapter {
           };
         }
       }
+      await this.uploadOutboundFiles({
+        channelId: params.target.channelId,
+        intent: params.intent,
+        threadTs: params.target.threadTs ?? lastTs,
+      });
       return {
         outcome: "presented",
         channel: this.channel,

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -220,7 +220,7 @@ export function buildSlackBlocksForIntent(params: {
       blocks.push({
         type: "image",
         image_url: part.url,
-        alt_text: alt,
+        alt_text: truncateSlackPlainText(alt, 2_000),
         title: {
           type: "plain_text",
           text: truncateSlackPlainText(alt, 2_000),

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -56,6 +56,13 @@ export type SlackMarkdownBlock = {
   text: string;
 };
 
+export type SlackImageBlock = {
+  type: "image";
+  image_url: string;
+  alt_text: string;
+  title?: SlackTextObject & { type: "plain_text" };
+};
+
 export type SlackContextBlock = {
   type: "context";
   block_id?: string;
@@ -79,6 +86,7 @@ export type SlackActionsBlock = {
 export type SlackBlock =
   | SlackActionsBlock
   | SlackContextBlock
+  | SlackImageBlock
   | SlackMarkdownBlock
   | SlackSectionBlock;
 
@@ -201,6 +209,24 @@ export function buildSlackBlocksForIntent(params: {
         },
       ],
     });
+  }
+
+  if (params.intent.kind === "message") {
+    for (const [index, part] of params.intent.parts.entries()) {
+      if (part.type !== "image" || !/^https:\/\//iu.test(part.url)) {
+        continue;
+      }
+      const alt = part.alt?.trim() || `Assistant image ${index + 1}`;
+      blocks.push({
+        type: "image",
+        image_url: part.url,
+        alt_text: alt,
+        title: {
+          type: "plain_text",
+          text: truncateSlackPlainText(alt, 2_000),
+        },
+      });
+    }
   }
 
   if (params.actionBlocks) {
@@ -685,7 +711,7 @@ function renderContentParts(parts: MessagingContentPart[]): string {
     .map((part) => {
       if (part.type === "text") return part.text;
       if (part.type === "file") return part.description ?? part.name;
-      if (part.type === "image") return "[image]";
+      if (part.type === "image") return part.alt ?? "[image]";
       return "";
     })
     .filter(Boolean)

--- a/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
+++ b/packages/messaging/providers/telegram/src/__tests__/telegram-grammy-adapter.test.ts
@@ -165,6 +165,53 @@ describe("adaptGrammyBot", () => {
 });
 
 describe("TelegramAdapter callback persistence", () => {
+  it("sends every assistant image", async () => {
+    const api = fakeTelegramApi();
+    const sendPhoto = vi.spyOn(api, "sendPhoto");
+    const adapter = new TelegramAdapter({
+      api,
+      config: {
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        botToken: "token",
+        channel: "telegram",
+      },
+      now: () => 1_700_000_000_000,
+      store: fakeCallbackStore(),
+    });
+
+    await adapter.deliver({
+      id: "assistant-images",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "Two screenshots" },
+        { type: "image", url: "data:image/png;base64,AQID", alt: "One" },
+        { type: "image", url: "https://example.com/two.png", alt: "Two" },
+      ],
+      audit: {
+        actor: { platformUserId: "user-1" },
+        channel: {
+          channel: "telegram",
+          conversation: { id: "42", kind: "dm" },
+        },
+        occurredAt: 1,
+      },
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(sendPhoto.mock.calls[0]?.[0]).toMatchObject({
+      caption: expect.stringContaining("Two screenshots"),
+      chat_id: 42,
+      photo: new Uint8Array([1, 2, 3]),
+    });
+    expect(sendPhoto.mock.calls[1]?.[0]).toMatchObject({
+      caption: undefined,
+      chat_id: 42,
+      photo: "https://example.com/two.png",
+    });
+  });
+
   it("registers Agent and Monitor with Telegram bot commands", async () => {
     const grammyBot = createGrammyBot();
     const adapter = new TelegramAdapter({

--- a/packages/messaging/providers/telegram/src/telegram-adapter.ts
+++ b/packages/messaging/providers/telegram/src/telegram-adapter.ts
@@ -869,17 +869,17 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     const replyMarkup = await this.buildReplyMarkup(intent, actions);
     const files = uploadableFileParts(intent);
     const text = files.length > 0 ? textForTelegramIntentWithoutFiles(intent) : textForTelegramIntent(intent);
-    const image = this.firstImagePayload(intent);
+    const images = this.imagePayloads(intent);
     const sentMessages: TelegramSentMessage[] = [];
     let outcome: MessagingDeliveryResult["outcome"] = "presented";
     this.options.logger?.debug(
-      `telegram deliver begin kind=${intent.kind} mode=${intent.delivery?.mode ?? "new"} target=${this.compactTypingTarget(target)} chars=${text.length} actions=${actions.length} image=${Boolean(image)} files=${files.length} preview="${compactPreview(text)}"`,
+      `telegram deliver begin kind=${intent.kind} mode=${intent.delivery?.mode ?? "new"} target=${this.compactTypingTarget(target)} chars=${text.length} actions=${actions.length} images=${images.length} files=${files.length} preview="${compactPreview(text)}"`,
     );
 
     if (
       intent.delivery?.mode === "update" &&
       target.messageId &&
-      !image &&
+      images.length === 0 &&
       files.length === 0 &&
       Buffer.byteLength(text || " ", "utf8") <= 4096
     ) {
@@ -943,18 +943,39 @@ export class TelegramAdapter implements TelegramProviderAdapter {
           }),
         );
       }
-    } else if (image) {
-      sentMessages.push(
-        await this.bot.api.sendPhoto({
-          caption: text.slice(0, 1024) || undefined,
-          chat_id: target.chatId,
-          message_thread_id: target.messageThreadId,
-          parse_mode: text ? "HTML" : undefined,
-          filename: image.filename,
-          photo: image.source,
-          reply_markup: replyMarkup,
-        }),
-      );
+    } else if (images.length > 0) {
+      const caption = text && Buffer.byteLength(text, "utf8") <= 1024
+        ? text
+        : undefined;
+      if (text && !caption) {
+        const chunks = splitTelegramHtml(text);
+        for (const chunk of chunks) {
+          sentMessages.push(
+            await this.bot.api.sendMessage({
+              chat_id: target.chatId,
+              disable_web_page_preview: true,
+              message_thread_id: target.messageThreadId,
+              parse_mode: "HTML",
+              text: chunk,
+            }),
+          );
+        }
+      }
+
+      const lastImageIndex = images.length - 1;
+      for (const [index, image] of images.entries()) {
+        sentMessages.push(
+          await this.bot.api.sendPhoto({
+            caption: index === 0 ? caption : undefined,
+            chat_id: target.chatId,
+            message_thread_id: target.messageThreadId,
+            parse_mode: caption && index === 0 ? "HTML" : undefined,
+            filename: image.filename,
+            photo: image.source,
+            reply_markup: index === lastImageIndex ? replyMarkup : undefined,
+          }),
+        );
+      }
     } else {
       const chunks = splitTelegramHtml(text || " ");
       const lastChunkIndex = chunks.length - 1;
@@ -2115,24 +2136,20 @@ export class TelegramAdapter implements TelegramProviderAdapter {
     };
   }
 
-  private firstImagePayload(
+  private imagePayloads(
     intent: MessagingSurfaceIntent,
-  ): { filename?: string; source: string | Uint8Array } | undefined {
+  ): Array<{ filename?: string; source: string | Uint8Array }> {
     if (intent.kind !== "message") {
-      return undefined;
+      return [];
     }
 
-    const url = intent.parts.find((part) => part.type === "image" && "url" in part)?.url;
-    if (!url) {
-      return undefined;
-    }
-
-    const dataImage = parseDataImageUrl(url);
-    if (dataImage) {
-      return dataImage;
-    }
-
-    return { source: url };
+    return intent.parts.flatMap((part) => {
+      if (part.type !== "image" || !part.url) {
+        return [];
+      }
+      const dataImage = parseDataImageUrl(part.url);
+      return [dataImage ?? { source: part.url }];
+    });
   }
 
   private async deliverActivity(


### PR DESCRIPTION
## Summary

- resolve final assistant image parts and local Markdown image links through the durable transcript image cache before outbound messaging delivery
- attach images to final and resumed assistant messages, including a follow-up image message when text was finalized through streaming
- add provider-native delivery for Telegram, Discord, Slack, Mattermost, and Feishu; preserve LINE's HTTPS-only image behavior

## Why

Final assistant text already flowed through the backend event bus to messaging adapters, but the controller reduced completed responses to one text part. Local screenshot links also used renderer-only or machine-local URLs, so external users could not receive the images.

## User impact

Users in bound messaging conversations now receive assistant-generated screenshots and other final-response images. Local temporary images are copied into the profile-owned transcript cache first, so delivery and later hydration do not depend on `/tmp` surviving.

LINE can render HTTPS image URLs but cannot upload local bytes, so local-only images degrade to the text response there.

## Validation

- focused messaging and image tests: 9 files, 542 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`
- `pnpm lint:colors`
- `pnpm licenses:check`
