### PR TITLE
fix(desktop): prevent startup watchdog false positive

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -115,7 +115,7 @@ const BrowserWindowMock = vi.fn(function BrowserWindow(
     }
   );
   browserWindowState.setWindowOpenHandler = vi.fn();
-  browserWindowState.show = vi.fn();
+  browserWindowState.show = vi.fn(() => emitWindowEvent("show"));
 
   return {
     loadFile: browserWindowState.loadFile,
@@ -478,6 +478,16 @@ describe("createMainWindow", () => {
 
     expect(startupCpuProfiler.attachWindow).toHaveBeenCalledTimes(1);
     expect(browserWindowState.loadURL).toHaveBeenCalledWith("http://127.0.0.1:5173");
+  });
+
+  it("reports an early show event before createMainWindow returns", async () => {
+    const onShown = vi.fn();
+
+    const { createMainWindow } = await import("../window");
+    createMainWindow({ onShown });
+
+    expect(browserWindowState.show).toHaveBeenCalledTimes(1);
+    expect(onShown).toHaveBeenCalledTimes(1);
   });
 
   it("starts and stops heap diagnostics when enabled", async () => {

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -94,6 +94,9 @@ const buildFromTemplateMock = vi.fn((template: unknown) => ({
   template,
 }));
 const shellOpenExternalMock = vi.fn(async () => undefined);
+const shellOpenPathMock = vi.fn(async () => "");
+const shellShowItemInFolderMock = vi.fn();
+const showMessageBoxSyncMock = vi.fn(() => 0);
 const setNameMock = vi.fn();
 const setAboutPanelOptionsMock = vi.fn();
 const showAboutPanelMock = vi.fn();
@@ -168,6 +171,11 @@ vi.mock("electron", () => ({
   },
   shell: {
     openExternal: shellOpenExternalMock,
+    openPath: shellOpenPathMock,
+    showItemInFolder: shellShowItemInFolderMock,
+  },
+  dialog: {
+    showMessageBoxSync: showMessageBoxSyncMock,
   },
   protocol: {
     handle: protocolHandleMock,
@@ -320,6 +328,7 @@ vi.mock("../ipc/window-pointer", () => ({
 }));
 
 vi.mock("../log", () => ({
+  getMainLogFilePath: vi.fn(() => "/tmp/profile-dev.main.log"),
   initializeMainLogger: initializeMainLoggerMock,
   resolveMainLogProfileName: resolveMainLogProfileNameMock,
   getMainLogger: vi.fn(() => ({
@@ -536,6 +545,11 @@ describe("bootstrapApp", () => {
     disposeMessagingStatusIpcHandlersMock.mockReset();
     setApplicationMenuMock.mockReset();
     shellOpenExternalMock.mockReset();
+    shellOpenPathMock.mockReset();
+    shellOpenPathMock.mockResolvedValue("");
+    shellShowItemInFolderMock.mockReset();
+    showMessageBoxSyncMock.mockReset();
+    showMessageBoxSyncMock.mockReturnValue(0);
     buildFromTemplateMock.mockClear();
     setNameMock.mockReset();
     setAboutPanelOptionsMock.mockReset();
@@ -582,6 +596,7 @@ describe("bootstrapApp", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    vi.useRealTimers();
     vi.unstubAllEnvs();
   });
 
@@ -606,6 +621,7 @@ describe("bootstrapApp", () => {
 
     expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(registerAppServerIpcHandlersMock).toHaveBeenCalledTimes(1);
@@ -631,6 +647,54 @@ describe("bootstrapApp", () => {
       expect.objectContaining({ onFocus: expect.any(Function) }),
     );
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the watchdog when the window shows before createMainWindow returns", async () => {
+    vi.useFakeTimers();
+    startupProfilerInstance.start.mockResolvedValue();
+    createMainWindowMock.mockImplementation(
+      (options?: { onShown?: () => void }) => {
+        options?.onShown?.();
+        return {
+          isVisible: () => false,
+          on: (event: string, handler: (...args: unknown[]) => void) => {
+            mainWindowHandlers.set(event, handler);
+          },
+          once: (event: string, handler: (...args: unknown[]) => void) => {
+            mainWindowHandlers.set(event, handler);
+          },
+        };
+      },
+    );
+
+    await import("../index");
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    expect(showMessageBoxSyncMock).not.toHaveBeenCalled();
+    expect(mainLogErrorMock).not.toHaveBeenCalledWith(
+      "startup failed before the main window appeared",
+      expect.anything(),
+    );
+  });
+
+  it("surfaces a boot failure when the main window never shows", async () => {
+    vi.useFakeTimers();
+    startupProfilerInstance.start.mockResolvedValue();
+
+    await import("../index");
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(25_000);
+
+    expect(showMessageBoxSyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "PwrAgent failed to start",
+      }),
+    );
+    expect(mainLogErrorMock).toHaveBeenCalledWith(
+      "startup failed before the main window appeared",
+      expect.objectContaining({ reason: "watchdog-timeout" }),
+    );
   });
 
   it("sets the About panel version without duplicating it as a build value", async () => {
@@ -671,6 +735,7 @@ describe("bootstrapApp", () => {
     expect(messagingLeaseStartMock).toHaveBeenCalledTimes(1);
     expect(registerMessagingStatusIpcHandlersMock).toHaveBeenCalledTimes(1);
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
   });
@@ -861,6 +926,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(listThreadsMock).toHaveBeenCalledWith({
@@ -877,6 +943,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(listThreadsMock).not.toHaveBeenCalled();
@@ -1004,6 +1071,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(mainLogWarnMock).toHaveBeenCalledWith(
@@ -1043,6 +1111,7 @@ describe("bootstrapApp", () => {
     await flushMicrotasks();
 
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(mainLogErrorMock).toHaveBeenCalledWith(
@@ -1068,6 +1137,7 @@ describe("bootstrapApp", () => {
     activateHandler();
 
     expect(createMainWindowMock).toHaveBeenNthCalledWith(1, {
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
     expect(createMainWindowMock).toHaveBeenNthCalledWith(2, {
@@ -1410,6 +1480,7 @@ describe("bootstrapApp", () => {
       }),
     );
     expect(createMainWindowMock).toHaveBeenCalledWith({
+      onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
   });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -197,16 +197,9 @@ function startBootWatchdog(): void {
   bootWatchdogTimer.unref?.();
 }
 
-function markMainWindowBooted(window: BrowserWindow): void {
-  const onShown = (): void => {
-    mainWindowEverShown = true;
-    clearBootWatchdog();
-  };
-  if (window.isVisible()) {
-    onShown();
-    return;
-  }
-  window.once("show", onShown);
+function markMainWindowBooted(): void {
+  mainWindowEverShown = true;
+  clearBootWatchdog();
 }
 
 function formatBootError(error: unknown): string {
@@ -921,12 +914,9 @@ export function bootstrapApp(): void {
     registerMessagingStatusIpcHandlers();
     recordStartupProfileEvent({ type: "main-window-create:start" });
     const mainWindow = createMainWindow({
+      onShown: markMainWindowBooted,
       startupCpuProfiler,
     });
-    // Boot is "done" once the main window actually shows; this cancels the
-    // boot watchdog and downgrades later unhandled rejections from "fatal
-    // startup failure dialog" to "log only".
-    markMainWindowBooted(mainWindow);
     quitAppOnMainWindowClose(mainWindow);
     recordStartupProfileEvent({ type: "main-window-create:end" });
     recordStartupProfileEvent({ type: "startup-thread-list-prewarm:start" });

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -316,6 +316,7 @@ export function syncHotCpuProfilersFromSettings(
 }
 
 export function createMainWindow(options?: {
+  onShown?: () => void;
   startupCpuProfiler?: {
     attachWindow: (window: BrowserWindow) => void;
   };
@@ -385,6 +386,14 @@ export function createMainWindow(options?: {
       ],
     }
   });
+
+  // Register before renderer navigation can reach ready-to-show and call
+  // window.show(). The initial boot watchdog depends on this signal, and
+  // attaching its listener after createMainWindow returns can miss Electron's
+  // synchronous "show" event.
+  if (options?.onShown) {
+    window.once("show", options.onShown);
+  }
 
   if (isDevelopment) {
     mainLog.info("creating window", {


### PR DESCRIPTION
## Summary

- register the initial main-window boot completion callback before renderer navigation can emit `ready-to-show` and synchronously call `window.show()`
- remove the post-`createMainWindow` visibility probe that could miss the earlier `show` event and depend on transient Electron visibility state
- keep the 25-second watchdog active until Electron emits a real main-window `show` event

## Root cause

`createMainWindow` owns the `ready-to-show` handler and calls `window.show()` before returning. The boot watchdog previously attached its `show` listener only after that return. In the failing dev lifecycle, the `show` event had already fired, while the subsequent `isVisible()` fallback did not report the window as visible. The timer therefore survived and surfaced a false startup-failure dialog roughly 25 seconds later even though the renderer was initialized.

The callback is now passed into `createMainWindow`, which installs a one-shot `show` listener immediately after constructing the hidden `BrowserWindow` and before starting renderer navigation. A genuinely missing or never-shown window still leaves the watchdog armed and surfaces the existing native failure dialog.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/index.test.ts apps/desktop/src/main/__tests__/app-bootstrap.test.ts` (47 tests)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop build` (including main bundle boundary check)