### PR TITLE
fix(deps): resolve Dependabot alerts

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -42,7 +42,7 @@ BSD-2-Clause
 
 BSD-3-Clause
 ~~~~~~~~~~~~
-- fast-uri@3.1.4 | https://github.com/fastify/fast-uri
+- fast-uri@3.1.5 | https://github.com/fastify/fast-uri
 - ieee754@1.2.1 | https://github.com/feross/ieee754
 - qs@6.15.2 | https://github.com/ljharb/qs
 
@@ -69,7 +69,7 @@ MIT
 - @floating-ui/core@1.8.0 | https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 | https://github.com/floating-ui/floating-ui
 - @floating-ui/utils@0.2.12 | https://github.com/floating-ui/floating-ui
-- @hono/node-server@2.0.5 | https://github.com/honojs/node-server
+- @hono/node-server@2.0.10 | https://github.com/honojs/node-server
 - @modelcontextprotocol/sdk@1.30.0 | https://github.com/modelcontextprotocol/typescript-sdk
 - @napi-rs/canvas@0.1.100 | https://github.com/Brooooooklyn/canvas
 - @napi-rs/canvas-android-arm64@0.1.100 | https://github.com/Brooooooklyn/canvas
@@ -225,14 +225,14 @@ MIT
 - hast-util-to-text@4.0.2 | syntax-tree/hast-util-to-text
 - hast-util-whitespace@3.0.0 | syntax-tree/hast-util-whitespace
 - hastscript@9.0.1 | syntax-tree/hastscript
-- hono@4.12.31 | https://github.com/honojs/hono
+- hono@4.12.34 | https://github.com/honojs/hono
 - html-url-attributes@3.0.1 | https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 | jshttp/http-errors
 - iconv-lite@0.6.3 | https://github.com/ashtuchkin/iconv-lite
 - iconv-lite@0.7.3 | https://github.com/pillarjs/iconv-lite
 - indent-string@4.0.0 | sindresorhus/indent-string
 - inline-style-parser@0.2.7 | https://github.com/remarkablemark/inline-style-parser
-- ip-address@10.2.0 | https://github.com/beaugunderson/ip-address
+- ip-address@10.3.1 | https://github.com/beaugunderson/ip-address
 - ipaddr.js@1.9.1 | https://github.com/whitequark/ipaddr.js
 - is-alphabetical@2.0.1 | wooorm/is-alphabetical
 - is-alphanumerical@2.0.1 | wooorm/is-alphanumerical
@@ -447,13 +447,13 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-@hono/node-server@2.0.5 (MIT)
------------------------------
+@hono/node-server@2.0.10 (MIT)
+------------------------------
 
 Applies to:
-- @hono/node-server@2.0.5 (MIT)
+- @hono/node-server@2.0.10 (MIT)
 
-Representative file: @hono/node-server@2.0.5/LICENSE
+Representative file: @hono/node-server@2.0.10/LICENSE
 
 MIT License
 
@@ -3230,13 +3230,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-fast-uri@3.1.4 (BSD-3-Clause)
+fast-uri@3.1.5 (BSD-3-Clause)
 -----------------------------
 
 Applies to:
-- fast-uri@3.1.4 (BSD-3-Clause)
+- fast-uri@3.1.5 (BSD-3-Clause)
 
-Representative file: fast-uri@3.1.4/LICENSE
+Representative file: fast-uri@3.1.5/LICENSE
 
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -3762,13 +3762,13 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-hono@4.12.31 (MIT)
+hono@4.12.34 (MIT)
 ------------------
 
 Applies to:
-- hono@4.12.31 (MIT)
+- hono@4.12.34 (MIT)
 
-Representative file: hono@4.12.31/LICENSE
+Representative file: hono@4.12.34/LICENSE
 
 MIT License
 
@@ -3945,13 +3945,13 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-ip-address@10.2.0 (MIT)
+ip-address@10.3.1 (MIT)
 -----------------------
 
 Applies to:
-- ip-address@10.2.0 (MIT)
+- ip-address@10.3.1 (MIT)
 
-Representative file: ip-address@10.2.0/LICENSE
+Representative file: ip-address@10.3.1/LICENSE
 
 Copyright (C) 2011 by Beau Gunderson
 

--- a/package.json
+++ b/package.json
@@ -54,13 +54,19 @@
   "pnpm": {
     "overrides": {
       "@babel/core": "7.29.6",
-      "@hono/node-server": "2.0.5",
+      "@hono/node-server": "2.0.10",
       "@types/node": "^24.12.4",
       "axios": "^1.16.0",
+      "brace-expansion@1": "1.1.18",
+      "brace-expansion@2": "2.1.4",
+      "brace-expansion@5": "5.0.9",
       "esbuild": "0.28.1",
+      "fast-uri": "3.1.5",
       "form-data": "4.0.6",
+      "hono": "4.12.34",
+      "ip-address": "10.3.1",
       "js-yaml": "4.3.0",
-      "postcss": "8.5.20",
+      "postcss": "8.5.23",
       "prosemirror-model": "1.25.9",
       "prosemirror-view": "1.41.9",
       "protobufjs": "7.6.5",
@@ -68,8 +74,8 @@
       "rollup": "4.61.1",
       "tar": "7.5.22",
       "tmp": "0.2.7",
-      "undici@6": "6.27.0",
-      "undici@7": "7.28.0",
+      "undici@6": "6.28.0",
+      "undici@7": "7.29.0",
       "ws": "8.21.0"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,19 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  '@hono/node-server': 2.0.5
+  '@hono/node-server': 2.0.10
   '@types/node': ^24.12.4
   axios: ^1.16.0
+  brace-expansion@1: 1.1.18
+  brace-expansion@2: 2.1.4
+  brace-expansion@5: 5.0.9
   esbuild: 0.28.1
+  fast-uri: 3.1.5
   form-data: 4.0.6
+  hono: 4.12.34
+  ip-address: 10.3.1
   js-yaml: 4.3.0
-  postcss: 8.5.20
+  postcss: 8.5.23
   prosemirror-model: 1.25.9
   prosemirror-view: 1.41.9
   protobufjs: 7.6.5
@@ -20,8 +26,8 @@ overrides:
   rollup: 4.61.1
   tar: 7.5.22
   tmp: 0.2.7
-  undici@6: 6.27.0
-  undici@7: 7.28.0
+  undici@6: 6.28.0
+  undici@7: 7.29.0
   ws: 8.21.0
 
 pnpmfileChecksum: sha256-ENVI4WvTe5sygYLw830xNJB8CimBQgr6EM0Oi3TR7os=
@@ -840,11 +846,11 @@ packages:
   '@grammyjs/types@4.0.0':
     resolution: {integrity: sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==}
 
-  '@hono/node-server@2.0.5':
-    resolution: {integrity: sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1971,14 +1977,14 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
@@ -2510,8 +2516,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2732,8 +2738,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -2818,8 +2824,8 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3556,8 +3562,8 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -4134,12 +4140,12 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.27.0:
-    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4713,7 +4719,7 @@ snapshots:
       discord-api-types: 0.38.50
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.27.0
+      undici: 6.28.0
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -4776,7 +4782,7 @@ snapshots:
       semver: 7.8.5
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 7.28.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4978,9 +4984,9 @@ snapshots:
 
   '@grammyjs/types@4.0.0': {}
 
-  '@hono/node-server@2.0.5(hono@4.12.31)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -5065,7 +5071,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.5(hono@4.12.31)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -5075,7 +5081,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5987,7 +5993,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6133,16 +6139,16 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6416,7 +6422,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.27.0
+      undici: 6.28.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6737,7 +6743,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6784,7 +6790,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7090,7 +7096,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.31: {}
+  hono@4.12.34: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -7174,7 +7180,7 @@ snapshots:
 
   interpret@3.1.1: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7263,7 +7269,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7827,19 +7833,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -7895,7 +7901,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.22
       tinyglobby: 0.2.17
-      undici: 6.27.0
+      undici: 6.28.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -8040,7 +8046,7 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  postcss@8.5.20:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -8787,9 +8793,9 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.27.0: {}
+  undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8890,7 +8896,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.20
+      postcss: 8.5.23
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -8904,7 +8910,7 @@ snapshots:
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ minimumReleaseAgeExclude:
   - '@pwrdrvr/agent-acp'
   - '@pwrdrvr/agent-client'
   - '@babel/core@7.29.6'
+  - '@hono/node-server'
   - '@esbuild/aix-ppc64@0.28.1'
   - '@esbuild/android-arm64@0.28.1'
   - '@esbuild/android-arm@0.28.1'
@@ -40,9 +41,15 @@ minimumReleaseAgeExclude:
   - '@esbuild/win32-ia32@0.28.1'
   - '@esbuild/win32-x64@0.28.1'
   - esbuild@0.28.1
+  - brace-expansion
+  - fast-uri
   - form-data@4.0.6
+  - hono
+  - ip-address
+  - postcss
   - protobufjs@7.6.5
   - tmp@0.2.7
+  - undici
   - ws@8.21.0
 globalPnpmfile: ''
 ignoreScripts: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,6 @@ minimumReleaseAgeExclude:
   - '@pwrdrvr/agent-acp'
   - '@pwrdrvr/agent-client'
   - '@babel/core@7.29.6'
-  - '@hono/node-server'
   - '@esbuild/aix-ppc64@0.28.1'
   - '@esbuild/android-arm64@0.28.1'
   - '@esbuild/android-arm@0.28.1'
@@ -41,15 +40,9 @@ minimumReleaseAgeExclude:
   - '@esbuild/win32-ia32@0.28.1'
   - '@esbuild/win32-x64@0.28.1'
   - esbuild@0.28.1
-  - brace-expansion
-  - fast-uri
   - form-data@4.0.6
-  - hono
-  - ip-address
-  - postcss
   - protobufjs@7.6.5
   - tmp@0.2.7
-  - undici
   - ws@8.21.0
 globalPnpmfile: ''
 ignoreScripts: false


### PR DESCRIPTION
## Summary

- pin patched transitive releases for `@hono/node-server`, `hono`, `ip-address`, `undici`, `fast-uri`, `postcss`, and all installed `brace-expansion` major lines
- retain pnpm's seven-day `minimumReleaseAge` safeguard for future versions; no broad public-package exclusions are added
- regenerate `THIRD_PARTY_LICENSES` for the production dependency changes

## Why

The default branch resolved several transitive dependencies to versions covered by the repository's open Dependabot advisories. Exact patched releases are enforced through pnpm overrides and the lockfile, while future dependency resolutions remain subject to the repository's package maturity policy.

The registry audit also identified the installed `brace-expansion@5.0.8` path as vulnerable even though that path was not yet present in the Dependabot alert inventory. This PR updates it to `5.0.9` as well.

## Validation

- `pnpm install --frozen-lockfile` — succeeds without release-age exclusions for the updated public packages
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `pnpm licenses:check` — package licenses and generated third-party notice pass
- `pnpm lint` — SQL, Codex storage, renderer colors, Electron policy, license, ESLint, typecheck, and dependency boundaries pass (existing warnings only)
- `pnpm test` — 5,873 active tests passed; three unrelated filesystem/shell tests hit their 5-second timeout under full-suite load
- focused rerun of the two affected test files — 462/462 tests passed
- `git diff --check`
