### PR TITLE
fix(desktop): keep unknown composer files as references

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14678,6 +14678,46 @@ command = "pnpm dev"
     }
   });
 
+  it("preserves enriched local file references for Grok turns", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-grok-local-file-"));
+    const filePath = path.join(root, "notes.txt");
+    const text = "Inspect the disk image only if needed.\n";
+    await writeFile(filePath, text, "utf8");
+    const grokClient = new MockBackendClient({ threads: [] });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient,
+      overlayStore: createOverlayStoreMock(),
+      resolvePdfAnalysisEnabled: () => false,
+    });
+
+    try {
+      await registry.startTurn({
+        backend: "grok",
+        threadId: "thread-grok-local-file",
+        input: [
+          { type: "text", text: "Use the attached notes." },
+          { type: "localFile", name: "notes.txt", path: filePath },
+        ],
+      });
+
+      expect(grokClient.lastStartTurnParams?.input).toEqual([
+        { type: "text", text: "Use the attached notes." },
+        {
+          type: "localFile",
+          name: "notes.txt",
+          path: filePath,
+          mimeType: "text/plain",
+          sizeBytes: Buffer.byteLength(text),
+          textPreview: text,
+        },
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("persists the Codex title helper as a system sub-agent with usage", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14638,6 +14638,46 @@ command = "pnpm dev"
     }
   });
 
+  it("enriches local file references with bounded metadata before backend handoff", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-local-file-"));
+    const filePath = path.join(root, "notes.txt");
+    const text = "Inspect the disk image only if needed.\n";
+    await writeFile(filePath, text, "utf8");
+    const codexClient = new MockBackendClient({ threads: [] });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      resolvePdfAnalysisEnabled: () => false,
+    });
+
+    try {
+      await registry.startTurn({
+        backend: "codex",
+        threadId: "thread-local-file",
+        input: [
+          { type: "text", text: "Use the attached notes." },
+          { type: "localFile", name: "notes.txt", path: filePath },
+        ],
+      });
+
+      expect(codexClient.lastStartTurnParams?.input).toEqual([
+        { type: "text", text: "Use the attached notes." },
+        {
+          type: "localFile",
+          name: "notes.txt",
+          path: filePath,
+          mimeType: "text/plain",
+          sizeBytes: Buffer.byteLength(text),
+          textPreview: text,
+        },
+      ]);
+    } finally {
+      await registry.close();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("persists the Codex title helper as a system sub-agent with usage", async () => {
     const titleService = {
       generateTitle: vi.fn(async () => ({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -7068,6 +7068,9 @@ describe("CodexAppServerClient", () => {
           type: "localFile",
           name: "Jeep",
           path: "/Users/huntharo/Downloads/Jeep",
+          mimeType: "text/plain",
+          sizeBytes: 12,
+          textPreview: "hello world\n",
         },
       ],
     });
@@ -7076,10 +7079,22 @@ describe("CodexAppServerClient", () => {
     const turnStart = transport!.sentMessages
       .map((message) => JSON.parse(message) as { method?: string; params?: { input?: unknown[] } })
       .find((payload) => payload.method === "turn/start");
+    const fileContext = turnStart?.params?.input?.[0] as
+      | { text?: string }
+      | undefined;
+    expect(fileContext?.text).toContain(
+      "Jeep: /Users/huntharo/Downloads/Jeep (Type: text/plain | Size: 12 B)",
+    );
+    expect(fileContext?.text).toContain(
+      "<pwragent-local-file-preview>\nhello world\n\n</pwragent-local-file-preview>",
+    );
+    expect(fileContext?.text).toContain(
+      "provided local path references rather than raw file payloads",
+    );
     expect(turnStart?.params?.input).toEqual([
       expect.objectContaining({
         type: "text",
-        text: expect.stringContaining("Files attached or referenced from PwrAgent"),
+        text: expect.any(String),
       }),
       {
         type: "text",

--- a/apps/desktop/src/main/__tests__/local-file-input.test.ts
+++ b/apps/desktop/src/main/__tests__/local-file-input.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  truncate,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -103,7 +110,15 @@ describe("enrichLocalFileInputs", () => {
 
     await expect(
       enrichLocalFileInputs([
-        { type: "localFile", name: "large.log", path: logPath },
+        {
+          type: "localFile",
+          name: "large.log",
+          path: logPath,
+          mimeType: "text/injected",
+          sizeBytes: 1,
+          textPreview: "caller-supplied preview",
+          textPreviewTruncated: true,
+        },
       ]),
     ).resolves.toEqual([
       {
@@ -123,7 +138,12 @@ describe("enrichLocalFileInputs", () => {
 
     await expect(
       enrichLocalFileInputs([
-        { type: "localFile", name: "not-really-text.txt", path: textPath },
+        {
+          type: "localFile",
+          name: "not-really-text.txt",
+          path: textPath,
+          textPreview: "caller-supplied preview",
+        },
       ]),
     ).resolves.toEqual([
       {
@@ -151,6 +171,7 @@ describe("enrichLocalFileInputs", () => {
         type: "localFile" as const,
         name: `notes-${index}.txt`,
         path: filePath,
+        ...(index === 4 ? { textPreview: "caller-supplied preview" } : {}),
       })),
     );
 
@@ -168,5 +189,114 @@ describe("enrichLocalFileInputs", () => {
       );
     }
     expect(results[4]).not.toHaveProperty("textPreview");
+  });
+
+  it("does not inspect Codex-owned session storage", async () => {
+    const root = await makeTempRoot();
+    const sessionPath = path.join(
+      root,
+      ".codex",
+      "sessions",
+      "2026",
+      "08",
+      "04",
+      "rollout-private.jsonl",
+    );
+    await mkdir(path.dirname(sessionPath), { recursive: true });
+    await writeFile(sessionPath, "private rollout data\n");
+
+    await expect(
+      enrichLocalFileInputs([
+        {
+          type: "localFile",
+          name: "rollout-private.jsonl",
+          path: sessionPath,
+          mimeType: "application/x-injected",
+          sizeBytes: 1,
+          textPreview: "caller-supplied preview",
+          textPreviewTruncated: true,
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "rollout-private.jsonl",
+        path: sessionPath,
+      },
+    ]);
+  });
+
+  it("does not inspect symlinks into Codex-owned session storage", async () => {
+    const root = await makeTempRoot();
+    const privateRoot = path.join(root, "custom-codex-home");
+    const sessionPath = path.join(privateRoot, "sessions", "rollout-private.jsonl");
+    const linkedPath = path.join(root, "notes.jsonl");
+    await mkdir(path.dirname(sessionPath), { recursive: true });
+    await writeFile(sessionPath, "private rollout data\n");
+    await symlink(sessionPath, linkedPath);
+
+    await expect(
+      enrichLocalFileInputs(
+        [{ type: "localFile", name: "notes.jsonl", path: linkedPath }],
+        { privateStorageRoots: [privateRoot] },
+      ),
+    ).resolves.toEqual([
+      { type: "localFile", name: "notes.jsonl", path: linkedPath },
+    ]);
+  });
+
+  it("still previews repository files inside Codex-managed worktrees", async () => {
+    const root = await makeTempRoot();
+    const notesPath = path.join(
+      root,
+      ".codex",
+      "worktrees",
+      "test-worktree",
+      "project",
+      "notes.txt",
+    );
+    const text = "Repository-owned notes\n";
+    await mkdir(path.dirname(notesPath), { recursive: true });
+    await writeFile(notesPath, text);
+
+    await expect(
+      enrichLocalFileInputs([
+        { type: "localFile", name: "notes.txt", path: notesPath },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "notes.txt",
+        path: notesPath,
+        mimeType: "text/plain",
+        sizeBytes: Buffer.byteLength(text),
+        textPreview: text,
+      },
+    ]);
+  });
+
+  it("discards caller-derived context when local inspection fails", async () => {
+    const root = await makeTempRoot();
+    const missingPath = path.join(root, "missing.txt");
+
+    await expect(
+      enrichLocalFileInputs([
+        {
+          type: "localFile",
+          name: "missing.txt",
+          path: missingPath,
+          mimeType: "text/injected",
+          sizeBytes: 999,
+          textPreview: "caller-supplied preview",
+          textPreviewTruncated: true,
+        },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "missing.txt",
+        path: missingPath,
+      },
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/local-file-input.test.ts
+++ b/apps/desktop/src/main/__tests__/local-file-input.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  enrichLocalFileInputs,
+  MAX_LOCAL_TEXT_FILE_BYTES,
+  MAX_LOCAL_TEXT_PREVIEW_BYTES,
+  MAX_TURN_LOCAL_TEXT_PREVIEW_BYTES,
+} from "../app-server/local-file-input";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map(async (root) => {
+      await rm(root, { force: true, recursive: true });
+    }),
+  );
+});
+
+async function makeTempRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-local-files-"));
+  tempRoots.push(root);
+  return root;
+}
+
+describe("enrichLocalFileInputs", () => {
+  it("adds stat and inferred MIME metadata without reading large binary files", async () => {
+    const root = await makeTempRoot();
+    const isoPath = path.join(root, "windows-11.iso");
+    const tiffPath = path.join(root, "large-scan.tiff");
+    await writeFile(isoPath, "CD001-not-a-pdf");
+    await writeFile(tiffPath, new Uint8Array([73, 73, 42, 0]));
+    await truncate(tiffPath, 400 * 1024 * 1024);
+
+    await expect(
+      enrichLocalFileInputs([
+        { type: "localFile", name: "windows-11.iso", path: isoPath },
+        { type: "localFile", name: "large-scan.tiff", path: tiffPath },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "windows-11.iso",
+        path: isoPath,
+        mimeType: "application/x-iso9660-image",
+        sizeBytes: 15,
+      },
+      {
+        type: "localFile",
+        name: "large-scan.tiff",
+        path: tiffPath,
+        mimeType: "image/tiff",
+        sizeBytes: 400 * 1024 * 1024,
+      },
+    ]);
+  });
+
+  it("includes a bounded preview for a validated small UTF-8 text file", async () => {
+    const root = await makeTempRoot();
+    const notesPath = path.join(root, "notes.md");
+    const text = "# Notes\n\nInspect the attached ISO only if needed.\n";
+    await writeFile(notesPath, text);
+
+    await expect(
+      enrichLocalFileInputs([
+        { type: "localFile", name: "notes.md", path: notesPath },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "notes.md",
+        path: notesPath,
+        mimeType: "text/markdown",
+        sizeBytes: Buffer.byteLength(text),
+        textPreview: text,
+      },
+    ]);
+  });
+
+  it("truncates previews independently from the small-file eligibility limit", async () => {
+    const root = await makeTempRoot();
+    const notesPath = path.join(root, "notes.txt");
+    await writeFile(notesPath, "a".repeat(MAX_LOCAL_TEXT_PREVIEW_BYTES + 100));
+
+    const [result] = await enrichLocalFileInputs([
+      { type: "localFile", name: "notes.txt", path: notesPath },
+    ]);
+
+    expect(result).toMatchObject({
+      mimeType: "text/plain",
+      sizeBytes: MAX_LOCAL_TEXT_PREVIEW_BYTES + 100,
+      textPreview: "a".repeat(MAX_LOCAL_TEXT_PREVIEW_BYTES),
+      textPreviewTruncated: true,
+    });
+  });
+
+  it("does not preview known text files above 10 KiB", async () => {
+    const root = await makeTempRoot();
+    const logPath = path.join(root, "large.log");
+    await writeFile(logPath, "a".repeat(MAX_LOCAL_TEXT_FILE_BYTES + 1));
+
+    await expect(
+      enrichLocalFileInputs([
+        { type: "localFile", name: "large.log", path: logPath },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "large.log",
+        path: logPath,
+        mimeType: "text/plain",
+        sizeBytes: MAX_LOCAL_TEXT_FILE_BYTES + 1,
+      },
+    ]);
+  });
+
+  it("does not preview invalid UTF-8 even when the extension is textual", async () => {
+    const root = await makeTempRoot();
+    const textPath = path.join(root, "not-really-text.txt");
+    await writeFile(textPath, new Uint8Array([0xff, 0xfe, 0x00, 0x01]));
+
+    await expect(
+      enrichLocalFileInputs([
+        { type: "localFile", name: "not-really-text.txt", path: textPath },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "localFile",
+        name: "not-really-text.txt",
+        path: textPath,
+        mimeType: "text/plain",
+        sizeBytes: 4,
+      },
+    ]);
+  });
+
+  it("caps the combined text preview budget for one turn", async () => {
+    const root = await makeTempRoot();
+    const paths = await Promise.all(
+      Array.from({ length: 5 }, async (_, index) => {
+        const filePath = path.join(root, `notes-${index}.txt`);
+        await writeFile(filePath, String(index).repeat(MAX_LOCAL_TEXT_PREVIEW_BYTES));
+        return filePath;
+      }),
+    );
+
+    const results = await enrichLocalFileInputs(
+      paths.map((filePath, index) => ({
+        type: "localFile" as const,
+        name: `notes-${index}.txt`,
+        path: filePath,
+      })),
+    );
+
+    expect(MAX_TURN_LOCAL_TEXT_PREVIEW_BYTES).toBe(
+      4 * MAX_LOCAL_TEXT_PREVIEW_BYTES,
+    );
+    for (const result of results.slice(0, 4)) {
+      expect(result).toEqual(
+        expect.objectContaining({
+          textPreview: expect.stringMatching(/^\d+$/u),
+        }),
+      );
+      expect((result as { textPreview: string }).textPreview).toHaveLength(
+        MAX_LOCAL_TEXT_PREVIEW_BYTES,
+      );
+    }
+    expect(results[4]).not.toHaveProperty("textPreview");
+  });
+});

--- a/apps/desktop/src/main/__tests__/pdf-turn-input-preparation.test.ts
+++ b/apps/desktop/src/main/__tests__/pdf-turn-input-preparation.test.ts
@@ -203,4 +203,28 @@ describe("preparePdfTurnInput", () => {
       pdfAttachments: [],
     });
   });
+
+  it("does not apply the PDF size limit to a large non-PDF local file", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-file-turn-"));
+    tempRoots.push(root);
+    const isoPath = path.join(root, "windows-11.iso");
+    await writeFile(isoPath, "CD001-not-a-pdf");
+
+    await expect(
+      preparePdfTurnInput({
+        handling: "model_directed",
+        input: [
+          { type: "text", text: "Inspect this disk image if needed." },
+          { type: "localFile", name: "windows-11.iso", path: isoPath },
+        ],
+        maxAttachmentBytes: 5,
+      }),
+    ).resolves.toEqual({
+      input: [
+        { type: "text", text: "Inspect this disk image if needed." },
+        { type: "localFile", name: "windows-11.iso", path: isoPath },
+      ],
+      pdfAttachments: [],
+    });
+  });
 });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -786,8 +786,7 @@ export function inputToAcpPrompt(
     }
 
     if (item.type === "localFile") {
-      const fileName = item.name?.trim() || path.basename(item.path);
-      const text = `[Local file: ${fileName} (${item.path})]`;
+      const text = formatAcpLocalFileReference(item);
       promptContent.push({ type: "text", text });
       parts.push({ type: "text", text });
       continue;
@@ -813,6 +812,46 @@ export function inputToAcpPrompt(
     promptContent,
     parts,
   };
+}
+
+function formatAcpLocalFileReference(
+  item: Extract<AppServerTurnInputItem, { type: "localFile" }>,
+): string {
+  const fileName = item.name?.trim() || path.basename(item.path);
+  const metadata = [
+    item.mimeType ? `Type: ${item.mimeType}` : undefined,
+    typeof item.sizeBytes === "number"
+      ? `Size: ${formatAcpByteSize(item.sizeBytes)}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const reference = metadata.length > 0
+    ? `[Local file reference: ${fileName} (${item.path}) | ${metadata.join(" | ")}]`
+    : `[Local file reference: ${fileName} (${item.path})]`;
+  if (!item.textPreview) {
+    return reference;
+  }
+  return [
+    reference,
+    item.textPreviewTruncated
+      ? "Validated text preview (truncated):"
+      : "Validated text preview:",
+    "<pwragent-local-file-preview>",
+    item.textPreview,
+    "</pwragent-local-file-preview>",
+  ].join("\n");
+}
+
+function formatAcpByteSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
 }
 
 function parseImageDataUrl(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -404,6 +404,7 @@ import {
   type ThreadTurnQueueSubmissionResult,
 } from "./thread-turn-queue";
 import { materializeLocalImageInputs } from "./image-input-files";
+import { enrichLocalFileInputs } from "./local-file-input";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import {
   PdfAttachmentStore,
@@ -10269,7 +10270,7 @@ export class DesktopBackendRegistry {
         });
         // ACP adapters already accept data-URL image parts. Keeping those
         // intact avoids changing their established image payload contract.
-        const input = preparedPdfInput.input;
+        const input = await enrichLocalFileInputs(preparedPdfInput.input);
         if (this.usesSlashControlledAcpExecutionModes(params.backend)) {
           await this.flushQueuedExecutionModeIfPresent(
             params.threadId,
@@ -10378,7 +10379,9 @@ export class DesktopBackendRegistry {
         input: params.input,
       });
       pdfAttachments = preparedPdfInput.pdfAttachments;
-      input = await materializeLocalImageInputs(preparedPdfInput.input);
+      input = await materializeLocalImageInputs(
+        await enrichLocalFileInputs(preparedPdfInput.input),
+      );
       turnParams = await this.resolveModelSettings(params.backend, {
         ...params,
         model: migrationApplied
@@ -11663,6 +11666,7 @@ export class DesktopBackendRegistry {
     params: SteerTurnRequest,
     messageOrigin?: AppServerThreadMessageOrigin,
   ): Promise<SteerTurnResponse> {
+    const input = await enrichLocalFileInputs(params.input);
     const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
       backend: params.backend,
       threadId: params.threadId,
@@ -11678,7 +11682,7 @@ export class DesktopBackendRegistry {
       }
       return await client.steerTurn({
         threadId: params.threadId,
-        input: params.input,
+        input,
         expectedTurnId: params.expectedTurnId,
       });
     };

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -485,23 +485,6 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
-function localFilesAsTextInput(
-  input: AppServerTurnInputItem[],
-): AppServerTurnInputItem[] {
-  return input.flatMap((item) => {
-    if (item.type !== "localFile") {
-      return [item];
-    }
-    const name = item.name?.trim() || path.basename(item.path);
-    return [
-      {
-        type: "text" as const,
-        text: `[Local file reference: ${name} (${item.path})]`,
-      },
-    ];
-  });
-}
-
 function assistantOutputForTurn(
   replay: AppServerThreadReplay,
   turnId: string,
@@ -6188,6 +6171,7 @@ export class DesktopBackendRegistry {
   >;
   private readonly resolveCodexFastAllowedFn: () => boolean;
   private readonly resolvePdfAnalysisEnabledFn: () => boolean;
+  private readonly localFilePrivateStorageRoots: readonly string[];
   private readonly pdfAttachmentStore = new PdfAttachmentStore();
   private readonly pdfToolMcpServer?: AgentToolMcpServerLike;
   /**
@@ -6371,6 +6355,7 @@ export class DesktopBackendRegistry {
       options?.codexEnvironmentHydrationStore ??
       createDefaultCodexEnvironmentHydrationStore();
     const codexHome = codexEnv?.CODEX_HOME?.trim() || undefined;
+    this.localFilePrivateStorageRoots = codexHome ? [codexHome] : [];
     const createsLiveGrokClient = !options?.grokClient && !replayClients?.grokClient;
     const isLiveGrokAvailable = (): boolean => resolveAgentCoreGrokEnabled();
     const resolveLiveGrokApiKey = (): string | undefined => {
@@ -10270,7 +10255,9 @@ export class DesktopBackendRegistry {
         });
         // ACP adapters already accept data-URL image parts. Keeping those
         // intact avoids changing their established image payload contract.
-        const input = await enrichLocalFileInputs(preparedPdfInput.input);
+        const input = await enrichLocalFileInputs(preparedPdfInput.input, {
+          privateStorageRoots: this.localFilePrivateStorageRoots,
+        });
         if (this.usesSlashControlledAcpExecutionModes(params.backend)) {
           await this.flushQueuedExecutionModeIfPresent(
             params.threadId,
@@ -10380,7 +10367,9 @@ export class DesktopBackendRegistry {
       });
       pdfAttachments = preparedPdfInput.pdfAttachments;
       input = await materializeLocalImageInputs(
-        await enrichLocalFileInputs(preparedPdfInput.input),
+        await enrichLocalFileInputs(preparedPdfInput.input, {
+          privateStorageRoots: this.localFilePrivateStorageRoots,
+        }),
       );
       turnParams = await this.resolveModelSettings(params.backend, {
         ...params,
@@ -10503,7 +10492,7 @@ export class DesktopBackendRegistry {
             }, params.executionMode)
           : await this.grokClient.startTurn({
               threadId: params.threadId,
-              input: localFilesAsTextInput(input),
+              input,
               model: turnParams.model,
               serviceTier: turnParams.serviceTier,
               reasoningEffort: turnParams.reasoningEffort,
@@ -11666,7 +11655,9 @@ export class DesktopBackendRegistry {
     params: SteerTurnRequest,
     messageOrigin?: AppServerThreadMessageOrigin,
   ): Promise<SteerTurnResponse> {
-    const input = await enrichLocalFileInputs(params.input);
+    const input = await enrichLocalFileInputs(params.input, {
+      privateStorageRoots: this.localFilePrivateStorageRoots,
+    });
     const pendingMessageOriginId = this.registerPendingThreadMessageOrigin({
       backend: params.backend,
       threadId: params.threadId,

--- a/apps/desktop/src/main/app-server/local-file-input.ts
+++ b/apps/desktop/src/main/app-server/local-file-input.ts
@@ -1,4 +1,5 @@
-import { open } from "node:fs/promises";
+import { open, realpath } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import type {
   AppServerLocalFileInputItem,
@@ -101,6 +102,18 @@ const KNOWN_TEXT_BASENAMES = new Set([
   "readme",
 ]);
 
+const PRIVATE_STORAGE_DIRECTORIES = new Set([
+  "archived_sessions",
+  "rollouts",
+  "sessions",
+]);
+
+const PRIVATE_STORAGE_ROOT_FILES = [
+  /^history\.jsonl$/u,
+  /^state(?:_[^.]+)?\.sqlite(?:-(?:shm|wal))?$/u,
+  /^state\.db(?:-(?:shm|wal))?$/u,
+];
+
 /**
  * Add bounded metadata to explicit local-file references without turning them
  * into uploads. Only known text types whose entire file is at most 10 KiB are
@@ -108,6 +121,7 @@ const KNOWN_TEXT_BASENAMES = new Set([
  */
 export async function enrichLocalFileInputs(
   input: AppServerTurnInputItem[],
+  options?: { privateStorageRoots?: readonly string[] },
 ): Promise<AppServerTurnInputItem[]> {
   let remainingPreviewBytes = MAX_TURN_LOCAL_TEXT_PREVIEW_BYTES;
   const enriched: AppServerTurnInputItem[] = [];
@@ -117,7 +131,11 @@ export async function enrichLocalFileInputs(
       enriched.push(item);
       continue;
     }
-    const result = await inspectLocalFile(item, remainingPreviewBytes);
+    const result = await inspectLocalFile(
+      item,
+      remainingPreviewBytes,
+      options?.privateStorageRoots ?? [],
+    );
     enriched.push(result.item);
     remainingPreviewBytes -= result.previewBytes;
   }
@@ -128,14 +146,23 @@ export async function enrichLocalFileInputs(
 async function inspectLocalFile(
   item: AppServerLocalFileInputItem,
   remainingPreviewBytes: number,
+  privateStorageRoots: readonly string[],
 ): Promise<{ item: AppServerLocalFileInputItem; previewBytes: number }> {
-  const knownType = knownLocalFileType(item.path);
+  const cleanItem = discardDerivedContext(item);
+  const inspectedPath = await resolveInspectableLocalFilePath(
+    cleanItem.path,
+    privateStorageRoots,
+  );
+  if (!inspectedPath) {
+    return { item: cleanItem, previewBytes: 0 };
+  }
+  const knownType = knownLocalFileType(cleanItem.path);
   try {
-    const handle = await open(item.path, "r");
+    const handle = await open(inspectedPath, "r");
     try {
       const stats = await handle.stat();
       if (!stats.isFile()) {
-        return { item, previewBytes: 0 };
+        return { item: cleanItem, previewBytes: 0 };
       }
       const metadata = {
         ...(knownType ? { mimeType: knownType.mimeType } : {}),
@@ -147,7 +174,7 @@ async function inspectLocalFile(
         || stats.size > MAX_LOCAL_TEXT_FILE_BYTES
         || remainingPreviewBytes <= 0
       ) {
-        return { item: { ...item, ...metadata }, previewBytes: 0 };
+        return { item: { ...cleanItem, ...metadata }, previewBytes: 0 };
       }
 
       const data = Buffer.allocUnsafe(stats.size);
@@ -160,13 +187,13 @@ async function inspectLocalFile(
           bytesRead,
         );
         if (result.bytesRead === 0) {
-          return { item: { ...item, ...metadata }, previewBytes: 0 };
+          return { item: { ...cleanItem, ...metadata }, previewBytes: 0 };
         }
         bytesRead += result.bytesRead;
       }
       const text = decodeValidatedUtf8Text(data);
       if (!text) {
-        return { item: { ...item, ...metadata }, previewBytes: 0 };
+        return { item: { ...cleanItem, ...metadata }, previewBytes: 0 };
       }
       const previewBudget = Math.min(
         MAX_LOCAL_TEXT_PREVIEW_BYTES,
@@ -176,7 +203,7 @@ async function inspectLocalFile(
       const previewBytes = Buffer.byteLength(textPreview, "utf8");
       return {
         item: {
-          ...item,
+          ...cleanItem,
           ...metadata,
           textPreview,
           ...(previewBytes < Buffer.byteLength(text, "utf8")
@@ -189,8 +216,107 @@ async function inspectLocalFile(
       await handle.close();
     }
   } catch {
-    return { item, previewBytes: 0 };
+    return { item: cleanItem, previewBytes: 0 };
   }
+}
+
+function discardDerivedContext(
+  item: AppServerLocalFileInputItem,
+): AppServerLocalFileInputItem {
+  const cleanItem = { ...item };
+  delete cleanItem.mimeType;
+  delete cleanItem.sizeBytes;
+  delete cleanItem.textPreview;
+  delete cleanItem.textPreviewTruncated;
+  return cleanItem;
+}
+
+async function resolveInspectableLocalFilePath(
+  filePath: string,
+  privateStorageRoots: readonly string[],
+): Promise<string | undefined> {
+  const configuredRoots = configuredPrivateStorageRoots(privateStorageRoots);
+  if (isPrivateStoragePath(filePath, configuredRoots)) {
+    return undefined;
+  }
+  try {
+    const resolvedPath = await realpath(filePath);
+    const canonicalRoots = await Promise.all(
+      configuredRoots.map(async (root) => {
+        try {
+          return await realpath(root);
+        } catch {
+          return path.resolve(root);
+        }
+      }),
+    );
+    return isPrivateStoragePath(resolvedPath, canonicalRoots)
+      ? undefined
+      : resolvedPath;
+  } catch {
+    return undefined;
+  }
+}
+
+function configuredPrivateStorageRoots(
+  privateStorageRoots: readonly string[],
+): string[] {
+  return [
+    path.join(os.homedir(), ".codex"),
+    process.env.CODEX_HOME?.trim(),
+    ...privateStorageRoots,
+  ].filter((root): root is string => Boolean(root));
+}
+
+function isPrivateStoragePath(
+  filePath: string,
+  privateStorageRoots: readonly string[],
+): boolean {
+  const resolvedPath = path.resolve(filePath);
+  for (const root of privateStorageRoots) {
+    const relativePath = path.relative(path.resolve(root), resolvedPath);
+    if (
+      isPathInsideRoot(relativePath)
+      && isPrivateStorageRelativePath(relativePath)
+    ) {
+      return true;
+    }
+  }
+
+  const components = resolvedPath.split(path.sep);
+  for (let index = 0; index < components.length; index += 1) {
+    if (components[index]?.toLowerCase() !== ".codex") {
+      continue;
+    }
+    const relativePath = components.slice(index + 1).join(path.sep);
+    if (isPrivateStorageRelativePath(relativePath)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isPathInsideRoot(relativePath: string): boolean {
+  return relativePath !== ""
+    && relativePath !== ".."
+    && !relativePath.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relativePath);
+}
+
+function isPrivateStorageRelativePath(relativePath: string): boolean {
+  let components = relativePath.split(path.sep).filter(Boolean);
+  if (components[0]?.toLowerCase() === "profiles" && components.length >= 3) {
+    components = components.slice(2);
+  }
+  const first = components[0]?.toLowerCase();
+  if (!first || first === "worktrees") {
+    return false;
+  }
+  if (PRIVATE_STORAGE_DIRECTORIES.has(first)) {
+    return true;
+  }
+  return components.length === 1
+    && PRIVATE_STORAGE_ROOT_FILES.some((pattern) => pattern.test(first));
 }
 
 function knownLocalFileType(filePath: string): KnownLocalFileType | undefined {

--- a/apps/desktop/src/main/app-server/local-file-input.ts
+++ b/apps/desktop/src/main/app-server/local-file-input.ts
@@ -1,0 +1,249 @@
+import { open } from "node:fs/promises";
+import path from "node:path";
+import type {
+  AppServerLocalFileInputItem,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+
+export const MAX_LOCAL_TEXT_FILE_BYTES = 10 * 1024;
+export const MAX_LOCAL_TEXT_PREVIEW_BYTES = 4 * 1024;
+export const MAX_TURN_LOCAL_TEXT_PREVIEW_BYTES = 16 * 1024;
+
+type KnownLocalFileType = {
+  mimeType: string;
+  text?: true;
+};
+
+const KNOWN_LOCAL_FILE_TYPES = new Map<string, KnownLocalFileType>([
+  [".7z", { mimeType: "application/x-7z-compressed" }],
+  [".bash", { mimeType: "text/x-shellscript", text: true }],
+  [".c", { mimeType: "text/x-c", text: true }],
+  [".cfg", { mimeType: "text/plain", text: true }],
+  [".cjs", { mimeType: "text/javascript", text: true }],
+  [".conf", { mimeType: "text/plain", text: true }],
+  [".cpp", { mimeType: "text/x-c++", text: true }],
+  [".css", { mimeType: "text/css", text: true }],
+  [".csv", { mimeType: "text/csv", text: true }],
+  [".dmg", { mimeType: "application/x-apple-diskimage" }],
+  [".doc", { mimeType: "application/msword" }],
+  [
+    ".docx",
+    {
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    },
+  ],
+  [".gif", { mimeType: "image/gif" }],
+  [".go", { mimeType: "text/x-go", text: true }],
+  [".gz", { mimeType: "application/gzip" }],
+  [".h", { mimeType: "text/x-c", text: true }],
+  [".heic", { mimeType: "image/heic" }],
+  [".heif", { mimeType: "image/heif" }],
+  [".hpp", { mimeType: "text/x-c++", text: true }],
+  [".htm", { mimeType: "text/html", text: true }],
+  [".html", { mimeType: "text/html", text: true }],
+  [".ini", { mimeType: "text/plain", text: true }],
+  [".iso", { mimeType: "application/x-iso9660-image" }],
+  [".java", { mimeType: "text/x-java-source", text: true }],
+  [".jpeg", { mimeType: "image/jpeg" }],
+  [".jpg", { mimeType: "image/jpeg" }],
+  [".js", { mimeType: "text/javascript", text: true }],
+  [".json", { mimeType: "application/json", text: true }],
+  [".jsonl", { mimeType: "application/x-ndjson", text: true }],
+  [".jsx", { mimeType: "text/jsx", text: true }],
+  [".log", { mimeType: "text/plain", text: true }],
+  [".md", { mimeType: "text/markdown", text: true }],
+  [".mjs", { mimeType: "text/javascript", text: true }],
+  [".mov", { mimeType: "video/quicktime" }],
+  [".mp3", { mimeType: "audio/mpeg" }],
+  [".mp4", { mimeType: "video/mp4" }],
+  [".pdf", { mimeType: "application/pdf" }],
+  [".png", { mimeType: "image/png" }],
+  [".ps1", { mimeType: "text/plain", text: true }],
+  [".py", { mimeType: "text/x-python", text: true }],
+  [".rb", { mimeType: "text/x-ruby", text: true }],
+  [".rs", { mimeType: "text/x-rust", text: true }],
+  [".sh", { mimeType: "text/x-shellscript", text: true }],
+  [".sql", { mimeType: "application/sql", text: true }],
+  [".svg", { mimeType: "image/svg+xml", text: true }],
+  [".tar", { mimeType: "application/x-tar" }],
+  [".tif", { mimeType: "image/tiff" }],
+  [".tiff", { mimeType: "image/tiff" }],
+  [".toml", { mimeType: "application/toml", text: true }],
+  [".ts", { mimeType: "text/typescript", text: true }],
+  [".tsv", { mimeType: "text/tab-separated-values", text: true }],
+  [".tsx", { mimeType: "text/tsx", text: true }],
+  [".txt", { mimeType: "text/plain", text: true }],
+  [".wav", { mimeType: "audio/wav" }],
+  [".webp", { mimeType: "image/webp" }],
+  [
+    ".xlsx",
+    {
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    },
+  ],
+  [".xml", { mimeType: "application/xml", text: true }],
+  [".yaml", { mimeType: "application/yaml", text: true }],
+  [".yml", { mimeType: "application/yaml", text: true }],
+  [".zip", { mimeType: "application/zip" }],
+  [".zsh", { mimeType: "text/x-shellscript", text: true }],
+]);
+
+const KNOWN_TEXT_BASENAMES = new Set([
+  ".editorconfig",
+  ".gitattributes",
+  ".gitignore",
+  ".npmrc",
+  "dockerfile",
+  "license",
+  "makefile",
+  "readme",
+]);
+
+/**
+ * Add bounded metadata to explicit local-file references without turning them
+ * into uploads. Only known text types whose entire file is at most 10 KiB are
+ * read, UTF-8 validated, and given a small preview under a per-turn budget.
+ */
+export async function enrichLocalFileInputs(
+  input: AppServerTurnInputItem[],
+): Promise<AppServerTurnInputItem[]> {
+  let remainingPreviewBytes = MAX_TURN_LOCAL_TEXT_PREVIEW_BYTES;
+  const enriched: AppServerTurnInputItem[] = [];
+
+  for (const item of input) {
+    if (item.type !== "localFile") {
+      enriched.push(item);
+      continue;
+    }
+    const result = await inspectLocalFile(item, remainingPreviewBytes);
+    enriched.push(result.item);
+    remainingPreviewBytes -= result.previewBytes;
+  }
+
+  return enriched;
+}
+
+async function inspectLocalFile(
+  item: AppServerLocalFileInputItem,
+  remainingPreviewBytes: number,
+): Promise<{ item: AppServerLocalFileInputItem; previewBytes: number }> {
+  const knownType = knownLocalFileType(item.path);
+  try {
+    const handle = await open(item.path, "r");
+    try {
+      const stats = await handle.stat();
+      if (!stats.isFile()) {
+        return { item, previewBytes: 0 };
+      }
+      const metadata = {
+        ...(knownType ? { mimeType: knownType.mimeType } : {}),
+        sizeBytes: stats.size,
+      };
+      if (
+        !knownType?.text
+        || stats.size === 0
+        || stats.size > MAX_LOCAL_TEXT_FILE_BYTES
+        || remainingPreviewBytes <= 0
+      ) {
+        return { item: { ...item, ...metadata }, previewBytes: 0 };
+      }
+
+      const data = Buffer.allocUnsafe(stats.size);
+      let bytesRead = 0;
+      while (bytesRead < data.byteLength) {
+        const result = await handle.read(
+          data,
+          bytesRead,
+          data.byteLength - bytesRead,
+          bytesRead,
+        );
+        if (result.bytesRead === 0) {
+          return { item: { ...item, ...metadata }, previewBytes: 0 };
+        }
+        bytesRead += result.bytesRead;
+      }
+      const text = decodeValidatedUtf8Text(data);
+      if (!text) {
+        return { item: { ...item, ...metadata }, previewBytes: 0 };
+      }
+      const previewBudget = Math.min(
+        MAX_LOCAL_TEXT_PREVIEW_BYTES,
+        remainingPreviewBytes,
+      );
+      const textPreview = utf8Prefix(text, previewBudget);
+      const previewBytes = Buffer.byteLength(textPreview, "utf8");
+      return {
+        item: {
+          ...item,
+          ...metadata,
+          textPreview,
+          ...(previewBytes < Buffer.byteLength(text, "utf8")
+            ? { textPreviewTruncated: true }
+            : {}),
+        },
+        previewBytes,
+      };
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return { item, previewBytes: 0 };
+  }
+}
+
+function knownLocalFileType(filePath: string): KnownLocalFileType | undefined {
+  const extension = path.extname(filePath).toLowerCase();
+  const knownExtension = KNOWN_LOCAL_FILE_TYPES.get(extension);
+  if (knownExtension) {
+    return knownExtension;
+  }
+  return KNOWN_TEXT_BASENAMES.has(path.basename(filePath).toLowerCase())
+    ? { mimeType: "text/plain", text: true }
+    : undefined;
+}
+
+function decodeValidatedUtf8Text(data: Uint8Array): string | undefined {
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(data);
+  } catch {
+    return undefined;
+  }
+  text = text.replace(/^\uFEFF/u, "");
+  if (!text || hasDisallowedTextControl(text)) {
+    return undefined;
+  }
+  return text;
+}
+
+function hasDisallowedTextControl(text: string): boolean {
+  for (const character of text) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (
+      codePoint <= 0x08
+      || codePoint === 0x0b
+      || codePoint === 0x0c
+      || (codePoint >= 0x0e && codePoint <= 0x1f)
+      || codePoint === 0x7f
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function utf8Prefix(text: string, maxBytes: number): string {
+  let bytes = 0;
+  let prefix = "";
+  for (const character of text) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > maxBytes) {
+      break;
+    }
+    prefix += character;
+    bytes += characterBytes;
+  }
+  return prefix;
+}

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2980,6 +2980,9 @@ function buildFileChangeDiff(params: {
 }
 
 function formatByteSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  }
   if (bytes >= 1024 * 1024) {
     return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
   }
@@ -6376,7 +6379,9 @@ async function prepareCodexUserInput(params: {
   for (const input of params.input) {
     if (input.type === "localFile") {
       const name = input.name?.trim() || path.basename(input.path);
-      fileReferences.push(formatCodexFileReference({ name }, input.path));
+      fileReferences.push(
+        formatCodexFileReference({ ...input, name }, input.path),
+      );
       prepared.push({
         type: "mention",
         name,
@@ -6409,7 +6414,7 @@ async function prepareCodexUserInput(params: {
       text: [
         "Files attached or referenced from PwrAgent are available locally for this turn:",
         ...fileReferences,
-        "Use local tools to inspect these files as needed.",
+        "PwrAgent provided local path references rather than raw file payloads. Small validated text previews may appear above; use local tools to inspect files as needed.",
       ].join("\n"),
       text_elements: [],
     },
@@ -6419,17 +6424,38 @@ async function prepareCodexUserInput(params: {
 
 function formatCodexFileReference(
   file: Pick<AppServerFileInputItem, "name" | "mimeType" | "sizeBytes">
-    | Pick<AppServerLocalFileInputItem, "name">,
+    | Pick<
+        AppServerLocalFileInputItem,
+        | "mimeType"
+        | "name"
+        | "sizeBytes"
+        | "textPreview"
+        | "textPreviewTruncated"
+      >,
   filePath: string,
 ): string {
-  const type = "mimeType" in file ? file.mimeType : undefined;
-  const size =
-    "sizeBytes" in file && typeof file.sizeBytes === "number"
-      ? ` | Size: ${formatByteSize(file.sizeBytes)}`
-      : "";
-  return type
-    ? `- ${file.name}: ${filePath} (Type: ${type}${size})`
+  const metadata = [
+    file.mimeType ? `Type: ${file.mimeType}` : undefined,
+    typeof file.sizeBytes === "number"
+      ? `Size: ${formatByteSize(file.sizeBytes)}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const reference = metadata.length > 0
+    ? `- ${file.name}: ${filePath} (${metadata.join(" | ")})`
     : `- ${file.name}: ${filePath}`;
+  if (!("textPreview" in file) || !file.textPreview) {
+    return reference;
+  }
+  const previewLabel = file.textPreviewTruncated
+    ? "Validated text preview (truncated):"
+    : "Validated text preview:";
+  return [
+    reference,
+    previewLabel,
+    "<pwragent-local-file-preview>",
+    file.textPreview,
+    "</pwragent-local-file-preview>",
+  ].join("\n");
 }
 
 function buildTurnStartPayload(params: {

--- a/apps/desktop/src/main/pdf/pdf-turn-input-preparation.ts
+++ b/apps/desktop/src/main/pdf/pdf-turn-input-preparation.ts
@@ -285,13 +285,13 @@ async function readLocalPdfCandidate(
       if (!stats.isFile()) {
         return { kind: "not_pdf" };
       }
-      if (stats.size > maxAttachmentBytes) {
-        return { kind: "too_large", name };
-      }
       const header = Buffer.alloc(PDF_MAGIC.byteLength);
       await handle.read(header, 0, header.byteLength, 0);
       if (!isPdfData(header)) {
         return { kind: "not_pdf" };
+      }
+      if (stats.size > maxAttachmentBytes) {
+        return { kind: "too_large", name };
       }
       const data = Buffer.allocUnsafe(stats.size);
       let bytesRead = 0;

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10501,7 +10501,9 @@ function getImageFilesFromDataTransfer(dataTransfer: DataTransfer): ComposerImag
       continue;
     }
 
-    const type = isImageMimeType(item.type) ? item.type : inferTransferImageType(file);
+    const type = isSupportedComposerImageMimeType(item.type)
+      ? item.type
+      : inferTransferImageType(file);
     if (!type) {
       continue;
     }
@@ -10555,7 +10557,10 @@ function getNonImageFilesFromDataTransfer(dataTransfer: DataTransfer): File[] {
     }
 
     foundFileItem = true;
-    if (isImageMimeType(item.type) || inferTransferImageType(file)) {
+    if (
+      isSupportedComposerImageMimeType(item.type)
+      || inferTransferImageType(file)
+    ) {
       continue;
     }
 
@@ -10600,7 +10605,7 @@ function buildFileKey(file: File): string {
 }
 
 function inferTransferImageType(file: File): string | undefined {
-  if (isImageMimeType(file.type)) {
+  if (isSupportedComposerImageMimeType(file.type)) {
     return file.type;
   }
 
@@ -10608,8 +10613,23 @@ function inferTransferImageType(file: File): string | undefined {
   return extension === "gif" ? "image/gif" : undefined;
 }
 
-function isImageMimeType(type: string): boolean {
-  return type.toLowerCase().startsWith("image/");
+// Keep this list aligned with formats the composer deliberately normalizes or
+// preserves. An arbitrary `image/*` MIME (for example, a huge TIFF) is a local
+// file reference, not authorization to read and upload its contents.
+function isSupportedComposerImageMimeType(type: string): boolean {
+  switch (type.trim().toLowerCase()) {
+    case "image/gif":
+    case "image/heic":
+    case "image/heif":
+    case "image/jpeg":
+    case "image/jpg":
+    case "image/png":
+    case "image/svg+xml":
+    case "image/webp":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function isGifFile(file: File, type: string): boolean {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -14831,6 +14831,80 @@ describe("Composer", () => {
     }
   });
 
+  it("keeps a 400 MB unsupported TIFF drop as a path-only file reference", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/huntharo";
+    try {
+      const startTurn = vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        turnId: "turn-1",
+      }));
+      const tiffFile = new File(
+        [new Uint8Array([73, 73, 42, 0])],
+        "large-scan.tiff",
+        { type: "image/tiff" },
+      );
+      Object.defineProperty(tiffFile, "size", { value: 400 * 1024 * 1024 });
+
+      render(
+        <Composer
+          desktopApi={{
+            onAgentEvent: () => () => undefined,
+            getPathForFile: () => "/Users/huntharo/Scans/large-scan.tiff",
+            startTurn,
+          }}
+          disabled={false}
+          skills={[]}
+          thread={{
+            id: "thread-1",
+            title: "Inspect scan",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [],
+            inbox: { inInbox: false },
+          }}
+        />
+      );
+
+      const textarea = screen.getByLabelText("Reply");
+      fireEvent.drop(textarea, {
+        dataTransfer: {
+          files: [],
+          items: [
+            { kind: "file", type: "image/tiff", getAsFile: () => tiffFile },
+          ],
+        },
+      });
+
+      expect(await screen.findByText("large-scan.tiff")).toBeInTheDocument();
+      expect(normalizeImageFile).not.toHaveBeenCalled();
+
+      await clickButton("Send");
+
+      await waitFor(() => {
+        expect(startTurn).toHaveBeenCalledWith({
+          backend: "codex",
+          threadId: "thread-1",
+          input: [
+            {
+              type: "text",
+              text: "[@large-scan.tiff](~/Scans/large-scan.tiff)",
+            },
+            {
+              type: "localFile",
+              name: "large-scan.tiff",
+              path: "/Users/huntharo/Scans/large-scan.tiff",
+            },
+          ],
+        });
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
   it("shows the PDF analysis indicator for an extensionless explicit file reference", async () => {
     (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
       "/Users/huntharo";

--- a/packages/agent-core/src/__tests__/ai-sdk-message-builder.test.ts
+++ b/packages/agent-core/src/__tests__/ai-sdk-message-builder.test.ts
@@ -139,6 +139,9 @@ describe("buildAiSdkMessages", () => {
             type: "localFile",
             name: "Jeep",
             path: "/tmp/Jeep",
+            mimeType: "text/plain",
+            sizeBytes: 12,
+            textPreview: "hello world\n",
             pdfRenderProfile: "high",
           },
         ],
@@ -148,7 +151,17 @@ describe("buildAiSdkMessages", () => {
         role: "user",
         content: [
           { type: "text", text: "Compare this document." },
-          { type: "text", text: "[Local file reference: Jeep (/tmp/Jeep)]" },
+          {
+            type: "text",
+            text: [
+              "[Local file reference: Jeep (/tmp/Jeep) | Type: text/plain | Size: 12 B]",
+              "Validated text preview:",
+              "<pwragent-local-file-preview>",
+              "hello world",
+              "",
+              "</pwragent-local-file-preview>",
+            ].join("\n"),
+          },
         ],
       },
     ]);

--- a/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
+++ b/packages/agent-core/src/__tests__/codex-turn-lifecycle.test.ts
@@ -21,6 +21,9 @@ describe("Codex turn lifecycle", () => {
           type: "localFile",
           name: "Jeep",
           path: "/tmp/Jeep",
+          mimeType: "text/plain",
+          sizeBytes: 12,
+          textPreview: "hello world\n",
           pdfRenderProfile: "high",
         },
         {
@@ -47,6 +50,9 @@ describe("Codex turn lifecycle", () => {
         type: "localFile",
         name: "Jeep",
         path: "/tmp/Jeep",
+        mimeType: "text/plain",
+        sizeBytes: 12,
+        textPreview: "hello world\n",
         pdfRenderProfile: "high",
       },
       {

--- a/packages/agent-core/src/app-server/codex-app-server.ts
+++ b/packages/agent-core/src/app-server/codex-app-server.ts
@@ -542,12 +542,29 @@ function normalizeTurnInput(value: unknown): AppServerTurnInputItem[] {
     }
     if (type === "localFile") {
       const pdfRenderProfile = record.pdfRenderProfile;
+      const mimeType = typeof record.mimeType === "string"
+        ? record.mimeType.trim()
+        : "";
+      const sizeBytes = record.sizeBytes;
+      const textPreview = typeof record.textPreview === "string"
+        ? record.textPreview
+        : "";
       return {
         type: "localFile",
         ...(typeof record.name === "string" && record.name.trim()
           ? { name: record.name.trim() }
           : {}),
         path: asRequiredString(record.path, "localFile input requires path"),
+        ...(mimeType ? { mimeType } : {}),
+        ...(typeof sizeBytes === "number"
+          && Number.isFinite(sizeBytes)
+          && sizeBytes >= 0
+          ? { sizeBytes }
+          : {}),
+        ...(textPreview ? { textPreview } : {}),
+        ...(textPreview && record.textPreviewTruncated === true
+          ? { textPreviewTruncated: true }
+          : {}),
         ...(pdfRenderProfile === "low"
           || pdfRenderProfile === "medium"
           || pdfRenderProfile === "high"

--- a/packages/agent-core/src/providers/ai-sdk-message-builder.ts
+++ b/packages/agent-core/src/providers/ai-sdk-message-builder.ts
@@ -43,10 +43,9 @@ export async function buildAiSdkMessages(params: {
       continue;
     }
     if (item.type === "localFile") {
-      const name = item.name?.trim() || path.basename(item.path);
       content.push({
         type: "text",
-        text: `[Local file reference: ${name} (${item.path})]`,
+        text: formatLocalFileReference(item),
       });
       continue;
     }
@@ -65,6 +64,46 @@ export async function buildAiSdkMessages(params: {
     content,
   } satisfies UserModelMessage);
   return messages;
+}
+
+function formatLocalFileReference(
+  item: Extract<AppServerTurnInputItem, { type: "localFile" }>,
+): string {
+  const name = item.name?.trim() || path.basename(item.path);
+  const metadata = [
+    item.mimeType ? `Type: ${item.mimeType}` : undefined,
+    typeof item.sizeBytes === "number"
+      ? `Size: ${formatByteSize(item.sizeBytes)}`
+      : undefined,
+  ].filter((value): value is string => Boolean(value));
+  const reference = metadata.length > 0
+    ? `[Local file reference: ${name} (${item.path}) | ${metadata.join(" | ")}]`
+    : `[Local file reference: ${name} (${item.path})]`;
+  if (!item.textPreview) {
+    return reference;
+  }
+  return [
+    reference,
+    item.textPreviewTruncated
+      ? "Validated text preview (truncated):"
+      : "Validated text preview:",
+    "<pwragent-local-file-preview>",
+    item.textPreview,
+    "</pwragent-local-file-preview>",
+  ].join("\n");
+}
+
+function formatByteSize(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} B`;
 }
 
 function parseFileInput(

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -49,6 +49,14 @@ export type AppServerLocalFileInputItem = {
   /** User-visible filename / attachment label when available. */
   name?: string;
   path: string;
+  /** Best-effort MIME type inferred without reading the full file. */
+  mimeType?: string;
+  /** Size observed from the explicitly referenced local file. */
+  sizeBytes?: number;
+  /** Bounded preview included only for a validated, small UTF-8 text file. */
+  textPreview?: string;
+  /** True when textPreview contains only a prefix of the validated file. */
+  textPreviewTruncated?: boolean;
   /** Rendering preference when this local file is classified as a PDF. */
   pdfRenderProfile?: AppServerPdfRenderProfile;
 };


### PR DESCRIPTION
## What changed

- Verify local-file PDF magic bytes before applying PDF-specific size limits.
- Restrict drag-and-drop image handling to formats the composer deliberately supports.
- Route unsupported image MIME types, including TIFF, through the path-only local-file reference flow.
- Enrich local references with file size and conservative extension-based MIME metadata.
- Include content only for known text types when the entire file is at most 10 KiB, UTF-8 validation succeeds, and no disallowed control bytes are present.
- Cap text previews at 4 KiB per file and 16 KiB across one turn.
- Reject Codex-owned session, rollout, history, and database paths before classification or file opening, including symlink targets and custom Codex homes.
- Discard caller-supplied metadata and preview fields, then restore only freshly observed and validated context.
- Carry the same metadata/preview contract through Codex, ACP, and Grok-compatible backends, including turn steering.

## Root cause

The local PDF preflight checked file size before reading the PDF header, so every file above the PDF analysis limit was classified as an oversized PDF. Separately, the composer treated any `image/*` MIME as a supported image and attempted to normalize its contents.

The initial bounded-context implementation also trusted derived fields already present on local-file inputs and converted Grok local-file inputs back to legacy path-only text. It did not reject Codex-private storage before inspecting a textual extension.

The Codex App Server turn schema has text, image, local-image, skill, and mention inputs, but no generic local-file payload. Arbitrary files therefore remain `mention` path references; bounded metadata and validated text previews travel as text.

## Impact

Dragging a large ISO, TIFF, archive, office document, or unknown file does not make PwrAgent read or upload its contents. The model receives its name, local path, observed size, and a MIME guess when PwrAgent recognizes the extension, then decides whether to inspect the path with local tools.

Small, definitely textual files can provide useful context without opening an unbounded input path. Files above 10 KiB, unknown types, invalid UTF-8, binary/control-heavy content, and protected Codex storage receive no content preview. Codex-managed worktree source files remain eligible because they are repository data, not Codex-private storage.

## Validation

- 599 focused tests across composer, PDF preparation, local-file policy, backend handoff, Codex client, and agent-core input handling
- `pnpm lint:codex-storage`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
