### PR TITLE
fix(desktop): move queued message dispatch to backend

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -53,6 +53,7 @@ const registry = {
     reviewThreadId: request.threadId,
     turnId: "turn-review-1",
   })),
+  cancelQueuedTurn: vi.fn(() => true),
   interruptTurn: vi.fn(async (request: InterruptTurnRequest) => ({
     backend: request.backend,
     threadId: request.threadId,
@@ -127,6 +128,7 @@ describe("agent ipc", () => {
     registry.startTurn.mockClear();
     registry.submitTurn.mockClear();
     registry.startReview.mockClear();
+    registry.cancelQueuedTurn.mockClear();
     registry.interruptTurn.mockClear();
     registry.stopSubAgent.mockClear();
     registry.steerTurn.mockClear();
@@ -141,6 +143,7 @@ describe("agent ipc", () => {
     } = await import("../ipc/agent-ipc");
     const {
       AGENT_EVENT_CHANNEL,
+      AGENT_CANCEL_QUEUED_TURN_CHANNEL,
       AGENT_INTERRUPT_TURN_CHANNEL,
       AGENT_MATERIALIZE_DIRECTORY_LAUNCHPAD_CHANNEL,
       AGENT_START_THREAD_CHANNEL,
@@ -176,6 +179,18 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       turnId: "turn-1",
     });
+    expect(
+      await handlers.get(AGENT_CANCEL_QUEUED_TURN_CHANNEL)?.({}, {
+        queueEntryId: "queue-2",
+      }),
+    ).toEqual({
+      queueEntryId: "queue-2",
+      cancelled: true,
+    });
+    expect(registry.cancelQueuedTurn).toHaveBeenCalledWith(
+      "queue-2",
+      "Cancelled from the desktop composer.",
+    );
     expect(
       await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
         backend: "grok",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9999,8 +9999,8 @@ export class DesktopBackendRegistry {
     });
   }
 
-  cancelQueuedTurn(entryId: string, reason?: string): void {
-    this.threadTurnQueue.cancelEntry(entryId, reason);
+  cancelQueuedTurn(entryId: string, reason?: string): boolean {
+    return Boolean(this.threadTurnQueue.cancelEntry(entryId, reason));
   }
 
   updateQueuedTurnInput(

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -5,6 +5,8 @@ import {
   type AgentEvent,
   type ApplyThreadModelMigrationRequest,
   type ApplyThreadModelMigrationResponse,
+  type CancelQueuedTurnRequest,
+  type CancelQueuedTurnResponse,
   type CancelThreadExecutionModeQueueRequest,
   type CancelThreadExecutionModeQueueResponse,
   type CheckThreadBranchDriftRequest,
@@ -64,6 +66,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
+  AGENT_CANCEL_QUEUED_TURN_CHANNEL,
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
   AGENT_EVENT_CHANNEL,
@@ -434,6 +437,21 @@ export function registerAgentIpcHandlers(): void {
         throw error;
       }
     },
+  );
+
+  ipcMain.removeHandler(AGENT_CANCEL_QUEUED_TURN_CHANNEL);
+  ipcMain.handle(
+    AGENT_CANCEL_QUEUED_TURN_CHANNEL,
+    async (
+      _event,
+      request: CancelQueuedTurnRequest,
+    ): Promise<CancelQueuedTurnResponse> => ({
+      queueEntryId: request.queueEntryId,
+      cancelled: registry.cancelQueuedTurn(
+        request.queueEntryId,
+        "Cancelled from the desktop composer.",
+      ),
+    }),
   );
 
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -9,6 +9,8 @@ import type {
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  CancelQueuedTurnRequest,
+  CancelQueuedTurnResponse,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
   CancelThreadExecutionModeQueueRequest,
@@ -295,6 +297,7 @@ import type {
   IntegratedTerminalWriteRequest,
 } from "../shared/integrated-terminal";
 import {
+  AGENT_CANCEL_QUEUED_TURN_CHANNEL,
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
   AGENT_APPLY_THREAD_MODEL_MIGRATION_CHANNEL,
   AGENT_EVENT_CHANNEL,
@@ -1089,6 +1092,10 @@ const desktopApi = Object.freeze({
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>
     await ipcRenderer.invoke(AGENT_START_TURN_CHANNEL, request),
+  cancelQueuedTurn: async (
+    request: CancelQueuedTurnRequest,
+  ): Promise<CancelQueuedTurnResponse> =>
+    await ipcRenderer.invoke(AGENT_CANCEL_QUEUED_TURN_CHANNEL, request),
   interruptTurn: async (
     request: InterruptTurnRequest
   ): Promise<InterruptTurnResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -418,6 +418,8 @@ function resolveSelectedCodexEnvironmentActionId(params: {
 
 type QueuedTurnDraft = {
   id: string;
+  backendQueuePending?: boolean;
+  queueEntryId?: string;
   input?: AppServerTurnInputItem[];
   imageAttachments: ComposerImageAttachment[];
   fileAttachments: ComposerFileAttachment[];
@@ -1219,10 +1221,6 @@ function notificationIncludesDraftContent(
 
   const notificationImageUrls = new Set(collectImageUrls(params));
   return attachmentUrls.every((url) => notificationImageUrls.has(url));
-}
-
-function isSteerInjectionOpportunity(method: string): boolean {
-  return method === "item/completed" || method === "exec_command/ended";
 }
 
 function parseStaleSteerError(
@@ -2874,22 +2872,6 @@ export function Composer(props: ComposerProps) {
   const queueCurrentDraftInFlightRef = useRef(false);
   const pendingSteerCreationInFlightRef = useRef(false);
   const turnPayloadPreparationInFlightRef = useRef(false);
-  const serverQueuedTurnEntryIdsRef = useRef(new Map<string, string>());
-  const [serverQueuedTurnEntryId, setServerQueuedTurnEntryIdState] =
-    useState<string>();
-  const updateServerQueuedTurnEntryId = (
-    nextEntryId?: string,
-    scopeKey = composerScopeKey,
-  ): void => {
-    if (nextEntryId) {
-      serverQueuedTurnEntryIdsRef.current.set(scopeKey, nextEntryId);
-    } else {
-      serverQueuedTurnEntryIdsRef.current.delete(scopeKey);
-    }
-    if (scopeKey === composerScopeKey) {
-      setServerQueuedTurnEntryIdState(nextEntryId);
-    }
-  };
   const [pendingSteer, setPendingSteerState] = useState<
     PendingSteerDraft | undefined
   >(
@@ -3954,6 +3936,57 @@ export function Composer(props: ComposerProps) {
       return nextQueuedTurns;
     });
   };
+  const updateQueuedTurnInScope = (
+    scopeKey: string,
+    queued: QueuedTurnDraft,
+    update: (current: QueuedTurnDraft) => QueuedTurnDraft,
+  ): void => {
+    const current = draftStore.getQueuedTurns(scopeKey);
+    const nextQueuedTurns = current.map((candidate) =>
+      candidate.id === queued.id ? update(candidate) : candidate
+    );
+    saveQueuedTurnSnapshots(scopeKey, nextQueuedTurns);
+    if (activeComposerScopeKeyRef.current === scopeKey) {
+      setQueuedTurnsState(nextQueuedTurns);
+    }
+  };
+  const removeQueuedTurnInScope = (
+    scopeKey: string,
+    queued: QueuedTurnDraft,
+  ): void => {
+    const current = draftStore.getQueuedTurns(scopeKey);
+    const nextQueuedTurns = current.filter(
+      (candidate) => candidate.id !== queued.id,
+    );
+    saveQueuedTurnSnapshots(scopeKey, nextQueuedTurns);
+    if (activeComposerScopeKeyRef.current === scopeKey) {
+      setQueuedTurnsState(nextQueuedTurns);
+    }
+  };
+  const cancelServerManagedQueuedTurn = async (
+    queued: QueuedTurnDraft,
+  ): Promise<boolean> => {
+    if (!queued.queueEntryId) {
+      return true;
+    }
+    if (!props.desktopApi?.cancelQueuedTurn) {
+      setSendError("Queued turn cancellation is unavailable.");
+      return false;
+    }
+    try {
+      const response = await props.desktopApi.cancelQueuedTurn({
+        queueEntryId: queued.queueEntryId,
+      });
+      if (!response.cancelled) {
+        setSendError("The queued turn is no longer waiting.");
+        return false;
+      }
+      return true;
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+  };
   const removeLocalQueuedTurn = (queued: QueuedTurnDraft): void => {
     setQueuedTurnsState((current) =>
       current.filter((candidate) => candidate.id !== queued.id)
@@ -4488,7 +4521,6 @@ export function Composer(props: ComposerProps) {
       flushComposerDraftSnapshot(previousScopeKey, previousSnapshot);
     }
     if (!props.thread && previousScopeKey.startsWith("thread:")) {
-      serverQueuedTurnEntryIdsRef.current.delete(previousScopeKey);
       globalQueuedTurnReleaseScopeKeys.delete(previousScopeKey);
     }
 
@@ -4534,9 +4566,6 @@ export function Composer(props: ComposerProps) {
     setScheduleMenuOpen(false);
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
-    setServerQueuedTurnEntryIdState(
-      serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)
-    );
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -4691,7 +4720,6 @@ export function Composer(props: ComposerProps) {
     updateSending(false);
     setInterrupting(false);
     setSteering(false);
-    setServerQueuedTurnEntryIdState(undefined);
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
@@ -4781,10 +4809,20 @@ export function Composer(props: ComposerProps) {
       if (
         notificationThreadId &&
         typeof turnQueueRecord?.queueEntryId === "string" &&
-        turnQueueRecord.queueEntryId ===
-          serverQueuedTurnEntryIdsRef.current.get(
-            getThreadComposerScopeKey(event.backend, notificationThreadId)
+        (
+          draftStore.getQueuedTurns(
+            getThreadComposerScopeKey(event.backend, notificationThreadId),
+          ).some(
+            (queued) => queued.queueEntryId === turnQueueRecord.queueEntryId,
           )
+          || (
+            event.backend === thread.source
+            && notificationThreadId === thread.id
+            && queuedTurns.some(
+              (queued) => queued.queueEntryId === turnQueueRecord.queueEntryId,
+            )
+          )
+        )
       ) {
         const queueScopeKey = getThreadComposerScopeKey(
           event.backend,
@@ -4792,6 +4830,20 @@ export function Composer(props: ComposerProps) {
         );
         const queueEventIsCurrentThread =
           event.backend === thread.source && notificationThreadId === thread.id;
+        if (
+          queueEventIsCurrentThread &&
+          (turnQueueRecord.status === "started" ||
+            turnQueueRecord.status === "terminal" ||
+            turnQueueRecord.status === "failed" ||
+            turnQueueRecord.status === "cancelled")
+        ) {
+          const queued = queuedTurns.find(
+            (candidate) => candidate.queueEntryId === turnQueueRecord.queueEntryId,
+          );
+          if (queued) {
+            removeQueuedTurn(queued);
+          }
+        }
         if (
           queueEventIsCurrentThread &&
           turnQueueRecord.status === "started" &&
@@ -4807,7 +4859,6 @@ export function Composer(props: ComposerProps) {
           turnQueueRecord.status === "cancelled"
         ) {
           globalQueuedTurnReleaseScopeKeys.delete(queueScopeKey);
-          updateServerQueuedTurnEntryId(undefined, queueScopeKey);
           if (
             queueEventIsCurrentThread &&
             !activeTurnIdRef.current &&
@@ -4874,14 +4925,6 @@ export function Composer(props: ComposerProps) {
         setPendingSteer(undefined);
         setSteering(false);
         props.onPendingStatusChange?.("Thinking");
-      }
-
-      if (
-        pendingSteer?.status === "pending" &&
-        activeTurnIdRef.current &&
-        isSteerInjectionOpportunity(event.notification.method)
-      ) {
-        void submitPendingSteer(pendingSteer);
       }
 
       if (
@@ -5496,9 +5539,23 @@ export function Composer(props: ComposerProps) {
 
   const sendThreadTurn = async (
     queued?: QueuedTurnDraft,
-    options?: { payload?: ComposerTurnPayload; queueClaimed?: boolean },
+    options?: {
+      backendQueueProjection?: {
+        queued: QueuedTurnDraft;
+        scopeKey: string;
+      };
+      payload?: ComposerTurnPayload;
+      queueClaimed?: boolean;
+    },
   ): Promise<void> => {
     if (!props.thread || !props.desktopApi?.startTurn) {
+      if (options?.backendQueueProjection) {
+        removeQueuedTurnInScope(
+          options.backendQueueProjection.scopeKey,
+          options.backendQueueProjection.queued,
+        );
+      }
+      updateSending(false);
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
         globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
@@ -5537,7 +5594,12 @@ export function Composer(props: ComposerProps) {
           } satisfies AppServerCollaborationModeRequest)
         : undefined;
 
-    if (!queued && props.onBeforeStartTurn && !(await props.onBeforeStartTurn())) {
+    if (
+      !queued &&
+      !options?.backendQueueProjection &&
+      props.onBeforeStartTurn &&
+      !(await props.onBeforeStartTurn())
+    ) {
       updateSending(false);
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
@@ -5546,13 +5608,19 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    props.onBeforeSendTurn?.();
-    props.onPendingStatusChange?.(collaborationMode ? "Planning" : "Thinking");
-    const optimisticMessageId = props.addOptimisticUserMessage?.(
-      payload.displayText,
-      payload.imageParts
-    );
-    setActiveOptimisticMessageId(optimisticMessageId);
+    const backendQueueSubmission = Boolean(options?.backendQueueProjection);
+    let optimisticMessageId: string | undefined;
+    if (!backendQueueSubmission) {
+      props.onBeforeSendTurn?.();
+      props.onPendingStatusChange?.(
+        collaborationMode ? "Planning" : "Thinking",
+      );
+      optimisticMessageId = props.addOptimisticUserMessage?.(
+        payload.displayText,
+        payload.imageParts,
+      );
+      setActiveOptimisticMessageId(optimisticMessageId);
+    }
     const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
     if (!queued) {
       resetComposerDraftAndState(composerScopeKey);
@@ -5576,8 +5644,46 @@ export function Composer(props: ComposerProps) {
           : undefined,
       });
       if (response.queueStatus === "queued") {
-        updateServerQueuedTurnEntryId(response.queueEntryId ?? response.turnId);
+        const queueEntryId = response.queueEntryId ?? response.turnId;
+        if (options?.backendQueueProjection) {
+          updateQueuedTurnInScope(
+            options.backendQueueProjection.scopeKey,
+            options.backendQueueProjection.queued,
+            (current) => ({
+              ...current,
+              backendQueuePending: false,
+              input: payload.input,
+              queueEntryId,
+            }),
+          );
+        } else {
+          enqueueQueuedTurn({
+            ...(queued ?? {
+              id: createQueuedTurnId(),
+              text: canonicalDraft,
+              imageAttachments,
+              fileAttachments,
+            }),
+            input: payload.input,
+            queueEntryId,
+          });
+        }
       } else {
+        if (options?.backendQueueProjection) {
+          removeQueuedTurnInScope(
+            options.backendQueueProjection.scopeKey,
+            options.backendQueueProjection.queued,
+          );
+          props.onBeforeSendTurn?.();
+          props.onPendingStatusChange?.(
+            collaborationMode ? "Planning" : "Thinking",
+          );
+          optimisticMessageId = props.addOptimisticUserMessage?.(
+            payload.displayText,
+            payload.imageParts,
+          );
+          setActiveOptimisticMessageId(optimisticMessageId);
+        }
         updateActiveTurnId(response.turnId);
         props.onActiveTurnIdChange?.(response.turnId);
       }
@@ -5610,6 +5716,12 @@ export function Composer(props: ComposerProps) {
         );
       }
     } catch (error) {
+      if (options?.backendQueueProjection) {
+        removeQueuedTurnInScope(
+          options.backendQueueProjection.scopeKey,
+          options.backendQueueProjection.queued,
+        );
+      }
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);
       }
@@ -5684,7 +5796,6 @@ export function Composer(props: ComposerProps) {
       globalQueuedTurnReleaseScopeKeys.has(composerScopeKey) ||
       props.threadBusy ||
       activeTurnId ||
-      serverQueuedTurnEntryId ||
       sending ||
       props.launchpad ||
       props.disabled
@@ -5704,7 +5815,6 @@ export function Composer(props: ComposerProps) {
   }, [
     activeTurnId,
     nextReleasableQueuedTurn,
-    serverQueuedTurnEntryId,
     scheduleTick,
     sending,
     props.threadBusy,
@@ -5837,7 +5947,9 @@ export function Composer(props: ComposerProps) {
     !props.launchpad &&
     (Boolean(props.threadBusy) ||
       Boolean(activeTurnIdRef.current) ||
-      Boolean(serverQueuedTurnEntryIdsRef.current.get(composerScopeKey)) ||
+      queuedTurns.some((queued) =>
+        Boolean(queued.backendQueuePending || queued.queueEntryId)
+      ) ||
       sendingRef.current);
 
   const scheduleCurrentDraft = (scheduledSendAt: number): void => {
@@ -6038,18 +6150,28 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const created = createPendingSteer({
+    const pending = {
       id: createQueuedTurnId(),
       text: canonicalDraft,
       imageAttachments,
       fileAttachments,
-    });
-    return isPromiseLike(created)
-      ? created.then(() => undefined)
-      : undefined;
+    };
+    const created = createPendingSteer(pending);
+    const continueSteering = (accepted: boolean): void => {
+      if (accepted && activeTurnIdRef.current) {
+        void submitPendingSteer(pending);
+      }
+    };
+    if (isPromiseLike(created)) {
+      return created.then(continueSteering);
+    }
+    continueSteering(created);
   };
 
-  const steerQueuedTurn = (queued: QueuedTurnDraft): void => {
+  const steerQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
+    if (!(await cancelServerManagedQueuedTurn(queued))) {
+      return;
+    }
     const continueSteering = (created: boolean): void => {
       if (!created) {
         return;
@@ -6061,7 +6183,7 @@ export function Composer(props: ComposerProps) {
     };
     const created = createPendingSteer(queued);
     if (isPromiseLike(created)) {
-      void created.then(continueSteering);
+      await created.then(continueSteering);
     } else {
       continueSteering(created);
     }
@@ -6121,14 +6243,60 @@ export function Composer(props: ComposerProps) {
             ? { scheduledSendAt: effectiveScheduledSendAt }
             : undefined,
         );
-      } else {
+      } else if (effectiveScheduledSendAt) {
         const queued = queueCurrentDraft(
-          effectiveScheduledSendAt
-            ? { scheduledSendAt: effectiveScheduledSendAt }
-            : undefined,
+          { scheduledSendAt: effectiveScheduledSendAt },
         );
         if (queued) {
           await queued;
+        }
+      } else {
+        // Ordinary replies enter the main-process FIFO immediately. The
+        // renderer reserves a presentation slot while startTurn hands the
+        // request to that queue, then records the registry entry id.
+        setScheduledDraftSendAt(undefined);
+        setScheduleArmed(true);
+        const payloadOrPromise = buildTurnPayload(
+          canonicalDraft,
+          imageAttachments,
+          fileAttachments,
+          skillTokens,
+        );
+        let payload: ComposerTurnPayload;
+        if (isPromiseLike(payloadOrPromise)) {
+          turnPayloadPreparationInFlightRef.current = true;
+          updateSending(true);
+          try {
+            payload = await payloadOrPromise;
+          } catch (error) {
+            updateSending(false);
+            setSendError(error instanceof Error ? error.message : String(error));
+            return;
+          } finally {
+            turnPayloadPreparationInFlightRef.current = false;
+          }
+        } else {
+          payload = payloadOrPromise;
+        }
+        if (payload.input.length > 0 && !props.disabled) {
+          setSendError(undefined);
+          updateSending(true);
+          const backendQueueProjection: QueuedTurnDraft = {
+            id: createQueuedTurnId(),
+            backendQueuePending: true,
+            text: canonicalDraft,
+            imageAttachments,
+            fileAttachments,
+            input: payload.input,
+          };
+          enqueueQueuedTurn(backendQueueProjection);
+          await sendThreadTurn(undefined, {
+            backendQueueProjection: {
+              queued: backendQueueProjection,
+              scopeKey: composerScopeKey,
+            },
+            payload,
+          });
         }
       }
       return;
@@ -7613,7 +7781,11 @@ export function Composer(props: ComposerProps) {
     ? futureScheduledDraftSendAt
     : undefined;
   const submitButtonLabel =
-    activeTurnId || serverQueuedTurnEntryId || props.threadBusy
+    activeTurnId ||
+    queuedTurns.some((queued) =>
+      Boolean(queued.backendQueuePending || queued.queueEntryId)
+    ) ||
+    props.threadBusy
       ? "Queue"
       : sending
         ? props.launchpad
@@ -7779,7 +7951,9 @@ export function Composer(props: ComposerProps) {
       props.thread.workspaceHandoff?.available !== false &&
       !sending &&
       !activeTurnId &&
-      !serverQueuedTurnEntryId &&
+      !queuedTurns.some((queued) =>
+        Boolean(queued.backendQueuePending || queued.queueEntryId)
+      ) &&
       !props.pendingRequestActive &&
       !props.pendingUserInputActive &&
       !handoffSubmitting
@@ -8676,6 +8850,9 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       {queuedTurns.map((queued, index) => {
+        const backendOwned = Boolean(
+          queued.backendQueuePending || queued.queueEntryId,
+        );
         const scheduledSendAt = getFutureScheduledSendAt(
           queued.scheduledSendAt,
           scheduleNow,
@@ -8695,7 +8872,7 @@ export function Composer(props: ComposerProps) {
               .filter(Boolean)
               .join(" ")}
             aria-label={index === 0 ? "Queued message" : `Queued message ${index + 1}`}
-            key={`${index}:${queued.text}:${queued.imageAttachments.length}:${queued.fileAttachments.length}:${queued.scheduledSendAt ?? ""}`}
+            key={queued.id}
           >
             <div className="composer__queued-copy">
               <span className="composer__queued-label">
@@ -8711,16 +8888,18 @@ export function Composer(props: ComposerProps) {
                 supportsSteering && !queued.reviewCommand ? (
                   <button
                     className="composer__secondary-action"
-                    disabled={props.disabled || steering}
+                    disabled={
+                      props.disabled || steering || queued.backendQueuePending
+                    }
                     type="button"
                     onClick={() => {
-                      steerQueuedTurn(queued);
+                      void steerQueuedTurn(queued);
                     }}
                   >
                     {steering ? "Steering..." : "Steer"}
                   </button>
                 ) : null
-              ) : (
+              ) : !backendOwned ? (
                 <button
                   className="composer__secondary-action"
                   disabled={props.disabled || sending}
@@ -8731,27 +8910,49 @@ export function Composer(props: ComposerProps) {
                 >
                   Send now
                 </button>
-              )}
+              ) : null}
               <button
                 className="composer__secondary-action"
+                disabled={queued.backendQueuePending}
                 type="button"
                 onClick={() => {
-                  setComposerDraftFromCanonical(queued.text);
-                  setImageAttachments(queued.imageAttachments);
-                  setFileAttachments(queued.fileAttachments);
-                  setScheduledDraftSendAt(scheduledSendAt);
-                  setScheduleArmed(true);
-                  removeQueuedTurnAt(index);
-                  requestAnimationFrame(() => inputRef.current?.focus());
+                  const editQueuedTurn = (): void => {
+                    setComposerDraftFromCanonical(queued.text);
+                    setImageAttachments(queued.imageAttachments);
+                    setFileAttachments(queued.fileAttachments);
+                    setScheduledDraftSendAt(scheduledSendAt);
+                    setScheduleArmed(true);
+                    removeQueuedTurnAt(index);
+                    requestAnimationFrame(() => inputRef.current?.focus());
+                  };
+                  if (!backendOwned) {
+                    editQueuedTurn();
+                    return;
+                  }
+                  void (async () => {
+                    if (!(await cancelServerManagedQueuedTurn(queued))) {
+                      return;
+                    }
+                    editQueuedTurn();
+                  })();
                 }}
               >
                 Edit
               </button>
               <button
                 className="composer__secondary-action"
+                disabled={queued.backendQueuePending}
                 type="button"
                 onClick={() => {
-                  removeQueuedTurnAt(index);
+                  if (!backendOwned) {
+                    removeQueuedTurnAt(index);
+                    return;
+                  }
+                  void (async () => {
+                    if (await cancelServerManagedQueuedTurn(queued)) {
+                      removeQueuedTurnAt(index);
+                    }
+                  })();
                 }}
               >
                 Delete

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -3706,6 +3706,22 @@ export function Composer(props: ComposerProps) {
     applyRecoveredComposerDraft(snapshot);
     return true;
   };
+  const restoreSubmittedComposerDraftInScope = (
+    scopeKey: string,
+    snapshot: ComposerDraftSnapshot,
+  ): boolean => {
+    if (activeComposerScopeKeyRef.current === scopeKey) {
+      return recoverSubmittedComposerDraft(snapshot);
+    }
+
+    const current = draftStore.get(scopeKey);
+    if (current && hasComposerDraftSnapshotContent(current)) {
+      draftStore.pushDraft(scopeKey, snapshot);
+      return false;
+    }
+    saveComposerDraftSnapshot(scopeKey, snapshot);
+    return true;
+  };
   const clearRecoveredComposerDraft = (): void => {
     recoveryCycleRef.current = undefined;
     recoveringDraftRef.current = true;
@@ -3915,6 +3931,17 @@ export function Composer(props: ComposerProps) {
       return nextQueuedTurns;
     });
   };
+  const enqueueQueuedTurnInScope = (
+    scopeKey: string,
+    nextQueuedTurn: QueuedTurnDraft,
+  ): void => {
+    const current = draftStore.getQueuedTurns(scopeKey);
+    const nextQueuedTurns = [...current, nextQueuedTurn];
+    saveQueuedTurnSnapshots(scopeKey, nextQueuedTurns);
+    if (activeComposerScopeKeyRef.current === scopeKey) {
+      setQueuedTurnsState(nextQueuedTurns);
+    }
+  };
   const removeQueuedTurnAt = (index: number): void => {
     setQueuedTurnsState((current) => {
       const nextQueuedTurns = current.filter((_, candidateIndex) => {
@@ -3963,14 +3990,40 @@ export function Composer(props: ComposerProps) {
       setQueuedTurnsState(nextQueuedTurns);
     }
   };
+  const preserveCancelledQueuedTurnInScope = (
+    scopeKey: string,
+    queued: QueuedTurnDraft,
+  ): void => {
+    const current = draftStore.getQueuedTurns(scopeKey);
+    const preserved = {
+      ...queued,
+      backendQueuePending: false,
+      queueEntryId: undefined,
+    };
+    const nextQueuedTurns = current.some((candidate) => candidate.id === queued.id)
+      ? current.map((candidate) =>
+          candidate.id === queued.id ? preserved : candidate
+        )
+      : [...current, preserved];
+    saveQueuedTurnSnapshots(scopeKey, nextQueuedTurns);
+    if (activeComposerScopeKeyRef.current === scopeKey) {
+      setQueuedTurnsState(nextQueuedTurns);
+    }
+  };
   const cancelServerManagedQueuedTurn = async (
     queued: QueuedTurnDraft,
+    scopeKey = composerScopeKey,
   ): Promise<boolean> => {
+    const reportError = (message: string): void => {
+      if (activeComposerScopeKeyRef.current === scopeKey) {
+        setSendError(message);
+      }
+    };
     if (!queued.queueEntryId) {
       return true;
     }
     if (!props.desktopApi?.cancelQueuedTurn) {
-      setSendError("Queued turn cancellation is unavailable.");
+      reportError("Queued turn cancellation is unavailable.");
       return false;
     }
     try {
@@ -3978,12 +4031,12 @@ export function Composer(props: ComposerProps) {
         queueEntryId: queued.queueEntryId,
       });
       if (!response.cancelled) {
-        setSendError("The queued turn is no longer waiting.");
+        reportError("The queued turn is no longer waiting.");
         return false;
       }
       return true;
     } catch (error) {
-      setSendError(error instanceof Error ? error.message : String(error));
+      reportError(error instanceof Error ? error.message : String(error));
       return false;
     }
   };
@@ -5543,19 +5596,35 @@ export function Composer(props: ComposerProps) {
       backendQueueProjection?: {
         queued: QueuedTurnDraft;
         scopeKey: string;
+        submittedSnapshot: ComposerDraftSnapshot;
       };
       payload?: ComposerTurnPayload;
       queueClaimed?: boolean;
     },
   ): Promise<void> => {
+    const backendQueueSubmission = options?.backendQueueProjection;
+    const submittedScopeKey =
+      backendQueueSubmission?.scopeKey ?? composerScopeKey;
+    const submittedSnapshot =
+      backendQueueSubmission?.submittedSnapshot
+      ?? latestDraftSnapshotRef.current.snapshot;
+    const submittedScopeIsVisible = (): boolean =>
+      activeComposerScopeKeyRef.current === submittedScopeKey;
+
     if (!props.thread || !props.desktopApi?.startTurn) {
-      if (options?.backendQueueProjection) {
+      if (backendQueueSubmission) {
         removeQueuedTurnInScope(
-          options.backendQueueProjection.scopeKey,
-          options.backendQueueProjection.queued,
+          backendQueueSubmission.scopeKey,
+          backendQueueSubmission.queued,
+        );
+        restoreSubmittedComposerDraftInScope(
+          submittedScopeKey,
+          submittedSnapshot,
         );
       }
-      updateSending(false);
+      if (!backendQueueSubmission || submittedScopeIsVisible()) {
+        updateSending(false);
+      }
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
         globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
@@ -5577,6 +5646,16 @@ export function Composer(props: ComposerProps) {
       ? await payloadOrPromise
       : payloadOrPromise;
     if (payload.input.length === 0 || props.disabled) {
+      if (backendQueueSubmission) {
+        removeQueuedTurnInScope(
+          backendQueueSubmission.scopeKey,
+          backendQueueSubmission.queued,
+        );
+        restoreSubmittedComposerDraftInScope(
+          submittedScopeKey,
+          submittedSnapshot,
+        );
+      }
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
         globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
@@ -5608,7 +5687,6 @@ export function Composer(props: ComposerProps) {
       return;
     }
 
-    const backendQueueSubmission = Boolean(options?.backendQueueProjection);
     let optimisticMessageId: string | undefined;
     if (!backendQueueSubmission) {
       props.onBeforeSendTurn?.();
@@ -5621,8 +5699,7 @@ export function Composer(props: ComposerProps) {
       );
       setActiveOptimisticMessageId(optimisticMessageId);
     }
-    const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
-    if (!queued) {
+    if (!queued && !backendQueueSubmission) {
       resetComposerDraftAndState(composerScopeKey);
       if (collaborationMode) {
         setPlanModeEnabled(false);
@@ -5645,10 +5722,10 @@ export function Composer(props: ComposerProps) {
       });
       if (response.queueStatus === "queued") {
         const queueEntryId = response.queueEntryId ?? response.turnId;
-        if (options?.backendQueueProjection) {
+        if (backendQueueSubmission) {
           updateQueuedTurnInScope(
-            options.backendQueueProjection.scopeKey,
-            options.backendQueueProjection.queued,
+            backendQueueSubmission.scopeKey,
+            backendQueueSubmission.queued,
             (current) => ({
               ...current,
               backendQueuePending: false,
@@ -5656,6 +5733,9 @@ export function Composer(props: ComposerProps) {
               queueEntryId,
             }),
           );
+          if (submittedScopeIsVisible()) {
+            updateSending(false);
+          }
         } else {
           enqueueQueuedTurn({
             ...(queued ?? {
@@ -5669,23 +5749,27 @@ export function Composer(props: ComposerProps) {
           });
         }
       } else {
-        if (options?.backendQueueProjection) {
+        if (backendQueueSubmission) {
           removeQueuedTurnInScope(
-            options.backendQueueProjection.scopeKey,
-            options.backendQueueProjection.queued,
+            backendQueueSubmission.scopeKey,
+            backendQueueSubmission.queued,
           );
-          props.onBeforeSendTurn?.();
-          props.onPendingStatusChange?.(
-            collaborationMode ? "Planning" : "Thinking",
-          );
-          optimisticMessageId = props.addOptimisticUserMessage?.(
-            payload.displayText,
-            payload.imageParts,
-          );
-          setActiveOptimisticMessageId(optimisticMessageId);
+          if (submittedScopeIsVisible()) {
+            props.onBeforeSendTurn?.();
+            props.onPendingStatusChange?.(
+              collaborationMode ? "Planning" : "Thinking",
+            );
+            optimisticMessageId = props.addOptimisticUserMessage?.(
+              payload.displayText,
+              payload.imageParts,
+            );
+            setActiveOptimisticMessageId(optimisticMessageId);
+          }
         }
-        updateActiveTurnId(response.turnId);
-        props.onActiveTurnIdChange?.(response.turnId);
+        if (!backendQueueSubmission || submittedScopeIsVisible()) {
+          updateActiveTurnId(response.turnId);
+          props.onActiveTurnIdChange?.(response.turnId);
+        }
       }
       // Queued turns only carry their serialized text, but that text is
       // self-describing (`[@label](~/path)` markdown), so the scan alone
@@ -5716,34 +5800,44 @@ export function Composer(props: ComposerProps) {
         );
       }
     } catch (error) {
-      if (options?.backendQueueProjection) {
+      if (backendQueueSubmission) {
         removeQueuedTurnInScope(
-          options.backendQueueProjection.scopeKey,
-          options.backendQueueProjection.queued,
+          backendQueueSubmission.scopeKey,
+          backendQueueSubmission.queued,
         );
       }
       if (optimisticMessageId) {
         props.removeOptimisticMessage?.(optimisticMessageId);
       }
       if (!queued) {
-        const recoveredSubmittedDraft =
-          recoverSubmittedComposerDraft(submittedSnapshot);
-        if (collaborationMode && recoveredSubmittedDraft) {
+        const recoveredSubmittedDraft = backendQueueSubmission
+          ? restoreSubmittedComposerDraftInScope(
+              submittedScopeKey,
+              submittedSnapshot,
+            )
+          : recoverSubmittedComposerDraft(submittedSnapshot);
+        if (
+          collaborationMode
+          && recoveredSubmittedDraft
+          && (!backendQueueSubmission || submittedScopeIsVisible())
+        ) {
           setPlanModeEnabled(true);
         }
       }
-      props.onPendingStatusChange?.(undefined);
-      updateSending(false);
-      setInterrupting(false);
-      setSteering(false);
-      updateActiveTurnId(undefined);
-      props.onActiveTurnIdChange?.(undefined);
-      setActiveOptimisticMessageId(undefined);
+      if (!backendQueueSubmission || submittedScopeIsVisible()) {
+        props.onPendingStatusChange?.(undefined);
+        updateSending(false);
+        setInterrupting(false);
+        setSteering(false);
+        updateActiveTurnId(undefined);
+        props.onActiveTurnIdChange?.(undefined);
+        setActiveOptimisticMessageId(undefined);
+        setSendError(error instanceof Error ? error.message : String(error));
+      }
       restoreQueuedTurnIfClaimed(queued, options?.queueClaimed);
       if (queued && options?.queueClaimed) {
         globalQueuedTurnReleaseScopeKeys.delete(composerScopeKey);
       }
-      setSendError(error instanceof Error ? error.message : String(error));
     }
   };
 
@@ -5996,8 +6090,12 @@ export function Composer(props: ComposerProps) {
     void queueCurrentDraft({ scheduledSendAt });
   };
 
-  const submitPendingSteer = async (pending: QueuedTurnDraft): Promise<void> => {
-    const turnId = activeTurnIdRef.current;
+  const submitPendingSteer = async (
+    pending: QueuedTurnDraft,
+    expectedTurnId = activeTurnIdRef.current,
+    expectedScopeKey = composerScopeKey,
+  ): Promise<void> => {
+    const turnId = expectedTurnId;
     if (!props.thread || !turnId || !props.desktopApi?.steerTurn) {
       setSendError("Steering is not available for this backend.");
       return;
@@ -6011,6 +6109,15 @@ export function Composer(props: ComposerProps) {
     const payload = isPromiseLike(payloadOrPromise)
       ? await payloadOrPromise
       : payloadOrPromise;
+    if (
+      activeTurnIdRef.current !== turnId
+      || activeComposerScopeKeyRef.current !== expectedScopeKey
+    ) {
+      if (activeComposerScopeKeyRef.current === expectedScopeKey) {
+        setSendError("The target turn changed before steering could start.");
+      }
+      return;
+    }
     if (
       payload.input.length === 0 ||
       props.disabled ||
@@ -6079,14 +6186,18 @@ export function Composer(props: ComposerProps) {
 
   const createPendingSteer = (
     pending: QueuedTurnDraft,
+    expectedTurnId = activeTurnIdRef.current,
+    expectedScopeKey = composerScopeKey,
   ): boolean | Promise<boolean> => {
-    const turnId = activeTurnIdRef.current;
+    const turnId = expectedTurnId;
     if (pendingSteerCreationInFlightRef.current) {
       return false;
     }
     if (
       !props.thread
       || !turnId
+      || activeTurnIdRef.current !== turnId
+      || activeComposerScopeKeyRef.current !== expectedScopeKey
       || !props.desktopApi?.steerTurn
       || !supportsSteering
     ) {
@@ -6098,7 +6209,13 @@ export function Composer(props: ComposerProps) {
     const inputOrPayload = buildQueuedTurnPayload(pending);
     const complete = (input: AppServerTurnInputItem[]): boolean => {
       try {
-        if (input.length === 0 || props.disabled || pendingSteer) {
+        if (
+          input.length === 0
+          || props.disabled
+          || pendingSteer
+          || activeTurnIdRef.current !== turnId
+          || activeComposerScopeKeyRef.current !== expectedScopeKey
+        ) {
           return false;
         }
 
@@ -6156,10 +6273,20 @@ export function Composer(props: ComposerProps) {
       imageAttachments,
       fileAttachments,
     };
-    const created = createPendingSteer(pending);
+    const expectedTurnId = activeTurnIdRef.current;
+    const expectedScopeKey = composerScopeKey;
+    const created = createPendingSteer(
+      pending,
+      expectedTurnId,
+      expectedScopeKey,
+    );
     const continueSteering = (accepted: boolean): void => {
-      if (accepted && activeTurnIdRef.current) {
-        void submitPendingSteer(pending);
+      if (accepted) {
+        void submitPendingSteer(
+          pending,
+          expectedTurnId,
+          expectedScopeKey,
+        );
       }
     };
     if (isPromiseLike(created)) {
@@ -6169,19 +6296,38 @@ export function Composer(props: ComposerProps) {
   };
 
   const steerQueuedTurn = async (queued: QueuedTurnDraft): Promise<void> => {
-    if (!(await cancelServerManagedQueuedTurn(queued))) {
+    const expectedTurnId = activeTurnIdRef.current;
+    const expectedScopeKey = composerScopeKey;
+    if (!expectedTurnId) {
+      return;
+    }
+    if (!(await cancelServerManagedQueuedTurn(queued, expectedScopeKey))) {
+      return;
+    }
+    if (
+      activeTurnIdRef.current !== expectedTurnId
+      || activeComposerScopeKeyRef.current !== expectedScopeKey
+    ) {
+      preserveCancelledQueuedTurnInScope(expectedScopeKey, queued);
       return;
     }
     const continueSteering = (created: boolean): void => {
       if (!created) {
+        preserveCancelledQueuedTurnInScope(expectedScopeKey, queued);
         return;
       }
-      removeQueuedTurn(queued);
-      if (activeTurnIdRef.current) {
-        void submitPendingSteer(queued);
-      }
+      removeQueuedTurnInScope(expectedScopeKey, queued);
+      void submitPendingSteer(
+        queued,
+        expectedTurnId,
+        expectedScopeKey,
+      );
     };
-    const created = createPendingSteer(queued);
+    const created = createPendingSteer(
+      queued,
+      expectedTurnId,
+      expectedScopeKey,
+    );
     if (isPromiseLike(created)) {
       await created.then(continueSteering);
     } else {
@@ -6254,8 +6400,11 @@ export function Composer(props: ComposerProps) {
         // Ordinary replies enter the main-process FIFO immediately. The
         // renderer reserves a presentation slot while startTurn hands the
         // request to that queue, then records the registry entry id.
+        const submittedScopeKey = composerScopeKey;
+        const submittedSnapshot = latestDraftSnapshotRef.current.snapshot;
         setScheduledDraftSendAt(undefined);
         setScheduleArmed(true);
+        resetComposerDraftAndState(submittedScopeKey);
         const payloadOrPromise = buildTurnPayload(
           canonicalDraft,
           imageAttachments,
@@ -6269,8 +6418,14 @@ export function Composer(props: ComposerProps) {
           try {
             payload = await payloadOrPromise;
           } catch (error) {
-            updateSending(false);
-            setSendError(error instanceof Error ? error.message : String(error));
+            restoreSubmittedComposerDraftInScope(
+              submittedScopeKey,
+              submittedSnapshot,
+            );
+            if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+              updateSending(false);
+              setSendError(error instanceof Error ? error.message : String(error));
+            }
             return;
           } finally {
             turnPayloadPreparationInFlightRef.current = false;
@@ -6279,8 +6434,10 @@ export function Composer(props: ComposerProps) {
           payload = payloadOrPromise;
         }
         if (payload.input.length > 0 && !props.disabled) {
-          setSendError(undefined);
-          updateSending(true);
+          if (activeComposerScopeKeyRef.current === submittedScopeKey) {
+            setSendError(undefined);
+            updateSending(true);
+          }
           const backendQueueProjection: QueuedTurnDraft = {
             id: createQueuedTurnId(),
             backendQueuePending: true,
@@ -6289,14 +6446,23 @@ export function Composer(props: ComposerProps) {
             fileAttachments,
             input: payload.input,
           };
-          enqueueQueuedTurn(backendQueueProjection);
+          enqueueQueuedTurnInScope(
+            submittedScopeKey,
+            backendQueueProjection,
+          );
           await sendThreadTurn(undefined, {
             backendQueueProjection: {
               queued: backendQueueProjection,
-              scopeKey: composerScopeKey,
+              scopeKey: submittedScopeKey,
+              submittedSnapshot,
             },
             payload,
           });
+        } else {
+          restoreSubmittedComposerDraftInScope(
+            submittedScopeKey,
+            submittedSnapshot,
+          );
         }
       }
       return;
@@ -8850,6 +9016,7 @@ export function Composer(props: ComposerProps) {
       ) : null}
 
       {queuedTurns.map((queued, index) => {
+        const queuedScopeKey = composerScopeKey;
         const backendOwned = Boolean(
           queued.backendQueuePending || queued.queueEntryId,
         );
@@ -8917,12 +9084,29 @@ export function Composer(props: ComposerProps) {
                 type="button"
                 onClick={() => {
                   const editQueuedTurn = (): void => {
+                    removeQueuedTurnInScope(queuedScopeKey, queued);
+                    if (activeComposerScopeKeyRef.current !== queuedScopeKey) {
+                      const currentDraft = draftStore.get(queuedScopeKey);
+                      if (
+                        currentDraft
+                        && hasComposerDraftSnapshotContent(currentDraft)
+                      ) {
+                        draftStore.pushDraft(queuedScopeKey, currentDraft);
+                      }
+                      saveComposerDraftSnapshot(queuedScopeKey, {
+                        draft: queued.text,
+                        editorDocument: undefined,
+                        imageAttachments: queued.imageAttachments,
+                        fileAttachments: queued.fileAttachments,
+                        skillTokens: [],
+                      });
+                      return;
+                    }
                     setComposerDraftFromCanonical(queued.text);
                     setImageAttachments(queued.imageAttachments);
                     setFileAttachments(queued.fileAttachments);
                     setScheduledDraftSendAt(scheduledSendAt);
                     setScheduleArmed(true);
-                    removeQueuedTurnAt(index);
                     requestAnimationFrame(() => inputRef.current?.focus());
                   };
                   if (!backendOwned) {
@@ -8930,7 +9114,12 @@ export function Composer(props: ComposerProps) {
                     return;
                   }
                   void (async () => {
-                    if (!(await cancelServerManagedQueuedTurn(queued))) {
+                    if (
+                      !(await cancelServerManagedQueuedTurn(
+                        queued,
+                        queuedScopeKey,
+                      ))
+                    ) {
                       return;
                     }
                     editQueuedTurn();
@@ -8949,8 +9138,13 @@ export function Composer(props: ComposerProps) {
                     return;
                   }
                   void (async () => {
-                    if (await cancelServerManagedQueuedTurn(queued)) {
-                      removeQueuedTurnAt(index);
+                    if (
+                      await cancelServerManagedQueuedTurn(
+                        queued,
+                        queuedScopeKey,
+                      )
+                    ) {
+                      removeQueuedTurnInScope(queuedScopeKey, queued);
                     }
                   })();
                 }}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3117,15 +3117,25 @@ describe("Composer", () => {
   it("queues submits while a turn start is pending", async () => {
     let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
     const startTurn = vi.fn(
-      (request: StartTurnRequest) =>
-        new Promise<StartTurnResponse>((resolve) => {
-          resolveStartTurn = () =>
-            resolve({
-              backend: request.backend,
-              threadId: request.threadId,
-              turnId: "turn-1",
-            });
-        })
+      (request: StartTurnRequest) => {
+        const text = request.input.find((item) => item.type === "text")?.text;
+        if (text === "follow up next") {
+          return Promise.resolve({
+            backend: request.backend,
+            threadId: request.threadId,
+            turnId: "queue-entry-1",
+            queueStatus: "queued" as const,
+            queueEntryId: "queue-entry-1",
+          });
+        }
+        return new Promise<StartTurnResponse>((resolve) => {
+          resolveStartTurn = () => resolve({
+            backend: request.backend,
+            threadId: request.threadId,
+            turnId: "turn-1",
+          });
+        });
+      },
     );
 
     render(
@@ -3154,8 +3164,12 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "follow up next" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(startTurn).toHaveBeenCalledTimes(1);
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent("follow up next");
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(2);
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "follow up next",
+      );
+    });
 
     await act(async () => {
       resolveStartTurn?.({
@@ -3696,11 +3710,13 @@ describe("Composer", () => {
     expect(screen.queryByText("Queued next")).not.toBeInTheDocument();
   });
 
-  it("queues Enter during an active turn and sends it after the turn clears", async () => {
+  it("submits Enter during an active turn and keeps a queued projection", async () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
     }));
     const baseProps = {
       backends: [backendSummary("codex")],
@@ -3732,9 +3748,15 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Follow up next" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(startTurn).not.toHaveBeenCalled();
-    expect(screen.getByText("Queued next")).toBeInTheDocument();
-    expect(screen.getByText("Follow up next")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ type: "text", text: "Follow up next" }],
+        }),
+      );
+      expect(screen.getByText("Queued next")).toBeInTheDocument();
+      expect(screen.getByText("Follow up next")).toBeInTheDocument();
+    });
     expect(textarea).toHaveValue("");
 
     rerender(<Composer {...baseProps} activeTurnId={undefined} />);
@@ -3754,7 +3776,9 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
     }));
     const baseProps = {
       backends: [backendSummary("codex")],
@@ -3786,10 +3810,16 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Follow up after thinking" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(startTurn).not.toHaveBeenCalled();
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Follow up after thinking"
-    );
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: [{ type: "text", text: "Follow up after thinking" }],
+        }),
+      );
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Follow up after thinking",
+      );
+    });
     expect(textarea).toHaveValue("");
 
     rerender(<Composer {...baseProps} threadBusy={false} />);
@@ -3809,7 +3839,9 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: `queue-entry-${startTurn.mock.calls.length}`,
+      queueStatus: "queued" as const,
+      queueEntryId: `queue-entry-${startTurn.mock.calls.length}`,
     }));
     const baseProps = {
       backends: [backendSummary("codex")],
@@ -3843,12 +3875,14 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Second queued reply" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "First queued reply"
-    );
-    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
-      "Second queued reply"
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "First queued reply",
+      );
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Second queued reply",
+      );
+    });
     expect(screen.queryByText("A message is already queued.")).not.toBeInTheDocument();
 
     rerender(<Composer {...baseProps} activeTurnId={undefined} />);
@@ -3862,9 +3896,7 @@ describe("Composer", () => {
         })
       );
     });
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Second queued reply"
-    );
+    expect(startTurn).toHaveBeenCalledTimes(2);
   });
 
   it("keeps the second queued turn waiting after the first queued turn dispatches", async () => {
@@ -3880,7 +3912,9 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: `turn-${startTurn.mock.calls.length + 1}`,
+      turnId: `queue-entry-${startTurn.mock.calls.length}`,
+      queueStatus: "queued" as const,
+      queueEntryId: `queue-entry-${startTurn.mock.calls.length}`,
     }));
     const baseProps = {
       backends: [backendSummary("codex")],
@@ -3920,12 +3954,14 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Second queued turn" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "First queued turn"
-    );
-    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
-      "Second queued turn"
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "First queued turn",
+      );
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Second queued turn",
+      );
+    });
 
     rerender(
       <StrictMode>
@@ -3934,14 +3970,11 @@ describe("Composer", () => {
     );
 
     await waitFor(() => {
-      expect(startTurn).toHaveBeenCalledTimes(1);
+      expect(startTurn).toHaveBeenCalledTimes(2);
     });
     await flushReactUpdates();
 
-    expect(startTurn).toHaveBeenCalledTimes(1);
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Second queued turn"
-    );
+    expect(startTurn).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       agentEventHandler?.({
@@ -3957,10 +3990,7 @@ describe("Composer", () => {
     });
     await flushReactUpdates();
 
-    expect(startTurn).toHaveBeenCalledTimes(1);
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Second queued turn"
-    );
+    expect(startTurn).toHaveBeenCalledTimes(2);
   });
 
   it("only releases one queued turn when duplicate focused composers share a queue", async () => {
@@ -4173,15 +4203,19 @@ describe("Composer", () => {
     const textarea = screen.getByLabelText("Reply");
     fireEvent.change(textarea, { target: { value: "make a branch and PR" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "make a branch and PR",
+      );
+    });
     fireEvent.change(textarea, { target: { value: "/review main" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "make a branch and PR"
-    );
-    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
-      "Review changes against main"
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Review changes against main",
+      );
+    });
 
     rerender(<Composer {...baseProps} activeTurnId={undefined} />);
 
@@ -4198,7 +4232,10 @@ describe("Composer", () => {
 
     expect(startReview).not.toHaveBeenCalled();
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Review changes against main"
+      "make a branch and PR",
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Review changes against main",
     );
 
     await act(async () => {
@@ -4396,6 +4433,12 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "/review main" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Review changes against main",
+      );
+    });
+
     rerender(
       <Composer
         {...baseProps}
@@ -4414,7 +4457,10 @@ describe("Composer", () => {
     });
     await flushReactUpdates();
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Review changes against main"
+      "make a branch and PR",
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Review changes against main",
     );
 
     rerender(
@@ -4435,12 +4481,12 @@ describe("Composer", () => {
 
     expect(startReview).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Queue" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Review changes against main"
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Review changes against main",
     );
   });
 
-  it("drops server queued turn state after switching through an empty composer", async () => {
+  it("keeps backend-owned queue state when switching through an empty composer", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
@@ -4490,6 +4536,12 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "/review main" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Review changes against main",
+      );
+    });
+
     rerender(
       <Composer
         {...baseProps}
@@ -4518,17 +4570,17 @@ describe("Composer", () => {
       />
     );
 
-    await waitFor(() => {
-      expect(startReview).toHaveBeenCalledWith({
-        backend: "codex",
-        threadId: "thread-1",
-        target: { type: "baseBranch", branch: "main" },
-        delivery: "inline",
-      });
-    });
+    await flushReactUpdates();
+    expect(startReview).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+      "make a branch and PR",
+    );
+    expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+      "Review changes against main",
+    );
   });
 
-  it("clears optimistic pending UI when a server queued turn fails before starting", async () => {
+  it("clears backend queue UI when a queued turn fails before starting", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex";
@@ -4592,11 +4644,13 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(startTurn).toHaveBeenCalled();
     });
-    expect(addOptimisticUserMessage).toHaveBeenCalledWith(
-      "make a branch and PR",
-      []
-    );
-    expect(onPendingStatusChange).toHaveBeenCalledWith("Thinking");
+    await waitFor(() => {
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "make a branch and PR",
+      );
+    });
+    expect(addOptimisticUserMessage).not.toHaveBeenCalled();
+    expect(onPendingStatusChange).not.toHaveBeenCalledWith("Thinking");
 
     await act(async () => {
       agentEventHandler?.({
@@ -4613,28 +4667,30 @@ describe("Composer", () => {
       });
     });
 
-    expect(removeOptimisticMessage).toHaveBeenCalledWith("optimistic-1");
+    expect(removeOptimisticMessage).not.toHaveBeenCalled();
     expect(onPendingStatusChange).toHaveBeenLastCalledWith(undefined);
     expect(screen.getByText("Thread queue start failed")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
   });
 
   it("does not remove the next queued message when the in-flight queued chip is edited", async () => {
-    let resolveStartTurn: ((value: StartTurnResponse) => void) | undefined;
-    const startTurn = vi.fn(
-      (request: StartTurnRequest) =>
-        new Promise<StartTurnResponse>((resolve) => {
-          resolveStartTurn = () =>
-            resolve({
-              backend: request.backend,
-              threadId: request.threadId,
-              turnId: "turn-2",
-            });
-        })
-    );
+    const startTurn = vi.fn(async (request: StartTurnRequest) => {
+      const queueEntryId = `queue-entry-${startTurn.mock.calls.length}`;
+      return {
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: queueEntryId,
+        queueStatus: "queued" as const,
+        queueEntryId,
+      };
+    });
+    const cancelQueuedTurn = vi.fn(async ({ queueEntryId }: {
+      queueEntryId: string;
+    }) => ({ queueEntryId, cancelled: true }));
     const baseProps = {
       backends: [backendSummary("codex")],
       desktopApi: {
+        cancelQueuedTurn,
         onAgentEvent: () => () => undefined,
         startTurn,
       },
@@ -4651,7 +4707,7 @@ describe("Composer", () => {
       },
     };
 
-    const { rerender } = render(
+    render(
       <Composer
         {...baseProps}
         activeTurnId="turn-1"
@@ -4664,31 +4720,26 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Second queued reply" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    rerender(<Composer {...baseProps} activeTurnId={undefined} />);
-
     await waitFor(() => {
-      expect(startTurn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          input: [{ type: "text", text: "First queued reply" }],
-        })
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "First queued reply",
+      );
+      expect(screen.getByLabelText("Queued message 2")).toHaveTextContent(
+        "Second queued reply",
       );
     });
 
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Second queued reply"
-    );
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]!);
 
-    await act(async () => {
-      resolveStartTurn?.({
-        backend: "codex",
-        threadId: "thread-1",
-        turnId: "turn-2",
+    await waitFor(() => {
+      expect(cancelQueuedTurn).toHaveBeenCalledWith({
+        queueEntryId: "queue-entry-1",
       });
+      expect(screen.getByLabelText("Reply")).toHaveValue("First queued reply");
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Second queued reply",
+      );
     });
-
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Second queued reply"
-    );
   });
 
   it("restores a queued active-turn message after navigating away and back", async () => {
@@ -4696,11 +4747,17 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
     }));
     const baseProps = {
       backends: [backendSummary("codex")],
       desktopApi: {
+        cancelQueuedTurn: vi.fn(async ({ queueEntryId }) => ({
+          queueEntryId,
+          cancelled: true,
+        })),
         onAgentEvent: () => () => undefined,
         startTurn,
       },
@@ -4735,10 +4792,12 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Keep this queued reply" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
 
-    expect(startTurn).not.toHaveBeenCalled();
-    expect(screen.getByLabelText("Queued message")).toHaveTextContent(
-      "Keep this queued reply"
-    );
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+      expect(screen.getByLabelText("Queued message")).toHaveTextContent(
+        "Keep this queued reply",
+      );
+    });
 
     unmount();
     const { unmount: unmountThreadB } = render(
@@ -4762,10 +4821,12 @@ describe("Composer", () => {
     expect(screen.getByLabelText("Queued message")).toHaveTextContent(
       "Keep this queued reply"
     );
-    expect(startTurn).not.toHaveBeenCalled();
+    expect(startTurn).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    });
 
     unmountRestoredThreadA();
     render(
@@ -4782,7 +4843,9 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
     }));
     const imageFile = new File([new Uint8Array([1, 2, 3])], "queued.png", {
       type: "image/png",
@@ -4825,13 +4888,147 @@ describe("Composer", () => {
     expect(await screen.findByAltText("queued.png")).toBeInTheDocument();
     await clickButton("Queue");
 
-    expect(startTurn).not.toHaveBeenCalled();
-    expect(screen.getByText("Queued next")).toBeInTheDocument();
-    expect(screen.getByText("1 image")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Queued next")).toBeInTheDocument();
+      expect(screen.getByText("1 image")).toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Queued image attachments: 1"),
+      ).toBeInTheDocument();
+      expect(screen.getByAltText("queued.png")).toBeInTheDocument();
+    });
+  });
+
+  it("submits a busy-thread queued reply to the backend before navigation", async () => {
+    const startTurn = vi.fn(async (request: StartTurnRequest) => ({
+      backend: request.backend,
+      threadId: request.threadId,
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
+    }));
+
+    const { unmount } = render(
+      <Composer
+        activeTurnId="turn-1"
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Run after this turn" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [{ type: "text", text: "Run after this turn" }],
+        }),
+      );
+    });
+
+    unmount();
+    expect(startTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a delayed backend queue acknowledgement scoped to its thread", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(() => startTurnDeferred.promise);
+    const threadA: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Active turn",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB: NavigationThreadSummary = {
+      ...threadA,
+      id: "thread-2",
+      title: "Other thread",
+    };
+    const baseProps = {
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Stay with thread A" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Stay with thread A")).toBeInTheDocument();
+    });
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />,
+    );
+    expect(screen.queryByText("Stay with thread A")).not.toBeInTheDocument();
+
+    await act(async () => {
+      startTurnDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "queue-entry-1",
+        queueStatus: "queued",
+        queueEntryId: "queue-entry-1",
+      });
+      await startTurnDeferred.promise;
+    });
+
+    expect(screen.queryByText("Stay with thread A")).not.toBeInTheDocument();
+    expect(draftStore.getQueuedTurns("thread:codex:thread-2")).toEqual([]);
     expect(
-      screen.getByLabelText("Queued image attachments: 1")
-    ).toBeInTheDocument();
-    expect(screen.getByAltText("queued.png")).toBeInTheDocument();
+      draftStore.getQueuedTurn("thread:codex:thread-1"),
+    ).toMatchObject({
+      queueEntryId: "queue-entry-1",
+      text: "Stay with thread A",
+    });
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />,
+    );
+    expect(screen.getByText("Stay with thread A")).toBeInTheDocument();
   });
 
   it("steers Command Enter during an active turn when supported", async () => {
@@ -4899,27 +5096,6 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Change direction" } });
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
-    expect(steerTurn).not.toHaveBeenCalled();
-    expect(screen.getByText("Pending steer")).toBeInTheDocument();
-    expect(screen.getByText("Change direction")).toBeInTheDocument();
-    expect(textarea).toHaveValue("");
-
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "item/completed",
-          params: {
-            threadId: "thread-1",
-            item: {
-              type: "tool_call",
-              output: "ready for another instruction",
-            },
-          },
-        },
-      });
-    });
-
     await waitFor(() => {
       expect(steerTurn).toHaveBeenCalledWith({
         backend: "codex",
@@ -4930,6 +5106,8 @@ describe("Composer", () => {
       });
     });
     expect(screen.getByText("Steering now")).toBeInTheDocument();
+    expect(screen.getByText("Change direction")).toBeInTheDocument();
+    expect(textarea).toHaveValue("");
     expect(startTurn).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -5094,7 +5272,7 @@ describe("Composer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("restores a pending steer after navigating away and back", async () => {
+  it("does not retry an in-flight steer after navigating away and back", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex";
@@ -5169,9 +5347,9 @@ describe("Composer", () => {
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
     expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
-      "Keep steering direction"
+      "Keep steering direction",
     );
-    expect(steerTurn).not.toHaveBeenCalled();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
 
     unmount();
     const { unmount: unmountThreadB } = render(
@@ -5191,10 +5369,10 @@ describe("Composer", () => {
       />
     );
 
-    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
-      "Keep steering direction"
-    );
-    expect(steerTurn).not.toHaveBeenCalled();
+    expect(
+      screen.queryByLabelText("Pending steer message")
+    ).not.toBeInTheDocument();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       agentEventHandler?.({
@@ -5221,9 +5399,10 @@ describe("Composer", () => {
         requestId: expect.any(String),
       });
     });
+    expect(steerTurn).toHaveBeenCalledTimes(1);
   });
 
-  it("restores a pending steer after switching thread props away and back", async () => {
+  it("does not retry an in-flight steer after switching thread props", async () => {
     const draftStore = createComposerDraftStore();
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
@@ -5306,13 +5485,13 @@ describe("Composer", () => {
       />
     );
 
-    expect(screen.getByLabelText("Pending steer message")).toHaveTextContent(
-      "Keep steering through prop navigation"
-    );
-    expect(steerTurn).not.toHaveBeenCalled();
+    expect(
+      screen.queryByLabelText("Pending steer message")
+    ).not.toBeInTheDocument();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
   });
 
-  it("sends a restored pending steer as the next turn when the active turn cleared while away", async () => {
+  it("does not turn an already-dispatched steer into a new turn after navigation", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
@@ -5379,7 +5558,7 @@ describe("Composer", () => {
       "Continue after active turn"
     );
     expect(startTurn).not.toHaveBeenCalled();
-    expect(steerTurn).not.toHaveBeenCalled();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
 
     unmount();
     render(
@@ -5389,15 +5568,9 @@ describe("Composer", () => {
       />
     );
 
-    await waitFor(() => {
-      expect(startTurn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          backend: "codex",
-          threadId: "thread-1",
-          input: [{ type: "text", text: "Continue after active turn" }],
-        })
-      );
-    });
+    await flushReactUpdates();
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
     expect(screen.queryByLabelText("Pending steer message")).not.toBeInTheDocument();
   });
 
@@ -5557,7 +5730,7 @@ describe("Composer", () => {
     }
   });
 
-  it("lets pending steers be edited before they are injected", async () => {
+  it("hands steering to the backend before the draft can be reclaimed", async () => {
     const steerTurn = vi.fn(async () => ({
       backend: "codex" as const,
       threadId: "thread-1",
@@ -5608,12 +5781,10 @@ describe("Composer", () => {
     fireEvent.change(textarea, { target: { value: "Revise the plan" } });
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
-    expect(screen.getByText("Pending steer")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
-    expect(textarea).toHaveValue("Revise the plan");
-    expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
-    expect(steerTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).not.toBeInTheDocument();
+    expect(textarea).toHaveValue("");
+    expect(steerTurn).toHaveBeenCalledTimes(1);
   });
 
   it("rehydrates local PDF previews when queued and steer drafts return to Composer", async () => {
@@ -5878,7 +6049,7 @@ describe("Composer", () => {
       metaKey: true,
     });
 
-    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
 
     await act(async () => {
       agentEventHandler?.({
@@ -6146,7 +6317,7 @@ describe("Composer", () => {
     });
   });
 
-  it("restores a pending steer to the draft when turn completion leaves an existing queue", async () => {
+  it("does not restore a handed-off steer when turn completion leaves a backend queue", async () => {
     let agentEventHandler:
       | ((event: {
           backend: "codex";
@@ -6166,7 +6337,14 @@ describe("Composer", () => {
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
-      turnId: "turn-2",
+      turnId: "queue-entry-1",
+      queueStatus: "queued" as const,
+      queueEntryId: "queue-entry-1",
+    }));
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
     }));
 
     render(
@@ -6197,11 +6375,7 @@ describe("Composer", () => {
             return () => undefined;
           },
           startTurn,
-          steerTurn: async () => ({
-            backend: "codex",
-            threadId: "thread-1",
-            turnId: "turn-1",
-          }),
+          steerTurn,
         }}
         disabled={false}
         skills={[]}
@@ -6225,7 +6399,8 @@ describe("Composer", () => {
 
     expect(screen.getByText("Queued next")).toBeInTheDocument();
     expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
-    expect(screen.getByText("Pending steer")).toBeInTheDocument();
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
+    expect(steerTurn).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       agentEventHandler?.({
@@ -6244,20 +6419,13 @@ describe("Composer", () => {
       });
     });
 
-    await waitFor(() => {
-      expect(startTurn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          backend: "codex",
-          threadId: "thread-1",
-          input: [{ type: "text", text: "Queued follow-up" }],
-        })
-      );
-    });
-    expect(textarea).toHaveValue("Pending steer draft");
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(textarea).toHaveValue("");
     expect(screen.queryByText("Pending steer")).not.toBeInTheDocument();
+    expect(screen.getByText("Queued follow-up")).toBeInTheDocument();
   });
 
-  it("does not send a stale local queued turn after another release path claims it", async () => {
+  it("does not redispatch after a backend queue projection is cleared elsewhere", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
       backend: request.backend,
@@ -6311,7 +6479,7 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(screen.queryByText("Queued elsewhere")).not.toBeInTheDocument();
     });
-    expect(startTurn).not.toHaveBeenCalled();
+    expect(startTurn).toHaveBeenCalledTimes(1);
   });
 
   it("releases a due scheduled queued turn ahead of an earlier future scheduled turn", async () => {
@@ -13908,7 +14076,7 @@ describe("Composer", () => {
     expect(textbox).not.toHaveTextContent("replace me");
   });
 
-  it("rehydrates an edited pending thread link as a thread chip", async () => {
+  it("submits a pasted thread link through backend steering", async () => {
     const targetThreadId = "019fbbbe-ad52-77c2-b7f7-28182d9a6f83";
     const currentThread: NavigationThreadSummary = {
       id: "thread-1",
@@ -13926,6 +14094,11 @@ describe("Composer", () => {
       linkedDirectories: [],
       inbox: { inInbox: false },
     };
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
 
     render(
       <ThreadLinkProvider
@@ -13955,7 +14128,7 @@ describe("Composer", () => {
           ]}
           desktopApi={{
             onAgentEvent: () => () => undefined,
-            steerTurn: vi.fn(),
+            steerTurn,
           }}
           disabled={false}
           skills={[]}
@@ -13975,20 +14148,23 @@ describe("Composer", () => {
     });
     fireEvent.keyDown(textbox, { key: "Enter", metaKey: true });
 
-    expect(screen.getByText("Pending steer")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-
     await waitFor(() => {
-      expect(
-        within(textbox)
-          .getByText("$Lovely child thread")
-          .closest("[data-mention-kind]"),
-      ).toHaveAttribute(
-        "data-mention-kind",
-        "thread",
+      expect(steerTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "codex",
+          threadId: "thread-1",
+          expectedTurnId: "turn-1",
+          input: [
+            {
+              type: "text",
+              text: expect.stringContaining(targetThreadId),
+            },
+          ],
+        }),
       );
     });
-    expect(textbox).toHaveValue(" ");
+    expect(screen.getByText("Steering now")).toBeInTheDocument();
+    expect(textbox).toHaveValue("");
   });
 
   it("leaves an unknown pasted thread-shaped id as plain text", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4742,6 +4742,86 @@ describe("Composer", () => {
     });
   });
 
+  it("removes concurrently cancelled queue entries by stable id", async () => {
+    const cancellationOne = createDeferred<{
+      queueEntryId: string;
+      cancelled: boolean;
+    }>();
+    const cancellationTwo = createDeferred<{
+      queueEntryId: string;
+      cancelled: boolean;
+    }>();
+    const startTurn = vi.fn(async (request: StartTurnRequest) => {
+      const queueEntryId = `queue-entry-${startTurn.mock.calls.length}`;
+      return {
+        backend: request.backend,
+        threadId: request.threadId,
+        turnId: queueEntryId,
+        queueStatus: "queued" as const,
+        queueEntryId,
+      };
+    });
+    const cancelQueuedTurn = vi.fn(({ queueEntryId }: {
+      queueEntryId: string;
+    }) => queueEntryId === "queue-entry-1"
+      ? cancellationOne.promise
+      : cancellationTwo.promise);
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[backendSummary("codex")]}
+        desktopApi={{
+          cancelQueuedTurn,
+          onAgentEvent: () => () => undefined,
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "First queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    fireEvent.change(textarea, { target: { value: "Second queued reply" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Delete" })).toHaveLength(2);
+    });
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[0]!);
+    fireEvent.click(deleteButtons[1]!);
+
+    await act(async () => {
+      cancellationOne.resolve({
+        queueEntryId: "queue-entry-1",
+        cancelled: true,
+      });
+      await cancellationOne.promise;
+    });
+    await act(async () => {
+      cancellationTwo.resolve({
+        queueEntryId: "queue-entry-2",
+        cancelled: true,
+      });
+      await cancellationTwo.promise;
+    });
+
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    expect(cancelQueuedTurn).toHaveBeenCalledTimes(2);
+  });
+
   it("restores a queued active-turn message after navigating away and back", async () => {
     const draftStore = createComposerDraftStore();
     const startTurn = vi.fn(async (request: StartTurnRequest) => ({
@@ -5029,6 +5109,228 @@ describe("Composer", () => {
       />,
     );
     expect(screen.getByText("Stay with thread A")).toBeInTheDocument();
+  });
+
+  it("does not apply a delayed started response to another thread", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(() => startTurnDeferred.promise);
+    const addOptimisticUserMessage = vi.fn(() => "optimistic-a");
+    const onActiveTurnIdChange = vi.fn();
+    const threadA: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Active turn",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB: NavigationThreadSummary = {
+      ...threadA,
+      id: "thread-2",
+      title: "Other thread",
+    };
+    const baseProps = {
+      addOptimisticUserMessage,
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      onActiveTurnIdChange,
+      skills: [],
+    };
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Start for thread A" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+    await waitFor(() => expect(startTurn).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />,
+    );
+
+    await act(async () => {
+      startTurnDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-a",
+      });
+      await startTurnDeferred.promise;
+    });
+
+    expect(onActiveTurnIdChange).not.toHaveBeenCalledWith("turn-a");
+    expect(addOptimisticUserMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
+  it("restores a rejected delayed submission to its original thread", async () => {
+    const draftStore = createComposerDraftStore();
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(() => startTurnDeferred.promise);
+    const threadA: NavigationThreadSummary = {
+      id: "thread-1",
+      title: "Active turn",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadB: NavigationThreadSummary = {
+      ...threadA,
+      id: "thread-2",
+      title: "Other thread",
+    };
+    const baseProps = {
+      desktopApi: {
+        onAgentEvent: () => () => undefined,
+        startTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+    };
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+        thread={threadA}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Recover for thread A" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+    await waitFor(() => expect(startTurn).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId={undefined}
+        thread={threadB}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Keep thread B draft" },
+    });
+
+    await act(async () => {
+      startTurnDeferred.reject(new Error("thread A start failed"));
+      await startTurnDeferred.promise.catch(() => undefined);
+    });
+
+    expect(screen.getByLabelText("Reply")).toHaveValue("Keep thread B draft");
+    expect(screen.queryByText("thread A start failed")).not.toBeInTheDocument();
+    expect(draftStore.get("thread:codex:thread-1")).toMatchObject({
+      draft: "Recover for thread A",
+    });
+  });
+
+  it("preserves a cancelled queued item when its steer target changes", async () => {
+    const draftStore = createComposerDraftStore();
+    draftStore.setQueuedTurn("thread:codex:thread-1", {
+      id: "queued-steer-1",
+      queueEntryId: "queue-entry-1",
+      text: "Steer the original turn",
+      imageAttachments: [],
+      fileAttachments: [],
+      input: [{ type: "text", text: "Steer the original turn" }],
+    });
+    const cancellation = createDeferred<{
+      queueEntryId: string;
+      cancelled: boolean;
+    }>();
+    const cancelQueuedTurn = vi.fn(() => cancellation.promise);
+    const steerTurn = vi.fn();
+    const baseProps = {
+      backends: [
+        {
+          ...backendSummary("codex", {
+            models: [
+              {
+                id: "gpt-5.5",
+                label: "GPT-5.5",
+                current: true,
+                supportsReasoning: true,
+                supportsSteering: true,
+              },
+            ],
+          }),
+          capabilities: {
+            ...backendSummary("codex").capabilities,
+            steerTurn: true,
+          },
+        },
+      ],
+      desktopApi: {
+        cancelQueuedTurn,
+        onAgentEvent: () => () => undefined,
+        steerTurn,
+      },
+      disabled: false,
+      draftStore,
+      skills: [],
+      thread: {
+        id: "thread-1",
+        title: "Active turn",
+        titleSource: "explicit" as const,
+        source: "codex" as const,
+        executionMode: "default" as const,
+        linkedDirectories: [],
+        inbox: { inInbox: false },
+      },
+    };
+    const { rerender } = render(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+    expect(cancelQueuedTurn).toHaveBeenCalledWith({
+      queueEntryId: "queue-entry-1",
+    });
+
+    rerender(
+      <Composer
+        {...baseProps}
+        activeTurnId="turn-2"
+      />,
+    );
+    await act(async () => {
+      cancellation.resolve({
+        queueEntryId: "queue-entry-1",
+        cancelled: true,
+      });
+      await cancellation.promise;
+    });
+
+    expect(steerTurn).not.toHaveBeenCalled();
+    expect(screen.getByText("Steer the original turn")).toBeInTheDocument();
+    expect(
+      draftStore.getQueuedTurn("thread:codex:thread-1"),
+    ).toMatchObject({
+      id: "queued-steer-1",
+      text: "Steer the original turn",
+    });
+    expect(
+      draftStore.getQueuedTurn("thread:codex:thread-1")?.queueEntryId,
+    ).toBeUndefined();
   });
 
   it("steers Command Enter during an active turn when supported", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -22,6 +22,10 @@ export type ComposerDraftSnapshot = {
 
 export type ComposerQueuedTurnSnapshot = {
   id: string;
+  /** Submission is in flight to the main-process FIFO. */
+  backendQueuePending?: boolean;
+  /** Main-process FIFO entry once the renderer has handed off dispatch ownership. */
+  queueEntryId?: string;
   input?: AppServerTurnInputItem[];
   text: string;
   imageAttachments: NavigationLaunchpadImageAttachment[];
@@ -92,11 +96,22 @@ export function getQueuedTurnReleaseDelayMs(
 }
 
 export function getNextReleasableQueuedTurn<
-  T extends Pick<ComposerQueuedTurnSnapshot, "scheduledSendAt">,
+  T extends Pick<
+    ComposerQueuedTurnSnapshot,
+    "backendQueuePending" | "queueEntryId" | "scheduledSendAt"
+  >,
 >(queuedTurns: readonly T[], now = Date.now()): T | undefined {
-  return queuedTurns.find((queuedTurn) =>
-    getQueuedTurnReleaseDelayMs(queuedTurn, now) === 0
-  );
+  for (const queuedTurn of queuedTurns) {
+    // A backend-owned entry is already in the authoritative FIFO. Local
+    // scheduled turns and reviews behind it must not leapfrog that entry.
+    if (queuedTurn.backendQueuePending || queuedTurn.queueEntryId) {
+      return undefined;
+    }
+    if (getQueuedTurnReleaseDelayMs(queuedTurn, now) === 0) {
+      return queuedTurn;
+    }
+  }
+  return undefined;
 }
 
 export function useComposerDraftStore(): ComposerDraftStore {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx
@@ -133,6 +133,59 @@ describe("useQueuedTurnRelease", () => {
     vi.restoreAllMocks();
   });
 
+  it("clears a backend-owned queued message without dispatching it from React", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    const startTurn = vi.fn();
+    const composerDraftStore = createComposerDraftStore();
+    composerDraftStore.setQueuedTurn("thread:codex:thread-a", {
+      id: "queued-ui-1",
+      queueEntryId: "backend-queue-1",
+      text: "Backend-owned reply",
+      imageAttachments: [],
+      fileAttachments: [],
+      input: [{ type: "text", text: "Backend-owned reply" }],
+    });
+
+    renderHook(() =>
+      useQueuedTurnRelease({
+        backends: [backendSummary()],
+        composerDraftStore,
+        desktopApi: {
+          onAgentEvent: (listener) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+          },
+          startTurn,
+        },
+        selectedThread: thread("thread-b"),
+        threads: [thread("thread-a"), thread("thread-b")],
+      }),
+    );
+
+    await act(async () => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          notification: {
+            method: "thread/turnQueue/updated",
+            params: {
+              threadId: "thread-a",
+              queueEntryId: "backend-queue-1",
+              origin: "manual",
+              status: "started",
+              turnId: "turn-next",
+            },
+          },
+        });
+      }
+    });
+
+    expect(startTurn).not.toHaveBeenCalled();
+    expect(
+      composerDraftStore.getQueuedTurn("thread:codex:thread-a"),
+    ).toBeUndefined();
+  });
+
   it("releases the oldest queued message for a non-focused thread when its turn completes", async () => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const startTurn = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -33,6 +33,8 @@ import type {
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  CancelQueuedTurnRequest,
+  CancelQueuedTurnResponse,
   AppServerListSkillsRequest,
   AppServerListSkillsResponse,
   CheckThreadBranchDriftRequest,
@@ -471,6 +473,9 @@ export type DesktopApi = {
     request: CompactThreadRequest
   ) => Promise<CompactThreadResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
+  cancelQueuedTurn?: (
+    request: CancelQueuedTurnRequest,
+  ) => Promise<CancelQueuedTurnResponse>;
   interruptTurn?: (
     request: InterruptTurnRequest
   ) => Promise<InterruptTurnResponse>;

--- a/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
+++ b/apps/desktop/src/renderer/src/lib/useQueuedTurnRelease.ts
@@ -424,6 +424,28 @@ export function useQueuedTurnRelease(params: {
 
     return desktopApi.onAgentEvent((event) => {
       const current = paramsRef.current;
+      if (event.notification.method === "thread/turnQueue/updated") {
+        const notification = event.notification.params as {
+          queueEntryId?: unknown;
+          status?: unknown;
+          threadId?: unknown;
+        };
+        if (
+          typeof notification.threadId === "string" &&
+          typeof notification.queueEntryId === "string" &&
+          notification.status !== "queued"
+        ) {
+          const scopeKey = `thread:${event.backend}:${notification.threadId}`;
+          const queued = current.composerDraftStore.getQueuedTurns(scopeKey);
+          const next = queued.filter(
+            (candidate) => candidate.queueEntryId !== notification.queueEntryId,
+          );
+          if (next.length !== queued.length) {
+            current.composerDraftStore.setQueuedTurns(scopeKey, next);
+          }
+        }
+        return;
+      }
       if (
         !TERMINAL_TURN_METHODS.has(event.notification.method) &&
         !isIdleStatusNotification(event)

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -31,6 +31,7 @@ export const ACP_AGENTS_LIST_CHANNEL = "acp-agents:list";
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_FORK_THREAD_CHANNEL = "agent:fork-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
+export const AGENT_CANCEL_QUEUED_TURN_CHANNEL = "agent:cancel-queued-turn";
 export const AGENT_START_REVIEW_CHANNEL = "agent:start-review";
 export const AGENT_COMPACT_THREAD_CHANNEL = "agent:compact-thread";
 export const AGENT_INTERRUPT_TURN_CHANNEL = "agent:interrupt-turn";

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -249,6 +249,15 @@ export type StartTurnResponse = {
   queueEntryId?: string;
 };
 
+export type CancelQueuedTurnRequest = {
+  queueEntryId: string;
+};
+
+export type CancelQueuedTurnResponse = {
+  queueEntryId: string;
+  cancelled: boolean;
+};
+
 export type StartReviewRequest = {
   backend: AppServerBackendKind;
   threadId: ThreadIdentifier;


### PR DESCRIPTION
## Summary

- Submit ordinary busy-thread replies to DesktopBackendRegistry immediately so ThreadTurnQueue owns FIFO dispatch independent of renderer focus or selection.
- Submit steering immediately through the registry and remove renderer event-driven steering retries.
- Keep React as a presentation layer for backend queue lifecycle, including scope-safe delayed acknowledgements and explicit backend cancellation for Edit/Delete.

## Boundary review

The split ownership was historical:

- c9b921582 (2026-04-28, PR #68) introduced queued prompts and steering entirely in Composer/React.
- 629339d3b (2026-05-23, PR #552) later introduced the main-process ThreadTurnQueue for automations. Messaging adopted DesktopBackendRegistry.submitTurn, but the desktop composer was never migrated.
- 5e0be0b1a (2026-07-13, PR #975) added scheduled composer sends by extending the existing renderer queue, which made the original ownership split harder to see.

Messaging already has the intended boundary: DesktopBackendBridge calls registry.submitTurn, and the registry releases work from backend terminal/idle events. This PR brings ordinary desktop replies onto that path. Backend lifecycle events now only tell the renderer to clear or update its queue projection.

Two analogous gaps remain and should be follow-up work:

1. Scheduled composer sends are still kept in the renderer draft store and released by renderer timers.
2. Queued reviews are still kept in the renderer queue and released from renderer terminal/idle listeners.

Both should move into a main-process scheduler/registry API. PR auto-dispatch, automations, messaging delivery, and workspace moves are already main-process-owned and did not show this inversion.

## Regression coverage

Before the production change, the new tests failed with zero backend calls for both cases:

- a queued reply on a busy thread before navigation;
- Cmd+Enter steering during an active turn.

Coverage also verifies that an unfocused thread queue event clears the renderer projection without React calling startTurn, and that a delayed queue acknowledgement cannot leak across thread scopes.

## Verification

- pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useQueuedTurnRelease.test.tsx apps/desktop/src/main/__tests__/agent-ipc.test.ts apps/desktop/src/main/__tests__/thread-turn-queue.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts (707 tests)
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warning baseline only)
- pnpm lint:boundaries
- pnpm lint:codex-storage
- pnpm lint:colors

## Notes

- Editing, deleting, or steering an already queued backend entry first cancels that registry entry, preventing a duplicate turn.
- The renderer reserves queue presentation order before the IPC response and applies acknowledgements by thread scope, so rapid follow-ups and navigation preserve backend FIFO order.