### PR TITLE
fix(desktop): inherit Codex environment across handoff worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20417,7 +20417,7 @@ command = "pnpm dev"
       branchName: "origin/master",
       directoryKind: "directory",
       directoryLabel: "repo",
-      directoryPath: expectedDir(repoPath),
+      directoryPath: repoPath,
       workMode: "worktree",
     });
     expect(commandRunner).toHaveBeenCalledTimes(1);
@@ -23452,9 +23452,11 @@ script = "printf setup"
   it("does not inherit a project Codex environment runtime for no-workspace handoffs", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-none-env-"));
     const repoPath = path.join(root, "search-compare");
+    const ignoredCwd = path.join(root, "other-project");
     const scratchPath = path.join(root, "profiles", "sstk", "projects", "2026-06-30-c2acd2");
     try {
       await mkdir(repoPath, { recursive: true });
+      await mkdir(ignoredCwd, { recursive: true });
       try {
         await git(repoPath, ["init", "-b", "main"]);
       } catch {
@@ -23500,23 +23502,24 @@ script = "printf setup"
           },
         ],
       });
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "full-access",
+            codexEnvironmentRuntime: sourceRuntime,
+            extraLinkedDirectories: [linkedDirectory],
+          },
+        },
+      });
       const registry = new DesktopBackendRegistry({
         codexClient,
         createScratchProjectDirectory: async () => scratchPath,
         grokClient: new MockBackendClient({
           initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
         }),
-        overlayStore: createOverlayStoreMock({
-          overlays: {
-            "codex:ordinary-thread": {
-              backend: "codex",
-              threadId: "ordinary-thread",
-              executionMode: "full-access",
-              codexEnvironmentRuntime: sourceRuntime,
-              extraLinkedDirectories: [linkedDirectory],
-            },
-          },
-        }),
+        overlayStore,
         threadTitleGenerationService: null,
       });
       await registry.publishLocalEvent({
@@ -23543,7 +23546,9 @@ script = "printf setup"
           arguments: {
             task: "Use /Users/huntharo/GIPHY/giphy-services from the prompt only.",
             title: "Prompt-only target",
+            groupingMode: "subthread",
             workspaceMode: "none",
+            cwd: ignoredCwd,
           },
         },
       } as AppServerPendingRequestNotification);
@@ -23563,6 +23568,18 @@ script = "printf setup"
           kind: "non_git",
           worktreeCreationAvailable: false,
         },
+      });
+      expect(payload).toMatchObject({
+        groupingMode: "subthread",
+        groupedUnderThreadId: "ordinary-thread",
+      });
+      await expect(
+        overlayStore.getThreadOverlayState({
+          backend: "codex",
+          threadId: "thread-1",
+        }),
+      ).resolves.toMatchObject({
+        parentThreadId: "ordinary-thread",
       });
       expect(payload.inheritedSettings).not.toHaveProperty(
         "codexEnvironmentRuntime",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20241,9 +20241,10 @@ command = "pnpm dev"
     }
   });
 
-  it("rehydrates inherited Codex environment runtime for clean new-worktree handoffs", async () => {
+  it("rehydrates inherited Codex environment runtime when an explicit cwd is the caller worktree's repository", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-env-"));
     const repoPath = path.join(root, "repo");
+    const callerWorktreePath = path.join(root, "caller-worktree");
     const worktreePath = path.join(root, "worktree");
     try {
       await mkdir(repoPath, { recursive: true });
@@ -20263,6 +20264,7 @@ command = "pnpm dev"
       "-m",
       "initial",
     ]);
+    await mkdir(callerWorktreePath, { recursive: true });
     await mkdir(path.join(worktreePath, ".codex", "environments"), { recursive: true });
     await writeFile(
       path.join(worktreePath, ".codex", "environments", "environment.toml"),
@@ -20284,12 +20286,12 @@ command = "pnpm dev"
       environmentId: "environment",
       environmentName: "GifGrabber",
       executionTarget: "local",
-      cwd: repoPath,
+      cwd: callerWorktreePath,
       setupStatus: "completed",
       setupCommand: "printf setup",
       shellEnvironment: {
-        PATH: `${repoPath}/.venv/bin:/usr/bin`,
-        VIRTUAL_ENV: `${repoPath}/.venv`,
+        PATH: `${callerWorktreePath}/.venv/bin:/usr/bin`,
+        VIRTUAL_ENV: `${callerWorktreePath}/.venv`,
       },
       selectedActionIdByEnvironmentId: {
         environment: "dev",
@@ -20335,10 +20337,11 @@ command = "pnpm dev"
           source: "codex",
           linkedDirectories: [
             {
-              id: expectedDir(repoPath),
-              kind: "local",
+              id: expectedDir(callerWorktreePath),
+              kind: "worktree",
               label: "repo",
               path: expectedDir(repoPath),
+              worktreePath: expectedDir(callerWorktreePath),
             },
           ],
           updatedAt: 1000,
@@ -20354,10 +20357,11 @@ command = "pnpm dev"
           codexEnvironmentRuntime: sourceRuntime,
           extraLinkedDirectories: [
             {
-              id: expectedDir(repoPath),
-              kind: "local",
+              id: expectedDir(callerWorktreePath),
+              kind: "worktree",
               label: "repo",
               path: expectedDir(repoPath),
+              worktreePath: expectedDir(callerWorktreePath),
             },
           ],
         },
@@ -20401,6 +20405,7 @@ command = "pnpm dev"
           task: "Implement the export failure alert on master.",
           title: "Swift export alert",
           workspaceMode: "new_worktree",
+          cwd: repoPath,
           branchName: "origin/master",
         },
       },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -21509,16 +21509,18 @@ export class DesktopBackendRegistry {
           ? projectLocalCwd
           : sourceCwd;
     const childProjectBoundary =
-      requestedProjectBoundary
-      ?? await this.resolveHandoffProjectBoundaryPath({
-        cwd: cwdForChild,
-        linkedDirectory:
-          workspaceMode === "project_local"
-            ? sourceLinkedDirectory?.kind === "local"
-              ? sourceLinkedDirectory
-              : undefined
-            : sourceLinkedDirectory,
-      });
+      workspaceMode === "none"
+        ? undefined
+        : requestedProjectBoundary
+          ?? await this.resolveHandoffProjectBoundaryPath({
+            cwd: cwdForChild,
+            linkedDirectory:
+              workspaceMode === "project_local"
+                ? sourceLinkedDirectory?.kind === "local"
+                  ? sourceLinkedDirectory
+                  : undefined
+                : sourceLinkedDirectory,
+          });
     const groupingMode: HandoffTaskGroupingMode =
       requestedGroupingMode === "subthread" &&
       backend === sourceBackend &&

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1298,15 +1298,25 @@ function sameResolvedPath(
 
 function shouldInheritHandoffCodexEnvironmentRuntime(params: {
   callerCwd?: string;
+  callerProjectBoundary?: string;
   requestedCwd?: string;
+  requestedProjectBoundary?: string;
   workspaceMode: HandoffTaskWorkspaceMode;
 }): boolean {
   if (params.workspaceMode === "none") {
     return false;
   }
   return (
-    !params.requestedCwd ||
-    sameResolvedPath(params.requestedCwd, params.callerCwd)
+    !params.requestedCwd
+    || sameResolvedPath(params.requestedCwd, params.callerCwd)
+    || (
+      Boolean(params.callerProjectBoundary)
+      && Boolean(params.requestedProjectBoundary)
+      && sameResolvedPath(
+        params.callerProjectBoundary,
+        params.requestedProjectBoundary,
+      )
+    )
   );
 }
 
@@ -21431,6 +21441,16 @@ export class DesktopBackendRegistry {
       );
     }
 
+    const callerProjectBoundary = await this.resolveHandoffProjectBoundaryPath({
+      cwd: callerCwd,
+      linkedDirectory: callerLinkedDirectory,
+    });
+    const requestedProjectBoundary = requestedCwd
+      ? await this.resolveHandoffProjectBoundaryPath({
+          cwd: sourceCwd,
+          linkedDirectory: sourceLinkedDirectory,
+        })
+      : undefined;
     const inheritedSettings: HandoffTaskInheritedSettings = {
       backend,
       executionMode,
@@ -21451,14 +21471,16 @@ export class DesktopBackendRegistry {
       approvalPolicy: request.args.approvalPolicy ?? modeSettings.approvalPolicy,
       sandbox: request.args.sandbox ?? modeSettings.sandbox,
       codexEnvironmentRuntime:
-        backend === "codex" &&
-        shouldInheritHandoffCodexEnvironmentRuntime({
+        backend === "codex"
+        && shouldInheritHandoffCodexEnvironmentRuntime({
           callerCwd,
+          callerProjectBoundary,
           requestedCwd,
+          requestedProjectBoundary,
           workspaceMode,
         })
-        ? sourceOverlay.codexEnvironmentRuntime
-        : undefined,
+          ? sourceOverlay.codexEnvironmentRuntime
+          : undefined,
     };
     const projectLocalCwd =
       workspaceMode === "project_local"
@@ -21486,19 +21508,17 @@ export class DesktopBackendRegistry {
         : workspaceMode === "project_local"
           ? projectLocalCwd
           : sourceCwd;
-    const callerProjectBoundary = await this.resolveHandoffProjectBoundaryPath({
-      cwd: callerCwd,
-      linkedDirectory: callerLinkedDirectory,
-    });
-    const childProjectBoundary = await this.resolveHandoffProjectBoundaryPath({
-      cwd: cwdForChild,
-      linkedDirectory:
-        workspaceMode === "project_local"
-          ? sourceLinkedDirectory?.kind === "local"
-            ? sourceLinkedDirectory
-            : undefined
-          : sourceLinkedDirectory,
-    });
+    const childProjectBoundary =
+      requestedProjectBoundary
+      ?? await this.resolveHandoffProjectBoundaryPath({
+        cwd: cwdForChild,
+        linkedDirectory:
+          workspaceMode === "project_local"
+            ? sourceLinkedDirectory?.kind === "local"
+              ? sourceLinkedDirectory
+              : undefined
+            : sourceLinkedDirectory,
+      });
     const groupingMode: HandoffTaskGroupingMode =
       requestedGroupingMode === "subthread" &&
       backend === sourceBackend &&


### PR DESCRIPTION
## Summary

- inherit a parent Codex Environment when a handoff explicitly names another checkout of the same Git repository
- keep true cross-project and no-workspace handoffs isolated
- cover the observed managed-worktree → primary-checkout → new-worktree path

## Root cause

`handoff_task` documented that omitted settings inherit, while also telling agents to pass `cwd` when a project is named. The backend only preserved the Codex Environment when that explicit `cwd` exactly matched the parent worktree path. A same-repository primary checkout therefore looked cross-project, so the child discovered the environment label later but skipped inherited setup/hydration.

The inheritance decision now accepts either the same path or a positively resolved shared project boundary.

## Validation

- regression test failed before the fix because the environment setup runner was called 0 times
- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts` (432 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
