### PR TITLE
fix(messaging): route mention prose to default agents

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1646,6 +1646,99 @@ describe("MessagingController", () => {
     );
   });
 
+  it.each([
+    "telegram",
+    "discord",
+    "slack",
+    "mattermost",
+    "feishu",
+    "line",
+  ] as const)(
+    "routes natural language beginning with a command verb to the %s provider default Agent",
+    async (provider) => {
+      const navigation = buildNavigationSnapshot();
+      navigation.threads[0] = {
+        ...navigation.threads[0]!,
+        title: "Provider Default Agent",
+        agent: {
+          name: "Provider Default Agent",
+          instructionLineCount: 1,
+          instructionsTooLong: false,
+          updatedAt: 1500,
+        },
+      };
+      const harness = await createHarness({
+        channel: provider,
+        navigation,
+      });
+      const channel = {
+        channel: provider,
+        conversation: {
+          id: `${provider}-channel-1`,
+          kind: "channel" as const,
+          workspaceId: `${provider}-workspace-1`,
+        },
+      };
+      await harness.store.upsertDefaultAgentAssignment({
+        id: `default-agent:${provider}:provider`,
+        scope: {
+          kind: "provider",
+          channel: provider,
+        },
+        target: {
+          kind: "agent",
+          backend: "codex",
+          threadId: "thread-1",
+        },
+        createdAt: 1000,
+        updatedAt: 1000,
+      });
+
+      await harness.controller.handleInboundEvent(
+        buildTextEvent("new phone who dis?", {
+          botMention: provider !== "feishu" && provider !== "line",
+          channel,
+        }),
+      );
+
+      expect(harness.startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          input: [{ type: "text", text: "new phone who dis?" }],
+          threadId: "thread-1",
+        }),
+      );
+      expect(harness.delivered).not.toContainEqual(
+        expect.objectContaining({ kind: "project_picker" }),
+      );
+    },
+  );
+
+  it("preserves exact at-mention command shortcuts", async () => {
+    const harness = await createHarness({ channel: "slack" });
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "slack-channel-1",
+        kind: "channel" as const,
+        workspaceId: "slack-workspace-1",
+      },
+    };
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("new", {
+        botMention: true,
+        channel,
+      }),
+    );
+
+    expect(harness.startTurn).not.toHaveBeenCalled();
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "project_picker",
+      prompt: expect.stringContaining("Choose a project for the new PwrAgent thread"),
+    });
+  });
+
   it("routes an addressed root when its adapter cannot create a child", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -17808,8 +17808,15 @@ function parseMentionCommand(
   text: string,
 ): { command: string; args: string[] } | undefined {
   const tokens = text.trim().split(/\s+/).filter(Boolean);
+  // Keep mention commands deliberately unambiguous. A bare known verb such
+  // as `@bot new` is a convenient control shortcut, but addressed prose such
+  // as `@bot new phone who dis?` belongs to the bound/default Agent. Commands
+  // with arguments remain available through their explicit slash form.
+  if (tokens.length !== 1) {
+    return undefined;
+  }
   const command = matchMessagingCommandVerb(tokens[0] ?? "");
-  return command ? { command, args: tokens.slice(1) } : undefined;
+  return command ? { command, args: [] } : undefined;
 }
 
 function skillSearchCwdsForThreadState(

--- a/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
+++ b/packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts
@@ -362,6 +362,62 @@ describe("MattermostAdapter — capability profile", () => {
     ]);
   });
 
+  it("dispatches natural language after a leading bot mention as addressed text", async () => {
+    const wsHooks: WebSocketHooks = {
+      fireMessage: () => {},
+      fireClose: () => {},
+    };
+    const events: MessagingInboundEvent[] = [];
+    const adapter = new MattermostAdapter({
+      callbackHandleStore: fakeStore,
+      client: fakeClient4({
+        createdPosts: [],
+        patchedPosts: [],
+      }),
+      config: {
+        ...baseConfig,
+        authorizedActorIds: [
+          { id: "haroldabcdefghijklmnopqr12", displayName: "" },
+        ],
+      },
+      logger: silentLogger,
+      websocketClient: fakeWebSocketClient(undefined, wsHooks),
+      callbackServer: {
+        start: async () => {},
+        stop: async () => {},
+        signContext: () => ({ hmac: "x", issuedAt: 0 }),
+      } as never,
+      now: () => 1_700_000_000_000,
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    wsHooks.fireMessage({
+      event: "posted",
+      data: {
+        channel_type: "D",
+        channel_display_name: "PwrAgent",
+        sender_name: "harold",
+        post: JSON.stringify({
+          id: "postpostabcdefghijklmn1234",
+          channel_id: "channelabcdefghijklmn12345",
+          user_id: "haroldabcdefghijklmnopqr12",
+          message: "@pwragent new phone who dis?",
+        }),
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        botMention: true,
+        kind: "text",
+        text: "new phone who dis?",
+      }),
+    ]);
+  });
+
   it("rejects group DM posts from authorized actors when no workspace or conversation is authorized", async () => {
     const wsHooks: WebSocketHooks = {
       fireMessage: () => {},

--- a/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
+++ b/packages/messaging/providers/mattermost/src/mattermost-adapter.ts
@@ -918,26 +918,31 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       return;
     }
 
-    // `@<botUsername> <verb>` text mention → command. Works on every
-    // Mattermost server version (the WS `posted` event always carries
-    // full thread context via `post.root_id`), unlike v10.x slash
-    // commands which need the response_url workaround. Users get a
-    // path that "just works" in threads without depending on server
-    // version. The mention prefix is case-insensitive because
-    // Mattermost's autocomplete inserts the canonical username but
-    // users may type-correct or use shell-style tab completion.
+    // Normalize leading bot mentions to the same addressed-text shape used by
+    // Slack, Telegram, and Discord. The controller owns the channel-neutral
+    // decision between an exact mention command (`@bot new`) and natural
+    // language (`@bot new phone who dis?`). Bare mentions remain the canonical
+    // Help shortcut. The mention prefix is case-insensitive because
+    // Mattermost's autocomplete inserts the canonical username but users may
+    // type-correct or use shell-style tab completion.
     const stripped = stripBotMention(messageText, this.botUsername);
     if (stripped !== undefined) {
-      await this.dispatchCommandEvent({
-        actor,
-        channel: channelRef,
-        eventId: post.id,
-        // Synthesize the slash form so `dispatchCommandEvent`'s
-        // existing parser strips the leading `/` and produces a
-        // standard `MessagingInboundCommandEvent` — the controller
-        // sees the same shape regardless of slash-vs-mention origin.
-        rawText: stripped.length === 0 ? "/help" : `/${stripped}`,
-      });
+      if (stripped.length === 0) {
+        await this.dispatchCommandEvent({
+          actor,
+          channel: channelRef,
+          eventId: post.id,
+          rawText: "/help",
+        });
+      } else {
+        await this.dispatchTextEvent({
+          actor,
+          botMention: true,
+          channel: channelRef,
+          eventId: post.id,
+          text: stripped,
+        });
+      }
       return;
     }
 
@@ -1266,6 +1271,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
 
   private async dispatchTextEvent(params: {
     actor: MessagingActorIdentity;
+    botMention?: boolean;
     channel: MessagingChannelRef;
     eventId: string;
     text: string;
@@ -1279,6 +1285,7 @@ export class MattermostAdapter implements MattermostProviderAdapter {
       receivedAt: this.now(),
       actor: params.actor,
       channel: params.channel,
+      ...(params.botMention ? { botMention: true } : {}),
       text: params.text,
     });
   }


### PR DESCRIPTION
## What changed

- Treat an at-mention as a messaging control command only when the mention remainder is exactly one known command verb.
- Route multi-word addressed prose such as `@PwrAgent new phone who dis?` to the active binding or effective default Agent.
- Keep exact shortcuts such as `@PwrAgent new` working; slash commands remain the explicit form for commands with arguments.
- Normalize non-empty Mattermost bot mentions as addressed text, matching Slack, Telegram, and Discord.
- Add a default-Agent routing matrix for Telegram, Discord, Slack, Mattermost, Feishu, and LINE.

## Root cause

Slack correctly stripped the app mention and emitted addressed text. The shared controller then parsed the first word, `new`, as the New-thread control command even though more prose followed. That command path ran before default-Agent resolution, so it opened the project picker instead of starting a turn on the provider default Agent.

The existing tests covered default-Agent routing with non-command-leading prose and covered intentional exact mention commands separately, but never combined a default Agent with natural language beginning with a reserved verb. Mattermost also had a provider-specific parity gap: it converted every leading mention with trailing text into a command event.

## User impact

Provider-wide default Agents now receive ordinary addressed messages even when the first word happens to be `new`, `status`, `resume`, or another messaging command verb. Exact at-mention shortcuts and explicit slash commands continue to work.

## Validation

Red regression evidence before the fix:

- Controller regression failed for Telegram, Discord, and Slack (zero turns started).
- Mattermost adapter regression received a `command: new` event instead of addressed text.

Green checks:

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts packages/messaging/providers/mattermost/src/__tests__/mattermost-adapter.test.ts` — 384 passed.
- All six provider adapter suites — 31 files, 387 tests passed.
- `pnpm test apps/desktop/src/main/__tests__/messaging-config.test.ts` — 32 passed.
- `pnpm typecheck` — passed.
- `pnpm lint:eslint` — passed with the repository's existing warning baseline.
- `pnpm lint:boundaries` — passed.

A full-workspace Vitest run was attempted, but unrelated Git/config integration tests exceeded their fixed 5-second timeouts under concurrent execution. The Slack messaging-config suite that timed out in the grouped run passed 32/32 when rerun alone.
