### PR TITLE
fix(desktop): polish environment setup status

### DIFF
--- a/apps/desktop/e2e/codex-environment-setup.spec.ts
+++ b/apps/desktop/e2e/codex-environment-setup.spec.ts
@@ -391,6 +391,16 @@ test("selected environments run setup and show transcript output", async () => {
         .getByRole("region", { name: "Preparing transcript" })
         .getByRole("heading", { name: "Running environment setup" }),
     ).toBeVisible();
+    const pendingSetup = app.window.getByRole("region", {
+      name: "Preparing transcript",
+    });
+    await expect(pendingSetup.getByText("Running", { exact: true })).toBeVisible();
+    await expect(
+      pendingSetup.getByRole("button", { name: "Copy setup path" }),
+    ).toBeVisible();
+    await expect(
+      pendingSetup.getByRole("button", { name: "Copy setup command" }),
+    ).toBeVisible();
     await expect(
       app.window
         .locator('[aria-label="Setup command"]')
@@ -399,7 +409,9 @@ test("selected environments run setup and show transcript output", async () => {
     await expect(app.window.locator('[aria-label="Setup output"]')).toContainText(
       "setup-output",
     );
-
+    await expect(
+      pendingSetup.getByRole("button", { name: "Copy setup output" }),
+    ).toBeVisible();
     await expect(
       app.window.getByRole("heading", { level: 2, name: "hello env" }),
     ).toBeVisible();

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -79,6 +79,7 @@ import { ThreadFindBar } from "./ThreadFindBar";
 import { ThreadHeader } from "./ThreadHeader";
 import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { ImageLightbox } from "./ImageLightbox";
+import { TranscriptCopyButton } from "./TranscriptCopyButton";
 import { TranscriptList } from "./TranscriptList";
 import { LiveWorkRail } from "./LiveWorkRail";
 import {
@@ -223,25 +224,58 @@ function applyLaunchpadEnvironmentSetupProgress(
   };
 }
 
-function formatSetupStatus(progress?: LaunchpadEnvironmentSetupProgress): string {
+function formatSetupStatus(progress?: LaunchpadEnvironmentSetupProgress): {
+  heading: string;
+  label: string;
+  tone: "failed" | "running" | "success";
+} {
   if (!progress || progress.status === "starting" || progress.status === "running") {
-    return "running";
+    return {
+      heading: "Running environment setup",
+      label: "Running",
+      tone: "running",
+    };
   }
   if (progress.status === "completed") {
-    return progress.exitCode === undefined ? "completed" : `exit ${progress.exitCode}`;
+    if (progress.exitCode === undefined) {
+      return {
+        heading: "Environment setup complete",
+        label: "Success",
+        tone: "success",
+      };
+    }
+    if (progress.exitCode === 0) {
+      return {
+        heading: "Environment setup complete",
+        label: "Success (exit code 0)",
+        tone: "success",
+      };
+    }
+    return {
+      heading: "Environment setup failed",
+      label: `Failed (exit code ${progress.exitCode})`,
+      tone: "failed",
+    };
   }
-  return "failed";
+  return {
+    heading: "Environment setup failed",
+    label: "Failed",
+    tone: "failed",
+  };
 }
 
 function LaunchpadEnvironmentSetupPending(props: {
   command?: string;
   cwd?: string;
+  desktopApi?: Pick<DesktopApi, "copyText">;
   directoryLabel: string;
   environmentName?: string;
   progress?: LaunchpadEnvironmentSetupProgress;
 }) {
   const output = props.progress?.output ?? "";
   const error = props.progress?.error;
+  const renderedOutput = `${output}${error ? `\n${error}` : ""}`;
+  const status = formatSetupStatus(props.progress);
   const outputRef = useRef<HTMLPreElement>(null);
 
   useEffect(() => {
@@ -261,10 +295,12 @@ function LaunchpadEnvironmentSetupPending(props: {
         <div className="launchpad-pending__header">
           <div>
             <p className="eyebrow">Preparing transcript</p>
-            <h3>Running environment setup</h3>
+            <h3>{status.heading}</h3>
           </div>
-          <span className="launchpad-pending__status">
-            {formatSetupStatus(props.progress)}
+          <span
+            className={`launchpad-pending__status launchpad-pending__status--${status.tone}`}
+          >
+            {status.label}
           </span>
         </div>
         <dl className="launchpad-pending__meta">
@@ -277,24 +313,52 @@ function LaunchpadEnvironmentSetupPending(props: {
             <dd>{props.directoryLabel}</dd>
           </div>
           {props.cwd ? (
-            <div>
-              <dt>Path</dt>
+            <div className="launchpad-pending__meta-path">
+              <dt className="launchpad-pending__meta-label">
+                <span>Path</span>
+                <TranscriptCopyButton
+                  className="transcript-copy-button--setup"
+                  desktopApi={props.desktopApi}
+                  label="Copy setup path"
+                  text={props.cwd}
+                />
+              </dt>
               <dd>{props.cwd}</dd>
             </div>
           ) : null}
         </dl>
         <div className="launchpad-pending__command" aria-label="Setup command">
-          <div className="launchpad-pending__command-label">Command</div>
+          <div className="launchpad-pending__section-header">
+            <div className="launchpad-pending__command-label">Command</div>
+            {props.command ? (
+              <TranscriptCopyButton
+                className="transcript-copy-button--setup"
+                desktopApi={props.desktopApi}
+                label="Copy setup command"
+                text={props.command}
+              />
+            ) : null}
+          </div>
           <pre>
             <code>{props.command ? `$ ${props.command}` : "$"}</code>
           </pre>
         </div>
         <div className="launchpad-pending__output" aria-label="Setup output">
-          <div className="launchpad-pending__command-label">
-            {error ? "Output and errors" : "Output"}
+          <div className="launchpad-pending__section-header">
+            <div className="launchpad-pending__command-label">
+              {error ? "Output and errors" : "Output"}
+            </div>
+            {renderedOutput ? (
+              <TranscriptCopyButton
+                className="transcript-copy-button--setup"
+                desktopApi={props.desktopApi}
+                label={error ? "Copy setup output and errors" : "Copy setup output"}
+                text={renderedOutput}
+              />
+            ) : null}
           </div>
           <pre ref={outputRef}>
-            <code>{`${output}${error ? `\n${error}` : ""}` || "Waiting for output..."}</code>
+            <code>{renderedOutput || "Waiting for output..."}</code>
           </pre>
         </div>
       </div>
@@ -2595,6 +2659,7 @@ export function ThreadView(props: ThreadViewProps) {
                   pendingForkEnvironmentSetup.command
                 }
                 cwd={launchpadSetupProgress?.cwd ?? pendingForkEnvironmentSetup.cwd}
+                desktopApi={props.desktopApi}
                 directoryLabel={pendingForkEnvironmentSetup.directoryLabel}
                 environmentName={
                   launchpadSetupProgress?.environmentName ??
@@ -2753,6 +2818,7 @@ export function ThreadView(props: ThreadViewProps) {
                   cwd={
                     launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath
                   }
+                  desktopApi={props.desktopApi}
                   directoryLabel={selectedLaunchpad.directoryLabel}
                   environmentName={
                     launchpadSetupProgress?.environmentName ??

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -213,7 +213,10 @@ function applyLaunchpadEnvironmentSetupProgress(
   if (event.phase === "failed") {
     return {
       ...base,
+      durationMs: event.durationMs,
       error: event.error,
+      exitCode: event.exitCode,
+      output: event.output ?? base.output,
       status: "failed",
     };
   }
@@ -257,6 +260,13 @@ function formatSetupStatus(progress?: LaunchpadEnvironmentSetupProgress): {
       tone: "failed",
     };
   }
+  if (progress.exitCode !== undefined) {
+    return {
+      heading: "Environment setup failed",
+      label: `Failed (exit code ${progress.exitCode})`,
+      tone: "failed",
+    };
+  }
   return {
     heading: "Environment setup failed",
     label: "Failed",
@@ -266,6 +276,7 @@ function formatSetupStatus(progress?: LaunchpadEnvironmentSetupProgress): {
 
 function LaunchpadEnvironmentSetupPending(props: {
   command?: string;
+  confirmedCwd?: string;
   cwd?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
   directoryLabel: string;
@@ -316,12 +327,14 @@ function LaunchpadEnvironmentSetupPending(props: {
             <div className="launchpad-pending__meta-path">
               <dt className="launchpad-pending__meta-label">
                 <span>Path</span>
-                <TranscriptCopyButton
-                  className="transcript-copy-button--setup"
-                  desktopApi={props.desktopApi}
-                  label="Copy setup path"
-                  text={props.cwd}
-                />
+                {props.confirmedCwd ? (
+                  <TranscriptCopyButton
+                    className="transcript-copy-button--setup"
+                    desktopApi={props.desktopApi}
+                    label="Copy setup path"
+                    text={props.confirmedCwd}
+                  />
+                ) : null}
               </dt>
               <dd>{props.cwd}</dd>
             </div>
@@ -2658,6 +2671,7 @@ export function ThreadView(props: ThreadViewProps) {
                   launchpadSetupProgress?.command ??
                   pendingForkEnvironmentSetup.command
                 }
+                confirmedCwd={launchpadSetupProgress?.cwd}
                 cwd={launchpadSetupProgress?.cwd ?? pendingForkEnvironmentSetup.cwd}
                 desktopApi={props.desktopApi}
                 directoryLabel={pendingForkEnvironmentSetup.directoryLabel}
@@ -2815,6 +2829,7 @@ export function ThreadView(props: ThreadViewProps) {
                     launchpadSetupProgress?.command ??
                     selectedLaunchpadCodexEnvironment?.setupScript
                   }
+                  confirmedCwd={launchpadSetupProgress?.cwd}
                   cwd={
                     launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath
                   }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1538,7 +1538,9 @@ describe("ThreadView", () => {
     let setupProgress: Parameters<
       NonNullable<DesktopApi["onCodexEnvironmentSetupProgress"]>
     >[0] = () => undefined;
+    const copyText = vi.fn(async () => undefined);
     const desktopApi = {
+      copyText,
       onCodexEnvironmentSetupProgress: (callback: typeof setupProgress) => {
         setupProgress = callback;
         return () => undefined;
@@ -1594,6 +1596,44 @@ describe("ThreadView", () => {
     expect(screen.getByLabelText("Setup output")).toHaveTextContent(
       "installing dependencies",
     );
+    expect(screen.getByRole("button", { name: "Copy setup path" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Copy setup command" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Copy setup output" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy setup path" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy setup command" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy setup output" }));
+
+    await waitFor(() => {
+      expect(copyText).toHaveBeenNthCalledWith(
+        1,
+        "/repo/app/.worktrees/thread-fork/app",
+      );
+      expect(copyText).toHaveBeenNthCalledWith(2, "pnpm install");
+      expect(copyText).toHaveBeenNthCalledWith(3, "installing dependencies\n");
+    });
+
+    act(() => {
+      setupProgress({
+        at: Date.now(),
+        command: "pnpm install",
+        cwd: "/repo/app/.worktrees/thread-fork/app",
+        directoryKey: "fork:codex:thread-parent:new-worktree",
+        durationMs: 1200,
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        exitCode: 0,
+        output: "installing dependencies\n",
+        phase: "completed",
+      });
+    });
+
+    expect(screen.getByText("Success (exit code 0)")).toHaveClass(
+      "launchpad-pending__status--success",
+    );
+    expect(
+      screen.getByRole("heading", { name: "Environment setup complete" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps launch failures closable from the pending setup screen", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -1532,6 +1532,10 @@ describe("ThreadView", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Setup command")).toHaveTextContent("pnpm install");
     expect(screen.getAllByText("PwrSnap").length).toBeGreaterThan(0);
+    expect(screen.getByText("/repo")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy setup path" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows pending environment setup while a forked worktree is preparing", async () => {
@@ -1560,6 +1564,7 @@ describe("ThreadView", () => {
         pendingForkEnvironmentSetup={{
           backend: "codex",
           command: "pnpm install",
+          cwd: "/repo/app",
           directoryKey: "fork:codex:thread-parent:new-worktree",
           directoryLabel: "PwrAgent",
           environmentId: "pwragent",
@@ -1576,6 +1581,10 @@ describe("ThreadView", () => {
       screen.getByRole("heading", { name: "Running environment setup" }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Setup command")).toHaveTextContent("pnpm install");
+    expect(screen.getByText("/repo/app")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy setup path" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Forking thread" })).toBeInTheDocument();
     expect(screen.getByLabelText("New thread context")).toBeInTheDocument();
 
@@ -1634,6 +1643,32 @@ describe("ThreadView", () => {
     expect(
       screen.getByRole("heading", { name: "Environment setup complete" }),
     ).toBeInTheDocument();
+
+    act(() => {
+      setupProgress({
+        at: Date.now(),
+        command: "pnpm install",
+        cwd: "/repo/app/.worktrees/thread-fork/app",
+        directoryKey: "fork:codex:thread-parent:new-worktree",
+        durationMs: 1400,
+        environmentId: "pwragent",
+        environmentName: "PwrAgent",
+        error: "Setup failed with exit code 17",
+        exitCode: 17,
+        output: "dependency install failed\n",
+        phase: "failed",
+      });
+    });
+
+    expect(screen.getByText("Failed (exit code 17)")).toHaveClass(
+      "launchpad-pending__status--failed",
+    );
+    expect(
+      screen.getByRole("heading", { name: "Environment setup failed" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Setup output")).toHaveTextContent(
+      "dependency install failed",
+    );
   });
 
   it("keeps launch failures closable from the pending setup screen", async () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -398,6 +398,27 @@ describe("Tangerine Terminal theme contract", () => {
     expect(setupComposerRule).toContain("min-height: 0;");
   });
 
+  it("keeps environment setup status, copying, and path wrapping on theme tokens", () => {
+    const setupRule = extractRuleBody(css, ".launchpad-pending--setup");
+    const successRule = extractRuleBody(
+      css,
+      ".launchpad-pending__status--success"
+    );
+    const copyButtonRule = extractRuleBody(
+      css,
+      ".transcript-copy-button.transcript-copy-button--setup"
+    );
+
+    expect(setupRule).toContain("container-type: inline-size;");
+    expect(successRule).toContain("border-color: var(--success-border);");
+    expect(successRule).toContain("background: var(--success-soft);");
+    expect(successRule).toContain("color: var(--success-text);");
+    expect(copyButtonRule).toContain("opacity: 1;");
+    expect(css).toMatch(
+      /@container \(max-width: 1000px\)\s*\{[\s\S]*?\.launchpad-pending__meta-path\s*\{[\s\S]*?grid-column:\s*1 \/ -1;/
+    );
+  });
+
   it("keeps launchpad composer errors selectable and directly copyable", () => {
     const errorRule = extractRuleBody(css, ".composer__meta--copyable");
     const errorTextRule = extractRuleBody(css, ".composer__meta-text");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9057,6 +9057,7 @@ textarea,
      while the run is still in progress. */
   user-select: text;
   -webkit-user-select: text;
+  container-type: inline-size;
 }
 
 .launchpad-pending__header {
@@ -9082,6 +9083,18 @@ textarea,
   text-transform: uppercase;
 }
 
+.launchpad-pending__status--success {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
+}
+
+.launchpad-pending__status--failed {
+  border-color: var(--danger-border);
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+
 .launchpad-pending h3 {
   margin: 4px 0 0;
   color: var(--text-primary);
@@ -9098,7 +9111,10 @@ textarea,
 
 .launchpad-pending__meta {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns:
+    minmax(0, 0.8fr)
+    minmax(0, 0.8fr)
+    minmax(0, 1.6fr);
   gap: 12px;
   margin: 0;
   padding: 0;
@@ -9117,6 +9133,22 @@ textarea,
   letter-spacing: 0;
   line-height: 1.2;
   text-transform: uppercase;
+}
+
+.launchpad-pending__meta-label,
+.launchpad-pending__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.launchpad-pending__meta-label {
+  margin-bottom: 5px;
+}
+
+.launchpad-pending__meta-label .transcript-copy-button--setup {
+  margin-top: -5px;
 }
 
 .launchpad-pending__meta dd {
@@ -9142,6 +9174,10 @@ textarea,
   max-height: min(230px, 36vh);
 }
 
+.launchpad-pending__command .launchpad-pending__section-header {
+  margin-bottom: 5px;
+}
+
 .launchpad-pending__command pre,
 .launchpad-pending__output pre {
   margin: 0;
@@ -9161,11 +9197,21 @@ textarea,
   overflow: hidden;
 }
 
-.launchpad-pending__output .launchpad-pending__command-label {
+.launchpad-pending__output .launchpad-pending__section-header {
   flex: 0 0 auto;
-  margin: 0;
-  padding: 12px 12px 8px;
+  padding: 8px 10px 8px 12px;
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.launchpad-pending__section-header .launchpad-pending__command-label {
+  margin: 0;
+}
+
+.transcript-copy-button.transcript-copy-button--setup {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  opacity: 1;
 }
 
 .launchpad-pending__output pre {
@@ -9173,6 +9219,16 @@ textarea,
   min-height: 0;
   padding: 12px;
   overflow: auto;
+}
+
+@container (max-width: 1000px) {
+  .launchpad-pending__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .launchpad-pending__meta-path {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## Summary

- replace the technical `Exit 0` setup state with a green `Success (exit code 0)` badge and matching completion heading
- keep non-zero exits and setup failures in the semantic danger treatment
- move long setup paths to a full-width second row when the setup pane narrows
- add the standard copy affordance to Path, Command, and Output
- extend renderer, theme-contract, and Electron E2E coverage

## Why

The setup status used the accent treatment for every state and exposed a raw exit code even when setup succeeded. The metadata grid also gave long paths only one third of the pane, causing awkward wrapping, and the setup details lacked the copy interaction used elsewhere in the desktop app.

## User impact

Environment setup now communicates success in plain language, keeps long paths readable in constrained layouts, and lets operators copy the path, raw command, or current output directly.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test:desktop-e2e e2e/codex-environment-setup.spec.ts --grep "selected environments run setup and show transcript output"`
- `pnpm lint:eslint`
- `pnpm typecheck`
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- visual QA in the deterministic Electron environment-setup fixture at the constrained pane width with the context rail open
