### PR TITLE
fix(desktop): keep thread busy indicators synchronized

### DIFF
--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -198,7 +198,7 @@ test("renders the desktop shell with the black-first Tangerine Terminal theme", 
   }
 });
 
-test("keeps workflow states and narrow desktop layout readable", async ({}, testInfo) => {
+test("keeps workflow states, scanner phases, and narrow desktop layout stable", async ({}, testInfo) => {
   const app = await launchElectronApp({
     fixturePath: path.resolve(
       themeSpecDir,
@@ -257,6 +257,15 @@ test("keeps workflow states and narrow desktop layout readable", async ({}, test
     );
     await expect(app.window.getByRole("status")).toContainText("Waiting for approval");
     await expect(app.window.locator(".thinking-scanner").first()).toBeVisible();
+    const scannerStartTimes = await app.window
+      .locator(".thinking-scanner__beam")
+      .evaluateAll((elements) =>
+        elements.flatMap((element) =>
+          element.getAnimations().map((animation) => animation.startTime)
+        )
+      );
+    expect(scannerStartTimes.length).toBeGreaterThan(1);
+    expect(new Set(scannerStartTimes)).toEqual(new Set([0]));
 
     // Issue #240: transcript-panel is transparent — read against the
     // app-shell `--bg-app` for the readability calc.

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThinkingScanner.tsx
@@ -1,41 +1,29 @@
-import { useRef } from "react";
-import type { CSSProperties } from "react";
-
 type ThinkingScannerProps = {
   compact?: boolean;
 };
 
-const SCAN_DURATION_MS = 1800;
-
-type ThinkingScannerStyle = CSSProperties & {
-  "--thinking-scanner-delay": string;
-};
-
-function getThinkingScannerPhaseMs(): number {
-  if (typeof performance === "undefined" || typeof performance.now !== "function") {
-    return 0;
+function syncThinkingScannerAnimation(element: HTMLDivElement | null): void {
+  if (!element || typeof element.getAnimations !== "function") {
+    return;
   }
 
-  return performance.now() % SCAN_DURATION_MS;
+  for (const animation of element.getAnimations()) {
+    // CSS animations normally start when their element's styles resolve. That
+    // leaves scanners mounted during separate, busy renderer commits with
+    // permanently different phases. Pin each animation to the document
+    // timeline's origin instead: the compositor advances every scanner from
+    // one shared epoch without a React tick or a root-level style mutation.
+    animation.startTime = 0;
+  }
 }
 
 export function ThinkingScanner(props: ThinkingScannerProps = {}) {
-  const phaseMsRef = useRef<number | undefined>(undefined);
-  if (phaseMsRef.current === undefined) {
-    phaseMsRef.current = getThinkingScannerPhaseMs();
-  }
-
-  const style: ThinkingScannerStyle = {
-    "--thinking-scanner-delay": `${-phaseMsRef.current}ms`,
-  };
-
   return (
     <div
       aria-hidden="true"
       className={`thinking-scanner${props.compact ? " thinking-scanner--mini" : ""}`}
-      style={style}
     >
-      <div className="thinking-scanner__beam" />
+      <div className="thinking-scanner__beam" ref={syncThinkingScannerAnimation} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx
@@ -2,14 +2,37 @@ import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThinkingScanner } from "../ThinkingScanner";
 
+const originalGetAnimationsDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  "getAnimations"
+);
+
 describe("ThinkingScanner", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    if (originalGetAnimationsDescriptor) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "getAnimations",
+        originalGetAnimationsDescriptor
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "getAnimations");
+    }
   });
 
-  it("syncs scanners with a local animation phase and no runtime clock", () => {
-    vi.spyOn(performance, "now").mockReturnValue(2250);
+  it("pins scanners to one document-timeline epoch with no runtime clock", () => {
+    const animations = [
+      { startTime: 975 },
+      { startTime: 2275 },
+    ];
+    let animationIndex = 0;
+    const getAnimations = vi.fn(() => [animations[animationIndex++]]);
+    Object.defineProperty(HTMLElement.prototype, "getAnimations", {
+      configurable: true,
+      value: getAnimations,
+    });
     const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame");
     const setTimeoutSpy = vi.spyOn(window, "setTimeout");
 
@@ -22,9 +45,8 @@ describe("ThinkingScanner", () => {
 
     const scanners = Array.from(document.querySelectorAll<HTMLElement>(".thinking-scanner"));
     expect(scanners).toHaveLength(2);
-    expect(
-      scanners.map((scanner) => scanner.style.getPropertyValue("--thinking-scanner-delay"))
-    ).toEqual(["-450ms", "-450ms"]);
+    expect(getAnimations).toHaveBeenCalledTimes(2);
+    expect(animations.map((animation) => animation.startTime)).toEqual([0, 0]);
     expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -178,7 +178,6 @@ describe("Tangerine Terminal theme contract", () => {
   it("does not leave unresolved theme token references in app.css", () => {
     const localTokens = new Set([
       "thinking-scanner-beam-width",
-      "thinking-scanner-delay",
       "thinking-scanner-travel",
       // Sidebar rail/lane inset system — defined on `.sidebar`, not `:root`.
       "sidebar-rail-inset",
@@ -1117,13 +1116,13 @@ describe("Tangerine Terminal theme contract", () => {
     expect(css).not.toContain("--thinking-scanner-mini-offset");
     expect(css).toContain("@keyframes pwragent-thinking-scanner-sweep");
     expect(css).toMatch(
-      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-delay:\s*0ms;[\s\S]*?--thinking-scanner-travel:\s*44px;[\s\S]*?width:\s*62px;[\s\S]*?\}/
+      /\.thinking-scanner\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*18px;[\s\S]*?--thinking-scanner-travel:\s*44px;[\s\S]*?width:\s*62px;[\s\S]*?\}/
     );
     expect(css).toMatch(
       /\.thinking-scanner--mini\s*\{[\s\S]*?--thinking-scanner-beam-width:\s*6px;[\s\S]*?--thinking-scanner-travel:\s*10px;[\s\S]*?width:\s*16px;[\s\S]*?\}/
     );
     expect(css).toMatch(
-      /\.thinking-scanner__beam\s*\{[\s\S]*?animation:\s*pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;[\s\S]*?animation-delay:\s*var\(--thinking-scanner-delay\);[\s\S]*?\}/
+      /\.thinking-scanner__beam\s*\{[\s\S]*?animation:\s*pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;[\s\S]*?\}/
     );
   });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12254,7 +12254,6 @@ a.transcript-message__messaging-origin:focus-visible {
 .thinking-scanner {
   position: relative;
   --thinking-scanner-beam-width: 18px;
-  --thinking-scanner-delay: 0ms;
   --thinking-scanner-travel: 44px;
   width: 62px;
   height: 6px;
@@ -12289,7 +12288,6 @@ a.transcript-message__messaging-origin:focus-visible {
     0 0 10px color-mix(in srgb, var(--accent) 42%, transparent),
     0 0 18px color-mix(in srgb, var(--accent) 22%, transparent);
   animation: pwragent-thinking-scanner-sweep 1800ms ease-in-out infinite;
-  animation-delay: var(--thinking-scanner-delay);
   opacity: 0.76;
   transform: translateX(0);
   will-change: opacity, transform;


### PR DESCRIPTION
## Summary

- pin each busy-indicator CSS animation to the document timeline origin when its beam mounts
- remove the render-time negative delay that could preserve mount latency as permanent phase skew
- add unit and Electron E2E coverage for the shared animation epoch

## Root cause

The compositor animation itself was lightweight, but each scanner calculated a negative delay from `performance.now()` during React render. CSS animation time begins later, when styles resolve. Under sustained renderer load, the gap between those moments can vary between scanner mounts, and that variance remains as permanent phase skew.

The fix sets each beam animation `startTime` to the same document-timeline origin. Chromium then advances all scanners from one epoch on the compositor. There is no recurring JavaScript clock, React state update, root DOM mutation, or root CSS-variable write.

## Impact

Busy indicators remain visually synchronized even when they mount in separate delayed commits on a heavily loaded machine, while preserving the localized compositor-only animation path.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThinkingScanner.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx`
- `pnpm test:desktop-e2e apps/desktop/e2e/tangerine-terminal-theme.spec.ts`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm --filter @pwragent/desktop typecheck`