### PR TITLE
test(desktop): make hot CPU profiler timer test deterministic

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -443,6 +443,9 @@ describe("RendererHotCpuProfiler", () => {
 
       expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.start");
       expect(getAppMetrics).toHaveBeenCalledTimes(3);
+      // `Profiler.start` precedes async profile-start bookkeeping. Wait until
+      // its duration timer is registered before asking fake timers to run it.
+      await vi.waitFor(() => expect(vi.getTimerCount()).toBe(1));
 
       await vi.advanceTimersByTimeAsync(config.intervalMs * 4);
       expect(getAppMetrics).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary

- wait for the renderer profile duration timer to be registered before driving fake timers
- keep the existing sampling-pause and Profiler.stop assertions unchanged
- limit the change to the flaky profiler unit test

## Root cause

The sample timer callback starts captureSample asynchronously without returning its promise. During a hot sample, startProfile calls Profiler.start, then awaits file-backed profile-start event bookkeeping before it installs profileDurationTimer. The test used the earlier debugger attach and Profiler.start calls as its readiness boundary, so under full-suite Windows load runOnlyPendingTimersAsync could execute before the duration timer existed and therefore never call Profiler.stop.

Waiting for the single registered fake timer observes the exact durable boundary the test needs before it drives that timer.

## Validation

- focused renderer-hot-cpu-profiler test file: 20 consecutive passes, 14 tests per run
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing repository warnings only)
- git diff --check

CI evidence: https://github.com/pwrdrvr/PwrAgent/actions/runs/30871023112