### PR TITLE
feat(desktop): add inline code copy affordance

### DIFF
--- a/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
+++ b/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
@@ -47,9 +47,29 @@ test("renders markdown edge cases without breaking transcript boundaries", async
     await expect(transcript.locator("br")).toHaveCount(1);
     await expect(transcript.locator("em", { hasText: "Italic text" })).toBeVisible();
     await expect(transcript.locator("del", { hasText: "struck text" })).toBeVisible();
-    await expect(
-      transcript.locator("code.transcript-message__code", { hasText: "inline code" })
-    ).toBeVisible();
+    const inlineCode = transcript.locator(".transcript-message__inline-code", {
+      hasText: "inline code",
+    });
+    await expect(inlineCode.locator("code.transcript-message__code"))
+      .toBeVisible();
+
+    const inlineCopyButton = inlineCode.getByRole("button", {
+      name: "Copy inline code",
+    });
+    await expect(inlineCopyButton).toHaveCSS("opacity", "0");
+    await inlineCode.hover();
+    await expect(inlineCopyButton).toHaveCSS("opacity", "1");
+
+    await app.electronApp.evaluate(({ clipboard }) => {
+      clipboard.writeText("");
+    });
+    await inlineCopyButton.click();
+    await expect
+      .poll(async () =>
+        await app.electronApp.evaluate(({ clipboard }) => clipboard.readText())
+      )
+      .toBe("inline code");
+    await expect(inlineCopyButton).toHaveAccessibleName("Copied inline code");
 
     const markdownLiteralBlock = transcript.locator("pre code").filter({
       hasText: "**not bold**",

--- a/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
+++ b/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
@@ -53,9 +53,8 @@ test("renders markdown edge cases without breaking transcript boundaries", async
     await expect(inlineCode.locator("code.transcript-message__code"))
       .toBeVisible();
 
-    const inlineCopyButton = inlineCode.getByRole("button", {
-      name: "Copy inline code",
-    });
+    const inlineCopyButton = inlineCode.locator(".transcript-copy-button--inline");
+    await expect(inlineCopyButton).toHaveAccessibleName("Copy inline code");
     await expect(inlineCopyButton).toHaveCSS("opacity", "0");
     await inlineCode.hover();
     await expect(inlineCopyButton).toHaveCSS("opacity", "1");

--- a/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
+++ b/apps/desktop/e2e/thread-markdown-edge-cases.spec.ts
@@ -53,11 +53,23 @@ test("renders markdown edge cases without breaking transcript boundaries", async
     await expect(inlineCode.locator("code.transcript-message__code"))
       .toBeVisible();
 
-    const inlineCopyButton = inlineCode.locator(".transcript-copy-button--inline");
+    const inlineCopyButton = inlineCode;
     await expect(inlineCopyButton).toHaveAccessibleName("Copy inline code");
-    await expect(inlineCopyButton).toHaveCSS("opacity", "0");
+    await expect
+      .poll(async () =>
+        await inlineCopyButton.evaluate((element) =>
+          getComputedStyle(element, "::before").opacity
+        )
+      )
+      .toBe("0");
     await inlineCode.hover();
-    await expect(inlineCopyButton).toHaveCSS("opacity", "1");
+    await expect
+      .poll(async () =>
+        await inlineCopyButton.evaluate((element) =>
+          getComputedStyle(element, "::before").opacity
+        )
+      )
+      .toBe("1");
 
     await app.electronApp.evaluate(({ clipboard }) => {
       clipboard.writeText("");

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -109,20 +109,21 @@ function TranscriptCode(props: {
 
   const copyText = extractTextContent(props.children);
 
+  if (!copyText) {
+    return <code className="transcript-message__code">{props.children}</code>;
+  }
+
   return (
-    <span className="transcript-message__inline-code">
+    <TranscriptCopyButton
+      as="span"
+      className="transcript-message__inline-code transcript-copy-button--inline"
+      copiedLabel="Copied inline code"
+      desktopApi={props.desktopApi}
+      label="Copy inline code"
+      text={copyText}
+    >
       <code className="transcript-message__code">{props.children}</code>
-      {copyText ? (
-        <TranscriptCopyButton
-          as="span"
-          className="transcript-copy-button--inline"
-          copiedLabel="Copied inline code"
-          desktopApi={props.desktopApi}
-          label="Copy inline code"
-          text={copyText}
-        />
-      ) : null}
-    </span>
+    </TranscriptCopyButton>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -114,6 +114,7 @@ function TranscriptCode(props: {
       <code className="transcript-message__code">{props.children}</code>
       {copyText ? (
         <TranscriptCopyButton
+          as="span"
           className="transcript-copy-button--inline"
           copiedLabel="Copied inline code"
           desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -79,6 +79,7 @@ const CodeBlockContext = createContext(false);
 function TranscriptCode(props: {
   children: ReactNode;
   className?: string;
+  desktopApi?: Pick<DesktopApi, "copyText">;
   threadLinks: ThreadLinkContextValue | undefined;
 }) {
   const insideCodeBlock = useContext(CodeBlockContext);
@@ -102,10 +103,25 @@ function TranscriptCode(props: {
     }
   }
 
+  if (isBlockCode) {
+    return <code className={props.className}>{props.children}</code>;
+  }
+
+  const copyText = extractTextContent(props.children);
+
   return (
-    <code className={isBlockCode ? props.className : "transcript-message__code"}>
-      {props.children}
-    </code>
+    <span className="transcript-message__inline-code">
+      <code className="transcript-message__code">{props.children}</code>
+      {copyText ? (
+        <TranscriptCopyButton
+          className="transcript-copy-button--inline"
+          copiedLabel="Copied inline code"
+          desktopApi={props.desktopApi}
+          label="Copy inline code"
+          text={copyText}
+        />
+      ) : null}
+    </span>
   );
 }
 
@@ -417,7 +433,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       },
       code(codeProps) {
         return (
-          <TranscriptCode className={codeProps.className} threadLinks={threadLinks}>
+          <TranscriptCode
+            className={codeProps.className}
+            desktopApi={props.desktopApi}
+            threadLinks={threadLinks}
+          >
             {codeProps.children}
           </TranscriptCode>
         );

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -75,6 +75,7 @@ type EditorApplication = DesktopApplicationsSnapshot["editors"][number];
  * from an inline span.
  */
 const CodeBlockContext = createContext(false);
+const MarkdownLinkContext = createContext(false);
 
 function TranscriptCode(props: {
   children: ReactNode;
@@ -83,12 +84,13 @@ function TranscriptCode(props: {
   threadLinks: ThreadLinkContextValue | undefined;
 }) {
   const insideCodeBlock = useContext(CodeBlockContext);
+  const insideLink = useContext(MarkdownLinkContext);
   const isBlockCode = insideCodeBlock || (props.className?.includes("language-") ?? false);
 
   // Only inline code on a navigation-capable surface can become a chip; skip
   // the text extraction entirely on block code and on the Activity/Changelog/
   // file-viewer surfaces (no `threadLinks` context there).
-  if (!isBlockCode && props.threadLinks) {
+  if (!isBlockCode && !insideLink && props.threadLinks) {
     // Transcripts written before the link protocol existed — and any model
     // that ignores the `threadLink` convention — put the bare thread id in a
     // code span. Recognizing it makes those threads reachable without asking
@@ -105,6 +107,10 @@ function TranscriptCode(props: {
 
   if (isBlockCode) {
     return <code className={props.className}>{props.children}</code>;
+  }
+
+  if (insideLink) {
+    return <code className="transcript-message__code">{props.children}</code>;
   }
 
   const copyText = extractTextContent(props.children);
@@ -258,6 +264,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         const label = extractTextContent(anchorProps.children).trim();
         const linkedImage = findMarkdownLinkedImagePart(props.imageParts, localTarget);
         const source = sourceForNode(markdownText, anchorProps.node);
+        const linkedChildren = (
+          <MarkdownLinkContext.Provider value={true}>
+            {anchorProps.children}
+          </MarkdownLinkContext.Provider>
+        );
 
         if (isImplicitBareAutolink({ href, label, source })) {
           return <>{anchorProps.children}</>;
@@ -286,7 +297,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         if (pullRequestNumber) {
           return (
             <PullRequestNumberLinkChip number={pullRequestNumber}>
-              {anchorProps.children}
+              {linkedChildren}
             </PullRequestNumberLinkChip>
           );
         }
@@ -307,7 +318,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
               }}
               title="Open image in PwrAgent"
             >
-              {anchorProps.children}
+              {linkedChildren}
             </a>
           );
         }
@@ -373,7 +384,7 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
             target="_blank"
             title={isLocalMarkdownFile ? "Open in PwrAgent" : href || undefined}
           >
-            {anchorProps.children}
+            {linkedChildren}
           </a>
         );
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
 type TranscriptCopyButtonProps = {
   as?: "button" | "span";
+  children?: ReactNode;
   className?: string;
   copiedLabel?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
@@ -62,6 +63,7 @@ export function TranscriptCopyButton(props: TranscriptCopyButtonProps) {
           }
         }}
       >
+        {props.children}
       </span>
     );
   }
@@ -75,6 +77,7 @@ export function TranscriptCopyButton(props: TranscriptCopyButtonProps) {
       title={label}
       onClick={activate}
     >
+      {props.children}
     </button>
   );
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCopyButton.tsx
@@ -3,6 +3,7 @@ import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
 type TranscriptCopyButtonProps = {
+  as?: "button" | "span";
   className?: string;
   copiedLabel?: string;
   desktopApi?: Pick<DesktopApi, "copyText">;
@@ -22,31 +23,57 @@ export function TranscriptCopyButton(props: TranscriptCopyButtonProps) {
     };
   }, []);
 
+  const label = copied ? props.copiedLabel ?? "Copied" : props.label;
+  const activate = (event: {
+    preventDefault: () => void;
+    stopPropagation: () => void;
+  }): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    void copyText(props.text, props.desktopApi)
+      .then(() => {
+        if (resetTimerRef.current) {
+          window.clearTimeout(resetTimerRef.current);
+        }
+        setCopied(true);
+        resetTimerRef.current = window.setTimeout(() => {
+          setCopied(false);
+          resetTimerRef.current = undefined;
+        }, 1400);
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to copy transcript text", error);
+      });
+  };
+
+  if (props.as === "span") {
+    return (
+      <span
+        role="button"
+        tabIndex={0}
+        className={["transcript-copy-button", props.className].filter(Boolean).join(" ")}
+        data-copied={copied ? "true" : undefined}
+        aria-label={label}
+        title={label}
+        onClick={activate}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            activate(event);
+          }
+        }}
+      >
+      </span>
+    );
+  }
+
   return (
     <button
       type="button"
       className={["transcript-copy-button", props.className].filter(Boolean).join(" ")}
       data-copied={copied ? "true" : undefined}
-      aria-label={copied ? props.copiedLabel ?? "Copied" : props.label}
-      title={copied ? props.copiedLabel ?? "Copied" : props.label}
-      onClick={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        void copyText(props.text, props.desktopApi)
-          .then(() => {
-            if (resetTimerRef.current) {
-              window.clearTimeout(resetTimerRef.current);
-            }
-            setCopied(true);
-            resetTimerRef.current = window.setTimeout(() => {
-              setCopied(false);
-              resetTimerRef.current = undefined;
-            }, 1400);
-          })
-          .catch((error: unknown) => {
-            console.error("Failed to copy transcript text", error);
-          });
-      }}
+      aria-label={label}
+      title={label}
+      onClick={activate}
     >
     </button>
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -864,6 +864,30 @@ describe("ThreadMarkdown", () => {
     });
   });
 
+  it("copies inline code without its markdown delimiters", async () => {
+    const desktopCopyText = vi.fn(async () => undefined);
+
+    const { container } = render(
+      <ThreadMarkdown
+        desktopApi={{ copyText: desktopCopyText }}
+        text={"Switch to `agent/inline-code-copy` when ready."}
+      />
+    );
+
+    const inlineCode = container.querySelector(".transcript-message__inline-code");
+    expect(inlineCode).toContainElement(
+      screen.getByText("agent/inline-code-copy", { selector: "code" })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy inline code" }));
+
+    await waitFor(() => {
+      expect(desktopCopyText).toHaveBeenCalledWith("agent/inline-code-copy");
+    });
+    expect(screen.getByRole("button", { name: "Copied inline code" }))
+      .toBeInTheDocument();
+  });
+
   it("renders long fenced code blocks without expand controls", () => {
     const lines = Array.from({ length: 21 }, (_, index) => `line ${index + 1}`);
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -105,6 +105,22 @@ describe("ThreadMarkdown", () => {
       "title",
       "Open in PwrAgent"
     );
+    expect(
+      screen.getByRole("link", { name: "AGENTS.md" }).querySelector('[role="button"]')
+    ).toBeNull();
+  });
+
+  it("keeps inline code link text navigable instead of turning it into a copy control", () => {
+    render(
+      <ThreadMarkdown text={"Read [`npm install`](https://example.com/install)."} />
+    );
+
+    const link = screen.getByRole("link", { name: "npm install" });
+    const code = link.querySelector<HTMLElement>("code.transcript-message__code");
+    expect(link).toHaveAttribute("href", "https://example.com/install");
+    expect(code).toHaveTextContent("npm install");
+    expect(link.querySelector('[role="button"]')).toBeNull();
+    expect(fireEvent.click(code!)).toBe(true);
   });
 
   it("leaves LaTeX untypeset when experimental math rendering is disabled", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -879,7 +879,9 @@ describe("ThreadMarkdown", () => {
       screen.getByText("agent/inline-code-copy", { selector: "code" })
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Copy inline code" }));
+    const inlineCopyButton = screen.getByRole("button", { name: "Copy inline code" });
+    expect(inlineCopyButton.tagName).toBe("SPAN");
+    fireEvent.keyDown(inlineCopyButton, { key: "Enter" });
 
     await waitFor(() => {
       expect(desktopCopyText).toHaveBeenCalledWith("agent/inline-code-copy");

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -946,6 +946,23 @@ describe("Tangerine Terminal theme contract", () => {
     expect(inlineCodeRule).toContain("max-width: 100%;");
   });
 
+  it("reveals the inline code copy affordance on hover and keyboard focus", () => {
+    const inlineCodeWrapperRule = extractRuleBody(
+      css,
+      ".transcript-message__inline-code",
+    );
+    expect(inlineCodeWrapperRule).toContain("position: relative;");
+    expect(inlineCodeWrapperRule).toContain("max-width: 100%;");
+
+    const inlineCopyRule = extractRuleBody(css, ".transcript-copy-button--inline");
+    expect(inlineCopyRule).toContain("position: absolute;");
+    expect(inlineCopyRule).toContain("right: 3px;");
+
+    expect(css).toMatch(
+      /\.transcript-message__inline-code:hover \.transcript-copy-button--inline,\s*\.transcript-message__inline-code:focus-within \.transcript-copy-button--inline,[\s\S]*?\{[\s\S]*?opacity:\s*1;[\s\S]*?\}/,
+    );
+  });
+
   it("wraps fenced code blocks the same way the composer does", () => {
     // The composer's `<pre>` uses `white-space: pre-wrap` so a pasted
     // long line wraps inside the input rather than scrolling. The

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -946,7 +946,7 @@ describe("Tangerine Terminal theme contract", () => {
     expect(inlineCodeRule).toContain("max-width: 100%;");
   });
 
-  it("reveals the inline code copy affordance on hover and keyboard focus", () => {
+  it("overlays the inline code copy affordance on hover and keyboard focus", () => {
     const inlineCodeWrapperRule = extractRuleBody(
       css,
       ".transcript-message__inline-code",
@@ -957,6 +957,9 @@ describe("Tangerine Terminal theme contract", () => {
     const inlineCopyRule = extractRuleBody(css, ".transcript-copy-button--inline");
     expect(inlineCopyRule).toContain("opacity: 1;");
     expect(inlineCopyRule).toContain("background: transparent;");
+    expect(css).not.toMatch(
+      /\.transcript-message__inline-code \.transcript-message__code\s*\{/,
+    );
 
     expect(css).toMatch(
       /\.transcript-copy-button--inline:hover::before,\s*\.transcript-copy-button--inline:focus-visible::before,[\s\S]*?\{[\s\S]*?opacity:\s*1;[\s\S]*?\}/,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -955,11 +955,11 @@ describe("Tangerine Terminal theme contract", () => {
     expect(inlineCodeWrapperRule).toContain("max-width: 100%;");
 
     const inlineCopyRule = extractRuleBody(css, ".transcript-copy-button--inline");
-    expect(inlineCopyRule).toContain("position: absolute;");
-    expect(inlineCopyRule).toContain("right: 3px;");
+    expect(inlineCopyRule).toContain("opacity: 1;");
+    expect(inlineCopyRule).toContain("background: transparent;");
 
     expect(css).toMatch(
-      /\.transcript-message__inline-code:hover \.transcript-copy-button--inline,\s*\.transcript-message__inline-code:focus-within \.transcript-copy-button--inline,[\s\S]*?\{[\s\S]*?opacity:\s*1;[\s\S]*?\}/,
+      /\.transcript-copy-button--inline:hover::before,\s*\.transcript-copy-button--inline:focus-visible::before,[\s\S]*?\{[\s\S]*?opacity:\s*1;[\s\S]*?\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -953,10 +953,12 @@ describe("Tangerine Terminal theme contract", () => {
     );
     expect(inlineCodeWrapperRule).toContain("position: relative;");
     expect(inlineCodeWrapperRule).toContain("max-width: 100%;");
+    expect(inlineCodeWrapperRule).toContain("vertical-align: baseline;");
 
     const inlineCopyRule = extractRuleBody(css, ".transcript-copy-button--inline");
     expect(inlineCopyRule).toContain("opacity: 1;");
     expect(inlineCopyRule).toContain("background: transparent;");
+    expect(inlineCopyRule).not.toContain("vertical-align: text-bottom;");
     expect(css).not.toMatch(
       /\.transcript-message__inline-code \.transcript-message__code\s*\{/,
     );

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -961,8 +961,20 @@ describe("Tangerine Terminal theme contract", () => {
       /\.transcript-message__inline-code \.transcript-message__code\s*\{/,
     );
 
+    const inlineOverlayRule = extractRuleBody(
+      css,
+      ".transcript-copy-button--inline::after",
+    );
+    expect(inlineOverlayRule).toContain("border: 1px solid var(--border-subtle);");
+    expect(inlineOverlayRule).toContain(
+      "background: color-mix(in srgb, var(--bg-panel-elevated) 92%, transparent);",
+    );
+
     expect(css).toMatch(
       /\.transcript-copy-button--inline:hover::before,\s*\.transcript-copy-button--inline:focus-visible::before,[\s\S]*?\{[\s\S]*?opacity:\s*1;[\s\S]*?\}/,
+    );
+    expect(css).toMatch(
+      /\.transcript-copy-button--inline:hover::after,\s*\.transcript-copy-button--inline:focus-visible::after,[\s\S]*?\{[\s\S]*?border-color:\s*var\(--accent-border\);[\s\S]*?opacity:\s*1;[\s\S]*?\}/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10034,7 +10034,7 @@ a.transcript-message__messaging-origin:focus-visible {
   position: relative;
   display: inline-block;
   max-width: 100%;
-  vertical-align: text-bottom;
+  vertical-align: baseline;
 }
 
 .transcript-copy-button--inline {
@@ -10046,7 +10046,6 @@ a.transcript-message__messaging-origin:focus-visible {
   color: inherit;
   background: transparent;
   opacity: 1;
-  vertical-align: text-bottom;
 }
 
 .transcript-copy-button--inline::before {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10037,10 +10037,6 @@ a.transcript-message__messaging-origin:focus-visible {
   vertical-align: text-bottom;
 }
 
-.transcript-message__inline-code .transcript-message__code {
-  padding-right: 27px;
-}
-
 .transcript-copy-button--inline {
   width: auto;
   height: auto;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10030,6 +10030,38 @@ a.transcript-message__messaging-origin:focus-visible {
   overflow-wrap: anywhere;
 }
 
+.transcript-message__inline-code {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: text-bottom;
+}
+
+.transcript-message__inline-code .transcript-message__code {
+  padding-right: 27px;
+}
+
+.transcript-copy-button--inline {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+}
+
+.transcript-copy-button--inline::before {
+  width: 11px;
+  height: 11px;
+}
+
+.transcript-message__inline-code:hover .transcript-copy-button--inline,
+.transcript-message__inline-code:focus-within .transcript-copy-button--inline,
+.transcript-copy-button--inline[data-copied="true"] {
+  opacity: 1;
+}
+
 .transcript-message__pre-wrap {
   position: relative;
 }
@@ -10058,6 +10090,7 @@ a.transcript-message__messaging-origin:focus-visible {
 @media (hover: none) {
   .transcript-copy-button--message,
   .transcript-copy-button--section,
+  .transcript-copy-button--inline,
   .transcript-copy-button--activity {
     opacity: 1;
   }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10042,23 +10042,42 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 .transcript-copy-button--inline {
-  position: absolute;
-  right: 3px;
-  bottom: 3px;
-  width: 18px;
-  height: 18px;
-  border-radius: 4px;
-  background: var(--bg-panel-elevated);
+  width: auto;
+  height: auto;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  color: inherit;
+  background: transparent;
+  opacity: 1;
+  vertical-align: text-bottom;
 }
 
 .transcript-copy-button--inline::before {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
   width: 11px;
   height: 11px;
+  background: var(--text-muted);
+  opacity: 0;
+  transition:
+    background 120ms ease,
+    opacity 120ms ease;
 }
 
-.transcript-message__inline-code:hover .transcript-copy-button--inline,
-.transcript-message__inline-code:focus-within .transcript-copy-button--inline,
+.transcript-copy-button--inline:hover,
+.transcript-copy-button--inline:focus-visible,
 .transcript-copy-button--inline[data-copied="true"] {
+  border-color: transparent;
+  color: inherit;
+  background: transparent;
+}
+
+.transcript-copy-button--inline:hover::before,
+.transcript-copy-button--inline:focus-visible::before,
+.transcript-copy-button--inline[data-copied="true"]::before {
+  background: var(--accent-bright);
   opacity: 1;
 }
 
@@ -10092,6 +10111,10 @@ a.transcript-message__messaging-origin:focus-visible {
   .transcript-copy-button--section,
   .transcript-copy-button--inline,
   .transcript-copy-button--activity {
+    opacity: 1;
+  }
+
+  .transcript-copy-button--inline::before {
     opacity: 1;
   }
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10052,13 +10052,33 @@ a.transcript-message__messaging-origin:focus-visible {
 .transcript-copy-button--inline::before {
   position: absolute;
   right: 6px;
-  bottom: 6px;
+  top: 50%;
+  z-index: 2;
   width: 11px;
   height: 11px;
   background: var(--text-muted);
   opacity: 0;
+  transform: translateY(-50%);
   transition:
     background 120ms ease,
+    opacity 120ms ease;
+}
+
+.transcript-copy-button--inline::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0;
+  z-index: 1;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--bg-panel-elevated) 92%, transparent);
+  opacity: 0;
+  transform: translateY(-50%);
+  transition:
+    border-color 120ms ease,
     opacity 120ms ease;
 }
 
@@ -10074,6 +10094,13 @@ a.transcript-message__messaging-origin:focus-visible {
 .transcript-copy-button--inline:focus-visible::before,
 .transcript-copy-button--inline[data-copied="true"]::before {
   background: var(--accent-bright);
+  opacity: 1;
+}
+
+.transcript-copy-button--inline:hover::after,
+.transcript-copy-button--inline:focus-visible::after,
+.transcript-copy-button--inline[data-copied="true"]::after {
+  border-color: var(--accent-border);
   opacity: 1;
 }
 
@@ -10111,6 +10138,10 @@ a.transcript-message__messaging-origin:focus-visible {
   }
 
   .transcript-copy-button--inline::before {
+    opacity: 1;
+  }
+
+  .transcript-copy-button--inline::after {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary

- I added a compact copy control to rendered inline code spans.
- I reveal the control on hover, keyboard focus, and hoverless input while preserving the existing inline-code wrapping behavior.
- I reuse the transcript copy interaction so the control copies only the code text and reports a temporary copied state.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx` (91 tests)
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

- I added Electron coverage for hover visibility, clipboard contents, and copied-state accessibility. The local macOS VM runner was unavailable, so that headed test is left to CI.
