### PR TITLE
feat(federation): add Noise and Tailscale transports

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  CancelQueuedTurnRequest,
   CancelThreadExecutionModeQueueRequest,
   CompactThreadRequest,
   ForkThreadRequest,
@@ -118,6 +119,10 @@ const federationMock = vi.hoisted(() => {
       threadId: request.threadId,
       turnId: "remote-turn-1",
       queueStatus: "started" as const,
+    })),
+    cancelQueuedTurn: vi.fn(async (request: CancelQueuedTurnRequest) => ({
+      queueEntryId: request.queueEntryId,
+      cancelled: true,
     })),
     startReview: vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,
@@ -305,6 +310,7 @@ describe("agent ipc", () => {
       "../ipc/agent-ipc"
     );
     const {
+      AGENT_CANCEL_QUEUED_TURN_CHANNEL,
       AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
       AGENT_COMPACT_THREAD_CHANNEL,
       AGENT_FORK_THREAD_CHANNEL,
@@ -351,6 +357,10 @@ describe("agent ipc", () => {
       federationTarget,
       threadId: "thread-1",
       input: [{ type: "text", text: "Ship it" }],
+    });
+    await handlers.get(AGENT_CANCEL_QUEUED_TURN_CHANNEL)?.({}, {
+      federationTarget,
+      queueEntryId: "queue-1",
     });
     await handlers.get(AGENT_START_REVIEW_CHANNEL)?.({}, {
       backend: "codex",
@@ -455,6 +465,10 @@ describe("agent ipc", () => {
       threadId: "thread-1",
       input: [{ type: "text", text: "Ship it" }],
     });
+    expect(federationMock.remoteBackend.cancelQueuedTurn).toHaveBeenCalledWith({
+      queueEntryId: "queue-1",
+    });
+    expect(registry.cancelQueuedTurn).not.toHaveBeenCalled();
     expect(federationMock.remoteBackend.startReview).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -342,6 +342,31 @@ describe("DesktopSettingsService", () => {
     });
   });
 
+  it("persists and reuses a federation Noise static keypair", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const secretStore = new MemoryDesktopSecretStore();
+    const service = new DesktopSettingsService({ configPath, env: {}, secretStore });
+
+    const first = await service.getOrCreateFederationNoiseStaticKeyPair();
+    expect(first.privateKeyBase64.length).toBeGreaterThan(0);
+    expect(Buffer.from(first.publicKeyBase64, "base64").length).toBe(32);
+
+    // A fresh service over the same secret store reuses the persisted key.
+    const reopened = new DesktopSettingsService({ configPath, env: {}, secretStore });
+    const second = await reopened.getOrCreateFederationNoiseStaticKeyPair();
+    expect(second.privateKeyBase64).toBe(first.privateKeyBase64);
+    expect(second.publicKeyBase64).toBe(first.publicKeyBase64);
+
+    // Stored under its own secret name, distinct from the Ed25519 identity.
+    expect(await secretStore.getSecret("federationNoiseStaticPrivateKey")).toBe(
+      first.privateKeyBase64,
+    );
+    expect(
+      await secretStore.getSecret("federationInstancePrivateKey"),
+    ).toBeUndefined();
+  });
+
   it("defaults federation settings and exposes stored federation secrets", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -217,6 +217,11 @@ describe("DesktopSettingsService", () => {
       cloudflareMtlsEnabled: { value: true, source: "config" },
       cloudflareAccessServiceAuthEnabled: { value: true, source: "config" },
       instancePrivateKey: { configured: false, source: "unset", writable: true },
+      noiseStaticPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
       cloudflareClientCertificate: {
         configured: false,
         source: "unset",
@@ -390,6 +395,11 @@ describe("DesktopSettingsService", () => {
         source: "default",
       },
       instancePrivateKey: { configured: false, source: "unset", writable: true },
+      noiseStaticPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
     });
 
     await service.writeConfigPatch({

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -31,6 +31,10 @@ describe("federation backend bridge", () => {
         cleanup: [],
       })),
       startTurn: vi.fn(),
+      cancelQueuedTurn: vi.fn(async ({ queueEntryId }) => ({
+        queueEntryId,
+        cancelled: true,
+      })),
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -71,11 +75,27 @@ describe("federation backend bridge", () => {
         createdAt: 1_100,
       },
     });
+    await router.routeEnvelope({
+      sourcePeerId: "client_one",
+      envelope: {
+        id: "request-3",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
+        params: { queueEntryId: "queue-1" },
+        protocolVersion: 1,
+        sourceInstanceId: "client_one",
+        targetInstanceId: "gateway_one",
+        createdAt: 1_200,
+      },
+    });
 
     expect(backend.listThreads).toHaveBeenCalledWith({ backend: "codex" });
     expect(backend.archiveThread).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
+    });
+    expect(backend.cancelQueuedTurn).toHaveBeenCalledWith({
+      queueEntryId: "queue-1",
     });
     expect(replies).toMatchObject([
       {
@@ -92,6 +112,14 @@ describe("federation backend bridge", () => {
         result: {
           backend: "codex",
           threadId: "thread-1",
+        },
+      },
+      {
+        kind: "response",
+        requestId: "request-3",
+        result: {
+          queueEntryId: "queue-1",
+          cancelled: true,
         },
       },
     ]);
@@ -192,6 +220,31 @@ describe("federation backend bridge", () => {
       result: { scheduledCount: 1 },
     });
     await expect(refreshPending).resolves.toEqual({ scheduledCount: 1 });
+
+    const cancelPending = client.cancelQueuedTurn({ queueEntryId: "queue-1" });
+    const cancelRequest = sent.at(-1)!;
+    expect(cancelRequest).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
+      params: { queueEntryId: "queue-1" },
+    });
+    rpc.receiveEnvelope({
+      id: "response-4",
+      kind: "response",
+      requestId: cancelRequest.id,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_400,
+      result: {
+        queueEntryId: "queue-1",
+        cancelled: true,
+      },
+    });
+    await expect(cancelPending).resolves.toEqual({
+      queueEntryId: "queue-1",
+      cancelled: true,
+    });
   });
 
   it("executes directory Git status refreshes on the target instance", async () => {
@@ -353,6 +406,7 @@ describe("federation backend bridge", () => {
       startThread: vi.fn(),
       forkThread: vi.fn(),
       startTurn: vi.fn(),
+      cancelQueuedTurn: vi.fn(),
       startReview: vi.fn(),
       compactThread: vi.fn(async () => ({
         backend: "codex" as const,
@@ -517,6 +571,7 @@ describe("federation backend bridge", () => {
         startThread: vi.fn(),
         forkThread: vi.fn(),
         startTurn: vi.fn(),
+        cancelQueuedTurn: vi.fn(),
         startReview: vi.fn(),
         compactThread: vi.fn(),
         interruptTurn: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -61,17 +61,18 @@ describe("federation enrollment", () => {
     );
   });
 
-  it("rejects legacy invites before attempting enrollment", () => {
-    const legacyInvite = `pwragent-federation:${Buffer.from(JSON.stringify({
-      version: 1,
-      token: "legacy-token",
+  it("rejects unsupported invite versions before attempting enrollment", () => {
+    const unsupportedInvite = `pwragent-federation:${Buffer.from(JSON.stringify({
+      version: FEDERATION_INVITE_VERSION + 1,
+      token: "unsupported-token",
       gatewayInstanceId: "gateway_one",
-      gatewayPublicKeyPem: "legacy-key",
+      gatewayPublicKeyPem: "unsupported-key",
+      gatewayNoisePublicKey: "unsupported-noise-key",
       gatewayUrl: "ws://127.0.0.1:47830",
       expiresAt: 2_000,
     }), "utf8").toString("base64url")}`;
 
-    expect(() => decodeFederationInvite(legacyInvite, 1_000)).toThrow(
+    expect(() => decodeFederationInvite(unsupportedInvite, 1_000)).toThrow(
       `Unsupported federation invite version. Expected version ${FEDERATION_INVITE_VERSION}.`,
     );
   });

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -33,13 +33,15 @@ afterEach(() => {
 });
 
 describe("federation enrollment", () => {
-  it("carries the pinned gateway public key in a one-time invite", () => {
+  it("carries the pinned gateway signing and Noise keys in a one-time invite", () => {
     const gatewayKeyPair = generateFederationIdentityKeyPair();
+    const gatewayNoisePublicKey = "gateway-noise-public-key";
     const invite = encodeFederationInvite({
       version: 1,
       token: "invite-token-1234567890",
       gatewayInstanceId: "gateway_one",
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      gatewayNoisePublicKey,
       gatewayUrl: "ws://127.0.0.1:47830",
       expiresAt: 2_000,
     });
@@ -49,6 +51,7 @@ describe("federation enrollment", () => {
       token: "invite-token-1234567890",
       gatewayInstanceId: "gateway_one",
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      gatewayNoisePublicKey,
       gatewayUrl: "ws://127.0.0.1:47830",
       expiresAt: 2_000,
     });

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FEDERATION_INVITE_VERSION } from "@pwragent/shared";
 import {
   buildFederationProofMessage,
   completeFederationEnrollment,
@@ -37,7 +38,7 @@ describe("federation enrollment", () => {
     const gatewayKeyPair = generateFederationIdentityKeyPair();
     const gatewayNoisePublicKey = "gateway-noise-public-key";
     const invite = encodeFederationInvite({
-      version: 1,
+      version: FEDERATION_INVITE_VERSION,
       token: "invite-token-1234567890",
       gatewayInstanceId: "gateway_one",
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
@@ -47,7 +48,7 @@ describe("federation enrollment", () => {
     });
 
     expect(decodeFederationInvite(invite, 1_000)).toEqual({
-      version: 1,
+      version: FEDERATION_INVITE_VERSION,
       token: "invite-token-1234567890",
       gatewayInstanceId: "gateway_one",
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
@@ -57,6 +58,21 @@ describe("federation enrollment", () => {
     });
     expect(() => decodeFederationInvite(invite, 2_000)).toThrow(
       "Federation invite has expired.",
+    );
+  });
+
+  it("rejects legacy invites before attempting enrollment", () => {
+    const legacyInvite = `pwragent-federation:${Buffer.from(JSON.stringify({
+      version: 1,
+      token: "legacy-token",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: "legacy-key",
+      gatewayUrl: "ws://127.0.0.1:47830",
+      expiresAt: 2_000,
+    }), "utf8").toString("base64url")}`;
+
+    expect(() => decodeFederationInvite(legacyInvite, 1_000)).toThrow(
+      `Unsupported federation invite version. Expected version ${FEDERATION_INVITE_VERSION}.`,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/federation-noise.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-noise.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  NoiseIKHandshake,
+  generateNoiseStaticKeyPair,
+  noiseKeyPairFromRawPrivate,
+  type NoiseKeyPair,
+} from "../federation/federation-noise";
+
+// Official test vector for Noise_IK_25519_ChaChaPoly_SHA256 (snow / noise-c
+// vector set). Fixed static + ephemeral keys make the handshake deterministic
+// so we can byte-compare against the canonical ciphertexts. This is the real
+// correctness guarantee for the hand-written state machine.
+const VECTOR = {
+  prologue:
+    "5468657265206973206e6f20726967687420616e642077726f6e672e2054686572652773206f6e6c792066756e20616e6420626f72696e672e",
+  initStatic: "f49f93c5112c0787acc808d61716d7e090e076a58f15a3f78d92773f8dcb473b",
+  initEphemeral:
+    "dae68498c41315cff7e4a34dded8d973199d8f0cf3fcb8b6651c169de77de8be",
+  initRemoteStatic:
+    "2ea5942829bac414e25aa4cbb1bcc43394816ebb1bd12550d7d0eb4415e42951",
+  respStatic: "b790546f98b1e933c48cd01f17e7b281469d46fcacc9a3b584ae65b1d6272e8e",
+  respEphemeral:
+    "c0875a5b59c8492bd2135e5432d7d484f938e0a1f5009428c4bcb70b2f69f69f",
+  messages: [
+    {
+      payload: "95a8f51c435a9530ff1f30868ed7b23ec952eb513c26a0774fed82d2978a8c81",
+      ciphertext:
+        "6d21fec9141f3f37cc464e936a48b2d9521b5a44e0f3d960895d3c3fba30282f731f445c25e898e2534ac0536715b24308c108fc46bd260c887b36c3f68e3a05654fc8295c068ed53fb2022560961224e0b10b0835e1efc82fc587cd50f7178fe3d9eb06e0351c6e7334162c10bed670bfa2a105f7b2768a140b3fd597782601",
+    },
+    {
+      payload: "b866b807a6d8b83182b884dbfedc861843c5082bd6e480cb54e4245a72083041",
+      ciphertext:
+        "e64e1fb8701c4f4bc3850b255fea657d4d835338b059c89acc99628fbe52473b41a4e79e3c1e6abc46bf80f078a005e15d8a3e04f989af3e6cb99b52031165006163ac3e17b928af8c116009d7bf4fb2",
+    },
+    {
+      payload: "e3a4937faef391028f759758b428b57652e0069a8dee64dfed01b60846938740",
+      ciphertext:
+        "2bebe19102169cdfe79cf41e38930bfd20a5b2fc78ccf33e853ddd939c0983174656eb27b61464a607762848892ca1c0",
+    },
+    {
+      payload: "693972f27b0cb98aeac1fb54d782125431e7540e0cb2fa882cf51a8184d724fd",
+      ciphertext:
+        "c7c56da33b45d12f4754e17978bd49999c9c8f51d00db460f902aba2e6e245d0c46662f507915de8596f43b1d175f1db",
+    },
+  ],
+} as const;
+
+function hex(value: string): Buffer {
+  return Buffer.from(value, "hex");
+}
+
+function fixedEphemeral(rawPrivateHex: string): () => NoiseKeyPair {
+  return () => noiseKeyPairFromRawPrivate(hex(rawPrivateHex));
+}
+
+describe("Noise_IK_25519_ChaChaPoly_SHA256", () => {
+  it("derives the responder static public key from the vector private seed", () => {
+    const resp = noiseKeyPairFromRawPrivate(hex(VECTOR.respStatic));
+    expect(resp.publicKeyRaw.toString("hex")).toBe(VECTOR.initRemoteStatic);
+  });
+
+  it("matches the official handshake and transport ciphertexts", () => {
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: noiseKeyPairFromRawPrivate(hex(VECTOR.initStatic)),
+      remoteStaticPublicKey: hex(VECTOR.initRemoteStatic),
+      prologue: hex(VECTOR.prologue),
+      generateEphemeral: fixedEphemeral(VECTOR.initEphemeral),
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: noiseKeyPairFromRawPrivate(hex(VECTOR.respStatic)),
+      prologue: hex(VECTOR.prologue),
+      generateEphemeral: fixedEphemeral(VECTOR.respEphemeral),
+    });
+
+    // Message 1: initiator -> responder.
+    const msg1 = initiator.writeMessage1(hex(VECTOR.messages[0].payload));
+    expect(msg1.toString("hex")).toBe(VECTOR.messages[0].ciphertext);
+    expect(responder.readMessage1(msg1).toString("hex")).toBe(
+      VECTOR.messages[0].payload,
+    );
+
+    // The responder learns and exposes the initiator's static key (the higher
+    // layer pins this — "only a caller I approved").
+    expect(responder.remoteStaticPublicKey()?.toString("hex")).toBe(
+      noiseKeyPairFromRawPrivate(hex(VECTOR.initStatic)).publicKeyRaw.toString(
+        "hex",
+      ),
+    );
+
+    // Message 2: responder -> initiator.
+    const msg2 = responder.writeMessage2(hex(VECTOR.messages[1].payload));
+    expect(msg2.toString("hex")).toBe(VECTOR.messages[1].ciphertext);
+    expect(initiator.readMessage2(msg2).toString("hex")).toBe(
+      VECTOR.messages[1].payload,
+    );
+
+    const initiatorTransport = initiator.split();
+    const responderTransport = responder.split();
+
+    // Both ends derive the same handshake hash (binds higher-layer proofs).
+    expect(initiatorTransport.handshakeHash.toString("hex")).toBe(
+      responderTransport.handshakeHash.toString("hex"),
+    );
+
+    // Transport message 3: initiator -> responder.
+    const t1 = initiatorTransport.encrypt(hex(VECTOR.messages[2].payload));
+    expect(t1.toString("hex")).toBe(VECTOR.messages[2].ciphertext);
+    expect(responderTransport.decrypt(t1).toString("hex")).toBe(
+      VECTOR.messages[2].payload,
+    );
+
+    // Transport message 4: responder -> initiator.
+    const t2 = responderTransport.encrypt(hex(VECTOR.messages[3].payload));
+    expect(t2.toString("hex")).toBe(VECTOR.messages[3].ciphertext);
+    expect(initiatorTransport.decrypt(t2).toString("hex")).toBe(
+      VECTOR.messages[3].payload,
+    );
+  });
+
+  it("completes a handshake with random keys and exchanges encrypted traffic", () => {
+    const gateway = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: gateway.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: gateway,
+    });
+
+    responder.readMessage1(initiator.writeMessage1());
+    initiator.readMessage2(responder.writeMessage2());
+
+    const clientChannel = initiator.split();
+    const gatewayChannel = responder.split();
+
+    const message = Buffer.from("startTurn: rm -rf nothing", "utf8");
+    const onWire = clientChannel.encrypt(message);
+    expect(onWire.equals(message)).toBe(false); // ciphertext != plaintext
+    expect(gatewayChannel.decrypt(onWire).toString("utf8")).toBe(
+      message.toString("utf8"),
+    );
+    // Reverse direction.
+    const reply = Buffer.from("ok", "utf8");
+    expect(
+      clientChannel.decrypt(gatewayChannel.encrypt(reply)).toString("utf8"),
+    ).toBe("ok");
+  });
+
+  it("rejects a tampered transport frame", () => {
+    const gateway = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: gateway.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({ role: "responder", localStatic: gateway });
+    responder.readMessage1(initiator.writeMessage1());
+    initiator.readMessage2(responder.writeMessage2());
+    const clientChannel = initiator.split();
+    const gatewayChannel = responder.split();
+
+    const frame = clientChannel.encrypt(Buffer.from("authentic", "utf8"));
+    const tampered = Buffer.from(frame);
+    tampered[0] ^= 0x01;
+    expect(() => gatewayChannel.decrypt(tampered)).toThrow();
+  });
+
+  it("fails the handshake when the client pins the wrong gateway key (MITM / wrong machine)", () => {
+    const realGateway = generateNoiseStaticKeyPair();
+    const attacker = generateNoiseStaticKeyPair();
+    const client = generateNoiseStaticKeyPair();
+
+    // Client pins the ATTACKER's key but connects to the real gateway.
+    const initiator = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: client,
+      remoteStaticPublicKey: attacker.publicKeyRaw,
+    });
+    const responder = new NoiseIKHandshake({
+      role: "responder",
+      localStatic: realGateway,
+    });
+
+    // The real gateway cannot decrypt message 1 because the `es`/`ss` DH
+    // outputs diverge from what the client mixed against the attacker key.
+    expect(() => responder.readMessage1(initiator.writeMessage1())).toThrow();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-noise.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-noise.test.ts
@@ -6,41 +6,40 @@ import {
   type NoiseKeyPair,
 } from "../federation/federation-noise";
 
-// Official test vector for Noise_IK_25519_ChaChaPoly_SHA256 (snow / noise-c
-// vector set). Fixed static + ephemeral keys make the handshake deterministic
-// so we can byte-compare against the canonical ciphertexts. This is the real
-// correctness guarantee for the hand-written state machine.
+// Independent screech/titanous-noise test vector for
+// Noise_IK_25519_AESGCM_SHA256. Fixed static + ephemeral keys make the
+// handshake deterministic so we can byte-compare against canonical
+// ciphertexts from another implementation.
 const VECTOR = {
-  prologue:
-    "5468657265206973206e6f20726967687420616e642077726f6e672e2054686572652773206f6e6c792066756e20616e6420626f72696e672e",
-  initStatic: "f49f93c5112c0787acc808d61716d7e090e076a58f15a3f78d92773f8dcb473b",
+  prologue: "6e6f74736563726574",
+  initStatic: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
   initEphemeral:
-    "dae68498c41315cff7e4a34dded8d973199d8f0cf3fcb8b6651c169de77de8be",
+    "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
   initRemoteStatic:
-    "2ea5942829bac414e25aa4cbb1bcc43394816ebb1bd12550d7d0eb4415e42951",
-  respStatic: "b790546f98b1e933c48cd01f17e7b281469d46fcacc9a3b584ae65b1d6272e8e",
+    "07a37cbc142093c8b755dc1b10e86cb426374ad16aa853ed0bdfc0b2b86d1c7c",
+  respStatic: "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
   respEphemeral:
-    "c0875a5b59c8492bd2135e5432d7d484f938e0a1f5009428c4bcb70b2f69f69f",
+    "4142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f60",
   messages: [
     {
-      payload: "95a8f51c435a9530ff1f30868ed7b23ec952eb513c26a0774fed82d2978a8c81",
+      payload: "746573745f6d73675f30",
       ciphertext:
-        "6d21fec9141f3f37cc464e936a48b2d9521b5a44e0f3d960895d3c3fba30282f731f445c25e898e2534ac0536715b24308c108fc46bd260c887b36c3f68e3a05654fc8295c068ed53fb2022560961224e0b10b0835e1efc82fc587cd50f7178fe3d9eb06e0351c6e7334162c10bed670bfa2a105f7b2768a140b3fd597782601",
+        "358072d6365880d1aeea329adf9121383851ed21a28e3b75e965d0d2cd16625419d6fab175300a577115c701c41ed681373f0432f81d3bf8676bd05216cd1919e61b75ccef0c0cf0b216fcdf371d0859e6d8177aa9777fe9b8435bb6f8202c3acd9051a9aee0a63e76f6",
     },
     {
-      payload: "b866b807a6d8b83182b884dbfedc861843c5082bd6e480cb54e4245a72083041",
+      payload: "746573745f6d73675f31",
       ciphertext:
-        "e64e1fb8701c4f4bc3850b255fea657d4d835338b059c89acc99628fbe52473b41a4e79e3c1e6abc46bf80f078a005e15d8a3e04f989af3e6cb99b52031165006163ac3e17b928af8c116009d7bf4fb2",
+        "64b101b1d0be5a8704bd078f9895001fc03e8e9f9522f188dd128d9846d4846658a7bb8caac5097833909e90778571d34ce0e5b6ea4c3a76f102",
     },
     {
-      payload: "e3a4937faef391028f759758b428b57652e0069a8dee64dfed01b60846938740",
+      payload: "79656c6c6f777375626d6172696e65",
       ciphertext:
-        "2bebe19102169cdfe79cf41e38930bfd20a5b2fc78ccf33e853ddd939c0983174656eb27b61464a607762848892ca1c0",
+        "80a75e75c8e8d2e9c2a6c7bc6e550c4997d6d2b45429a530821c4aa5d36f27",
     },
     {
-      payload: "693972f27b0cb98aeac1fb54d782125431e7540e0cb2fa882cf51a8184d724fd",
+      payload: "7375626d6172696e6579656c6c6f77",
       ciphertext:
-        "c7c56da33b45d12f4754e17978bd49999c9c8f51d00db460f902aba2e6e245d0c46662f507915de8596f43b1d175f1db",
+        "b8475410da62a98493d33a1e669f8f56dd8f61d449b53bd375299c3435424a",
     },
   ],
 } as const;
@@ -53,7 +52,7 @@ function fixedEphemeral(rawPrivateHex: string): () => NoiseKeyPair {
   return () => noiseKeyPairFromRawPrivate(hex(rawPrivateHex));
 }
 
-describe("Noise_IK_25519_ChaChaPoly_SHA256", () => {
+describe("Noise_IK_25519_AESGCM_SHA256", () => {
   it("derives the responder static public key from the vector private seed", () => {
     const resp = noiseKeyPairFromRawPrivate(hex(VECTOR.respStatic));
     expect(resp.publicKeyRaw.toString("hex")).toBe(VECTOR.initRemoteStatic);

--- a/apps/desktop/src/main/__tests__/federation-rpc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-rpc.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { FederationRpcEndpoint } from "../federation/federation-rpc";
+
+describe("FederationRpcEndpoint", () => {
+  it("rejects and removes a request when its route fails synchronously", async () => {
+    const endpoint = new FederationRpcEndpoint({
+      localInstanceId: "client_one",
+      remoteInstanceId: "gateway_one",
+      sendEnvelope: () => {
+        throw new Error("Federation peer gateway_one is not connected.");
+      },
+    });
+
+    await expect(endpoint.request({
+      method: "backend.getNavigationSnapshot",
+      params: {},
+    })).rejects.toThrow("Federation peer gateway_one is not connected.");
+    expect(
+      (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(0);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -229,7 +229,9 @@ describe("DesktopFederationRuntime", () => {
 
   it("marks gateway-advertised routes disconnected when the gateway closes", () => {
     const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    const publishedEvents: AgentEvent[] = [];
     runtime.localInstanceId = "client_one";
+    runtime.setAgentEventPublisher((event) => publishedEvents.push(event));
     runtime.store = () => ({
       getPeer: () => undefined,
       listPeers: () => [],
@@ -277,6 +279,49 @@ describe("DesktopFederationRuntime", () => {
       },
     ]);
     expect(runtime.connectedPeerTargets()).toEqual([]);
+    expect(
+      publishedEvents.map((event) => ({
+        target: event.federationTarget,
+        notification: event.notification,
+      })),
+    ).toMatchObject([
+      {
+        target: { scope: "remote", instanceId: "gateway_one" },
+        notification: {
+          method: "federation/peerStatus/changed",
+          params: { instanceId: "gateway_one", status: "connected" },
+        },
+      },
+      {
+        target: { scope: "remote", instanceId: "client_two" },
+        notification: {
+          method: "federation/peerStatus/changed",
+          params: { instanceId: "client_two", status: "connected" },
+        },
+      },
+      {
+        target: { scope: "remote", instanceId: "gateway_one" },
+        notification: {
+          method: "federation/peerStatus/changed",
+          params: {
+            instanceId: "gateway_one",
+            status: "disconnected",
+            unavailableReason: "Gateway transport closed.",
+          },
+        },
+      },
+      {
+        target: { scope: "remote", instanceId: "client_two" },
+        notification: {
+          method: "federation/peerStatus/changed",
+          params: {
+            instanceId: "client_two",
+            status: "disconnected",
+            unavailableReason: "Gateway transport closed.",
+          },
+        },
+      },
+    ]);
   });
 
   it("falls back to the gateway when a client targets a sibling peer", () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -35,6 +35,18 @@ type RuntimeHarness = {
     sourcePeerId: FederationInstanceId,
   ) => boolean;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
+  recordClientConnection: (params: {
+    gatewayInstanceId: FederationInstanceId;
+    gatewayUrl: string;
+    client: {
+      sessionId: string;
+      capabilities: FederationCapability[];
+      sendEnvelope: (envelope: FederationProtocolEnvelope) => void;
+      close: () => void;
+    };
+    connectionMode: "enroll" | "reconnect";
+    connectedAt: number;
+  }) => void;
   disconnectAdvertisedPeers: (reason: string) => void;
   registerGatewayConnection: (connection: FederationGatewayConnection) => void;
   remoteBackend: (target?: {
@@ -61,6 +73,13 @@ type RuntimeHarness = {
     publisher: (event: CodexEnvironmentSetupProgressEvent) => void,
   ) => void;
   store: () => {
+    appendAudit?: (entry: {
+      peerId?: FederationInstanceId;
+      sessionId?: string;
+      kind: string;
+      createdAt: number;
+      detail?: string;
+    }) => void;
     getPeer: (peerId: FederationInstanceId) => {
       label: string;
       status: "connected";
@@ -224,6 +243,92 @@ describe("DesktopFederationRuntime", () => {
     expect(runtime.visiblePeers()).toMatchObject([
       { id: "gateway_one", status: "connected" },
       { id: "client_two", status: "connected" },
+    ]);
+  });
+
+  it("records a successful client session and preserves its timing", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    const audits: Array<{
+      peerId?: FederationInstanceId;
+      sessionId?: string;
+      kind: string;
+      createdAt: number;
+      detail?: string;
+    }> = [];
+    runtime.localInstanceId = "client_one";
+    runtime.remotePeerDirectory.set("gateway_one", {
+      id: "gateway_one",
+      label: "Mac Mini",
+      role: "gateway",
+      status: "connected",
+      capabilities: ["remote_window"],
+    });
+    runtime.store = () => ({
+      appendAudit: (entry) => audits.push(entry),
+      getPeer: () => undefined,
+      listPeers: () => [],
+    });
+
+    runtime.recordClientConnection({
+      gatewayInstanceId: "gateway_one",
+      gatewayUrl: "ws://192.168.6.163:47830",
+      client: {
+        sessionId: "session:gateway_one",
+        capabilities: ["remote_window", "thread_navigation"],
+        sendEnvelope: () => undefined,
+        close: () => undefined,
+      },
+      connectionMode: "reconnect",
+      connectedAt: 5_000,
+    });
+
+    expect([...runtime.remotePeerDirectory.values()]).toMatchObject([
+      {
+        id: "gateway_one",
+        label: "Mac Mini",
+        status: "connected",
+        endpoint: "ws://192.168.6.163:47830",
+        lastConnectedAt: 5_000,
+        lastActivityAt: 5_000,
+      },
+    ]);
+    expect(audits).toEqual([
+      {
+        peerId: "gateway_one",
+        sessionId: "session:gateway_one",
+        kind: "connected",
+        createdAt: 5_000,
+        detail: "reconnect",
+      },
+    ]);
+
+    runtime.applyPeerDirectory({
+      id: "peers-1",
+      kind: "notification",
+      method: "federation.peerDirectory",
+      params: {
+        peers: [
+          {
+            id: "gateway_one",
+            label: "Mac Mini",
+            role: "gateway",
+            status: "connected",
+            capabilities: ["remote_window", "thread_navigation"],
+          },
+        ],
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "client_one",
+      createdAt: 5_001,
+    });
+
+    expect([...runtime.remotePeerDirectory.values()]).toMatchObject([
+      {
+        id: "gateway_one",
+        lastConnectedAt: 5_000,
+        lastActivityAt: 5_000,
+      },
     ]);
   });
 

--- a/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { FederationTailscaleService } from "../federation/federation-tailscale";
+
+describe("FederationTailscaleService", () => {
+  it("reports only sanitized local Tailscale status", async () => {
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({
+        command: "/usr/local/bin/tailscale",
+        version: "1.98.10",
+      }),
+      runCommand: async (_command, args) => {
+        if (args[0] === "status") {
+          return commandResult(JSON.stringify({
+            BackendState: "Running",
+            Self: {
+              Online: true,
+              DNSName: "studio.example.ts.net.",
+              TailscaleIPs: ["100.64.0.1"],
+              NodeKey: "nodekey:secret",
+            },
+            CurrentTailnet: { Name: "Example Tailnet" },
+            Peer: { secret: { HostName: "private-peer" } },
+          }));
+        }
+        if (args[0] === "serve") {
+          return commandResult(JSON.stringify({
+            Web: { "studio.example.ts.net:443": { Handlers: {
+              "/pwragent-federation": { Proxy: "http://127.0.0.1:47830" },
+            } } },
+          }));
+        }
+        return commandResult("{}");
+      },
+    });
+
+    await expect(service.readStatus()).resolves.toEqual({
+      installed: true,
+      connected: true,
+      version: "1.98.10",
+      backendState: "Running",
+      dnsName: "studio.example.ts.net",
+      tailnetName: "Example Tailnet",
+      serveConfigured: true,
+      funnelConfigured: false,
+      gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
+      unavailableReason: undefined,
+    });
+  });
+
+  it("configures only the dedicated PwrAgent Funnel path", async () => {
+    let configured = false;
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args[0] === "status") {
+        return commandResult(JSON.stringify({
+          BackendState: "Running",
+          Self: { Online: true, DNSName: "studio.example.ts.net." },
+        }));
+      }
+      if (args[0] === "funnel" && args[1] === "--bg") {
+        configured = true;
+        return commandResult("");
+      }
+      if (args[0] === "funnel") {
+        return commandResult(configured
+          ? JSON.stringify({
+              Web: { Handlers: {
+                "/pwragent-federation": {
+                  Proxy: "http://127.0.0.1:47830",
+                },
+              } },
+            })
+          : "{}");
+      }
+      return commandResult("{}");
+    });
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand,
+    });
+
+    await expect(service.configure({
+      mode: "funnel",
+      listenPort: 47_830,
+    })).resolves.toMatchObject({
+      gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
+      status: { funnelConfigured: true },
+    });
+    expect(runCommand).toHaveBeenCalledWith("tailscale", [
+      "funnel",
+      "--bg",
+      "--yes",
+      "--set-path=/pwragent-federation",
+      "http://127.0.0.1:47830",
+    ]);
+    expect(runCommand.mock.calls.flatMap((call) => call[1])).not.toContain("reset");
+  });
+
+  it("does not run setup while Tailscale is disconnected", async () => {
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args[0] === "status") {
+        return commandResult(JSON.stringify({ BackendState: "Stopped" }));
+      }
+      return commandResult("{}");
+    });
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand,
+    });
+
+    await expect(service.configure({ mode: "serve", listenPort: 47_830 }))
+      .rejects.toThrow("not connected");
+    expect(runCommand).not.toHaveBeenCalledWith(
+      "tailscale",
+      expect.arrayContaining(["--bg"]),
+    );
+  });
+});
+
+function commandResult(stdout: string) {
+  return { stdout, stderr: "" };
+}

--- a/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
@@ -50,6 +50,40 @@ describe("FederationTailscaleService", () => {
       "/usr/local/bin/tailscale",
       ["status", "--json", "--peers=false"],
     );
+    expect(runCommand).not.toHaveBeenCalledWith(
+      "/usr/local/bin/tailscale",
+      ["funnel", "status", "--json"],
+    );
+  });
+
+  it("does not mistake a private Serve handler for Funnel", async () => {
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand: async (_command, args) => commandResult(
+        args[0] === "status"
+          ? JSON.stringify({
+              BackendState: "Running",
+              Self: { Online: true, DNSName: "studio.example.ts.net." },
+            })
+          : JSON.stringify({
+              TCP: { "443": { HTTPS: true } },
+              Web: {
+                "studio.example.ts.net:443": {
+                  Handlers: {
+                    "/pwragent-federation": {
+                      Proxy: "http://127.0.0.1:47830",
+                    },
+                  },
+                },
+              },
+            }),
+      ),
+    });
+
+    await expect(service.readStatus()).resolves.toMatchObject({
+      serveConfigured: true,
+      funnelConfigured: false,
+    });
   });
 
   it("configures only the dedicated PwrAgent Funnel path", async () => {
@@ -67,14 +101,21 @@ describe("FederationTailscaleService", () => {
         configured = true;
         return commandResult("");
       }
-      if (args[0] === "funnel") {
+      if (args[0] === "serve") {
         return commandResult(configured
           ? JSON.stringify({
-              Web: { Handlers: {
-                "/pwragent-federation": {
-                  Proxy: "http://127.0.0.1:47830",
+              Web: {
+                "studio.example.ts.net:443": {
+                  Handlers: {
+                    "/pwragent-federation": {
+                      Proxy: "http://127.0.0.1:47830",
+                    },
+                  },
                 },
-              } },
+              },
+              AllowFunnel: {
+                "studio.example.ts.net:443": true,
+              },
             })
           : "{}");
       }

--- a/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-tailscale.test.ts
@@ -3,34 +3,35 @@ import { FederationTailscaleService } from "../federation/federation-tailscale";
 
 describe("FederationTailscaleService", () => {
   it("reports only sanitized local Tailscale status", async () => {
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args[0] === "status") {
+        return commandResult(JSON.stringify({
+          BackendState: "Running",
+          Self: {
+            Online: true,
+            DNSName: "studio.example.ts.net.",
+            TailscaleIPs: ["100.64.0.1"],
+            NodeKey: "nodekey:secret",
+          },
+          CurrentTailnet: { Name: "Example Tailnet" },
+          Peer: { secret: { HostName: "private-peer" } },
+        }));
+      }
+      if (args[0] === "serve") {
+        return commandResult(JSON.stringify({
+          Web: { "studio.example.ts.net:443": { Handlers: {
+            "/pwragent-federation": { Proxy: "http://127.0.0.1:47830" },
+          } } },
+        }));
+      }
+      return commandResult("{}");
+    });
     const service = new FederationTailscaleService({
       discoverCommand: async () => ({
         command: "/usr/local/bin/tailscale",
         version: "1.98.10",
       }),
-      runCommand: async (_command, args) => {
-        if (args[0] === "status") {
-          return commandResult(JSON.stringify({
-            BackendState: "Running",
-            Self: {
-              Online: true,
-              DNSName: "studio.example.ts.net.",
-              TailscaleIPs: ["100.64.0.1"],
-              NodeKey: "nodekey:secret",
-            },
-            CurrentTailnet: { Name: "Example Tailnet" },
-            Peer: { secret: { HostName: "private-peer" } },
-          }));
-        }
-        if (args[0] === "serve") {
-          return commandResult(JSON.stringify({
-            Web: { "studio.example.ts.net:443": { Handlers: {
-              "/pwragent-federation": { Proxy: "http://127.0.0.1:47830" },
-            } } },
-          }));
-        }
-        return commandResult("{}");
-      },
+      runCommand,
     });
 
     await expect(service.readStatus()).resolves.toEqual({
@@ -45,10 +46,15 @@ describe("FederationTailscaleService", () => {
       gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
       unavailableReason: undefined,
     });
+    expect(runCommand).toHaveBeenCalledWith(
+      "/usr/local/bin/tailscale",
+      ["status", "--json", "--peers=false"],
+    );
   });
 
   it("configures only the dedicated PwrAgent Funnel path", async () => {
     let configured = false;
+    const events: string[] = [];
     const runCommand = vi.fn(async (_command: string, args: string[]) => {
       if (args[0] === "status") {
         return commandResult(JSON.stringify({
@@ -57,6 +63,7 @@ describe("FederationTailscaleService", () => {
         }));
       }
       if (args[0] === "funnel" && args[1] === "--bg") {
+        events.push("publish");
         configured = true;
         return commandResult("");
       }
@@ -76,6 +83,9 @@ describe("FederationTailscaleService", () => {
     const service = new FederationTailscaleService({
       discoverCommand: async () => ({ command: "tailscale" }),
       runCommand,
+      verifyListener: async () => {
+        events.push("verify-listener");
+      },
     });
 
     await expect(service.configure({
@@ -93,6 +103,7 @@ describe("FederationTailscaleService", () => {
       "http://127.0.0.1:47830",
     ]);
     expect(runCommand.mock.calls.flatMap((call) => call[1])).not.toContain("reset");
+    expect(events).toEqual(["verify-listener", "publish"]);
   });
 
   it("does not run setup while Tailscale is disconnected", async () => {
@@ -113,6 +124,94 @@ describe("FederationTailscaleService", () => {
       "tailscale",
       expect.arrayContaining(["--bg"]),
     );
+  });
+
+  it("accepts status documents larger than the previous one MiB limit", async () => {
+    const largeStatus = JSON.stringify({
+      BackendState: "Running",
+      Self: { Online: true, DNSName: "studio.example.ts.net." },
+      Padding: "x".repeat(2 * 1024 * 1024),
+    });
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand: async (_command, args) =>
+        commandResult(args[0] === "status" ? largeStatus : "{}"),
+    });
+
+    await expect(service.readStatus()).resolves.toMatchObject({
+      connected: true,
+      dnsName: "studio.example.ts.net",
+    });
+  });
+
+  it("never exposes raw command output through status errors", async () => {
+    const privateTopology = "private-peer.internal 100.64.0.42 nodekey:secret";
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand: async () => {
+        throw new Error(privateTopology);
+      },
+    });
+
+    const status = await service.readStatus();
+    expect(status.unavailableReason).toContain("command failed");
+    expect(status.unavailableReason).not.toContain(privateTopology);
+    expect(status).not.toHaveProperty("stdout");
+    expect(status).not.toHaveProperty("stderr");
+  });
+
+  it("does not publish when listener ownership verification fails", async () => {
+    const runCommand = vi.fn(async (_command: string, args: string[]) => {
+      if (args[0] === "status") {
+        return commandResult(JSON.stringify({
+          BackendState: "Running",
+          Self: { Online: true, DNSName: "studio.example.ts.net." },
+        }));
+      }
+      return commandResult("{}");
+    });
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand,
+      verifyListener: async () => {
+        throw new Error("PwrAgent listener is not bound.");
+      },
+    });
+
+    await expect(service.configure({ mode: "funnel", listenPort: 47_830 }))
+      .rejects.toThrow("not bound");
+    expect(runCommand).not.toHaveBeenCalledWith(
+      "tailscale",
+      expect.arrayContaining(["--bg"]),
+    );
+  });
+
+  it("never exposes raw command output through setup errors", async () => {
+    const privateTopology = "private-peer.internal 100.64.0.42 nodekey:secret";
+    const service = new FederationTailscaleService({
+      discoverCommand: async () => ({ command: "tailscale" }),
+      runCommand: async (_command, args) => {
+        if (args[0] === "status") {
+          return commandResult(JSON.stringify({
+            BackendState: "Running",
+            Self: { Online: true, DNSName: "studio.example.ts.net." },
+          }));
+        }
+        if (args[0] === "serve" && args[1] === "--bg") {
+          throw new Error(privateTopology);
+        }
+        return commandResult("{}");
+      },
+      verifyListener: async () => undefined,
+    });
+
+    const setup = service.configure({ mode: "serve", listenPort: 47_830 });
+    await expect(setup)
+      .rejects.toThrow(
+        "Tailscale Serve command failed. Run it in Terminal for details.",
+      );
+    await expect(setup)
+      .rejects.not.toThrow(privateTopology);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -200,6 +200,8 @@ describe("federation transport", () => {
     const received = new Promise<FederationProtocolEnvelope>((resolve) => {
       server = new FederationGatewayWebSocketServer({
         gatewayInstanceId: "gateway_one",
+        gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         host: "127.0.0.1",
         port: 0,
         store,
@@ -226,6 +228,7 @@ describe("federation transport", () => {
         url,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         peerInstanceId: "client_one",
         privateKeyPem: clientKeyPair.privateKeyPem,
         publicKeyPem: clientKeyPair.publicKeyPem,
@@ -276,6 +279,8 @@ describe("federation transport", () => {
     });
     server = new FederationGatewayWebSocketServer({
       gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
       host: "127.0.0.1",
       port: 0,
       store,
@@ -288,6 +293,7 @@ describe("federation transport", () => {
         url,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
         peerInstanceId: "client_one",
         privateKeyPem: clientKeyPair.privateKeyPem,
         publicKeyPem: clientKeyPair.publicKeyPem,

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -14,6 +14,7 @@ import {
   generateFederationIdentityKeyPair,
   signFederationMessage,
 } from "../federation/federation-identity";
+import { generateNoiseStaticKeyPair } from "../federation/federation-noise";
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
@@ -183,6 +184,123 @@ describe("federation transport", () => {
         detail: "reconnect",
       },
     ]);
+  });
+
+  it("runs an encrypted, channel-bound handshake and carries envelopes (Noise mode)", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-encrypted",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        noiseStatic: gatewayNoise,
+        onEnvelope: (envelope, connection) => {
+          connection.sendEnvelope({
+            id: "response-1",
+            kind: "response",
+            requestId: envelope.id,
+            protocolVersion: 1,
+            sourceInstanceId: "gateway_one",
+            targetInstanceId: connection.peerId,
+            createdAt: 2_000,
+            result: { ok: true },
+          });
+          resolve(envelope);
+        },
+      });
+    });
+    const { url } = await server!.start();
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+        onEnvelope: resolve,
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(received).resolves.toMatchObject({ id: "request-1", kind: "request" });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "request-1",
+      result: { ok: true },
+    });
+    expect(store.getPeer("client_one")).toMatchObject({
+      status: "connected",
+      pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
+    });
+  });
+
+  it("fails when the client pins the wrong gateway Noise key (wrong machine / MITM)", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const attackerNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-wrong-gateway",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      noiseStatic: gatewayNoise,
+    });
+    const { url } = await server.start();
+
+    await expect(
+      connectFederationClient({
+        url,
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        // Pin the WRONG (attacker) gateway key — the handshake must fail.
+        gatewayNoisePublicKey: attackerNoise.publicKeyRaw,
+      }),
+    ).rejects.toThrow();
+    expect(store.getPeer("client_one")).toBeUndefined();
   });
 
   it("rejects auth proofs signed with a client-selected nonce", async () => {

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import WebSocket, { WebSocketServer } from "ws";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import {
+  FEDERATION_PROTOCOL_VERSION,
+  FEDERATION_TRANSPORT_VERSION,
+  type FederationProtocolEnvelope,
+} from "@pwragent/shared";
 import {
   buildFederationGatewayAcceptedMessage,
   buildFederationGatewayChallengeMessage,
@@ -14,7 +18,10 @@ import {
   generateFederationIdentityKeyPair,
   signFederationMessage,
 } from "../federation/federation-identity";
-import { generateNoiseStaticKeyPair } from "../federation/federation-noise";
+import {
+  generateNoiseStaticKeyPair,
+  NoiseIKHandshake,
+} from "../federation/federation-noise";
 import { FederationStore } from "../federation/federation-store";
 import {
   connectFederationClient,
@@ -265,6 +272,160 @@ describe("federation transport", () => {
     });
   });
 
+  it("advertises the required Noise transport version before the handshake", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      noiseStatic: gatewayNoise,
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    const reader = new TestSocketReader(socket);
+    await waitForSocketOpen(socket);
+
+    expect(JSON.parse((await reader.next()).toString("utf8"))).toEqual({
+      kind: "transport.hello",
+      transportVersion: FEDERATION_TRANSPORT_VERSION,
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      encryption: "noise_ik_25519_aesgcm_sha256",
+    });
+    socket.close();
+  });
+
+  it("rejects a legacy gateway before starting the Noise handshake", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    rawServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    rawServer.on("connection", (socket) => {
+      socket.send(JSON.stringify({
+        kind: "auth.challenge",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        nonce: "legacy-challenge",
+        signatureBase64: "legacy-signature",
+      }));
+    });
+    const url = await websocketServerUrl(rawServer);
+
+    await expect(connectFederationClient({
+      url,
+      mode: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      noiseStatic: clientNoise,
+      gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+    })).rejects.toThrow(
+      `Federation gateway does not support required Noise transport version ${FEDERATION_TRANSPORT_VERSION}.`,
+    );
+  });
+
+  it("closes an established session after encrypted frame authentication fails", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-tampered-frame",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    let resolveConnected: (() => void) | undefined;
+    const connected = new Promise<void>((resolve) => {
+      resolveConnected = resolve;
+    });
+    let resolveDisconnected: (() => void) | undefined;
+    const disconnected = new Promise<void>((resolve) => {
+      resolveDisconnected = resolve;
+    });
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      noiseStatic: gatewayNoise,
+      onConnection: () => resolveConnected?.(),
+      onDisconnect: () => resolveDisconnected?.(),
+    });
+    const { url } = await server.start();
+    const socket = new WebSocket(url);
+    const reader = new TestSocketReader(socket);
+    await waitForSocketOpen(socket);
+    await reader.next();
+
+    const handshake = new NoiseIKHandshake({
+      role: "initiator",
+      localStatic: clientNoise,
+      remoteStaticPublicKey: gatewayNoise.publicKeyRaw,
+    });
+    socket.send(handshake.writeMessage1());
+    handshake.readMessage2(await reader.next());
+    const transport = handshake.split();
+    const challenge = JSON.parse(
+      transport.decrypt(await reader.next()).toString("utf8"),
+    ) as {
+      nonce: string;
+    };
+    const capabilities = ["remote_window"] as const;
+    socket.send(transport.encrypt(Buffer.from(JSON.stringify({
+      kind: "auth",
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "client_one",
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      nonce: challenge.nonce,
+      capabilities,
+      signatureBase64: signFederationMessage({
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        message: buildFederationProofMessage({
+          purpose: "enroll",
+          gatewayInstanceId: "gateway_one",
+          peerInstanceId: "client_one",
+          publicKeyPem: clientKeyPair.publicKeyPem,
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          nonce: challenge.nonce,
+          capabilities,
+          channelBinding: transport.handshakeHash.toString("base64"),
+        }),
+      }),
+      inviteToken: invite.token,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      label: "Client",
+      role: "client",
+    }), "utf8")));
+    const accepted = JSON.parse(
+      transport.decrypt(await reader.next()).toString("utf8"),
+    ) as { kind: string };
+    expect(accepted.kind).toBe("auth.accepted");
+    await connected;
+
+    const socketClosed = new Promise<void>((resolve) => {
+      socket.once("close", () => resolve());
+    });
+    socket.send(Buffer.alloc(32, 0xa5));
+
+    await socketClosed;
+    await disconnected;
+    expect(server.closePeer("client_one")).toBe(false);
+    expect(store.listAudit({ peerId: "client_one" })[0]).toMatchObject({
+      kind: "disconnected",
+      detail: "transport_closed",
+    });
+  });
+
   it("fails when the client pins the wrong gateway Noise key (wrong machine / MITM)", async () => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     const attackerNoise = generateNoiseStaticKeyPair();
@@ -499,4 +660,55 @@ function nextSocketMessage(socket: WebSocket): Promise<unknown> {
     });
     socket.once("error", reject);
   });
+}
+
+class TestSocketReader {
+  private readonly queue: Buffer[] = [];
+  private pending?: {
+    resolve: (frame: Buffer) => void;
+    reject: (error: Error) => void;
+  };
+  private failure?: Error;
+
+  constructor(socket: WebSocket) {
+    socket.on("message", (raw) => this.push(rawDataToBuffer(raw)));
+    socket.once("close", () => this.fail(new Error("WebSocket closed")));
+    socket.once("error", (error) =>
+      this.fail(error instanceof Error ? error : new Error(String(error))),
+    );
+  }
+
+  next(): Promise<Buffer> {
+    const queued = this.queue.shift();
+    if (queued) return Promise.resolve(queued);
+    if (this.failure) return Promise.reject(this.failure);
+    return new Promise((resolve, reject) => {
+      this.pending = { resolve, reject };
+    });
+  }
+
+  private push(frame: Buffer): void {
+    if (this.pending) {
+      const { resolve } = this.pending;
+      this.pending = undefined;
+      resolve(frame);
+      return;
+    }
+    this.queue.push(frame);
+  }
+
+  private fail(error: Error): void {
+    this.failure ??= error;
+    if (this.pending) {
+      const { reject } = this.pending;
+      this.pending = undefined;
+      reject(error);
+    }
+  }
+}
+
+function rawDataToBuffer(raw: WebSocket.RawData): Buffer {
+  if (Buffer.isBuffer(raw)) return raw;
+  if (Array.isArray(raw)) return Buffer.concat(raw);
+  return Buffer.from(raw as ArrayBuffer);
 }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -8,6 +8,8 @@ import type {
   AgentEvent,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  CancelQueuedTurnRequest,
+  CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueRequest,
   CancelThreadExecutionModeQueueResponse,
   CompactThreadRequest,
@@ -74,6 +76,7 @@ export const FEDERATION_BACKEND_METHODS = {
   startThread: "backend.startThread",
   forkThread: "backend.forkThread",
   startTurn: "backend.startTurn",
+  cancelQueuedTurn: "backend.cancelQueuedTurn",
   startReview: "backend.startReview",
   compactThread: "backend.compactThread",
   interruptTurn: "backend.interruptTurn",
@@ -126,6 +129,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.cancelQueuedTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startReview]: "turn_control",
   [FEDERATION_BACKEND_METHODS.compactThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.interruptTurn]: "turn_control",
@@ -172,6 +176,9 @@ export type FederationBackendOperations = {
     >,
   ): Promise<ForkThreadResponse>;
   startTurn(request: StartTurnRequest): Promise<StartTurnResponse>;
+  cancelQueuedTurn(
+    request: CancelQueuedTurnRequest,
+  ): Promise<CancelQueuedTurnResponse>;
   startReview(request: StartReviewRequest): Promise<StartReviewResponse>;
   compactThread(request: CompactThreadRequest): Promise<CompactThreadResponse>;
   interruptTurn(request: InterruptTurnRequest): Promise<InterruptTurnResponse>;
@@ -300,6 +307,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.startTurn(
         envelope.params as StartTurnRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
+    async (envelope) =>
+      await params.backend.cancelQueuedTurn(
+        envelope.params as CancelQueuedTurnRequest,
       ),
   );
   params.router.registerHandler(
@@ -530,6 +544,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async startReview(request: StartReviewRequest): Promise<StartReviewResponse> {
     return await this.rpc.request<StartReviewResponse>({
       method: FEDERATION_BACKEND_METHODS.startReview,
+      params: request,
+    });
+  }
+
+  async cancelQueuedTurn(
+    request: CancelQueuedTurnRequest,
+  ): Promise<CancelQueuedTurnResponse> {
+    return await this.rpc.request<CancelQueuedTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -5,6 +5,7 @@ import type {
   FederationPeerSummary,
 } from "@pwragent/shared";
 import {
+  FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
   isFederationInstanceId,
 } from "@pwragent/shared";
@@ -26,7 +27,7 @@ export type FederationEnrollmentInvite = FederationEnrollmentEntry & {
 };
 
 export type FederationInvitePayload = {
-  version: 1;
+  version: typeof FEDERATION_INVITE_VERSION;
   token: string;
   gatewayInstanceId: FederationInstanceId;
   gatewayPublicKeyPem: string;
@@ -83,8 +84,12 @@ export function decodeFederationInvite(
   const parsed = JSON.parse(
     Buffer.from(encoded, "base64url").toString("utf8"),
   ) as Partial<FederationInvitePayload>;
+  if (parsed.version !== FEDERATION_INVITE_VERSION) {
+    throw new Error(
+      `Unsupported federation invite version. Expected version ${FEDERATION_INVITE_VERSION}.`,
+    );
+  }
   if (
-    parsed.version !== 1 ||
     typeof parsed.token !== "string" ||
     typeof parsed.gatewayInstanceId !== "string" ||
     typeof parsed.gatewayPublicKeyPem !== "string" ||

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -30,6 +30,7 @@ export type FederationInvitePayload = {
   token: string;
   gatewayInstanceId: FederationInstanceId;
   gatewayPublicKeyPem: string;
+  gatewayNoisePublicKey: string;
   gatewayUrl: string;
   expiresAt: number;
 };
@@ -87,6 +88,7 @@ export function decodeFederationInvite(
     typeof parsed.token !== "string" ||
     typeof parsed.gatewayInstanceId !== "string" ||
     typeof parsed.gatewayPublicKeyPem !== "string" ||
+    typeof parsed.gatewayNoisePublicKey !== "string" ||
     typeof parsed.gatewayUrl !== "string" ||
     typeof parsed.expiresAt !== "number"
   ) {

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -103,6 +103,8 @@ export function completeFederationEnrollment(params: {
   gatewayInstanceId: FederationInstanceId;
   inviteToken: string;
   now: number;
+  /** Base64 Noise handshake hash to bind the identity proof to the channel. */
+  channelBinding?: string;
   peer: {
     instanceId: FederationInstanceId;
     label: string;
@@ -157,6 +159,7 @@ export function completeFederationEnrollment(params: {
     protocolVersion: params.peer.protocolVersion,
     nonce: params.peer.nonce,
     capabilities: params.peer.capabilities,
+    channelBinding: params.channelBinding,
   });
   const signatureValid = verifyFederationMessageSignature({
     publicKeyPem: params.peer.publicKeyPem,
@@ -206,6 +209,8 @@ export function authenticateFederationReconnect(params: {
   requestedCapabilities: readonly FederationCapability[];
   signatureBase64: string;
   now: number;
+  /** Base64 Noise handshake hash to bind the identity proof to the channel. */
+  channelBinding?: string;
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peerInstanceId)) {
     return {
@@ -243,6 +248,7 @@ export function authenticateFederationReconnect(params: {
     protocolVersion: params.protocolVersion,
     nonce: params.nonce,
     capabilities: params.requestedCapabilities,
+    channelBinding: params.channelBinding,
   });
   const signatureValid = verifyFederationMessageSignature({
     publicKeyPem: peer.pinnedPublicKeyPem,
@@ -279,9 +285,17 @@ export function buildFederationProofMessage(params: {
   protocolVersion: number;
   nonce: string;
   capabilities: readonly FederationCapability[];
+  /**
+   * Base64 Noise handshake hash binding this identity proof to the specific
+   * encrypted channel. Empty in tunnel mode. If a MITM splices a different
+   * channel, the client and gateway derive different hashes, the reconstructed
+   * proof message differs, and the Ed25519 signature fails to verify.
+   */
+  channelBinding?: string;
 }): string {
   return JSON.stringify({
     capabilities: params.capabilities.slice().sort(),
+    channelBinding: params.channelBinding ?? "",
     gatewayInstanceId: params.gatewayInstanceId,
     nonce: params.nonce,
     peerInstanceId: params.peerInstanceId,

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -1,0 +1,349 @@
+// Noise_IK_25519_ChaChaPoly_SHA256 — a hand-written implementation of the one
+// Noise handshake pattern federation needs, built on Node's audited crypto
+// primitives (X25519, ChaCha20-Poly1305, HMAC-SHA256). We implement only the
+// state-machine plumbing; every cryptographic primitive is delegated to
+// OpenSSL via node:crypto. Correctness is locked down against the official
+// Noise test vectors in federation-noise.test.ts.
+//
+// IK gives us exactly the two properties LAN federation needs:
+//   - the initiator (client) knows the responder's (gateway's) static public
+//     key in advance and the handshake proves the gateway holds it (the client
+//     "connects to the machine it approved");
+//   - the responder learns and authenticates the initiator's static key (the
+//     gateway "only talks to a caller it approved").
+// Plus confidentiality + integrity + forward secrecy on every transport frame.
+//
+// IK message pattern (from the Noise spec):
+//   <- s                 (pre-message: initiator already knows responder static)
+//   -> e, es, s, ss      (message 1, initiator -> responder)
+//   <- e, ee, se         (message 2, responder -> initiator)
+//   ... Split() -> transport cipher states
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  generateKeyPairSync,
+  type KeyObject,
+} from "node:crypto";
+
+const PROTOCOL_NAME = "Noise_IK_25519_ChaChaPoly_SHA256";
+const HASHLEN = 32;
+const TAGLEN = 16;
+const KEYLEN = 32;
+
+// Fixed DER prefixes for raw <-> KeyObject conversion of X25519 keys (RFC 8410).
+const X25519_SPKI_PREFIX = Buffer.from("302a300506032b656e032100", "hex"); // + 32-byte public
+const X25519_PKCS8_PREFIX = Buffer.from(
+  "302e020100300506032b656e04220420",
+  "hex",
+); // + 32-byte private seed
+
+export type NoiseKeyPair = {
+  privateKey: KeyObject;
+  publicKeyRaw: Buffer;
+};
+
+export type NoiseRole = "initiator" | "responder";
+
+export type NoiseTransport = {
+  /** Encrypt an outbound transport frame (AEAD, monotonic nonce). */
+  encrypt(plaintext: Buffer): Buffer;
+  /** Decrypt an inbound transport frame; throws on tamper/replay. */
+  decrypt(ciphertext: Buffer): Buffer;
+  /** Final handshake hash `h` — bind higher-layer identity proofs to this. */
+  handshakeHash: Buffer;
+};
+
+function sha256(data: Buffer): Buffer {
+  return createHash("sha256").update(data).digest();
+}
+
+function hmac(key: Buffer, data: Buffer): Buffer {
+  return createHmac("sha256", key).update(data).digest();
+}
+
+// Noise's HKDF (HMAC chain), returning the first two 32-byte outputs.
+function hkdf2(chainingKey: Buffer, ikm: Buffer): [Buffer, Buffer] {
+  const tempKey = hmac(chainingKey, ikm);
+  const output1 = hmac(tempKey, Buffer.from([0x01]));
+  const output2 = hmac(tempKey, Buffer.concat([output1, Buffer.from([0x02])]));
+  return [output1, output2];
+}
+
+export function rawPublicKey(key: KeyObject): Buffer {
+  return Buffer.from(key.export({ type: "spki", format: "der" })).subarray(
+    -KEYLEN,
+  );
+}
+
+export function importNoisePublicKey(raw: Buffer): KeyObject {
+  if (raw.length !== KEYLEN) {
+    throw new Error("Invalid X25519 public key length");
+  }
+  return createPublicKey({
+    key: Buffer.concat([X25519_SPKI_PREFIX, raw]),
+    format: "der",
+    type: "spki",
+  });
+}
+
+export function generateNoiseStaticKeyPair(): NoiseKeyPair {
+  const { privateKey, publicKey } = generateKeyPairSync("x25519");
+  return { privateKey, publicKeyRaw: rawPublicKey(publicKey) };
+}
+
+// Rebuild a keypair from a raw 32-byte X25519 private seed. Used for the
+// persisted static key and for injecting fixed keys in test vectors.
+export function noiseKeyPairFromRawPrivate(raw: Buffer): NoiseKeyPair {
+  if (raw.length !== KEYLEN) {
+    throw new Error("Invalid X25519 private key length");
+  }
+  const privateKey = createPrivateKey({
+    key: Buffer.concat([X25519_PKCS8_PREFIX, raw]),
+    format: "der",
+    type: "pkcs8",
+  });
+  return { privateKey, publicKeyRaw: rawPublicKey(createPublicKey(privateKey)) };
+}
+
+export function rawPrivateKey(key: KeyObject): Buffer {
+  return Buffer.from(key.export({ type: "pkcs8", format: "der" })).subarray(
+    -KEYLEN,
+  );
+}
+
+function dh(localPrivate: KeyObject, remoteRaw: Buffer): Buffer {
+  return diffieHellman({
+    privateKey: localPrivate,
+    publicKey: importNoisePublicKey(remoteRaw),
+  });
+}
+
+class CipherState {
+  private key?: Buffer;
+  private nonce = 0n;
+
+  initializeKey(key: Buffer): void {
+    this.key = key;
+    this.nonce = 0n;
+  }
+
+  hasKey(): boolean {
+    return this.key !== undefined;
+  }
+
+  private nextNonce(): Buffer {
+    // Noise nonce: 4 zero bytes followed by the 64-bit counter, little-endian.
+    const buf = Buffer.alloc(12);
+    buf.writeBigUInt64LE(this.nonce, 4);
+    return buf;
+  }
+
+  encryptWithAd(ad: Buffer, plaintext: Buffer): Buffer {
+    if (this.key === undefined) return plaintext;
+    if (this.nonce >= 0xffffffffffffffffn) {
+      throw new Error("Noise nonce exhausted");
+    }
+    const cipher = createCipheriv("chacha20-poly1305", this.key, this.nextNonce(), {
+      authTagLength: TAGLEN,
+    });
+    cipher.setAAD(ad, { plaintextLength: plaintext.length });
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    this.nonce += 1n;
+    return Buffer.concat([ciphertext, tag]);
+  }
+
+  decryptWithAd(ad: Buffer, data: Buffer): Buffer {
+    if (this.key === undefined) return data;
+    if (data.length < TAGLEN) {
+      throw new Error("Noise ciphertext too short");
+    }
+    if (this.nonce >= 0xffffffffffffffffn) {
+      throw new Error("Noise nonce exhausted");
+    }
+    const ciphertext = data.subarray(0, data.length - TAGLEN);
+    const tag = data.subarray(data.length - TAGLEN);
+    const decipher = createDecipheriv(
+      "chacha20-poly1305",
+      this.key,
+      this.nextNonce(),
+      { authTagLength: TAGLEN },
+    );
+    decipher.setAAD(ad, { plaintextLength: ciphertext.length });
+    decipher.setAuthTag(tag);
+    // final() throws if the tag does not verify; only advance on success.
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]);
+    this.nonce += 1n;
+    return plaintext;
+  }
+}
+
+class SymmetricState {
+  private chainingKey: Buffer;
+  hash: Buffer;
+  readonly cipher = new CipherState();
+
+  constructor() {
+    const name = Buffer.from(PROTOCOL_NAME, "utf8");
+    // Protocol name is <= HASHLEN, so h is the name zero-padded to 32 bytes —
+    // NOT hashed.
+    this.hash =
+      name.length <= HASHLEN
+        ? Buffer.concat([name, Buffer.alloc(HASHLEN - name.length)])
+        : sha256(name);
+    this.chainingKey = Buffer.from(this.hash);
+  }
+
+  mixKey(ikm: Buffer): void {
+    const [chainingKey, tempKey] = hkdf2(this.chainingKey, ikm);
+    this.chainingKey = chainingKey;
+    this.cipher.initializeKey(tempKey);
+  }
+
+  mixHash(data: Buffer): void {
+    this.hash = sha256(Buffer.concat([this.hash, data]));
+  }
+
+  encryptAndHash(plaintext: Buffer): Buffer {
+    const ciphertext = this.cipher.encryptWithAd(this.hash, plaintext);
+    this.mixHash(ciphertext);
+    return ciphertext;
+  }
+
+  decryptAndHash(ciphertext: Buffer): Buffer {
+    const plaintext = this.cipher.decryptWithAd(this.hash, ciphertext);
+    this.mixHash(ciphertext);
+    return plaintext;
+  }
+
+  split(): [CipherState, CipherState] {
+    const [k1, k2] = hkdf2(this.chainingKey, Buffer.alloc(0));
+    const c1 = new CipherState();
+    c1.initializeKey(k1);
+    const c2 = new CipherState();
+    c2.initializeKey(k2);
+    return [c1, c2];
+  }
+}
+
+export type NoiseHandshakeOptions = {
+  role: NoiseRole;
+  localStatic: NoiseKeyPair;
+  /** Required for the initiator: the pinned responder (gateway) static pubkey. */
+  remoteStaticPublicKey?: Buffer;
+  prologue?: Buffer;
+  /** Test seam: supply a deterministic ephemeral keypair. Defaults to random. */
+  generateEphemeral?: () => NoiseKeyPair;
+};
+
+export class NoiseIKHandshake {
+  private readonly sym = new SymmetricState();
+  private readonly role: NoiseRole;
+  private readonly localStatic: NoiseKeyPair;
+  private readonly generateEphemeral: () => NoiseKeyPair;
+  private localEphemeral?: NoiseKeyPair;
+  private remoteStatic?: Buffer;
+  private remoteEphemeral?: Buffer;
+
+  constructor(options: NoiseHandshakeOptions) {
+    this.role = options.role;
+    this.localStatic = options.localStatic;
+    this.generateEphemeral =
+      options.generateEphemeral ?? generateNoiseStaticKeyPair;
+
+    this.sym.mixHash(options.prologue ?? Buffer.alloc(0));
+
+    // Pre-message: IK has `<- s` (responder static), hashed by both sides.
+    if (this.role === "initiator") {
+      if (!options.remoteStaticPublicKey) {
+        throw new Error("Initiator requires the pinned responder static key");
+      }
+      this.remoteStatic = Buffer.from(options.remoteStaticPublicKey);
+      this.sym.mixHash(this.remoteStatic);
+    } else {
+      this.sym.mixHash(this.localStatic.publicKeyRaw);
+    }
+  }
+
+  /** Initiator: write message 1 (e, es, s, ss + payload). */
+  writeMessage1(payload: Buffer = Buffer.alloc(0)): Buffer {
+    if (this.role !== "initiator") throw new Error("writeMessage1 is initiator-only");
+    if (!this.remoteStatic) throw new Error("Missing pinned responder static");
+    this.localEphemeral = this.generateEphemeral();
+    this.sym.mixHash(this.localEphemeral.publicKeyRaw);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteStatic)); // es
+    const encStatic = this.sym.encryptAndHash(this.localStatic.publicKeyRaw); // s
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteStatic)); // ss
+    const encPayload = this.sym.encryptAndHash(payload);
+    return Buffer.concat([this.localEphemeral.publicKeyRaw, encStatic, encPayload]);
+  }
+
+  /** Responder: read message 1. Returns the (decrypted) payload. */
+  readMessage1(message: Buffer): Buffer {
+    if (this.role !== "responder") throw new Error("readMessage1 is responder-only");
+    let offset = 0;
+    this.remoteEphemeral = message.subarray(offset, offset + KEYLEN);
+    offset += KEYLEN;
+    this.sym.mixHash(this.remoteEphemeral);
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteEphemeral)); // es
+    const encStatic = message.subarray(offset, offset + KEYLEN + TAGLEN);
+    offset += KEYLEN + TAGLEN;
+    this.remoteStatic = this.sym.decryptAndHash(encStatic); // s
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteStatic)); // ss
+    return this.sym.decryptAndHash(message.subarray(offset));
+  }
+
+  /** Responder: write message 2 (e, ee, se + payload). */
+  writeMessage2(payload: Buffer = Buffer.alloc(0)): Buffer {
+    if (this.role !== "responder") throw new Error("writeMessage2 is responder-only");
+    if (!this.remoteEphemeral || !this.remoteStatic) {
+      throw new Error("writeMessage2 requires readMessage1 first");
+    }
+    this.localEphemeral = this.generateEphemeral();
+    this.sym.mixHash(this.localEphemeral.publicKeyRaw);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteEphemeral)); // ee
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteStatic)); // se (responder: DH(e, rs))
+    const encPayload = this.sym.encryptAndHash(payload);
+    return Buffer.concat([this.localEphemeral.publicKeyRaw, encPayload]);
+  }
+
+  /** Initiator: read message 2. Returns the (decrypted) payload. */
+  readMessage2(message: Buffer): Buffer {
+    if (this.role !== "initiator") throw new Error("readMessage2 is initiator-only");
+    if (!this.localEphemeral) throw new Error("readMessage2 requires writeMessage1 first");
+    let offset = 0;
+    this.remoteEphemeral = message.subarray(offset, offset + KEYLEN);
+    offset += KEYLEN;
+    this.sym.mixHash(this.remoteEphemeral);
+    this.sym.mixKey(dh(this.localEphemeral.privateKey, this.remoteEphemeral)); // ee
+    this.sym.mixKey(dh(this.localStatic.privateKey, this.remoteEphemeral)); // se (initiator: DH(s, re))
+    return this.sym.decryptAndHash(message.subarray(offset));
+  }
+
+  /** The remote static key the responder learned during the handshake. */
+  remoteStaticPublicKey(): Buffer | undefined {
+    return this.remoteStatic ? Buffer.from(this.remoteStatic) : undefined;
+  }
+
+  /** Finalize: split into directional transport cipher states. */
+  split(): NoiseTransport {
+    const [c1, c2] = this.sym.split();
+    // Initiator sends with the first cipher state; responder with the second.
+    const send = this.role === "initiator" ? c1 : c2;
+    const recv = this.role === "initiator" ? c2 : c1;
+    const handshakeHash = Buffer.from(this.sym.hash);
+    return {
+      handshakeHash,
+      encrypt: (plaintext) => send.encryptWithAd(Buffer.alloc(0), plaintext),
+      decrypt: (ciphertext) => recv.decryptWithAd(Buffer.alloc(0), ciphertext),
+    };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -116,6 +116,29 @@ export function rawPrivateKey(key: KeyObject): Buffer {
   );
 }
 
+export type FederationNoiseStaticKeyPair = {
+  /** Raw 32-byte X25519 private seed, base64. Persisted in the secret store. */
+  privateKeyBase64: string;
+  /** Raw 32-byte X25519 public key, base64. Pinned by peers. */
+  publicKeyBase64: string;
+};
+
+export function generateFederationNoiseStaticKeyPair(): FederationNoiseStaticKeyPair {
+  const keyPair = generateNoiseStaticKeyPair();
+  return {
+    privateKeyBase64: rawPrivateKey(keyPair.privateKey).toString("base64"),
+    publicKeyBase64: keyPair.publicKeyRaw.toString("base64"),
+  };
+}
+
+export function noisePublicKeyBase64FromPrivateBase64(
+  privateKeyBase64: string,
+): string {
+  return noiseKeyPairFromRawPrivate(
+    Buffer.from(privateKeyBase64, "base64"),
+  ).publicKeyRaw.toString("base64");
+}
+
 function dh(localPrivate: KeyObject, remoteRaw: Buffer): Buffer {
   return diffieHellman({
     privateKey: localPrivate,

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -1,6 +1,6 @@
-// Noise_IK_25519_ChaChaPoly_SHA256 — a hand-written implementation of the one
+// Noise_IK_25519_AESGCM_SHA256 — a hand-written implementation of the one
 // Noise handshake pattern federation needs, built on Node's audited crypto
-// primitives (X25519, ChaCha20-Poly1305, HMAC-SHA256). We implement only the
+// primitives (X25519, AES-256-GCM, HMAC-SHA256). We implement only the
 // state-machine plumbing; every cryptographic primitive is delegated to
 // OpenSSL via node:crypto. Correctness is locked down against the official
 // Noise test vectors in federation-noise.test.ts.
@@ -30,7 +30,7 @@ import {
   type KeyObject,
 } from "node:crypto";
 
-const PROTOCOL_NAME = "Noise_IK_25519_ChaChaPoly_SHA256";
+const PROTOCOL_NAME = "Noise_IK_25519_AESGCM_SHA256";
 const HASHLEN = 32;
 const TAGLEN = 16;
 const KEYLEN = 32;
@@ -160,9 +160,10 @@ class CipherState {
   }
 
   private nextNonce(): Buffer {
-    // Noise nonce: 4 zero bytes followed by the 64-bit counter, little-endian.
+    // AESGCM Noise nonce: 4 zero bytes followed by the 64-bit counter,
+    // big-endian (Noise Protocol Framework section 14.3).
     const buf = Buffer.alloc(12);
-    buf.writeBigUInt64LE(this.nonce, 4);
+    buf.writeBigUInt64BE(this.nonce, 4);
     return buf;
   }
 
@@ -171,7 +172,7 @@ class CipherState {
     if (this.nonce >= 0xffffffffffffffffn) {
       throw new Error("Noise nonce exhausted");
     }
-    const cipher = createCipheriv("chacha20-poly1305", this.key, this.nextNonce(), {
+    const cipher = createCipheriv("aes-256-gcm", this.key, this.nextNonce(), {
       authTagLength: TAGLEN,
     });
     cipher.setAAD(ad, { plaintextLength: plaintext.length });
@@ -192,7 +193,7 @@ class CipherState {
     const ciphertext = data.subarray(0, data.length - TAGLEN);
     const tag = data.subarray(data.length - TAGLEN);
     const decipher = createDecipheriv(
-      "chacha20-poly1305",
+      "aes-256-gcm",
       this.key,
       this.nextNonce(),
       { authTagLength: TAGLEN },

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -58,7 +58,18 @@ export class FederationRpcEndpoint {
         timer,
       });
     });
-    this.options.sendEnvelope(envelope);
+    try {
+      this.options.sendEnvelope(envelope);
+    } catch (error) {
+      const pending = this.pending.get(id);
+      if (pending) {
+        clearTimeout(pending.timer);
+        this.pending.delete(id);
+        pending.reject(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
     return promise;
   }
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -111,11 +111,13 @@ import {
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
 } from "./federation-transport";
+import { noiseKeyPairFromRawPrivate } from "./federation-noise";
 
 const log = getMainLogger("pwragent:federation-runtime");
 const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const GATEWAY_PUBLIC_KEY_META_KEY = "federation_gateway_public_key_pem";
+const GATEWAY_NOISE_PUBLIC_KEY_META_KEY = "federation_gateway_noise_public_key";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
@@ -306,6 +308,8 @@ export class DesktopFederationRuntime {
     const expiresAt = now + Math.max(60_000, Math.min(request.ttlMs ?? 3_600_000, 86_400_000));
     const gatewayIdentity = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
+    const noise =
+      await getDesktopSettingsService().getOrCreateFederationNoiseStaticKeyPair();
     const entry = createFederationEnrollmentInvite({
       store: this.store(),
       token: randomBytes(24).toString("base64url"),
@@ -323,6 +327,7 @@ export class DesktopFederationRuntime {
         gatewayInstanceId: this.ensureLocalInstanceId(),
         gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
         gatewayUrl,
+        gatewayNoisePublicKey: noise.publicKeyBase64,
         expiresAt,
       }),
       expiresAt,
@@ -338,6 +343,10 @@ export class DesktopFederationRuntime {
     const stateDb = getAppStateDb();
     stateDb.setMeta(GATEWAY_INSTANCE_ID_META_KEY, payload.gatewayInstanceId);
     stateDb.setMeta(GATEWAY_PUBLIC_KEY_META_KEY, payload.gatewayPublicKeyPem);
+    stateDb.setMeta(
+      GATEWAY_NOISE_PUBLIC_KEY_META_KEY,
+      payload.gatewayNoisePublicKey,
+    );
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
     await getDesktopSettingsService().writeConfigPatch({
       federation: {
@@ -455,6 +464,12 @@ export class DesktopFederationRuntime {
     this.router = router;
     this.subscribeLocalBackendEvents();
 
+    const noise =
+      await getDesktopSettingsService().getOrCreateFederationNoiseStaticKeyPair();
+    const noiseStatic = noiseKeyPairFromRawPrivate(
+      Buffer.from(noise.privateKeyBase64, "base64"),
+    );
+
     if (mode === "gateway" || mode === "dual") {
       const gatewayIdentity = await getDesktopSettingsService()
         .getOrCreateFederationIdentityKeyPair();
@@ -465,6 +480,7 @@ export class DesktopFederationRuntime {
         host: settings.federation.listenHost.value,
         port: settings.federation.listenPort.value,
         store: this.store(),
+        noiseStatic,
         onConnection: (connection) => this.registerGatewayConnection(connection),
         onDisconnect: (connection) => this.unregisterGatewayConnection(connection),
         onEnvelope: (envelope, connection) =>
@@ -509,6 +525,14 @@ export class DesktopFederationRuntime {
       throw new Error("Federation client mode is missing its pinned gateway key.");
     }
     this.gatewayInstanceId = gatewayInstanceId;
+    const gatewayNoisePublicKeyBase64 = getAppStateDb().getMeta(
+      GATEWAY_NOISE_PUBLIC_KEY_META_KEY,
+    );
+    if (!gatewayNoisePublicKeyBase64) {
+      throw new Error(
+        "Federation client mode is missing its pinned gateway encryption key. Re-import the federation invite.",
+      );
+    }
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
@@ -538,6 +562,8 @@ export class DesktopFederationRuntime {
         "Cloudflare Access service auth is enabled but its credentials are missing.",
       );
     }
+    const noise =
+      await settingsService.getOrCreateFederationNoiseStaticKeyPair();
     this.gatewayUrl = gatewayUrl;
     const connectionGeneration = ++this.connectionGeneration;
     const client = await connectFederationClient({
@@ -565,6 +591,13 @@ export class DesktopFederationRuntime {
       clientPrivateKey: cloudflareMtlsEnabled
         ? cloudflareCredentials.clientPrivateKey
         : undefined,
+      noiseStatic: noiseKeyPairFromRawPrivate(
+        Buffer.from(noise.privateKeyBase64, "base64"),
+      ),
+      gatewayNoisePublicKey: Buffer.from(
+        gatewayNoisePublicKeyBase64,
+        "base64",
+      ),
       onClose: () => {
         if (
           this.stopping ||

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -40,6 +40,7 @@ import type {
   TrustCodexProjectResponse,
 } from "@pwragent/shared";
 import {
+  FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
   buildFederatedThreadRef,
   isRemoteFederationTarget,
@@ -346,7 +347,7 @@ export class DesktopFederationRuntime {
     });
     return {
       invite: encodeFederationInvite({
-        version: 1,
+        version: FEDERATION_INVITE_VERSION,
         token: entry.token,
         gatewayInstanceId: this.ensureLocalInstanceId(),
         gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4,10 +4,12 @@ import type {
   AppServerListSkillsResponse,
   AppServerListThreadsResponse,
   AppServerReadThreadResponse,
+  CancelQueuedTurnResponse,
   CancelThreadExecutionModeQueueResponse,
   CompactThreadResponse,
   CodexEnvironmentSetupProgressEvent,
   FederationCapability,
+  FederationConnectionState,
   FederationDiagnosticEvent,
   FederatedSearchRequest,
   FederatedSearchResponse,
@@ -43,6 +45,7 @@ import {
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
   type AppServerReadThreadRequest,
+  type CancelQueuedTurnRequest,
   type CancelThreadExecutionModeQueueRequest,
   type CompactThreadRequest,
   type ForkThreadRequest,
@@ -153,6 +156,13 @@ export class DesktopFederationRuntime {
     FederationInstanceId,
     FederationPeerSummary
   >();
+  private readonly publishedPeerStatuses = new Map<
+    FederationInstanceId,
+    {
+      status: FederationConnectionState;
+      unavailableReason?: string;
+    }
+  >();
   private publishAgentEvent?: (event: AgentEvent) => void;
   private publishEnvironmentSetupProgress?: (
     event: CodexEnvironmentSetupProgressEvent,
@@ -210,6 +220,17 @@ export class DesktopFederationRuntime {
   async stop(): Promise<void> {
     this.stopping = true;
     this.connectionGeneration += 1;
+    if (isAppStateInitialized()) {
+      for (const peer of this.visiblePeers()) {
+        if (peer.status === "connected") {
+          this.publishPeerStatus(
+            peer.id,
+            "disconnected",
+            "Federation runtime stopped.",
+          );
+        }
+      }
+    }
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = undefined;
@@ -226,6 +247,7 @@ export class DesktopFederationRuntime {
     this.gatewayInstanceId = undefined;
     this.rpcByPeer.clear();
     this.remotePeerDirectory.clear();
+    this.publishedPeerStatuses.clear();
     this.reconnectAttempt = 0;
     this.lastConnectionError = undefined;
     this.gatewayListenerError = undefined;
@@ -287,6 +309,7 @@ export class DesktopFederationRuntime {
     this.server?.closePeer(peerId);
     this.unregisterPeer(peerId);
     this.remotePeerDirectory.delete(peerId);
+    this.publishPeerStatus(peerId, "revoked");
     this.broadcastPeerDirectory();
     return publicPeerSummary({
       ...peer,
@@ -608,6 +631,11 @@ export class DesktopFederationRuntime {
         this.client = undefined;
         this.lastConnectionError = "Federation gateway connection closed.";
         this.unregisterPeer(gatewayInstanceId);
+        this.publishPeerStatus(
+          gatewayInstanceId,
+          "disconnected",
+          this.lastConnectionError,
+        );
         this.disconnectAdvertisedPeers(this.lastConnectionError);
         this.scheduleReconnect(gatewayUrl);
       },
@@ -627,6 +655,7 @@ export class DesktopFederationRuntime {
       capabilities: DEFAULT_CAPABILITIES,
       sendEnvelope: (envelope) => this.client?.sendEnvelope(envelope),
     });
+    this.publishPeerStatus(gatewayInstanceId, "connected");
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
@@ -644,6 +673,13 @@ export class DesktopFederationRuntime {
     this.lastConnectionError = redactFederationDiagnostic(
       error instanceof Error ? error.message : String(error),
     );
+    if (this.gatewayInstanceId) {
+      this.publishPeerStatus(
+        this.gatewayInstanceId,
+        "disconnected",
+        this.lastConnectionError,
+      );
+    }
     this.disconnectAdvertisedPeers(this.lastConnectionError);
     this.store().appendAudit({
       peerId: this.gatewayInstanceId,
@@ -680,6 +716,7 @@ export class DesktopFederationRuntime {
       capabilities: connection.capabilities,
       sendEnvelope: connection.sendEnvelope,
     });
+    this.publishPeerStatus(connection.peerId, "connected");
     this.broadcastPeerDirectory();
   }
 
@@ -689,6 +726,11 @@ export class DesktopFederationRuntime {
       return;
     }
     this.unregisterPeer(connection.peerId);
+    this.publishPeerStatus(
+      connection.peerId,
+      "disconnected",
+      "Federation peer connection closed.",
+    );
     this.broadcastPeerDirectory();
   }
 
@@ -707,6 +749,11 @@ export class DesktopFederationRuntime {
         status: peer.status === "revoked" ? "revoked" : "disconnected",
         unavailableReason: reason,
       });
+      this.publishPeerStatus(
+        peerId,
+        peer.status === "revoked" ? "revoked" : "disconnected",
+        reason,
+      );
     }
     for (const rpc of this.rpcByPeer.values()) {
       rpc.rejectAll(new Error(reason));
@@ -942,13 +989,53 @@ export class DesktopFederationRuntime {
     }
 
     const notification = envelope as FederationPeerDirectoryNotification & typeof envelope;
+    const previousPeers = new Map(this.remotePeerDirectory);
     this.remotePeerDirectory.clear();
     for (const peer of notification.params.peers) {
       if (peer.id !== this.ensureLocalInstanceId()) {
         this.remotePeerDirectory.set(peer.id, { ...peer, canRevoke: false });
+        previousPeers.delete(peer.id);
+        this.publishPeerStatus(peer.id, peer.status, peer.unavailableReason);
       }
     }
+    for (const peerId of previousPeers.keys()) {
+      this.publishPeerStatus(
+        peerId,
+        "disconnected",
+        "Federation peer is no longer advertised by the gateway.",
+      );
+    }
     return true;
+  }
+
+  private publishPeerStatus(
+    instanceId: FederationInstanceId,
+    status: FederationConnectionState,
+    unavailableReason?: string,
+  ): void {
+    const previous = this.publishedPeerStatuses.get(instanceId);
+    if (
+      previous?.status === status
+      && previous.unavailableReason === unavailableReason
+    ) {
+      return;
+    }
+    this.publishedPeerStatuses.set(instanceId, { status, unavailableReason });
+    this.publishAgentEvent?.({
+      backend: "codex",
+      federationTarget: {
+        scope: "remote",
+        instanceId,
+      },
+      notification: {
+        method: "federation/peerStatus/changed",
+        params: {
+          instanceId,
+          status,
+          ...(unavailableReason ? { unavailableReason } : {}),
+        },
+      },
+    });
   }
 
   private subscribeLocalBackendEvents(): void {
@@ -1145,6 +1232,17 @@ function localBackendOperations(): FederationBackendOperations {
       request: StartReviewRequest,
     ): Promise<StartReviewResponse> {
       return await getDesktopBackendRegistry().startReview(request);
+    },
+    async cancelQueuedTurn(
+      request: CancelQueuedTurnRequest,
+    ): Promise<CancelQueuedTurnResponse> {
+      return {
+        queueEntryId: request.queueEntryId,
+        cancelled: getDesktopBackendRegistry().cancelQueuedTurn(
+          request.queueEntryId,
+          "Cancelled from a federated desktop composer.",
+        ),
+      };
     },
     async compactThread(
       request: CompactThreadRequest,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -18,6 +18,7 @@ import type {
   FederationInstanceRole,
   FederationPeerSummary,
   FederationProtocolEnvelope,
+  FederationSessionId,
   ForkThreadResponse,
   HandoffThreadWorkspaceResponse,
   InterruptTurnResponse,
@@ -557,6 +558,7 @@ export class DesktopFederationRuntime {
       );
     }
     const pendingInviteToken = getAppStateDb().getMeta(PENDING_INVITE_TOKEN_META_KEY);
+    const connectionMode = pendingInviteToken ? "enroll" : "reconnect";
     const keyPair = await getDesktopSettingsService()
       .getOrCreateFederationIdentityKeyPair();
     const settingsService = getDesktopSettingsService();
@@ -589,9 +591,16 @@ export class DesktopFederationRuntime {
       await settingsService.getOrCreateFederationNoiseStaticKeyPair();
     this.gatewayUrl = gatewayUrl;
     const connectionGeneration = ++this.connectionGeneration;
+    this.store().appendAudit({
+      peerId: gatewayInstanceId,
+      kind: "connect_attempt",
+      createdAt: Date.now(),
+      detail: connectionMode,
+    });
+    const clientSession: { id?: FederationSessionId } = {};
     const client = await connectFederationClient({
       url: gatewayUrl,
-      mode: pendingInviteToken ? "enroll" : "reconnect",
+      mode: connectionMode,
       gatewayInstanceId,
       gatewayPublicKeyPem,
       peerInstanceId: this.ensureLocalInstanceId(),
@@ -630,6 +639,13 @@ export class DesktopFederationRuntime {
         }
         this.client = undefined;
         this.lastConnectionError = "Federation gateway connection closed.";
+        this.store().appendAudit({
+          peerId: gatewayInstanceId,
+          sessionId: clientSession.id,
+          kind: "disconnected",
+          createdAt: Date.now(),
+          detail: "transport_closed",
+        });
         this.unregisterPeer(gatewayInstanceId);
         this.publishPeerStatus(
           gatewayInstanceId,
@@ -642,6 +658,7 @@ export class DesktopFederationRuntime {
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
     });
+    clientSession.id = client.sessionId;
     if (
       this.stopping ||
       connectionGeneration !== this.connectionGeneration
@@ -655,6 +672,13 @@ export class DesktopFederationRuntime {
       capabilities: DEFAULT_CAPABILITIES,
       sendEnvelope: (envelope) => this.client?.sendEnvelope(envelope),
     });
+    this.recordClientConnection({
+      gatewayInstanceId,
+      gatewayUrl,
+      client,
+      connectionMode,
+      connectedAt: Date.now(),
+    });
     this.publishPeerStatus(gatewayInstanceId, "connected");
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
@@ -662,6 +686,37 @@ export class DesktopFederationRuntime {
     this.reconnectAttempt = 0;
     this.lastConnectionError = undefined;
     log.info("federation client connected", { gatewayUrl });
+  }
+
+  private recordClientConnection(params: {
+    gatewayInstanceId: FederationInstanceId;
+    gatewayUrl: string;
+    client: FederationClientWebSocketClient;
+    connectionMode: "enroll" | "reconnect";
+    connectedAt: number;
+  }): void {
+    const existing = this.remotePeerDirectory.get(params.gatewayInstanceId);
+    this.remotePeerDirectory.set(params.gatewayInstanceId, {
+      id: params.gatewayInstanceId,
+      label: existing?.label ?? this.defaultPeerLabel(params.gatewayInstanceId),
+      role: "gateway",
+      status: "connected",
+      capabilities: [...params.client.capabilities],
+      protocolVersion:
+        existing?.protocolVersion ?? FEDERATION_PROTOCOL_VERSION,
+      endpoint: existing?.endpoint ?? params.gatewayUrl,
+      profileName: existing?.profileName,
+      lastConnectedAt: params.connectedAt,
+      lastActivityAt: params.connectedAt,
+      canRevoke: false,
+    });
+    this.store().appendAudit({
+      peerId: params.gatewayInstanceId,
+      sessionId: params.client.sessionId,
+      kind: "connected",
+      createdAt: params.connectedAt,
+      detail: params.connectionMode,
+    });
   }
 
   private handleClientConnectionFailure(
@@ -993,7 +1048,13 @@ export class DesktopFederationRuntime {
     this.remotePeerDirectory.clear();
     for (const peer of notification.params.peers) {
       if (peer.id !== this.ensureLocalInstanceId()) {
-        this.remotePeerDirectory.set(peer.id, { ...peer, canRevoke: false });
+        const previous = previousPeers.get(peer.id);
+        this.remotePeerDirectory.set(peer.id, {
+          ...peer,
+          lastConnectedAt: peer.lastConnectedAt ?? previous?.lastConnectedAt,
+          lastActivityAt: peer.lastActivityAt ?? previous?.lastActivityAt,
+          canRevoke: false,
+        });
         previousPeers.delete(peer.id);
         this.publishPeerStatus(peer.id, peer.status, peer.unavailableReason);
       }

--- a/apps/desktop/src/main/federation/federation-tailscale.ts
+++ b/apps/desktop/src/main/federation/federation-tailscale.ts
@@ -1,0 +1,243 @@
+import { execFile as execFileCallback } from "node:child_process";
+import type {
+  ConfigureFederationTailscaleRequest,
+  ConfigureFederationTailscaleResponse,
+  FederationTailscaleStatus,
+} from "@pwragent/shared";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { discoverCommands } from "../settings/command-discovery";
+
+const PWRAGENT_TAILSCALE_PATH = "/pwragent-federation";
+const COMMAND_TIMEOUT_MS = 15_000;
+
+type TailscaleCommandSource = "path" | "application";
+
+type TailscaleCommand = {
+  command: string;
+  version?: string;
+};
+
+type TailscaleCommandResult = {
+  stdout: string;
+  stderr: string;
+};
+
+type FederationTailscaleServiceOptions = {
+  discoverCommand?: () => Promise<TailscaleCommand | undefined>;
+  env?: NodeJS.ProcessEnv;
+  runCommand?: (
+    command: string,
+    args: string[],
+  ) => Promise<TailscaleCommandResult>;
+};
+
+export class FederationTailscaleService {
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly discoverCommandOverride?: FederationTailscaleServiceOptions["discoverCommand"];
+  private readonly runCommandOverride?: FederationTailscaleServiceOptions["runCommand"];
+
+  constructor(options: FederationTailscaleServiceOptions = {}) {
+    this.env = options.env ?? process.env;
+    this.discoverCommandOverride = options.discoverCommand;
+    this.runCommandOverride = options.runCommand;
+  }
+
+  async readStatus(): Promise<FederationTailscaleStatus> {
+    const discovered = await this.discoverCommand();
+    if (!discovered) {
+      return {
+        installed: false,
+        connected: false,
+        serveConfigured: false,
+        funnelConfigured: false,
+        unavailableReason: "Tailscale CLI was not found.",
+      };
+    }
+
+    try {
+      const [statusResult, serveResult, funnelResult] = await Promise.all([
+        this.runCommand(discovered.command, ["status", "--json"]),
+        this.runCommand(discovered.command, ["serve", "status", "--json"]),
+        this.runCommand(discovered.command, ["funnel", "status", "--json"]),
+      ]);
+      const statusJson = parseJsonObject(statusResult.stdout, "Tailscale status");
+      const self = readObject(statusJson.Self);
+      const currentTailnet = readObject(statusJson.CurrentTailnet);
+      const dnsName = readString(self?.DNSName)?.replace(/\.$/, "");
+      const backendState = readString(statusJson.BackendState);
+      const connected = self?.Online === true || backendState === "Running";
+
+      return {
+        installed: true,
+        connected,
+        version: discovered.version,
+        backendState,
+        dnsName,
+        tailnetName: readString(currentTailnet?.Name),
+        serveConfigured: hasPwrAgentHandler(serveResult.stdout),
+        funnelConfigured: hasPwrAgentHandler(funnelResult.stdout),
+        gatewayUrl: dnsName ? buildGatewayUrl(dnsName) : undefined,
+        unavailableReason: connected
+          ? undefined
+          : "Tailscale is installed but this device is not connected.",
+      };
+    } catch (error) {
+      return {
+        installed: true,
+        connected: false,
+        version: discovered.version,
+        serveConfigured: false,
+        funnelConfigured: false,
+        unavailableReason: errorMessage(error),
+      };
+    }
+  }
+
+  async configure(
+    request: ConfigureFederationTailscaleRequest,
+  ): Promise<ConfigureFederationTailscaleResponse> {
+    if (!Number.isInteger(request.listenPort) || request.listenPort < 1 || request.listenPort > 65_535) {
+      throw new Error("Tailscale setup requires a valid federation listen port.");
+    }
+    if (request.mode !== "serve" && request.mode !== "funnel") {
+      throw new Error("Unsupported Tailscale federation mode.");
+    }
+
+    const discovered = await this.discoverCommand();
+    if (!discovered) {
+      throw new Error("Tailscale CLI was not found.");
+    }
+
+    const before = await this.readStatus();
+    if (!before.connected) {
+      throw new Error(
+        before.unavailableReason ?? "Connect this device to Tailscale before setup.",
+      );
+    }
+
+    await this.runCommand(discovered.command, [
+      request.mode,
+      "--bg",
+      "--yes",
+      `--set-path=${PWRAGENT_TAILSCALE_PATH}`,
+      `http://127.0.0.1:${request.listenPort}`,
+    ]);
+
+    const status = await this.readStatus();
+    if (!status.gatewayUrl) {
+      throw new Error("Tailscale did not report a MagicDNS name after setup.");
+    }
+    if (request.mode === "serve" && !status.serveConfigured) {
+      throw new Error("Tailscale Serve did not report the PwrAgent handler after setup.");
+    }
+    if (request.mode === "funnel" && !status.funnelConfigured) {
+      throw new Error("Tailscale Funnel did not report the PwrAgent handler after setup.");
+    }
+
+    return {
+      status,
+      gatewayUrl: status.gatewayUrl,
+    };
+  }
+
+  private async discoverCommand(): Promise<TailscaleCommand | undefined> {
+    if (this.discoverCommandOverride) {
+      return await this.discoverCommandOverride();
+    }
+    const discovery = await discoverCommands<TailscaleCommandSource>({
+      fixedCandidates: [],
+      autoCandidates: [
+        { command: "tailscale", source: "path" },
+        {
+          command: "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+          source: "application",
+        },
+      ],
+      env: this.env,
+      parseVersion: (output) => output.match(/\b\d+\.\d+(?:\.\d+)?\b/)?.[0],
+      includeFailedAutoCandidates: "if-none-executable",
+    });
+    const selected = discovery.candidates.find((candidate) => candidate.selected);
+    return selected
+      ? { command: selected.command, version: selected.version }
+      : undefined;
+  }
+
+  private async runCommand(
+    command: string,
+    args: string[],
+  ): Promise<TailscaleCommandResult> {
+    if (this.runCommandOverride) {
+      return await this.runCommandOverride(command, args);
+    }
+    return await new Promise<TailscaleCommandResult>((resolve, reject) => {
+      execFileCallback(
+        command,
+        args,
+        {
+          env: buildPwrAgentChildProcessEnv(this.env),
+          timeout: COMMAND_TIMEOUT_MS,
+          maxBuffer: 1024 * 1024,
+        },
+        (error, stdout, stderr) => {
+          if (error) {
+            const detail = `${stderr || stdout}`.trim();
+            reject(new Error(detail || error.message));
+            return;
+          }
+          resolve({ stdout: String(stdout), stderr: String(stderr) });
+        },
+      );
+    });
+  }
+}
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    const object = readObject(parsed);
+    if (!object) {
+      throw new Error(`${label} did not return an object.`);
+    }
+    return object;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`${label} returned invalid JSON.`, { cause: error });
+    }
+    throw error;
+  }
+}
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function hasPwrAgentHandler(value: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return JSON.stringify(parsed).includes(PWRAGENT_TAILSCALE_PATH);
+  } catch {
+    return false;
+  }
+}
+
+function buildGatewayUrl(dnsName: string): string {
+  return `wss://${dnsName}${PWRAGENT_TAILSCALE_PATH}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+let federationTailscaleService: FederationTailscaleService | undefined;
+
+export function getFederationTailscaleService(): FederationTailscaleService {
+  federationTailscaleService ??= new FederationTailscaleService();
+  return federationTailscaleService;
+}

--- a/apps/desktop/src/main/federation/federation-tailscale.ts
+++ b/apps/desktop/src/main/federation/federation-tailscale.ts
@@ -60,16 +60,16 @@ export class FederationTailscaleService {
     }
 
     try {
-      const [statusResult, serveResult, funnelResult] = await Promise.all([
+      const [statusResult, serveResult] = await Promise.all([
         this.runCommand(discovered.command, [
           "status",
           "--json",
           "--peers=false",
         ]),
         this.runCommand(discovered.command, ["serve", "status", "--json"]),
-        this.runCommand(discovered.command, ["funnel", "status", "--json"]),
       ]);
       const statusJson = parseJsonObject(statusResult.stdout, "Tailscale status");
+      const serveJson = parseJsonObject(serveResult.stdout, "Tailscale Serve status");
       const self = readObject(statusJson.Self);
       const currentTailnet = readObject(statusJson.CurrentTailnet);
       const dnsName = readString(self?.DNSName)?.replace(/\.$/, "");
@@ -83,8 +83,8 @@ export class FederationTailscaleService {
         backendState,
         dnsName,
         tailnetName: readString(currentTailnet?.Name),
-        serveConfigured: hasPwrAgentHandler(serveResult.stdout),
-        funnelConfigured: hasPwrAgentHandler(funnelResult.stdout),
+        serveConfigured: hasPwrAgentHandler(serveJson),
+        funnelConfigured: hasPwrAgentFunnel(serveJson),
         gatewayUrl: dnsName ? buildGatewayUrl(dnsName) : undefined,
         unavailableReason: connected
           ? undefined
@@ -234,13 +234,28 @@ function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function hasPwrAgentHandler(value: string): boolean {
-  try {
-    const parsed: unknown = JSON.parse(value);
-    return JSON.stringify(parsed).includes(PWRAGENT_TAILSCALE_PATH);
-  } catch {
-    return false;
-  }
+function pwrAgentHandlerHostPorts(
+  serveConfig: Record<string, unknown>,
+): string[] {
+  const web = readObject(serveConfig.Web);
+  if (!web) return [];
+  return Object.entries(web)
+    .filter(([, value]) => {
+      const handlers = readObject(readObject(value)?.Handlers);
+      return handlers?.[PWRAGENT_TAILSCALE_PATH] !== undefined;
+    })
+    .map(([hostPort]) => hostPort);
+}
+
+function hasPwrAgentHandler(serveConfig: Record<string, unknown>): boolean {
+  return pwrAgentHandlerHostPorts(serveConfig).length > 0;
+}
+
+function hasPwrAgentFunnel(serveConfig: Record<string, unknown>): boolean {
+  const allowFunnel = readObject(serveConfig.AllowFunnel);
+  if (!allowFunnel) return false;
+  return pwrAgentHandlerHostPorts(serveConfig)
+    .some((hostPort) => allowFunnel[hostPort] === true);
 }
 
 function buildGatewayUrl(dnsName: string): string {

--- a/apps/desktop/src/main/federation/federation-tailscale.ts
+++ b/apps/desktop/src/main/federation/federation-tailscale.ts
@@ -6,9 +6,11 @@ import type {
 } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { discoverCommands } from "../settings/command-discovery";
+import { getDesktopFederationRuntime } from "./federation-runtime";
 
 const PWRAGENT_TAILSCALE_PATH = "/pwragent-federation";
 const COMMAND_TIMEOUT_MS = 15_000;
+const COMMAND_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
 type TailscaleCommandSource = "path" | "application";
 
@@ -29,17 +31,20 @@ type FederationTailscaleServiceOptions = {
     command: string,
     args: string[],
   ) => Promise<TailscaleCommandResult>;
+  verifyListener?: (listenPort: number) => Promise<void>;
 };
 
 export class FederationTailscaleService {
   private readonly env: NodeJS.ProcessEnv;
   private readonly discoverCommandOverride?: FederationTailscaleServiceOptions["discoverCommand"];
   private readonly runCommandOverride?: FederationTailscaleServiceOptions["runCommand"];
+  private readonly verifyListener: (listenPort: number) => Promise<void>;
 
   constructor(options: FederationTailscaleServiceOptions = {}) {
     this.env = options.env ?? process.env;
     this.discoverCommandOverride = options.discoverCommand;
     this.runCommandOverride = options.runCommand;
+    this.verifyListener = options.verifyListener ?? verifyPwrAgentListener;
   }
 
   async readStatus(): Promise<FederationTailscaleStatus> {
@@ -56,7 +61,11 @@ export class FederationTailscaleService {
 
     try {
       const [statusResult, serveResult, funnelResult] = await Promise.all([
-        this.runCommand(discovered.command, ["status", "--json"]),
+        this.runCommand(discovered.command, [
+          "status",
+          "--json",
+          "--peers=false",
+        ]),
         this.runCommand(discovered.command, ["serve", "status", "--json"]),
         this.runCommand(discovered.command, ["funnel", "status", "--json"]),
       ]);
@@ -88,7 +97,10 @@ export class FederationTailscaleService {
         version: discovered.version,
         serveConfigured: false,
         funnelConfigured: false,
-        unavailableReason: errorMessage(error),
+        unavailableReason: publicTailscaleError(
+          error,
+          "Unable to read Tailscale status.",
+        ),
       };
     }
   }
@@ -115,6 +127,7 @@ export class FederationTailscaleService {
       );
     }
 
+    await this.verifyListener(request.listenPort);
     await this.runCommand(discovered.command, [
       request.mode,
       "--bg",
@@ -168,7 +181,11 @@ export class FederationTailscaleService {
     args: string[],
   ): Promise<TailscaleCommandResult> {
     if (this.runCommandOverride) {
-      return await this.runCommandOverride(command, args);
+      try {
+        return await this.runCommandOverride(command, args);
+      } catch (error) {
+        throw commandError(args, error);
+      }
     }
     return await new Promise<TailscaleCommandResult>((resolve, reject) => {
       execFileCallback(
@@ -177,12 +194,11 @@ export class FederationTailscaleService {
         {
           env: buildPwrAgentChildProcessEnv(this.env),
           timeout: COMMAND_TIMEOUT_MS,
-          maxBuffer: 1024 * 1024,
+          maxBuffer: COMMAND_MAX_BUFFER_BYTES,
         },
         (error, stdout, stderr) => {
           if (error) {
-            const detail = `${stderr || stdout}`.trim();
-            reject(new Error(detail || error.message));
+            reject(commandError(args, error));
             return;
           }
           resolve({ stdout: String(stdout), stderr: String(stderr) });
@@ -231,8 +247,37 @@ function buildGatewayUrl(dnsName: string): string {
   return `wss://${dnsName}${PWRAGENT_TAILSCALE_PATH}`;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+class TailscaleCommandError extends Error {
+  constructor(message: string, cause: unknown) {
+    super(message, { cause });
+    this.name = "TailscaleCommandError";
+  }
+}
+
+function commandError(args: string[], cause: unknown): TailscaleCommandError {
+  const label = args[0] === "serve"
+    ? "Tailscale Serve"
+    : args[0] === "funnel"
+      ? "Tailscale Funnel"
+      : "Tailscale status";
+  return new TailscaleCommandError(
+    `${label} command failed. Run it in Terminal for details.`,
+    cause,
+  );
+}
+
+function publicTailscaleError(error: unknown, fallback: string): string {
+  return error instanceof TailscaleCommandError ? error.message : fallback;
+}
+
+async function verifyPwrAgentListener(listenPort: number): Promise<void> {
+  const health = await getDesktopFederationRuntime().health();
+  const expectedListenUrl = `ws://127.0.0.1:${listenPort}`;
+  if (health.listenUrl !== expectedListenUrl) {
+    throw new Error(
+      "PwrAgent must be listening on the selected loopback port before Tailscale setup.",
+    );
+  }
 }
 
 let federationTailscaleService: FederationTailscaleService | undefined;

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -25,6 +25,11 @@ import {
   verifyFederationMessageSignature,
 } from "./federation-identity";
 import {
+  NoiseIKHandshake,
+  type NoiseKeyPair,
+  type NoiseTransport,
+} from "./federation-noise";
+import {
   federationFailure,
   type FederationRedactedFailure,
 } from "./federation-redaction";
@@ -100,6 +105,13 @@ export type FederationGatewayWebSocketServerOptions = {
   port: number;
   store: FederationStore;
   sessions?: FederationSessionRegistry;
+  /**
+   * Gateway's Noise static keypair. When set, every connection runs a Noise_IK
+   * handshake (responder role) before auth, and all frames are encrypted. When
+   * unset, the transport runs in plaintext "tunnel" mode (confidentiality is
+   * expected from an outer TLS tunnel, e.g. Cloudflare).
+   */
+  noiseStatic?: NoiseKeyPair;
   onConnection?: (connection: FederationGatewayConnection) => void;
   onDisconnect?: (connection: FederationGatewayConnection) => void;
   onEnvelope?: (
@@ -131,7 +143,7 @@ export class FederationGatewayWebSocketServer {
     this.stopping = false;
     this.httpServer = http.createServer();
     this.wsServer = new WebSocketServer({ server: this.httpServer });
-    this.wsServer.on("connection", (socket) => this.handleSocket(socket));
+    this.wsServer.on("connection", (socket) => void this.handleSocket(socket));
 
     await new Promise<void>((resolve, reject) => {
       const server = this.httpServer;
@@ -180,8 +192,29 @@ export class FederationGatewayWebSocketServer {
     return true;
   }
 
-  private handleSocket(socket: WebSocket): void {
-    let connection: FederationGatewayConnection | undefined;
+  private async handleSocket(socket: WebSocket): Promise<void> {
+    const reader = new FederationFrameReader(socket);
+
+    // Phase 1: Noise_IK handshake (responder). Skipped in tunnel mode.
+    let transport: NoiseTransport | undefined;
+    let channelBinding = "";
+    if (this.options.noiseStatic) {
+      try {
+        const handshake = new NoiseIKHandshake({
+          role: "responder",
+          localStatic: this.options.noiseStatic,
+        });
+        handshake.readMessage1(await reader.next());
+        socket.send(handshake.writeMessage2());
+        transport = handshake.split();
+        channelBinding = transport.handshakeHash.toString("base64");
+      } catch {
+        socket.close();
+        return;
+      }
+    }
+
+    // Phase 2: signed identity auth, carried inside the encrypted channel.
     const challengeNonce = `challenge:${randomUUID()}`;
     const challengeMessage = buildFederationGatewayChallengeMessage({
       gatewayInstanceId: this.options.gatewayInstanceId,
@@ -189,103 +222,124 @@ export class FederationGatewayWebSocketServer {
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       nonce: challengeNonce,
     });
-    sendSocketMessage(socket, {
-      kind: "auth.challenge",
-      gatewayInstanceId: this.options.gatewayInstanceId,
-      gatewayPublicKeyPem: this.options.gatewayPublicKeyPem,
-      protocolVersion: FEDERATION_PROTOCOL_VERSION,
-      nonce: challengeNonce,
-      signatureBase64: signFederationMessage({
-        privateKeyPem: this.options.gatewayPrivateKeyPem,
-        message: challengeMessage,
-      }),
-    });
-    socket.once("message", (raw) => {
-      const message = parseSocketMessage(raw);
-      if (!message || message.kind !== "auth") {
-        this.options.store.appendAudit({
-          kind: "rejected",
-          createdAt: Date.now(),
-          detail: "policy_denied",
-        });
-        sendSocketMessage(socket, {
+    sendFrame(
+      socket,
+      {
+        kind: "auth.challenge",
+        gatewayInstanceId: this.options.gatewayInstanceId,
+        gatewayPublicKeyPem: this.options.gatewayPublicKeyPem,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        nonce: challengeNonce,
+        signatureBase64: signFederationMessage({
+          privateKeyPem: this.options.gatewayPrivateKeyPem,
+          message: challengeMessage,
+        }),
+      },
+      transport,
+    );
+
+    let authFrame: Buffer;
+    try {
+      authFrame = await reader.next();
+    } catch {
+      return;
+    }
+    const message = decodeFrame(authFrame, transport);
+    if (!message || message.kind !== "auth") {
+      this.options.store.appendAudit({
+        kind: "rejected",
+        createdAt: Date.now(),
+        detail: "policy_denied",
+      });
+      sendFrame(
+        socket,
+        {
           kind: "auth.rejected",
           failure: federationFailure("policy_denied"),
-        });
-        socket.close();
-        return;
-      }
+        },
+        transport,
+      );
+      socket.close();
+      return;
+    }
+    this.options.store.appendAudit({
+      peerId: isFederationInstanceId(message.peerInstanceId)
+        ? message.peerInstanceId
+        : undefined,
+      kind: "connect_attempt",
+      createdAt: Date.now(),
+      detail: message.mode,
+    });
+    if (message.nonce !== challengeNonce) {
       this.options.store.appendAudit({
         peerId: isFederationInstanceId(message.peerInstanceId)
           ? message.peerInstanceId
           : undefined,
-        kind: "connect_attempt",
+        kind: "rejected",
         createdAt: Date.now(),
-        detail: message.mode,
+        detail: "policy_denied",
       });
-      if (message.nonce !== challengeNonce) {
-        this.options.store.appendAudit({
-          peerId: isFederationInstanceId(message.peerInstanceId)
-            ? message.peerInstanceId
-            : undefined,
-          kind: "rejected",
-          createdAt: Date.now(),
-          detail: "policy_denied",
-        });
-        sendSocketMessage(socket, {
+      sendFrame(
+        socket,
+        {
           kind: "auth.rejected",
           failure: federationFailure("policy_denied"),
-        });
-        socket.close();
-        return;
-      }
-      const decision = this.authenticate(message);
-      if (!decision.accepted) {
-        this.options.store.appendAudit({
-          peerId: isFederationInstanceId(message.peerInstanceId)
-            ? message.peerInstanceId
-            : undefined,
-          kind: "rejected",
-          createdAt: Date.now(),
-          detail: decision.failure.code,
-        });
-        sendSocketMessage(socket, {
-          kind: "auth.rejected",
-          failure: decision.failure,
-        });
-        socket.close();
-        return;
-      }
-
-      const sessionId = `federation-session:${randomUUID()}`;
-      this.sessions.openSession({
-        sessionId,
-        peerId: decision.peer.id,
-        connectedAt: Date.now(),
-        capabilities: decision.capabilities,
-      });
-      connection = {
-        peerId: decision.peer.id,
-        sessionId,
-        capabilities: decision.capabilities,
-        sendEnvelope: (envelope) => {
-          sendSocketMessage(socket, { kind: "envelope", envelope });
         },
-        close: () => socket.close(),
-      };
-      const previous = this.connections.get(connection.peerId);
-      if (previous && previous.sessionId !== connection.sessionId) {
-        previous.close();
-      }
-      this.connections.set(connection.peerId, connection);
+        transport,
+      );
+      socket.close();
+      return;
+    }
+    const decision = this.authenticate(message, channelBinding);
+    if (!decision.accepted) {
       this.options.store.appendAudit({
-        peerId: connection.peerId,
-        sessionId,
-        kind: "connected",
+        peerId: isFederationInstanceId(message.peerInstanceId)
+          ? message.peerInstanceId
+          : undefined,
+        kind: "rejected",
         createdAt: Date.now(),
-        detail: message.mode,
+        detail: decision.failure.code,
       });
-      sendSocketMessage(socket, {
+      sendFrame(
+        socket,
+        { kind: "auth.rejected", failure: decision.failure },
+        transport,
+      );
+      socket.close();
+      return;
+    }
+
+    const sessionId = `federation-session:${randomUUID()}`;
+    this.sessions.openSession({
+      sessionId,
+      peerId: decision.peer.id,
+      connectedAt: Date.now(),
+      capabilities: decision.capabilities,
+    });
+    const connection: FederationGatewayConnection = {
+      peerId: decision.peer.id,
+      sessionId,
+      capabilities: decision.capabilities,
+      sendEnvelope: (envelope) => {
+        sendFrame(socket, { kind: "envelope", envelope }, transport);
+      },
+      close: () => socket.close(),
+    };
+    const previous = this.connections.get(connection.peerId);
+    if (previous && previous.sessionId !== connection.sessionId) {
+      previous.close();
+    }
+    this.connections.set(connection.peerId, connection);
+    this.options.store.appendAudit({
+      peerId: connection.peerId,
+      sessionId,
+      kind: "connected",
+      createdAt: Date.now(),
+      detail: message.mode,
+    });
+    sendFrame(
+      socket,
+      {
         kind: "auth.accepted",
         gatewayInstanceId: this.options.gatewayInstanceId,
         sessionId,
@@ -303,41 +357,47 @@ export class FederationGatewayWebSocketServer {
             capabilities: decision.capabilities,
           }),
         }),
+      },
+      transport,
+    );
+    this.options.onConnection?.(connection);
+    socket.once("close", () => {
+      this.sessions.closeSession({
+        sessionId,
+        closedAt: Date.now(),
+        reason: "transport_closed",
       });
-      this.options.onConnection?.(connection);
-
-      socket.on("message", (nextRaw) => {
-        const next = parseSocketMessage(nextRaw);
-        if (!next || next.kind !== "envelope" || !connection) return;
-        this.sessions.heartbeat(sessionId, Date.now());
-        this.options.onEnvelope?.(next.envelope, connection);
-      });
-      socket.once("close", () => {
-        this.sessions.closeSession({
+      if (this.connections.get(connection.peerId)?.sessionId === sessionId) {
+        this.connections.delete(connection.peerId);
+      }
+      if (!this.stopping) {
+        this.options.store.appendAudit({
+          peerId: connection.peerId,
           sessionId,
-          closedAt: Date.now(),
-          reason: "transport_closed",
+          kind: "disconnected",
+          createdAt: Date.now(),
+          detail: "transport_closed",
         });
-        if (connection) {
-          if (this.connections.get(connection.peerId)?.sessionId === sessionId) {
-            this.connections.delete(connection.peerId);
-          }
-          if (!this.stopping) {
-            this.options.store.appendAudit({
-              peerId: connection.peerId,
-              sessionId,
-              kind: "disconnected",
-              createdAt: Date.now(),
-              detail: "transport_closed",
-            });
-          }
-          this.options.onDisconnect?.(connection);
-        }
-      });
+      }
+      this.options.onDisconnect?.(connection);
     });
+
+    // Phase 3: stream envelopes.
+    for (;;) {
+      let frame: Buffer;
+      try {
+        frame = await reader.next();
+      } catch {
+        return;
+      }
+      const next = decodeFrame(frame, transport);
+      if (!next || next.kind !== "envelope") continue;
+      this.sessions.heartbeat(sessionId, Date.now());
+      this.options.onEnvelope?.(next.envelope, connection);
+    }
   }
 
-  private authenticate(message: FederationSocketAuthMessage) {
+  private authenticate(message: FederationSocketAuthMessage, channelBinding: string) {
     if (message.gatewayInstanceId !== this.options.gatewayInstanceId) {
       return {
         accepted: false as const,
@@ -356,6 +416,7 @@ export class FederationGatewayWebSocketServer {
         gatewayInstanceId: this.options.gatewayInstanceId,
         inviteToken: message.inviteToken,
         now: Date.now(),
+        channelBinding,
         peer: {
           instanceId: message.peerInstanceId,
           label: message.label ?? message.peerInstanceId,
@@ -378,6 +439,7 @@ export class FederationGatewayWebSocketServer {
       nonce: message.nonce,
       requestedCapabilities: message.capabilities,
       signatureBase64: message.signatureBase64,
+      channelBinding,
       now: Date.now(),
     });
   }
@@ -407,6 +469,10 @@ export async function connectFederationClient(params: {
   headers?: Record<string, string>;
   clientCertificate?: string;
   clientPrivateKey?: string;
+  /** Client's Noise static keypair. Enables encryption (initiator role). */
+  noiseStatic?: NoiseKeyPair;
+  /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
+  gatewayNoisePublicKey?: Buffer;
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
   onClose?: () => void;
 }): Promise<FederationClientWebSocketClient> {
@@ -415,11 +481,43 @@ export async function connectFederationClient(params: {
     cert: params.clientCertificate,
     key: params.clientPrivateKey,
   });
-  const [challenge] = await Promise.all([
-    waitForAuthChallenge(socket),
-    waitForOpen(socket),
-  ]);
+  // Attach the reader before "open" so no inbound frame can be missed.
+  const reader = new FederationFrameReader(socket);
+  await waitForOpen(socket);
+
+  // Phase 1: Noise_IK handshake (initiator). Skipped in tunnel mode.
+  let transport: NoiseTransport | undefined;
+  let channelBinding = "";
+  if (params.noiseStatic) {
+    if (!params.gatewayNoisePublicKey) {
+      socket.close();
+      throw new Error("Missing pinned gateway Noise key for encrypted federation");
+    }
+    try {
+      const handshake = new NoiseIKHandshake({
+        role: "initiator",
+        localStatic: params.noiseStatic,
+        remoteStaticPublicKey: params.gatewayNoisePublicKey,
+      });
+      socket.send(handshake.writeMessage1());
+      handshake.readMessage2(await reader.next());
+      transport = handshake.split();
+      channelBinding = transport.handshakeHash.toString("base64");
+    } catch (error) {
+      socket.close();
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+  }
+
+  // Phase 2: identity auth.
+  const challenge = decodeFrame(await reader.next(), transport);
+  if (challenge?.kind === "auth.rejected") {
+    socket.close();
+    throw new Error(challenge.failure.code);
+  }
   if (
+    !challenge ||
+    challenge.kind !== "auth.challenge" ||
     challenge.gatewayInstanceId !== params.gatewayInstanceId ||
     challenge.gatewayPublicKeyPem !== params.gatewayPublicKeyPem ||
     challenge.protocolVersion !== FEDERATION_PROTOCOL_VERSION
@@ -449,6 +547,7 @@ export async function connectFederationClient(params: {
     protocolVersion: FEDERATION_PROTOCOL_VERSION,
     nonce: challenge.nonce,
     capabilities: params.capabilities,
+    channelBinding,
   });
   const authMessage: FederationSocketAuthMessage = {
     kind: "auth",
@@ -469,9 +568,17 @@ export async function connectFederationClient(params: {
     endpoint: params.endpoint,
     profileName: params.profileName,
   };
+  sendFrame(socket, authMessage, transport);
 
-  sendSocketMessage(socket, authMessage);
-  const accepted = await waitForAuthResult(socket);
+  const accepted = decodeFrame(await reader.next(), transport);
+  if (accepted?.kind === "auth.rejected") {
+    socket.close();
+    throw new Error(accepted.failure.code);
+  }
+  if (!accepted || accepted.kind !== "auth.accepted") {
+    socket.close();
+    throw new Error("Unexpected federation auth response");
+  }
   const acceptedSignatureValid =
     accepted.gatewayInstanceId === params.gatewayInstanceId &&
     accepted.nonce === challenge.nonce &&
@@ -502,24 +609,91 @@ export async function connectFederationClient(params: {
   };
   socket.once("close", notifyTransportEnded);
   socket.once("error", notifyTransportEnded);
-  socket.on("message", (raw) => {
-    const message = parseSocketMessage(raw);
-    if (message?.kind === "envelope") {
-      params.onEnvelope?.(message.envelope);
+
+  // Phase 3: stream envelopes.
+  void (async () => {
+    for (;;) {
+      let frame: Buffer;
+      try {
+        frame = await reader.next();
+      } catch {
+        return;
+      }
+      const message = decodeFrame(frame, transport);
+      if (message?.kind === "envelope") {
+        params.onEnvelope?.(message.envelope);
+      }
     }
-  });
+  })();
+
   return {
     sessionId: accepted.sessionId,
     capabilities: accepted.capabilities,
     sendEnvelope: (envelope) => {
-      sendSocketMessage(socket, { kind: "envelope", envelope });
+      sendFrame(socket, { kind: "envelope", envelope }, transport);
     },
     close: () => socket.close(),
   };
 }
 
+// A race-free, ordered reader over a WebSocket's discrete messages. Attaching
+// it before any await guarantees no frame is dropped between socket events and
+// the next read — important because the Noise handshake and auth exchange must
+// consume frames in a strict order.
+class FederationFrameReader {
+  private readonly queue: Buffer[] = [];
+  private pending?: { resolve: (frame: Buffer) => void; reject: (error: Error) => void };
+  private failure?: Error;
+
+  constructor(socket: WebSocket) {
+    socket.on("message", (raw) => this.push(rawDataToBuffer(raw)));
+    socket.once("close", () => this.fail(new Error("Federation socket closed")));
+    socket.once("error", (error) =>
+      this.fail(error instanceof Error ? error : new Error(String(error))),
+    );
+  }
+
+  private push(frame: Buffer): void {
+    if (this.pending) {
+      const { resolve } = this.pending;
+      this.pending = undefined;
+      resolve(frame);
+      return;
+    }
+    this.queue.push(frame);
+  }
+
+  private fail(error: Error): void {
+    this.failure ??= error;
+    if (this.pending) {
+      const { reject } = this.pending;
+      this.pending = undefined;
+      reject(error);
+    }
+  }
+
+  next(): Promise<Buffer> {
+    const queued = this.queue.shift();
+    if (queued) return Promise.resolve(queued);
+    if (this.failure) return Promise.reject(this.failure);
+    return new Promise((resolve, reject) => {
+      this.pending = { resolve, reject };
+    });
+  }
+}
+
+function rawDataToBuffer(raw: WebSocket.RawData): Buffer {
+  if (Buffer.isBuffer(raw)) return raw;
+  if (Array.isArray(raw)) return Buffer.concat(raw);
+  return Buffer.from(raw as ArrayBuffer);
+}
+
 function waitForOpen(socket: WebSocket): Promise<void> {
   return new Promise((resolve, reject) => {
+    if (socket.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
     const cleanup = () => {
       socket.off("open", onOpen);
       socket.off("error", onError);
@@ -537,70 +711,23 @@ function waitForOpen(socket: WebSocket): Promise<void> {
   });
 }
 
-function waitForAuthChallenge(socket: WebSocket): Promise<FederationSocketChallengeMessage> {
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      socket.off("message", onMessage);
-      socket.off("error", onError);
-    };
-    const onMessage = (raw: WebSocket.RawData) => {
-      cleanup();
-      const message = parseSocketMessage(raw);
-      if (message?.kind === "auth.challenge") {
-        resolve(message);
-        return;
-      }
-      if (message?.kind === "auth.rejected") {
-        reject(new Error(message.failure.code));
-        return;
-      }
-      reject(new Error("Unexpected federation auth challenge"));
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    socket.once("message", onMessage);
-    socket.once("error", onError);
-  });
-}
-
-function waitForAuthResult(socket: WebSocket): Promise<FederationSocketAcceptedMessage> {
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      socket.off("message", onMessage);
-      socket.off("error", onError);
-    };
-    const onMessage = (raw: WebSocket.RawData) => {
-      cleanup();
-      const message = parseSocketMessage(raw);
-      if (message?.kind === "auth.accepted") {
-        resolve(message);
-        return;
-      }
-      if (message?.kind === "auth.rejected") {
-        reject(new Error(message.failure.code));
-        return;
-      }
-      reject(new Error("Unexpected federation auth response"));
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    socket.once("message", onMessage);
-    socket.once("error", onError);
-  });
-}
-
-function sendSocketMessage(socket: WebSocket, message: FederationSocketMessage): void {
+function sendFrame(
+  socket: WebSocket,
+  message: FederationSocketMessage,
+  transport?: NoiseTransport,
+): void {
   if (socket.readyState !== WebSocket.OPEN) return;
-  socket.send(JSON.stringify(message));
+  const json = Buffer.from(JSON.stringify(message), "utf8");
+  socket.send(transport ? transport.encrypt(json) : json);
 }
 
-function parseSocketMessage(raw: WebSocket.RawData): FederationSocketMessage | undefined {
+function decodeFrame(
+  frame: Buffer,
+  transport?: NoiseTransport,
+): FederationSocketMessage | undefined {
   try {
-    const parsed = JSON.parse(raw.toString()) as Partial<FederationSocketMessage>;
+    const json = transport ? transport.decrypt(frame) : frame;
+    const parsed = JSON.parse(json.toString("utf8")) as Partial<FederationSocketMessage>;
     if (parsed.kind === "auth" && isAuthMessage(parsed)) return parsed;
     if (parsed.kind === "auth.challenge" && isChallengeMessage(parsed)) return parsed;
     if (parsed.kind === "auth.accepted" && isAcceptedMessage(parsed)) return parsed;

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -8,6 +8,7 @@ import type {
   FederationProtocolEnvelope,
   FederationSessionId,
 } from "@pwragent/shared";
+import { getMainLogger } from "../log";
 import {
   FEDERATION_PROTOCOL_VERSION,
   isFederationCapability,
@@ -35,6 +36,8 @@ import {
 } from "./federation-redaction";
 import { FederationSessionRegistry } from "./federation-session-state";
 import type { FederationStore } from "./federation-store";
+
+const log = getMainLogger("pwragent:federation-transport");
 
 type FederationSocketAuthMessage = {
   kind: "auth";
@@ -209,6 +212,7 @@ export class FederationGatewayWebSocketServer {
         transport = handshake.split();
         channelBinding = transport.handshakeHash.toString("base64");
       } catch {
+        log.warn("federation Noise handshake rejected");
         socket.close();
         return;
       }

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -11,6 +11,7 @@ import type {
 import { getMainLogger } from "../log";
 import {
   FEDERATION_PROTOCOL_VERSION,
+  FEDERATION_TRANSPORT_VERSION,
   isFederationCapability,
   isFederationInstanceId,
 } from "@pwragent/shared";
@@ -38,6 +39,14 @@ import { FederationSessionRegistry } from "./federation-session-state";
 import type { FederationStore } from "./federation-store";
 
 const log = getMainLogger("pwragent:federation-transport");
+const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
+
+type FederationSocketTransportHelloMessage = {
+  kind: "transport.hello";
+  transportVersion: number;
+  protocolVersion: number;
+  encryption: typeof FEDERATION_NOISE_TRANSPORT;
+};
 
 type FederationSocketAuthMessage = {
   kind: "auth";
@@ -86,6 +95,7 @@ type FederationSocketEnvelopeMessage = {
 };
 
 type FederationSocketMessage =
+  | FederationSocketTransportHelloMessage
   | FederationSocketAuthMessage
   | FederationSocketChallengeMessage
   | FederationSocketAcceptedMessage
@@ -202,6 +212,12 @@ export class FederationGatewayWebSocketServer {
     let transport: NoiseTransport | undefined;
     let channelBinding = "";
     if (this.options.noiseStatic) {
+      sendFrame(socket, {
+        kind: "transport.hello",
+        transportVersion: FEDERATION_TRANSPORT_VERSION,
+        protocolVersion: FEDERATION_PROTOCOL_VERSION,
+        encryption: FEDERATION_NOISE_TRANSPORT,
+      });
       try {
         const handshake = new NoiseIKHandshake({
           role: "responder",
@@ -248,7 +264,13 @@ export class FederationGatewayWebSocketServer {
     } catch {
       return;
     }
-    const message = decodeFrame(authFrame, transport);
+    let message: FederationSocketMessage | undefined;
+    try {
+      message = decodeFrame(authFrame, transport);
+    } catch {
+      closeAfterFrameAuthenticationFailure(socket);
+      return;
+    }
     if (!message || message.kind !== "auth") {
       this.options.store.appendAudit({
         kind: "rejected",
@@ -394,7 +416,13 @@ export class FederationGatewayWebSocketServer {
       } catch {
         return;
       }
-      const next = decodeFrame(frame, transport);
+      let next: FederationSocketMessage | undefined;
+      try {
+        next = decodeFrame(frame, transport);
+      } catch {
+        closeAfterFrameAuthenticationFailure(socket);
+        return;
+      }
       if (!next || next.kind !== "envelope") continue;
       this.sessions.heartbeat(sessionId, Date.now());
       this.options.onEnvelope?.(next.envelope, connection);
@@ -497,6 +525,19 @@ export async function connectFederationClient(params: {
       socket.close();
       throw new Error("Missing pinned gateway Noise key for encrypted federation");
     }
+    const hello = decodeFrame(await reader.next());
+    if (
+      !hello
+      || hello.kind !== "transport.hello"
+      || hello.transportVersion !== FEDERATION_TRANSPORT_VERSION
+      || hello.protocolVersion !== FEDERATION_PROTOCOL_VERSION
+      || hello.encryption !== FEDERATION_NOISE_TRANSPORT
+    ) {
+      socket.close(1002, "Unsupported federation transport");
+      throw new Error(
+        `Federation gateway does not support required Noise transport version ${FEDERATION_TRANSPORT_VERSION}.`,
+      );
+    }
     try {
       const handshake = new NoiseIKHandshake({
         role: "initiator",
@@ -514,7 +555,13 @@ export async function connectFederationClient(params: {
   }
 
   // Phase 2: identity auth.
-  const challenge = decodeFrame(await reader.next(), transport);
+  let challenge: FederationSocketMessage | undefined;
+  try {
+    challenge = decodeFrame(await reader.next(), transport);
+  } catch (error) {
+    closeAfterFrameAuthenticationFailure(socket);
+    throw error;
+  }
   if (challenge?.kind === "auth.rejected") {
     socket.close();
     throw new Error(challenge.failure.code);
@@ -574,7 +621,13 @@ export async function connectFederationClient(params: {
   };
   sendFrame(socket, authMessage, transport);
 
-  const accepted = decodeFrame(await reader.next(), transport);
+  let accepted: FederationSocketMessage | undefined;
+  try {
+    accepted = decodeFrame(await reader.next(), transport);
+  } catch (error) {
+    closeAfterFrameAuthenticationFailure(socket);
+    throw error;
+  }
   if (accepted?.kind === "auth.rejected") {
     socket.close();
     throw new Error(accepted.failure.code);
@@ -623,7 +676,13 @@ export async function connectFederationClient(params: {
       } catch {
         return;
       }
-      const message = decodeFrame(frame, transport);
+      let message: FederationSocketMessage | undefined;
+      try {
+        message = decodeFrame(frame, transport);
+      } catch {
+        closeAfterFrameAuthenticationFailure(socket);
+        return;
+      }
       if (message?.kind === "envelope") {
         params.onEnvelope?.(message.envelope);
       }
@@ -725,13 +784,31 @@ function sendFrame(
   socket.send(transport ? transport.encrypt(json) : json);
 }
 
+function closeAfterFrameAuthenticationFailure(socket: WebSocket): void {
+  log.warn("encrypted federation frame authentication failed; closing session");
+  socket.close(1008, "Encrypted federation frame authentication failed");
+}
+
 function decodeFrame(
   frame: Buffer,
   transport?: NoiseTransport,
 ): FederationSocketMessage | undefined {
+  let json = frame;
+  if (transport) {
+    try {
+      json = transport.decrypt(frame);
+    } catch {
+      throw new FederationFrameAuthenticationError();
+    }
+  }
   try {
-    const json = transport ? transport.decrypt(frame) : frame;
     const parsed = JSON.parse(json.toString("utf8")) as Partial<FederationSocketMessage>;
+    if (
+      parsed.kind === "transport.hello"
+      && isTransportHelloMessage(parsed)
+    ) {
+      return parsed;
+    }
     if (parsed.kind === "auth" && isAuthMessage(parsed)) return parsed;
     if (parsed.kind === "auth.challenge" && isChallengeMessage(parsed)) return parsed;
     if (parsed.kind === "auth.accepted" && isAcceptedMessage(parsed)) return parsed;
@@ -745,6 +822,24 @@ function decodeFrame(
   } catch {
     return undefined;
   }
+}
+
+class FederationFrameAuthenticationError extends Error {
+  constructor() {
+    super("Encrypted federation frame authentication failed");
+    this.name = "FederationFrameAuthenticationError";
+  }
+}
+
+function isTransportHelloMessage(
+  value: Partial<FederationSocketTransportHelloMessage>,
+): value is FederationSocketTransportHelloMessage {
+  return (
+    value.kind === "transport.hello"
+    && typeof value.transportVersion === "number"
+    && typeof value.protocolVersion === "number"
+    && value.encryption === FEDERATION_NOISE_TRANSPORT
+  );
 }
 
 function isAuthMessage(value: Partial<FederationSocketAuthMessage>): value is FederationSocketAuthMessage {

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -505,13 +505,24 @@ export function registerAgentIpcHandlers(): void {
     async (
       _event,
       request: CancelQueuedTurnRequest,
-    ): Promise<CancelQueuedTurnResponse> => ({
-      queueEntryId: request.queueEntryId,
-      cancelled: registry.cancelQueuedTurn(
-        request.queueEntryId,
-        "Cancelled from the desktop composer.",
-      ),
-    }),
+    ): Promise<CancelQueuedTurnResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        const { federationTarget, ...remoteRequest } = request;
+        return await getDesktopFederationRuntime()
+          .remoteBackend(federationTarget)
+          .cancelQueuedTurn(remoteRequest);
+      }
+      return {
+        queueEntryId: request.queueEntryId,
+        cancelled: registry.cancelQueuedTurn(
+          request.queueEntryId,
+          "Cancelled from the desktop composer.",
+        ),
+      };
+    },
   );
 
   ipcMain.removeHandler(AGENT_START_REVIEW_CHANNEL);

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from "electron";
 import type {
+  ConfigureFederationTailscaleRequest,
+  ConfigureFederationTailscaleResponse,
   GenerateFederationInviteRequest,
   GenerateFederationInviteResponse,
   ImportFederationInviteRequest,
@@ -10,6 +12,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationTailscaleStatusRequest,
+  ReadFederationTailscaleStatusResponse,
   RevokeFederationPeerRequest,
   RevokeFederationPeerResponse,
 } from "@pwragent/shared";
@@ -21,8 +25,11 @@ import {
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
+  FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
+  FEDERATION_TAILSCALE_STATUS_CHANNEL,
 } from "../../shared/ipc";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
+import { getFederationTailscaleService } from "../federation/federation-tailscale";
 import { createMainWindow } from "../window";
 
 export function registerFederationIpcHandlers(): void {
@@ -32,6 +39,25 @@ export function registerFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_REVOKE_PEER_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_TAILSCALE_STATUS_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
+  ipcMain.handle(
+    FEDERATION_TAILSCALE_STATUS_CHANNEL,
+    async (
+      _event,
+      _request?: ReadFederationTailscaleStatusRequest,
+    ): Promise<ReadFederationTailscaleStatusResponse> => ({
+      status: await getFederationTailscaleService().readStatus(),
+    }),
+  );
+  ipcMain.handle(
+    FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
+    async (
+      _event,
+      request: ConfigureFederationTailscaleRequest,
+    ): Promise<ConfigureFederationTailscaleResponse> =>
+      await getFederationTailscaleService().configure(request),
+  );
   ipcMain.handle(
     FEDERATION_GET_DIAGNOSTICS_CHANNEL,
     async (
@@ -136,4 +162,6 @@ export function disposeFederationIpcHandlers(): void {
   ipcMain.removeHandler(FEDERATION_GENERATE_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_IMPORT_INVITE_CHANNEL);
   ipcMain.removeHandler(FEDERATION_REVOKE_PEER_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_TAILSCALE_STATUS_CHANNEL);
+  ipcMain.removeHandler(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL);
 }

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -502,6 +502,11 @@ export class DesktopSettingsService {
       undefined,
       secretStorage.available,
     );
+    const federationNoiseStaticPrivateKey = await this.readSecretState(
+      "federationNoiseStaticPrivateKey",
+      undefined,
+      secretStorage.available,
+    );
     const federationCloudflareClientCertificate = await this.readSecretState(
       "federationCloudflareClientCertificate",
       undefined,
@@ -764,6 +769,7 @@ export class DesktopSettingsService {
           false,
         ),
         instancePrivateKey: federationInstancePrivateKey,
+        noiseStaticPrivateKey: federationNoiseStaticPrivateKey,
         cloudflareClientCertificate: federationCloudflareClientCertificate,
         cloudflareClientPrivateKey: federationCloudflareClientPrivateKey,
         cloudflareAccessClientId: federationCloudflareAccessClientId,

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -66,6 +66,11 @@ import {
   publicKeyPemFromPrivateKey,
   type FederationIdentityKeyPair,
 } from "../federation/federation-identity";
+import {
+  generateFederationNoiseStaticKeyPair,
+  noisePublicKeyBase64FromPrivateBase64,
+  type FederationNoiseStaticKeyPair,
+} from "../federation/federation-noise";
 
 import {
   applyDesktopSettingsPatch,
@@ -1428,6 +1433,24 @@ export class DesktopSettingsService {
       accessClientId,
       accessClientSecret,
     };
+  }
+
+  async getOrCreateFederationNoiseStaticKeyPair(): Promise<FederationNoiseStaticKeyPair> {
+    const existing = await this.options.secretStore.getSecret(
+      "federationNoiseStaticPrivateKey",
+    );
+    if (existing) {
+      return {
+        privateKeyBase64: existing,
+        publicKeyBase64: noisePublicKeyBase64FromPrivateBase64(existing),
+      };
+    }
+    const keyPair = generateFederationNoiseStaticKeyPair();
+    await this.options.secretStore.setSecret(
+      "federationNoiseStaticPrivateKey",
+      keyPair.privateKeyBase64,
+    );
+    return keyPair;
   }
 
   resolveTelegramBotTokenSync(): string | undefined {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -222,6 +222,8 @@ import type {
   DesktopMessagingContactLookupRequest,
   DesktopMessagingContactLookupResponse,
   DesktopSettingsWriteResponse,
+  ConfigureFederationTailscaleRequest,
+  ConfigureFederationTailscaleResponse,
   GenerateFederationInviteRequest,
   GenerateFederationInviteResponse,
   ImportFederationInviteRequest,
@@ -248,6 +250,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationTailscaleStatusRequest,
+  ReadFederationTailscaleStatusResponse,
   RevokeFederationPeerRequest,
   RevokeFederationPeerResponse,
   ReadDesktopSettingsRequest,
@@ -417,6 +421,8 @@ import {
   FEDERATION_IMPORT_INVITE_CHANNEL,
   FEDERATION_OPEN_WINDOW_CHANNEL,
   FEDERATION_REVOKE_PEER_CHANNEL,
+  FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
+  FEDERATION_TAILSCALE_STATUS_CHANNEL,
   CODEX_ENVIRONMENT_SETUP_PROGRESS_CHANNEL,
   COMPOSER_DRAFT_CLEAR_CHANNEL,
   COMPOSER_DRAFT_LIST_CANDIDATES_CHANNEL,
@@ -808,6 +814,14 @@ const desktopApi = Object.freeze({
     request: RevokeFederationPeerRequest,
   ): Promise<RevokeFederationPeerResponse> =>
     await ipcRenderer.invoke(FEDERATION_REVOKE_PEER_CHANNEL, request),
+  readFederationTailscaleStatus: async (
+    request?: ReadFederationTailscaleStatusRequest,
+  ): Promise<ReadFederationTailscaleStatusResponse> =>
+    await ipcRenderer.invoke(FEDERATION_TAILSCALE_STATUS_CHANNEL, request),
+  configureFederationTailscale: async (
+    request: ConfigureFederationTailscaleRequest,
+  ): Promise<ConfigureFederationTailscaleResponse> =>
+    await ipcRenderer.invoke(FEDERATION_TAILSCALE_CONFIGURE_CHANNEL, request),
   ...(isDevelopment
     ? {
         getRuntimeIdentity: async (): Promise<RuntimeIdentity> =>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -492,6 +492,11 @@ describe("App", () => {
           source: "unset",
           writable: true,
         },
+        noiseStaticPrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
         cloudflareClientCertificate: {
           configured: false,
           source: "unset",

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -4036,7 +4036,11 @@ export function Composer(props: ComposerProps) {
       return false;
     }
     try {
+      const federationTarget =
+        props.thread?.federation?.ref.target
+        ?? readRendererFederationTarget();
       const response = await props.desktopApi.cancelQueuedTurn({
+        ...(federationTarget ? { federationTarget } : {}),
         queueEntryId: queued.queueEntryId,
       });
       if (!response.cancelled) {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4814,6 +4814,83 @@ describe("Composer", () => {
     });
   });
 
+  it("cancels the owning peer's queued turn before remote steering", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const cancelQueuedTurn = vi.fn(async ({ queueEntryId }: {
+      queueEntryId: string;
+    }) => ({ queueEntryId, cancelled: true }));
+    const steerTurn = vi.fn(async () => ({
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+    }));
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        backends={[
+          {
+            ...backendSummary("codex"),
+            capabilities: {
+              ...backendSummary("codex").capabilities,
+              steerTurn: true,
+            },
+          },
+        ]}
+        desktopApi={{
+          cancelQueuedTurn,
+          onAgentEvent: () => () => undefined,
+          startTurn: vi.fn(async () => ({
+            backend: "codex" as const,
+            threadId: "thread-1",
+            turnId: "queue-entry-1",
+            queueStatus: "queued" as const,
+            queueEntryId: "queue-entry-1",
+          })),
+          steerTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Remote active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          federation: {
+            ref: {
+              backend: "codex",
+              target: federationTarget,
+              threadId: "thread-1",
+            },
+            instanceLabel: "Remote",
+            peerStatus: "connected",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    const textarea = screen.getByLabelText("Reply");
+    fireEvent.change(textarea, { target: { value: "Steer remotely" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    await screen.findByLabelText("Queued message");
+    fireEvent.click(screen.getByRole("button", { name: "Steer" }));
+
+    await waitFor(() => {
+      expect(cancelQueuedTurn).toHaveBeenCalledWith({
+        federationTarget,
+        queueEntryId: "queue-entry-1",
+      });
+      expect(steerTurn).toHaveBeenCalledWith(
+        expect.objectContaining({ federationTarget }),
+      );
+    });
+  });
+
   it("removes concurrently cancelled queue entries by stable id", async () => {
     const cancellationOne = createDeferred<{
       queueEntryId: string;

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -145,29 +145,49 @@ export function FederationSettings(props: FederationSettingsProps) {
   }, [props.desktopApi]);
 
   const configureTailscale = async (tailscaleMode: FederationTailscaleMode) => {
-    if (!props.desktopApi?.configureFederationTailscale) return;
+    if (
+      !props.desktopApi?.configureFederationTailscale
+      || !props.desktopApi.readFederationHealth
+    ) return;
     setActionError(undefined);
     setTailscaleConfiguring(tailscaleMode);
     try {
       const parsedListenPort = Number.parseInt(listenPort, 10);
+      const gatewayMode = mode === "dual" ? "dual" : "gateway";
+      const listenerWritten = await props.onWriteConfig({
+        federation: {
+          mode: gatewayMode,
+          listenHost: "127.0.0.1",
+          listenPort: parsedListenPort,
+        },
+      });
+      if (!listenerWritten) {
+        throw new Error(
+          "PwrAgent could not start the federation listener. Tailscale was not changed.",
+        );
+      }
+      const listenerHealth = await props.desktopApi.readFederationHealth({});
+      const expectedListenUrl = `ws://127.0.0.1:${parsedListenPort}`;
+      if (listenerHealth.health.listenUrl !== expectedListenUrl) {
+        throw new Error(
+          "PwrAgent did not bind the selected loopback port. Tailscale was not changed.",
+        );
+      }
       const response = await props.desktopApi.configureFederationTailscale({
         mode: tailscaleMode,
         listenPort: parsedListenPort,
       });
       const written = await props.onWriteConfig({
         federation: {
-          mode: mode === "dual" ? "dual" : "gateway",
-          listenHost: "127.0.0.1",
-          listenPort: parsedListenPort,
           publicUrl: response.gatewayUrl,
         },
       });
       if (!written) {
         throw new Error(
-          "Tailscale was configured, but PwrAgent federation settings could not be saved.",
+          "Tailscale was configured, but its Public URL could not be saved.",
         );
       }
-      setMode(mode === "dual" ? "dual" : "gateway");
+      setMode(gatewayMode);
       setListenHost("127.0.0.1");
       setPublicUrl(response.gatewayUrl);
       setTailscaleStatus(response.status);
@@ -641,7 +661,8 @@ export function FederationSettings(props: FederationSettingsProps) {
                   props.saving ||
                   Boolean(tailscaleConfiguring) ||
                   !tailscaleStatus?.connected ||
-                  !props.desktopApi?.configureFederationTailscale
+                  !props.desktopApi?.configureFederationTailscale ||
+                  !props.desktopApi?.readFederationHealth
                 }
                 onClick={() => void configureTailscale("serve")}
               >
@@ -673,7 +694,8 @@ export function FederationSettings(props: FederationSettingsProps) {
                     Boolean(tailscaleConfiguring) ||
                     !tailscaleStatus?.connected ||
                     !funnelAcknowledged ||
-                    !props.desktopApi?.configureFederationTailscale
+                    !props.desktopApi?.configureFederationTailscale ||
+                    !props.desktopApi?.readFederationHealth
                   }
                   onClick={() => void configureTailscale("funnel")}
                 >

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -5,6 +5,7 @@ import type {
   DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
   FederationConnectionState,
+  FederationCapability,
   FederationDiagnosticEvent,
   FederationHealthStatus,
   FederationInstanceRole,
@@ -13,6 +14,7 @@ import type {
 } from "@pwragent/shared";
 import { DESKTOP_FEDERATION_MODES } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { formatRunningDurationMs } from "../../lib/format-duration";
 import {
   SettingsField,
   SettingsPanelHead,
@@ -216,6 +218,7 @@ export function FederationSettings(props: FederationSettingsProps) {
       publicUrl: trimmedOrUndefined(props.snapshot.federation.publicUrl.value),
       peers: [],
     } satisfies FederationHealthStatus);
+  const now = Date.now();
 
   return (
     <SettingsSectionStack paneId="federation" aria-label="Federation settings">
@@ -504,6 +507,11 @@ export function FederationSettings(props: FederationSettingsProps) {
         title="Federation Instances"
         chip={`${effectiveHealth.peers.length}`}
       >
+        <p className="federation-peer-help">
+          Choose Browse remote threads to open a separate window for a
+          connected instance. Threads, prompts, approvals, environments, and
+          files stay on that machine.
+        </p>
         {effectiveHealth.peers.length === 0 ? (
           <p className="settings-empty">No federation instances.</p>
         ) : (
@@ -518,15 +526,29 @@ export function FederationSettings(props: FederationSettingsProps) {
                   <span>
                     Protocol {peer.protocolVersion ?? "unknown"} ·{" "}
                     {peer.capabilities.length} capabilities
-                    {peer.lastActivityAt
-                      ? ` · Active ${formatTimestamp(peer.lastActivityAt)}`
-                      : ""}
+                  </span>
+                  {peer.lastConnectedAt ? (
+                    <span>
+                      Connected {formatTimestamp(peer.lastConnectedAt)}
+                      {peer.status === "connected"
+                        ? ` · Current session ${formatRunningDurationMs(
+                            Math.max(0, now - peer.lastConnectedAt),
+                          )}`
+                        : ""}
+                    </span>
+                  ) : null}
+                  {peer.lastActivityAt
+                  && peer.lastActivityAt !== peer.lastConnectedAt ? (
+                    <span>Last activity {formatTimestamp(peer.lastActivityAt)}</span>
+                  ) : null}
+                  <span>
+                    Available: {formatFederationCapabilities(peer.capabilities)}
                   </span>
                   {peer.unavailableReason ? (
                     <span>{peer.unavailableReason}</span>
                   ) : null}
                   <button
-                    className="button button--ghost"
+                    className="button button--secondary"
                     type="button"
                     disabled={
                       peer.status !== "connected" ||
@@ -539,7 +561,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                       });
                     }}
                   >
-                    Open
+                    Browse remote threads
                   </button>
                   {peer.canRevoke ? (
                     <button
@@ -976,6 +998,27 @@ function diagnosticEventLabel(kind: FederationDiagnosticEvent["kind"]): string {
 
 function formatTimestamp(value: number): string {
   return new Date(value).toLocaleString();
+}
+
+const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {
+  remote_window: "open a remote workspace",
+  thread_navigation: "browse and create threads",
+  thread_detail: "read transcripts",
+  turn_control: "prompt, steer, and interrupt",
+  pending_request_control: "handle approvals and questions",
+  environment_actions: "run environments and scripts",
+  federated_search: "search remote threads",
+  messaging_route: "route messaging threads",
+  gateway_relay: "reach sibling instances",
+};
+
+function formatFederationCapabilities(
+  capabilities: FederationCapability[],
+): string {
+  if (capabilities.length === 0) return "no remote actions advertised";
+  return capabilities
+    .map((capability) => FEDERATION_CAPABILITY_LABELS[capability])
+    .join(" · ");
 }
 
 function trimmedOrUndefined(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -154,7 +154,7 @@ export function FederationSettings(props: FederationSettingsProps) {
     setActionError(undefined);
     setTailscaleConfiguring(tailscaleMode);
     try {
-      const parsedListenPort = Number.parseInt(listenPort, 10);
+      const parsedListenPort = parseFederationListenPort(listenPort);
       const gatewayMode = mode === "dual" ? "dual" : "gateway";
       const listenerWritten = await props.onWriteConfig({
         federation: {
@@ -998,6 +998,20 @@ function diagnosticEventLabel(kind: FederationDiagnosticEvent["kind"]): string {
 
 function formatTimestamp(value: number): string {
   return new Date(value).toLocaleString();
+}
+
+function parseFederationListenPort(value: string): number {
+  const trimmed = value.trim();
+  const port = Number(trimmed);
+  if (
+    !/^\d+$/.test(trimmed)
+    || !Number.isInteger(port)
+    || port < 1
+    || port > 65_535
+  ) {
+    throw new Error("Listen port must be an integer between 1 and 65535.");
+  }
+  return port;
 }
 
 const FEDERATION_CAPABILITY_LABELS: Record<FederationCapability, string> = {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -261,6 +261,42 @@ export function FederationSettings(props: FederationSettingsProps) {
       </SettingsSection>
 
       <SettingsSection
+        eyebrow="End-to-end security"
+        title="PwrAgent Encrypted Transport"
+        chip="Required"
+        chipKind="ok"
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Protocol"
+            sub="Every federation frame is encrypted before it enters the WebSocket transport."
+            control={<code>Noise IK · X25519 · ChaCha20-Poly1305 · SHA-256</code>}
+          />
+          <SettingsField
+            label="Channel key"
+            sub="Created automatically and stored in the system credential store."
+            control={
+              <span>
+                {props.snapshot.federation.noiseStaticPrivateKey.configured
+                  ? "Stored securely"
+                  : "Created when federation starts"}
+              </span>
+            }
+          />
+          <SettingsField
+            label="Gateway pinning"
+            sub="Enrollment invites pin both the gateway signing key and Noise channel key."
+            control={<span>Required</span>}
+          />
+          <p className="settings-note">
+            The signed federation identity proof is bound to the Noise handshake.
+            Cloudflare, Tailscale, SSH, and TLS can add outer transport controls,
+            but they do not replace this application-level encryption.
+          </p>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
         eyebrow="Enrollment"
         title="Invites"
         chip={generatedInvite ? "Generated" : "Ready"}

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -8,6 +8,8 @@ import type {
   FederationDiagnosticEvent,
   FederationHealthStatus,
   FederationInstanceRole,
+  FederationTailscaleMode,
+  FederationTailscaleStatus,
 } from "@pwragent/shared";
 import { DESKTOP_FEDERATION_MODES } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -39,6 +41,11 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [actionError, setActionError] = useState<string>();
+  const [tailscaleStatus, setTailscaleStatus] = useState<FederationTailscaleStatus>();
+  const [tailscaleLoading, setTailscaleLoading] = useState(false);
+  const [tailscaleConfiguring, setTailscaleConfiguring] =
+    useState<FederationTailscaleMode>();
+  const [funnelAcknowledged, setFunnelAcknowledged] = useState(false);
   const [generatedInvite, setGeneratedInvite] = useState("");
   const [inviteToImport, setInviteToImport] = useState("");
   const [revokingPeerId, setRevokingPeerId] = useState<string>();
@@ -114,14 +121,64 @@ export function FederationSettings(props: FederationSettingsProps) {
     }
   };
 
+  const loadTailscaleStatus = async () => {
+    if (!props.desktopApi?.readFederationTailscaleStatus) return;
+    setTailscaleLoading(true);
+    try {
+      const response = await props.desktopApi.readFederationTailscaleStatus({});
+      setTailscaleStatus(response.status);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTailscaleLoading(false);
+    }
+  };
+
   useEffect(() => {
     void loadHealth();
+    void loadTailscaleStatus();
     const refreshInterval = window.setInterval(() => {
       void loadHealth();
     }, 2_000);
     return () => window.clearInterval(refreshInterval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
+
+  const configureTailscale = async (tailscaleMode: FederationTailscaleMode) => {
+    if (!props.desktopApi?.configureFederationTailscale) return;
+    setActionError(undefined);
+    setTailscaleConfiguring(tailscaleMode);
+    try {
+      const parsedListenPort = Number.parseInt(listenPort, 10);
+      const response = await props.desktopApi.configureFederationTailscale({
+        mode: tailscaleMode,
+        listenPort: parsedListenPort,
+      });
+      const written = await props.onWriteConfig({
+        federation: {
+          mode: mode === "dual" ? "dual" : "gateway",
+          listenHost: "127.0.0.1",
+          listenPort: parsedListenPort,
+          publicUrl: response.gatewayUrl,
+        },
+      });
+      if (!written) {
+        throw new Error(
+          "Tailscale was configured, but PwrAgent federation settings could not be saved.",
+        );
+      }
+      setMode(mode === "dual" ? "dual" : "gateway");
+      setListenHost("127.0.0.1");
+      setPublicUrl(response.gatewayUrl);
+      setTailscaleStatus(response.status);
+      await props.onSettingsChanged();
+      await loadHealth();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setTailscaleConfiguring(undefined);
+    }
+  };
 
   const effectiveHealth =
     health ??
@@ -157,6 +214,7 @@ export function FederationSettings(props: FederationSettingsProps) {
             }
             onClick={() => {
               void loadHealth();
+              void loadTailscaleStatus();
             }}
           >
             {loading ? "Refreshing..." : "Refresh"}
@@ -165,6 +223,9 @@ export function FederationSettings(props: FederationSettingsProps) {
       />
 
       {error ? <p className="settings-row__error">{error}</p> : null}
+      {actionError ? (
+        <p className="settings-row__error">{actionError}</p>
+      ) : null}
 
       <SettingsSection
         eyebrow="Setup"
@@ -215,7 +276,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Public URL"
-            sub="Cloudflare Tunnel URL or local WebSocket URL for peers."
+            sub="Cloudflare Tunnel, Tailscale, or local WebSocket URL for peers."
             control={
               <input
                 value={publicUrl}
@@ -288,7 +349,7 @@ export function FederationSettings(props: FederationSettingsProps) {
             sub="Enrollment invites pin both the gateway signing key and Noise channel key."
             control={<span>Required</span>}
           />
-          <p className="settings-note">
+          <p className="federation-security-note">
             The signed federation identity proof is bound to the Noise handshake.
             Cloudflare, Tailscale, SSH, and TLS can add outer transport controls,
             but they do not replace this application-level encryption.
@@ -370,9 +431,6 @@ export function FederationSettings(props: FederationSettingsProps) {
               Import invite
             </button>
           </div>
-          {actionError ? (
-            <p className="settings-row__error">{actionError}</p>
-          ) : null}
         </div>
       </SettingsSection>
 
@@ -520,6 +578,118 @@ export function FederationSettings(props: FederationSettingsProps) {
             ))}
           </dl>
         )}
+      </SettingsSection>
+
+      <SettingsSection
+        eyebrow="Private network / public relay"
+        title="Tailscale Serve / Funnel Setup"
+        chip={
+          tailscaleStatus?.funnelConfigured
+            ? "Funnel"
+            : tailscaleStatus?.serveConfigured
+              ? "Serve"
+              : tailscaleStatus?.connected
+                ? "Ready"
+                : "Not ready"
+        }
+        chipKind={
+          tailscaleStatus?.serveConfigured || tailscaleStatus?.funnelConfigured
+            ? "ok"
+            : "muted"
+        }
+      >
+        <div className="settings-fields">
+          <SettingsField
+            label="Tailscale CLI"
+            sub="PwrAgent delegates account login, HTTPS certificates, and routing to Tailscale."
+            control={
+              <span>
+                {tailscaleLoading
+                  ? "Checking..."
+                  : tailscaleStatus?.installed
+                    ? `Installed${tailscaleStatus.version ? ` · ${tailscaleStatus.version}` : ""}`
+                    : "Not found"}
+              </span>
+            }
+          />
+          <SettingsField
+            label="Tailnet"
+            sub="Serve is reachable only by devices authorized in this tailnet."
+            control={
+              <span>
+                {tailscaleStatus?.connected
+                  ? tailscaleStatus.tailnetName ?? "Connected"
+                  : tailscaleStatus?.unavailableReason ?? "Not connected"}
+              </span>
+            }
+          />
+          <SettingsField
+            label="Gateway URL"
+            sub="A dedicated path avoids replacing unrelated Serve or Funnel handlers."
+            control={
+              <code>{tailscaleStatus?.gatewayUrl ?? "Available after Tailscale login"}</code>
+            }
+          />
+          <SettingsField
+            label="Tailscale Serve"
+            sub="Private HTTPS/WebSocket reachability for authenticated tailnet devices."
+            control={
+              <button
+                className="button button--secondary"
+                type="button"
+                disabled={
+                  props.saving ||
+                  Boolean(tailscaleConfiguring) ||
+                  !tailscaleStatus?.connected ||
+                  !props.desktopApi?.configureFederationTailscale
+                }
+                onClick={() => void configureTailscale("serve")}
+              >
+                {tailscaleConfiguring === "serve"
+                  ? "Setting up Serve..."
+                  : "Set up Tailscale Serve"}
+              </button>
+            }
+          />
+          <SettingsField
+            label="Tailscale Funnel"
+            sub="Public HTTPS/WebSocket reachability. Internet traffic reaches Tailscale's edge before PwrAgent authentication rejects unknown peers."
+            control={
+              <div className="federation-tailscale-actions">
+                <label>
+                  <input
+                    aria-label="Acknowledge public Funnel exposure"
+                    type="checkbox"
+                    checked={funnelAcknowledged}
+                    onChange={(event) => setFunnelAcknowledged(event.target.checked)}
+                  />{" "}
+                  I understand this creates a public endpoint
+                </label>
+                <button
+                  className="button button--secondary"
+                  type="button"
+                  disabled={
+                    props.saving ||
+                    Boolean(tailscaleConfiguring) ||
+                    !tailscaleStatus?.connected ||
+                    !funnelAcknowledged ||
+                    !props.desktopApi?.configureFederationTailscale
+                  }
+                  onClick={() => void configureTailscale("funnel")}
+                >
+                  {tailscaleConfiguring === "funnel"
+                    ? "Setting up Funnel..."
+                    : "Set up Tailscale Funnel"}
+                </button>
+              </div>
+            }
+          />
+          <p className="federation-security-note">
+            Both modes proxy only <code>/pwragent-federation</code> to the local
+            loopback listener. PwrAgent does not run Tailscale reset commands or
+            remove other handlers.
+          </p>
+        </div>
       </SettingsSection>
 
       <SettingsSection

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -351,7 +351,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           <SettingsField
             label="Protocol"
             sub="Every federation frame is encrypted before it enters the WebSocket transport."
-            control={<code>Noise IK · X25519 · ChaCha20-Poly1305 · SHA-256</code>}
+            control={<code>Noise IK · X25519 · AES-256-GCM · SHA-256</code>}
           />
           <SettingsField
             label="Channel key"

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
+  DesktopSettingsConfigPatch,
   DesktopSettingsSnapshot,
   FederationHealthStatus,
   ReadFederationDiagnosticsResponse,
@@ -273,6 +274,7 @@ describe("FederationSettings", () => {
   });
 
   it("requires public exposure acknowledgement before setting up Tailscale Funnel", async () => {
+    const events: string[] = [];
     const status = {
       installed: true,
       connected: true,
@@ -283,15 +285,30 @@ describe("FederationSettings", () => {
       funnelConfigured: false,
       gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
     };
-    const configureFederationTailscale = vi.fn(async () => ({
-      status: { ...status, funnelConfigured: true },
-      gatewayUrl: status.gatewayUrl,
-    }));
-    const onWriteConfig = vi.fn(async () => true);
+    const configureFederationTailscale = vi.fn(async () => {
+      events.push("publish");
+      return {
+        status: { ...status, funnelConfigured: true },
+        gatewayUrl: status.gatewayUrl,
+      };
+    });
+    const onWriteConfig = vi.fn(async (patch: DesktopSettingsConfigPatch) => {
+      events.push(patch.federation?.publicUrl ? "save-url" : "bind-listener");
+      return true;
+    });
     render(
       <FederationSettings
         desktopApi={{
           configureFederationTailscale,
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "gateway" as const,
+              status: "listening" as const,
+              listenUrl: "ws://127.0.0.1:8765",
+              peers: [],
+            },
+          })),
           readFederationTailscaleStatus: vi.fn(async () => ({ status })),
         }}
         onClearSecret={vi.fn(async () => true)}
@@ -316,21 +333,73 @@ describe("FederationSettings", () => {
     fireEvent.click(funnelButton);
 
     await waitFor(() =>
+      expect(onWriteConfig).toHaveBeenNthCalledWith(1, {
+        federation: {
+          mode: "gateway",
+          listenHost: "127.0.0.1",
+          listenPort: 8765,
+        },
+      }),
+    );
+    await waitFor(() =>
       expect(configureFederationTailscale).toHaveBeenCalledWith({
         mode: "funnel",
         listenPort: 8765,
       }),
     );
     await waitFor(() =>
-      expect(onWriteConfig).toHaveBeenCalledWith({
+      expect(onWriteConfig).toHaveBeenNthCalledWith(2, {
         federation: {
-          mode: "gateway",
-          listenHost: "127.0.0.1",
-          listenPort: 8765,
           publicUrl: "wss://studio.example.ts.net/pwragent-federation",
         },
       }),
     );
+    expect(events).toEqual(["bind-listener", "publish", "save-url"]);
+  });
+
+  it("does not publish a Tailscale route when the listener cannot bind", async () => {
+    const status = {
+      installed: true,
+      connected: true,
+      serveConfigured: false,
+      funnelConfigured: false,
+      gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
+    };
+    const configureFederationTailscale = vi.fn();
+    render(
+      <FederationSettings
+        desktopApi={{
+          configureFederationTailscale,
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "gateway" as const,
+              status: "degraded" as const,
+              unavailableReason: "listen EADDRINUSE: address already in use",
+              peers: [],
+            },
+          })),
+          readFederationTailscaleStatus: vi.fn(async () => ({ status })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    const serveButton = await screen.findByRole("button", {
+      name: "Set up Tailscale Serve",
+    });
+    await waitFor(() => expect(serveButton).toBeEnabled());
+    fireEvent.click(serveButton);
+
+    expect(await screen.findByText(
+      "PwrAgent did not bind the selected loopback port. Tailscale was not changed.",
+    )).toBeInTheDocument();
+    expect(configureFederationTailscale).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -59,7 +59,7 @@ describe("FederationSettings", () => {
     expect(await screen.findByText("Instance Federation")).toBeInTheDocument();
     expect(screen.getByText("PwrAgent Encrypted Transport")).toBeInTheDocument();
     expect(
-      screen.getByText("Noise IK · X25519 · ChaCha20-Poly1305 · SHA-256"),
+      screen.getByText("Noise IK · X25519 · AES-256-GCM · SHA-256"),
     ).toBeInTheDocument();
     expect(screen.getByText("Stored securely")).toBeInTheDocument();
     expect(screen.getByText("ws://127.0.0.1:8765")).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -271,6 +271,67 @@ describe("FederationSettings", () => {
       });
     });
   });
+
+  it("requires public exposure acknowledgement before setting up Tailscale Funnel", async () => {
+    const status = {
+      installed: true,
+      connected: true,
+      version: "1.98.10",
+      dnsName: "studio.example.ts.net",
+      tailnetName: "Example Tailnet",
+      serveConfigured: false,
+      funnelConfigured: false,
+      gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
+    };
+    const configureFederationTailscale = vi.fn(async () => ({
+      status: { ...status, funnelConfigured: true },
+      gatewayUrl: status.gatewayUrl,
+    }));
+    const onWriteConfig = vi.fn(async () => true);
+    render(
+      <FederationSettings
+        desktopApi={{
+          configureFederationTailscale,
+          readFederationTailscaleStatus: vi.fn(async () => ({ status })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+
+    expect(await screen.findByText("Example Tailnet")).toBeInTheDocument();
+    const funnelButton = screen.getByRole("button", {
+      name: "Set up Tailscale Funnel",
+    });
+    expect(funnelButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("checkbox", {
+      name: "Acknowledge public Funnel exposure",
+    }));
+    expect(funnelButton).toBeEnabled();
+    fireEvent.click(funnelButton);
+
+    await waitFor(() =>
+      expect(configureFederationTailscale).toHaveBeenCalledWith({
+        mode: "funnel",
+        listenPort: 8765,
+      }),
+    );
+    await waitFor(() =>
+      expect(onWriteConfig).toHaveBeenCalledWith({
+        federation: {
+          mode: "gateway",
+          listenHost: "127.0.0.1",
+          listenPort: 8765,
+          publicUrl: "wss://studio.example.ts.net/pwragent-federation",
+        },
+      }),
+    );
+  });
 });
 
 function settingsSnapshot(): DesktopSettingsSnapshot {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -75,6 +75,72 @@ describe("FederationSettings", () => {
     );
   });
 
+  it("explains remote actions and shows current connection timing", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-04T21:07:05.000Z"));
+    const lastConnectedAt = Date.now() - 65_000;
+    const openFederationWindow = vi.fn();
+    const health: FederationHealthStatus = {
+      enabled: true,
+      role: "client",
+      status: "connected",
+      peers: [
+        {
+          id: "gateway_one",
+          label: "Mac Mini",
+          role: "gateway",
+          status: "connected",
+          capabilities: [
+            "remote_window",
+            "thread_navigation",
+            "turn_control",
+            "pending_request_control",
+          ],
+          protocolVersion: 1,
+          lastConnectedAt,
+          lastActivityAt: lastConnectedAt,
+        },
+      ],
+    };
+
+    render(
+      <FederationSettings
+        desktopApi={{
+          openFederationWindow,
+          readFederationDiagnostics: vi.fn(async () => ({
+            health,
+            events: [],
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText(
+      "Choose Browse remote threads to open a separate window for a connected instance. Threads, prompts, approvals, environments, and files stay on that machine.",
+    )).toBeInTheDocument();
+    expect(screen.getByText(/Current session 1m 5s/)).toBeInTheDocument();
+    expect(screen.getByText(
+      /Available: open a remote workspace · browse and create threads/,
+    )).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "Browse remote threads",
+    }));
+    expect(openFederationWindow).toHaveBeenCalledWith({
+      target: { scope: "remote", instanceId: "gateway_one" },
+      label: "Mac Mini",
+    });
+  });
+
   it("falls back to the settings snapshot when diagnostics are unavailable", () => {
     render(
       <FederationSettings
@@ -154,7 +220,8 @@ describe("FederationSettings", () => {
 
     expect(await screen.findByText("bad_signature")).toBeInTheDocument();
     expect(screen.getByText("Transport closed.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Browse remote threads" }))
+      .toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
 
@@ -214,7 +281,8 @@ describe("FederationSettings", () => {
       await Promise.resolve();
     });
     expect(screen.getByText("Connected")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Open" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Browse remote threads" }))
+      .toBeEnabled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_000);
@@ -223,7 +291,8 @@ describe("FederationSettings", () => {
     expect(screen.getByText("Connecting")).toBeInTheDocument();
     expect(screen.getAllByText("Federation gateway connection closed."))
       .toHaveLength(2);
-    expect(screen.getByRole("button", { name: "Open" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Browse remote threads" }))
+      .toBeDisabled();
     view.unmount();
     vi.useRealTimers();
   });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -56,6 +56,11 @@ describe("FederationSettings", () => {
     );
 
     expect(await screen.findByText("Instance Federation")).toBeInTheDocument();
+    expect(screen.getByText("PwrAgent Encrypted Transport")).toBeInTheDocument();
+    expect(
+      screen.getByText("Noise IK · X25519 · ChaCha20-Poly1305 · SHA-256"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Stored securely")).toBeInTheDocument();
     expect(screen.getByText("ws://127.0.0.1:8765")).toBeInTheDocument();
     expect(
       screen.getByText("wss://pwragent.example.com/federation"),
@@ -284,6 +289,11 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
       },
       cloudflareMtlsEnabled: { value: true, source: "config" },
       cloudflareAccessServiceAuthEnabled: { value: false, source: "config" },
+      noiseStaticPrivateKey: {
+        configured: true,
+        source: "keychain",
+        writable: true,
+      },
       cloudflareClientCertificate: {
         configured: false,
         source: "unset",

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -426,6 +426,58 @@ describe("FederationSettings", () => {
     expect(events).toEqual(["bind-listener", "publish", "save-url"]);
   });
 
+  it.each(["", "not-a-port", "0", "65536", "47830.5"])(
+    "rejects invalid Tailscale listen port %j before saving settings",
+    async (listenPort) => {
+      const status = {
+        installed: true,
+        connected: true,
+        serveConfigured: false,
+        funnelConfigured: false,
+        gatewayUrl: "wss://studio.example.ts.net/pwragent-federation",
+      };
+      const configureFederationTailscale = vi.fn();
+      const onWriteConfig = vi.fn(async () => true);
+      render(
+        <FederationSettings
+          desktopApi={{
+            configureFederationTailscale,
+            readFederationHealth: vi.fn(async () => ({
+              health: {
+                enabled: true,
+                role: "gateway" as const,
+                status: "listening" as const,
+                listenUrl: "ws://127.0.0.1:8765",
+                peers: [],
+              },
+            })),
+            readFederationTailscaleStatus: vi.fn(async () => ({ status })),
+          }}
+          onClearSecret={vi.fn(async () => true)}
+          onReplaceSecret={vi.fn(async () => true)}
+          saving={false}
+          snapshot={settingsSnapshot()}
+          onSettingsChanged={vi.fn()}
+          onWriteConfig={onWriteConfig}
+        />,
+      );
+
+      fireEvent.change(screen.getByDisplayValue("8765"), {
+        target: { value: listenPort },
+      });
+      const serveButton = await screen.findByRole("button", {
+        name: "Set up Tailscale Serve",
+      });
+      fireEvent.click(serveButton);
+
+      expect(await screen.findByText(
+        "Listen port must be an integer between 1 and 65535.",
+      )).toBeInTheDocument();
+      expect(onWriteConfig).not.toHaveBeenCalled();
+      expect(configureFederationTailscale).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not publish a Tailscale route when the listener cannot bind", async () => {
     const status = {
       installed: true,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -213,6 +213,11 @@ function createSnapshot(
         source: "unset",
         writable: true,
       },
+      noiseStaticPrivateKey: {
+        configured: false,
+        source: "unset",
+        writable: true,
+      },
       cloudflareClientCertificate: {
         configured: false,
         source: "unset",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -1990,6 +1990,103 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("marks a remote snapshot unavailable and refreshes it after reconnect", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const listeners = new Set<
+      Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+    >();
+    let title = "Before disconnect";
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-remote"],
+      threads: [
+        {
+          id: "thread-remote",
+          title,
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        listeners.add(callback);
+        return () => {
+          listeners.delete(callback);
+        };
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.selectedThread?.title).toBe("Before disconnect");
+    });
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "disconnected",
+              unavailableReason: "Federation gateway connection closed.",
+            },
+          },
+        });
+      }
+    });
+
+    expect(result.current.error).toBe("Federation gateway connection closed.");
+    expect(result.current.selectedThread?.title).toBe("Before disconnect");
+
+    title = "After reconnect";
+    act(() => {
+      for (const listener of listeners) {
+        listener({
+          backend: "codex",
+          federationTarget,
+          notification: {
+            method: "federation/peerStatus/changed",
+            params: {
+              instanceId: "remote-instance",
+              status: "connected",
+            },
+          },
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+      expect(result.current.selectedThread?.title).toBe("After reconnect");
+      expect(result.current.error).toBeUndefined();
+    });
+    expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+      federationTarget,
+      forceRefresh: true,
+      refreshMode: "full",
+    });
+  });
+
   it("surfaces archive worktree cleanup failures returned by the desktop bridge", async () => {
     let archived = false;
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -2087,6 +2087,59 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("retries a failed remote snapshot until its route recovers", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    (window as unknown as {
+      __pwragentFederationTarget?: unknown;
+    }).__pwragentFederationTarget = federationTarget;
+    const snapshot = {
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: ["codex:thread-remote"],
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Recovered remotely",
+          titleSource: "explicit" as const,
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: { inInbox: true },
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    };
+    const getNavigationSnapshot = vi.fn()
+      .mockRejectedValueOnce(new Error("Unexpected server response: 502"))
+      .mockResolvedValue(snapshot);
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Unexpected server response: 502");
+    });
+    await waitFor(() => {
+      expect(result.current.selectedThread?.title).toBe("Recovered remotely");
+      expect(result.current.error).toBeUndefined();
+    }, { timeout: 2_500 });
+    expect(getNavigationSnapshot).toHaveBeenCalledTimes(2);
+    expect(getNavigationSnapshot).toHaveBeenLastCalledWith({
+      federationTarget,
+      forceRefresh: true,
+      refreshMode: "full",
+    });
+  });
+
   it("surfaces archive worktree cleanup failures returned by the desktop bridge", async () => {
     let archived = false;
     const getNavigationSnapshot = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -63,6 +63,8 @@ import type {
   PrAutoDispatchBudgetStatus,
   DraftAutomationPromptRequest,
   DraftAutomationPromptResponse,
+  ConfigureFederationTailscaleRequest,
+  ConfigureFederationTailscaleResponse,
   GetAutomationRunArtifactRequest,
   GetAutomationRunArtifactResponse,
   EnsureDirectoryLaunchpadRequest,
@@ -96,6 +98,8 @@ import type {
   ReadFederationHealthResponse,
   ReadFederationDiagnosticsRequest,
   ReadFederationDiagnosticsResponse,
+  ReadFederationTailscaleStatusRequest,
+  ReadFederationTailscaleStatusResponse,
   RevokeFederationPeerRequest,
   RevokeFederationPeerResponse,
   ReorderDirectoryPinsRequest,
@@ -452,6 +456,12 @@ export type DesktopApi = {
   revokeFederationPeer?: (
     request: RevokeFederationPeerRequest,
   ) => Promise<RevokeFederationPeerResponse>;
+  readFederationTailscaleStatus?: (
+    request?: ReadFederationTailscaleStatusRequest,
+  ) => Promise<ReadFederationTailscaleStatusResponse>;
+  configureFederationTailscale?: (
+    request: ConfigureFederationTailscaleRequest,
+  ) => Promise<ConfigureFederationTailscaleResponse>;
   ping?: () => string;
   listSkills?: (
     request?: AppServerListSkillsRequest

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3096,6 +3096,28 @@ export function useThreadNavigation(
 
       markNavigationActivity({ refreshOnIdleResume: false });
       const method = event.notification.method as string;
+      if (method === "federation/peerStatus/changed") {
+        const params = event.notification.params as {
+          instanceId: string;
+          status: string;
+          unavailableReason?: string;
+        };
+        if (params.status === "connected") {
+          scheduleRefresh(undefined, undefined, false, {
+            forceRefresh: true,
+            refreshMode: "full",
+          });
+          return;
+        }
+        setState((current) => ({
+          ...current,
+          loading: false,
+          refreshing: false,
+          error: params.unavailableReason ??
+            `Federation peer ${params.instanceId} is ${params.status}.`,
+        }));
+        return;
+      }
       if (method === "navigation/directoryGitStatus/updated") {
         const params = event.notification
           .params as NavigationDirectoryGitStatusUpdatedNotification["params"];

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -84,6 +84,7 @@ const ROOT_NEW_THREAD_WORKSPACE_LABEL = "Workspaces";
 const NAVIGATION_BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60_000;
 const NAVIGATION_BACKGROUND_REFRESH_IDLE_AFTER_MS = 30 * 60_000;
 const NAVIGATION_FOCUS_REFRESH_MIN_INTERVAL_MS = 60_000;
+const NAVIGATION_REMOTE_RECOVERY_MAX_DELAY_MS = 30_000;
 const DEFAULT_BROWSE_MODE: BrowseMode = "inbox";
 const NAVIGATION_ACTIVITY_EVENTS = [
   "input",
@@ -2582,6 +2583,7 @@ export function useThreadNavigation(
   const focusRefreshInFlightRef = useRef(false);
   const focusRefreshQueuedRef = useRef(false);
   const lastFocusRefreshCompletedAtRef = useRef(0);
+  const remoteRecoveryAttemptRef = useRef(0);
   const lastNavigationActivityAtRef = useRef(Date.now());
   const backgroundRefreshIdleRef = useRef(false);
   const launchpadUpdateRevisionRef = useRef(new Map<string, number>());
@@ -2695,6 +2697,7 @@ export function useThreadNavigation(
         const snapshot = snapshotRequest
           ? await desktopApi.getNavigationSnapshot(snapshotRequest)
           : await desktopApi.getNavigationSnapshot();
+        remoteRecoveryAttemptRef.current = 0;
         desktopApi.recordStartupProfileEvent?.("navigation-refresh:snapshot", {
           directoryCount: snapshot.directories.length,
           forceRefresh: Boolean(options?.forceRefresh),
@@ -3028,6 +3031,38 @@ export function useThreadNavigation(
 
     void refresh();
   }, [enabled, refresh]);
+
+  useEffect(() => {
+    if (
+      !enabled
+      || !desktopApi?.getNavigationSnapshot
+      || !state.error
+      || !readRendererFederationTarget()
+    ) {
+      return;
+    }
+
+    const delayMs = Math.min(
+      1_000 * 2 ** remoteRecoveryAttemptRef.current,
+      NAVIGATION_REMOTE_RECOVERY_MAX_DELAY_MS,
+    );
+    remoteRecoveryAttemptRef.current += 1;
+    const timer = setTimeout(() => {
+      scheduleRefresh(undefined, undefined, false, {
+        forceRefresh: true,
+        refreshMode: "full",
+      });
+    }, delayMs);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [
+    desktopApi?.getNavigationSnapshot,
+    enabled,
+    scheduleRefresh,
+    state.error,
+  ]);
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8540,6 +8540,14 @@ textarea,
   gap: 6px;
 }
 
+.federation-peer-help {
+  margin: 0;
+  padding: 14px 18px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .federation-tailscale-actions {
   display: flex;
   align-items: flex-start;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8540,6 +8540,28 @@ textarea,
   gap: 6px;
 }
 
+.federation-tailscale-actions {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.federation-tailscale-actions label {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.federation-security-note {
+  margin: 0;
+  padding: 14px 18px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .settings-license-actions {
   display: flex;
   flex-direction: column;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -6,6 +6,9 @@ export const FEDERATION_GET_DIAGNOSTICS_CHANNEL = "federation:get-diagnostics";
 export const FEDERATION_GENERATE_INVITE_CHANNEL = "federation:generate-invite";
 export const FEDERATION_IMPORT_INVITE_CHANNEL = "federation:import-invite";
 export const FEDERATION_REVOKE_PEER_CHANNEL = "federation:revoke-peer";
+export const FEDERATION_TAILSCALE_STATUS_CHANNEL = "federation:tailscale-status";
+export const FEDERATION_TAILSCALE_CONFIGURE_CHANNEL =
+  "federation:tailscale-configure";
 export const APP_SERVER_READ_THREAD_CHANNEL = "app-server:read-thread";
 export const APP_SERVER_GET_THREAD_FILE_DIFF_CHANNEL =
   "app-server:get-thread-file-diff";

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -363,6 +363,17 @@ used isolated PwrAgent roots and the `dev` profile. The gateway listened only on
 | Environment setup streaming and worktree handoff | Both directions | Not completed | Deferred from this transport-focused run. | No manual pass should be claimed. |
 | Sibling client relay | Client through gateway to client | Not run | Optional third-profile scenario was not used. | No manual pass should be claimed. |
 
+A same-day follow-up used a packaged PwrAgent client and a Mac Mini gateway over
+the local LAN. The transport connected, but the client activity list ended on
+an earlier failure because successful client handshakes were not audited. The
+gateway card also omitted its connection timestamp and reduced negotiated
+features to a capability count behind a generic **Open** button. The follow-up
+fix records client attempts, successful connections, and disconnects; preserves
+the current session timestamp; shows its running duration; names the available
+remote actions; and uses **Browse remote threads** as the entry point. Focused
+automated coverage passes, but this presentation change still needs a packaged
+two-machine visual retest.
+
 Tailscale Funnel was disabled after the public test and the private Serve route
 was restored for the remaining scenarios. Final teardown removed that Serve
 handler too. The tailnet-level Funnel capability remains enabled because the

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -86,10 +86,10 @@ direct connections that do not use a public tunnel, external certificate
 authority, or stable DNS hostname. It uses a persistent channel key in addition
 to the canonical Ed25519 instance identity.
 
-The implementation uses `Noise_IK_25519_ChaChaPoly_SHA256`:
+The implementation uses `Noise_IK_25519_AESGCM_SHA256`:
 
 - X25519 static and ephemeral keys establish the channel
-- ChaCha20-Poly1305 encrypts and authenticates every frame
+- AES-256-GCM encrypts and authenticates every frame
 - SHA-256 supplies the Noise transcript and key derivation hash
 - the initiator knows the gateway's static Noise key before connecting
 - the gateway learns and authenticates the enrolled client's static key during

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -174,10 +174,13 @@ https://<device>.<tailnet>.ts.net/pwragent-federation
   -> http://127.0.0.1:<federation-port>
 ```
 
-PwrAgent then switches the gateway listener to loopback and stores the matching
-`wss://` URL as its Public URL. Tailscale owns login, device identity, HTTPS
-certificates, and tailnet policy; PwrAgent never reads or stores Tailscale
-credentials.
+Before invoking Tailscale, Settings switches the gateway listener to loopback,
+waits for the runtime restart, and verifies that PwrAgent owns the selected
+port. The main process repeats that ownership check immediately before the CLI
+mutation. A failed or occupied listener therefore cannot publish an unrelated
+localhost service. After setup succeeds, PwrAgent stores the matching `wss://`
+URL as its Public URL. Tailscale owns login, device identity, HTTPS certificates,
+and tailnet policy; PwrAgent never reads or stores Tailscale credentials.
 
 ### Tailscale Funnel
 

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -1,0 +1,314 @@
+# Federation Connectivity and Security Reference
+
+This document is source material for user-facing PwrAgent documentation. It
+explains the available ways to connect PwrAgent instances, which component
+encrypts each part of the path, where unwanted traffic is rejected, and which
+security boundary remains authoritative.
+
+Federation is disabled by default. An operator explicitly enables a gateway,
+enrolls each client with a short-lived invite, and can revoke an enrolled peer.
+
+## The Three Independent Questions
+
+Every federation setup needs clear answers to three different questions:
+
+1. **Reachability:** How does the client reach the gateway?
+2. **Transport protection:** What prevents an observer from reading or changing
+   messages while they cross the network?
+3. **PwrAgent identity:** How does the gateway know that the caller is an
+   enrolled PwrAgent instance, and how does the client know it reached the
+   intended gateway?
+
+A tunnel or VPN answers the first two questions. It does not replace PwrAgent's
+own enrollment and signed peer authentication. Conversely, application-level
+peer authentication does not by itself make a plain `ws://` network path
+confidential.
+
+## Connection Options at a Glance
+
+| Option | Exposure | Network encryption | Outer admission gate | PwrAgent peer authentication | Intended use |
+|---|---|---|---|---|---|
+| Loopback `ws://` | Same machine only | Not needed across a network | Operating-system loopback | Required | Two isolated profiles on one machine |
+| Direct LAN `ws://` | LAN interface | None | Host firewall only | Required | Avoid unless an encrypted overlay is protecting the path |
+| SSH reverse tunnel | SSH endpoint | SSH | SSH key and server access | Required | Development, temporary administration, and VM labs |
+| PwrAgent encrypted transport | Configured listener | PwrAgent secure channel | PwrAgent enrollment | Required and channel-bound | Direct LAN or other private routed networks |
+| Tailscale Serve | Tailnet only | Tailscale/WireGuard plus HTTPS | Tailnet identity and grants | Required | Private access among the operator's enrolled devices |
+| Tailscale Funnel | Public hostname | HTTPS plus encrypted Tailscale relay | Public by default | Required | Public reachability when Cloudflare is not desired |
+| Cloudflare Tunnel | Public hostname | TLS plus encrypted tunnel | Optional Access, mTLS, WAF, or IP policy | Required | Stable Internet reachability without an inbound home-network port |
+
+The safest default for a public hostname is to use both an edge admission gate
+and PwrAgent peer authentication. The safest private-network option is an
+authenticated private overlay such as Tailscale Serve, with PwrAgent peer
+authentication still enabled.
+
+## PwrAgent Enrollment and Peer Authentication
+
+Each PwrAgent profile owns an Ed25519 identity key stored through encrypted
+desktop secret storage. A gateway invite contains the information a client
+needs to reach and authenticate the intended gateway. Enrollment is short-lived
+and single-use. The gateway pins the enrolled client's public identity, and the
+client pins the gateway identity supplied by the invite.
+
+Later connections must prove possession of the matching private key with a
+fresh signed challenge. Revocation closes the active connection and prevents
+that identity from reconnecting.
+
+This authentication is mandatory for every connection option. Cloudflare,
+Tailscale, SSH, TLS certificates, and source-IP rules are independent outer
+layers; none is accepted as a substitute for the enrolled PwrAgent identity.
+
+## Direct and Local Connections
+
+### Same-machine loopback
+
+A listener on `127.0.0.1` is reachable only by processes on the same machine.
+This is suitable for local development and for testing two isolated PwrAgent
+profiles. A plain `ws://` URL does not cross a physical network in this setup.
+
+Other local processes can still attempt to connect, so PwrAgent peer
+authentication remains required.
+
+### Direct LAN
+
+A listener on `0.0.0.0`, a LAN address, or another non-loopback interface is a
+different security posture. Plain `ws://` traffic crossing that interface is
+readable and modifiable by an on-path attacker even though an unenrolled caller
+cannot complete PwrAgent authentication.
+
+Do not describe signed enrollment as transport encryption. Direct LAN use
+needs PwrAgent's encrypted transport or an encrypted network layer such as
+Tailscale, SSH, or another trusted VPN.
+
+## PwrAgent Encrypted Transport
+
+PwrAgent's encrypted transport is intended to protect direct connections
+without requiring a public tunnel, external certificate authority, or stable
+DNS hostname. It uses a persistent channel key in addition to the canonical
+Ed25519 instance identity.
+
+The secure channel must provide:
+
+- mutual proof that the parties possess the expected channel keys
+- confidentiality and authenticated encryption for every federation frame
+- forward secrecy from fresh ephemeral handshake keys
+- monotonically increasing transport nonces so replayed frames fail
+- binding between the encrypted channel and PwrAgent's signed identity proof
+- a pinned gateway channel key carried by the enrollment invite
+- fail-closed behavior when the expected gateway key is missing or wrong
+
+The WebSocket remains the framing and streaming transport. Application frames
+inside it are ciphertext rather than readable JSON.
+
+This protects PwrAgent traffic, but it does not provide automatic LAN discovery,
+NAT traversal, a public hostname, or a firewall. Operators still choose how one
+machine routes to the other.
+
+## SSH Reverse Tunnel
+
+SSH is an external transport option, not a PwrAgent-managed feature. A reverse
+tunnel is useful when a development VM can accept SSH connections but should
+not expose a PwrAgent listener to the LAN.
+
+Example topology:
+
+```text
+PwrAgent client in VM
+  -> VM 127.0.0.1:47830
+  -> SSH reverse forwarding
+  -> host 127.0.0.1:47830
+  -> PwrAgent gateway
+```
+
+SSH encrypts the cross-machine segment and controls who may create the tunnel.
+PwrAgent still performs enrollment and signed peer authentication inside it.
+The SSH process lifecycle, host-key verification, keys, and reconnect behavior
+remain the operator's responsibility.
+
+## Tailscale
+
+PwrAgent can use a Tailscale-provided URL or route without treating Tailscale
+identity as PwrAgent identity.
+
+### Tailscale Serve
+
+Tailscale Serve is the preferred Tailscale posture for personal federation. It
+proxies a loopback HTTP service to an HTTPS URL available only inside the
+operator's tailnet. Tailscale network grants apply before a peer can reach the
+service.
+
+```text
+Enrolled client in tailnet
+  -> Tailscale HTTPS endpoint
+  -> encrypted tailnet path
+  -> Tailscale Serve on gateway machine
+  -> gateway 127.0.0.1:47830
+  -> PwrAgent peer authentication
+```
+
+Keep the PwrAgent gateway on loopback. Do not trust forwarded identity headers
+as a replacement for PwrAgent enrollment. Devices outside the tailnet should
+not be able to reach the Serve URL.
+
+### Tailscale Funnel
+
+Tailscale Funnel publishes a local service to the public Internet through a
+Tailscale hostname and encrypted relay. It hides the machine's public address
+and avoids an inbound router port, but the hostname is public. Funnel does not
+provide Tailscale Serve's tailnet-user identity headers.
+
+Random Internet clients can therefore reach the public Funnel edge and attempt
+the WebSocket upgrade. PwrAgent authentication is the primary admission gate at
+the application. Use Funnel only when public reachability is intentional and
+document its wider attack surface.
+
+## Cloudflare Tunnel
+
+Cloudflare Tunnel uses an outbound `cloudflared` connection from the gateway
+machine to Cloudflare. The PwrAgent listener stays on `127.0.0.1`; no router
+port or publicly routable origin address is required.
+
+```text
+Client
+  -> Cloudflare edge
+  -> Cloudflare Access, mTLS, WAF, or IP policy
+  -> encrypted Cloudflare Tunnel
+  -> cloudflared on gateway machine
+  -> gateway 127.0.0.1:47830
+  -> PwrAgent peer authentication
+```
+
+The gateway's Public URL is the `wss://` Cloudflare hostname. That URL is
+embedded in newly generated enrollment invites.
+
+### Without an edge admission policy
+
+The origin IP and listener remain hidden, but the hostname is public. Random
+Internet clients can reach Cloudflare and their accepted HTTP/WebSocket upgrade
+traffic can traverse the tunnel to the loopback listener. PwrAgent must reject
+unenrolled callers.
+
+This is better than opening a home-network port, but it exposes more of the
+application protocol to hostile traffic than a deny-by-default Access policy.
+
+### Cloudflare Access service token
+
+A Service Auth policy can require the `CF-Access-Client-Id` and
+`CF-Access-Client-Secret` headers. PwrAgent stores these values in encrypted
+desktop secret storage and supplies them only on the WebSocket upgrade.
+
+Cloudflare rejects a request without the correct token before forwarding it
+through the tunnel. A service token is a bearer credential: anyone who copies
+both values can pass this outer gate until the token expires or is revoked.
+PwrAgent peer authentication still protects the inner control plane.
+
+### Cloudflare Access mTLS
+
+An Access Service Auth policy can require a client certificate signed by a CA
+associated with the federation hostname. PwrAgent stores the PEM certificate
+and private key in encrypted desktop secret storage and supplies them during
+the TLS handshake.
+
+With the exact hostname covered by the Access application and no applicable
+Bypass policy, a caller without a valid certificate is rejected at Cloudflare's
+edge. It does not receive a WebSocket upgrade, and its request is not forwarded
+through the tunnel to `cloudflared` or the PwrAgent listener.
+
+The `Valid Certificate` selector accepts any valid client certificate issued by
+the configured CA. Use a narrower Common Name policy or separate certificate
+issuance policy when individual-device admission matters. Certificate expiry,
+revocation, and private-key protection remain operational responsibilities.
+
+The PwrAgent mTLS setting only presents client credentials. It does not create
+the CA, issue a certificate, configure the Cloudflare Access application, or
+attach an mTLS policy. Access service tokens and mTLS may be required together
+for defense in depth.
+
+## Rejection Boundaries
+
+| Failure | Rejected by | Reaches PwrAgent listener? |
+|---|---|---|
+| Client outside a Tailscale Serve grant | Tailscale network policy | No |
+| Random caller to a Tailscale Funnel hostname | No outer identity gate by default | Yes, unless another edge control is added |
+| Missing Cloudflare Access service token | Cloudflare Access | No |
+| Missing or invalid Cloudflare client certificate | Cloudflare Access mTLS | No |
+| Caller with edge credentials but no PwrAgent enrollment | PwrAgent gateway | Yes, then rejected during authentication |
+| Revoked PwrAgent identity | PwrAgent gateway | Yes, then rejected during authentication |
+| Wrong gateway identity returned to a client | PwrAgent client | Connection rejected |
+| Modified encrypted PwrAgent frame | PwrAgent secure channel | Frame/session rejected |
+
+## Recommended Postures
+
+### Same machine
+
+- Loopback listener
+- PwrAgent enrollment and signed peer authentication
+
+### Private personal devices
+
+- Tailscale Serve to a loopback PwrAgent listener
+- Restrictive tailnet grants
+- PwrAgent enrollment and signed peer authentication
+- PwrAgent encrypted transport as an additional application-layer boundary
+
+### Public Internet hostname
+
+- Loopback PwrAgent listener
+- Cloudflare Tunnel
+- Deny-by-default Access application
+- mTLS or a narrowly scoped Access service token; both when practical
+- PwrAgent enrollment and signed peer authentication
+- No direct router or firewall exposure of the listener
+
+### Development VM
+
+- Loopback listener on both machines
+- SSH reverse tunnel or Tailscale Serve
+- Dedicated test profiles and roots
+- PwrAgent enrollment and signed peer authentication
+
+## Verification Checklist
+
+Documentation should not claim a connection option works end to end until the
+following behavior has been observed:
+
+- correct client connects and both instances report Connected
+- client verifies the intended gateway identity
+- unenrolled and revoked clients are rejected
+- live remote events stream without refresh
+- disconnect and reconnect states recover without local fallback
+- remote paths and filesystem changes occur only on the owning machine
+- packet or raw-frame inspection does not reveal federation JSON when PwrAgent
+  encrypted transport is enabled
+- modified and replayed encrypted frames are rejected
+- Tailscale Serve URL is unreachable from a device outside the allowed tailnet
+- Tailscale Funnel is treated as publicly reachable
+- Cloudflare hostname without Access credentials receives `401` or `403`
+- Cloudflare mTLS hostname without a client certificate receives `403`
+- rejected Cloudflare traffic produces no connection or authentication event at
+  the local PwrAgent listener
+- correctly credentialed Cloudflare traffic still fails without an enrolled
+  PwrAgent identity
+- tunnel interruption produces an unavailable state and recovery reconnects the
+  same peer identity
+
+Record the exact outer service configuration during testing. A successful
+PwrAgent connection alone cannot prove that an edge rejection policy was active.
+
+## Current Validation Status
+
+The merged federation baseline has been manually exercised between a host and a
+macOS development VM through an SSH reverse tunnel. That proves the remote
+workflow and the SSH-protected route, not Cloudflare, Tailscale, or the PwrAgent
+encrypted transport.
+
+Cloudflare configuration, secret storage, and client credential plumbing have
+automated coverage, but the Cloudflare Tunnel, Access service-token, and mTLS
+paths still require live validation against a real Cloudflare account.
+
+Tailscale-specific federation setup and live validation have not yet been
+completed.
+
+An earlier Noise-based encrypted transport implementation passed official Noise
+vectors, tamper and wrong-gateway tests, real-socket encrypted RPC coverage, and
+project CI. It is being reintroduced on top of the merged federation baseline;
+the validation status in this document should be updated when that work lands.

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -115,6 +115,20 @@ pinned by the importing client. The private key is generated automatically and
 stored through the desktop credential store. There is deliberately no setting
 that disables Noise: encryption is part of the federation transport contract.
 
+Noise-capable federation uses invite version 2 and a version-2 transport
+preface before the Noise handshake. The preface contains only the protocol,
+transport version, and required cipher-suite name; it contains no identity or
+secret material. Its purpose is to make mixed old/new deployments reject
+immediately instead of having one side wait for plaintext JSON while the other
+waits for a Noise handshake. A profile enrolled by a pre-Noise build must
+import a newly generated invite before it can connect to a Noise-required
+gateway.
+
+An authenticated-encryption failure, including tampering or replay, is fatal to
+the current WebSocket session. PwrAgent closes the socket so pending operations
+fail and normal unavailable/reconnect handling can begin; it does not keep a
+session marked Connected after its receive nonce can no longer advance.
+
 This protects PwrAgent traffic, but it does not provide automatic LAN discovery,
 NAT traversal, a public hostname, or a firewall. Operators still choose how one
 machine routes to the other.

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -115,14 +115,12 @@ pinned by the importing client. The private key is generated automatically and
 stored through the desktop credential store. There is deliberately no setting
 that disables Noise: encryption is part of the federation transport contract.
 
-Noise-capable federation uses invite version 2 and a version-2 transport
+The initial federation protocol uses invite version 1 and a version-1 transport
 preface before the Noise handshake. The preface contains only the protocol,
 transport version, and required cipher-suite name; it contains no identity or
-secret material. Its purpose is to make mixed old/new deployments reject
-immediately instead of having one side wait for plaintext JSON while the other
-waits for a Noise handshake. A profile enrolled by a pre-Noise build must
-import a newly generated invite before it can connect to a Noise-required
-gateway.
+secret material. It provides an explicit negotiation boundary so unsupported
+transports reject immediately instead of having one side wait for plaintext
+JSON while the other waits for a Noise handshake.
 
 An authenticated-encryption failure, including tampering or replay, is fatal to
 the current WebSocket session. PwrAgent closes the socket so pending operations

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -337,34 +337,59 @@ PwrAgent connection alone cannot prove that an edge rejection policy was active.
 
 ## Current Validation Status
 
-The federation baseline has been manually exercised between a host and a macOS
-development VM through an SSH reverse tunnel. That proves the remote workflow
-and the SSH-protected route, not Cloudflare or Tailscale.
+The following results were recorded on August 4, 2026 between a host macOS
+PwrAgent gateway and the trusted `pwrsnap-dev` Tart macOS VM. Both applications
+used isolated PwrAgent roots and the `dev` profile. The gateway listened only on
+`127.0.0.1:47830`; Tailscale Serve published the dedicated federation path.
 
-The Noise implementation passes the official Noise protocol vectors plus
-focused coverage for tampering, replay/counter behavior, wrong gateway pins,
-real-socket encrypted RPC, invite key pinning, identity channel binding, and
-credential-store persistence. A fresh two-machine manual run and raw-frame
-inspection remain to be completed before documentation claims live validation.
+| Workflow | Direction | Result | Latency and UX observation | Evidence |
+|---|---|---|---|---|
+| Tailscale Serve setup | Host gateway | Pass | Settings verified the loopback listener before changing Tailscale and stored the generated `wss://` URL. | `tailscale serve status --json` mapped only `/pwragent-federation` to `127.0.0.1:47830`; both instances reported Connected. |
+| Noise encrypted transport | Both directions | Pass | Transparent after enrollment. An Electron cipher-availability defect was found and fixed by using the supported AES-GCM Noise suite. | Live remote RPC and event streams worked through `Noise_IK_25519_AESGCM_SHA256`; non-Noise WebSocket attempts were rejected before federation authentication. |
+| Enrollment | VM client to host gateway | Pass with UX concern | The one-time invite was about 599 characters. Moving it between machines through Screen Sharing was awkward and error-prone; direct-port pairing was not comfortable. | The VM imported the invite, pinned the gateway, and reconnected with the same peer identity. |
+| Browse, open, resume, and rename threads | Both directions | Pass | Thread lists generally appeared within a few seconds. A remote window could briefly select a stale first thread during connection recovery; choosing the isolated test thread succeeded. | VM renamed the host test thread to `tailscale host dogfood`; host opened `VM federation ready`. |
+| Prompt and live event streaming | Both directions | Pass | Assistant, reasoning, command, usage, and lifecycle events arrived without a manual refresh. | Host and VM test threads displayed live remote turns. |
+| Queue, compact, interrupt, and steer | VM to host | Pass after fix | Remote steering initially canceled the queue on the VM and failed. Queue cancellation is now routed to the owning peer; the retest entered `Steering now` and completed normally. | Host replied `remote steer passed` in the same active turn; focused RPC, IPC, and composer tests cover the routing fix. |
+| Model and execution settings | VM to host | Pass | Remote model and access changes updated the owning host thread. | Model changed from GPT-5.5 to GPT-5.4; Default Access changed to Full Access. |
+| Approval handling | VM to host | Pass | The approval appeared on the controlling VM, not on the host desktop, and the accepted result streamed back. | Full Access command approval completed on the host thread. |
+| Federated search | VM controlling host | Pass | Results included both machines and displayed their instance label. | A VM-owned result opened as remote; no local substitute thread was used. |
+| Filesystem ownership / no fallback | Both directions | Pass | Absolute paths remained visibly machine-specific. | Host-only project `2026-08-04-401004` did not exist on the VM; VM-only project `2026-08-04-943759` did not exist on the host. |
+| Gateway unavailable state | VM viewing host | Pass after fix | The already-open remote window retained its transcript and immediately replaced the sidebar with an explicit route error. | Stopping the host gateway produced a remote `navigation:get-snapshot` unavailable error; no local thread list appeared. |
+| Gateway recovery | VM viewing host | Pass after fix, delayed | The open window recovered in the background without reopening Settings or the peer. A sustained outage took roughly two minutes because reconnect backoff and a 30-second RPC timeout overlapped. Bounded navigation retries and unroutable-RPC cleanup were added. | The error cleared and the host thread list repopulated while the remote window was unfocused. |
+| Peer revocation | Host gateway to VM client | Pass | Revocation immediately closed the active connection and disabled Open and Revoke for the peer. Re-enrollment was not repeated during teardown. | The peer changed from Connected to Revoked and a `transport_closed` diagnostic appeared at the same time. |
+| Tailscale Funnel setup | Host gateway | Partial | Settings correctly required public-exposure acknowledgement. Enabling Funnel required a one-time tailnet policy change. | Funnel status, public DNS, dedicated path, and Settings `Funnel` badge were verified. A true off-tailnet WebSocket session was not completed. |
+| Tailscale Funnel external reachability | External client | Not proven | Host and VM shared the same public egress. Forced public-edge TLS attempts hit Tailscale's same-egress/hairpin behavior and ended before a WebSocket handshake. | Public DNS and Funnel status proved publication, not successful off-network federation. |
+| Cloudflare Tunnel, Access token, and mTLS | External client | Not run live | The account and local `cloudflared` installation were inspected only for later test preparation. | Automated configuration and credential-plumbing tests pass; no live Access rejection boundary was claimed. |
+| Environment setup streaming and worktree handoff | Both directions | Not completed | Deferred from this transport-focused run. | No manual pass should be claimed. |
+| Sibling client relay | Client through gateway to client | Not run | Optional third-profile scenario was not used. | No manual pass should be claimed. |
 
-Cloudflare configuration, secret storage, and client credential plumbing have
+Tailscale Funnel was disabled after the public test and the private Serve route
+was restored for the remaining scenarios. Final teardown removed that Serve
+handler too. The tailnet-level Funnel capability remains enabled because the
+one-time Tailscale account action applies to tailnet policy rather than a single
+PwrAgent handler. Documentation should distinguish that persistent account
+capability from an actively published Funnel route.
+
+The live run did not inspect packet payloads directly. It proved that the Noise
+handshake and encrypted remote workflow operate in Electron and that malformed
+non-Noise connections fail closed. Automated coverage still supplies the
+protocol-vector, tampering, replay/counter, wrong-pin, identity-binding,
+real-socket encrypted-RPC, and credential-store checks.
+
+Cloudflare configuration, secret storage, and client-credential plumbing have
 automated coverage, but the Cloudflare Tunnel, Access service-token, and mTLS
-paths still require live validation against a real Cloudflare account.
+paths still require live testing against a deny-by-default Access application.
+That future test must verify both the Cloudflare response and the absence of a
+corresponding connection at the local PwrAgent listener.
 
-Tailscale Serve/Funnel discovery and setup now have focused automated coverage.
-The implementation reports only sanitized local device status to the renderer,
-uses a dedicated path, never invokes a broad reset, requires Funnel exposure
-acknowledgement, and writes the resulting `wss://` URL into PwrAgent gateway
-settings. Live Serve and Funnel validation remain to be completed after the
-operator selects the intended Tailscale account.
-
-## Dogfood Environment Readiness and Morning Runbook
+## Dogfood Environment Baseline and Follow-up Runbook
 
 The following observations were read-only and specific to the test environment
-on August 4, 2026. They are not product prerequisites:
+before the August 4, 2026 live run. They are not product prerequisites or a
+description of the post-test state:
 
-- the Tailscale CLI is installed and connected; no Serve or Funnel handler was
-  configured during the overnight implementation
+- the Tailscale CLI was installed and connected; no Serve or Funnel handler was
+  configured before the live test
 - `cloudflared` 2026.2.0 is installed, but the local CLI has no default origin
   certificate and therefore cannot administer account tunnels by name
 - the Cloudflare Zero Trust account is on the Free plan and already has working

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -81,12 +81,21 @@ Tailscale, SSH, or another trusted VPN.
 
 ## PwrAgent Encrypted Transport
 
-PwrAgent's encrypted transport is intended to protect direct connections
-without requiring a public tunnel, external certificate authority, or stable
-DNS hostname. It uses a persistent channel key in addition to the canonical
-Ed25519 instance identity.
+PwrAgent's encrypted transport protects every federation connection, including
+direct connections that do not use a public tunnel, external certificate
+authority, or stable DNS hostname. It uses a persistent channel key in addition
+to the canonical Ed25519 instance identity.
 
-The secure channel must provide:
+The implementation uses `Noise_IK_25519_ChaChaPoly_SHA256`:
+
+- X25519 static and ephemeral keys establish the channel
+- ChaCha20-Poly1305 encrypts and authenticates every frame
+- SHA-256 supplies the Noise transcript and key derivation hash
+- the initiator knows the gateway's static Noise key before connecting
+- the gateway learns and authenticates the enrolled client's static key during
+  the handshake
+
+The secure channel provides:
 
 - mutual proof that the parties possess the expected channel keys
 - confidentiality and authenticated encryption for every federation frame
@@ -96,8 +105,15 @@ The secure channel must provide:
 - a pinned gateway channel key carried by the enrollment invite
 - fail-closed behavior when the expected gateway key is missing or wrong
 
-The WebSocket remains the framing and streaming transport. Application frames
-inside it are ciphertext rather than readable JSON.
+The WebSocket remains the framing and streaming transport. The Noise handshake
+runs before PwrAgent identity authentication, and the signed identity proof is
+bound to the Noise handshake hash. Application frames inside the WebSocket are
+ciphertext rather than readable JSON.
+
+The gateway Noise public key is embedded in the one-time enrollment invite and
+pinned by the importing client. The private key is generated automatically and
+stored through the desktop credential store. There is deliberately no setting
+that disables Noise: encryption is part of the federation transport contract.
 
 This protects PwrAgent traffic, but it does not provide automatic LAN discovery,
 NAT traversal, a public hostname, or a firewall. Operators still choose how one
@@ -149,6 +165,20 @@ Keep the PwrAgent gateway on loopback. Do not trust forwarded identity headers
 as a replacement for PwrAgent enrollment. Devices outside the tailnet should
 not be able to reach the Serve URL.
 
+Settings -> Federation -> Tailscale Serve / Funnel Setup detects the local
+Tailscale CLI and connected tailnet. **Set up Tailscale Serve** asks the CLI to
+proxy only this route:
+
+```text
+https://<device>.<tailnet>.ts.net/pwragent-federation
+  -> http://127.0.0.1:<federation-port>
+```
+
+PwrAgent then switches the gateway listener to loopback and stores the matching
+`wss://` URL as its Public URL. Tailscale owns login, device identity, HTTPS
+certificates, and tailnet policy; PwrAgent never reads or stores Tailscale
+credentials.
+
 ### Tailscale Funnel
 
 Tailscale Funnel publishes a local service to the public Internet through a
@@ -160,6 +190,14 @@ Random Internet clients can therefore reach the public Funnel edge and attempt
 the WebSocket upgrade. PwrAgent authentication is the primary admission gate at
 the application. Use Funnel only when public reachability is intentional and
 document its wider attack surface.
+
+The Settings action requires an explicit acknowledgement that Funnel creates a
+public endpoint. It uses the same dedicated `/pwragent-federation` path. Setup
+never calls `tailscale serve reset` or `tailscale funnel reset`, because those
+commands can delete unrelated routes. Current Tailscale CLI releases do not
+offer a path-scoped removal command for a node-level handler, so operators must
+inspect `tailscale serve status --json` and `tailscale funnel status --json`
+before manually changing or resetting a machine with other handlers.
 
 ## Cloudflare Tunnel
 
@@ -296,19 +334,94 @@ PwrAgent connection alone cannot prove that an edge rejection policy was active.
 
 ## Current Validation Status
 
-The merged federation baseline has been manually exercised between a host and a
-macOS development VM through an SSH reverse tunnel. That proves the remote
-workflow and the SSH-protected route, not Cloudflare, Tailscale, or the PwrAgent
-encrypted transport.
+The federation baseline has been manually exercised between a host and a macOS
+development VM through an SSH reverse tunnel. That proves the remote workflow
+and the SSH-protected route, not Cloudflare or Tailscale.
+
+The Noise implementation passes the official Noise protocol vectors plus
+focused coverage for tampering, replay/counter behavior, wrong gateway pins,
+real-socket encrypted RPC, invite key pinning, identity channel binding, and
+credential-store persistence. A fresh two-machine manual run and raw-frame
+inspection remain to be completed before documentation claims live validation.
 
 Cloudflare configuration, secret storage, and client credential plumbing have
 automated coverage, but the Cloudflare Tunnel, Access service-token, and mTLS
 paths still require live validation against a real Cloudflare account.
 
-Tailscale-specific federation setup and live validation have not yet been
-completed.
+Tailscale Serve/Funnel discovery and setup now have focused automated coverage.
+The implementation reports only sanitized local device status to the renderer,
+uses a dedicated path, never invokes a broad reset, requires Funnel exposure
+acknowledgement, and writes the resulting `wss://` URL into PwrAgent gateway
+settings. Live Serve and Funnel validation remain to be completed after the
+operator selects the intended Tailscale account.
 
-An earlier Noise-based encrypted transport implementation passed official Noise
-vectors, tamper and wrong-gateway tests, real-socket encrypted RPC coverage, and
-project CI. It is being reintroduced on top of the merged federation baseline;
-the validation status in this document should be updated when that work lands.
+## Dogfood Environment Readiness and Morning Runbook
+
+The following observations were read-only and specific to the test environment
+on August 4, 2026. They are not product prerequisites:
+
+- the Tailscale CLI is installed and connected; no Serve or Funnel handler was
+  configured during the overnight implementation
+- `cloudflared` 2026.2.0 is installed, but the local CLI has no default origin
+  certificate and therefore cannot administer account tunnels by name
+- the Cloudflare Zero Trust account is on the Free plan and already has working
+  Tunnel and Access resources, so the required product surfaces are available
+- no dedicated PwrAgent federation tunnel, Access application, service token,
+  or mTLS root certificate was created
+- the Cloudflare mTLS certificate list is currently empty
+
+### Tailscale live test
+
+1. Confirm the host and VM are signed into the intended test tailnet.
+2. Start isolated host and VM PwrAgent profiles with the gateway listener on
+   `127.0.0.1`.
+3. In host Settings, confirm Tailscale reports the expected tailnet and DNS
+   name. Do not continue if the account is wrong.
+4. Select **Set up Tailscale Serve**. Verify the dedicated path appears in
+   `tailscale serve status --json` without changing unrelated handlers.
+5. Enroll the VM from the new invite and run browse, prompt streaming, steer,
+   interrupt, approval, remote-file, and reconnect scenarios.
+6. Confirm the Serve URL is unavailable from a device outside the authorized
+   tailnet or outside the applicable grants.
+7. After the private workflow passes, acknowledge public exposure and select
+   **Set up Tailscale Funnel**.
+8. Confirm the hostname is publicly reachable, an unenrolled caller is rejected
+   by PwrAgent, and an enrolled client completes the Noise and identity
+   handshakes.
+9. Inspect both status documents before cleanup. Do not use a broad Tailscale
+   reset if the machine has unrelated Serve/Funnel handlers.
+
+### Cloudflare live test
+
+Use new, clearly named dogfood resources. Do not edit or reuse an existing
+tunnel, Access application, policy, service credential, or hostname.
+
+1. Choose a temporary hostname in a Cloudflare-managed test domain, for example
+   `federation-dogfood.example.com`.
+2. Create a dedicated remotely managed tunnel and run its token-based
+   `cloudflared` connector on the host. Do not depend on the absent local origin
+   certificate.
+3. Map only the temporary hostname/path to
+   `http://127.0.0.1:<federation-port>` and set the PwrAgent Public URL to the
+   corresponding `wss://` URL.
+4. Create a dedicated self-hosted Access application with a deny-by-default
+   Service Auth policy. Do not add a Bypass policy covering the hostname.
+5. For the service-token pass, create a short-lived dedicated token, require it
+   in the Access policy, store its ID and secret in PwrAgent Settings, and enable
+   Access service auth.
+6. Verify a request without the token is rejected at the Cloudflare edge and
+   produces no PwrAgent connection diagnostic. Then verify the correct token
+   passes the edge but an unenrolled PwrAgent still fails the inner handshake.
+7. For the mTLS pass, create a temporary test CA and client certificate, upload
+   only the CA certificate to Cloudflare, associate the exact hostname, and add
+   a `Valid Certificate` or narrower Common Name Service Auth rule. Store the
+   client certificate and key in PwrAgent Settings and enable mTLS.
+8. Verify a request without the client certificate is rejected at Cloudflare
+   and never reaches the local listener. Then verify the valid certificate
+   passes the edge but still requires the pinned Noise gateway and enrolled
+   PwrAgent identity.
+9. Run the full remote workflow, interrupt the connector to observe unavailable
+   and recovery states, and compare Cloudflare Access logs with PwrAgent
+   diagnostic timestamps.
+10. Remove only the temporary dogfood hostname, Access application, policies,
+    credentials, certificate objects, and tunnel after recording evidence.

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -145,6 +145,11 @@ describe("desktop settings contracts", () => {
           source: "unset",
           writable: true,
         },
+        noiseStaticPrivateKey: {
+          configured: false,
+          source: "unset",
+          writable: true,
+        },
         cloudflareClientCertificate: {
           configured: false,
           source: "unset",

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -254,6 +254,7 @@ export type StartTurnResponse = {
 };
 
 export type CancelQueuedTurnRequest = {
+  federationTarget?: FederationTarget;
   queueEntryId: string;
 };
 

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -101,6 +101,37 @@ export type ReadFederationHealthResponse = {
   health: FederationHealthStatus;
 };
 
+export type FederationTailscaleMode = "serve" | "funnel";
+
+export type FederationTailscaleStatus = {
+  installed: boolean;
+  connected: boolean;
+  version?: string;
+  backendState?: string;
+  dnsName?: string;
+  tailnetName?: string;
+  serveConfigured: boolean;
+  funnelConfigured: boolean;
+  gatewayUrl?: string;
+  unavailableReason?: string;
+};
+
+export type ReadFederationTailscaleStatusRequest = Record<string, never>;
+
+export type ReadFederationTailscaleStatusResponse = {
+  status: FederationTailscaleStatus;
+};
+
+export type ConfigureFederationTailscaleRequest = {
+  mode: FederationTailscaleMode;
+  listenPort: number;
+};
+
+export type ConfigureFederationTailscaleResponse = {
+  status: FederationTailscaleStatus;
+  gatewayUrl: string;
+};
+
 export type FederationDiagnosticEventKind =
   | "connect_attempt"
   | "connected"

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -6,8 +6,8 @@ import type {
 } from "./normalized-app-server";
 
 export const FEDERATION_PROTOCOL_VERSION = 1;
-export const FEDERATION_INVITE_VERSION = 2;
-export const FEDERATION_TRANSPORT_VERSION = 2;
+export const FEDERATION_INVITE_VERSION = 1;
+export const FEDERATION_TRANSPORT_VERSION = 1;
 
 export const FEDERATION_CAPABILITIES = [
   "remote_window",

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -6,6 +6,8 @@ import type {
 } from "./normalized-app-server";
 
 export const FEDERATION_PROTOCOL_VERSION = 1;
+export const FEDERATION_INVITE_VERSION = 2;
+export const FEDERATION_TRANSPORT_VERSION = 2;
 
 export const FEDERATION_CAPABILITIES = [
   "remote_window",

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -3,7 +3,10 @@ import type {
   MessagingChannelKind,
   MessagingConversationKind,
 } from "./messaging";
-import type { FederationTarget } from "./federation";
+import type {
+  FederationConnectionState,
+  FederationTarget,
+} from "./federation";
 import type {
   PrSummary,
   ThreadPrAutoDispatchEventKind,
@@ -1012,6 +1015,15 @@ export type AppServerToolRequestUserInputNotification = {
   };
 };
 
+export type FederationPeerStatusChangedNotification = {
+  method: "federation/peerStatus/changed";
+  params: {
+    instanceId: string;
+    status: FederationConnectionState;
+    unavailableReason?: string;
+  };
+};
+
 export type AppServerMcpElicitationAction = "accept" | "decline" | "cancel";
 
 export type AppServerMcpElicitationSchema = {
@@ -1619,4 +1631,5 @@ export type AppServerNotification =
         collapsed: boolean;
       };
     }
+  | FederationPeerStatusChangedNotification
   | AppServerPendingRequestNotification;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -544,6 +544,7 @@ export type DesktopFederationSettingsSnapshot = {
   cloudflareMtlsEnabled: DesktopSettingsValue<boolean>;
   cloudflareAccessServiceAuthEnabled: DesktopSettingsValue<boolean>;
   instancePrivateKey: DesktopSettingsSecretState;
+  noiseStaticPrivateKey: DesktopSettingsSecretState;
   cloudflareClientCertificate: DesktopSettingsSecretState;
   cloudflareClientPrivateKey: DesktopSettingsSecretState;
   cloudflareAccessClientId: DesktopSettingsSecretState;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -272,6 +272,7 @@ export type DesktopSettingsSecretName =
   | "lineChannelAccessToken"
   | "lineChannelSecret"
   | "federationInstancePrivateKey"
+  | "federationNoiseStaticPrivateKey"
   | "federationCloudflareClientCertificate"
   | "federationCloudflareClientPrivateKey"
   | "federationCloudflareAccessClientId"
@@ -311,6 +312,7 @@ export function isMessagingRuntimeSecret(
       return true;
     case "grokApiKey":
     case "federationInstancePrivateKey":
+    case "federationNoiseStaticPrivateKey":
     case "federationCloudflareClientCertificate":
     case "federationCloudflareClientPrivateKey":
     case "federationCloudflareAccessClientId":


### PR DESCRIPTION
## What

- require Noise IK encryption for every federation WebSocket session
- pin gateway Noise keys in the initial version-1 invites and bind signed peer identity to the Noise handshake
- advertise an explicit version-1 Noise transport preface so unsupported peers reject immediately instead of deadlocking
- close and unregister sessions after any encrypted-frame authentication failure
- add guarded Tailscale Serve and Funnel setup on the dedicated `/pwragent-federation` path, including pre-persistence port validation
- route remote steering to the owning instance and repair stale/unavailable remote-window recovery
- clean up unroutable RPC requests immediately instead of leaving timeout promises behind
- record successful client connection lifecycles and make remote capabilities and the remote-window entry point explicit
- document connection choices, layered encryption, rejection boundaries, risks, caveats, and the August 4 dogfood results

## Live dogfood

Tested between the host gateway and trusted `pwrsnap-dev` Tart VM with `PWRAGENT_PROFILE=dev` and isolated PwrAgent roots.

Passed:

- mandatory Noise transport in Electron using `Noise_IK_25519_AESGCM_SHA256`
- Tailscale Serve enrollment and two-way remote thread control
- browse, open, resume, rename, prompt streaming, queue, compact, interrupt, and steer
- remote model/execution changes and approvals on the controlling machine
- federated search and host/VM filesystem no-fallback proof
- unavailable state, background reconnect recovery, and peer revocation

A packaged direct-LAN client-to-Mac-Mini follow-up connected successfully but exposed presentation defects: the client audit ended on an earlier failure, the peer had no connection timestamp/duration, and negotiated capabilities were hidden behind a generic `Open` button. The fix records client attempts/success/disconnects, preserves current-session timing, names available actions, and presents a prominent `Browse remote threads` entry point. Automated coverage passes; the updated packaged presentation still needs a two-machine visual retest.

Partially proven:

- Funnel setup, public DNS, status, dedicated route, and Settings state passed
- a true off-tailnet WebSocket session was not completed because both test machines shared the same public egress

Not claimed:

- live Cloudflare Tunnel/Access/mTLS rejection boundaries
- environment setup streaming, worktree handoff, or optional sibling relay

The evidence table and follow-up procedure are in `docs/federation-connectivity-reference.md`.

## Validation

- 16 focused Vitest files, 573 tests passed
- regressions cover unsupported transport/invite version rejection, fatal tampered-frame session closure, and invalid Tailscale ports before mutation
- full workspace typecheck passed
- ESLint passed with 0 errors and no new warnings
- dependency boundaries and renderer color lint passed
- disruptive live Electron validation ran in the Tart development VM, not on the host desktop

## Teardown

- temporary peer revoked
- Funnel and Serve handlers removed; `tailscale serve status --json` is `{}`
- isolated host and guest PwrAgent processes stopped
- guest repository restored to its pre-test commit
- isolated dogfood roots/helper removed
- guest Tailscale installation and account connection intentionally retained
- tailnet-level Funnel capability remains enabled; no Cloudflare resources were created or changed

