### PR TITLE
feat(desktop): add mark unread thread action

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -36,6 +36,12 @@ const federationMock = vi.hoisted(() => {
       archivedAt: 6_000,
       cleanup: [],
     })),
+    markThreadSeen: vi.fn(async (request: MarkThreadSeenRequest) => ({
+      backend: request.backend ?? "codex",
+      threadId: request.threadId,
+      seenAt: request.seenAt ?? 6_000,
+      seenUpdatedAt: request.seenUpdatedAt,
+    })),
     renameThread: vi.fn(async (request: RenameThreadRequest) => ({
       backend: request.backend,
       threadId: request.threadId,
@@ -758,6 +764,7 @@ describe("app server ipc", () => {
     renameThread.mockClear();
     federationMock.remoteBackend.renameThread.mockClear();
     federationMock.remoteBackend.archiveThread.mockClear();
+    federationMock.remoteBackend.markThreadSeen.mockClear();
     federationMock.runtime.remoteBackend.mockClear();
     listThreads.mockClear();
     readThread.mockClear();
@@ -2235,6 +2242,40 @@ describe("app server ipc", () => {
       threadId: "thread-1",
       seenAt: 2000,
       seenUpdatedAt: 3000,
+    });
+  });
+
+  it("marks remote threads seen on the owning federation peer", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_MARK_THREAD_SEEN_CHANNEL } = await import("../../shared/ipc");
+
+    registerAppServerIpcHandlers();
+
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
+    const response = await handlers.get(NAVIGATION_MARK_THREAD_SEEN_CHANNEL)?.({}, {
+      backend: "codex",
+      federationTarget,
+      threadId: "thread-remote",
+      seenUpdatedAt: 3_000,
+    } satisfies MarkThreadSeenRequest);
+
+    expect(federationMock.runtime.remoteBackend).toHaveBeenCalledWith(
+      federationTarget,
+    );
+    expect(federationMock.remoteBackend.markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-remote",
+      seenUpdatedAt: 3_000,
+    });
+    expect(markThreadSeen).not.toHaveBeenCalled();
+    expect(response).toEqual({
+      backend: "codex",
+      threadId: "thread-remote",
+      seenAt: 6_000,
+      seenUpdatedAt: 3_000,
     });
   });
 

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -169,6 +169,105 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("routes mark-seen requests through the remote overlay owner", async () => {
+    const backend = {
+      markThreadSeen: vi.fn(async () => ({
+        backend: "codex" as const,
+        threadId: "thread-1",
+        seenAt: 2_000,
+        seenUpdatedAt: 1_999,
+      })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "client_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+      now: () => 2_000,
+    });
+    router.registerConnection({
+      peerId: "gateway_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "mark-seen-request",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.markThreadSeen,
+        params: {
+          backend: "codex",
+          threadId: "thread-1",
+          seenUpdatedAt: 1_999,
+        },
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: "client_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(backend.markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-1",
+      seenUpdatedAt: 1_999,
+    });
+    expect(replies).toMatchObject([{
+      kind: "response",
+      requestId: "mark-seen-request",
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        seenUpdatedAt: 1_999,
+      },
+    }]);
+
+    const sent: FederationProtocolEnvelope[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "gateway_one",
+      remoteInstanceId: "client_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+      now: () => 3_000,
+    });
+    const client = new FederationRemoteBackendClient(rpc);
+    const pending = client.markThreadSeen({
+      backend: "codex",
+      threadId: "thread-1",
+      seenUpdatedAt: 1_999,
+    });
+    const request = sent[0]!;
+    expect(request).toMatchObject({
+      kind: "request",
+      method: FEDERATION_BACKEND_METHODS.markThreadSeen,
+      params: {
+        backend: "codex",
+        threadId: "thread-1",
+        seenUpdatedAt: 1_999,
+      },
+    });
+    rpc.receiveEnvelope({
+      id: "mark-seen-response",
+      kind: "response",
+      requestId: request.id,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 3_100,
+      result: {
+        backend: "codex",
+        threadId: "thread-1",
+        seenAt: 3_100,
+        seenUpdatedAt: 1_999,
+      },
+    });
+    await expect(pending).resolves.toMatchObject({
+      threadId: "thread-1",
+      seenUpdatedAt: 1_999,
+    });
+  });
+
   it("requires thread-detail capability for remote thread reads", async () => {
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -278,6 +377,7 @@ describe("federation backend bridge", () => {
       readThread: vi.fn(),
       listSkills: vi.fn(),
       listBackends: vi.fn(),
+      markThreadSeen: vi.fn(),
       archiveThread: vi.fn(),
       startThread: vi.fn(),
       forkThread: vi.fn(),
@@ -441,6 +541,7 @@ describe("federation backend bridge", () => {
         readThread: vi.fn(),
         listSkills: vi.fn(),
         listBackends: vi.fn(),
+        markThreadSeen: vi.fn(),
         archiveThread: vi.fn(),
         startThread: vi.fn(),
         forkThread: vi.fn(),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -26,6 +26,8 @@ import type {
   MaterializeDirectoryLaunchpadOptions,
   MaterializeDirectoryLaunchpadRequest,
   MaterializeDirectoryLaunchpadResponse,
+  MarkThreadSeenRequest,
+  MarkThreadSeenResponse,
   NavigationSnapshot,
   DesktopApplicationsSnapshot,
   OpenDesktopApplicationRequest,
@@ -68,6 +70,7 @@ export const FEDERATION_BACKEND_METHODS = {
   readThread: "backend.readThread",
   listSkills: "backend.listSkills",
   listBackends: "backend.listBackends",
+  markThreadSeen: "backend.markThreadSeen",
   archiveThread: "backend.archiveThread",
   startThread: "backend.startThread",
   forkThread: "backend.forkThread",
@@ -119,6 +122,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.readThread]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listSkills]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.listBackends]: "thread_detail",
+  [FEDERATION_BACKEND_METHODS.markThreadSeen]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.archiveThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
@@ -158,6 +162,7 @@ export type FederationBackendOperations = {
     request?: AppServerListSkillsRequest,
   ): Promise<AppServerListSkillsResponse>;
   listBackends(request?: ListBackendsRequest): Promise<ListBackendsResponse>;
+  markThreadSeen(request: MarkThreadSeenRequest): Promise<MarkThreadSeenResponse>;
   archiveThread(request: ArchiveThreadRequest): Promise<ArchiveThreadResponse>;
   startThread(request: StartThreadRequest): Promise<StartThreadResponse>;
   forkThread(
@@ -257,6 +262,13 @@ export function registerFederationBackendHandlers(params: {
     async (envelope) =>
       await params.backend.listBackends(
         (envelope.params ?? {}) as ListBackendsRequest,
+      ),
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.markThreadSeen,
+    async (envelope) =>
+      await params.backend.markThreadSeen(
+        envelope.params as MarkThreadSeenRequest,
       ),
   );
   params.router.registerHandler(
@@ -488,6 +500,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<ArchiveThreadResponse> {
     return await this.rpc.request<ArchiveThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.archiveThread,
+      params: request,
+    });
+  }
+
+  async markThreadSeen(
+    request: MarkThreadSeenRequest,
+  ): Promise<MarkThreadSeenResponse> {
+    return await this.rpc.request<MarkThreadSeenResponse>({
+      method: FEDERATION_BACKEND_METHODS.markThreadSeen,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -20,6 +20,7 @@ import type {
   HandoffThreadWorkspaceResponse,
   InterruptTurnResponse,
   MaterializeDirectoryLaunchpadResponse,
+  MarkThreadSeenResponse,
   OpenDesktopApplicationResponse,
   QueueThreadExecutionModeResponse,
   RenameThreadResponse,
@@ -51,6 +52,7 @@ import {
   type InterruptTurnRequest,
   type MaterializeDirectoryLaunchpadRequest,
   type MaterializeDirectoryLaunchpadOptions,
+  type MarkThreadSeenRequest,
   type NavigationSnapshot,
   type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
@@ -70,6 +72,7 @@ import {
   type TrustCodexProjectRequest,
 } from "@pwragent/shared";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
+import { getDesktopOverlayStore } from "../app-server/desktop-overlay-store";
 import { rewriteTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { getMainLogger } from "../log";
 import {
@@ -1065,6 +1068,17 @@ function localBackendOperations(): FederationBackendOperations {
     },
     async listBackends(request = {}) {
       return await getDesktopBackendRegistry().listBackends(request);
+    },
+    async markThreadSeen(
+      request: MarkThreadSeenRequest,
+    ): Promise<MarkThreadSeenResponse> {
+      const backend = request.backend ?? "codex";
+      return await getDesktopOverlayStore().markThreadSeen({
+        backend,
+        seenAt: request.seenAt,
+        seenUpdatedAt: request.seenUpdatedAt,
+        threadId: request.threadId,
+      });
     },
     async archiveThread(request) {
       return await getDesktopBackendRegistry().archiveThread(request);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -2751,6 +2751,15 @@ class DesktopAppServerService {
   async markThreadSeen(
     request: MarkThreadSeenRequest,
   ): Promise<MarkThreadSeenResponse> {
+    if (
+      request.federationTarget
+      && isRemoteFederationTarget(request.federationTarget)
+    ) {
+      const { federationTarget, ...remoteRequest } = request;
+      return await getDesktopFederationRuntime()
+        .remoteBackend(federationTarget)
+        .markThreadSeen(remoteRequest);
+    }
     const backend = request.backend ?? "codex";
 
     const response = await this.getOverlayStore().markThreadSeen({

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1536,6 +1536,9 @@ function DesktopAppShell(props: {
           onMarkThreadsSeen={
             desktopApi?.markThreadSeen ? navigation.markThreadsSeen : undefined
           }
+          onMarkThreadUnread={
+            desktopApi?.markThreadSeen ? navigation.markThreadUnread : undefined
+          }
           onRenameThread={navigation.renameThread}
           onSetThreadReaction={navigation.setThreadReaction}
           onSetThreadPin={navigation.setThreadPin}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -4890,7 +4890,9 @@ describe("Composer", () => {
       await cancellationTwo.promise;
     });
 
-    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    });
     expect(cancelQueuedTurn).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -135,6 +135,7 @@ type SidebarProps = {
   onOpenProfile?: (profile: string) => Promise<void>;
   onSelectThread: (thread: NavigationThreadSummary) => void;
   onMarkThreadsSeen?: (threads: NavigationThreadSummary[]) => Promise<void>;
+  onMarkThreadUnread?: (thread: NavigationThreadSummary) => Promise<void>;
   onArchiveThread?: (
     thread: NavigationThreadSummary,
     options?: ArchiveThreadOptions,
@@ -888,6 +889,11 @@ export function Sidebar(props: SidebarProps) {
     void props.onSetThreadPin?.(thread, !thread.pinnedRank);
   };
 
+  const markUnreadFromContextMenu = (thread: NavigationThreadSummary): void => {
+    setContextMenu(undefined);
+    void props.onMarkThreadUnread?.(thread);
+  };
+
   const openDirectoryContextMenu = (
     directory: NavigationDirectorySummary,
     position: ThreadContextMenuPosition,
@@ -1106,6 +1112,13 @@ export function Sidebar(props: SidebarProps) {
   const contextMenuCanArchive = contextMenu && !contextMenuIsBulk
     ? canArchiveThread(contextMenu.thread)
     : false;
+  const contextMenuCanMarkUnread = Boolean(
+    contextMenu &&
+      !contextMenuIsBulk &&
+      !contextMenu.thread.inbox.inInbox &&
+      contextMenu.thread.updatedAt !== undefined &&
+      props.onMarkThreadUnread,
+  );
   const contextMenuChildThreadCount = contextMenu && !contextMenuIsBulk
     ? props.threads.filter(
         (thread) =>
@@ -1189,6 +1202,7 @@ export function Sidebar(props: SidebarProps) {
     contextMenuCanUnlinkSubthread ||
     contextMenuShowMoveItems ||
     contextMenuCanRename ||
+    contextMenuCanMarkUnread ||
     contextMenuCanArchive;
   const contextMenuHasTopActions =
     contextMenuHasPinAction ||
@@ -1843,6 +1857,17 @@ export function Sidebar(props: SidebarProps) {
                       }
                     >
                       Rename Thread
+                    </button>
+                  ) : null}
+                  {contextMenuCanMarkUnread ? (
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() =>
+                        markUnreadFromContextMenu(contextMenu.thread)
+                      }
+                    >
+                      Mark Unread
                     </button>
                   ) : null}
                   {contextMenuCanArchive && contextMenuHasChildThreads ? (

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3242,6 +3242,71 @@ describe("Sidebar", () => {
     ]);
   });
 
+  it("marks a read thread unread from the thread context menu", async () => {
+    const readThread: NavigationThreadSummary = {
+      ...sharedThread,
+      inbox: {
+        inInbox: false,
+        lastSeenUpdatedAt: sharedThread.updatedAt,
+      },
+    };
+    const onMarkThreadUnread = vi.fn(async () => undefined);
+
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[readThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-1"
+        threads={[readThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onMarkThreadUnread={onMarkThreadUnread}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+    await clickElement(screen.getByRole("menuitem", { name: "Mark Unread" }));
+
+    expect(onMarkThreadUnread).toHaveBeenCalledWith(readThread);
+    expect(screen.queryByRole("menuitem", { name: "Mark Unread" }))
+      .not.toBeInTheDocument();
+  });
+
+  it("omits Mark Unread for an already-unread thread", () => {
+    render(
+      <Sidebar
+        backends={backends}
+        browseMode="recents"
+        createThreadError={undefined}
+        directories={directories}
+        inboxThreads={[updatedSinceSeenThread]}
+        launchpadError={undefined}
+        loading={false}
+        creatingThread={undefined}
+        selectedItemKey="codex:thread-updated"
+        threads={[updatedSinceSeenThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onMarkThreadUnread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open thread actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Mark Unread" }))
+      .not.toBeInTheDocument();
+  });
+
   it("flips the thread actions menu above the overflow button near the viewport bottom", () => {
     Object.defineProperty(window, "innerHeight", {
       configurable: true,

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -555,7 +555,11 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("marks a read thread unread until the user returns to it", async () => {
+  it("marks a remote read thread unread until the user returns to it", async () => {
+    const federationTarget = {
+      scope: "remote" as const,
+      instanceId: "remote-instance",
+    };
     const markThreadSeen = vi.fn(
       async (
         request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0],
@@ -579,6 +583,14 @@ describe("useThreadNavigation", () => {
           summary: "Read thread summary",
           source: "codex" as const,
           linkedDirectories: [],
+          federation: {
+            instanceLabel: "Remote Mac",
+            ref: {
+              backend: "codex" as const,
+              target: federationTarget,
+              threadId: "thread-read",
+            },
+          },
           inbox: {
             inInbox: false,
             lastSeenUpdatedAt: 2_000,
@@ -622,6 +634,7 @@ describe("useThreadNavigation", () => {
 
     expect(markThreadSeen).toHaveBeenCalledWith({
       backend: "codex",
+      federationTarget,
       threadId: "thread-read",
       seenUpdatedAt: 1_999,
     });
@@ -652,6 +665,7 @@ describe("useThreadNavigation", () => {
     await waitFor(() => {
       expect(markThreadSeen).toHaveBeenCalledWith({
         backend: "codex",
+        federationTarget,
         threadId: "thread-read",
         seenUpdatedAt: 2_000,
       });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -555,6 +555,109 @@ describe("useThreadNavigation", () => {
     });
   });
 
+  it("marks a read thread unread until the user returns to it", async () => {
+    const markThreadSeen = vi.fn(
+      async (
+        request: Parameters<NonNullable<DesktopApi["markThreadSeen"]>>[0],
+      ) => ({
+        backend: request.backend ?? "codex",
+        threadId: request.threadId,
+        seenAt: Date.now(),
+        seenUpdatedAt: request.seenUpdatedAt,
+      }),
+    );
+    const getNavigationSnapshot = vi.fn(async () => ({
+      backend: "all" as const,
+      fetchedAt: Date.now(),
+      unchanged: false,
+      inboxThreadKeys: [],
+      threads: [
+        {
+          id: "thread-read",
+          title: "Read thread",
+          titleSource: "explicit" as const,
+          summary: "Read thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+            lastSeenUpdatedAt: 2_000,
+          },
+          updatedAt: 2_000,
+        },
+        {
+          id: "thread-other",
+          title: "Other thread",
+          titleSource: "explicit" as const,
+          summary: "Other thread summary",
+          source: "codex" as const,
+          linkedDirectories: [],
+          inbox: {
+            inInbox: false,
+            lastSeenUpdatedAt: 1_500,
+          },
+          updatedAt: 1_500,
+        },
+      ],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      markThreadSeen,
+      onAgentEvent: () => () => undefined,
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads).toHaveLength(2);
+    });
+
+    await act(async () => {
+      await result.current.markThreadUnread(result.current.threads[0]!);
+    });
+
+    expect(markThreadSeen).toHaveBeenCalledWith({
+      backend: "codex",
+      threadId: "thread-read",
+      seenUpdatedAt: 1_999,
+    });
+    expect(result.current.threads[0]?.inbox).toMatchObject({
+      inInbox: true,
+      reason: "updated-since-seen",
+      lastSeenUpdatedAt: 1_999,
+    });
+    expect(result.current.snapshot?.inboxThreadKeys).toEqual([
+      "codex:thread-read",
+    ]);
+
+    act(() => {
+      result.current.selectThread(result.current.threads[1]!);
+    });
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-other",
+        seenUpdatedAt: 1_500,
+      });
+    });
+    expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+
+    act(() => {
+      result.current.selectThread(result.current.threads[0]!);
+    });
+    await waitFor(() => {
+      expect(markThreadSeen).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-read",
+        seenUpdatedAt: 2_000,
+      });
+    });
+  });
+
   it("marks the selected thread seen again when a refresh advances it", async () => {
     const listeners = new Set<(event: any) => void>();
     const markThreadSeen = vi.fn(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1314,6 +1314,65 @@ function markThreadSeenInSnapshot(
   return markThreadsSeenInSnapshot(snapshot, [params]);
 }
 
+function markThreadUnreadInSnapshot(
+  snapshot: NavigationSnapshot | undefined,
+  params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    seenUpdatedAt: number;
+  },
+): NavigationSnapshot | undefined {
+  if (!snapshot) {
+    return snapshot;
+  }
+
+  const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+  let changed = false;
+  const threads = snapshot.threads.map((thread) => {
+    if (buildThreadIdentityKey(thread.source, thread.id) !== threadKey) {
+      return thread;
+    }
+
+    changed = true;
+    return {
+      ...thread,
+      inbox: {
+        ...thread.inbox,
+        inInbox: true,
+        reason: "updated-since-seen" as const,
+        lastSeenUpdatedAt: params.seenUpdatedAt,
+      },
+    };
+  });
+
+  if (!changed) {
+    return snapshot;
+  }
+
+  const threadInboxByKey = new Map(
+    threads.map((thread) => [
+      buildThreadIdentityKey(thread.source, thread.id),
+      thread.inbox.inInbox,
+    ]),
+  );
+
+  return {
+    ...snapshot,
+    directories: snapshot.directories.map((directory) => ({
+      ...directory,
+      needsAttentionCount: directory.threadKeys.reduce(
+        (count, candidateKey) =>
+          count + (threadInboxByKey.get(candidateKey) ? 1 : 0),
+        0,
+      ),
+    })),
+    inboxThreadKeys: snapshot.inboxThreadKeys.includes(threadKey)
+      ? snapshot.inboxThreadKeys
+      : [threadKey, ...snapshot.inboxThreadKeys],
+    threads,
+  };
+}
+
 function removeThreadFromSnapshot(
   snapshot: NavigationSnapshot | undefined,
   params: {
@@ -2433,6 +2492,7 @@ export function useThreadNavigation(
   setBrowseMode: (browseMode: BrowseMode) => void;
   selectThread: (thread: NavigationThreadSummary) => void;
   markThreadsSeen: (threads: NavigationThreadSummary[]) => Promise<void>;
+  markThreadUnread: (thread: NavigationThreadSummary) => Promise<void>;
   showThread: (params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -4103,6 +4163,45 @@ export function useThreadNavigation(
       setPendingSeenThreadKey((current) =>
         current && markedThreadKeys.has(current) ? undefined : current,
       );
+    },
+    [markThreadSeen],
+  );
+
+  const markThreadUnread = useCallback(
+    async (thread: NavigationThreadSummary): Promise<void> => {
+      if (!markThreadSeen || thread.updatedAt === undefined) {
+        return;
+      }
+
+      const threadKey = buildThreadIdentityKey(thread.source, thread.id);
+      const seenUpdatedAt = Math.max(0, thread.updatedAt - 1);
+      await markThreadSeen({
+        backend: thread.source,
+        threadId: thread.id,
+        seenUpdatedAt,
+      });
+      if (!mountedRef.current) {
+        return;
+      }
+
+      manuallySelectedThreadKeysRef.current.delete(threadKey);
+      submittedSeenUpdatedAtByThreadKeyRef.current.delete(threadKey);
+      setPendingSeenThreadKey((current) =>
+        current === threadKey ? undefined : current,
+      );
+      setRetainedUnreadThread((current) =>
+        current && buildThreadIdentityKey(current.source, current.id) === threadKey
+          ? undefined
+          : current,
+      );
+      setState((current) => ({
+        ...current,
+        response: markThreadUnreadInSnapshot(current.response, {
+          backend: thread.source,
+          threadId: thread.id,
+          seenUpdatedAt,
+        }),
+      }));
     },
     [markThreadSeen],
   );
@@ -6358,6 +6457,7 @@ export function useThreadNavigation(
     setBrowseMode: updateBrowseMode,
     selectThread,
     markThreadsSeen,
+    markThreadUnread,
     showThread,
     archiveThread,
     archiveWorktree,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -3976,6 +3976,9 @@ export function useThreadNavigation(
       try {
         await markThreadSeenRequest({
           backend: threadToMarkSeen.source,
+          ...(threadToMarkSeen.federation?.ref.target
+            ? { federationTarget: threadToMarkSeen.federation.ref.target }
+            : {}),
           threadId: threadToMarkSeen.id,
           seenUpdatedAt: threadToMarkSeen.updatedAt,
         });
@@ -4122,6 +4125,9 @@ export function useThreadNavigation(
         unreadThreads.map(async (thread) => {
           await markThreadSeen({
             backend: thread.source,
+            ...(thread.federation?.ref.target
+              ? { federationTarget: thread.federation.ref.target }
+              : {}),
             threadId: thread.id,
             seenUpdatedAt: thread.updatedAt,
           });
@@ -4177,6 +4183,9 @@ export function useThreadNavigation(
       const seenUpdatedAt = Math.max(0, thread.updatedAt - 1);
       await markThreadSeen({
         backend: thread.source,
+        ...(thread.federation?.ref.target
+          ? { federationTarget: thread.federation.ref.target }
+          : {}),
         threadId: thread.id,
         seenUpdatedAt,
       });

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -971,6 +971,7 @@ export type SetNavigationBrowseModeResponse = {
 
 export type MarkThreadSeenRequest = {
   backend?: AppServerBackendKind;
+  federationTarget?: FederationTarget;
   threadId: ThreadIdentifier;
   seenAt?: number;
   seenUpdatedAt?: number;


### PR DESCRIPTION
## Summary

- add a **Mark Unread** action to the context menu for read threads
- persist the unread marker through the existing thread seen-update state
- keep a selected thread unread until the operator navigates back to it
- hide the action when a thread is already unread

## Why

Operators sometimes finish reading a thread but need a lightweight reminder to return to it later. Re-marking the thread unread restores the existing orange unread marker without introducing a separate reminder model.

## User impact

Right-clicking a read thread now offers **Mark Unread**. The thread immediately returns to the unread state and remains there until it is selected again.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (197 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`