### PR TITLE
fix(messaging): deduplicate assistant message delivery

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -13132,6 +13132,130 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("posts one assistant message when final image resolution overlaps terminal idle", async () => {
+    let releaseImageResolution: (() => void) | undefined;
+    let markImageResolutionStarted: (() => void) | undefined;
+    const imageResolutionStarted = new Promise<void>((resolve) => {
+      markImageResolutionStarted = resolve;
+    });
+    const imageResolutionReleased = new Promise<void>((resolve) => {
+      releaseImageResolution = resolve;
+    });
+    const harness = await createHarness({
+      resolveAssistantMessageImages: async () => {
+        markImageResolutionStarted?.();
+        await imageResolutionReleased;
+        return [];
+      },
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "inProgress" },
+        },
+      },
+    } satisfies AgentEvent);
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-message-1",
+          delta: "Final answer.",
+        },
+      },
+    } satisfies AgentEvent);
+
+    const finalMessage = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-message-1",
+            type: "agentMessage",
+            phase: "final",
+            text: "Final answer.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await imageResolutionStarted;
+
+    const terminalIdle = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/status/changed",
+        params: {
+          threadId: "thread-1",
+          status: { type: "idle" },
+        },
+      },
+    } satisfies AgentEvent);
+    await terminalIdle;
+    releaseImageResolution?.();
+    await finalMessage;
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && intent.role === "assistant",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [expect.objectContaining({ text: "Final answer." })],
+      }),
+    ]);
+  });
+
+  it("never posts the same backend assistant message id twice", async () => {
+    const harness = await createHarness();
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    for (const [turnId, text] of [
+      ["turn-1", "Final answer."],
+      ["turn-2", "Final answer replayed."],
+    ] as const) {
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId,
+            item: {
+              id: "assistant-message-1",
+              type: "agentMessage",
+              phase: "final",
+              text,
+            },
+          },
+        },
+      } satisfies AgentEvent);
+    }
+
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "message" && intent.role === "assistant",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [expect.objectContaining({ text: "Final answer." })],
+      }),
+    ]);
+  });
+
   it("posts buffered delta text as one message when streaming is disabled and terminal output is empty", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -12080,6 +12080,84 @@ describe("MessagingController", () => {
     ]);
   });
 
+  it("delivers resolved assistant images once when terminal resolution wins the race", async () => {
+    let releaseItemResolution: (() => void) | undefined;
+    let markItemResolutionStarted: (() => void) | undefined;
+    const itemResolutionStarted = new Promise<void>((resolve) => {
+      markItemResolutionStarted = resolve;
+    });
+    const itemResolutionReleased = new Promise<void>((resolve) => {
+      releaseItemResolution = resolve;
+    });
+    const image = {
+      type: "image" as const,
+      url: "data:image/png;base64,AQID",
+      alt: "Race result",
+      source: "assistant" as const,
+    };
+    let resolutionCount = 0;
+    const harness = await createHarness({
+      resolveAssistantMessageImages: async () => {
+        resolutionCount += 1;
+        if (resolutionCount === 1) {
+          markItemResolutionStarted?.();
+          await itemResolutionReleased;
+        }
+        return [image];
+      },
+    });
+    await bindThread(harness);
+    harness.delivered.length = 0;
+
+    const itemCompleted = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-message-1",
+            type: "agentMessage",
+            phase: "final",
+            text: "Done.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await itemResolutionStarted;
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Done." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    releaseItemResolution?.();
+    await itemCompleted;
+
+    const deliveredImages = harness.delivered.flatMap((intent) =>
+      intent.kind === "message"
+        ? intent.parts.filter((part) => part.type === "image")
+        : [],
+    );
+    expect(deliveredImages).toEqual([
+      expect.objectContaining({
+        alt: "Race result",
+        url: "data:image/png;base64,AQID",
+      }),
+    ]);
+  });
+
   it("falls back with a final assistant message per binding", async () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const harness = await createHarness({

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -336,6 +336,12 @@ type AssistantStreamBuffer = AssistantStreamDelta & {
   text: string;
 };
 
+type AssistantMessageDeliveryIdentity = {
+  itemId?: string;
+  threadId?: string;
+  turnId?: string;
+};
+
 type AutomationTurnMessagingContext = {
   automationName?: string;
   automationRunId?: string;
@@ -1427,26 +1433,46 @@ export class MessagingController {
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
         ) {
+          // Claim the stable backend item before image resolution yields. A
+          // nearly-simultaneous idle/terminal event may flush the same buffered
+          // deltas while this lookup is in flight; both paths must contend for
+          // one item identity before either can create a provider message.
+          const assistantMessageClaimed = this.markAssistantMessageDelivered(
+            event,
+            binding,
+            assistantText,
+          );
           const assistantImages = await this.resolveAssistantMessageImages(
             assistantText,
             event,
             binding,
           );
-          const deliveredFinalStream = await this.flushAssistantStreamForEvent(
-            event,
-            binding,
-            assistantText,
-          );
-          if (deliveredFinalStream) {
-            this.markAssistantMessageDelivered(event, binding, assistantText);
+          if (!assistantMessageClaimed) {
             await this.deliverAssistantImages(assistantImages, event, binding);
           } else {
-            await this.deliverAssistantMessage(
-              assistantText,
+            const deliveredFinalStream = await this.flushAssistantStreamForEvent(
               event,
               binding,
-              assistantImages,
+              assistantText,
             );
+            if (deliveredFinalStream) {
+              await this.deliverAssistantImages(
+                assistantImages,
+                event,
+                binding,
+                undefined,
+                true,
+              );
+            } else {
+              await this.deliverAssistantMessage(
+                assistantText,
+                event,
+                binding,
+                assistantImages,
+                undefined,
+                true,
+              );
+            }
           }
         } else if (!automationTurnEvent) {
           // NON-final agentMessage completions (e.g. Codex "commentary" phases
@@ -4863,7 +4889,10 @@ export class MessagingController {
     binding: MessagingBindingRecord,
   ): Promise<void> {
     const streamingEnabled = this.isStreamingResponsesEnabledForBinding(binding);
-    const fallbackTexts: string[] = [];
+    const fallbackMessages: Array<{
+      identity: AssistantMessageDeliveryIdentity;
+      text: string;
+    }> = [];
     for (const bufferKey of this.assistantStreamBufferKeysForEvent(event, binding)) {
       const buffer = this.assistantStreamBuffers.get(bufferKey);
       if (!buffer) {
@@ -4879,7 +4908,14 @@ export class MessagingController {
       // (immediately discarded) final `stream_update`. Same single-message
       // outcome, without churning the delivery budget on a doomed stream edit.
       if (!streamingEnabled) {
-        fallbackTexts.push(text);
+        fallbackMessages.push({
+          identity: {
+            itemId: buffer.itemId,
+            threadId: buffer.threadId,
+            turnId: buffer.turnId,
+          },
+          text,
+        });
         this.assistantStreamBuffers.delete(bufferKey);
         this.assistantStreamDeliveryQueues.delete(bufferKey);
         continue;
@@ -4892,15 +4928,27 @@ export class MessagingController {
       });
       const result = await this.enqueueAssistantStreamBufferDelivery(bufferKey, binding, true);
       if (!isVisibleAssistantStreamDelivery(result)) {
-        fallbackTexts.push(text);
+        fallbackMessages.push({
+          identity: {
+            itemId: buffer.itemId,
+            threadId: buffer.threadId,
+            turnId: buffer.turnId,
+          },
+          text,
+        });
       }
       this.assistantStreamBuffers.delete(bufferKey);
       this.assistantStreamDeliveryQueues.delete(bufferKey);
     }
 
-    const fallbackText = fallbackTexts.join("\n\n").trim();
-    if (fallbackText) {
-      await this.deliverAssistantMessage(fallbackText, event, binding);
+    for (const fallback of fallbackMessages) {
+      await this.deliverAssistantMessage(
+        fallback.text,
+        event,
+        binding,
+        [],
+        fallback.identity,
+      );
     }
   }
 
@@ -5033,16 +5081,22 @@ export class MessagingController {
     event: AgentEvent,
     binding: MessagingBindingRecord,
     images: MessagingImagePart[] = [],
+    identity?: AssistantMessageDeliveryIdentity,
+    deliveryClaimed = false,
   ): Promise<void> {
-    if (!this.markAssistantMessageDelivered(event, binding, text)) {
-      await this.deliverAssistantImages(images, event, binding);
+    if (
+      !deliveryClaimed
+      && !this.markAssistantMessageDelivered(event, binding, text, identity)
+    ) {
+      await this.deliverAssistantImages(images, event, binding, identity);
       return;
     }
     if (images.length > 0) {
-      this.markAssistantMessageDelivered(
+      this.rememberAssistantMessageContentDelivered(
         event,
         binding,
         assistantImageDeliverySignature(images),
+        identity,
       );
     }
     this.logger.debug?.(
@@ -5073,19 +5127,29 @@ export class MessagingController {
     images: MessagingImagePart[],
     event: AgentEvent,
     binding: MessagingBindingRecord,
+    identity?: AssistantMessageDeliveryIdentity,
+    deliveryClaimed = false,
   ): Promise<void> {
     if (images.length === 0) {
       return;
     }
     if (
-      !this.markAssistantMessageDelivered(
+      !deliveryClaimed
+      && !this.markAssistantMessageDelivered(
         event,
         binding,
         assistantImageDeliverySignature(images),
+        identity,
       )
     ) {
       return;
     }
+    this.rememberAssistantMessageContentDelivered(
+      event,
+      binding,
+      assistantImageDeliverySignature(images),
+      identity,
+    );
     await this.deliver(
       {
         id: this.newIntentId("assistant-images"),
@@ -5247,13 +5311,27 @@ export class MessagingController {
     event: AgentEvent,
     binding: MessagingBindingRecord,
     text: string,
+    identity?: AssistantMessageDeliveryIdentity,
   ): boolean {
-    const key = assistantMessageDeliveryKey(event, binding, text);
-    if (this.deliveredAssistantMessageKeys.has(key)) {
+    const keys = assistantMessageDeliveryKeys(event, binding, text, identity);
+    if (keys.some((key) => this.deliveredAssistantMessageKeys.has(key))) {
       return false;
     }
-    this.deliveredAssistantMessageKeys.add(key);
+    for (const key of keys) {
+      this.deliveredAssistantMessageKeys.add(key);
+    }
     return true;
+  }
+
+  private rememberAssistantMessageContentDelivered(
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+    text: string,
+    identity?: AssistantMessageDeliveryIdentity,
+  ): void {
+    this.deliveredAssistantMessageKeys.add(
+      assistantMessageContentDeliveryKey(event, binding, text, identity),
+    );
   }
 
   updateAuthorizedActorIds(actorIds: readonly string[]): void {
@@ -17398,30 +17476,70 @@ function shouldRecordOutboundActivity(
   return intent.kind !== "activity" && intent.kind !== "dismiss";
 }
 
-function assistantMessageDeliveryKey(
+function assistantMessageDeliveryKeys(
   event: AgentEvent,
   binding: MessagingBindingRecord,
   text: string,
+  identity?: AssistantMessageDeliveryIdentity,
+): string[] {
+  const contentKey = assistantMessageContentDeliveryKey(
+    event,
+    binding,
+    text,
+    identity,
+  );
+  const itemId = identity?.itemId ?? assistantItemIdForBackendEvent(event);
+  if (!itemId) {
+    return [contentKey];
+  }
+  // Backend item identity is authoritative and intentionally independent of
+  // turn/text: replaying one item with changed metadata must never post it
+  // again. Keep the content alias so a later turn/completed event, which may
+  // omit the item id, is deduped against the same already-delivered message.
+  return [
+    [
+      binding.id,
+      event.backend,
+      assistantMessageThreadId(event, identity),
+      `item:${itemId}`,
+    ].join("\0"),
+    contentKey,
+  ];
+}
+
+function assistantMessageContentDeliveryKey(
+  event: AgentEvent,
+  binding: MessagingBindingRecord,
+  text: string,
+  identity?: AssistantMessageDeliveryIdentity,
 ): string {
   const params = event.notification.params as {
-    threadId?: unknown;
     turn?: { id?: unknown };
     turnId?: unknown;
   };
-  const threadId = typeof params.threadId === "string" ? params.threadId : "";
   const turnId =
-    typeof params.turnId === "string"
+    identity?.turnId
+    ?? (typeof params.turnId === "string"
       ? params.turnId
       : typeof params.turn?.id === "string"
         ? params.turn.id
-        : "";
+        : "");
   return [
     binding.id,
     event.backend,
-    threadId,
+    assistantMessageThreadId(event, identity),
     turnId,
-    createHash("sha256").update(text).digest("base64url"),
+    `text:${createHash("sha256").update(text).digest("base64url")}`,
   ].join("\0");
+}
+
+function assistantMessageThreadId(
+  event: AgentEvent,
+  identity?: AssistantMessageDeliveryIdentity,
+): string {
+  const params = event.notification.params as { threadId?: unknown };
+  return identity?.threadId
+    ?? (typeof params.threadId === "string" ? params.threadId : "");
 }
 
 function isThreadStatusIdleEvent(event: AgentEvent): boolean {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -5091,16 +5091,21 @@ export class MessagingController {
       await this.deliverAssistantImages(images, event, binding, identity);
       return;
     }
-    if (images.length > 0) {
-      this.rememberAssistantMessageContentDelivered(
+    // Text and image ownership are independent. Another completion event may
+    // have posted these images while this path awaited resolution, even though
+    // this path already owns the backend item/text delivery.
+    const messageImages =
+      images.length > 0
+      && this.claimAssistantMessageContentDelivery(
         event,
         binding,
         assistantImageDeliverySignature(images),
         identity,
-      );
-    }
+      )
+        ? images
+        : [];
     this.logger.debug?.(
-      `messaging assistant deliver thread=${binding.threadId} binding=${binding.id} chars=${text.length} images=${images.length} preview="${compactLogPreview(text)}"`,
+      `messaging assistant deliver thread=${binding.threadId} binding=${binding.id} chars=${text.length} images=${messageImages.length} preview="${compactLogPreview(text)}"`,
     );
 
     await this.deliver(
@@ -5116,7 +5121,7 @@ export class MessagingController {
             text,
             markdown: "markdown",
           },
-          ...images,
+          ...messageImages,
         ],
       },
       binding,
@@ -5133,9 +5138,19 @@ export class MessagingController {
     if (images.length === 0) {
       return;
     }
-    if (
-      !deliveryClaimed
-      && !this.markAssistantMessageDelivered(
+    if (!deliveryClaimed) {
+      if (
+        !this.markAssistantMessageDelivered(
+          event,
+          binding,
+          assistantImageDeliverySignature(images),
+          identity,
+        )
+      ) {
+        return;
+      }
+    } else if (
+      !this.claimAssistantMessageContentDelivery(
         event,
         binding,
         assistantImageDeliverySignature(images),
@@ -5144,12 +5159,6 @@ export class MessagingController {
     ) {
       return;
     }
-    this.rememberAssistantMessageContentDelivered(
-      event,
-      binding,
-      assistantImageDeliverySignature(images),
-      identity,
-    );
     await this.deliver(
       {
         id: this.newIntentId("assistant-images"),
@@ -5323,15 +5332,18 @@ export class MessagingController {
     return true;
   }
 
-  private rememberAssistantMessageContentDelivered(
+  private claimAssistantMessageContentDelivery(
     event: AgentEvent,
     binding: MessagingBindingRecord,
     text: string,
     identity?: AssistantMessageDeliveryIdentity,
-  ): void {
-    this.deliveredAssistantMessageKeys.add(
-      assistantMessageContentDeliveryKey(event, binding, text, identity),
-    );
+  ): boolean {
+    const key = assistantMessageContentDeliveryKey(event, binding, text, identity);
+    if (this.deliveredAssistantMessageKeys.has(key)) {
+      return false;
+    }
+    this.deliveredAssistantMessageKeys.add(key);
+    return true;
   }
 
   updateAuthorizedActorIds(actorIds: readonly string[]): void {


### PR DESCRIPTION
## Summary

- claim final assistant delivery by stable backend item ID before asynchronous image resolution
- carry that item identity through terminal stream fallbacks
- retain content aliases so ID-less terminal replays remain deduplicated
- add regression coverage for the Slack idle/image-resolution race and repeated item IDs across changed turn/text metadata

## Root cause

Final assistant handling awaited transcript image resolution before claiming or clearing the buffered response. A nearly simultaneous `thread/status/changed: idle` event could flush those same buffered deltas to Slack while image resolution was still in flight. The final-item path then resumed and posted the identical text again. Existing deduplication keyed primarily on turn and text, so the idle event and `item/completed` event did not share an identity.

## Impact

A backend assistant item can now create at most one normal outbound assistant message per binding, even if it is replayed with changed text or turn metadata. Late image-only content remains independently deliverable when it was not part of the original message.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts` — 343 passed
- `pnpm --filter @pwragent/desktop typecheck`
- targeted ESLint on the changed controller and test — no errors
- `git diff --check`
