### PR TITLE
test(desktop): harden flaky composer E2E

### DIFF
--- a/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
+++ b/apps/desktop/e2e/composer-draft-persistence-regression.spec.ts
@@ -490,8 +490,9 @@ test("recovers an accidentally deleted Tiptap reply draft from another blank com
     const tiptapInput = app.window.getByTestId("composer-tiptap-input");
     const textbox = app.window.getByRole("textbox", { name: "Reply" });
 
-    await textbox.focus();
-    await app.window.keyboard.type(deletedDraft);
+    // The recovery keystrokes are load-bearing here, not per-character typing.
+    // Avoid zero-delay key event loss on an overloaded shared macOS VM.
+    await textbox.fill(deletedDraft);
     await expect(tiptapInput).toHaveAttribute("data-value", deletedDraft);
 
     await app.window.keyboard.press(

--- a/apps/desktop/e2e/provider-model-selectors.spec.ts
+++ b/apps/desktop/e2e/provider-model-selectors.spec.ts
@@ -6,9 +6,23 @@ import type { AppServerBackendKind, NavigationLaunchpadDefaults } from "@pwragen
 import { launchElectronApp } from "./fixtures/electron-app";
 
 async function assertTangerineFocusRing(locator: Locator) {
-  await locator.focus();
-  await expect(locator).toHaveCSS("outline-color", "rgb(255, 138, 31)");
-  await expect(locator).toHaveCSS("outline-style", "solid");
+  await expect
+    .poll(async () =>
+      await locator.evaluate((element) => {
+        (element as HTMLElement).focus();
+        const style = getComputedStyle(element);
+        return {
+          isActive: document.activeElement === element,
+          outlineColor: style.outlineColor,
+          outlineStyle: style.outlineStyle,
+        };
+      })
+    )
+    .toEqual({
+      isActive: true,
+      outlineColor: "rgb(255, 138, 31)",
+      outlineStyle: "solid",
+    });
 }
 
 async function selectComposerOption(params: {

--- a/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
+++ b/apps/desktop/e2e/tangerine-terminal-theme.spec.ts
@@ -82,9 +82,29 @@ async function assertReadableText(params: {
 }
 
 async function assertTangerineFocusRing(locator: Locator, focusTarget = locator) {
-  await focusTarget.focus();
-  await expect(locator).toHaveCSS("outline-color", "rgb(255, 138, 31)");
-  await expect(locator).toHaveCSS("outline-style", "solid");
+  await expect
+    .poll(async () => {
+      await focusTarget.focus();
+      const [isActive, outline] = await Promise.all([
+        focusTarget.evaluate((element) => document.activeElement === element),
+        locator.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            outlineColor: style.outlineColor,
+            outlineStyle: style.outlineStyle,
+          };
+        }),
+      ]);
+      return {
+        isActive,
+        ...outline,
+      };
+    })
+    .toEqual({
+      isActive: true,
+      outlineColor: "rgb(255, 138, 31)",
+      outlineStyle: "solid",
+    });
 }
 
 async function openTodoThread(page: Page) {


### PR DESCRIPTION
## Summary

- seed the long composer recovery draft with `fill()` so the shared macOS VM cannot lose zero-delay per-character key events
- keep the load-bearing `Meta+A`, `Backspace`, and `ArrowUp` recovery interactions as real keyboard input
- focus and inspect dropdown focus-ring styles in one renderer task so asynchronous composer focus cannot race the assertion
- retry the theme focus-ring helper's focus and computed-style read as one assertion, including its nested send-button target

## Root cause

The shared macOS VM dropped one character from a long `keyboard.type()` call on both attempts of PR #1192 (`ArrowUp` became `rrowUp`, then `ArowUp`). The product behavior was not reached. A separate focus-ring assertion briefly observed the unfocused default outline color before passing on retry.

The same split focus/style assertion also existed in the broader Tangerine Terminal theme E2E. These changes harden only E2E setup and assertion mechanics; production behavior is unchanged.

## Validation

- `pnpm exec eslint apps/desktop/e2e/composer-draft-persistence-regression.spec.ts apps/desktop/e2e/provider-model-selectors.spec.ts`
- `pnpm exec eslint apps/desktop/e2e/tangerine-terminal-theme.spec.ts --rule 'no-empty-pattern: off'` (the file has two unrelated pre-existing empty fixture patterns outside the changed helper)
- `pnpm --filter @pwragent/desktop typecheck`
- focused Playwright discovery for all three changed specs

The local Tart VM lab was unavailable, so the draft PR's shared macOS VM check is the platform E2E validation.

Failure reference: https://github.com/pwrdrvr/PwrAgent/actions/runs/30915689863/job/92013159588
