### PR TITLE
fix(desktop): detect unborn Git workspaces

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -277,6 +277,7 @@ const readDirectoryStatusEntries = vi.fn((directories: Array<{ key: string }>) =
 );
 const readDirectoryGitStatusCache = vi.fn(async () => ({}));
 const writeDirectoryGitStatusCacheEntry = vi.fn(async () => undefined);
+const invalidateDirectoryStatus = vi.fn((_directoryPath?: string) => undefined);
 const readThreadGitWorkingStateCache = vi.fn(async () => ({}));
 const writeThreadGitWorkingStateCacheEntry = vi.fn(async () => undefined);
 type WorkingStateEntry = {
@@ -684,6 +685,7 @@ vi.mock("../app-server/backend-registry", () => {
     getThreadTranscriptImageRoots,
     readDirectoryStatuses,
     readDirectoryStatusEntries,
+    invalidateDirectoryStatus,
     readWorktreeWorkingStateEntries,
     invalidateWorktreeWorkingState,
     resolveEditCommitStates,
@@ -766,6 +768,7 @@ describe("app server ipc", () => {
     rememberCompleteNavigationSnapshot.mockClear();
     readDirectoryStatuses.mockClear();
     readDirectoryStatusEntries.mockClear();
+    invalidateDirectoryStatus.mockClear();
     readDirectoryGitStatusCache.mockClear();
     readDirectoryGitStatusCache.mockResolvedValue({});
     writeDirectoryGitStatusCacheEntry.mockClear();
@@ -4740,6 +4743,9 @@ describe("app server ipc", () => {
     await vi.waitFor(() => {
       expect(readDirectoryStatusEntries).toHaveBeenCalled();
     });
+    expect(invalidateDirectoryStatus).toHaveBeenCalledExactlyOnceWith(
+      "/repo/app",
+    );
     expect(readDirectoryStatusEntries.mock.calls[0]?.[0]).toEqual([
       expect.objectContaining({ key: "directory:/repo/app" }),
     ]);

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -41,6 +41,7 @@ const federationMock = vi.hoisted(() => {
       threadId: request.threadId,
       renamedAt: 6_000,
     })),
+    refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
   };
   return {
     remoteBackend,
@@ -760,6 +761,7 @@ describe("app server ipc", () => {
     renameThread.mockClear();
     federationMock.remoteBackend.renameThread.mockClear();
     federationMock.remoteBackend.archiveThread.mockClear();
+    federationMock.remoteBackend.refreshDirectoryGitStatuses.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
@@ -4749,6 +4751,40 @@ describe("app server ipc", () => {
     expect(readDirectoryStatusEntries.mock.calls[0]?.[0]).toEqual([
       expect.objectContaining({ key: "directory:/repo/app" }),
     ]);
+  });
+
+  it("routes remote directory git status refreshes to the owning federation peer", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL } = await import("../../shared/ipc");
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+
+    registerAppServerIpcHandlers();
+
+    await expect(
+      handlers.get(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL)?.(
+        {},
+        {
+          directoryKeys: ["directory:/remote/repo"],
+          federationTarget,
+          force: true,
+        },
+      ),
+    ).resolves.toEqual({ scheduledCount: 1 });
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(
+      federationMock.remoteBackend.refreshDirectoryGitStatuses,
+    ).toHaveBeenCalledExactlyOnceWith({
+      directoryKeys: ["directory:/remote/repo"],
+      force: true,
+    });
+    expect(readDirectoryStatusEntries).not.toHaveBeenCalled();
+    expect(invalidateDirectoryStatus).not.toHaveBeenCalled();
   });
 
   it("coalesces rapid forced directory git status re-enqueues for the same key", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -337,6 +337,7 @@ const setThreadPullRequestStatusToolHandler = vi.fn();
 const setThreadPullRequestCanonicalizer = vi.fn();
 const setThreadPullRequestWatchToolHandler = vi.fn();
 const setThreadPrAutoDispatchHandler = vi.fn();
+const setDirectoryGitStatusWriter = vi.fn();
 const setThreadPrAutoDispatchBatch = vi.fn(async () => undefined);
 const ensureDirectoryLaunchpad = vi.fn(async (request: {
   directoryKey: string;
@@ -696,6 +697,7 @@ vi.mock("../app-server/backend-registry", () => {
     setThreadPullRequestCanonicalizer,
     setThreadPullRequestWatchToolHandler,
     setThreadPrAutoDispatchHandler,
+    setDirectoryGitStatusWriter,
     setThreadPrAutoDispatchBatch,
     ensureDirectoryLaunchpad,
     getQueuedExecutionModesSnapshot: () => ({}),
@@ -788,6 +790,7 @@ describe("app server ipc", () => {
     setThreadPullRequestCanonicalizer.mockClear();
     setThreadPullRequestWatchToolHandler.mockClear();
     setThreadPrAutoDispatchHandler.mockClear();
+    setDirectoryGitStatusWriter.mockClear();
     setThreadPrAutoDispatchBatch.mockClear();
     ensureDirectoryLaunchpad.mockClear();
     markThreadSeen.mockClear();
@@ -956,6 +959,54 @@ describe("app server ipc", () => {
     expect(setThreadPullRequestCanonicalizer).toHaveBeenCalledWith(
       expect.any(Function),
     );
+  });
+
+  it("persists owner-refreshed directory Git status before publishing it", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+
+    registerAppServerIpcHandlers();
+
+    const writer = setDirectoryGitStatusWriter.mock.calls.at(-1)?.[0];
+    await writer?.({
+      directory: {
+        key: "directory:/owner/repo",
+        kind: "directory",
+        label: "repo",
+        path: "/owner/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+      },
+      directoryKey: "directory:/owner/repo",
+      fetchedAt: 2_000,
+      gitStatus: {
+        currentBranch: "main",
+        syncState: "in-sync",
+      },
+    });
+
+    expect(writeDirectoryGitStatusCacheEntry).toHaveBeenCalledExactlyOnceWith({
+      directoryKey: "directory:/owner/repo",
+      directoryPath: "/owner/repo",
+      fetchedAt: 2_000,
+      gitStatus: {
+        currentBranch: "main",
+        syncState: "in-sync",
+      },
+    });
+    expect(publishLocalEvent).toHaveBeenCalledExactlyOnceWith({
+      backend: "codex",
+      notification: {
+        method: "navigation/directoryGitStatus/updated",
+        params: {
+          directoryKey: "directory:/owner/repo",
+          fetchedAt: 2_000,
+          gitStatus: {
+            currentBranch: "main",
+            syncState: "in-sync",
+          },
+        },
+      },
+    });
   });
 
   it("hydrates the thread inspection PR canonicalizer from durable cache", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20111,6 +20111,7 @@ command = "pnpm dev"
             kind: "worktree" as const,
             branch: cwd === targetWorktreePath ? "HEAD" : "main",
             hasCommits: true,
+            headHasCommit: true,
             worktreeCreationAvailable: true,
           })),
           prepareLaunchpadWorkspace: vi.fn(async () => ({
@@ -20265,6 +20266,7 @@ command = "pnpm dev"
             kind: "worktree" as const,
             branch: "main",
             hasCommits: true,
+            headHasCommit: true,
             worktreeCreationAvailable: true,
           })),
           resolvePrimaryWorkspacePath: vi.fn(async (cwd?: string) => {
@@ -20470,6 +20472,7 @@ command = "pnpm dev"
           kind: "worktree" as const,
           branch: cwd === worktreePath ? "HEAD" : "main",
           hasCommits: true,
+          headHasCommit: true,
           worktreeCreationAvailable: true,
         })),
         prepareLaunchpadWorkspace,
@@ -20670,6 +20673,7 @@ script = "printf setup"
           kind: "worktree" as const,
           branch: cwd === worktreePath ? "HEAD" : "main",
           hasCommits: true,
+          headHasCommit: true,
           worktreeCreationAvailable: true,
         })),
         prepareLaunchpadWorkspace: vi.fn(async () => ({
@@ -22309,6 +22313,7 @@ script = "printf setup"
           kind: "worktree" as const,
           branch: cwd === worktreePath ? "HEAD" : "main",
           hasCommits: true,
+          headHasCommit: true,
           worktreeCreationAvailable: true,
         })),
         prepareLaunchpadWorkspace,
@@ -22457,7 +22462,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("describes unborn Git workspaces and rejects new worktree handoffs precisely", async () => {
+  it("describes unborn Git workspaces and gates worktrees on available refs", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-unborn-"));
     const repoPath = path.join(root, "repo");
     const remotePath = path.join(root, "origin.git");
@@ -22609,11 +22614,95 @@ script = "printf setup"
       });
       expect(codexClient.lastStartThreadParams).toBe(projectLocalStartParams);
 
+      const seedPath = path.join(root, "seed");
+      await mkdir(seedPath, { recursive: true });
+      await git(seedPath, ["init", "-b", "main"]);
+      await writeFile(path.join(seedPath, "README.md"), "seed\n", "utf8");
+      await git(seedPath, ["add", "README.md"]);
+      await git(seedPath, [
+        "-c",
+        "user.name=PwrAgent Tests",
+        "-c",
+        "user.email=tests@pwragent.local",
+        "commit",
+        "-m",
+        "initial",
+      ]);
+      await git(seedPath, ["remote", "add", "origin", remotePath]);
+      await git(seedPath, ["push", "origin", "main"]);
+      await git(repoPath, [
+        "fetch",
+        "origin",
+        "main:refs/remotes/origin/main",
+      ]);
+
+      const fetchedProjectLocalResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "call-project-local-fetched",
+          requestId: "call-project-local-fetched",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: {
+            task: "Inspect the fetched base.",
+            title: "Fetched base",
+            workspaceMode: "project_local",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(fetchedProjectLocalResponse).toMatchObject({ success: true });
+      const fetchedProjectLocalPayload = JSON.parse(
+        (fetchedProjectLocalResponse as { contentItems: Array<{ text: string }> })
+          .contentItems[0]!.text,
+      );
+      expect(fetchedProjectLocalPayload.workspace).toMatchObject({
+        mode: "project_local",
+        cwd: expectedDir(repoPath),
+        branch: "main",
+        git: {
+          kind: "git_local",
+          repositoryState: "unborn",
+          worktreeCreationAvailable: true,
+        },
+      });
+      expect(fetchedProjectLocalPayload.workspace.git).not.toHaveProperty(
+        "unavailableReason",
+      );
+
+      const remoteWorktreeResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "call-worktree-fetched",
+          requestId: "call-worktree-fetched",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: {
+            task: "Work from the fetched base.",
+            title: "Fetched worktree",
+            workspaceMode: "new_worktree",
+            branchName: "origin/main",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(remoteWorktreeResponse).toMatchObject({ success: true });
+      const createdWorktree = codexClient.lastStartThreadParams?.cwd;
+      expect(createdWorktree).toBeDefined();
+      expect(createdWorktree).not.toBe(expectedDir(repoPath));
+      expect(await git(createdWorktree!, ["rev-parse", "HEAD"])).toBe(
+        await git(repoPath, ["rev-parse", "origin/main"]),
+      );
+
       await registry.close();
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 
   it("starts project-local handoffs in the primary repo checkout instead of the caller worktree", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-project-local-"));

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2255,6 +2255,8 @@ describe("DesktopBackendRegistry", () => {
       } as never,
     });
     const events: AgentEvent[] = [];
+    const writeDirectoryGitStatus = vi.fn(async () => undefined);
+    registry.setDirectoryGitStatusWriter(writeDirectoryGitStatus);
     const unsubscribe = registry.onEvent((event) => {
       events.push(event);
     });
@@ -2298,20 +2300,19 @@ describe("DesktopBackendRegistry", () => {
           path: "/owner/repo",
         }),
       ]);
-      expect(events).toContainEqual({
-        backend: "codex",
-        notification: {
-          method: "navigation/directoryGitStatus/updated",
-          params: {
-            directoryKey: "directory:/owner/repo",
-            fetchedAt: expect.any(Number),
-            gitStatus: {
-              currentBranch: "main",
-              syncState: "in-sync",
-            },
-          },
+      expect(writeDirectoryGitStatus).toHaveBeenCalledExactlyOnceWith({
+        directory: expect.objectContaining({
+          key: "directory:/owner/repo",
+          path: "/owner/repo",
+        }),
+        directoryKey: "directory:/owner/repo",
+        fetchedAt: expect.any(Number),
+        gitStatus: {
+          currentBranch: "main",
+          syncState: "in-sync",
         },
       });
+      expect(events).toEqual([]);
     } finally {
       unsubscribe();
       await registry.close();

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20261,6 +20261,12 @@ command = "pnpm dev"
           initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
         }),
         gitDirectoryService: {
+          inspectWorkspaceGit: vi.fn(async () => ({
+            kind: "worktree" as const,
+            branch: "main",
+            hasCommits: true,
+            worktreeCreationAvailable: true,
+          })),
           resolvePrimaryWorkspacePath: vi.fn(async (cwd?: string) => {
             if (cwd?.startsWith(targetRepoPath)) return targetRepoPath;
             if (cwd?.startsWith(parentRepoPath)) return parentRepoPath;
@@ -20460,6 +20466,12 @@ command = "pnpm dev"
       }),
       codexEnvironmentCommandRunner: commandRunner,
       gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+          kind: "worktree" as const,
+          branch: cwd === worktreePath ? "HEAD" : "main",
+          hasCommits: true,
+          worktreeCreationAvailable: true,
+        })),
         prepareLaunchpadWorkspace,
         recordCodexWorktreeOwnerThread,
       } as never,
@@ -20654,6 +20666,12 @@ script = "printf setup"
       }),
       codexEnvironmentCommandRunner: commandRunner,
       gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+          kind: "worktree" as const,
+          branch: cwd === worktreePath ? "HEAD" : "main",
+          hasCommits: true,
+          worktreeCreationAvailable: true,
+        })),
         prepareLaunchpadWorkspace: vi.fn(async () => ({
           cwd: worktreePath,
           repositoryPath: repoPath,
@@ -22287,6 +22305,12 @@ script = "printf setup"
       }),
       codexEnvironmentCommandRunner: commandRunner,
       gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+          kind: "worktree" as const,
+          branch: cwd === worktreePath ? "HEAD" : "main",
+          hasCommits: true,
+          worktreeCreationAvailable: true,
+        })),
         prepareLaunchpadWorkspace,
         recordCodexWorktreeOwnerThread: vi.fn(async () => {}),
       } as never,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24064,6 +24064,215 @@ script = "printf setup"
     await rm(root, { recursive: true, force: true });
   });
 
+  it("marks required-worktree handoffs failed when Git inspection fails", async () => {
+    const sourceDirectory = {
+      id: "directory:/repo/app",
+      kind: "local" as const,
+      label: "app",
+      path: "/repo/app",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [sourceDirectory],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const inspectError = new Error("fatal: bad object refs/heads/main");
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async () => {
+          throw inspectError;
+        }),
+      } as never,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "full-access",
+            extraLinkedDirectories: [sourceDirectory],
+          },
+        },
+      }),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "handoff-call-1",
+        requestId: "handoff-call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Repair the malformed repository.",
+          title: "Malformed repository repair",
+          workspaceMode: "new_worktree",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: expect.stringContaining("Git workspace inspection failed"),
+        },
+      ],
+    });
+    expect(codexClient.lastStartThreadParams).toBeUndefined();
+
+    const searchResponse = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "search-call-1",
+        requestId: "search-call-1",
+        namespace: "pwragent",
+        tool: "search_threads",
+        arguments: { query: "Malformed repository repair" },
+      },
+    } as AppServerPendingRequestNotification);
+    const searchPayload = JSON.parse(
+      (searchResponse as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(searchPayload.pendingHandoffs).toEqual([
+      expect.objectContaining({
+        status: "failed",
+        phase: "failed",
+        error: expect.stringContaining("Git workspace inspection failed"),
+      }),
+    ]);
+
+    await registry.close();
+  });
+
+  it("continues a no-workspace handoff when Git inspection is unavailable", async () => {
+    const sourceDirectory = {
+      id: "directory:/repo/app",
+      kind: "local" as const,
+      label: "app",
+      path: "/repo/app",
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+      threads: [
+        {
+          id: "ordinary-thread",
+          title: "Parent Thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [sourceDirectory],
+          updatedAt: 1000,
+        },
+      ],
+    });
+    const inspectWorkspaceGit = vi.fn(async () => {
+      throw new Error("EACCES: cannot inspect child workspace");
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      createScratchProjectDirectory: async () => "/repo/scratch",
+      grokClient: new MockBackendClient({
+        initializeError: new Error("grok unavailable"),
+      }),
+      gitDirectoryService: {
+        inspectWorkspaceGit,
+      } as never,
+      overlayStore: createOverlayStoreMock({
+        overlays: {
+          "codex:ordinary-thread": {
+            backend: "codex",
+            threadId: "ordinary-thread",
+            executionMode: "full-access",
+            extraLinkedDirectories: [sourceDirectory],
+          },
+        },
+      }),
+      threadTitleGenerationService: null,
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/started",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          turn: { id: "turn-1" },
+        },
+      },
+    });
+
+    const response = await codexClient.emitRequest({
+      method: "item/tool/call",
+      params: {
+        threadId: "ordinary-thread",
+        turnId: "turn-1",
+        callId: "handoff-call-1",
+        requestId: "handoff-call-1",
+        namespace: "pwragent",
+        tool: "handoff_task",
+        arguments: {
+          task: "Continue even if Git metadata cannot be read.",
+          title: "Unavailable child metadata",
+          workspaceMode: "none",
+        },
+      },
+    } as AppServerPendingRequestNotification);
+
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse(
+      (response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text,
+    );
+    expect(payload.workspace).toMatchObject({
+      mode: "none",
+      cwd: "/repo/scratch",
+    });
+    expect(payload.workspace.git).toEqual({
+      kind: "unavailable",
+      worktreeCreationAvailable: false,
+      unavailableReason:
+        "Git workspace inspection failed: EACCES: cannot inspect child workspace",
+    });
+    expect(inspectWorkspaceGit).toHaveBeenCalledTimes(2);
+    expect(codexClient.lastStartTurnParams?.threadId).toBe("thread-1");
+    const prompt =
+      (codexClient.lastStartTurnParams?.input[0] as { text?: string } | undefined)
+        ?.text ?? "";
+    expect(prompt).toContain("- Git: unavailable");
+    expect(prompt).toContain(
+      "- New worktree unavailable: Git workspace inspection failed: EACCES: cannot inspect child workspace",
+    );
+
+    await registry.close();
+  });
+
   it("schedules a dynamic-tool review until the invoking turn completes", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -22466,6 +22466,8 @@ script = "printf setup"
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-unborn-"));
     const repoPath = path.join(root, "repo");
     const remotePath = path.join(root, "origin.git");
+    const unpublishedBaseReason =
+      "Worktrees are unavailable because this repository has no published base branch yet. Create the initial commit in the Local checkout and publish the default branch. Worktrees will be enabled once a remote base branch is available.";
     try {
       await git(root, ["init", "--bare", "-b", "main", remotePath]);
       await mkdir(repoPath, { recursive: true });
@@ -22558,8 +22560,7 @@ script = "printf setup"
           kind: "git_local",
           repositoryState: "unborn",
           worktreeCreationAvailable: false,
-          unavailableReason:
-            "Repository has no commits yet; create the initial commit before allocating a worktree.",
+          unavailableReason: unpublishedBaseReason,
         },
       });
       const prompt =
@@ -22569,7 +22570,7 @@ script = "printf setup"
       expect(prompt).toContain("- Git: git_local");
       expect(prompt).toContain("- Git repository state: unborn");
       expect(prompt).toContain(
-        "- New worktree unavailable: Repository has no commits yet; create the initial commit before allocating a worktree.",
+        `- New worktree unavailable: ${unpublishedBaseReason}`,
       );
       const projectLocalStartParams = codexClient.lastStartThreadParams;
 
@@ -22597,8 +22598,7 @@ script = "printf setup"
       );
       expect(worktreePayload).toMatchObject({
         code: "unsupported_workspace",
-        message:
-          "Repository has no commits yet; create the initial commit before allocating a worktree.",
+        message: unpublishedBaseReason,
         data: {
           workspace: {
             branch: "main",
@@ -22606,8 +22606,7 @@ script = "printf setup"
               kind: "git_local",
               repositoryState: "unborn",
               worktreeCreationAvailable: false,
-              unavailableReason:
-                "Repository has no commits yet; create the initial commit before allocating a worktree.",
+              unavailableReason: unpublishedBaseReason,
             },
           },
         },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -24252,7 +24252,7 @@ script = "printf setup"
     );
     expect(payload.workspace).toMatchObject({
       mode: "none",
-      cwd: "/repo/scratch",
+      cwd: expectedDir("/repo/scratch"),
     });
     expect(payload.workspace.git).toEqual({
       kind: "unavailable",

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -20107,6 +20107,12 @@ command = "pnpm dev"
           initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
         }),
         gitDirectoryService: {
+          inspectWorkspaceGit: vi.fn(async (cwd: string) => ({
+            kind: "worktree" as const,
+            branch: cwd === targetWorktreePath ? "HEAD" : "main",
+            hasCommits: true,
+            worktreeCreationAvailable: true,
+          })),
           prepareLaunchpadWorkspace: vi.fn(async () => ({
             cwd: targetWorktreePath,
             repositoryPath: targetRepoPath,
@@ -20841,6 +20847,9 @@ script = "printf setup"
       grokClient: new MockBackendClient({
         initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
       }),
+      gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async () => ({ kind: "non_git" as const })),
+      } as never,
       overlayStore,
       threadTitleGenerationService: null,
     });
@@ -22424,6 +22433,164 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("describes unborn Git workspaces and rejects new worktree handoffs precisely", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-unborn-"));
+    const repoPath = path.join(root, "repo");
+    const remotePath = path.join(root, "origin.git");
+    try {
+      await git(root, ["init", "--bare", "-b", "main", remotePath]);
+      await mkdir(repoPath, { recursive: true });
+      await git(repoPath, ["init", "-b", "main"]);
+      await git(repoPath, ["remote", "add", "origin", remotePath]);
+      await git(repoPath, ["config", "branch.main.remote", "origin"]);
+      await git(repoPath, ["config", "branch.main.merge", "refs/heads/main"]);
+      expect(await git(repoPath, ["status", "--short", "--branch"])).toContain(
+        "No commits yet on main...origin/main [gone]",
+      );
+
+      const linkedDirectory = {
+        id: expectedDir(repoPath),
+        kind: "local" as const,
+        label: "repo",
+        path: expectedDir(repoPath),
+      };
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/start", "thread/list", "turn/start"] },
+        threads: [
+          {
+            id: "ordinary-thread",
+            title: "Parent Thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1000,
+          },
+        ],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        grokClient: new MockBackendClient({
+          initializeError: new Error("grok app server unavailable: XAI_API_KEY is not set"),
+        }),
+        gitDirectoryService: new GitDirectoryService({
+          resolveWorktreeStorage: () => "in-repo",
+        }),
+        overlayStore: createOverlayStoreMock({
+          overlays: {
+            "codex:ordinary-thread": {
+              backend: "codex",
+              threadId: "ordinary-thread",
+              executionMode: "full-access",
+              extraLinkedDirectories: [linkedDirectory],
+            },
+          },
+        }),
+        threadTitleGenerationService: null,
+      });
+      await registry.publishLocalEvent({
+        backend: "codex",
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "ordinary-thread",
+            turnId: "turn-1",
+            turn: { id: "turn-1" },
+          },
+        },
+      });
+
+      const projectLocalResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "call-project-local",
+          requestId: "call-project-local",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: {
+            task: "Initialize the repository.",
+            title: "Initial commit",
+            workspaceMode: "project_local",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(projectLocalResponse).toMatchObject({ success: true });
+      const projectLocalPayload = JSON.parse(
+        (projectLocalResponse as { contentItems: Array<{ text: string }> })
+          .contentItems[0]!.text,
+      );
+      expect(projectLocalPayload.workspace).toMatchObject({
+        mode: "project_local",
+        cwd: expectedDir(repoPath),
+        branch: "main",
+        git: {
+          kind: "git_local",
+          repositoryState: "unborn",
+          worktreeCreationAvailable: false,
+          unavailableReason:
+            "Repository has no commits yet; create the initial commit before allocating a worktree.",
+        },
+      });
+      const prompt =
+        codexClient.lastStartTurnParams?.input[0]?.type === "text"
+          ? codexClient.lastStartTurnParams.input[0].text
+          : "";
+      expect(prompt).toContain("- Git: git_local");
+      expect(prompt).toContain("- Git repository state: unborn");
+      expect(prompt).toContain(
+        "- New worktree unavailable: Repository has no commits yet; create the initial commit before allocating a worktree.",
+      );
+      const projectLocalStartParams = codexClient.lastStartThreadParams;
+
+      const worktreeResponse = await codexClient.emitRequest({
+        method: "item/tool/call",
+        params: {
+          threadId: "ordinary-thread",
+          turnId: "turn-1",
+          callId: "call-worktree",
+          requestId: "call-worktree",
+          namespace: "pwragent",
+          tool: "handoff_task",
+          arguments: {
+            task: "Work in an isolated checkout.",
+            title: "Isolated work",
+            workspaceMode: "new_worktree",
+          },
+        },
+      } as AppServerPendingRequestNotification);
+
+      expect(worktreeResponse).toMatchObject({ success: false });
+      const worktreePayload = JSON.parse(
+        (worktreeResponse as { contentItems: Array<{ text: string }> })
+          .contentItems[0]!.text,
+      );
+      expect(worktreePayload).toMatchObject({
+        code: "unsupported_workspace",
+        message:
+          "Repository has no commits yet; create the initial commit before allocating a worktree.",
+        data: {
+          workspace: {
+            branch: "main",
+            git: {
+              kind: "git_local",
+              repositoryState: "unborn",
+              worktreeCreationAvailable: false,
+              unavailableReason:
+                "Repository has no commits yet; create the initial commit before allocating a worktree.",
+            },
+          },
+        },
+      });
+      expect(codexClient.lastStartThreadParams).toBe(projectLocalStartParams);
+
+      await registry.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("starts project-local handoffs in the primary repo checkout instead of the caller worktree", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-handoff-project-local-"));
     const repoPath = path.join(root, "repo");
@@ -23537,6 +23704,7 @@ script = "printf setup"
     try {
       await mkdir(repoPath, { recursive: true });
       await mkdir(ignoredCwd, { recursive: true });
+      await mkdir(scratchPath, { recursive: true });
       try {
         await git(repoPath, ["init", "-b", "main"]);
       } catch {
@@ -34866,6 +35034,9 @@ script = "printf setup"
       sessions,
       sessionId: childThreadId,
       startPrompt,
+      gitDirectoryService: {
+        inspectWorkspaceGit: vi.fn(async () => ({ kind: "non_git" as const })),
+      },
       overlayStore: createOverlayStoreMock({
         overlays: {
           [`${acpBackendId}:${parentThreadId}`]: {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2229,6 +2229,95 @@ function rememberCollapsedDirectoryWithPinnedThread(params: {
 }
 
 describe("DesktopBackendRegistry", () => {
+  it("refreshes only owner-known directory Git state for federation requests", async () => {
+    const invalidateDirectoryStatus = vi.fn();
+    const readDirectoryStatusEntries = vi.fn(
+      (directories: Array<{ key: string }>) =>
+        (async function* () {
+          for (const directory of directories) {
+            yield {
+              directoryKey: directory.key,
+              gitStatus: {
+                currentBranch: "main",
+                syncState: "in-sync" as const,
+              },
+            };
+          }
+        })(),
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitDirectoryService: {
+        invalidateDirectoryStatus,
+        readDirectoryStatusEntries,
+      } as never,
+    });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    registry.rememberCompleteNavigationSnapshot({
+      backend: "all",
+      directories: [
+        {
+          key: "directory:/owner/repo",
+          kind: "directory",
+          label: "repo",
+          path: "/owner/repo",
+          threadKeys: ["codex:thread-1"],
+          needsAttentionCount: 0,
+        },
+      ],
+      fetchedAt: 1_000,
+      inboxThreadKeys: ["codex:thread-1"],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+      threads: [],
+      unchanged: false,
+    });
+
+    try {
+      await expect(registry.refreshDirectoryGitStatuses({
+        directoryKeys: [
+          "directory:/owner/repo",
+          "directory:/viewer/secret",
+        ],
+        force: true,
+      })).resolves.toEqual({ scheduledCount: 1 });
+
+      expect(invalidateDirectoryStatus).toHaveBeenCalledExactlyOnceWith(
+        "/owner/repo",
+      );
+      expect(readDirectoryStatusEntries).toHaveBeenCalledExactlyOnceWith([
+        expect.objectContaining({
+          key: "directory:/owner/repo",
+          path: "/owner/repo",
+        }),
+      ]);
+      expect(events).toContainEqual({
+        backend: "codex",
+        notification: {
+          method: "navigation/directoryGitStatus/updated",
+          params: {
+            directoryKey: "directory:/owner/repo",
+            fetchedAt: expect.any(Number),
+            gitStatus: {
+              currentBranch: "main",
+              syncState: "in-sync",
+            },
+          },
+        },
+      });
+    } finally {
+      unsubscribe();
+      await registry.close();
+    }
+  });
+
   it("evaluates the current PR state when auto-fix is enabled", async () => {
     const preferenceChanged = vi.fn(async () => undefined);
     const sendPendingNow = vi.fn(async () => true);

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -167,6 +167,77 @@ describe("federation backend bridge", () => {
       threadId: "thread-1",
       cleanup: [],
     });
+
+    const refreshPending = client.refreshDirectoryGitStatuses({
+      directoryKeys: ["directory:/remote/repo"],
+      force: true,
+    });
+    const refreshRequest = sent.at(-1)!;
+    expect(refreshRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
+      params: {
+        directoryKeys: ["directory:/remote/repo"],
+        force: true,
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "response-3",
+      kind: "response",
+      requestId: refreshRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_300,
+      result: { scheduledCount: 1 },
+    });
+    await expect(refreshPending).resolves.toEqual({ scheduledCount: 1 });
+  });
+
+  it("executes directory Git status refreshes on the target instance", async () => {
+    const backend = {
+      refreshDirectoryGitStatuses: vi.fn(async () => ({ scheduledCount: 1 })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "refresh-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
+        params: {
+          directoryKeys: ["directory:/remote/repo"],
+          force: true,
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.refreshDirectoryGitStatuses).toHaveBeenCalledExactlyOnceWith({
+      directoryKeys: ["directory:/remote/repo"],
+      force: true,
+    });
+    expect(replies).toMatchObject([
+      {
+        kind: "response",
+        requestId: "refresh-request",
+        result: { scheduledCount: 1 },
+      },
+    ]);
   });
 
   it("requires thread-detail capability for remote thread reads", async () => {
@@ -312,6 +383,7 @@ describe("federation backend bridge", () => {
       stopCodexEnvironmentAction: vi.fn(),
       setCodexThreadEnvironment: vi.fn(),
       materializeDirectoryLaunchpad: vi.fn(),
+      refreshDirectoryGitStatuses: vi.fn(),
       handoffThreadWorkspace: vi.fn(),
       renameThread: vi.fn(),
       readApplications: vi.fn(),
@@ -458,6 +530,7 @@ describe("federation backend bridge", () => {
         runCodexEnvironmentAction: vi.fn(),
         stopCodexEnvironmentAction: vi.fn(),
         setCodexThreadEnvironment: vi.fn(),
+        refreshDirectoryGitStatuses: vi.fn(),
         materializeDirectoryLaunchpad: vi.fn(),
         handoffThreadWorkspace: vi.fn(),
         renameThread: vi.fn(),

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -251,6 +251,68 @@ describe("GitDirectoryService", () => {
     await workspace.rollback?.();
   }, 15_000);
 
+  it("prefers remote HEAD over a newer remote branch for an unborn HEAD", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-default-"));
+    cleanupPaths.push(rootDir);
+    const remoteDir = path.join(rootDir, "origin");
+    const repoDir = path.join(rootDir, "repo");
+    execFileSync("git", ["init", "-b", "main", remoteDir], { stdio: "ignore" });
+    runGit(remoteDir, ["config", "user.name", "PwrAgent Tests"]);
+    runGit(remoteDir, ["config", "user.email", "pwragent-tests@example.invalid"]);
+    execFileSync(
+      "git",
+      ["-C", remoteDir, "commit", "--allow-empty", "-m", "Main base"],
+      {
+        env: {
+          ...process.env,
+          GIT_AUTHOR_DATE: "2020-01-01T00:00:00Z",
+          GIT_COMMITTER_DATE: "2020-01-01T00:00:00Z",
+        },
+        stdio: "ignore",
+      },
+    );
+    runGit(remoteDir, ["checkout", "-b", "feature"]);
+    execFileSync(
+      "git",
+      ["-C", remoteDir, "commit", "--allow-empty", "-m", "Newer feature"],
+      {
+        env: {
+          ...process.env,
+          GIT_AUTHOR_DATE: "2020-01-02T00:00:00Z",
+          GIT_COMMITTER_DATE: "2020-01-02T00:00:00Z",
+        },
+        stdio: "ignore",
+      },
+    );
+    runGit(remoteDir, ["checkout", "main"]);
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+    runGit(repoDir, ["fetch", "origin"]);
+    runGit(repoDir, ["remote", "set-head", "origin", "main"]);
+    const mainRevision = runGit(repoDir, ["rev-parse", "origin/main^{commit}"]);
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+      runGit: runGitAsync,
+    });
+
+    const status = await service.readDirectoryStatus({ path: repoDir });
+    expect(status).toMatchObject({
+      defaultBranch: "origin/main",
+      baseBranches: ["origin/feature", "origin/main"],
+      worktreeCreationAvailable: true,
+    });
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
+    await workspace.rollback?.();
+  }, 15_000);
+
   it("refreshes cached unborn status after the initial branch is published", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-refresh-"));
     cleanupPaths.push(rootDir);

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -311,6 +311,31 @@ describe("GitDirectoryService", () => {
     expect(workspace.workMode).toBe("worktree");
     expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
     await workspace.rollback?.();
+
+    const explicitAttached = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "origin/main",
+      worktreeBranchMode: "attached",
+    });
+    expect(explicitAttached).toEqual({
+      cwd: toForwardSlashes(repoDir),
+      workMode: "local",
+    });
+
+    const implicitAttached = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      worktreeBranchMode: "attached",
+    });
+    expect(implicitAttached).toEqual({
+      cwd: toForwardSlashes(repoDir),
+      workMode: "local",
+    });
   }, 15_000);
 
   it("refreshes cached unborn status after the initial branch is published", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -175,8 +175,44 @@ describe("GitDirectoryService", () => {
       kind: "worktree",
       branch: "main",
       hasCommits: false,
+      headHasCommit: false,
       worktreeCreationAvailable: false,
     });
+  });
+
+  it("keeps an unborn HEAD distinct from a fetched remote worktree base", async () => {
+    const remoteDir = await createFixtureRepo();
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-remote-base-"));
+    cleanupPaths.push(remoteDir, repoDir);
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+    runGit(repoDir, ["fetch", "origin", "main:refs/remotes/origin/main"]);
+    const originRevision = runGit(repoDir, ["rev-parse", "origin/main^{commit}"]);
+
+    expect(runGit(repoDir, ["branch", "--show-current"])).toBe("main");
+    expect(runGit(repoDir, ["branch", "--list"])).toBe("");
+    await expect(inspectGitWorkspace(repoDir)).resolves.toEqual({
+      kind: "worktree",
+      branch: "main",
+      hasCommits: true,
+      headHasCommit: false,
+      worktreeCreationAvailable: true,
+    });
+
+    const service = new GitDirectoryService({
+      resolveWorktreeStorage: () => "in-repo",
+    });
+    const workspace = await service.prepareLaunchpadWorkspace({
+      directoryKind: "directory",
+      directoryLabel: "FixtureRepo",
+      directoryPath: repoDir,
+      workMode: "worktree",
+      branchName: "origin/main",
+    });
+
+    expect(workspace.workMode).toBe("worktree");
+    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(originRevision);
+    await workspace.rollback?.();
   });
 
   it("keeps ordinary repositories and linked worktrees worktree-capable", async () => {
@@ -190,12 +226,14 @@ describe("GitDirectoryService", () => {
       kind: "worktree",
       branch: "main",
       hasCommits: true,
+      headHasCommit: true,
       worktreeCreationAvailable: true,
     });
     await expect(inspectGitWorkspace(worktreeDir)).resolves.toEqual({
       kind: "worktree",
       branch: "release",
       hasCommits: true,
+      headHasCommit: true,
       worktreeCreationAvailable: true,
     });
   });
@@ -236,6 +274,30 @@ describe("GitDirectoryService", () => {
           throw failure;
         }),
       }),
+    ).rejects.toBe(failure);
+  });
+
+  it("does not treat a broken current branch ref as an unborn HEAD", async () => {
+    const failure = Object.assign(new Error("Git HEAD probe failed"), {
+      stderr: "fatal: bad object refs/heads/main",
+    });
+    const runGitCommand = vi.fn(async (_cwd: string, args: string[]) => {
+      const command = args.join(" ");
+      if (command === "rev-parse --is-inside-work-tree") return "true";
+      if (command === "branch --show-current") return "main";
+      if (command === "rev-list --max-count=1 --all") return "abc123";
+      if (command === "rev-parse --verify --quiet HEAD^{commit}") throw failure;
+      if (
+        command
+        === "for-each-ref --format=%(objectname) refs/heads/main"
+      ) {
+        return "abc123";
+      }
+      throw new Error(`Unexpected Git command: ${command}`);
+    });
+
+    await expect(
+      inspectGitWorkspace("/repo", { runGit: runGitCommand }),
     ).rejects.toBe(failure);
   });
 

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -33,6 +33,10 @@ function runGit(cwd: string, args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
 }
 
+async function runGitAsync(cwd: string, args: string[]): Promise<string> {
+  return runGit(cwd, args);
+}
+
 async function createFixtureRepo(): Promise<string> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-git-directory-service-"));
   execFileSync("git", ["init", rootDir], { stdio: "ignore" });
@@ -207,7 +211,7 @@ describe("GitDirectoryService", () => {
     });
   });
 
-  it("keeps an unborn HEAD distinct from a fetched remote worktree base", async () => {
+  it("uses a fetched remote worktree base implicitly for an unborn HEAD", async () => {
     const remoteDir = await createFixtureRepo();
     const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-remote-base-"));
     cleanupPaths.push(remoteDir, repoDir);
@@ -218,7 +222,9 @@ describe("GitDirectoryService", () => {
 
     expect(runGit(repoDir, ["branch", "--show-current"])).toBe("main");
     expect(runGit(repoDir, ["branch", "--list"])).toBe("");
-    await expect(inspectGitWorkspace(repoDir)).resolves.toEqual({
+    await expect(
+      inspectGitWorkspace(repoDir, { runGit: runGitAsync }),
+    ).resolves.toEqual({
       kind: "worktree",
       branch: "main",
       hasCommits: true,
@@ -228,6 +234,7 @@ describe("GitDirectoryService", () => {
 
     const service = new GitDirectoryService({
       resolveWorktreeStorage: () => "in-repo",
+      runGit: runGitAsync,
     });
     await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
       worktreeCreationAvailable: true,
@@ -237,13 +244,49 @@ describe("GitDirectoryService", () => {
       directoryLabel: "FixtureRepo",
       directoryPath: repoDir,
       workMode: "worktree",
-      branchName: "origin/main",
     });
 
     expect(workspace.workMode).toBe("worktree");
     expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(originRevision);
     await workspace.rollback?.();
-  });
+  }, 15_000);
+
+  it("refreshes cached unborn status after the initial branch is published", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-refresh-"));
+    cleanupPaths.push(rootDir);
+    const repoDir = path.join(rootDir, "repo");
+    const remoteDir = path.join(rootDir, "origin.git");
+    execFileSync("git", ["init", "--bare", "-b", "main", remoteDir], {
+      stdio: "ignore",
+    });
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    runGit(repoDir, ["config", "user.name", "PwrAgent Tests"]);
+    runGit(repoDir, ["config", "user.email", "pwragent-tests@example.invalid"]);
+    runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+    const service = new GitDirectoryService({
+      cacheTtlMs: 60_000,
+      runGit: runGitAsync,
+    });
+
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      worktreeCreationAvailable: false,
+    });
+
+    runGit(repoDir, ["commit", "--allow-empty", "-m", "Publish main"]);
+    runGit(repoDir, ["push", "--set-upstream", "origin", "main"]);
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      worktreeCreationAvailable: false,
+    });
+
+    service.invalidateDirectoryStatus(repoDir);
+    const refreshed = await service.readDirectoryStatus({ path: repoDir });
+    expect(refreshed).toMatchObject({
+      currentBranch: "main",
+      upstreamBranch: "origin/main",
+      syncState: "in-sync",
+    });
+    expect(refreshed?.worktreeCreationAvailable).toBeUndefined();
+  }, 15_000);
 
   it("keeps ordinary repositories and linked worktrees worktree-capable", async () => {
     const repoDir = await createFixtureRepo();

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_TRACKED_BRANCHES,
   capRecentBranchDetails,
   computeWorktreePath,
+  inspectGitWorkspace,
 } from "../app-server/git-directory-service";
 
 // The service forward-slashes the directory/worktree identifiers it returns
@@ -152,6 +153,90 @@ describe("GitDirectoryService", () => {
       cwd: toForwardSlashes(repoDir),
       workMode: "local",
     });
+  });
+
+  it("recognizes an unborn worktree with an empty origin as Git without a worktree base", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-inspection-"));
+    cleanupPaths.push(rootDir);
+    const repoDir = path.join(rootDir, "repo");
+    const remoteDir = path.join(rootDir, "origin.git");
+    execFileSync("git", ["init", "--bare", "-b", "main", remoteDir], {
+      stdio: "ignore",
+    });
+    execFileSync("git", ["init", "-b", "main", repoDir], { stdio: "ignore" });
+    runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+    runGit(repoDir, ["config", "branch.main.remote", "origin"]);
+    runGit(repoDir, ["config", "branch.main.merge", "refs/heads/main"]);
+
+    expect(runGit(repoDir, ["status", "--short", "--branch"])).toContain(
+      "No commits yet on main...origin/main [gone]",
+    );
+    await expect(inspectGitWorkspace(repoDir)).resolves.toEqual({
+      kind: "worktree",
+      branch: "main",
+      hasCommits: false,
+      worktreeCreationAvailable: false,
+    });
+  });
+
+  it("keeps ordinary repositories and linked worktrees worktree-capable", async () => {
+    const repoDir = await createFixtureRepo();
+    cleanupPaths.push(repoDir);
+    const worktreeDir = path.join(repoDir, ".worktrees", "release");
+    await mkdir(path.dirname(worktreeDir), { recursive: true });
+    runGit(repoDir, ["worktree", "add", worktreeDir, "release"]);
+
+    await expect(inspectGitWorkspace(repoDir)).resolves.toEqual({
+      kind: "worktree",
+      branch: "main",
+      hasCommits: true,
+      worktreeCreationAvailable: true,
+    });
+    await expect(inspectGitWorkspace(worktreeDir)).resolves.toEqual({
+      kind: "worktree",
+      branch: "release",
+      hasCommits: true,
+      worktreeCreationAvailable: true,
+    });
+  });
+
+  it("keeps normal non-Git directories classified as non-Git", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "pwragent-non-git-inspection-"));
+    cleanupPaths.push(directory);
+
+    await expect(inspectGitWorkspace(directory)).resolves.toEqual({
+      kind: "non_git",
+    });
+  });
+
+  it("recognizes an empty bare repository without treating it as a workspace", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-bare-inspection-"));
+    cleanupPaths.push(rootDir);
+    const bareDir = path.join(rootDir, "empty.git");
+    execFileSync("git", ["init", "--bare", "-b", "main", bareDir], {
+      stdio: "ignore",
+    });
+
+    await expect(inspectGitWorkspace(bareDir)).resolves.toEqual({
+      kind: "bare",
+      branch: "main",
+      hasCommits: false,
+      worktreeCreationAvailable: false,
+    });
+  });
+
+  it("does not turn unexpected Git probe failures into non-Git results", async () => {
+    const failure = Object.assign(new Error("Git workspace probe failed"), {
+      stderr: "fatal: bad object database",
+    });
+
+    await expect(
+      inspectGitWorkspace("/repo", {
+        runGit: vi.fn(async () => {
+          throw failure;
+        }),
+      }),
+    ).rejects.toBe(failure);
   });
 
   it("reports unborn git directories without surfacing raw HEAD errors", async () => {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -18,6 +18,7 @@ import {
   capRecentBranchDetails,
   computeWorktreePath,
   inspectGitWorkspace,
+  UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
 } from "../app-server/git-directory-service";
 
 // The service forward-slashes the directory/worktree identifiers it returns
@@ -180,6 +181,32 @@ describe("GitDirectoryService", () => {
     });
   });
 
+  it("keeps an unborn HEAD local-only when commits exist only under local refs", async () => {
+    const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-local-ref-"));
+    cleanupPaths.push(repoDir);
+    execFileSync("git", ["init", "-b", "seed", repoDir], { stdio: "ignore" });
+    execFileSync("git", ["-C", repoDir, "config", "user.name", "PwrAgent Tests"], {
+      stdio: "ignore",
+    });
+    execFileSync(
+      "git",
+      ["-C", repoDir, "config", "user.email", "pwragent-tests@example.invalid"],
+      { stdio: "ignore" },
+    );
+    execFileSync("git", ["-C", repoDir, "commit", "--allow-empty", "-m", "Seed ref"], {
+      stdio: "ignore",
+    });
+    runGit(repoDir, ["checkout", "--orphan", "main"]);
+
+    await expect(inspectGitWorkspace(repoDir)).resolves.toEqual({
+      kind: "worktree",
+      branch: "main",
+      hasCommits: true,
+      headHasCommit: false,
+      worktreeCreationAvailable: false,
+    });
+  });
+
   it("keeps an unborn HEAD distinct from a fetched remote worktree base", async () => {
     const remoteDir = await createFixtureRepo();
     const repoDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-unborn-remote-base-"));
@@ -201,6 +228,9 @@ describe("GitDirectoryService", () => {
 
     const service = new GitDirectoryService({
       resolveWorktreeStorage: () => "in-repo",
+    });
+    await expect(service.readDirectoryStatus({ path: repoDir })).resolves.toMatchObject({
+      worktreeCreationAvailable: true,
     });
     const workspace = await service.prepareLaunchpadWorkspace({
       directoryKind: "directory",
@@ -311,13 +341,15 @@ describe("GitDirectoryService", () => {
       branches: [],
       handoffBranches: [],
       syncState: "untracked",
+      worktreeCreationAvailable: false,
+      worktreeCreationUnavailableReason:
+        UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
     });
   });
 
-  it("creates a worktree from the default branch when the checked-out branch is unborn", async () => {
+  it("keeps an unborn checkout local when its default branch exists only locally", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);
-    const mainRevision = runGit(repoDir, ["rev-parse", "main"]);
     runGit(repoDir, ["checkout", "--orphan", "scratch"]);
     const service = new GitDirectoryService({
       resolveWorktreeStorage: () => "in-repo",
@@ -327,6 +359,9 @@ describe("GitDirectoryService", () => {
       branches: expect.arrayContaining(["main"]),
       defaultBranch: "main",
       syncState: "untracked",
+      worktreeCreationAvailable: false,
+      worktreeCreationUnavailableReason:
+        UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
     });
     expect(status).not.toHaveProperty("currentBranch");
 
@@ -337,11 +372,10 @@ describe("GitDirectoryService", () => {
       workMode: "worktree",
     });
 
-    expect(workspace.workMode).toBe("worktree");
-    await expect(realpath(workspace.repositoryPath!)).resolves.toBe(await realpath(repoDir));
-    expect(workspace.cwd).toBeDefined();
-    expect(runGit(workspace.cwd!, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe("HEAD");
-    expect(runGit(workspace.cwd!, ["rev-parse", "HEAD"])).toBe(mainRevision);
+    expect(workspace).toEqual({
+      cwd: toForwardSlashes(repoDir),
+      workMode: "local",
+    });
   });
 
   it("falls back to local mode when an explicit worktree base branch is stale", async () => {
@@ -904,6 +938,18 @@ describe("GitDirectoryService", () => {
         calls.push({ args, cwd, env });
         if (args.join(" ") === "rev-parse --show-toplevel") {
           return repoDir;
+        }
+        if (args.join(" ") === "rev-parse --is-inside-work-tree") {
+          return "true";
+        }
+        if (args.join(" ") === "branch --show-current") {
+          return "main";
+        }
+        if (args.join(" ") === "rev-list --max-count=1 --all") {
+          return "0123456789abcdef0123456789abcdef01234567";
+        }
+        if (args.join(" ") === "rev-parse --verify --quiet HEAD^{commit}") {
+          return "0123456789abcdef0123456789abcdef01234567";
         }
         if (args.join(" ") === "rev-parse --verify main^{commit}") {
           return "0123456789abcdef0123456789abcdef01234567";

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3557,6 +3557,108 @@ describe("MessagingController", () => {
     );
   });
 
+  it("keeps unpublished unborn repositories local in messaging", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        branches: ["seed"],
+        baseBranches: ["seed"],
+        syncState: "untracked",
+        worktreeCreationAvailable: false,
+      },
+    };
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+
+    expect(harness.delivered.at(-1)).toMatchObject({
+      kind: "confirmation",
+      body: expect.stringContaining("Workspace: Local"),
+      actions: expect.not.arrayContaining([
+        expect.objectContaining({ id: "browse:new:workspace:toggle" }),
+        expect.objectContaining({ id: "browse:new:workspace:worktree" }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:workspace:worktree" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      body: expect.stringContaining("Workspace: Local"),
+    });
+  });
+
+  it("offers a fetched remote base to messaging for an unborn HEAD", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.directories[0] = {
+      ...navigation.directories[0]!,
+      gitStatus: {
+        branches: [],
+        baseBranches: ["origin/main"],
+        syncState: "untracked",
+        worktreeCreationAvailable: true,
+      },
+    };
+    const harness = await createHarness({ navigation });
+
+    await harness.controller.handleInboundEvent(buildCommandEvent("/resume --new"));
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({
+        actionId: "browse:select-project",
+        value: {
+          directoryKey: "directory:pwragent",
+          label: "PwrAgent",
+          path: "/repo/pwragent",
+        },
+      }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:workspace:toggle",
+          label: "Start In: Local",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildCallbackEvent({ actionId: "browse:new:workspace:toggle" }),
+    );
+    expect(harness.delivered.at(-1)).toMatchObject({
+      body: expect.stringContaining("Workspace: New Worktree"),
+      actions: expect.arrayContaining([
+        expect.objectContaining({
+          id: "browse:new:base-branch",
+          label: "Base: origin/main",
+        }),
+      ]),
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("Start from the fetched default branch"),
+    );
+    expect(harness.materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchpad: expect.objectContaining({
+          workMode: "worktree",
+          branchName: "origin/main",
+        }),
+      }),
+      expectMaterializeOptions(),
+    );
+  });
+
   it("keeps non-git new-thread prompts local when a worktree action is requested", async () => {
     const harness = await createHarness();
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -3605,7 +3605,8 @@ describe("MessagingController", () => {
       ...navigation.directories[0]!,
       gitStatus: {
         branches: [],
-        baseBranches: ["origin/main"],
+        baseBranches: ["origin/feature", "origin/main"],
+        defaultBranch: "origin/main",
         syncState: "untracked",
         worktreeCreationAvailable: true,
       },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -337,7 +337,10 @@ import { getDesktopOverlayStore } from "./desktop-overlay-store";
 import { createProtocolCaptureFromEnv } from "../testing/protocol-capture";
 import type { ProtocolCaptureStore } from "../testing/capture-store";
 import { createReplayClientsFromEnv } from "../testing/replay-runtime";
-import { GitDirectoryService } from "./git-directory-service";
+import {
+  GitDirectoryService,
+  UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
+} from "./git-directory-service";
 import type { DirectoryGitStatusEntry } from "./git-directory-service";
 import { GitWorkingStateService } from "./git-working-state-service";
 import type {
@@ -21999,11 +22002,18 @@ export class DesktopBackendRegistry {
         },
       };
     }
-    const unavailableReason = !repository.hasCommits
-      ? "Repository has no commits yet; create the initial commit before allocating a worktree."
-      : !repository.worktreeCreationAvailable
-        ? "Repository has no local or remote branch commit available; create or fetch a branch before allocating a worktree."
-        : undefined;
+    let unavailableReason: string | undefined;
+    if (!repository.worktreeCreationAvailable) {
+      if (!repository.headHasCommit) {
+        unavailableReason = UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON;
+      } else if (!repository.hasCommits) {
+        unavailableReason =
+          "Repository has no commits yet; create the initial commit before allocating a worktree.";
+      } else {
+        unavailableReason =
+          "Repository has no local or remote branch commit available; create or fetch a branch before allocating a worktree.";
+      }
+    }
     return {
       mode: params.mode,
       cwd,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -136,6 +136,9 @@ import {
   type TurnOffCodexFastEverywhereResponse,
   type QueueThreadExecutionModeRequest,
   type QueueThreadExecutionModeResponse,
+  type RefreshDirectoryGitStatusesRequest,
+  type RefreshDirectoryGitStatusesResponse,
+  type NavigationDirectoryGitStatusUpdatedNotification,
   type CancelThreadExecutionModeQueueRequest,
   type CancelThreadExecutionModeQueueResponse,
   type ThreadMessagingBindingTransition,
@@ -5959,6 +5962,10 @@ export class DesktopBackendRegistry {
     string,
     CreatedThreadDirectoryVisibility
   >();
+  private navigationDirectoriesByKey = new Map<
+    string,
+    NavigationDirectorySummary
+  >();
   private createdThreadVisibilityPinnedRanks: string[] = [];
   private readonly createdThreadVisibilityLock = new PerKeyAsyncLock();
   private readonly activeThreadIdsByBackend = new Map<AppServerBackendKind, Set<string>>();
@@ -6835,6 +6842,9 @@ export class DesktopBackendRegistry {
           }),
         },
       ]),
+    );
+    this.navigationDirectoriesByKey = new Map(
+      snapshot.directories.map((directory) => [directory.key, directory]),
     );
   }
 
@@ -8871,6 +8881,41 @@ export class DesktopBackendRegistry {
 
   invalidateDirectoryStatus(directoryPath?: string): void {
     this.gitDirectoryService.invalidateDirectoryStatus(directoryPath);
+  }
+
+  async refreshDirectoryGitStatuses(
+    request: RefreshDirectoryGitStatusesRequest,
+  ): Promise<RefreshDirectoryGitStatusesResponse> {
+    const directoryKeys = [
+      ...new Set(request.directoryKeys.map((key) => key.trim()).filter(Boolean)),
+    ];
+    const directories = directoryKeys
+      .map((key) => this.navigationDirectoriesByKey.get(key))
+      .filter((directory): directory is NavigationDirectorySummary =>
+        Boolean(directory?.path?.trim()),
+      );
+    if (request.force !== false) {
+      for (const directory of directories) {
+        this.gitDirectoryService.invalidateDirectoryStatus(directory.path);
+      }
+    }
+    for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
+      directories,
+    )) {
+      const notification: NavigationDirectoryGitStatusUpdatedNotification = {
+        method: "navigation/directoryGitStatus/updated",
+        params: {
+          directoryKey: entry.directoryKey,
+          gitStatus: entry.gitStatus ?? null,
+          fetchedAt: Date.now(),
+        },
+      };
+      await this.emit({
+        backend: "codex",
+        notification,
+      } as unknown as AgentEvent);
+    }
+    return { scheduledCount: directories.length };
   }
 
   readWorktreeWorkingStateEntries(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5733,9 +5733,17 @@ function buildHandoffTaskPrompt(params: {
       : []),
     ...(params.workspace.branch ? [`- Branch: ${params.workspace.branch}`] : []),
     `- Git: ${params.workspace.git.kind}`,
+    ...(params.workspace.git.kind !== "none"
+      && params.workspace.git.kind !== "non_git"
+      && params.workspace.git.repositoryState
+      ? [`- Git repository state: ${params.workspace.git.repositoryState}`]
+      : []),
     `- New worktree supported: ${
       params.workspace.git.worktreeCreationAvailable ? "yes" : "no"
     }`,
+    ...(!params.workspace.git.worktreeCreationAvailable
+      ? [`- New worktree unavailable: ${params.workspace.git.unavailableReason}`]
+      : []),
     ...(params.codexEnvironmentStartupFailure
       ? [
           "",
@@ -21957,8 +21965,8 @@ export class DesktopBackendRegistry {
         },
       };
     }
-    const branch = await readCurrentGitBranch(cwd).catch(() => undefined);
-    if (!branch) {
+    const repository = await this.gitDirectoryService.inspectWorkspaceGit(cwd);
+    if (repository.kind === "non_git") {
       return {
         mode: params.mode,
         cwd,
@@ -21970,17 +21978,57 @@ export class DesktopBackendRegistry {
         },
       };
     }
+    const kind: "git_local" | "git_worktree" =
+      params.linkedDirectory?.kind === "worktree"
+        ? "git_worktree"
+        : "git_local";
+    if (repository.kind === "bare") {
+      return {
+        mode: params.mode,
+        cwd,
+        branch: repository.branch,
+        linkedDirectory: params.linkedDirectory,
+        git: {
+          kind,
+          repositoryState: "bare",
+          worktreeCreationAvailable: false,
+          unavailableReason:
+            "Bare Git repositories are not supported as handoff workspaces.",
+        },
+      };
+    }
+    if (repository.kind === "git_directory") {
+      return {
+        mode: params.mode,
+        cwd,
+        branch: repository.branch,
+        linkedDirectory: params.linkedDirectory,
+        git: {
+          kind,
+          repositoryState: "git_directory",
+          worktreeCreationAvailable: false,
+          unavailableReason:
+            "Git administration directories are not supported as handoff workspaces.",
+        },
+      };
+    }
+    const unavailableReason = !repository.hasCommits
+      ? "Repository has no commits yet; create the initial commit before allocating a worktree."
+      : !repository.worktreeCreationAvailable
+        ? "Repository has no local or remote branch commit available; create or fetch a branch before allocating a worktree."
+        : undefined;
     return {
       mode: params.mode,
       cwd,
-      branch,
+      branch: repository.branch,
       linkedDirectory: params.linkedDirectory,
       git: {
-        kind:
-          params.linkedDirectory?.kind === "worktree"
-            ? "git_worktree"
-            : "git_local",
-        worktreeCreationAvailable: true,
+        kind,
+        ...(!repository.hasCommits
+          ? { repositoryState: "unborn" as const }
+          : {}),
+        worktreeCreationAvailable: repository.worktreeCreationAvailable,
+        ...(unavailableReason ? { unavailableReason } : {}),
       },
     };
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -21982,7 +21982,8 @@ export class DesktopBackendRegistry {
       params.linkedDirectory?.kind === "worktree"
         ? "git_worktree"
         : "git_local";
-    if (repository.kind === "bare") {
+    if (repository.kind !== "worktree") {
+      const isBare = repository.kind === "bare";
       return {
         mode: params.mode,
         cwd,
@@ -21990,25 +21991,11 @@ export class DesktopBackendRegistry {
         linkedDirectory: params.linkedDirectory,
         git: {
           kind,
-          repositoryState: "bare",
+          repositoryState: repository.kind,
           worktreeCreationAvailable: false,
-          unavailableReason:
-            "Bare Git repositories are not supported as handoff workspaces.",
-        },
-      };
-    }
-    if (repository.kind === "git_directory") {
-      return {
-        mode: params.mode,
-        cwd,
-        branch: repository.branch,
-        linkedDirectory: params.linkedDirectory,
-        git: {
-          kind,
-          repositoryState: "git_directory",
-          worktreeCreationAvailable: false,
-          unavailableReason:
-            "Git administration directories are not supported as handoff workspaces.",
+          unavailableReason: isBare
+            ? "Bare Git repositories are not supported as handoff workspaces."
+            : "Git administration directories are not supported as handoff workspaces.",
         },
       };
     }
@@ -22024,7 +22011,7 @@ export class DesktopBackendRegistry {
       linkedDirectory: params.linkedDirectory,
       git: {
         kind,
-        ...(!repository.hasCommits
+        ...(!repository.headHasCommit
           ? { repositoryState: "unborn" as const }
           : {}),
         worktreeCreationAvailable: repository.worktreeCreationAvailable,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1523,6 +1523,13 @@ type ThreadPullRequestWatchToolHandler = (
   args: WatchThreadPullRequestToolArgs,
 ) => PwrAgentThreadInspectionResponse | Promise<PwrAgentThreadInspectionResponse>;
 
+type DirectoryGitStatusWriter = (params: {
+  directory?: NavigationDirectorySummary;
+  directoryKey: string;
+  fetchedAt: number;
+  gitStatus?: NavigationDirectoryGitStatus;
+}) => void | Promise<void>;
+
 type ThreadPrAutoDispatchHandler = {
   preferenceChanged: (request: SetThreadPrAutoDispatchRequest) => Promise<void>;
   preferencesChanged?: (
@@ -6114,6 +6121,7 @@ export class DesktopBackendRegistry {
   private threadPullRequestWatchToolHandler:
     | ThreadPullRequestWatchToolHandler
     | undefined;
+  private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestCanonicalizer:
     | ThreadPullRequestCanonicalizer
@@ -6802,6 +6810,12 @@ export class DesktopBackendRegistry {
     handler: ThreadPullRequestWatchToolHandler | null | undefined,
   ): void {
     this.threadPullRequestWatchToolHandler = handler ?? undefined;
+  }
+
+  setDirectoryGitStatusWriter(
+    writer: DirectoryGitStatusWriter | null | undefined,
+  ): void {
+    this.directoryGitStatusWriter = writer ?? undefined;
   }
 
   setThreadPrAutoDispatchHandler(
@@ -8902,12 +8916,23 @@ export class DesktopBackendRegistry {
     for await (const entry of this.gitDirectoryService.readDirectoryStatusEntries(
       directories,
     )) {
+      const fetchedAt = Date.now();
+      const directory = this.navigationDirectoriesByKey.get(entry.directoryKey);
+      if (this.directoryGitStatusWriter) {
+        await this.directoryGitStatusWriter({
+          directory,
+          directoryKey: entry.directoryKey,
+          fetchedAt,
+          gitStatus: entry.gitStatus,
+        });
+        continue;
+      }
       const notification: NavigationDirectoryGitStatusUpdatedNotification = {
         method: "navigation/directoryGitStatus/updated",
         params: {
           directoryKey: entry.directoryKey,
           gitStatus: entry.gitStatus ?? null,
-          fetchedAt: Date.now(),
+          fetchedAt,
         },
       };
       await this.emit({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8866,6 +8866,10 @@ export class DesktopBackendRegistry {
     return this.gitDirectoryService.readDirectoryStatusEntries(directories);
   }
 
+  invalidateDirectoryStatus(directoryPath?: string): void {
+    this.gitDirectoryService.invalidateDirectoryStatus(directoryPath);
+  }
+
   readWorktreeWorkingStateEntries(
     worktreePaths: string[],
     options?: GitWorkingStateEntryOptions,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -341,7 +341,10 @@ import {
   GitDirectoryService,
   UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
 } from "./git-directory-service";
-import type { DirectoryGitStatusEntry } from "./git-directory-service";
+import type {
+  DirectoryGitStatusEntry,
+  GitWorkspaceInspection,
+} from "./git-directory-service";
 import { GitWorkingStateService } from "./git-working-state-service";
 import type {
   GitWorkingStateEntryOptions,
@@ -5736,8 +5739,8 @@ function buildHandoffTaskPrompt(params: {
       : []),
     ...(params.workspace.branch ? [`- Branch: ${params.workspace.branch}`] : []),
     `- Git: ${params.workspace.git.kind}`,
-    ...(params.workspace.git.kind !== "none"
-      && params.workspace.git.kind !== "non_git"
+    ...((params.workspace.git.kind === "git_local"
+      || params.workspace.git.kind === "git_worktree")
       && params.workspace.git.repositoryState
       ? [`- Git repository state: ${params.workspace.git.repositoryState}`]
       : []),
@@ -21972,7 +21975,26 @@ export class DesktopBackendRegistry {
         },
       };
     }
-    const repository = await this.gitDirectoryService.inspectWorkspaceGit(cwd);
+    let repository: GitWorkspaceInspection;
+    try {
+      repository = await this.gitDirectoryService.inspectWorkspaceGit(cwd);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      backendRegistryLog.warn("thread handoff Git workspace inspection failed", {
+        cwd,
+        error: detail,
+      });
+      return {
+        mode: params.mode,
+        cwd,
+        linkedDirectory: params.linkedDirectory,
+        git: {
+          kind: "unavailable",
+          worktreeCreationAvailable: false,
+          unavailableReason: `Git workspace inspection failed: ${detail}`,
+        },
+      };
+    }
     if (repository.kind === "non_git") {
       return {
         mode: params.mode,

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -538,7 +538,11 @@ function resolveDefaultBranch(params: {
   branches: string[];
   remoteHead: string;
 }): string | undefined {
-  const remoteHead = params.remoteHead.replace(/^origin\//, "").trim();
+  const remoteHead = params.remoteHead.trim();
+  const localRemoteHead = remoteHead.replace(/^origin\//, "");
+  if (localRemoteHead && params.branches.includes(localRemoteHead)) {
+    return localRemoteHead;
+  }
   if (remoteHead && params.branches.includes(remoteHead)) {
     return remoteHead;
   }
@@ -929,10 +933,10 @@ export class GitDirectoryService {
       0,
       MAX_TRACKED_COMMITS,
     );
-    // Resolve the default branch against the FULL list so a rarely-committed
-    // `main` is still found, then cap everything we hold/persist downstream.
+    // Resolve against the full local + remote list so an unborn checkout can
+    // retain its remote default even when a newer remote branch sorts first.
     const defaultBranch = resolveDefaultBranch({
-      branches: parsedBranchDetailsAll.map((detail) => detail.name),
+      branches: parsedBaseBranchDetailsAll.map((detail) => detail.name),
       remoteHead: branchInventory.remoteHead,
     });
     const parsedBranchDetails = capRecentBranchDetails(parsedBranchDetailsAll, {

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -29,7 +29,10 @@ export type GitWorkspaceInspection =
   | {
       kind: "worktree";
       branch?: string;
+      /** Whether any repository ref resolves to a commit. */
       hasCommits: boolean;
+      /** Whether the selected workspace's HEAD resolves to a commit. */
+      headHasCommit: boolean;
       worktreeCreationAvailable: boolean;
     }
   | {
@@ -120,17 +123,13 @@ export async function inspectGitWorkspace(
     kind = bareRepository === "true" ? "bare" : "git_directory";
   }
 
-  const [rawBranch, anyCommit, worktreeBaseCommit] = await Promise.all([
+  const [rawBranch, anyCommit] = await Promise.all([
     runGit(cwd, ["branch", "--show-current"], options.env),
     runGit(cwd, ["rev-list", "--max-count=1", "--all"], options.env),
-    runGit(
-      cwd,
-      ["rev-list", "--max-count=1", "--branches", "--remotes=origin/HEAD"],
-      options.env,
-    ),
   ]);
   const hasCommits = Boolean(anyCommit.trim());
-  const branch = rawBranch.trim() || (hasCommits ? "HEAD" : undefined);
+  const currentBranch = rawBranch.trim();
+  const branch = currentBranch || (hasCommits ? "HEAD" : undefined);
   if (kind !== "worktree") {
     return {
       kind,
@@ -140,11 +139,34 @@ export async function inspectGitWorkspace(
     };
   }
 
+  let headHasCommit = true;
+  try {
+    await runGit(
+      cwd,
+      ["rev-parse", "--verify", "--quiet", "HEAD^{commit}"],
+      options.env,
+    );
+  } catch (error) {
+    if (!currentBranch) {
+      throw error;
+    }
+    const currentBranchObject = await runGit(
+      cwd,
+      ["for-each-ref", "--format=%(objectname)", `refs/heads/${currentBranch}`],
+      options.env,
+    );
+    if (currentBranchObject.trim()) {
+      throw error;
+    }
+    headHasCommit = false;
+  }
+
   return {
     kind,
     branch,
     hasCommits,
-    worktreeCreationAvailable: Boolean(worktreeBaseCommit.trim()),
+    headHasCommit,
+    worktreeCreationAvailable: hasCommits,
   };
 }
 

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -395,13 +395,6 @@ async function readPrimaryWorktreePath(
   return parseGitWorktreeEntries(worktreeList)[0]?.path;
 }
 
-function parseGitLines(output: string): string[] {
-  return output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean);
-}
-
 /**
  * Parses `for-each-ref refs/heads` output formatted as
  * `<short-name>\t<committerdate:unix>`, preserving the input order (which the
@@ -622,7 +615,7 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   }
 
   const sourceRoot = params.sourceRoot ?? params.repoRoot;
-  const [rawCurrentBranch, branchesOutput, remoteHead] = await Promise.all([
+  const [rawCurrentBranch, baseBranchesOutput, remoteHead] = await Promise.all([
     runGit(sourceRoot, ["rev-parse", "--abbrev-ref", "HEAD"], params.gitEnv).catch(
       () => "",
     ),
@@ -631,8 +624,9 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
       [
         "for-each-ref",
         "refs/heads",
+        "refs/remotes",
         "--sort=-committerdate",
-        "--format=%(refname:short)",
+        "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
       ],
       params.gitEnv,
     ).catch(() => ""),
@@ -643,12 +637,17 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
     ).catch(() => ""),
   ]);
   const currentBranch = rawCurrentBranch.trim() === "HEAD" ? "" : rawCurrentBranch;
-  const branches = parseGitLines(branchesOutput);
-  const defaultBranch = resolveDefaultBranch({ branches, remoteHead });
+  const baseBranches = parseGitBaseBranchDetails(baseBranchesOutput).map(
+    (detail) => detail.name,
+  );
+  const defaultBranch = resolveDefaultBranch({
+    branches: baseBranches,
+    remoteHead,
+  });
   const candidates = uniqueBranches([
     currentBranch,
     defaultBranch,
-    ...branches,
+    ...baseBranches,
   ]);
 
   for (const branch of candidates) {

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -604,15 +604,19 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
   repoRoot: string;
   sourceRoot?: string;
   requestedBranch?: string;
+  requireLocalBranch?: boolean;
   gitEnv?: NodeJS.ProcessEnv;
   runGit?: GitCommandRunner;
 }): Promise<string | undefined> {
   const runGit = params.runGit ?? defaultRunGit;
   const requestedBranch = sanitizeBranchName(params.requestedBranch ?? "");
   if (requestedBranch && requestedBranch !== "HEAD") {
+    const requestedRef = params.requireLocalBranch
+      ? `refs/heads/${requestedBranch}`
+      : requestedBranch;
     const commit = await runGit(
       params.repoRoot,
-      ["rev-parse", "--verify", `${requestedBranch}^{commit}`],
+      ["rev-parse", "--verify", `${requestedRef}^{commit}`],
       params.gitEnv,
     ).catch(() => "");
     return commit ? requestedBranch : undefined;
@@ -628,7 +632,7 @@ async function resolveVerifiedWorktreeBaseBranch(params: {
       [
         "for-each-ref",
         "refs/heads",
-        "refs/remotes",
+        ...(params.requireLocalBranch ? [] : ["refs/remotes"]),
         "--sort=-committerdate",
         "--format=%(refname)%09%(refname:short)%09%(committerdate:unix)%09%(symref)",
       ],
@@ -1248,6 +1252,7 @@ export class GitDirectoryService {
       gitEnv: this.gitEnv,
       repoRoot,
       requestedBranch: launchpad.branchName,
+      requireLocalBranch: launchpad.worktreeBranchMode === "attached",
       runGit: this.runGitCommand,
       sourceRoot,
     });

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -42,6 +42,9 @@ export type GitWorkspaceInspection =
       worktreeCreationAvailable: false;
     };
 
+export const UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON =
+  "Worktrees are unavailable because this repository has no published base branch yet. Create the initial commit in the Local checkout and publish the default branch. Worktrees will be enabled once a remote base branch is available.";
+
 // Directory/worktree identifiers are surfaced to the rest of the app
 // (thread links, navigation, cleanup results) as stable string keys.
 // `path.resolve`/`path.join` emit backslashes on Windows, so normalize
@@ -160,13 +163,22 @@ export async function inspectGitWorkspace(
     }
     headHasCommit = false;
   }
+  let remoteBranchCommit = "";
+  if (!headHasCommit) {
+    remoteBranchCommit = await runGit(
+      cwd,
+      ["rev-list", "--max-count=1", "--remotes"],
+      options.env,
+    );
+  }
 
   return {
     kind,
     branch,
     hasCommits,
     headHasCommit,
-    worktreeCreationAvailable: hasCommits,
+    worktreeCreationAvailable:
+      headHasCommit || Boolean(remoteBranchCommit.trim()),
   };
 }
 
@@ -879,21 +891,23 @@ export class GitDirectoryService {
       rawCurrentBranch,
       branchInventory,
       recentCommitsOutput,
+      workspaceInspection,
     ] = await Promise.all([
-        runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
-          () => "",
-        ),
-        this.readBranchInventory({ commonGitDir, repoRoot }),
-        runGit(
-          repoRoot,
-          [
-            "log",
-            `--max-count=${MAX_TRACKED_COMMITS}`,
-            "--format=%H%x1f%h%x1f%ct%x1f%s",
-          ],
-          gitEnv,
-        ).catch(() => ""),
-      ]);
+      runGit(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"], gitEnv).catch(
+        () => "",
+      ),
+      this.readBranchInventory({ commonGitDir, repoRoot }),
+      runGit(
+        repoRoot,
+        [
+          "log",
+          `--max-count=${MAX_TRACKED_COMMITS}`,
+          "--format=%H%x1f%h%x1f%ct%x1f%s",
+        ],
+        gitEnv,
+      ).catch(() => ""),
+      inspectGitWorkspace(cwd, { env: gitEnv, runGit }),
+    ]);
     const currentBranch =
       rawCurrentBranch.trim() === "HEAD" ? "" : rawCurrentBranch.trim();
     const upstreamBranch = await runGit(
@@ -932,6 +946,19 @@ export class GitDirectoryService {
     });
     const branches = parsedBranchDetails.map((detail) => detail.name);
     const baseBranches = parsedBaseBranchDetails.map((detail) => detail.name);
+    const unbornWorktreeAvailability =
+      workspaceInspection.kind === "worktree" && !workspaceInspection.headHasCommit
+        ? {
+            worktreeCreationAvailable:
+              workspaceInspection.worktreeCreationAvailable,
+            ...(!workspaceInspection.worktreeCreationAvailable
+              ? {
+                  worktreeCreationUnavailableReason:
+                    UNPUBLISHED_BASE_BRANCH_WORKTREE_REASON,
+                }
+              : {}),
+          }
+        : {};
     const worktreeBranchNames = new Set(
       parseGitWorktreeEntries(branchInventory.worktreeList)
         .map((entry) => entry.branch)
@@ -951,6 +978,7 @@ export class GitDirectoryService {
       );
     if (!currentBranch) {
       return {
+        ...unbornWorktreeAvailability,
         defaultBranch,
         branches,
         baseBranches,
@@ -971,6 +999,7 @@ export class GitDirectoryService {
 
     if (!upstreamBranch) {
       return {
+        ...unbornWorktreeAvailability,
         currentBranch,
         defaultBranch,
         branches,
@@ -1003,6 +1032,7 @@ export class GitDirectoryService {
             : "in-sync";
 
     return {
+      ...unbornWorktreeAvailability,
       currentBranch,
       upstreamBranch,
       ahead,
@@ -1189,6 +1219,19 @@ export class GitDirectoryService {
       this.gitEnv,
     );
     if (!sourceRoot) {
+      return {
+        cwd: directoryPath,
+        workMode: "local",
+      };
+    }
+    const workspaceInspection = await inspectGitWorkspace(directoryPath, {
+      env: this.gitEnv,
+      runGit: this.runGitCommand,
+    });
+    if (
+      workspaceInspection.kind !== "worktree"
+      || !workspaceInspection.worktreeCreationAvailable
+    ) {
       return {
         cwd: directoryPath,
         workMode: "local",

--- a/apps/desktop/src/main/app-server/git-directory-service.ts
+++ b/apps/desktop/src/main/app-server/git-directory-service.ts
@@ -24,6 +24,21 @@ type GitCommandRunner = (
   env?: NodeJS.ProcessEnv,
 ) => Promise<string>;
 
+export type GitWorkspaceInspection =
+  | { kind: "non_git" }
+  | {
+      kind: "worktree";
+      branch?: string;
+      hasCommits: boolean;
+      worktreeCreationAvailable: boolean;
+    }
+  | {
+      kind: "bare" | "git_directory";
+      branch?: string;
+      hasCommits: boolean;
+      worktreeCreationAvailable: false;
+    };
+
 // Directory/worktree identifiers are surfaced to the rest of the app
 // (thread links, navigation, cleanup results) as stable string keys.
 // `path.resolve`/`path.join` emit backslashes on Windows, so normalize
@@ -64,7 +79,73 @@ function errorText(error: unknown): string {
 }
 
 function isNotGitRepositoryError(error: unknown): boolean {
-  return errorText(error).includes("not a git repository");
+  return errorText(error).toLowerCase().includes("not a git repository");
+}
+
+export async function inspectGitWorkspace(
+  cwd: string,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    runGit?: GitCommandRunner;
+  } = {},
+): Promise<GitWorkspaceInspection> {
+  const runGit = options.runGit ?? defaultRunGit;
+  let insideWorktree: string;
+  try {
+    insideWorktree = (
+      await runGit(cwd, ["rev-parse", "--is-inside-work-tree"], options.env)
+    ).trim();
+  } catch (error) {
+    if (isNotGitRepositoryError(error)) {
+      return { kind: "non_git" };
+    }
+    throw error;
+  }
+  if (insideWorktree !== "true" && insideWorktree !== "false") {
+    throw new Error(
+      `Git returned an unexpected workspace probe result for ${cwd}: ${insideWorktree}`,
+    );
+  }
+
+  let kind: Exclude<GitWorkspaceInspection["kind"], "non_git"> = "worktree";
+  if (insideWorktree === "false") {
+    const bareRepository = (
+      await runGit(cwd, ["rev-parse", "--is-bare-repository"], options.env)
+    ).trim();
+    if (bareRepository !== "true" && bareRepository !== "false") {
+      throw new Error(
+        `Git returned an unexpected bare-repository probe result for ${cwd}: ${bareRepository}`,
+      );
+    }
+    kind = bareRepository === "true" ? "bare" : "git_directory";
+  }
+
+  const [rawBranch, anyCommit, worktreeBaseCommit] = await Promise.all([
+    runGit(cwd, ["branch", "--show-current"], options.env),
+    runGit(cwd, ["rev-list", "--max-count=1", "--all"], options.env),
+    runGit(
+      cwd,
+      ["rev-list", "--max-count=1", "--branches", "--remotes=origin/HEAD"],
+      options.env,
+    ),
+  ]);
+  const hasCommits = Boolean(anyCommit.trim());
+  const branch = rawBranch.trim() || (hasCommits ? "HEAD" : undefined);
+  if (kind !== "worktree") {
+    return {
+      kind,
+      branch,
+      hasCommits,
+      worktreeCreationAvailable: false,
+    };
+  }
+
+  return {
+    kind,
+    branch,
+    hasCommits,
+    worktreeCreationAvailable: Boolean(worktreeBaseCommit.trim()),
+  };
 }
 
 async function readGitRoot(
@@ -659,6 +740,13 @@ export class GitDirectoryService {
     const resolveStorage = normalized.resolveWorktreeStorage;
     this.resolveStorage = async () =>
       (await resolveStorage?.()) ?? DESKTOP_WORKTREE_STORAGE_DEFAULT;
+  }
+
+  async inspectWorkspaceGit(cwd: string): Promise<GitWorkspaceInspection> {
+    return await inspectGitWorkspace(cwd, {
+      env: this.gitEnv,
+      runGit: this.runGitCommand,
+    });
   }
 
   async readDirectoryStatuses(

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -32,6 +32,8 @@ import type {
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeRequest,
   QueueThreadExecutionModeResponse,
+  RefreshDirectoryGitStatusesRequest,
+  RefreshDirectoryGitStatusesResponse,
   RenameThreadRequest,
   RenameThreadResponse,
   RunCodexEnvironmentActionRequest,
@@ -85,6 +87,7 @@ export const FEDERATION_BACKEND_METHODS = {
   runCodexEnvironmentAction: "backend.runCodexEnvironmentAction",
   stopCodexEnvironmentAction: "backend.stopCodexEnvironmentAction",
   setCodexThreadEnvironment: "backend.setCodexThreadEnvironment",
+  refreshDirectoryGitStatuses: "backend.refreshDirectoryGitStatuses",
   materializeDirectoryLaunchpad: "backend.materializeDirectoryLaunchpad",
   handoffThreadWorkspace: "backend.handoffThreadWorkspace",
   renameThread: "backend.renameThread",
@@ -136,6 +139,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.runCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.stopCodexEnvironmentAction]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment]: "environment_actions",
+  [FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.materializeDirectoryLaunchpad]: "environment_actions",
   [FEDERATION_BACKEND_METHODS.handoffThreadWorkspace]: "turn_control",
   [FEDERATION_BACKEND_METHODS.renameThread]: "turn_control",
@@ -199,6 +203,9 @@ export type FederationBackendOperations = {
   setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse>;
+  refreshDirectoryGitStatuses(
+    request: RefreshDirectoryGitStatusesRequest,
+  ): Promise<RefreshDirectoryGitStatusesResponse>;
   materializeDirectoryLaunchpad(
     request: MaterializeDirectoryLaunchpadRequest,
     options?: MaterializeDirectoryLaunchpadOptions,
@@ -384,6 +391,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.setCodexThreadEnvironment(
         envelope.params as SetCodexThreadEnvironmentRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
+    async (envelope) =>
+      await params.backend.refreshDirectoryGitStatuses(
+        envelope.params as RefreshDirectoryGitStatusesRequest,
       ),
   );
   params.router.registerHandler(
@@ -622,6 +636,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<SetCodexThreadEnvironmentResponse> {
     return await this.rpc.request<SetCodexThreadEnvironmentResponse>({
       method: FEDERATION_BACKEND_METHODS.setCodexThreadEnvironment,
+      params: request,
+    });
+  }
+
+  async refreshDirectoryGitStatuses(
+    request: RefreshDirectoryGitStatusesRequest,
+  ): Promise<RefreshDirectoryGitStatusesResponse> {
+    return await this.rpc.request<RefreshDirectoryGitStatusesResponse>({
+      method: FEDERATION_BACKEND_METHODS.refreshDirectoryGitStatuses,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -22,6 +22,7 @@ import type {
   MaterializeDirectoryLaunchpadResponse,
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
+  RefreshDirectoryGitStatusesResponse,
   RenameThreadResponse,
   RunCodexEnvironmentActionResponse,
   SetAcpSessionRuntimeOptionResponse,
@@ -54,6 +55,7 @@ import {
   type NavigationSnapshot,
   type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
+  type RefreshDirectoryGitStatusesRequest,
   type RenameThreadRequest,
   type RunCodexEnvironmentActionRequest,
   type SetAcpSessionRuntimeOptionRequest,
@@ -1168,6 +1170,11 @@ function localBackendOperations(): FederationBackendOperations {
       request: SetCodexThreadEnvironmentRequest,
     ): Promise<SetCodexThreadEnvironmentResponse> {
       return await getDesktopBackendRegistry().setCodexThreadEnvironment(request);
+    },
+    async refreshDirectoryGitStatuses(
+      request: RefreshDirectoryGitStatusesRequest,
+    ): Promise<RefreshDirectoryGitStatusesResponse> {
+      return await getDesktopBackendRegistry().refreshDirectoryGitStatuses(request);
     },
     async materializeDirectoryLaunchpad(
       request: MaterializeDirectoryLaunchpadRequest,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2461,7 +2461,7 @@ class DesktopAppServerService {
     }
   }
 
-  private async writeDirectoryGitStatusEntry(params: {
+  async writeDirectoryGitStatusEntry(params: {
     directory?: NavigationSnapshot["directories"][number];
     directoryKey: string;
     fetchedAt: number;
@@ -5959,6 +5959,9 @@ export function registerAppServerIpcHandlers(): void {
   getDesktopBackendRegistry().setThreadPullRequestWatchToolHandler(
     async (args) => await appServerService.watchThreadPullRequestForTool(args),
   );
+  getDesktopBackendRegistry().setDirectoryGitStatusWriter(
+    async (params) => await appServerService.writeDirectoryGitStatusEntry(params),
+  );
   getDesktopBackendRegistry().setThreadPrAutoDispatchHandler({
     preferenceChanged: async (request) =>
       await appServerService.handleThreadPrAutoDispatchPreference(request),
@@ -6587,6 +6590,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   registry?.setThreadPullRequestStatusToolHandler(undefined);
   registry?.setThreadPullRequestCanonicalizer(undefined);
   registry?.setThreadPullRequestWatchToolHandler(undefined);
+  registry?.setDirectoryGitStatusWriter(undefined);
   registry?.setThreadPrAutoDispatchHandler(undefined);
   await appServerService.close();
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2177,6 +2177,15 @@ class DesktopAppServerService {
   async refreshDirectoryGitStatusesForKeys(
     request: RefreshDirectoryGitStatusesRequest,
   ): Promise<RefreshDirectoryGitStatusesResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .refreshDirectoryGitStatuses(remoteRequest);
+    }
     await this.loadDirectoryGitStatusCache();
     const directoryKeys = [
       ...new Set(request.directoryKeys.map((key) => key.trim()).filter(Boolean)),

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2244,7 +2244,10 @@ class DesktopAppServerService {
       automaticLimit: STARTUP_DIRECTORY_GIT_STATUS_REFRESH_LIMIT,
     });
 
-    const promise = this.refreshDirectoryGitStatuses(directories)
+    const promise = this.refreshDirectoryGitStatuses(
+      directories,
+      params.force === true,
+    )
       .catch((error) => {
         logDebug("directoryGitStatusRefresh:failed", {
           error: error instanceof Error ? error.message : String(error),
@@ -2421,6 +2424,7 @@ class DesktopAppServerService {
 
   private async refreshDirectoryGitStatuses(
     directories: NavigationSnapshot["directories"],
+    force = false,
   ): Promise<void> {
     const refreshableDirectories = directories.filter((directory) => directory.path?.trim());
     if (refreshableDirectories.length === 0) {
@@ -2428,6 +2432,11 @@ class DesktopAppServerService {
     }
 
     const registry = getDesktopBackendRegistry();
+    if (force) {
+      for (const directory of refreshableDirectories) {
+        registry.invalidateDirectoryStatus(directory.path);
+      }
+    }
     const directoryByKey = new Map(
       refreshableDirectories.map((directory) => [directory.key, directory]),
     );

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -16212,11 +16212,16 @@ function newThreadOptionsForSession(
 function canCreateNewThreadWorktree(
   directory: NavigationDirectorySummary | undefined,
 ): boolean {
+  if (!directory?.path || directory.kind !== "directory") {
+    return false;
+  }
+  if (directory.gitStatus?.worktreeCreationAvailable !== undefined) {
+    return directory.gitStatus.worktreeCreationAvailable;
+  }
   return Boolean(
-    directory?.path &&
-      directory.kind === "directory" &&
-      (directory.gitStatus?.currentBranch ||
-        (directory.gitStatus?.branches?.length ?? 0) > 0),
+    directory.gitStatus?.currentBranch
+    || (directory.gitStatus?.baseBranches?.length ?? 0) > 0
+    || (directory.gitStatus?.branches?.length ?? 0) > 0,
   );
 }
 
@@ -16376,6 +16381,7 @@ function resolveNewThreadBaseBranch(
   return (
     sanitizeBranchLabel(session.branchName) ??
     sanitizeBranchLabel(selectedDirectory?.gitStatus?.defaultBranch) ??
+    sanitizeBranchLabel(selectedDirectory?.gitStatus?.baseBranches?.[0]) ??
     sanitizeBranchLabel(selectedDirectory?.gitStatus?.branches?.[0]) ??
     sanitizeBranchLabel(selectedDirectory?.gitStatus?.currentBranch) ??
     "main"
@@ -16390,6 +16396,7 @@ function newThreadBranchChoices(
   const defaultBranch = resolveNewThreadBaseBranch(session, navigation, directory);
   const branches = [
     defaultBranch,
+    ...(directory?.gitStatus?.baseBranches ?? []),
     ...(directory?.gitStatus?.branches ?? []),
     directory?.gitStatus?.currentBranch,
   ].flatMap((branch) => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1784,6 +1784,7 @@ function ComposerDropdown(props: {
   kind?: "branch";
   tone?: "danger";
   onChange: (value: string) => void;
+  onPointerEnter?: () => void;
   options: ComposerDropdownOption[];
   tooltip?: string;
   value: string;
@@ -1808,6 +1809,7 @@ function ComposerDropdown(props: {
         .filter(Boolean)
         .join(" ")}
       data-tooltip={props.tooltip}
+      onPointerEnter={props.onPointerEnter}
       ref={ref}
     >
       <button
@@ -9981,6 +9983,17 @@ export function Composer(props: ComposerProps) {
               tooltip={
                 props.directory?.gitStatus?.worktreeCreationAvailable === false
                   ? props.directory.gitStatus.worktreeCreationUnavailableReason
+                  : undefined
+              }
+              onPointerEnter={
+                props.directory?.gitStatus?.worktreeCreationAvailable === false
+                && props.desktopApi?.refreshDirectoryGitStatuses
+                  ? () => {
+                      void props.desktopApi?.refreshDirectoryGitStatuses?.({
+                        directoryKeys: [props.launchpad!.directoryKey],
+                        force: true,
+                      });
+                    }
                   : undefined
               }
               onChange={(value) => {

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1785,6 +1785,7 @@ function ComposerDropdown(props: {
   tone?: "danger";
   onChange: (value: string) => void;
   options: ComposerDropdownOption[];
+  tooltip?: string;
   value: string;
 }) {
   const [open, setOpen] = useState(false);
@@ -1801,13 +1802,16 @@ function ComposerDropdown(props: {
         props.compact ? "composer-dropdown--compact" : "",
         props.kind === "branch" ? "composer-dropdown--branch" : "",
         props.tone === "danger" ? "composer-dropdown--danger" : "",
+        props.tooltip ? "tooltip-target" : "",
         open ? "composer-dropdown--open" : "",
       ]
         .filter(Boolean)
         .join(" ")}
+      data-tooltip={props.tooltip}
       ref={ref}
     >
       <button
+        aria-description={props.tooltip}
         aria-controls={open ? listboxId : undefined}
         aria-expanded={open}
         aria-haspopup="listbox"
@@ -9974,6 +9978,11 @@ export function Composer(props: ComposerProps) {
                 label: option.label,
                 value: option.value,
               }))}
+              tooltip={
+                props.directory?.gitStatus?.worktreeCreationAvailable === false
+                  ? props.directory.gitStatus.worktreeCreationUnavailableReason
+                  : undefined
+              }
               onChange={(value) => {
                 handleLaunchpadPatch({
                   workMode: value as NavigationLaunchpadDraft["workMode"],
@@ -11227,9 +11236,11 @@ function buildLaunchpadWorkspaceOptions(
   }
 
   const canCreateWorktree = Boolean(
-    directory?.path &&
+    directory?.gitStatus?.worktreeCreationAvailable !== false &&
+      directory?.path &&
       directory.kind === "directory" &&
-      (directory.gitStatus?.currentBranch ||
+      (directory.gitStatus?.worktreeCreationAvailable === true ||
+        directory.gitStatus?.currentBranch ||
         (directory.gitStatus?.branches?.length ?? 0) > 0 ||
         (launchpad.workMode === "worktree" &&
           Boolean(launchpad.parentThreadId)))

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -10966,6 +10966,59 @@ describe("Composer", () => {
     expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
   });
 
+  it("keeps unpublished unborn repositories local and explains why", () => {
+    const unavailableReason =
+      "Worktrees are unavailable because this repository has no published base branch yet. Create the initial commit in the Local checkout and publish the default branch. Worktrees will be enabled once a remote base branch is available.";
+
+    render(
+      <Composer
+        backends={[backendSummary("codex")]}
+        directory={{
+          key: "directory:/Users/huntharo/pwrdrvr/UnbornRepo",
+          kind: "directory",
+          label: "UnbornRepo",
+          path: "/Users/huntharo/pwrdrvr/UnbornRepo",
+          threadKeys: [],
+          needsAttentionCount: 0,
+          gitStatus: {
+            defaultBranch: "seed",
+            branches: ["seed"],
+            baseBranches: ["seed"],
+            syncState: "untracked",
+            worktreeCreationAvailable: false,
+            worktreeCreationUnavailableReason: unavailableReason,
+          },
+        }}
+        launchpad={{
+          directoryKey: "directory:/Users/huntharo/pwrdrvr/UnbornRepo",
+          directoryKind: "directory",
+          directoryLabel: "UnbornRepo",
+          directoryPath: "/Users/huntharo/pwrdrvr/UnbornRepo",
+          backend: "codex",
+          executionMode: "default",
+          prompt: "",
+          workMode: "worktree",
+          branchName: "seed",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+        onUpdateLaunchpad={async () => undefined}
+        skills={[]}
+      />
+    );
+
+    const workspaceMode = screen.getByLabelText("Workspace mode");
+    expect(workspaceMode).toBeDisabled();
+    expect(workspaceMode).toHaveValue("local");
+    expect(workspaceMode).toHaveTextContent("Local");
+    expect(workspaceMode).toHaveAttribute("aria-description", unavailableReason);
+    expect(workspaceMode.closest(".composer-dropdown")).toHaveAttribute(
+      "data-tooltip",
+      unavailableReason,
+    );
+    expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
+  });
+
   it("renders the worktree base branch menu as a branch chooser", () => {
     render(
       <Composer

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -10966,13 +10966,15 @@ describe("Composer", () => {
     expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
   });
 
-  it("keeps unpublished unborn repositories local and explains why", () => {
+  it("keeps unpublished unborn repositories local and refreshes Git status on hover", () => {
     const unavailableReason =
       "Worktrees are unavailable because this repository has no published base branch yet. Create the initial commit in the Local checkout and publish the default branch. Worktrees will be enabled once a remote base branch is available.";
+    const refreshDirectoryGitStatuses = vi.fn(async () => ({ scheduledCount: 1 }));
 
     render(
       <Composer
         backends={[backendSummary("codex")]}
+        desktopApi={{ refreshDirectoryGitStatuses } as DesktopApi}
         directory={{
           key: "directory:/Users/huntharo/pwrdrvr/UnbornRepo",
           kind: "directory",
@@ -11016,6 +11018,11 @@ describe("Composer", () => {
       "data-tooltip",
       unavailableReason,
     );
+    fireEvent.pointerEnter(workspaceMode.closest(".composer-dropdown")!);
+    expect(refreshDirectoryGitStatuses).toHaveBeenCalledExactlyOnceWith({
+      directoryKeys: ["directory:/Users/huntharo/pwrdrvr/UnbornRepo"],
+      force: true,
+    });
     expect(screen.queryByRole("option", { name: "New worktree" })).not.toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/federation-desktop-api.test.ts
@@ -3,10 +3,14 @@ import type { DesktopApi } from "../desktop-api";
 import { scopeDesktopApiToFederationTarget } from "../federation-desktop-api";
 
 describe("scopeDesktopApiToFederationTarget", () => {
-  it("routes application opens remotely and removes local path helpers", async () => {
+  it("routes remote filesystem operations to the owning peer and removes local path helpers", async () => {
     const openApplication = vi.fn(async () => ({ opened: true }));
+    const refreshDirectoryGitStatuses = vi.fn(async () => ({
+      scheduledCount: 1,
+    }));
     const desktopApi = {
       openApplication,
+      refreshDirectoryGitStatuses,
       openPath: vi.fn(),
       revealPath: vi.fn(),
       readMarkdownFile: vi.fn(),
@@ -28,11 +32,20 @@ describe("scopeDesktopApiToFederationTarget", () => {
       kind: "editor",
       targetPath: "/remote/repo/file.ts",
     });
+    await scopedApi?.refreshDirectoryGitStatuses?.({
+      directoryKeys: ["directory:/remote/repo"],
+      force: true,
+    });
 
     expect(openApplication).toHaveBeenCalledWith({
       applicationId: "vscode",
       kind: "editor",
       targetPath: "/remote/repo/file.ts",
+      federationTarget,
+    });
+    expect(refreshDirectoryGitStatuses).toHaveBeenCalledWith({
+      directoryKeys: ["directory:/remote/repo"],
+      force: true,
       federationTarget,
     });
     expect(scopedApi?.openPath).toBeUndefined();

--- a/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/federation-desktop-api.ts
@@ -9,11 +9,18 @@ export function scopeDesktopApiToFederationTarget(
     return desktopApi;
   }
   const openApplication = desktopApi.openApplication;
+  const refreshDirectoryGitStatuses = desktopApi.refreshDirectoryGitStatuses;
 
   return {
     ...desktopApi,
     openApplication: openApplication
       ? async (request) => await openApplication({
+          ...request,
+          federationTarget,
+        })
+      : undefined,
+    refreshDirectoryGitStatuses: refreshDirectoryGitStatuses
+      ? async (request) => await refreshDirectoryGitStatuses({
           ...request,
           federationTarget,
         })

--- a/docs/federation-architecture.md
+++ b/docs/federation-architecture.md
@@ -54,8 +54,11 @@ The RPC surface maps navigation and thread reads plus the remote operation
 surface used by desktop windows and messaging. It includes thread creation,
 fork/review, turn start/steer/interrupt/compact, pending-request submission,
 model and execution settings, environment actions, environment setup progress,
-and workspace handoff. Capability checks remain attached to every method, so an
-older or restricted peer fails closed instead of silently executing locally.
+workspace handoff, and explicit directory Git-status refreshes. Directory
+refresh requests carry owner-known directory keys rather than viewer-resolved
+paths; the target instance resolves those keys and runs Git locally. Capability
+checks remain attached to every method, so an older or restricted peer fails
+closed instead of silently executing locally.
 
 ## Diagnostics
 

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -151,7 +151,7 @@ describe("thread orchestration tool contracts", () => {
     expect(result.groupedUnderThreadId).toBeUndefined();
   });
 
-  it("models unborn repositories as Git workspaces that cannot allocate worktrees", () => {
+  it("models empty unborn repositories as Git workspaces that cannot allocate worktrees", () => {
     const origin = {
       sourceBackend: "codex",
       sourceThreadId: "thread-parent",
@@ -175,6 +175,30 @@ describe("thread orchestration tool contracts", () => {
     expect(JSON.parse(JSON.stringify(origin))).toEqual(origin);
     expect(origin.workspace.git.kind).toBe("git_local");
     expect(origin.workspace.git.worktreeCreationAvailable).toBe(false);
+  });
+
+  it("models unborn repositories with fetched refs as worktree-capable", () => {
+    const origin = {
+      sourceBackend: "codex",
+      sourceThreadId: "thread-parent",
+      seedMode: "clean",
+      groupingMode: "none",
+      createdAt: 1_773_000_000_000,
+      workspace: {
+        mode: "project_local",
+        cwd: "/repo",
+        branch: "main",
+        git: {
+          kind: "git_local",
+          repositoryState: "unborn",
+          worktreeCreationAvailable: true,
+        },
+      },
+    } satisfies ThreadHandoffOrigin;
+
+    expect(JSON.parse(JSON.stringify(origin))).toEqual(origin);
+    expect(origin.workspace.git.repositoryState).toBe("unborn");
+    expect(origin.workspace.git.worktreeCreationAvailable).toBe(true);
   });
 
   it("models pending same-thread workspace moves separately from task handoffs", () => {

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -167,7 +167,7 @@ describe("thread orchestration tool contracts", () => {
           repositoryState: "unborn",
           worktreeCreationAvailable: false,
           unavailableReason:
-            "Repository has no commits yet; create the initial commit before allocating a worktree.",
+            "Worktrees are unavailable because this repository has no published base branch yet. Create the initial commit in the Local checkout and publish the default branch. Worktrees will be enabled once a remote base branch is available.",
         },
       },
     } satisfies ThreadHandoffOrigin;

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -201,6 +201,29 @@ describe("thread orchestration tool contracts", () => {
     expect(origin.workspace.git.worktreeCreationAvailable).toBe(true);
   });
 
+  it("models Git inspection failures without misclassifying the workspace", () => {
+    const origin = {
+      sourceBackend: "codex",
+      sourceThreadId: "thread-parent",
+      seedMode: "clean",
+      groupingMode: "none",
+      createdAt: 1_773_000_000_000,
+      workspace: {
+        mode: "project_local",
+        cwd: "/repo",
+        git: {
+          kind: "unavailable",
+          worktreeCreationAvailable: false,
+          unavailableReason:
+            "Git workspace inspection failed: fatal: bad object refs/heads/main",
+        },
+      },
+    } satisfies ThreadHandoffOrigin;
+
+    expect(JSON.parse(JSON.stringify(origin))).toEqual(origin);
+    expect(origin.workspace.git.kind).toBe("unavailable");
+  });
+
   it("models pending same-thread workspace moves separately from task handoffs", () => {
     expect(DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY).toBe("detached-changes");
 

--- a/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
+++ b/packages/shared/src/contracts/__tests__/thread-orchestration-tools.test.ts
@@ -151,6 +151,32 @@ describe("thread orchestration tool contracts", () => {
     expect(result.groupedUnderThreadId).toBeUndefined();
   });
 
+  it("models unborn repositories as Git workspaces that cannot allocate worktrees", () => {
+    const origin = {
+      sourceBackend: "codex",
+      sourceThreadId: "thread-parent",
+      seedMode: "clean",
+      groupingMode: "none",
+      createdAt: 1_773_000_000_000,
+      workspace: {
+        mode: "project_local",
+        cwd: "/repo",
+        branch: "main",
+        git: {
+          kind: "git_local",
+          repositoryState: "unborn",
+          worktreeCreationAvailable: false,
+          unavailableReason:
+            "Repository has no commits yet; create the initial commit before allocating a worktree.",
+        },
+      },
+    } satisfies ThreadHandoffOrigin;
+
+    expect(JSON.parse(JSON.stringify(origin))).toEqual(origin);
+    expect(origin.workspace.git.kind).toBe("git_local");
+    expect(origin.workspace.git.worktreeCreationAvailable).toBe(false);
+  });
+
   it("models pending same-thread workspace moves separately from task handoffs", () => {
     expect(DEFAULT_MOVE_THREAD_WORKSPACE_STRATEGY).toBe("detached-changes");
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -684,6 +684,9 @@ export type NavigationDirectoryGitStatus = {
   currentBranch?: string;
   defaultBranch?: string;
   upstreamBranch?: string;
+  /** Reported when the selected checkout has an unborn HEAD. */
+  worktreeCreationAvailable?: boolean;
+  worktreeCreationUnavailableReason?: string;
   ahead?: number;
   behind?: number;
   branches?: string[];

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -767,6 +767,8 @@ export type NavigationThreadGitWorkingStateUpdatedNotification = {
 
 export type RefreshDirectoryGitStatusesRequest = {
   directoryKeys: string[];
+  /** Route filesystem inspection to the instance that owns these directories. */
+  federationTarget?: FederationTarget;
   force?: boolean;
 };
 

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -276,6 +276,11 @@ export type ThreadHandoffOriginWorkspace = {
         unavailableReason: string;
       }
     | {
+        kind: "unavailable";
+        worktreeCreationAvailable: false;
+        unavailableReason: string;
+      }
+    | {
         kind: "git_local" | "git_worktree";
         repositoryState?: "unborn" | "bare" | "git_directory";
         worktreeCreationAvailable: boolean;

--- a/packages/shared/src/contracts/thread-orchestration-tools.ts
+++ b/packages/shared/src/contracts/thread-orchestration-tools.ts
@@ -277,6 +277,7 @@ export type ThreadHandoffOriginWorkspace = {
       }
     | {
         kind: "git_local" | "git_worktree";
+        repositoryState?: "unborn" | "bare" | "git_directory";
         worktreeCreationAvailable: boolean;
         unavailableReason?: string;
       };


### PR DESCRIPTION
## Summary

- classify initialized repositories with an unborn HEAD as Git workspaces
- expose additive `repositoryState` metadata for unborn, bare, and Git-administration-directory cases
- report that unborn repositories need an initial commit before PwrAgent can allocate a worktree
- include repository state and the worktree-unavailability reason in handoff prompts and tool responses

## Root cause

Handoff workspace metadata used `git rev-parse --abbrev-ref HEAD` as both a branch probe and a repository-existence probe. Git exits nonzero for that command when HEAD is unborn, so PwrAgent converted a valid initialized repository into `kind: "non_git"`.

The new Git-layer inspection separates worktree detection, branch discovery, commit availability, and worktree-base availability. Only Git's actual not-a-repository failure maps to `non_git`; unrelated probe errors propagate.

## Compatibility

Normal non-Git directories remain `non_git`. Ordinary repositories and existing worktrees retain their existing `git_local` / `git_worktree` metadata. The new `repositoryState` field is optional and additive.

Empty bare repositories are recognized as Git but reported as unsupported handoff workspaces. An initialized worktree whose configured origin is empty is recognized as `git_local`, `repositoryState: "unborn"`, and `worktreeCreationAvailable: false`.

## Validation

- focused Git-directory and shared-contract tests: 43 passed
- focused handoff boundary tests: 5 passed
- final targeted unborn/bare/non-Git regression tests: 7 passed
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; repository warning baseline only)
- `pnpm lint:boundaries`
