### PR TITLE
fix(desktop): prevent macOS keychain dialogs in E2E

### DIFF
--- a/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
+++ b/apps/desktop/e2e/docs-site-screenshots.inspect.spec.ts
@@ -54,6 +54,17 @@ const WINDOW_SIZE = { width: 1440, height: 900 } as const;
 // See `fixtures/screenshot-appearance.ts` for the env-var contract.
 const SCREENSHOT_APPEARANCE = resolveScreenshotAppearance();
 
+function launchDocsSiteApp(
+  params: Parameters<typeof launchElectronApp>[0],
+): ReturnType<typeof launchElectronApp> {
+  return launchElectronApp({
+    ...params,
+    // Preserve production-like writable credential controls without allowing
+    // unsigned screenshot Electron to invoke the macOS keychain.
+    secretStorage: "memory",
+  });
+}
+
 test.skip(
   process.env.PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE !== "1",
   "Set PWRAGENT_DOCS_SITE_SCREENSHOT_CAPTURE=1 via the package script to capture docs-site screenshots.",
@@ -143,7 +154,7 @@ async function scrollMessagingPlatformIntoView(
 test("settings-applications — Settings → Applications panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -165,7 +176,7 @@ test("settings-applications — Settings → Applications panel", async () => {
 test("settings-worktrees — Settings → Worktrees panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -187,7 +198,7 @@ test("settings-worktrees — Settings → Worktrees panel", async () => {
 test("settings-models — Settings → Models panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -209,7 +220,7 @@ test("settings-models — Settings → Models panel", async () => {
 test("settings-profiles — Settings → Profiles panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -231,7 +242,7 @@ test("settings-profiles — Settings → Profiles panel", async () => {
 test("settings-general — Settings → General panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -253,7 +264,7 @@ test("settings-general — Settings → General panel", async () => {
 test("settings-experimental — Settings → Experimental panel", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -287,7 +298,7 @@ for (const shot of MESSAGING_PLATFORM_SHOTS) {
   test(`settings-messaging — ${shot.label}`, async () => {
     test.setTimeout(120_000);
 
-    const app = await launchElectronApp({
+    const app = await launchDocsSiteApp({
       fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
       windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -299,6 +310,16 @@ for (const shot of MESSAGING_PLATFORM_SHOTS) {
         navLabel: "Messaging",
         regionLabel: "Messaging settings",
       });
+
+      const messagingRegion = app.window.getByRole("region", {
+        name: "Messaging settings",
+      });
+      await expect(
+        messagingRegion.locator('input[type="password"]:disabled'),
+      ).toHaveCount(0);
+      await expect(
+        messagingRegion.getByText(/Secret storage disabled via/i),
+      ).toHaveCount(0);
 
       await scrollMessagingPlatformIntoView(app.window, shot.label);
 
@@ -352,7 +373,7 @@ async function navigateToTelegramPairing(page: Page): Promise<void> {
 test("messaging-pairing — frame 1: pairing token generated", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -393,7 +414,7 @@ test("messaging-pairing — frame 1: pairing token generated", async () => {
 test("messaging-pairing — frame 2: observed, approval prompt visible", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -466,7 +487,7 @@ test("messaging-pairing — frame 2: observed, approval prompt visible", async (
 test("messaging-pairing — frame 3: approved, user in authorized list", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -558,7 +579,7 @@ test("messaging-pairing — frame 3: approved, user in authorized list", async (
 test("messaging-activity-blocked — Messaging Activity showing rejected inbound", async () => {
   test.setTimeout(120_000);
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(specDir, "fixtures/smoke/replay.fixture.json"),
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -709,7 +730,7 @@ test("desktop-recents — Recents lens populated", async () => {
   // sidebar shows realistic thread titles rather than the smoke
   // fixture's blank state. The capture goes to docs-site/ under a
   // different filename so the docs-site/ folder is self-contained.
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(
       specDir,
       "fixtures/readme-recents-hero/replay.fixture.json",
@@ -753,7 +774,7 @@ test("desktop-skills-autocomplete — composer $ autocomplete showing skill list
   // realistic skill set (ce:plan, ce:brainstorm, ce:compound, ce:work,
   // adversarial-document-reviewer, …) so the dropdown reads as a
   // believable Codex setup rather than a synthetic stub.
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(
       specDir,
       "fixtures/skill-autocomplete-interactions/replay.fixture.json",
@@ -882,7 +903,7 @@ test("desktop-queued-turns — composer with /review queued behind an in-flight 
     "utf8",
   );
 
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath,
     windowSize: WINDOW_SIZE,
     appearance: SCREENSHOT_APPEARANCE,
@@ -951,7 +972,7 @@ test("desktop-onboarding-wizard — Codex profile step", async () => {
   // `suppressOnboarding: false` is the explicit opt-in, and the
   // wizard doesn't need the replay driver until it tries to spawn a
   // thread (which we won't do — we stop on the Codex Profile step).
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     suppressOnboarding: false,
     requiresReplayDriver: false,
     windowSize: WINDOW_SIZE,
@@ -1013,7 +1034,7 @@ test("desktop-live-work-rail — in-flight turn with diff + plan in the rail", a
   // test suite. That fixture's turn/diff/updated landing ends with
   // the protocol-summary "Edited 2 files, +4, -1" — a tight, visually
   // interesting state for the rail.
-  const app = await launchElectronApp({
+  const app = await launchDocsSiteApp({
     fixturePath: path.resolve(
       specDir,
       "fixtures/live-work-rail-toggle/replay.fixture.json",

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -10,6 +10,7 @@ import type {
 } from "@pwragent/shared";
 import { _electron as electron, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { applyDesktopSettingsPatch } from "../../src/main/settings/desktop-config";
+import { SECRET_STORAGE_DISABLED_ENV } from "../../src/main/settings/desktop-secret-store";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
@@ -179,6 +180,14 @@ export async function launchElectronApp(params: {
       env[key] = value;
     }
   }
+  // Every desktop E2E runs an unsigned development Electron binary. On
+  // macOS, allowing that binary to reach safeStorage can open a native
+  // "Keychain Not Found" modal that Playwright cannot observe or dismiss.
+  // Apply the documented dev-only escape hatch after per-spec overrides so
+  // no E2E can accidentally re-enable OS keychain UI. Profile instances
+  // spawned during onboarding graduation inherit this environment through
+  // openDesktopPwrAgentProfile(), covering both Electron processes.
+  env[SECRET_STORAGE_DISABLED_ENV] = "1";
 
   const electronApp = await electron.launch({
     args: [
@@ -321,7 +330,16 @@ export async function launchElectronApp(params: {
 export async function closeElectronApplication(
   electronApp: ElectronApplication,
 ): Promise<void> {
-  const child = electronApp.process();
+  let child: ElectronChildProcess;
+  try {
+    child = electronApp.process();
+  } catch {
+    // A graduation flow can quit the Playwright-owned bootstrap process
+    // before the test reaches finally. Once Playwright has disposed its
+    // Electron connection, process() throws while resolving the remote
+    // object; there is no remaining process tree for this helper to close.
+    return;
+  }
   try {
     await withTimeout(
       electronApp.evaluate(({ app }) => {

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -10,7 +10,10 @@ import type {
 } from "@pwragent/shared";
 import { _electron as electron, expect, type ElectronApplication, type Page } from "@playwright/test";
 import { applyDesktopSettingsPatch } from "../../src/main/settings/desktop-config";
-import { SECRET_STORAGE_DISABLED_ENV } from "../../src/main/settings/desktop-secret-store";
+import {
+  E2E_MEMORY_SECRET_STORAGE_ENV,
+  SECRET_STORAGE_DISABLED_ENV,
+} from "../../src/main/settings/desktop-secret-store";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 const ELECTRON_EVALUATE_QUIT_TIMEOUT_MS = 1_000;
@@ -95,6 +98,12 @@ export async function launchElectronApp(params: {
    * (every replay-backed spec).
    */
   contextRailPinned?: boolean;
+  /**
+   * Secret-store presentation for the launched E2E app. The default reports
+   * storage as unavailable while preventing native keychain access. `memory`
+   * keeps storage writable without safeStorage for production-facing captures.
+   */
+  secretStorage?: "disabled" | "memory";
   /**
    * Whether to seed `onboarding.completed = true` into the
    * `default` profile's config.toml before launch. Defaults to
@@ -187,7 +196,7 @@ export async function launchElectronApp(params: {
   // no E2E can accidentally re-enable OS keychain UI. Profile instances
   // spawned during onboarding graduation inherit this environment through
   // openDesktopPwrAgentProfile(), covering both Electron processes.
-  env[SECRET_STORAGE_DISABLED_ENV] = "1";
+  configureElectronE2eSecretStorageEnv(env, params.secretStorage);
 
   const electronApp = await electron.launch({
     args: [
@@ -318,6 +327,19 @@ export async function launchElectronApp(params: {
       await rm(homeRoot, { recursive: true, force: true });
     },
   };
+}
+
+export function configureElectronE2eSecretStorageEnv(
+  env: Record<string, string>,
+  mode: "disabled" | "memory" = "disabled",
+): void {
+  env[SECRET_STORAGE_DISABLED_ENV] = "1";
+  if (mode === "memory") {
+    env[E2E_MEMORY_SECRET_STORAGE_ENV] = "1";
+  } else {
+    // Do not inherit a screenshot process's memory mode into normal E2Es.
+    delete env[E2E_MEMORY_SECRET_STORAGE_ENV];
+  }
 }
 
 /**

--- a/apps/desktop/e2e/onboarding-wizard.spec.ts
+++ b/apps/desktop/e2e/onboarding-wizard.spec.ts
@@ -403,6 +403,15 @@ test.describe("Onboarding wizard", () => {
     // (only `personal/` and `work/`).
     const app = await launchElectronApp(wizardLaunchOptions);
     try {
+      // Unsigned Electron must never reach macOS safeStorage during E2E.
+      // This value is inherited by the detached `personal` process below;
+      // profiles-ipc.test.ts locks that spawn contract independently.
+      expect(
+        await app.electronApp.evaluate(() =>
+          process.env.PWRAGENT_DEV_DISABLE_SECRET_STORAGE
+        ),
+      ).toBe("1");
+
       // Walk the full wizard: Welcome → Thread → Models (xAI key) →
       // Codex profile (Multiple) → Name profiles (personal, work) →
       // Messaging warning (Skip).

--- a/apps/desktop/src/main/__tests__/desktop-secret-store.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-secret-store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  E2E_MEMORY_SECRET_STORAGE_ENV,
+  isE2eMemorySecretStorageEnabled,
+} from "../settings/desktop-secret-store";
+
+describe("E2E memory secret storage", () => {
+  const enabledEnv = {
+    PWRAGENT_E2E: "1",
+    [E2E_MEMORY_SECRET_STORAGE_ENV]: "1",
+  };
+
+  it("is available only to unpackaged E2E processes", () => {
+    expect(isE2eMemorySecretStorageEnabled(enabledEnv, false)).toBe(true);
+    expect(isE2eMemorySecretStorageEnabled(enabledEnv, true)).toBe(false);
+    expect(
+      isE2eMemorySecretStorageEnabled(
+        { [E2E_MEMORY_SECRET_STORAGE_ENV]: "1" },
+        false,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
+import {
+  closeElectronApplication,
+  configureElectronE2eSecretStorageEnv,
+} from "../../../e2e/fixtures/electron-app";
+import {
+  E2E_MEMORY_SECRET_STORAGE_ENV,
+  SECRET_STORAGE_DISABLED_ENV,
+} from "../settings/desktop-secret-store";
 
 describe("Electron E2E fixture teardown", () => {
   it("is a no-op after Playwright has already disposed a graduated bootstrap app", async () => {
@@ -12,5 +19,21 @@ describe("Electron E2E fixture teardown", () => {
     await expect(
       closeElectronApplication(electronApp as never),
     ).resolves.toBeUndefined();
+  });
+
+  it("keeps keychain access disabled while enabling writable screenshot storage", () => {
+    const env: Record<string, string> = {};
+
+    configureElectronE2eSecretStorageEnv(env, "memory");
+
+    expect(env).toMatchObject({
+      [E2E_MEMORY_SECRET_STORAGE_ENV]: "1",
+      [SECRET_STORAGE_DISABLED_ENV]: "1",
+    });
+
+    configureElectronE2eSecretStorageEnv(env);
+
+    expect(env[SECRET_STORAGE_DISABLED_ENV]).toBe("1");
+    expect(env[E2E_MEMORY_SECRET_STORAGE_ENV]).toBeUndefined();
   });
 });

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import { closeElectronApplication } from "../../../e2e/fixtures/electron-app";
+
+describe("Electron E2E fixture teardown", () => {
+  it("is a no-op after Playwright has already disposed a graduated bootstrap app", async () => {
+    const electronApp = {
+      process: vi.fn(() => {
+        throw new TypeError("Cannot read properties of undefined");
+      }),
+    };
+
+    await expect(
+      closeElectronApplication(electronApp as never),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/profiles-ipc.test.ts
@@ -10,6 +10,7 @@ import {
   setDefaultProfileName,
   startProfileRuntimeHeartbeat,
 } from "../profile";
+import { SECRET_STORAGE_DISABLED_ENV } from "../settings/desktop-secret-store";
 
 const spawnMock = vi.fn(() => ({
   unref: vi.fn(),
@@ -259,7 +260,7 @@ describe("profile IPC helpers", () => {
     expect(fs.existsSync(response.profileDir)).toBe(true);
   });
 
-  it("openDesktopPwrAgentProfile normalizes before launching", async () => {
+  it("openDesktopPwrAgentProfile normalizes and preserves the E2E secret-storage opt-out", async () => {
     const root = createRoot();
     const env = {
       [PWRAGENT_HOME_ENV]: root,
@@ -269,6 +270,7 @@ describe("profile IPC helpers", () => {
     ensureNamedProfileExists("my-work-profile", { env });
     vi.stubEnv(PWRAGENT_HOME_ENV, root);
     vi.stubEnv(PWRAGENT_PROFILE_ENV, "dev");
+    vi.stubEnv(SECRET_STORAGE_DISABLED_ENV, "1");
     const { openDesktopPwrAgentProfile } = await import("../ipc/profiles");
 
     const response = openDesktopPwrAgentProfile({ profile: "My Work Profile" });
@@ -280,6 +282,7 @@ describe("profile IPC helpers", () => {
       expect.objectContaining({
         env: expect.objectContaining({
           [PWRAGENT_PROFILE_ENV]: "my-work-profile",
+          [SECRET_STORAGE_DISABLED_ENV]: "1",
         }),
       }),
     );

--- a/apps/desktop/src/main/settings/desktop-secret-store.ts
+++ b/apps/desktop/src/main/settings/desktop-secret-store.ts
@@ -22,10 +22,30 @@ import type {
 export const SECRET_STORAGE_DISABLED_ENV =
   "PWRAGENT_DEV_DISABLE_SECRET_STORAGE";
 
+/**
+ * E2E-only writable secret-store mode. Documentation screenshot captures need
+ * production-like empty credential fields, but must not let unsigned Electron
+ * reach macOS safeStorage. The desktop singleton honors this only when the app
+ * is unpackaged and PWRAGENT_E2E=1 is also present.
+ */
+export const E2E_MEMORY_SECRET_STORAGE_ENV =
+  "PWRAGENT_E2E_MEMORY_SECRET_STORAGE";
+
 export function isSecretStorageDisabledByEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
   const raw = env[SECRET_STORAGE_DISABLED_ENV]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+export function isE2eMemorySecretStorageEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+  isPackaged = false,
+): boolean {
+  if (isPackaged || env.PWRAGENT_E2E !== "1") {
+    return false;
+  }
+  const raw = env[E2E_MEMORY_SECRET_STORAGE_ENV]?.trim().toLowerCase();
   return raw === "1" || raw === "true" || raw === "yes";
 }
 

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -4,6 +4,10 @@ import { DbBackedSafeStorageSecretStore } from "../state/secret-store-sqlite";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
 import { broadcastAppearanceChange } from "../appearance-broadcast";
 import { resolveBootstrapProfilePath } from "../profile";
+import {
+  isE2eMemorySecretStorageEnabled,
+  MemoryDesktopSecretStore,
+} from "./desktop-secret-store";
 
 let desktopSettingsService: DesktopSettingsService | undefined;
 
@@ -15,9 +19,15 @@ export function getDesktopSettingsService(): DesktopSettingsService {
     // them to the operator's chosen real profile before tearing the
     // bootstrap state down.
     const bootstrap = getAppStateMode() === "bootstrap";
+    const secretStore = isE2eMemorySecretStorageEnabled(
+      process.env,
+      app.isPackaged,
+    )
+      ? new MemoryDesktopSecretStore()
+      : new DbBackedSafeStorageSecretStore(safeStorage, getAppStateDb());
     desktopSettingsService = new DesktopSettingsService({
       defaultDeveloperMode: app.isPackaged === true ? false : true,
-      secretStore: new DbBackedSafeStorageSecretStore(safeStorage, getAppStateDb()),
+      secretStore,
       ...(bootstrap
         ? { configPath: resolveBootstrapProfilePath("config.toml") }
         : {}),


### PR DESCRIPTION
## Summary

- force the documented `PWRAGENT_DEV_DISABLE_SECRET_STORAGE=1` escape hatch in the shared desktop E2E launcher after per-spec environment overrides
- verify onboarding's Playwright-owned bootstrap process receives the opt-out and that graduated profile processes inherit it
- make E2E teardown tolerate onboarding graduation closing the bootstrap Electron connection before `finally`

## Root cause

The shared Electron fixture marked launches with `PWRAGENT_E2E=1` but did not disable secret storage. On unsigned macOS development Electron, onboarding's typed xAI key could therefore reach `safeStorage` and open the native “Keychain Not Found” dialog. The detached profile launch copies `process.env`, so the missing fixture variable affected both the bootstrap process and the graduated `personal` process.

The startup-error dialog is the existing 25-second watchdog correctly reporting that a spawned profile never painted while blocked by native UI. This PR leaves that diagnostic behavior unchanged instead of suppressing it.

This is independent of #1183; no provider-discovery code is changed.

## Production behavior

Packaged handling is unchanged. `rejectDevOnlyEnvVarsInProduction()` still logs, clears, and refuses `PWRAGENT_DEV_DISABLE_SECRET_STORAGE` before secret-store consumers run.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts apps/desktop/src/main/__tests__/profiles-ipc.test.ts apps/desktop/src/main/__tests__/secret-store-sqlite.test.ts apps/desktop/src/main/__tests__/index.test.ts` — 59 passed
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `pnpm lint:eslint` — 0 errors (existing warnings only)
- macOS Tart VM: full `e2e/onboarding-wizard.spec.ts` — 9 passed, no manual modal dismissal
