### PR TITLE
feat(desktop): open messaging settings from popover

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -324,6 +324,10 @@ function DesktopAppShell(props: {
   const openMessagingActivityWindow = useCallback(() => {
     void desktopApi?.openMessagingActivityWindow?.();
   }, [desktopApi]);
+  const openMessagingSettings = useCallback(() => {
+    setSettingsInitialSection("messaging");
+    setMainView("settings");
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -1187,6 +1191,7 @@ function DesktopAppShell(props: {
       }
     },
     onOpenMessagingActivity: openMessagingActivityWindow,
+    onOpenMessagingSettings: openMessagingSettings,
     onRevealSelectedThreadInList: revealSelectedThreadInList,
     contextRailPinned,
     onContextRailPinnedChange: setContextRailPinnedPersisted,
@@ -1391,6 +1396,7 @@ function DesktopAppShell(props: {
       <AppTitleBar
         desktopApi={desktopApi}
         onOpenMessagingActivity={openMessagingActivityWindow}
+        onOpenMessagingSettings={openMessagingSettings}
         layout={{
           sidebarOpen: !sidebarHidden,
           railOpen: contextRailPinned,
@@ -1549,6 +1555,7 @@ function DesktopAppShell(props: {
             <ThreadSearchPanel
               desktopApi={desktopApi}
               onOpenMessagingActivity={openMessagingActivityWindow}
+              onOpenMessagingSettings={openMessagingSettings}
               layout={{
                 sidebarOpen: !sidebarHidden,
                 railOpen: contextRailPinned,
@@ -1597,6 +1604,7 @@ function DesktopAppShell(props: {
                 desktopApi={desktopApi}
                 title="Loading..."
                 onOpenMessagingActivity={openMessagingActivityWindow}
+                onOpenMessagingSettings={openMessagingSettings}
                 layout={{
                   sidebarOpen: !sidebarHidden,
                   railOpen: contextRailPinned,
@@ -1646,6 +1654,7 @@ function DesktopAppShell(props: {
               threads={navigation.threads}
               onClose={() => setMainView("thread")}
               onOpenMessagingActivity={openMessagingActivityWindow}
+              onOpenMessagingSettings={openMessagingSettings}
               onRefreshNavigation={navigation.refresh}
               onSelectThread={(thread) => {
                 setMainView("thread");

--- a/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/AutomationsScreen.tsx
@@ -27,6 +27,7 @@ type AutomationsScreenProps = {
   desktopApi?: DesktopApi;
   onClose: () => void;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  onOpenMessagingSettings?: () => void;
   onRefreshNavigation?: () => Promise<void>;
   onSelectThread?: (thread: NavigationThreadSummary) => void;
   threads: NavigationThreadSummary[];
@@ -121,6 +122,7 @@ export function AutomationsScreen(props: AutomationsScreenProps) {
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={props.onOpenMessagingActivity}
+            onOpenSettings={props.onOpenMessagingSettings}
           />
         </header>
 

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -29,6 +29,7 @@ export type AppTitleBarLayoutControls = {
 export function AppTitleBar(props: {
   desktopApi?: DesktopApi;
   onOpenMessagingActivity?: () => void;
+  onOpenMessagingSettings?: () => void;
   layout?: AppTitleBarLayoutControls;
   actions?: {
     automationsActive: boolean;
@@ -99,6 +100,7 @@ export function AppTitleBar(props: {
             <MessagingStatusBar
               desktopApi={props.desktopApi}
               onOpenActivity={props.onOpenMessagingActivity}
+              onOpenSettings={props.onOpenMessagingSettings}
             />
           ) : null}
         </div>

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -212,9 +212,9 @@ describe("MessagingStatusBar", () => {
 
     expect(settingsButton.nextElementSibling).toBe(masterToggle);
     fireEvent.mouseEnter(settingsButton);
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Open Messaging Settings",
-    );
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveClass("messaging-status-tooltip");
+    expect(tooltip).toHaveTextContent("Open Messaging Settings");
 
     fireEvent.click(settingsButton);
 

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx
@@ -183,6 +183,48 @@ describe("MessagingStatusBar", () => {
     expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
   });
 
+  it("opens Messaging settings from the gear immediately before the master toggle", async () => {
+    const statuses = [
+      {
+        changedAt: 1000,
+        health: "enabled",
+        platform: "telegram",
+      },
+    ] satisfies MessagingPlatformStatus[];
+    const desktopApi: DesktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => statuses),
+      onMessagingPlatformStatusEvent: vi.fn(() => () => {}),
+    };
+    const onOpenSettings = vi.fn();
+
+    render(
+      <MessagingStatusBar
+        desktopApi={desktopApi}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 online/ }));
+    const settingsButton = await screen.findByRole("button", {
+      name: "Open Messaging Settings",
+    });
+    const masterToggle = screen.getByRole("button", { name: "On" });
+
+    expect(settingsButton.nextElementSibling).toBe(masterToggle);
+    fireEvent.mouseEnter(settingsButton);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Open Messaging Settings",
+    );
+
+    fireEvent.click(settingsButton);
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Messaging platforms" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("uses runtime-disabled settings instead of stale errored platform health", async () => {
     const statuses = [
       {

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -92,7 +92,9 @@ export function MessagingStatusBar(props: {
     hide: hideSettingsTooltip,
     show: showSettingsTooltip,
     tooltipNode: settingsTooltipNode,
-  } = useViewportTooltip({ className: "viewport-tooltip" });
+  } = useViewportTooltip({
+    className: "viewport-tooltip messaging-status-tooltip",
+  });
 
   const runtimeMessagingEnabled =
     settingsSnapshot?.runtime?.messaging?.disabled !== undefined

--- a/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.tsx
@@ -12,6 +12,8 @@ import {
   formatMessagingPlatformName,
   MESSAGING_PLATFORM_ICONS,
 } from "../../lib/messaging-platform-branding";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+import { SettingsIcon } from "../../icons/SettingsIcon";
 import { useMessagingPlatformStatuses } from "./useMessagingPlatformStatuses";
 import type { DesktopApi } from "../../lib/desktop-api";
 
@@ -61,6 +63,8 @@ export function MessagingStatusBar(props: {
    * scope the screen to it in the future.
    */
   onOpenActivity?: (platform?: MessagingChannelKind) => void;
+  /** Opens Settings directly to the Messaging section. */
+  onOpenSettings?: () => void;
 }) {
   const { statuses, activeAtByPlatform } = useMessagingPlatformStatuses(
     props.desktopApi,
@@ -84,6 +88,11 @@ export function MessagingStatusBar(props: {
   >({});
   const rootRef = useRef<HTMLDivElement | null>(null);
   const popoverId = useId();
+  const {
+    hide: hideSettingsTooltip,
+    show: showSettingsTooltip,
+    tooltipNode: settingsTooltipNode,
+  } = useViewportTooltip({ className: "viewport-tooltip" });
 
   const runtimeMessagingEnabled =
     settingsSnapshot?.runtime?.messaging?.disabled !== undefined
@@ -190,11 +199,13 @@ export function MessagingStatusBar(props: {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
       if (rootRef.current?.contains(event.target as Node)) return;
+      hideSettingsTooltip();
       setOpen(false);
       setPinned(false);
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
+      hideSettingsTooltip();
       setOpen(false);
       setPinned(false);
     };
@@ -204,7 +215,7 @@ export function MessagingStatusBar(props: {
       document.removeEventListener("pointerdown", onPointerDown);
       document.removeEventListener("keydown", onKeyDown);
     };
-  }, [open]);
+  }, [hideSettingsTooltip, open]);
 
   const handleToggleMessaging = async (): Promise<void> => {
     if (!props.desktopApi?.setMessagingEnabled) {
@@ -286,7 +297,10 @@ export function MessagingStatusBar(props: {
       aria-label="Messaging platform status"
       onPointerEnter={() => setOpen(true)}
       onPointerLeave={() => {
-        if (!pinned) setOpen(false);
+        if (!pinned) {
+          hideSettingsTooltip();
+          setOpen(false);
+        }
       }}
     >
       <button
@@ -301,6 +315,7 @@ export function MessagingStatusBar(props: {
         } messaging status.`}
         onClick={() => {
           if (pinned) {
+            hideSettingsTooltip();
             setOpen(false);
             setPinned(false);
             return;
@@ -340,22 +355,53 @@ export function MessagingStatusBar(props: {
                   {summary}
                 </div>
               </div>
-              <button
-                type="button"
-                className={`settings-switch messaging-status-popover__switch${
-                  messagingOn ? " is-on" : ""
-                }`}
-                aria-pressed={messagingOn}
-                disabled={togglePending}
-                onClick={() => {
-                  void handleToggleMessaging();
-                }}
-              >
-                <span aria-hidden="true" className="settings-switch__track">
-                  <span className="settings-switch__thumb" />
-                </span>
-                <span>{togglePending ? "..." : messagingOn ? "On" : "Off"}</span>
-              </button>
+              <div className="messaging-status-popover__head-actions">
+                {props.onOpenSettings ? (
+                  <button
+                    type="button"
+                    className="messaging-status-popover__settings"
+                    aria-label="Open Messaging Settings"
+                    onBlur={hideSettingsTooltip}
+                    onClick={() => {
+                      hideSettingsTooltip();
+                      setOpen(false);
+                      setPinned(false);
+                      props.onOpenSettings?.();
+                    }}
+                    onFocus={(event) =>
+                      showSettingsTooltip(
+                        event.currentTarget,
+                        "Open Messaging Settings",
+                      )
+                    }
+                    onMouseEnter={(event) =>
+                      showSettingsTooltip(
+                        event.currentTarget,
+                        "Open Messaging Settings",
+                      )
+                    }
+                    onMouseLeave={hideSettingsTooltip}
+                  >
+                    <SettingsIcon size={16} />
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className={`settings-switch messaging-status-popover__switch${
+                    messagingOn ? " is-on" : ""
+                  }`}
+                  aria-pressed={messagingOn}
+                  disabled={togglePending}
+                  onClick={() => {
+                    void handleToggleMessaging();
+                  }}
+                >
+                  <span aria-hidden="true" className="settings-switch__track">
+                    <span className="settings-switch__thumb" />
+                  </span>
+                  <span>{togglePending ? "..." : messagingOn ? "On" : "Off"}</span>
+                </button>
+              </div>
             </div>
             <div className="messaging-status-popover__rows">
               {displayStatuses.map((status) => (
@@ -390,6 +436,7 @@ export function MessagingStatusBar(props: {
                 type="button"
                 className="messaging-status-popover__activity"
                 onClick={() => {
+                  hideSettingsTooltip();
                   setOpen(false);
                   setPinned(false);
                   props.onOpenActivity?.();
@@ -401,6 +448,7 @@ export function MessagingStatusBar(props: {
           </div>
         </div>
       ) : null}
+      {settingsTooltipNode}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -248,6 +248,7 @@ export function SettingsScreen(props: {
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={onOpenActivity}
+            onOpenSettings={() => setSection("messaging")}
           />
         </header>
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -3993,6 +3993,40 @@ describe("SettingsScreen", () => {
     expect(current?.textContent).not.toBe("Messaging activity");
   });
 
+  it("opens the Messaging section from the title-bar popover gear", async () => {
+    const desktopApi = {
+      getMessagingPlatformStatuses: vi.fn(async () => [
+        {
+          platform: "telegram" as const,
+          health: "enabled" as const,
+          changedAt: 0,
+        },
+      ]),
+    } as unknown as Parameters<typeof SettingsScreen>[0]["desktopApi"];
+
+    render(
+      <SettingsScreen
+        desktopApi={desktopApi}
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Telegram/i }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Open Messaging Settings" }),
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".settings-titlebar__current")).toHaveTextContent(
+        "Messaging",
+      );
+    });
+    expect(
+      screen.getByRole("button", { name: "Messaging" }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
   it("places Exit Settings as the first row of the settings nav (NOT in the title bar)", () => {
     // Regression lock for the design contract: Exit Settings lives
     // INSIDE `.settings-nav` (left column), not inside the title-bar

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -35,6 +35,8 @@ type ThreadHeaderProps = {
   backends?: BackendSummary[];
   /** Forwarded to MessagingStatusBar - opens Messaging Activity. */
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  /** Forwarded to MessagingStatusBar - opens Settings at Messaging. */
+  onOpenMessagingSettings?: () => void;
   onRevealSelectedThreadInList?: () => void;
   /**
    * Window panel toggles. Rendered here (top-right, beside MSG) on
@@ -195,6 +197,7 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={props.onOpenMessagingActivity}
+            onOpenSettings={props.onOpenMessagingSettings}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -24,6 +24,7 @@ type ThreadPlaceholderHeaderProps = {
   projectLabel?: string;
   title: string;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  onOpenMessagingSettings?: () => void;
   /**
    * Window panel toggles — mirrors ThreadHeader so the loading / empty
    * states share the same chrome (no layout shift, no stoplight overlap).
@@ -106,6 +107,7 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={props.onOpenMessagingActivity}
+            onOpenSettings={props.onOpenMessagingSettings}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -874,6 +874,8 @@ export type ThreadViewProps = {
   onDismissFullAccessRiskWarning?: () => Promise<void>;
   /** Forwarded to ThreadHeader -> MessagingStatusBar - opens Messaging Activity. */
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  /** Forwarded to ThreadHeader -> MessagingStatusBar - opens Messaging settings. */
+  onOpenMessagingSettings?: () => void;
   onRevealSelectedThreadInList?: () => void;
   /**
    * Window-level layout state (owned by App). The context rail pin +
@@ -2597,6 +2599,7 @@ export function ThreadView(props: ThreadViewProps) {
           projectLabel={pendingForkEnvironmentSetup.directoryLabel}
           title="Forking thread"
           onOpenMessagingActivity={props.onOpenMessagingActivity}
+          onOpenMessagingSettings={props.onOpenMessagingSettings}
           layout={{
             sidebarOpen: !sidebarHidden,
             railOpen: contextRailPinned,
@@ -2652,6 +2655,7 @@ export function ThreadView(props: ThreadViewProps) {
           desktopApi={props.desktopApi}
           title="Pick a Thread"
           onOpenMessagingActivity={props.onOpenMessagingActivity}
+          onOpenMessagingSettings={props.onOpenMessagingSettings}
           layout={{
             sidebarOpen: !sidebarHidden,
             railOpen: contextRailPinned,
@@ -2743,6 +2747,7 @@ export function ThreadView(props: ThreadViewProps) {
           projectLabel={selectedLaunchpad.directoryLabel}
           title="New thread"
           onOpenMessagingActivity={props.onOpenMessagingActivity}
+          onOpenMessagingSettings={props.onOpenMessagingSettings}
           layout={{
             sidebarOpen: !sidebarHidden,
             railOpen: contextRailPinned,
@@ -2877,6 +2882,7 @@ export function ThreadView(props: ThreadViewProps) {
         thread={selectedThread!}
         backends={props.backends}
         onOpenMessagingActivity={props.onOpenMessagingActivity}
+        onOpenMessagingSettings={props.onOpenMessagingSettings}
         onRevealSelectedThreadInList={props.onRevealSelectedThreadInList}
         layout={{
           sidebarOpen: !sidebarHidden,

--- a/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-search/ThreadSearchPanel.tsx
@@ -53,6 +53,7 @@ type ThreadSearchPanelProps = {
     turnId?: string;
   }) => Promise<void> | void;
   onOpenMessagingActivity?: (platform?: MessagingChannelKind) => void;
+  onOpenMessagingSettings?: () => void;
   /**
    * Close the search screen (Escape). App routes this to history back so it
    * pops the search entry off the stack and returns to wherever you came from,
@@ -305,6 +306,7 @@ export function ThreadSearchPanel(props: ThreadSearchPanelProps) {
         desktopApi={props.desktopApi}
         title="Search"
         onOpenMessagingActivity={props.onOpenMessagingActivity}
+        onOpenMessagingSettings={props.onOpenMessagingSettings}
         layout={
           props.layout ? { ...props.layout, railToggleDisabled: true } : undefined
         }

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -372,6 +372,19 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("keeps the entire Messaging control interactive in Settings title bars", () => {
+    const titlebarDragRuleIndex = css.indexOf(".settings-titlebar * {");
+    const messagingNoDragRuleIndex = css.indexOf(
+      ".settings-titlebar .messaging-status-bar,",
+    );
+
+    expect(titlebarDragRuleIndex).toBeGreaterThan(-1);
+    expect(messagingNoDragRuleIndex).toBeGreaterThan(titlebarDragRuleIndex);
+    expect(css).toMatch(
+      /\.settings-titlebar \.messaging-status-bar,\s*\.settings-titlebar \.messaging-status-bar \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?\}/,
+    );
+  });
+
   it("keeps the thread title reveal hit target to the rendered title text", () => {
     const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
     const titleButtonRule = extractRuleBody(css, ".thread-header__title-button");

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -385,6 +385,19 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("layers Messaging popovers and tooltips above full-window settings", () => {
+    const appTitlebarRule = extractRuleBody(css, ".app-titlebar");
+    const settingsLayerRule = extractRuleBody(css, ".app-shell__settings-layer");
+    const messagingTooltipRule = extractRuleBody(
+      css,
+      ".messaging-status-tooltip",
+    );
+
+    expect(settingsLayerRule).toContain("z-index: 120;");
+    expect(appTitlebarRule).toContain("z-index: 130;");
+    expect(messagingTooltipRule).toContain("z-index: 140;");
+  });
+
   it("keeps the thread title reveal hit target to the rendered title text", () => {
     const compactTitleRule = extractRuleBody(css, ".thread-header__compact-title");
     const titleButtonRule = extractRuleBody(css, ".thread-header__title-button");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5719,8 +5719,19 @@ textarea,
 .settings-titlebar [role="button"] {
   -webkit-app-region: no-drag;
 }
-/* MessagingStatusBar already enforces no-drag on its whole subtree
-   via its own CSS (~line 211). No duplication needed here. */
+
+/* `.settings-titlebar *` is declared after the shared MessagingStatusBar
+   rules and has equal specificity, so it otherwise wins the cascade and
+   turns the controller's text/icon pixels plus the popover's transparent
+   hover bridge back into window-drag regions. The button's bare padding
+   stays clickable, which makes the failure look like a broken hover hitbox.
+   Keep this context-specific carve-out after the broad drag rule and use the
+   extra class specificity so every pixel in the shared control remains
+   interactive in Settings and Automations title bars. */
+.settings-titlebar .messaging-status-bar,
+.settings-titlebar .messaging-status-bar * {
+  -webkit-app-region: no-drag;
+}
 
 .settings-titlebar__breadcrumb {
   display: flex;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -566,9 +566,8 @@ textarea,
 
 .new-thread-menu {
   position: absolute;
-  /* Matches the title-bar z-index; the title bar forms its own stacking
-     context, so within the masthead this reliably layers above sibling
-     content without competing with it. */
+  /* Within the masthead, this reliably layers above sibling thread chrome
+     without competing with full-window overlays. */
   z-index: 40;
   top: 100%;
   right: 0;
@@ -644,7 +643,11 @@ textarea,
   top: 0;
   left: 0;
   right: 0;
-  z-index: 40;
+  /* Windows keeps the single global Messaging controller in this strip even
+     while Settings/Automations occupies the app-shell overlay layer (120).
+     The strip does not overlap that shell, but its popover extends into it, so
+     this parent stacking context must sit above the overlay. */
+  z-index: 130;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -13132,6 +13135,14 @@ a.transcript-message__messaging-origin:focus-visible {
   pointer-events: none;
   text-align: left;
   white-space: pre-wrap;
+}
+
+/* Messaging appears inside full-window Settings/Automations surfaces whose
+   overlay layer is 120. Its portal tooltip escapes that DOM subtree, so give
+   this one title-bar tooltip an explicit layer above the overlay and Windows
+   app title bar without raising every viewport tooltip globally. */
+.messaging-status-tooltip {
+  z-index: 140;
 }
 
 .context-rail__tooltip {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1471,6 +1471,43 @@ textarea,
   font: 500 11px/1.3 var(--font-sans, sans-serif);
 }
 
+.messaging-status-popover__head-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.messaging-status-popover__settings {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    color 80ms ease,
+    background 80ms ease;
+}
+
+.messaging-status-popover__settings:hover {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.messaging-status-popover__settings:focus-visible {
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .messaging-status-popover__switch {
   flex: 0 0 auto;
 }


### PR DESCRIPTION
## Summary

- add the existing gear icon immediately before the Messaging popover master on/off toggle
- show the tooltip and accessible label `Open Messaging Settings`
- deep-link directly to Settings → Messaging from thread, search, Automations, Settings, and Windows title-bar contexts
- close the popover and tooltip cleanly after navigation
- preserve hover and click handling over the MSG text, platform icons, and transparent popover bridge inside Settings-style title bars
- layer the Windows title-bar popover and Messaging gear tooltip above full-window Settings/Automations overlays

## Why

The Messaging status popover exposes runtime and per-provider controls, but configuring providers required navigating through Settings separately. This adds a direct, consistently placed route to the relevant settings section and keeps the complete control reliably interactive in every title-bar context.

## Root causes

The shared `.messaging-status-bar *` no-drag rule fixed the main thread header because it follows that header drag rule in the stylesheet. Settings declares `.settings-titlebar * { -webkit-app-region: drag; }` later with equal specificity, so it won the cascade for the MSG label, platform SVGs, and transparent hover bridge. Bare button padding remained no-drag, producing the misleading blank-space-only hover behavior.

Separately, the Windows `.app-titlebar` stacking context was below the full-window Settings/Automations layer, so its popover painted behind the overlay. The portal-rendered gear tooltip used the generic viewport-tooltip layer, which was also below those overlays on macOS/Linux.

The Settings-titlebar no-drag carve-out now has higher specificity, the Windows title bar sits above app-shell overlays, and the Messaging tooltip has a dedicated portal layer above both without raising every viewport tooltip globally.

## User impact

Operators can move from messaging status to configuration in one click, the popover remains open while crossing any part of the controller or its visual gap, and all controls remain visible and reachable over Settings and Automations.

## Validation

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/messaging-status/MessagingStatusBar.test.tsx apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx` (126 tests passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `git diff --check`