### PR TITLE
fix(desktop): preserve PR attachment order

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
@@ -317,6 +317,35 @@ describe("SqliteOverlayStore — thread PRs", () => {
     ]);
   });
 
+  it("appends explicitly attached PRs in attachment order", async () => {
+    const olderAttachment = pr({
+      ...prPassing,
+      number: 735,
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/735",
+    });
+    const newerAttachment = pr({
+      ...prPassing,
+      number: 1191,
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1191",
+    });
+
+    await store.addThreadPullRequestReference({
+      backend: "codex",
+      threadId: "thread-1",
+      pr: olderAttachment,
+    });
+    const added = await store.addThreadPullRequestReference({
+      backend: "codex",
+      threadId: "thread-1",
+      pr: newerAttachment,
+    });
+
+    expect(added.prs?.map((pullRequest) => pullRequest.number)).toEqual([
+      735,
+      1191,
+    ]);
+  });
+
   it("persists canonical PR status cache rows across reopen", async () => {
     await store.writePrStatusCacheEntries([
       {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -297,9 +297,11 @@ function mergePrSummariesByStatusKey(
     const normalized = normalizePrSummary(pr);
     byKey.set(buildPullRequestStatusKey(normalized), normalized);
   }
-  const merged = [...byKey.values()].sort((left, right) =>
-    buildPullRequestStatusKey(left).localeCompare(buildPullRequestStatusKey(right)),
-  );
+  // Map replacement retains the existing key's position, while a genuinely
+  // new attachment is appended. The renderer uses this persisted order for
+  // its left-to-right PR chips, so the most recently attached PR stays at the
+  // right edge instead of being reordered by its canonical string key.
+  const merged = [...byKey.values()];
   return merged.length > 0 ? merged : undefined;
 }
 


### PR DESCRIPTION
## Summary

- preserve the insertion order of thread pull request attachments
- append newly attached PRs at the right edge of the thread chip list
- keep deduplication and in-place status updates intact
- add a regression test using PR #735 followed by PR #1191

## Root cause

The overlay merge helper deduplicated PRs in a Map, then sorted the result by the canonical PR identity string. Lexicographic sorting placed #1191 before #735, even though #735 had been attached first.

## User impact

Thread PR chips now reflect attachment order from left to right, with the most recently attached PR at the right end of the list.

## Validation

- pnpm test apps/desktop/src/main/__tests__/overlay-store-prs.test.ts
- pnpm typecheck
- pnpm lint:eslint (0 errors; existing warning baseline only)
- pnpm lint:boundaries
- git diff --check