### PR TITLE
fix(desktop): tolerate exited Electron E2E handles

### DIFF
--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -352,7 +352,7 @@ export function configureElectronE2eSecretStorageEnv(
 export async function closeElectronApplication(
   electronApp: ElectronApplication,
 ): Promise<void> {
-  let child: ElectronChildProcess;
+  let child: ElectronChildProcess | undefined;
   try {
     child = electronApp.process();
   } catch {
@@ -360,6 +360,12 @@ export async function closeElectronApplication(
     // before the test reaches finally. Once Playwright has disposed its
     // Electron connection, process() throws while resolving the remote
     // object; there is no remaining process tree for this helper to close.
+    return;
+  }
+  if (!child) {
+    // Depending on the Playwright client version and disposal timing,
+    // `process()` can return undefined rather than throw after the channel is
+    // released. That has the same no-process-left-to-clean-up meaning.
     return;
   }
   try {

--- a/apps/desktop/src/main/__tests__/electron-app-close.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-app-close.test.ts
@@ -1,0 +1,15 @@
+import type { ElectronApplication } from "@playwright/test";
+import { describe, expect, it, vi } from "vitest";
+import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
+
+describe("closeElectronApplication", () => {
+  it("is a no-op after Playwright releases an exited Electron handle", async () => {
+    const process = vi.fn(() => {
+      throw new TypeError("Cannot read properties of undefined (reading '_object')");
+    });
+    const electronApp = { process } as unknown as ElectronApplication;
+
+    await expect(closeElectronApplication(electronApp)).resolves.toBeUndefined();
+    expect(process).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-app-close.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-app-close.test.ts
@@ -3,10 +3,18 @@ import { describe, expect, it, vi } from "vitest";
 import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
 
 describe("closeElectronApplication", () => {
-  it("is a no-op after Playwright releases an exited Electron handle", async () => {
+  it("is a no-op when Playwright throws for an exited Electron handle", async () => {
     const process = vi.fn(() => {
       throw new TypeError("Cannot read properties of undefined (reading '_object')");
     });
+    const electronApp = { process } as unknown as ElectronApplication;
+
+    await expect(closeElectronApplication(electronApp)).resolves.toBeUndefined();
+    expect(process).toHaveBeenCalledOnce();
+  });
+
+  it("is a no-op when Playwright returns no process for an exited Electron handle", async () => {
+    const process = vi.fn(() => undefined);
     const electronApp = { process } as unknown as ElectronApplication;
 
     await expect(closeElectronApplication(electronApp)).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

- make Electron E2E teardown return safely when Playwright has already released the handle for an app that exited itself
- preserve the existing bounded graceful-close and process-tree fallback for live apps
- add a unit regression for the closed-handle `process()` failure

## Root cause

The Multiple-mode onboarding test intentionally quits its bootstrap Electron app. Its `finally` then calls the fixture close helper, which unconditionally invoked `electronApp.process()`. Once Playwright had released the closed Electron channel, that call threw before fixture cleanup.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/electron-app-close.test.ts`
- `pnpm exec eslint --no-ignore apps/desktop/e2e/fixtures/electron-app.ts apps/desktop/src/main/__tests__/electron-app-close.test.ts`
- `pnpm --filter @pwragent/desktop typecheck`
- `git diff --check origin/main...HEAD`

The local Tart macOS VM lab is not provisioned on this host, so the headed onboarding E2E was not run locally. The shared macOS CI lane should exercise the exact regression path.
