### PR TITLE
fix(messaging): bound pending adapter startup

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1288,7 +1288,7 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("cancels pending adapter startup before stopping the runtime", async () => {
+  it("preserves a stop request that arrives before adapters register", async () => {
     await prepareRuntimeStore();
     const telegramStart = createDeferred<void>();
     const slowTelegramAdapter = createAdapter("telegram");
@@ -1318,14 +1318,15 @@ describe("DesktopMessagingRuntime", () => {
     });
 
     const startPromise = runtime.start();
-    await flushMicrotasks();
     const stopPromise = runtime.stop();
     await Promise.all([startPromise, stopPromise]);
 
     expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
     expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
     expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
-    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(1);
+    // The fast adapter settles after cancellation wins the race, so it gets
+    // both immediate failed-start cleanup and the late-start zombie guard.
+    expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(2);
     expect(runtime.isEnabled()).toBe(false);
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
@@ -1375,7 +1376,6 @@ describe("DesktopMessagingRuntime", () => {
     }));
 
     const startPromise = runtime.start();
-    await flushMicrotasks();
     const applyPromise = runtime.applyConfig({
       telegram: {
         channel: "telegram",

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1130,6 +1130,61 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("times out a stuck adapter start and reports an error without blocking other adapters", async () => {
+    await prepareRuntimeStore();
+    const stuckStart = createDeferred<void>();
+    const stuckAdapter = createAdapter("discord", {
+      start: vi.fn(async () => {
+        await stuckStart.promise;
+      }),
+    });
+    const workingAdapter = createAdapter("telegram");
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: () => [stuckAdapter, workingAdapter],
+      adapterStartTimeoutMs: 1,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    await runtime.start();
+
+    expect(stuckAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "discord",
+          health: "errored",
+          reason: "discord adapter startup did not complete within 1 ms.",
+        }),
+        expect.objectContaining({
+          platform: "telegram",
+          health: "enabled",
+        }),
+      ]),
+    );
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "messaging runtime config applied",
+      expect.objectContaining({
+        started: ["telegram"],
+        failed: ["discord"],
+      }),
+    );
+  });
+
   it("starts adapters in parallel and reports pending adapters as loading", async () => {
     await prepareRuntimeStore();
     const telegramStart = createDeferred<void>();
@@ -1174,6 +1229,9 @@ describe("DesktopMessagingRuntime", () => {
         health: "unknown",
       }),
     );
+    await waitFor(() => runtime.getPlatformStatuses().some(
+      (status) => status.platform === "discord" && status.health === "enabled",
+    ));
     expect(runtime.getPlatformStatuses()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1230,7 +1288,7 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
-  it("serializes stop requests behind pending startup", async () => {
+  it("cancels pending adapter startup before stopping the runtime", async () => {
     await prepareRuntimeStore();
     const telegramStart = createDeferred<void>();
     const slowTelegramAdapter = createAdapter("telegram");
@@ -1262,15 +1320,10 @@ describe("DesktopMessagingRuntime", () => {
     const startPromise = runtime.start();
     await flushMicrotasks();
     const stopPromise = runtime.stop();
-    await flushMicrotasks();
+    await Promise.all([startPromise, stopPromise]);
 
     expect(slowTelegramAdapter.start).toHaveBeenCalledTimes(1);
     expect(workingDiscordAdapter.start).toHaveBeenCalledTimes(1);
-    expect(slowTelegramAdapter.stop).not.toHaveBeenCalled();
-
-    telegramStart.resolve();
-    await Promise.all([startPromise, stopPromise]);
-
     expect(slowTelegramAdapter.stop).toHaveBeenCalledTimes(1);
     expect(workingDiscordAdapter.stop).toHaveBeenCalledTimes(1);
     expect(runtime.isEnabled()).toBe(false);
@@ -1285,6 +1338,77 @@ describe("DesktopMessagingRuntime", () => {
           health: "suspended",
         }),
       ]),
+    );
+  });
+
+  it("cancels a pending adapter start when that platform is disabled", async () => {
+    await prepareRuntimeStore();
+    const discordStart = createDeferred<void>();
+    const discordAdapter = createAdapter("discord");
+    discordAdapter.start.mockImplementation(async (listener) => {
+      discordAdapter.listener = listener;
+      await discordStart.promise;
+    });
+    const telegramAdapter = createAdapter("telegram");
+    const factory = vi.fn<DesktopMessagingAdapterFactory>(({ config }) => [
+      ...(config.discord ? [discordAdapter] : []),
+      ...(config.telegram ? [telegramAdapter] : []),
+    ]);
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = trackRuntime(new Runtime({
+      adapterFactory: factory,
+      backendBridge: createBackendBridge(),
+      config: {
+        discord: {
+          channel: "discord",
+          botToken: "discord-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    }));
+
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+    const applyPromise = runtime.applyConfig({
+      telegram: {
+        channel: "telegram",
+        botToken: "telegram-token",
+        authorizedActorIds: [{ id: "user-1", displayName: "" }],
+      },
+    });
+    await Promise.all([startPromise, applyPromise]);
+
+    expect(discordAdapter.stop).toHaveBeenCalledTimes(1);
+    expect(runtime.getPlatformStatuses()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "discord",
+          health: "suspended",
+          reason: "discord was disabled while adapter startup was still pending.",
+        }),
+        expect.objectContaining({
+          platform: "telegram",
+          health: "enabled",
+        }),
+      ]),
+    );
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: adapter startup cancelled",
+      expect.objectContaining({ channel: "discord" }),
+    );
+
+    discordStart.resolve();
+    await waitFor(() => discordAdapter.stop.mock.calls.length === 2);
+    expect(messagingLog.info).toHaveBeenCalledWith(
+      "discord: stopped adapter after late startup",
+      { channel: "discord" },
     );
   });
 

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -226,6 +226,14 @@ const DELIVERY_BUDGET_WARNING_TTL_MS = 30_000;
 const DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS = 30_000;
 const DEFAULT_ADAPTER_START_TIMEOUT_MS = 90_000;
 const FAILED_START_STOP_TIMEOUT_MS = 3_000;
+const CONFIGURABLE_MESSAGING_CHANNELS = [
+  "discord",
+  "feishu",
+  "line",
+  "mattermost",
+  "slack",
+  "telegram",
+] as const satisfies readonly MessagingChannelKind[];
 
 export type MessagingPairingChangedEvent = {
   at: number;
@@ -339,6 +347,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     MessagingChannelKind,
     PendingAdapterStart
   >();
+  private readonly pendingAdapterStartCancellationReasons = new Map<
+    MessagingChannelKind,
+    string
+  >();
+  private pendingAdapterStopReason?: string;
   private lifecycleQueue: Promise<void> = Promise.resolve();
   /**
    * Listeners notified whenever any controller mutates a binding
@@ -365,6 +378,8 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   ) {}
 
   async start(): Promise<void> {
+    this.pendingAdapterStopReason = undefined;
+    this.pendingAdapterStartCancellationReasons.clear();
     await this.enqueueLifecycle(async () => {
       const config = await this.loadConfig({ logStartupEligibility: true });
       await this.applyConfigNow(config);
@@ -372,9 +387,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   async stop(): Promise<void> {
-    this.cancelPendingAdapterStarts(
-      "Messaging was stopped while adapter startup was still pending.",
-    );
+    const reason = "Messaging was stopped while adapter startup was still pending.";
+    this.pendingAdapterStopReason = reason;
+    this.cancelPendingAdapterStarts(reason);
     await this.enqueueLifecycle(async () => {
       await this.stopNow();
     });
@@ -433,7 +448,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
-    this.cancelPendingAdapterStartsDisabledBy(config);
+    this.updatePendingAdapterStartIntent(config);
     await this.enqueueLifecycle(async () => {
       await this.applyConfigNow(config, options);
     });
@@ -972,23 +987,26 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     }
   }
 
-  private cancelPendingAdapterStartsDisabledBy(
+  private updatePendingAdapterStartIntent(
     config: DesktopMessagingConfig,
   ): void {
     if (config.enabled === false) {
-      this.cancelPendingAdapterStarts(
-        "Messaging was disabled while adapter startup was still pending.",
-      );
+      const reason =
+        "Messaging was disabled while adapter startup was still pending.";
+      this.pendingAdapterStopReason = reason;
+      this.cancelPendingAdapterStarts(reason);
       return;
     }
 
-    for (const [channel, pending] of this.pendingAdapterStarts) {
+    this.pendingAdapterStopReason = undefined;
+    for (const channel of CONFIGURABLE_MESSAGING_CHANNELS) {
       if (messagingChannelConfig(config, channel)) {
+        this.pendingAdapterStartCancellationReasons.delete(channel);
         continue;
       }
-      pending.cancel(
-        `${channel} was disabled while adapter startup was still pending.`,
-      );
+      const reason = `${channel} was disabled while adapter startup was still pending.`;
+      this.pendingAdapterStartCancellationReasons.set(channel, reason);
+      this.pendingAdapterStarts.get(channel)?.cancel(reason);
     }
   }
 
@@ -1316,6 +1334,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       cancel: (reason) => cancel?.(reason),
     };
     this.pendingAdapterStarts.set(adapter.channel, pending);
+    const queuedCancellationReason = this.pendingAdapterStopReason
+      ?? this.pendingAdapterStartCancellationReasons.get(adapter.channel);
+    if (queuedCancellationReason) {
+      pending.cancel(queuedCancellationReason);
+    }
 
     try {
       await Promise.race([startPromise, cancellation, timeout]);

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -191,6 +191,28 @@ type RunningMessagingAuthorization = {
   actorIdSet: Set<string>;
 };
 
+type PendingAdapterStart = {
+  cancel(reason: string): void;
+};
+
+type AdapterStartOutcome = "cancelled" | "failed" | "started";
+
+class AdapterStartCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdapterStartCancelledError";
+  }
+}
+
+class AdapterStartTimeoutError extends Error {
+  constructor(channel: MessagingChannelKind, timeoutMs: number) {
+    super(
+      `${channel} adapter startup did not complete within ${formatDuration(timeoutMs)}.`,
+    );
+    this.name = "AdapterStartTimeoutError";
+  }
+}
+
 const messagingLog = getMainLogger("pwragent:messaging");
 const PAIRING_INSTANCE_ID = "default";
 const DEFAULT_PAIRING_TTL_MS = 5 * 60 * 1000;
@@ -202,6 +224,8 @@ const PAIRING_TOKEN_ALPHABET =
 const RATE_LIMIT_HEALTH_BUFFER_MS = 2_000;
 const DELIVERY_BUDGET_WARNING_TTL_MS = 30_000;
 const DELIVERY_BUDGET_DIAGNOSTIC_THROTTLE_MS = 30_000;
+const DEFAULT_ADAPTER_START_TIMEOUT_MS = 90_000;
+const FAILED_START_STOP_TIMEOUT_MS = 3_000;
 
 export type MessagingPairingChangedEvent = {
   at: number;
@@ -311,6 +335,10 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   private readonly platformStatusListeners = new Set<
     (event: MessagingPlatformStatusEvent) => void
   >();
+  private readonly pendingAdapterStarts = new Map<
+    MessagingChannelKind,
+    PendingAdapterStart
+  >();
   private lifecycleQueue: Promise<void> = Promise.resolve();
   /**
    * Listeners notified whenever any controller mutates a binding
@@ -332,6 +360,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       config: DesktopMessagingConfig | DesktopMessagingConfigLoader;
       automationInboundHandler?: MessagingAutomationInboundHandler;
       automationInboundMatches?: MessagingAutomationInboundMatcher;
+      adapterStartTimeoutMs?: number;
     },
   ) {}
 
@@ -343,6 +372,9 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
   }
 
   async stop(): Promise<void> {
+    this.cancelPendingAdapterStarts(
+      "Messaging was stopped while adapter startup was still pending.",
+    );
     await this.enqueueLifecycle(async () => {
       await this.stopNow();
     });
@@ -401,6 +433,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<void> {
+    this.cancelPendingAdapterStartsDisabledBy(config);
     await this.enqueueLifecycle(async () => {
       await this.applyConfigNow(config, options);
     });
@@ -493,22 +526,25 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     const startResults = await Promise.all(
       [...nextAdapters.entries()].map(async ([channel, adapter]) => {
         if (this.runningAdapters.has(channel)) {
-          return { channel, started: false, unchanged: true };
+          return { channel, unchanged: true };
         }
 
-        const started = await this.startRunningAdapter({
+        const outcome = await this.startRunningAdapter({
           adapter,
           config,
           store,
         });
-        return { channel, started, unchanged: false };
+        return { channel, outcome, unchanged: false };
       }),
     );
     const startedChannels = startResults
-      .filter((result) => result.started)
+      .filter((result) => !result.unchanged && result.outcome === "started")
       .map((result) => result.channel);
     const failedChannels = startResults
-      .filter((result) => !result.unchanged && !result.started)
+      .filter((result) => !result.unchanged && result.outcome === "failed")
+      .map((result) => result.channel);
+    const cancelledChannels = startResults
+      .filter((result) => !result.unchanged && result.outcome === "cancelled")
       .map((result) => result.channel);
 
     this.syncRunningAdapterLists();
@@ -524,9 +560,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
       startedChannels.length > 0
       || stoppedChannels.length > 0
       || failedChannels.length > 0
+      || cancelledChannels.length > 0
       || hotUpdatedChannels.length > 0
     ) {
       messagingLog.info("messaging runtime config applied", {
+        cancelled: cancelledChannels.length > 0 ? cancelledChannels : undefined,
         hotUpdated: hotUpdatedChannels.length > 0 ? hotUpdatedChannels : undefined,
         started: startedChannels.length > 0 ? startedChannels : undefined,
         stopped: stoppedChannels.length > 0 ? stoppedChannels : undefined,
@@ -928,6 +966,32 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     await run;
   }
 
+  private cancelPendingAdapterStarts(reason: string): void {
+    for (const pending of this.pendingAdapterStarts.values()) {
+      pending.cancel(reason);
+    }
+  }
+
+  private cancelPendingAdapterStartsDisabledBy(
+    config: DesktopMessagingConfig,
+  ): void {
+    if (config.enabled === false) {
+      this.cancelPendingAdapterStarts(
+        "Messaging was disabled while adapter startup was still pending.",
+      );
+      return;
+    }
+
+    for (const [channel, pending] of this.pendingAdapterStarts) {
+      if (messagingChannelConfig(config, channel)) {
+        continue;
+      }
+      pending.cancel(
+        `${channel} was disabled while adapter startup was still pending.`,
+      );
+    }
+  }
+
   private async shouldDropAmbientSharedMessage(params: {
     channel: MessagingChannelKind;
     event: MessagingInboundEvent;
@@ -988,7 +1052,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     adapter: DesktopMessagingAdapter;
     config: DesktopMessagingConfig;
     store: MessagingStoreLike;
-  }): Promise<boolean> {
+  }): Promise<AdapterStartOutcome> {
     const { adapter, config, store } = params;
     const authorizedActorIds = [...adapter.authorizedActorIds];
     const authorization: RunningMessagingAuthorization = {
@@ -1087,7 +1151,7 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         });
       });
       this.setPlatformHealth(adapter.channel, "unknown");
-      await adapter.start?.(async (event) => {
+      await this.startAdapterWithDeadline(adapter, async (event) => {
         // Activity ping fires on every inbound, before authorization checks.
         this.emitPlatformActivity(adapter.channel);
         if (await this.handlePairingInbound(adapter, event, store)) {
@@ -1153,22 +1217,26 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
         // Best effort cleanup after startup failure.
       }
       controller.dispose();
-      try {
-        await adapter.stop?.();
-      } catch (stopError) {
-        messagingLog.warn(`${adapter.channel}: adapter stop after failed start threw`, {
+      const cancelled = error instanceof AdapterStartCancelledError;
+      if (cancelled) {
+        messagingLog.info(`${adapter.channel}: adapter startup cancelled`, {
           channel: adapter.channel,
-          error: stopError instanceof Error ? stopError.message : String(stopError),
+          reason: error.message,
+        });
+        this.setPlatformHealth(adapter.channel, "suspended", {
+          reason: error.message,
+        });
+      } else {
+        messagingLog.error(`${adapter.channel}: failed to start adapter`, {
+          channel: adapter.channel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        this.setPlatformHealth(adapter.channel, "errored", {
+          reason: error instanceof Error ? error.message : String(error),
         });
       }
-      messagingLog.error(`${adapter.channel}: failed to start adapter`, {
-        channel: adapter.channel,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      this.setPlatformHealth(adapter.channel, "errored", {
-        reason: error instanceof Error ? error.message : String(error),
-      });
-      return false;
+      await this.stopAdapterAfterFailedStart(adapter);
+      return cancelled ? "cancelled" : "failed";
     }
 
     const unsubscribeRuntimeError = adapter.onRuntimeError?.((reason) => {
@@ -1214,7 +1282,93 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     messagingLog.info(`${adapter.channel}: adapter started successfully`, {
       channel: adapter.channel,
     });
-    return true;
+    return "started";
+  }
+
+  private async startAdapterWithDeadline(
+    adapter: DesktopMessagingAdapter,
+    listener: (event: MessagingInboundEvent) => Promise<void>,
+  ): Promise<void> {
+    const timeoutMs = Math.max(
+      1,
+      this.options.adapterStartTimeoutMs ?? DEFAULT_ADAPTER_START_TIMEOUT_MS,
+    );
+    let cancel: ((reason: string) => void) | undefined;
+    let cancelled = false;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      cancel = (reason) => {
+        if (cancelled) return;
+        cancelled = true;
+        reject(new AdapterStartCancelledError(reason));
+      };
+    });
+    const startPromise = Promise.resolve().then(async () => {
+      await adapter.start?.(listener);
+    });
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new AdapterStartTimeoutError(adapter.channel, timeoutMs));
+      }, timeoutMs);
+      if (timeoutHandle.unref) timeoutHandle.unref();
+    });
+    const pending: PendingAdapterStart = {
+      cancel: (reason) => cancel?.(reason),
+    };
+    this.pendingAdapterStarts.set(adapter.channel, pending);
+
+    try {
+      await Promise.race([startPromise, cancellation, timeout]);
+    } catch (error) {
+      if (
+        error instanceof AdapterStartCancelledError
+        || error instanceof AdapterStartTimeoutError
+      ) {
+        void startPromise.then(
+          async () => this.stopAdapterAfterLateStart(adapter),
+          () => undefined,
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutHandle);
+      if (this.pendingAdapterStarts.get(adapter.channel) === pending) {
+        this.pendingAdapterStarts.delete(adapter.channel);
+      }
+    }
+  }
+
+  private async stopAdapterAfterFailedStart(
+    adapter: DesktopMessagingAdapter,
+  ): Promise<void> {
+    try {
+      await promiseWithTimeout(
+        Promise.resolve().then(async () => adapter.stop?.()),
+        FAILED_START_STOP_TIMEOUT_MS,
+        `${adapter.channel} adapter cleanup after failed startup`,
+      );
+    } catch (stopError) {
+      messagingLog.warn(`${adapter.channel}: adapter stop after failed start threw`, {
+        channel: adapter.channel,
+        error: stopError instanceof Error ? stopError.message : String(stopError),
+      });
+    }
+  }
+
+  private async stopAdapterAfterLateStart(
+    adapter: DesktopMessagingAdapter,
+  ): Promise<void> {
+    try {
+      await adapter.stop?.();
+      messagingLog.info(`${adapter.channel}: stopped adapter after late startup`, {
+        channel: adapter.channel,
+      });
+    } catch (error) {
+      messagingLog.warn(`${adapter.channel}: adapter stop after late start threw`, {
+        channel: adapter.channel,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async hotApplyRunningAdapter(
@@ -2377,6 +2531,57 @@ function degradationKey(
   id: string,
 ): string {
   return `${platform}:${kind}:${id}`;
+}
+
+function messagingChannelConfig(
+  config: DesktopMessagingConfig,
+  channel: MessagingChannelKind,
+): unknown {
+  switch (channel) {
+    case "discord":
+      return config.discord;
+    case "feishu":
+      return config.feishu;
+    case "line":
+      return config.line;
+    case "mattermost":
+      return config.mattermost;
+    case "slack":
+      return config.slack;
+    case "telegram":
+      return config.telegram;
+    default:
+      return undefined;
+  }
+}
+
+async function promiseWithTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(
+        new Error(`${operation} did not complete within ${formatDuration(timeoutMs)}.`),
+      );
+    }, timeoutMs);
+    if (timeoutHandle.unref) timeoutHandle.unref();
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs % 1000 === 0) {
+    const seconds = durationMs / 1000;
+    return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  }
+  return `${durationMs} ms`;
 }
 
 function streamingResponsesDefaultForChannel(


### PR DESCRIPTION
## Summary

- I bound messaging adapter startup to a 90-second deadline so a provider that never settles transitions from Loading to an actionable error state.
- I cancel pending startup immediately when the operator disables that platform or stops messaging, allowing the lifecycle queue and UI toggle to complete.
- I stop adapters that finish starting after cancellation so they cannot return as zombie connections.

## Verification

- I ran the focused messaging runtime suite: 52 tests passed.
- I ran the messaging lease and IPC suites: 45 tests passed.
- I ran `pnpm typecheck` successfully.
- I ran `pnpm lint:eslint` successfully with only the repository's existing warnings.
- I ran `pnpm lint:boundaries` successfully with no dependency violations.

## Notes

- I deliberately left the development-only `ws` dependency/bundling failure out of scope. This change hardens provider lifecycle error detection and operator cancellation generically.
- Operator cancellation reports the platform as suspended; an actual startup deadline reports it as errored with the timeout reason.
