### PR TITLE
fix(desktop): present local file paths consistently

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -23,8 +23,9 @@ import ReactMarkdown, { type Components, type UrlTransform } from "react-markdow
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { AppIcon } from "../../components/AppIcon";
-import { CloseIcon, FolderIcon, PopoutIcon } from "../../icons";
+import { CloseIcon, CopyIcon, FolderIcon, PopoutIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { copyText } from "../../lib/copy-text";
 import { repairNestedLanguageFences } from "../../lib/markdown-fences";
 import { useMarkdownMathRuntime } from "../../lib/markdown-rendering-options";
 import {
@@ -353,7 +354,9 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
             }}
             rel="noopener noreferrer"
             target="_blank"
-            title={isLocalMarkdownFile ? "Open in PwrAgent" : href || undefined}
+            title={isLocalMarkdownFile && localTarget
+              ? tildifyPath(localTarget.path)
+              : href || undefined}
           >
             {anchorProps.children}
           </a>
@@ -723,7 +726,22 @@ function MarkdownDocumentModal(props: {
         <header className="markdown-document-modal__head">
           <div className="markdown-document-modal__title-wrap">
             <h2 className="markdown-document-modal__title">{props.target.label}</h2>
-            <p className="markdown-document-modal__path">{props.target.path}</p>
+            <div className="markdown-document-modal__path-row">
+              <p className="markdown-document-modal__path">
+                {tildifyPath(props.target.path)}
+              </p>
+              <button
+                type="button"
+                className="markdown-document-modal__path-copy"
+                aria-label="Copy path"
+                title="Copy path to clipboard"
+                onClick={() => {
+                  void copyText(props.target.path, props.desktopApi);
+                }}
+              >
+                <CopyIcon size={13} aria-hidden="true" />
+              </button>
+            </div>
           </div>
           <div className="markdown-document-modal__actions">
             {props.editorApplication ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -103,8 +103,55 @@ describe("ThreadMarkdown", () => {
     );
     expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "title",
-      "Open in PwrAgent"
+      "/Users/huntharo/PwrAgent/AGENTS.md"
     );
+  });
+
+  it("tildifies PwrAgent file-link tooltips inside the home directory", () => {
+    const windowWithHomeDir = window as Window & { __pwragentHomeDir?: string };
+    const previousHomeDir = windowWithHomeDir.__pwragentHomeDir;
+    windowWithHomeDir.__pwragentHomeDir = "/Users/huntharo";
+
+    try {
+      render(
+        <ThreadMarkdown
+          text={"Open [`AGENTS.md`](/Users/huntharo/PwrAgent/AGENTS.md)."}
+        />
+      );
+
+      expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
+        "title",
+        "~/PwrAgent/AGENTS.md"
+      );
+    } finally {
+      windowWithHomeDir.__pwragentHomeDir = previousHomeDir;
+    }
+  });
+
+  it("shows a POSIX home-relative path in the PwrAgent document header", async () => {
+    const windowWithHomeDir = window as Window & { __pwragentHomeDir?: string };
+    const previousHomeDir = windowWithHomeDir.__pwragentHomeDir;
+    windowWithHomeDir.__pwragentHomeDir = "/Users/huntharo";
+
+    try {
+      render(
+        <ThreadMarkdown
+          desktopApi={{
+            readMarkdownFile: vi.fn(async (request: { path: string }) => ({
+              path: request.path,
+              content: "# AGENTS",
+            })),
+          }}
+          text={"Open [`AGENTS.md`](/Users/huntharo/PwrAgent/AGENTS.md)."}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("link", { name: "AGENTS.md" }));
+
+      expect(await screen.findByText("~/PwrAgent/AGENTS.md")).toBeInTheDocument();
+    } finally {
+      windowWithHomeDir.__pwragentHomeDir = previousHomeDir;
+    }
   });
 
   it("leaves LaTeX untypeset when experimental math rendering is disabled", () => {
@@ -330,6 +377,7 @@ describe("ThreadMarkdown", () => {
   it("opens markdown file links in a document modal and keeps the editor icon separate", async () => {
     const openApplication = vi.fn(async () => ({ opened: true as const }));
     const openMarkdownFileViewer = vi.fn(async () => ({ opened: true as const }));
+    const copyPath = vi.fn(async () => undefined);
     const readMarkdownFile = vi.fn(async (request: { path: string }) => ({
       path: request.path,
       content: "# AGENTS\n\nUse the repo guidance.",
@@ -359,7 +407,12 @@ describe("ThreadMarkdown", () => {
             discovery: { candidates: [] },
           },
         }}
-        desktopApi={{ openApplication, openMarkdownFileViewer, readMarkdownFile }}
+        desktopApi={{
+          copyText: copyPath,
+          openApplication,
+          openMarkdownFileViewer,
+          readMarkdownFile,
+        }}
         fileViewerContext={{
           key: "codex:thread-1",
           title: "Files - Thread title",
@@ -372,7 +425,7 @@ describe("ThreadMarkdown", () => {
 
     expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute(
       "title",
-      "Open in PwrAgent"
+      "/repo/PwrAgent/AGENTS.md"
     );
 
     fireEvent.click(
@@ -399,6 +452,11 @@ describe("ThreadMarkdown", () => {
     });
     expect(screen.getByRole("heading", { name: "AGENTS" })).toBeInTheDocument();
     expect(openApplication).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy path" }));
+    await waitFor(() => {
+      expect(copyPath).toHaveBeenCalledWith("/repo/PwrAgent/AGENTS.md");
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Open in detached files window" }));
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts
@@ -26,8 +26,10 @@ describe("tildifyPath", () => {
     );
   });
 
-  it("matches a back-slashed Windows home against a forward-slashed path", () => {
-    expect(tildifyPath("C:/Users/foo/dev/app", "C:\\Users\\foo")).toBe("~/dev/app");
+  it("keeps Windows home paths in their native form", () => {
+    expect(tildifyPath("C:\\Users\\foo\\dev\\app", "C:\\Users\\foo")).toBe(
+      "C:\\Users\\foo\\dev\\app",
+    );
   });
 
   it("returns the path unchanged when the home directory is unknown", () => {

--- a/apps/desktop/src/renderer/src/lib/tildify-path.ts
+++ b/apps/desktop/src/renderer/src/lib/tildify-path.ts
@@ -21,14 +21,17 @@ export function getHomeDir(): string | undefined {
  * unchanged when it doesn't live under home, or when the home directory is
  * unknown (e.g. in tests, or before the preload value is present).
  *
- * Separator-tolerant so a forward-slashed app path still matches a
- * back-slashed Windows home directory.
+ * `~` is a POSIX shell convention, so Windows paths remain native even when
+ * they are under the user's home directory.
  */
 export function tildifyPath(
   absolutePath: string,
   homeDir: string | undefined = getHomeDir(),
 ): string {
   if (!absolutePath || !homeDir) {
+    return absolutePath;
+  }
+  if (isWindowsPath(absolutePath)) {
     return absolutePath;
   }
   const home = homeDir.replace(/[/\\]+$/, "");
@@ -44,6 +47,10 @@ export function tildifyPath(
     return `~${absolutePath.slice(home.length)}`;
   }
   return absolutePath;
+}
+
+function isWindowsPath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
 }
 
 /**

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10279,9 +10279,9 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .markdown-document-modal__path-copy {
   display: inline-flex;
-  width: 18px;
-  height: 18px;
-  flex: 0 0 18px;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
   align-items: center;
   justify-content: center;
   margin-top: 2px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10263,11 +10263,41 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .markdown-document-modal__path {
   margin: 3px 0 0;
+  min-width: 0;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.35;
   overflow-wrap: anywhere;
+}
+
+.markdown-document-modal__path-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.markdown-document-modal__path-copy {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.markdown-document-modal__path-copy:hover,
+.markdown-document-modal__path-copy:focus-visible {
+  background: var(--bg-row-active);
+  color: var(--text-primary);
+  outline: none;
 }
 
 .markdown-document-modal__actions {


### PR DESCRIPTION
## Summary

- Show home-relative paths as `~/…` in local Markdown file-link tooltips and document headers on macOS/Linux.
- Add a copy-to-clipboard control beside the document-header path; it copies the full native path.
- Keep Windows home paths in their native `C:\Users\…` form instead of applying POSIX tilde notation.

## Why

Markdown document links previously exposed only a generic PwrAgent tooltip, and opened document headers showed a full path without a copy affordance.

## Impact

Local file paths are easier to identify and copy while preserving platform-appropriate notation.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts` (55 passing)
- `pnpm exec eslint apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx apps/desktop/src/renderer/src/lib/tildify-path.ts apps/desktop/src/renderer/src/lib/__tests__/tildify-path.test.ts` (no errors; two existing hook-dependency warnings in `ThreadMarkdown.tsx`)
