### PR TITLE
fix(desktop): improve onboarding provider discovery

### DIFF
--- a/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
@@ -977,10 +977,11 @@ test("desktop-onboarding-wizard — Codex profile step", async () => {
     requiresReplayDriver: false,
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
+    env: { PWRAGENT_CODEX_COMMAND: process.execPath },
   });
 
   try {
-    // Welcome → Thread presentation → Models / Providers → Codex
+    // Welcome → Thread presentation → AI Providers → Codex
     // profile. The Codex profile step is the most distinctive shot —
     // it shows the Shared / Isolated / Multiple cards that frame how
     // PwrAgent relates to a Codex install.
@@ -997,18 +998,13 @@ test("desktop-onboarding-wizard — Codex profile step", async () => {
     ).toBeVisible();
     await app.window.getByRole("button", { name: /^Continue/i }).click();
 
-    // Models / Providers — paste a dummy xAI key to clear the gate
-    // (Codex CLI isn't on PATH in the screenshot run env).
+    // AI Providers — the deterministic executable override clears the
+    // gate without collecting credentials in the wizard.
     await expect(
       app.window.getByRole("heading", {
-        name: /Pick at least one model backend/i,
+        name: /Install at least one AI provider/i,
       }),
     ).toBeVisible();
-    await app.window
-      .locator('input[type="password"]')
-      .first()
-      .fill("xai-screenshot-placeholder-key");
-    await app.window.getByRole("button", { name: /Use this key/i }).click();
     await app.window.getByRole("button", { name: /^Continue/i }).click();
 
     // Codex profile — this is the screenshot target.

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -626,6 +626,9 @@ test.describe("Onboarding wizard", () => {
           name: /Install at least one AI provider/i,
         }),
       ).toBeVisible();
+      await expect(
+        app.window.getByText(/brew update && brew install --cask codex/i),
+      ).toBeVisible();
       await app.window.getByRole("tab", { name: /Kimi Code/i }).click();
       await expect(
         app.window.getByText(/@moonshot-ai\/kimi-code/i),

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -28,7 +28,13 @@ const wizardLaunchOptions = {
   env: { PWRAGENT_CODEX_COMMAND: process.execPath },
 };
 
-const fakeProviderNames = ["codex", "kimi", "qwen", "grok"] as const;
+const fakeProviderNames = [
+  "codex",
+  "gemini",
+  "kimi",
+  "qwen",
+  "grok",
+] as const;
 type FakeProviderName = (typeof fakeProviderNames)[number];
 
 function fakeProviderScript(): string {
@@ -48,6 +54,8 @@ if (name === "qwen") {
   console.log("Run the agent over stdio");
 } else if (name === "kimi") {
   console.log("Agent Client Protocol server over stdio");
+} else if (name === "gemini") {
+  console.log("--acp");
 } else {
   console.log("Codex CLI");
 }
@@ -69,6 +77,7 @@ function wellKnownFakeProviderCommands(
           "codex",
         )
         : path.join(homeRoot, ".local", "bin", "codex"),
+    gemini: path.join(homeRoot, ".local", "bin", "gemini"),
     kimi: path.join(homeRoot, ".kimi-code", "bin", "kimi"),
     qwen: path.join(homeRoot, ".qwen", "bin", "qwen"),
     grok: path.join(homeRoot, ".grok", "bin", "grok"),
@@ -141,6 +150,7 @@ async function expectFakeProvidersFound(
 ): Promise<void> {
   const providerLabels: Record<FakeProviderName, string> = {
     codex: "Codex CLI",
+    gemini: "Gemini CLI",
     kimi: "Kimi Code",
     qwen: "Qwen Code",
     grok: "Grok Build",
@@ -629,6 +639,10 @@ test.describe("Onboarding wizard", () => {
       await expect(
         app.window.getByText(/brew update && brew install --cask codex/i),
       ).toBeVisible();
+      await app.window.getByRole("tab", { name: /Gemini CLI/i }).click();
+      await expect(
+        app.window.getByText(/@google\/gemini-cli/i),
+      ).toBeVisible();
       await app.window.getByRole("tab", { name: /Kimi Code/i }).click();
       await expect(
         app.window.getByText(/@moonshot-ai\/kimi-code/i),
@@ -644,7 +658,7 @@ test.describe("Onboarding wizard", () => {
   });
 
   test(
-    "refresh discovers Codex, Kimi, Qwen, and Grok from a custom PATH",
+    "refresh discovers Codex, Gemini, Kimi, Qwen, and Grok from a custom PATH",
     async () => {
       test.skip(process.platform === "win32", "Unix executable discovery only");
       const { app, commands } = await launchWizardWithFakeProviders("path");
@@ -658,7 +672,7 @@ test.describe("Onboarding wizard", () => {
   );
 
   test(
-    "refresh discovers Codex, Kimi, Qwen, and Grok from well-known locations",
+    "refresh discovers Codex, Gemini, Kimi, Qwen, and Grok from well-known locations",
     async () => {
       test.skip(process.platform === "win32", "Unix executable discovery only");
       const { app, commands } = await launchWizardWithFakeProviders("well-known");

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { launchElectronApp } from "./fixtures/electron-app";
@@ -26,6 +27,133 @@ const wizardLaunchOptions = {
   requiresReplayDriver: false,
   env: { PWRAGENT_CODEX_COMMAND: process.execPath },
 };
+
+const fakeProviderNames = ["codex", "kimi", "qwen", "grok"] as const;
+type FakeProviderName = (typeof fakeProviderNames)[number];
+
+function fakeProviderScript(): string {
+  return `#!${process.execPath}
+const path = require("node:path");
+const name = path.basename(process.argv[1]);
+const args = process.argv.slice(2);
+
+if (args.includes("--version")) {
+  console.log(name + " 999.0.0");
+  process.exit(0);
+}
+
+if (name === "qwen") {
+  console.log("Qwen Code");
+} else if (name === "grok") {
+  console.log("Run the agent over stdio");
+} else if (name === "kimi") {
+  console.log("Agent Client Protocol server over stdio");
+} else {
+  console.log("Codex CLI");
+}
+`;
+}
+
+function wellKnownFakeProviderCommands(
+  homeRoot: string,
+): Record<FakeProviderName, string> {
+  return {
+    codex:
+      process.platform === "darwin"
+        ? path.join(
+          homeRoot,
+          "Applications",
+          "Codex.app",
+          "Contents",
+          "Resources",
+          "codex",
+        )
+        : path.join(homeRoot, ".local", "bin", "codex"),
+    kimi: path.join(homeRoot, ".kimi-code", "bin", "kimi"),
+    qwen: path.join(homeRoot, ".qwen", "bin", "qwen"),
+    grok: path.join(homeRoot, ".grok", "bin", "grok"),
+  };
+}
+
+async function launchWizardWithFakeProviders(
+  source: "path" | "well-known",
+) {
+  const homeRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "pwragent-provider-discovery-e2e-"),
+  );
+  const customBin = path.join(homeRoot, ".bin");
+  const commands =
+    source === "path"
+      ? Object.fromEntries(
+        fakeProviderNames.map((name) => [name, path.join(customBin, name)]),
+      ) as Record<FakeProviderName, string>
+      : wellKnownFakeProviderCommands(homeRoot);
+
+  for (const command of Object.values(commands)) {
+    fs.mkdirSync(path.dirname(command), { recursive: true });
+    fs.writeFileSync(command, fakeProviderScript(), "utf8");
+    fs.chmodSync(command, 0o755);
+  }
+
+  const systemPath = "/usr/bin:/bin:/usr/sbin:/sbin";
+  const discoveryPath =
+    source === "path"
+      ? `${customBin}${path.delimiter}${systemPath}`
+      : systemPath;
+  const profile = `export PATH="${discoveryPath}"\n`;
+  for (const profileName of [".profile", ".bash_profile", ".zprofile"]) {
+    fs.writeFileSync(path.join(homeRoot, profileName), profile, "utf8");
+  }
+
+  try {
+    const app = await launchElectronApp({
+      homeRoot,
+      suppressOnboarding: false,
+      requiresReplayDriver: false,
+      env: {
+        PATH: discoveryPath,
+        PWRAGENT_CODEX_COMMAND: undefined,
+        SHELL: process.platform === "darwin" ? "/bin/zsh" : "/bin/bash",
+      },
+    });
+    return { app, commands };
+  } catch (error) {
+    fs.rmSync(homeRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function openProviderStepAndRefresh(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+): Promise<void> {
+  await app.window.getByRole("button", { name: /Get started/i }).click();
+  await app.window.getByRole("button", { name: /^Continue/i }).click();
+  const refresh = app.window.getByRole("button", {
+    name: /Refresh after install/i,
+  });
+  await refresh.click();
+  await expect(refresh).toHaveText("Refresh after install", { timeout: 20_000 });
+}
+
+async function expectFakeProvidersFound(
+  app: Awaited<ReturnType<typeof launchElectronApp>>,
+  commands: Record<FakeProviderName, string>,
+): Promise<void> {
+  const providerLabels: Record<FakeProviderName, string> = {
+    codex: "Codex CLI",
+    kimi: "Kimi Code",
+    qwen: "Qwen Code",
+    grok: "Grok Build",
+  };
+  for (const name of fakeProviderNames) {
+    await app.window
+      .getByRole("tab", { name: new RegExp(providerLabels[name], "i") })
+      .click();
+    const panel = app.window.getByRole("tabpanel");
+    await expect(panel.getByText("✓ Found v999.0.0")).toBeVisible();
+    await expect(panel.getByText(commands[name], { exact: true })).toBeVisible();
+  }
+}
 
 test.describe("Onboarding wizard", () => {
   test("Get started and Back buttons are clickable", async () => {
@@ -511,4 +639,32 @@ test.describe("Onboarding wizard", () => {
       await app.close();
     }
   });
+
+  test(
+    "refresh discovers Codex, Kimi, Qwen, and Grok from a custom PATH",
+    async () => {
+      test.skip(process.platform === "win32", "Unix executable discovery only");
+      const { app, commands } = await launchWizardWithFakeProviders("path");
+      try {
+        await openProviderStepAndRefresh(app);
+        await expectFakeProvidersFound(app, commands);
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
+  test(
+    "refresh discovers Codex, Kimi, Qwen, and Grok from well-known locations",
+    async () => {
+      test.skip(process.platform === "win32", "Unix executable discovery only");
+      const { app, commands } = await launchWizardWithFakeProviders("well-known");
+      try {
+        await openProviderStepAndRefresh(app);
+        await expectFakeProvidersFound(app, commands);
+      } finally {
+        await app.close();
+      }
+    },
+  );
 });

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -15,14 +15,16 @@ import { launchElectronApp } from "./fixtures/electron-app";
  * a real browser flow; integration of the login button is left to
  * unit tests (see `apps/desktop/src/main/__tests__/`).
  *
- * Defaults to xAI as the backend to satisfy the Models / Providers
- * gate, since the test runner doesn't have Codex CLI on PATH.
+ * Uses the test runner's executable as a deterministic discovery candidate.
+ * Its version output satisfies the provider gate without depending on a real
+ * Codex install or attempting an external login.
  */
 
 const wizardLaunchOptions = {
   // No `fixturePath`: thread replay isn't relevant for wizard-only specs.
   suppressOnboarding: false,
   requiresReplayDriver: false,
+  env: { PWRAGENT_CODEX_COMMAND: process.execPath },
 };
 
 test.describe("Onboarding wizard", () => {
@@ -81,18 +83,13 @@ test.describe("Onboarding wizard", () => {
       await app.window.getByText("Just the title", { exact: false }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
 
-      // Models / Providers — paste an xAI key to satisfy the gate (Codex
-      // CLI isn't on PATH in test env).
+      // AI Providers — the deterministic executable override satisfies
+      // discovery without collecting credentials in the wizard.
       await expect(
         app.window.getByRole("heading", {
-          name: /Pick at least one model backend/i,
+          name: /Install at least one AI provider/i,
         }),
       ).toBeVisible();
-      await app.window
-        .locator('input[type="password"]')
-        .first()
-        .fill("xai-e2e-test-key");
-      await app.window.getByRole("button", { name: /Use this key/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
 
       // Codex profile — pick Shared. The fresh HOME has no Codex auth.json,
@@ -145,11 +142,6 @@ test.describe("Onboarding wizard", () => {
       // Walk to the messaging-safety step (same path as the Shared walk).
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window
-        .locator('input[type="password"]')
-        .first()
-        .fill("xai-e2e-test-key");
-      await app.window.getByRole("button", { name: /Use this key/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
       await app.window
         .getByText("Reuse your existing Codex login", { exact: false })
@@ -213,11 +205,6 @@ test.describe("Onboarding wizard", () => {
       // Walk to the messaging-safety step (same Shared-mode path).
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window
-        .locator('input[type="password"]')
-        .first()
-        .fill("xai-e2e-test-key");
-      await app.window.getByRole("button", { name: /Use this key/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
       await app.window
         .getByText("Reuse your existing Codex login", { exact: false })
@@ -281,7 +268,7 @@ test.describe("Onboarding wizard", () => {
       await app.window.getByRole("button", { name: /^Continue/i }).click();
       await expect(
         app.window.getByRole("heading", {
-          name: /Pick at least one model backend/i,
+          name: /Install at least one AI provider/i,
         }),
       ).toBeVisible();
 
@@ -412,16 +399,11 @@ test.describe("Onboarding wizard", () => {
         ),
       ).toBe("1");
 
-      // Walk the full wizard: Welcome → Thread → Models (xAI key) →
+      // Walk the full wizard: Welcome → Thread → Models →
       // Codex profile (Multiple) → Name profiles (personal, work) →
       // Messaging warning (Skip).
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
-      await app.window
-        .locator('input[type="password"]')
-        .first()
-        .fill("xai-multi-key");
-      await app.window.getByRole("button", { name: /Use this key/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
       await app.window
         .getByText(/Set up several profiles at once/i)
@@ -443,6 +425,7 @@ test.describe("Onboarding wizard", () => {
       await expect(
         app.window.getByRole("heading", { name: /You.re operating/i }),
       ).toBeVisible();
+      await expect(app.window.getByText("Multiple — personal, work")).toBeVisible();
       await app.window
         .getByRole("button", { name: /Open my workspace/i })
         .click();
@@ -504,52 +487,26 @@ test.describe("Onboarding wizard", () => {
     }
   });
 
-  test("name step's xAI override is collapsed by default and expands on click", async () => {
+  test("provider tabs show CLI-specific install instructions", async () => {
     const app = await launchElectronApp(wizardLaunchOptions);
     try {
-      // Welcome → Thread presentation → Models → Codex profile.
+      // Welcome → Thread presentation → Models.
       await app.window.getByRole("button", { name: /Get started/i }).click();
       await app.window.getByRole("button", { name: /^Continue/i }).click();
-      // xAI key on Models step (satisfy backend gate).
-      await app.window
-        .locator('input[type="password"]')
-        .first()
-        .fill("xai-default-key");
-      await app.window.getByRole("button", { name: /Use this key/i }).click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-
-      // Pick Isolated mode.
-      await app.window
-        .getByText(/Create a fresh Codex profile/i)
-        .click();
-      await app.window.getByRole("button", { name: /^Continue/i }).click();
-
-      // Naming step appears.
       await expect(
         app.window.getByRole("heading", {
-          name: /Name and log in to your isolated profile/i,
+          name: /Install at least one AI provider/i,
         }),
       ).toBeVisible();
-
-      // Per-row xAI override is collapsed by default; the global key
-      // hint is shown because we set a global xAI key on Models step.
+      await app.window.getByRole("tab", { name: /Kimi Code/i }).click();
       await expect(
-        app.window.getByRole("button", {
-          name: /Override xAI key for this profile/i,
-        }),
+        app.window.getByText(/@moonshot-ai\/kimi-code/i),
       ).toBeVisible();
-
-      // Click to expand.
-      await app.window
-        .getByRole("button", {
-          name: /Override xAI key for this profile/i,
-        })
-        .click();
-
-      // Expanded — the password input becomes visible inside the row.
-      await expect(
-        app.window.locator(".onboarding-wizard__profile-row-xai input"),
-      ).toBeVisible();
+      await app.window.getByRole("tab", { name: /Qwen Code/i }).click();
+      await expect(app.window.getByText(/brew install qwen-code/i)).toBeVisible();
+      await app.window.getByRole("tab", { name: /Grok Build/i }).click();
+      await expect(app.window.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
+      await expect(app.window.getByText(/xAI API key/i)).toHaveCount(0);
     } finally {
       await app.close();
     }

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -827,7 +827,7 @@ describe("settings ipc", () => {
       now: () => 20,
     });
 
-    initializeAppState();
+    initializeAppState("bootstrap");
     try {
       registerSettingsIpcHandlers(service);
       // Even before any discovery (cache-only read), all four supported
@@ -885,9 +885,17 @@ describe("settings ipc", () => {
       ).toHaveBeenCalledWith(
         expect.objectContaining({ backendId: "acp:gemini" }),
         expect.objectContaining({
-          cwd: expect.stringContaining("acp-discovery-workspace"),
+          cwd: path.join(
+            tempRoot,
+            ".bootstrap",
+            "state",
+            "acp-discovery-workspace",
+          ),
         }),
       );
+      expect(
+        fs.existsSync(path.join(tempRoot, "profiles", "default")),
+      ).toBe(false);
     } finally {
       disposeAppState();
     }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -95,8 +95,12 @@ import type {
   AcpRegistryDistribution,
   AcpRegistrySnapshot,
 } from "../acp/acp-registry-types";
-import { getAppStateDb } from "../state/app-state";
-import { normalizeProfileName, resolveActiveProfileDir } from "../profile";
+import { getAppStateDb, getAppStateMode } from "../state/app-state";
+import {
+  normalizeProfileName,
+  resolveActiveProfileDir,
+  resolveBootstrapProfileDir,
+} from "../profile";
 
 const settingsIpcLog = getMainLogger("pwragent:settings");
 // Codex profile login now runs through @pwrdrvr/codex-discovery's
@@ -428,7 +432,9 @@ async function refreshAcpRuntimeCapabilities(
 
 async function ensureAcpRuntimeDiscoveryWorkspace(): Promise<string> {
   const directory = path.join(
-    resolveActiveProfileDir(),
+    getAppStateMode() === "bootstrap"
+      ? resolveBootstrapProfileDir()
+      : resolveActiveProfileDir(),
     "state",
     "acp-discovery-workspace",
   );

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -1680,7 +1680,10 @@ const ONBOARDING_BACKENDS: ReadonlyArray<{
       "OpenAI's coding agent. Sign in with your ChatGPT account after install.",
     docsUrl: "https://github.com/openai/codex",
     installCommands: [
-      { label: "Homebrew", command: "brew install --cask codex" },
+      {
+        label: "Homebrew (refresh first)",
+        command: "brew update && brew install --cask codex",
+      },
       { label: "npm", command: "npm install -g @openai/codex" },
     ],
   },

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -25,6 +25,7 @@ import type {
 } from "@pwragent/shared";
 import { isMessagingRuntimeSecret } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import {
   SLACK_APPROVAL_TARGET_LABELS,
   slackApplicableApprovalTargets,
@@ -1664,7 +1665,12 @@ function WizardFooter(props: {
    Step bodies
    ---------------------------------------------------------------- */
 
-type OnboardingBackendId = "codex" | "kimi" | "qwen" | "grok";
+type OnboardingBackendId =
+  | "codex"
+  | "gemini"
+  | "kimi"
+  | "qwen"
+  | "grok";
 
 const ONBOARDING_BACKENDS: ReadonlyArray<{
   id: OnboardingBackendId;
@@ -1685,6 +1691,17 @@ const ONBOARDING_BACKENDS: ReadonlyArray<{
         command: "brew update && brew install --cask codex",
       },
       { label: "npm", command: "npm install -g @openai/codex" },
+    ],
+  },
+  {
+    id: "gemini",
+    name: "Gemini CLI",
+    description:
+      "Google's terminal coding agent with Google-account and API-key login options.",
+    docsUrl: "https://geminicli.com/docs/get-started/installation/",
+    installCommands: [
+      { label: "Homebrew", command: "brew install gemini-cli" },
+      { label: "npm", command: "npm install -g @google/gemini-cli" },
     ],
   },
   {
@@ -1757,14 +1774,7 @@ export function isBackendRequirementSatisfied(
   snapshot: DesktopSettingsSnapshot | undefined,
   acpEntries: readonly AcpAgentSettingsEntry[],
 ): boolean {
-  return Boolean(selectedCodexCandidate(snapshot))
-    || acpEntries.some(
-      (entry) =>
-        (entry.registryId === "kimi"
-          || entry.registryId === "qwen"
-          || entry.registryId === "grok")
-        && entry.installed,
-    );
+  return installedOnboardingBackendNames(snapshot, acpEntries).length > 0;
 }
 
 export function BackendRequirementsStep(props: {
@@ -1811,6 +1821,7 @@ export function BackendRequirementsStep(props: {
       const acpResult = results[1];
       if (acpResult?.status === "fulfilled" && acpResult.value) {
         updateAcpEntries(acpResult.value.entries);
+        window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
         if (acpResult.value.error) setError(acpResult.value.error);
       }
       const failures = results.flatMap((result) =>
@@ -1834,6 +1845,7 @@ export function BackendRequirementsStep(props: {
       .then((response) => {
         if (!response) return;
         updateAcpEntries(response.entries);
+        window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
         if (response.error) setError(response.error);
       })
       .catch((caught: unknown) => {

--- a/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/OnboardingWizard.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type {
+  AcpAgentSettingsEntry,
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
   DesktopBootInfo,
@@ -71,7 +72,7 @@ type RailIndex = 0 | 1 | 2 | 3 | 4;
 
 const RAIL_STEPS: ReadonlyArray<{ label: string }> = [
   { label: "Thread presentation" },
-  { label: "Models / Providers" },
+  { label: "AI Providers" },
   { label: "Profiles" },
   { label: "Messaging" },
   { label: "Review" },
@@ -164,7 +165,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   //   - everything else (first-run, replay, missing-default-profile,
   //     bootstrap with no name supplied) → Welcome.
   // The flow from Welcome onward is:
-  //   Welcome → Thread presentation → Models / Providers (the backend
+  //   Welcome → Thread presentation → AI Providers (the backend
   //   gate) → Codex profile → optional Name profiles → Messaging
   //   warning → optional Messaging providers / Provider setup → Done.
   // Replay just doesn't persist `onboarding.completed` at Finish.
@@ -224,37 +225,20 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   // flashing then fading over 5s — to point the operator at the
   // checkbox they have to tick before the Continue button unlocks.
   const [ackFlashNonce, setAckFlashNonce] = useState(0);
-  // Buffered secrets (xAI API key + messaging tokens). The wizard
+  // Buffered messaging tokens. The wizard
   // collects values in renderer memory rather than writing them
   // through `replaceSecret` on input change. At Finish, the
   // `persistAndComplete` callback writes them to the operator's
   // chosen target profile(s) via `writeSecretsToProfile`. This
   // avoids stranding secrets in `.bootstrap/state.db` in bootstrap
-  // mode and supports per-profile xAI keys in Multiple mode (each
-  // profile row can override the global value below; see
-  // `bufferedSecretsPerProfile`).
+  // mode.
   const [bufferedSecrets, setBufferedSecrets] = useState<
     Record<string, string>
   >({});
   const setBufferedSecret = useCallback((name: string, value: string): void => {
     setBufferedSecrets((prev) => ({ ...prev, [name]: value }));
   }, []);
-  const bufferedGrokKey = bufferedSecrets.grokApiKey ?? "";
-  // Per-profile xAI key overrides keyed by the profile's committed
-  // name in the naming step. In Multiple mode the operator can keep
-  // some profiles on the global key (from Models / Providers) and
-  // override others — e.g. "personal profile uses my personal xAI
-  // key, work profile uses the work xAI key." A row without an
-  // entry here inherits the global `bufferedGrokKey` at graduation.
-  const [xaiKeyByProfile, setXaiKeyByProfile] = useState<Record<string, string>>(
-    {},
-  );
-  const setXaiKeyForProfile = useCallback(
-    (profileName: string, value: string): void => {
-      setXaiKeyByProfile((prev) => ({ ...prev, [profileName]: value }));
-    },
-    [],
-  );
+  const [acpEntries, setAcpEntries] = useState<AcpAgentSettingsEntry[]>([]);
   // Snapshot reported by the name-codex-profiles step: are all named
   // rows authenticated? Drives the footer Continue button's enabled
   // state. `codexLoginDeferred` is the operator's escape hatch — a
@@ -360,6 +344,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
   );
   const sharedNeedsLogin =
     codexProfileModel === "shared" && !codexDefaultProfile?.hasAuthFile;
+  const codexBackendReady = Boolean(
+    selectedCodexCandidate(props.settings.snapshot),
+  );
 
   // Conditional step graph — codexProfileModel="multiple" inserts the
   // name-codex-profiles step between codex-profile and messaging-safety;
@@ -379,7 +366,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
         case "thread-presentation":
           return "models-providers";
         case "models-providers":
-          return "codex-profile";
+          return codexBackendReady ? "codex-profile" : "messaging-safety";
         case "codex-profile":
           // Both Isolated (single new profile) and Multiple (1–5)
           // route through the naming step — they both need paired
@@ -417,6 +404,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     },
     [
       codexProfileModel,
+      codexBackendReady,
       orderedProviders.length,
       props.isReplay,
       providerSetupIndex,
@@ -447,6 +435,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
         case "shared-codex-login":
           return "codex-profile";
         case "messaging-safety":
+          if (!codexBackendReady) {
+            return "models-providers";
+          }
           // Back-out symmetry with `nextStep`: Shared bypasses the
           // naming step, anything else routes through it. Within
           // Shared, the login step only sits in the back chain when
@@ -472,6 +463,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     },
     [
       codexProfileModel,
+      codexBackendReady,
       entryWasBootstrapConfirm,
       orderedProviders.length,
       props.isReplay,
@@ -494,6 +486,12 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     if (next !== null) setStep(next);
   }, [orderedProviders.length, prevStep, providerSetupIndex, step]);
   const goNext = useCallback(() => {
+    if (step === "models-providers" && !codexBackendReady) {
+      // ACP-only operators do not need to configure or authenticate a Codex
+      // profile. Shared still gives bootstrap graduation the single default
+      // PwrAgent profile it needs at Finish.
+      setCodexProfileModel("shared");
+    }
     if (
       step === "provider-setup" &&
       providerSetupIndex + 1 < orderedProviders.length
@@ -506,7 +504,13 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
     }
     const next = nextStep(step);
     if (next !== null) setStep(next);
-  }, [nextStep, orderedProviders.length, providerSetupIndex, step]);
+  }, [
+    codexBackendReady,
+    nextStep,
+    orderedProviders.length,
+    providerSetupIndex,
+    step,
+  ]);
 
   // Inline "Skip messaging setup" button on the messaging-safety step.
   // Different from the footer skip link (which exits the wizard entirely
@@ -767,22 +771,10 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
             props.desktopApi,
             codexProfileNames,
           );
-          // Per-profile secret graduation: each created profile gets
-          // its own xAI key + messaging tokens written into ITS
-          // state.db keychain (not the bootstrap/active profile's).
-          // xAI key resolution per profile: a per-row override beats
-          // the global buffer. Messaging tokens stay global across
-          // profiles (the operator usually has one bot per platform).
+          // Secret graduation: messaging tokens are written into each
+          // created profile's state.db keychain, not the bootstrap profile.
           for (const target of created) {
-            const override = xaiKeyByProfile[target]?.trim();
-            const resolvedGrokKey =
-              override !== undefined && override.length > 0
-                ? override
-                : bufferedSecrets.grokApiKey ?? "";
-            await writeBufferedSecretsIfAny(target, {
-              ...bufferedSecrets,
-              grokApiKey: resolvedGrokKey,
-            });
+            await writeBufferedSecretsIfAny(target, bufferedSecrets);
           }
           const switchTo = created[0];
           if (switchTo) {
@@ -876,7 +868,6 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
       submitting,
       theme,
       writeBufferedSecretsIfAny,
-      xaiKeyByProfile,
     ],
   );
 
@@ -994,6 +985,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
             currentIndex={currentRailIndex}
             chosenDensity={density}
             chosenCodexProfileModel={codexProfileModel}
+            codexProfileSkipped={!codexBackendReady}
           />
         ) : null}
         <div className="onboarding-wizard__body">
@@ -1023,8 +1015,8 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
             <BackendRequirementsStep
               settings={props.settings}
               desktopApi={props.desktopApi}
-              bufferedGrokKey={bufferedGrokKey}
-              onBufferGrokKey={(value) => setBufferedSecret("grokApiKey", value)}
+              acpEntries={acpEntries}
+              onAcpEntriesChange={setAcpEntries}
             />
           ) : null}
           {step === "welcome" ? <WelcomeStep /> : null}
@@ -1055,9 +1047,6 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
               onChange={setCodexProfileNames}
               desktopApi={props.desktopApi}
               onAuthStateChange={setCodexAuthSnapshot}
-              globalXaiKey={bufferedGrokKey}
-              xaiKeyByProfile={xaiKeyByProfile}
-              onSetXaiKeyForProfile={setXaiKeyForProfile}
             />
           ) : null}
           {step === "shared-codex-login" ? (
@@ -1113,6 +1102,11 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           {step === "done" ? (
             <DoneStep
               density={density}
+              aiProviders={installedOnboardingBackendNames(
+                props.settings.snapshot,
+                acpEntries,
+              )}
+              codexAvailable={codexBackendReady}
               codexProfileModel={codexProfileModel}
               codexProfileNames={
                 codexProfileModel === "multiple" ? codexProfileNames : undefined
@@ -1142,7 +1136,7 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
           onDeferSharedLogin={() => setSharedLoginDeferred(true)}
           backendRequirementSatisfied={isBackendRequirementSatisfied(
             props.settings.snapshot,
-            bufferedGrokKey,
+            acpEntries,
           )}
           density={density}
           codexProfileModel={codexProfileModel}
@@ -1177,9 +1171,9 @@ export function OnboardingWizard(props: OnboardingWizardProps) {
  *
  * The middle button ("Skip and use default") runs the same
  * provisioning path that picking Shared mode + clicking Finish
- * would. The settings buffer (theme/density/messaging ack, plus
- * any xAI key the operator typed) still graduates onto the new
- * default profile, so they don't lose what they already typed.
+ * would. The settings buffer (theme/density, messaging acknowledgment,
+ * and any messaging credentials) still graduates onto the new default
+ * profile, so they don't lose what they already entered.
  */
 function DismissConfirmModal(props: {
   submitting: boolean;
@@ -1286,7 +1280,7 @@ function WizardTitlebar(props: {
       case "thread-presentation":
         return "Step 1 — Thread presentation";
       case "models-providers":
-        return "Step 2 — Models / Providers";
+        return "Step 2 — AI Providers";
       case "codex-profile":
         return "Step 3 — Codex profile";
       case "name-codex-profiles":
@@ -1327,13 +1321,16 @@ function WizardRail(props: {
   currentIndex: number;
   chosenDensity: DesktopAppearanceDensity;
   chosenCodexProfileModel: DesktopCodexProfileModel;
+  codexProfileSkipped?: boolean;
 }) {
   const labelOverrides: Record<number, string> = {
     0: props.currentIndex > 0 ? densityLabel(props.chosenDensity) : "Thread presentation",
-    1: "Models / Providers",
+    1: "AI Providers",
     2:
       props.currentIndex > 2
-        ? codexProfileLabel(props.chosenCodexProfileModel)
+        ? props.codexProfileSkipped
+          ? "Not needed"
+          : codexProfileLabel(props.chosenCodexProfileModel)
         : "Profiles",
     3: "Messaging",
     4: "Review",
@@ -1464,7 +1461,7 @@ function WizardFooter(props: {
   } else if (props.step === "models-providers") {
     hint = props.backendRequirementSatisfied
       ? "Ready"
-      : "Install Codex CLI or paste an xAI API key to continue";
+      : "Install Codex, Kimi Code, Qwen Code, or Grok Build to continue";
   } else if (props.step === "shared-codex-login") {
     if (props.sharedAuthed) {
       hint = "Codex logged in";
@@ -1667,249 +1664,335 @@ function WizardFooter(props: {
    Step bodies
    ---------------------------------------------------------------- */
 
-/**
- * Returns true when the live snapshot shows at least one valid backend
- * — either a discoverable Codex CLI candidate that's executable and at
- * the minimum supported version, OR an xAI/Grok API key configured in
- * the keychain. The wizard's Step 0 footer enables Continue based on
- * this; downstream wizard steps assume this has already been satisfied,
- * which lets them defer Codex CLI execution until a known-good backend
- * exists (see `CodexAppServerClient.isCodexBootstrapDeferred`).
- */
-function isBackendRequirementSatisfied(
+type OnboardingBackendId = "codex" | "kimi" | "qwen" | "grok";
+
+const ONBOARDING_BACKENDS: ReadonlyArray<{
+  id: OnboardingBackendId;
+  name: string;
+  description: string;
+  docsUrl: string;
+  installCommands: ReadonlyArray<{ label: string; command: string }>;
+}> = [
+  {
+    id: "codex",
+    name: "Codex CLI",
+    description:
+      "OpenAI's coding agent. Sign in with your ChatGPT account after install.",
+    docsUrl: "https://github.com/openai/codex",
+    installCommands: [
+      { label: "Homebrew", command: "brew install --cask codex" },
+      { label: "npm", command: "npm install -g @openai/codex" },
+    ],
+  },
+  {
+    id: "kimi",
+    name: "Kimi Code",
+    description:
+      "Moonshot AI's terminal coding agent with account or API-key login.",
+    docsUrl: "https://www.kimi.com/help/kimi-code/cli-getting-started",
+    installCommands: [
+      {
+        label: "macOS / Linux",
+        command: "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+      },
+      { label: "npm", command: "npm install -g @moonshot-ai/kimi-code" },
+    ],
+  },
+  {
+    id: "qwen",
+    name: "Qwen Code",
+    description:
+      "Qwen's agentic coding CLI with account and API-provider options.",
+    docsUrl: "https://qwenlm.github.io/qwen-code-docs/en/users/quickstart/",
+    installCommands: [
+      { label: "Homebrew", command: "brew install qwen-code" },
+      { label: "npm", command: "npm install -g @qwen-code/qwen-code@latest" },
+    ],
+  },
+  {
+    id: "grok",
+    name: "Grok Build",
+    description:
+      "xAI's coding agent. The CLI opens browser sign-in on first launch.",
+    docsUrl: "https://docs.x.ai/build/overview",
+    installCommands: [
+      {
+        label: "macOS / Linux",
+        command: "curl -fsSL https://x.ai/cli/install.sh | bash",
+      },
+    ],
+  },
+];
+
+function installedOnboardingBackendNames(
   snapshot: DesktopSettingsSnapshot | undefined,
-  bufferedGrokKey: string,
-): boolean {
-  if (!snapshot) return false;
-  const codexSelected = snapshot.models.codex.discovery.candidates.some(
-    (candidate) => candidate.selected && candidate.executable,
-  );
-  const grokConfigured = snapshot.models.grok.apiKey.configured;
-  // Buffered xAI key (entered in this wizard session but not yet
-  // written to a profile keychain) satisfies the gate too — the
-  // value will graduate to the chosen profile at Finish.
-  const grokBuffered = bufferedGrokKey.trim().length > 0;
-  return codexSelected || grokConfigured || grokBuffered;
+  acpEntries: readonly AcpAgentSettingsEntry[],
+): string[] {
+  return ONBOARDING_BACKENDS.flatMap((backend) => {
+    const installed =
+      backend.id === "codex"
+        ? Boolean(selectedCodexCandidate(snapshot))
+        : Boolean(acpEntryFor(acpEntries, backend.id)?.installed);
+    return installed ? [backend.name] : [];
+  });
 }
 
-function BackendRequirementsStep(props: {
-  settings: DesktopSettingsState;
-  desktopApi?: DesktopApi;
-  /** Buffered xAI key value (held in wizard state, not yet
-   *  encrypted+written to the keychain). Empty string means "no
-   *  key in buffer." */
-  bufferedGrokKey: string;
-  onBufferGrokKey: (value: string) => void;
-}) {
-  const snapshot = props.settings.snapshot;
-  const discovery = snapshot?.models.codex.discovery;
-  const grokKey = snapshot?.models.grok.apiKey;
-  const codexCandidate = discovery?.candidates.find(
+function selectedCodexCandidate(snapshot: DesktopSettingsSnapshot | undefined) {
+  return snapshot?.models.codex.discovery.candidates.find(
     (candidate) => candidate.selected && candidate.executable,
   );
-  const codexOk = Boolean(codexCandidate);
-  // Buffered key counts as "Grok configured" for the wizard's gate.
-  // The actual encrypt + write to the chosen profile's state.db
-  // happens at Finish via `writeSecretsToProfile` — see the comment
-  // on `WriteDesktopSecretsToProfileRequest` for why we defer.
-  const grokOk = Boolean(grokKey?.configured) || props.bufferedGrokKey.length > 0;
+}
 
+function acpEntryFor(
+  entries: readonly AcpAgentSettingsEntry[],
+  registryId: Exclude<OnboardingBackendId, "codex">,
+): AcpAgentSettingsEntry | undefined {
+  return entries.find((entry) => entry.registryId === registryId);
+}
+
+export function isBackendRequirementSatisfied(
+  snapshot: DesktopSettingsSnapshot | undefined,
+  acpEntries: readonly AcpAgentSettingsEntry[],
+): boolean {
+  return Boolean(selectedCodexCandidate(snapshot))
+    || acpEntries.some(
+      (entry) =>
+        (entry.registryId === "kimi"
+          || entry.registryId === "qwen"
+          || entry.registryId === "grok")
+        && entry.installed,
+    );
+}
+
+export function BackendRequirementsStep(props: {
+  settings: DesktopSettingsState;
+  desktopApi?: DesktopApi;
+  acpEntries: AcpAgentSettingsEntry[];
+  onAcpEntriesChange: (entries: AcpAgentSettingsEntry[]) => void;
+}) {
+  const [activeBackend, setActiveBackend] = useState<OnboardingBackendId>("codex");
   const [refreshing, setRefreshing] = useState(false);
-  const [grokKeyInput, setGrokKeyInput] = useState("");
+  const [error, setError] = useState<string>();
+  const initialAcpLoadStarted = useRef(false);
+  const snapshot = props.settings.snapshot;
+  const discovery = snapshot?.models.codex.discovery;
+  const codexCandidate = selectedCodexCandidate(snapshot);
+  const onAcpEntriesChange = props.onAcpEntriesChange;
 
-  const refresh = async (): Promise<void> => {
-    if (!props.desktopApi?.refreshCodexDiscovery || refreshing) return;
+  const updateAcpEntries = useCallback(
+    (entries: AcpAgentSettingsEntry[]): void => {
+      onAcpEntriesChange(entries);
+    },
+    [onAcpEntriesChange],
+  );
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (refreshing) return;
     setRefreshing(true);
+    setError(undefined);
     try {
-      await props.desktopApi.refreshCodexDiscovery({});
-      await props.settings.refresh();
-    } catch (caught) {
-       
-      console.warn("Onboarding: refreshCodexDiscovery failed", caught);
+      const results = await Promise.allSettled([
+        props.desktopApi?.refreshCodexDiscovery?.({}),
+        props.desktopApi?.listAcpAgents?.({ refresh: true, force: true }),
+      ]);
+      const codexResult = results[0];
+      if (
+        codexResult?.status === "fulfilled"
+        && codexResult.value
+        && props.settings.applySnapshot
+      ) {
+        props.settings.applySnapshot(codexResult.value.snapshot);
+      } else {
+        await props.settings.refresh();
+      }
+      const acpResult = results[1];
+      if (acpResult?.status === "fulfilled" && acpResult.value) {
+        updateAcpEntries(acpResult.value.entries);
+        if (acpResult.value.error) setError(acpResult.value.error);
+      }
+      const failures = results.flatMap((result) =>
+        result.status === "rejected" ? [String(result.reason)] : [],
+      );
+      if (failures.length > 0) setError(failures.join("; "));
     } finally {
       setRefreshing(false);
     }
-  };
+  }, [props.desktopApi, props.settings, refreshing, updateAcpEntries]);
 
-  const saveGrokKey = (): void => {
-    const value = grokKeyInput.trim();
-    if (!value) return;
-    props.onBufferGrokKey(value);
-    setGrokKeyInput("");
-  };
-  const clearGrokKey = (): void => {
-    props.onBufferGrokKey("");
-  };
+  useEffect(() => {
+    if (initialAcpLoadStarted.current || !props.desktopApi?.listAcpAgents) return;
+    initialAcpLoadStarted.current = true;
+    void props.desktopApi
+      .listAcpAgents({ refresh: false })
+      .then((response) => {
+        updateAcpEntries(response.entries);
+        return props.desktopApi?.listAcpAgents?.({ refresh: true });
+      })
+      .then((response) => {
+        if (!response) return;
+        updateAcpEntries(response.entries);
+        if (response.error) setError(response.error);
+      })
+      .catch((caught: unknown) => {
+        setError(caught instanceof Error ? caught.message : String(caught));
+      });
+  }, [props.desktopApi, updateAcpEntries]);
+
+  const backendInstalled = (id: OnboardingBackendId): boolean =>
+    id === "codex"
+      ? Boolean(codexCandidate)
+      : Boolean(acpEntryFor(props.acpEntries, id)?.installed);
+  const activeDefinition =
+    ONBOARDING_BACKENDS.find((backend) => backend.id === activeBackend)
+    ?? ONBOARDING_BACKENDS[0];
+  const activeAcpEntry =
+    activeBackend === "codex"
+      ? undefined
+      : acpEntryFor(props.acpEntries, activeBackend);
+  const activeCommand =
+    activeBackend === "codex"
+      ? codexCandidate?.command
+      : activeAcpEntry?.activeCommand;
+  const activeVersion =
+    activeBackend === "codex"
+      ? codexCandidate?.version
+      : activeAcpEntry?.version;
 
   return (
     <div className="onboarding-wizard__prereqs">
       <header className="onboarding-wizard__head">
         <h1 className="onboarding-wizard__title">
-          Pick at least one model backend to continue
+          Install at least one AI provider
         </h1>
         <p className="onboarding-wizard__sub">
-          PwrAgent runs on top of one or both of these providers. You only
-          need one to get started — the rest of the wizard configures
-          profiles and (optionally) messaging on top.
+          PwrAgent connects to provider CLIs already installed on this Mac.
+          Pick a tab for setup instructions, then refresh discovery.
         </p>
       </header>
 
-      <div className="onboarding-wizard__prereq-card">
+      <div
+        className="onboarding-wizard__backend-tabs"
+        role="tablist"
+        aria-label="AI providers"
+      >
+        {ONBOARDING_BACKENDS.map((backend) => {
+          const installed = backendInstalled(backend.id);
+          return (
+            <button
+              key={backend.id}
+              id={`onboarding-backend-tab-${backend.id}`}
+              type="button"
+              role="tab"
+              aria-controls="onboarding-backend-panel"
+              aria-selected={activeBackend === backend.id}
+              className={`onboarding-wizard__backend-tab${
+                activeBackend === backend.id ? " is-active" : ""
+              }`}
+              onClick={() => setActiveBackend(backend.id)}
+            >
+              <span>{backend.name}</span>
+              <span
+                className={`onboarding-wizard__backend-tab-dot${
+                  installed ? " is-installed" : ""
+                }`}
+                aria-label={installed ? "Installed" : "Not found"}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        id="onboarding-backend-panel"
+        className="onboarding-wizard__prereq-card"
+        role="tabpanel"
+        aria-labelledby={`onboarding-backend-tab-${activeBackend}`}
+      >
         <div className="onboarding-wizard__prereq-head">
           <div>
-            <div className="onboarding-wizard__prereq-title">Codex CLI</div>
+            <div className="onboarding-wizard__prereq-title">
+              {activeDefinition.name}
+            </div>
             <div className="onboarding-wizard__prereq-sub">
-              Required for the Codex backend. PwrAgent shells out to the
-              installed binary; we don&rsquo;t bundle it.
+              {activeDefinition.description}
             </div>
           </div>
           <span
             className={`onboarding-wizard__prereq-status ${
-              codexOk
+              backendInstalled(activeBackend)
                 ? "onboarding-wizard__prereq-status--ok"
                 : "onboarding-wizard__prereq-status--missing"
             }`}
           >
-            {codexOk ? (
-              <>
-                ✓ Found{codexCandidate?.version ? ` v${codexCandidate.version}` : ""}
-              </>
-            ) : (
-              "Not found"
-            )}
+            {backendInstalled(activeBackend)
+              ? `✓ Found${activeVersion ? ` v${activeVersion}` : ""}`
+              : "Not found"}
           </span>
         </div>
-        {codexOk ? (
+
+        {activeCommand ? (
           <div className="onboarding-wizard__prereq-detail">
-            <code>{codexCandidate?.command}</code>
-            <button
-              type="button"
-              className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-              disabled={refreshing}
-              onClick={() => void refresh()}
-            >
-              {refreshing ? "Refreshing…" : "Refresh"}
-            </button>
+            <code>{activeCommand}</code>
           </div>
-        ) : (
+        ) : activeBackend === "codex" ? (
           <div className="onboarding-wizard__prereq-detail">
             <details className="onboarding-wizard__prereq-paths">
               <summary>
-                Searched {discovery?.candidates.length ?? 0} location
-                {discovery && discovery.candidates.length === 1 ? "" : "s"}{" "}
-                — none with a usable Codex
+                Checked PATH and common install locations — no usable Codex
+                CLI found
               </summary>
-              <ul>
-                {discovery?.candidates.map((candidate) => (
-                  <li key={candidate.command}>
-                    <code>{candidate.command}</code>
-                    <span className="onboarding-wizard__prereq-paths-reason">
-                      {candidate.executable
-                        ? candidate.failureReason ?? "no version"
-                        : candidate.failureReason === "not_found"
-                          ? "not found"
-                          : candidate.failureReason ?? "not executable"}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              {discovery?.candidates.length ? (
+                <ul>
+                  {discovery.candidates.map((candidate) => (
+                    <li key={candidate.command}>
+                      <code>{candidate.command}</code>
+                      <span className="onboarding-wizard__prereq-paths-reason">
+                        {candidate.failureReason ?? "not executable"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>
+                  Homebrew installs are checked directly at both{" "}
+                  <code>/usr/local/bin/codex</code> (Intel) and{" "}
+                  <code>/opt/homebrew/bin/codex</code> (Apple silicon), even
+                  when the app&rsquo;s PATH does not include them.
+                </p>
+              )}
             </details>
-            <div className="onboarding-wizard__prereq-install">
-              <strong>Install:</strong>
-              <ul>
-                <li>
-                  npm: <code>npm install -g @openai/codex</code>
-                </li>
-                <li>
-                  pnpm: <code>pnpm add -g @openai/codex</code>
-                </li>
-                <li>
-                  Homebrew (macOS / Linux):{" "}
-                  <code>brew install --cask codex</code>
-                </li>
-              </ul>
-              <button
-                type="button"
-                className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-                disabled={refreshing}
-                onClick={() => void refresh()}
-              >
-                {refreshing ? "Refreshing…" : "Refresh after install"}
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-
-      <div className="onboarding-wizard__prereq-card">
-        <div className="onboarding-wizard__prereq-head">
-          <div>
-            <div className="onboarding-wizard__prereq-title">xAI API key</div>
-            <div className="onboarding-wizard__prereq-sub">
-              Required for the Grok backend. Encrypted with your OS keychain
-              and saved to the profile you pick on the next steps.
-            </div>
-          </div>
-          <span
-            className={`onboarding-wizard__prereq-status ${
-              grokOk
-                ? "onboarding-wizard__prereq-status--ok"
-                : "onboarding-wizard__prereq-status--missing"
-            }`}
-          >
-            {grokOk
-              ? props.bufferedGrokKey.length > 0
-                ? "✓ Ready"
-                : "✓ Configured"
-              : "Not configured"}
-          </span>
-        </div>
-        {!grokOk ? (
-          <div className="onboarding-wizard__prereq-detail">
-            <div className="onboarding-wizard__field-row">
-              <input
-                type="password"
-                className="onboarding-wizard__input"
-                placeholder="xai-…"
-                value={grokKeyInput}
-                onChange={(e) => setGrokKeyInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    saveGrokKey();
-                  }
-                }}
-              />
-              <button
-                type="button"
-                className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-                disabled={!grokKeyInput.trim()}
-                onClick={saveGrokKey}
-              >
-                Use this key
-              </button>
-            </div>
-            <div className="onboarding-wizard__prereq-link">
-              Get a key at{" "}
-              <code>https://console.x.ai/team/default/api-keys</code>
-            </div>
-          </div>
-        ) : props.bufferedGrokKey.length > 0 ? (
-          // Buffered (entered now, not yet saved). Show a small undo so
-          // the operator can clear/replace before Finish.
-          <div className="onboarding-wizard__prereq-detail">
-            <span className="onboarding-wizard__prereq-link">
-              We&rsquo;ll save this key into the profile you pick next.
-            </span>
-            <button
-              type="button"
-              className="onboarding-wizard__btn onboarding-wizard__btn--link"
-              onClick={clearGrokKey}
-            >
-              Clear / re-enter
-            </button>
           </div>
         ) : null}
+
+        <div className="onboarding-wizard__prereq-install">
+          <strong>Install or update {activeDefinition.name}:</strong>
+          <ul>
+            {activeDefinition.installCommands.map((install) => (
+              <li key={install.command}>
+                {install.label}: <code>{install.command}</code>
+              </li>
+            ))}
+          </ul>
+          <a href={activeDefinition.docsUrl} target="_blank" rel="noreferrer">
+            Open official setup guide ↗
+          </a>
+        </div>
+
+        <div className="onboarding-wizard__prereq-actions">
+          <button
+            type="button"
+            className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
+            disabled={refreshing}
+            onClick={() => void refresh()}
+          >
+            {refreshing ? "Refreshing all providers…" : "Refresh after install"}
+          </button>
+          {error ? (
+            <span className="onboarding-wizard__prereq-error" role="status">
+              {error}
+            </span>
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -2025,10 +2108,10 @@ function WelcomeStep() {
           <span className="onboarding-wizard__welcome-num">2</span>
           <div>
             <div className="onboarding-wizard__welcome-row-title">
-              Models / Providers
+              AI Providers
             </div>
             <div className="onboarding-wizard__welcome-row-sub">
-              Confirm Codex CLI is installed, or paste an xAI API key — one is
+              Install Codex CLI, Kimi Code, Qwen Code, or Grok Build — one is
               enough.
             </div>
           </div>
@@ -2496,6 +2579,8 @@ function MessagingProvidersStep(props: {
 
 function DoneStep(props: {
   density: DesktopAppearanceDensity;
+  aiProviders: string[];
+  codexAvailable: boolean;
   codexProfileModel: DesktopCodexProfileModel;
   codexProfileNames?: string[];
   messagingProviders: readonly OnboardingProvider[];
@@ -2540,9 +2625,15 @@ function DoneStep(props: {
           <dd>{densityLabel(props.density)}</dd>
         </div>
         <div>
-          <dt>Codex profile</dt>
-          <dd>{codexSummary}</dd>
+          <dt>AI providers</dt>
+          <dd>{props.aiProviders.join(", ")}</dd>
         </div>
+        {props.codexAvailable ? (
+          <div>
+            <dt>Codex profile</dt>
+            <dd>{codexSummary}</dd>
+          </div>
+        ) : null}
         <div>
           <dt>Messaging</dt>
           <dd>{messagingSummary}</dd>
@@ -2922,14 +3013,6 @@ function NameCodexProfilesStep(props: {
    *  root can gate the footer Continue button on "all named rows
    *  authenticated". `namedRows` excludes blank inputs. */
   onAuthStateChange: (snapshot: { allAuthed: boolean; namedRows: number }) => void;
-  /** Global xAI key from Models / Providers step (renderer buffer,
-   *  not yet written to a keychain). When a row's per-profile
-   *  override is unset, this value graduates to that profile. */
-  globalXaiKey: string;
-  /** Per-profile xAI key overrides keyed by the row's committed
-   *  name. Empty string = "no override; inherit global". */
-  xaiKeyByProfile: Record<string, string>;
-  onSetXaiKeyForProfile: (profileName: string, value: string) => void;
 }) {
   const maxCount = props.mode === "isolated" ? 1 : 5;
   const isSingle = props.mode === "isolated";
@@ -3215,16 +3298,6 @@ function NameCodexProfilesStep(props: {
                 ) : null}
               </div>
               <ProfileRowLoginStatus state={state} />
-              {normalized ? (
-                <ProfileRowXaiKey
-                  profileName={normalized}
-                  globalKey={props.globalXaiKey}
-                  override={props.xaiKeyByProfile[normalized] ?? ""}
-                  onChange={(value) =>
-                    props.onSetXaiKeyForProfile(normalized, value)
-                  }
-                />
-              ) : null}
             </div>
           );
         })}
@@ -3499,117 +3572,6 @@ function SharedCodexLoginStep(props: {
           <ProfileRowLoginStatus state={state} />
         </div>
       </div>
-    </div>
-  );
-}
-
-/**
- * Inline xAI API key control per profile row. Three states:
- *   - Hidden chip ("Add xAI key (optional)"): default when no global
- *     key set and no override. Expanding shows the input.
- *   - "Uses global xAI key" chip: rendered when the operator typed
- *     a global key on Models / Providers but didn't override here.
- *     Expanding shows the input with the global value pre-filled
- *     (operator can replace).
- *   - "Override active" chip: rendered when an override is set.
- *     Always shows the input collapsed-style with Clear button.
- *
- * Override values flow into the wizard's `xaiKeyByProfile` map and
- * graduate to the matching profile's keychain at Finish. Per-row
- * keys NEVER write to `replaceSecret` — same defer-and-graduate
- * pattern as the global key on Models / Providers.
- */
-function ProfileRowXaiKey(props: {
-  profileName: string;
-  globalKey: string;
-  override: string;
-  onChange: (value: string) => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const [value, setValue] = useState("");
-  const hasGlobal = props.globalKey.length > 0;
-  const hasOverride = props.override.length > 0;
-
-  const save = (): void => {
-    if (!value.trim()) return;
-    props.onChange(value.trim());
-    setValue("");
-    setExpanded(false);
-  };
-  const clear = (): void => {
-    props.onChange("");
-    setValue("");
-  };
-
-  if (!expanded && !hasOverride) {
-    return (
-      <div className="onboarding-wizard__profile-row-xai is-collapsed">
-        <button
-          type="button"
-          className="onboarding-wizard__btn onboarding-wizard__btn--link"
-          onClick={() => setExpanded(true)}
-        >
-          {hasGlobal
-            ? "Override xAI key for this profile"
-            : "+ Add xAI key (optional)"}
-        </button>
-        {hasGlobal ? (
-          <span className="onboarding-wizard__profile-row-xai-hint">
-            Uses global xAI key
-          </span>
-        ) : null}
-      </div>
-    );
-  }
-
-  return (
-    <div className="onboarding-wizard__profile-row-xai">
-      <input
-        type="password"
-        className="onboarding-wizard__input"
-        placeholder={
-          hasOverride
-            ? "Replace stored override (already set)"
-            : hasGlobal
-              ? "Override global xAI key"
-              : "xai-…"
-        }
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            save();
-          }
-        }}
-      />
-      <button
-        type="button"
-        className="onboarding-wizard__btn onboarding-wizard__btn--ghost"
-        disabled={!value.trim()}
-        onClick={save}
-      >
-        {hasOverride ? "Replace" : "Use this"}
-      </button>
-      {hasOverride ? (
-        <button
-          type="button"
-          className="onboarding-wizard__btn onboarding-wizard__btn--link"
-          onClick={clear}
-        >
-          Clear override
-        </button>
-      ) : null}
-      <button
-        type="button"
-        className="onboarding-wizard__btn onboarding-wizard__btn--link"
-        onClick={() => {
-          setExpanded(false);
-          setValue("");
-        }}
-      >
-        Cancel
-      </button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -7,8 +7,19 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { DesktopSettingsSecretName } from "@pwragent/shared";
-import { SecretFieldRow, validateProfileNames } from "../OnboardingWizard";
+import type {
+  AcpAgentSettingsEntry,
+  DesktopSettingsSecretName,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import type { DesktopSettingsState } from "../../settings/useDesktopSettings";
+import {
+  BackendRequirementsStep,
+  isBackendRequirementSatisfied,
+  SecretFieldRow,
+  validateProfileNames,
+} from "../OnboardingWizard";
 
 afterEach(() => {
   cleanup();
@@ -26,6 +37,130 @@ describe("validateProfileNames", () => {
 
   it("rejects duplicate normalized profile ids", () => {
     expect(validateProfileNames(["My Work", "my-work"])).toBe(false);
+  });
+});
+
+const noCodexSnapshot = {
+  models: {
+    codex: {
+      discovery: { candidates: [] },
+    },
+  },
+} as unknown as DesktopSettingsSnapshot;
+
+function acpEntry(
+  registryId: "kimi" | "qwen" | "grok",
+  installed = true,
+): AcpAgentSettingsEntry {
+  return {
+    backendId: `acp:${registryId}`,
+    registryId,
+    name: registryId,
+    authors: [],
+    distributionKind: "local",
+    distributionSource: registryId,
+    installable: false,
+    installed,
+    installStatus: installed ? "installed" : "not-installed",
+    authStatus: "not-required",
+    verificationStatus: "not-applicable",
+    ...(installed
+      ? {
+          activeCommand: `/usr/local/bin/${registryId}`,
+          instances: [
+            {
+              command: `/usr/local/bin/${registryId}`,
+              source: "fallback" as const,
+            },
+          ],
+        }
+      : { instances: [] }),
+  };
+}
+
+describe("AI provider onboarding", () => {
+  it("accepts any supported installed ACP provider", () => {
+    expect(isBackendRequirementSatisfied(noCodexSnapshot, [])).toBe(false);
+    expect(
+      isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("kimi")]),
+    ).toBe(true);
+    expect(
+      isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("qwen")]),
+    ).toBe(true);
+    expect(
+      isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("grok")]),
+    ).toBe(true);
+  });
+
+  it("shows provider-specific official install commands without an xAI key field", () => {
+    const settings = {
+      snapshot: noCodexSnapshot,
+      refresh: vi.fn(async () => undefined),
+    } as unknown as DesktopSettingsState;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        acpEntries={[]}
+        onAcpEntriesChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/brew install --cask codex/i)).toBeVisible();
+    fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
+    expect(screen.getByText(/@moonshot-ai\/kimi-code/i)).toBeVisible();
+    fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));
+    expect(screen.getByText(/brew install qwen-code/i)).toBeVisible();
+    fireEvent.click(screen.getByRole("tab", { name: /Grok Build/i }));
+    expect(screen.getByText(/x\.ai\/cli\/install\.sh/i)).toBeVisible();
+    expect(screen.queryByText(/xAI API key/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("refreshes Codex and ACP discovery together", async () => {
+    const settingsRefresh = vi.fn(async () => undefined);
+    const applySnapshot = vi.fn();
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: Date.now(),
+      entries: [acpEntry("qwen")],
+    }));
+    const refreshCodexDiscovery = vi.fn(async () => ({
+      snapshot: noCodexSnapshot,
+    }));
+    const onAcpEntriesChange = vi.fn();
+    const settings = {
+      snapshot: noCodexSnapshot,
+      refresh: settingsRefresh,
+      applySnapshot,
+    } as unknown as DesktopSettingsState;
+    const desktopApi = {
+      listAcpAgents,
+      refreshCodexDiscovery,
+    } as DesktopApi;
+
+    render(
+      <BackendRequirementsStep
+        settings={settings}
+        desktopApi={desktopApi}
+        acpEntries={[]}
+        onAcpEntriesChange={onAcpEntriesChange}
+      />,
+    );
+    await waitFor(() => expect(listAcpAgents).toHaveBeenCalledTimes(2));
+    listAcpAgents.mockClear();
+    onAcpEntriesChange.mockClear();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Refresh after install/i }),
+    );
+
+    await waitFor(() => {
+      expect(refreshCodexDiscovery).toHaveBeenCalledOnce();
+      expect(listAcpAgents).toHaveBeenCalledWith({ refresh: true, force: true });
+      expect(applySnapshot).toHaveBeenCalledWith(noCodexSnapshot);
+      expect(settingsRefresh).not.toHaveBeenCalled();
+      expect(onAcpEntriesChange).toHaveBeenCalledWith([acpEntry("qwen")]);
+    });
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -13,6 +13,7 @@ import type {
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../../lib/useBackendSummaries";
 import type { DesktopSettingsState } from "../../settings/useDesktopSettings";
 import {
   BackendRequirementsStep,
@@ -49,7 +50,7 @@ const noCodexSnapshot = {
 } as unknown as DesktopSettingsSnapshot;
 
 function acpEntry(
-  registryId: "kimi" | "qwen" | "grok",
+  registryId: "gemini" | "kimi" | "qwen" | "grok",
   installed = true,
 ): AcpAgentSettingsEntry {
   return {
@@ -82,6 +83,9 @@ describe("AI provider onboarding", () => {
   it("accepts any supported installed ACP provider", () => {
     expect(isBackendRequirementSatisfied(noCodexSnapshot, [])).toBe(false);
     expect(
+      isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("gemini")]),
+    ).toBe(true);
+    expect(
       isBackendRequirementSatisfied(noCodexSnapshot, [acpEntry("kimi")]),
     ).toBe(true);
     expect(
@@ -109,6 +113,8 @@ describe("AI provider onboarding", () => {
     expect(
       screen.getByText(/brew update && brew install --cask codex/i),
     ).toBeVisible();
+    fireEvent.click(screen.getByRole("tab", { name: /Gemini CLI/i }));
+    expect(screen.getByText(/@google\/gemini-cli/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
     expect(screen.getByText(/@moonshot-ai\/kimi-code/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));
@@ -130,6 +136,7 @@ describe("AI provider onboarding", () => {
       snapshot: noCodexSnapshot,
     }));
     const onAcpEntriesChange = vi.fn();
+    const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     const settings = {
       snapshot: noCodexSnapshot,
       refresh: settingsRefresh,
@@ -151,6 +158,7 @@ describe("AI provider onboarding", () => {
     await waitFor(() => expect(listAcpAgents).toHaveBeenCalledTimes(2));
     listAcpAgents.mockClear();
     onAcpEntriesChange.mockClear();
+    dispatchEvent.mockClear();
 
     fireEvent.click(
       screen.getByRole("button", { name: /Refresh after install/i }),
@@ -162,6 +170,9 @@ describe("AI provider onboarding", () => {
       expect(applySnapshot).toHaveBeenCalledWith(noCodexSnapshot);
       expect(settingsRefresh).not.toHaveBeenCalled();
       expect(onAcpEntriesChange).toHaveBeenCalledWith([acpEntry("qwen")]);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: BACKEND_SUMMARIES_REFRESH_EVENT }),
+      );
     });
   });
 });

--- a/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/onboarding/__tests__/wizard-provider-setup.test.tsx
@@ -106,7 +106,9 @@ describe("AI provider onboarding", () => {
       />,
     );
 
-    expect(screen.getByText(/brew install --cask codex/i)).toBeVisible();
+    expect(
+      screen.getByText(/brew update && brew install --cask codex/i),
+    ).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Kimi Code/i }));
     expect(screen.getByText(/@moonshot-ai\/kimi-code/i)).toBeVisible();
     fireEvent.click(screen.getByRole("tab", { name: /Qwen Code/i }));

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -18,6 +18,9 @@ export type DesktopSettingsState = {
   loading: boolean;
   saving: boolean;
   snapshot?: DesktopSettingsSnapshot;
+  /** Adopt a snapshot returned by a specialized refresh IPC without issuing
+   *  a second read that can race or obscure the result. */
+  applySnapshot?: (snapshot: DesktopSettingsSnapshot) => void;
   clearSecret: (secret: DesktopSettingsSecretName) => Promise<boolean>;
   refresh: () => Promise<void>;
   replaceSecret: (
@@ -148,6 +151,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
 
   return useMemo(
     () => ({
+      applySnapshot: setSnapshot,
       clearSecret,
       composerImplementation: DESKTOP_CHAT_REPLY_COMPOSER_DEFAULT,
       error,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20169,32 +20169,6 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--status-error);
 }
 
-/* Per-row xAI key control on Multiple/Isolated name step. Collapsed
-   state is a single subtle link (so a row without an override stays
-   visually quiet); expanding reveals an inline password input that
-   commits to the operator's per-profile override map at wizard
-   state level, then graduates at Finish. */
-.onboarding-wizard__profile-row-xai {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-left: 42px;
-  margin-top: 2px;
-  flex-wrap: wrap;
-}
-.onboarding-wizard__profile-row-xai.is-collapsed {
-  gap: 10px;
-}
-.onboarding-wizard__profile-row-xai .onboarding-wizard__input {
-  flex: 1 1 200px;
-  min-width: 200px;
-  font: 500 12px/1 var(--font-mono);
-}
-.onboarding-wizard__profile-row-xai-hint {
-  font: 400 11px/1.4 var(--font-sans, sans-serif);
-  color: var(--text-muted);
-}
-
 /* "I'll log in later" deferral link — intentionally low-affordance,
    sits between the spacer and the hint so the operator's eye still
    goes to the disabled Continue button first. */
@@ -20567,27 +20541,68 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* ============================================================
-   ONBOARDING WIZARD — Step 0: Backend requirements
+   ONBOARDING WIZARD — AI provider requirements
    Pre-rail prerequisite check shown before Welcome. Uses the
-   --narrow width (same as Welcome / Done) — two stacked cards
-   (Codex CLI + xAI key) read fine at 720px; anything wider just
-   leaves dead horizontal space.
+   --narrow width (same as Welcome / Done). Provider tabs keep four
+   CLI setup paths compact without stacking four full cards.
    ============================================================ */
 .onboarding-wizard__prereqs {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  /* Backend gate is two stacked cards (Codex CLI, xAI key). Constrain
-     the column so they don't stretch all the way across the 1120px
-     canvas and feel like wasted white space. */
+  /* Constrain the provider panel so it doesn't stretch across the
+     full 1120px canvas and feel like wasted horizontal space. */
   max-width: 720px;
   width: 100%;
   margin: 0 auto;
 }
+.onboarding-wizard__backend-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+.onboarding-wizard__backend-tab {
+  appearance: none;
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-secondary);
+  font: 600 12px/1.2 var(--font-sans, sans-serif);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  cursor: pointer;
+}
+.onboarding-wizard__backend-tab:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+.onboarding-wizard__backend-tab.is-active {
+  color: var(--text-primary);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.onboarding-wizard__backend-tab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+.onboarding-wizard__backend-tab-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex: 0 0 auto;
+}
+.onboarding-wizard__backend-tab-dot.is-installed {
+  background: var(--status-ok);
+}
 .onboarding-wizard__prereq-card {
   background: var(--bg-panel-elevated);
   border: 1px solid var(--border-subtle);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 14px 16px 16px;
   display: flex;
   flex-direction: column;
@@ -20646,6 +20661,11 @@ a.transcript-message__messaging-origin:focus-visible {
   cursor: pointer;
   list-style: revert;
 }
+.onboarding-wizard__prereq-paths p {
+  margin: 8px 0 0;
+  font: 400 11px/1.5 var(--font-sans, sans-serif);
+  color: var(--text-muted);
+}
 .onboarding-wizard__prereq-paths ul {
   list-style: none;
   margin: 8px 0 0;
@@ -20688,6 +20708,24 @@ a.transcript-message__messaging-origin:focus-visible {
   border: 1px solid var(--border-strong);
   border-radius: 3px;
   padding: 1px 5px;
+}
+.onboarding-wizard__prereq-install a {
+  color: var(--accent);
+  font: 600 11px/1.3 var(--font-sans, sans-serif);
+  text-decoration: none;
+}
+.onboarding-wizard__prereq-install a:hover {
+  text-decoration: underline;
+}
+.onboarding-wizard__prereq-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 30px;
+}
+.onboarding-wizard__prereq-error {
+  color: var(--danger-text);
+  font: 500 11px/1.35 var(--font-sans, sans-serif);
 }
 .onboarding-wizard__prereq-link {
   font: 400 12px/1.4 var(--font-sans, sans-serif);


### PR DESCRIPTION
## Summary

- fix onboarding Codex refresh so it applies the forced discovery result directly and reports the locations actually checked, including `/usr/local/bin/codex` on Intel Macs
- replace the wizard xAI API-key form with tabbed Codex CLI, Gemini CLI, Kimi Code, Qwen Code, and Grok Build install guidance
- refresh Codex and ACP provider discovery together, allow any displayed installed provider to satisfy onboarding, and skip Codex profile setup for ACP-only installs
- refresh the mounted backend-summary cache after onboarding ACP discovery so replay onboarding updates the composer immediately
- keep ACP runtime discovery in the transient bootstrap workspace so multi-profile onboarding does not create a phantom `default` profile
- exercise real executable discovery for all five providers from both a custom login-shell `PATH` and supported well-known install locations

## Root cause

The discovery library already checks both Intel and Apple-silicon Homebrew locations. Failed candidates are intentionally filtered from its returned candidate list, but the wizard displayed that filtered list length as the number of searched locations. Refresh also discarded the specialized refresh response and performed a second generic read, which could leave the UI stale.

The onboarding gate duplicated the displayed ACP-provider list and omitted Gemini. ACP refresh also invalidated main-process discovery without notifying the mounted renderer backend-summary cache.

## Validation

- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm test apps/desktop/src/main/__tests__/settings-ipc.test.ts apps/desktop/src/renderer/src/features/onboarding` (67 tests)
- `pnpm test:desktop-e2e onboarding-wizard.spec.ts` (11 tests)
- focused provider install/discovery E2Es (3 tests, including account-free Gemini executable shims)
- `pnpm lint:eslint` (0 errors; pre-existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `git diff --check`
