### PR TITLE
test(desktop): harden Windows viewport sizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,14 +32,9 @@
   to removing invalid `id` fields from response items whose type is `message`.
 - Use the project-local [desktop E2E fixture seeding skill](.agents/skills/desktop-e2e-fixture-seeding/SKILL.md) when seeding or refreshing desktop replay fixtures from live captured sessions.
 - For reliable desktop E2E runs, prefer `pnpm test:desktop-e2e` from the repo root. The package-level `pnpm --filter @pwragent/desktop test:e2e` path is also safe now because it builds `apps/desktop/out/` before launching Playwright.
-- **Run disruptive macOS desktop E2E in the Tart VM lab, not on the user's
-  desktop.** Headed Electron tests flash and steal focus. If
-  `~/pwragent-mac-vm/run-e2e.sh` is present, run the suite there; windows render
-  on the guest display and the host desktop is untouched. Use
-  `~/pwragent-mac-vm/run-e2e.sh --local <repo-path> [playwright args]` for a
-  committed, unpushed HEAD. The local lab details live in the
-  `macos-vm-e2e-lab` skill at
-  [`.agents/skills/macos-vm-e2e-lab/SKILL.md`](.agents/skills/macos-vm-e2e-lab/SKILL.md).
+- **An operator may have a lab available for off-desktop Windows or macOS E2E
+  testing.** Ask the operator for a pointer to the appropriate lab repository
+  or skill before running headed desktop E2E.
 - The macOS CI lane uses the selected-repository **PwrDrvr macOS**
   organization runner group, shared only with PwrSnap. Do not add a
   repository-scoped runner or widen access to the rest of the organization.

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -22,6 +22,14 @@ const ELECTRON_FORCE_EXIT_TIMEOUT_MS = 1_000;
 
 type ElectronChildProcess = ReturnType<ElectronApplication["process"]>;
 type CloseResult = "closed" | "rejected" | "timeout";
+type RendererViewport = {
+  innerHeight: number;
+  innerWidth: number;
+};
+type NativeContentSize = {
+  height: number;
+  width: number;
+};
 
 type LaunchResult = {
   electronApp: ElectronApplication;
@@ -238,7 +246,8 @@ export async function launchElectronApp(params: {
   }
 
   if (params.windowSize) {
-    await electronApp.evaluate(
+    const targetSize = params.windowSize;
+    const windowId = await electronApp.evaluate(
       ({ BrowserWindow }, size) => {
         const window = BrowserWindow.getAllWindows()[0];
         if (!window) {
@@ -247,20 +256,56 @@ export async function launchElectronApp(params: {
 
         window.setMinimumSize(0, 0);
         window.setContentSize(size.width, size.height);
+        return window.id;
       },
-      params.windowSize
+      targetSize
     );
 
+    let attempt = 0;
+    let previousRequest: NativeContentSize | null = null;
     await expect
-      .poll(async () =>
-        await window.evaluate(() => ({
+      .poll(async () => {
+        const observed = await window.evaluate(() => ({
           innerHeight: globalThis.innerHeight,
           innerWidth: globalThis.innerWidth,
-        }))
-      )
+        }));
+        if (
+          observed.innerHeight === targetSize.height
+          && observed.innerWidth === targetSize.width
+        ) {
+          return observed;
+        }
+
+        const request = nextRendererViewportRequest({
+          attempt,
+          observed,
+          previousRequest,
+          target: targetSize,
+        });
+        previousRequest = request;
+        attempt += 1;
+
+        await electronApp.evaluate(
+          ({ BrowserWindow }, resize) => {
+            const window = BrowserWindow.fromId(resize.windowId);
+            if (!window || window.isDestroyed()) {
+              throw new Error(
+                "Expected the replay E2E BrowserWindow to remain live while resizing",
+              );
+            }
+            window.setContentSize(resize.request.width, resize.request.height);
+          },
+          { request, windowId },
+        );
+
+        return await window.evaluate(() => ({
+          innerHeight: globalThis.innerHeight,
+          innerWidth: globalThis.innerWidth,
+        }));
+      })
       .toMatchObject({
-        innerHeight: params.windowSize.height,
-        innerWidth: params.windowSize.width,
+        innerHeight: targetSize.height,
+        innerWidth: targetSize.width,
       });
   }
 
@@ -327,6 +372,43 @@ export async function launchElectronApp(params: {
       await rm(homeRoot, { recursive: true, force: true });
     },
   };
+}
+
+/**
+ * Keep exact renderer layout contracts while compensating the native content
+ * request that produces them. Under platform scaling, Electron can turn a
+ * 1440x900 setContentSize request into a 1439x901 Chromium viewport. Feeding a
+ * small observed error back into the next native request reaches the exact
+ * renderer dimensions without weakening layout assertions. Far-from-target
+ * observations get only a 1px height nudge so a stale/coalesced native resize
+ * cannot cause an unbounded correction.
+ */
+export function nextRendererViewportRequest(params: {
+  attempt: number;
+  observed: RendererViewport;
+  previousRequest: NativeContentSize | null;
+  target: NativeContentSize;
+}): NativeContentSize {
+  const widthError = params.target.width - params.observed.innerWidth;
+  const heightError = params.target.height - params.observed.innerHeight;
+  const nearTarget = (error: number): boolean => Math.abs(error) <= 2;
+  const request = {
+    width:
+      params.target.width
+      + (nearTarget(widthError) ? widthError : 0),
+    height:
+      params.target.height
+      + (nearTarget(heightError) ? heightError : params.attempt % 2),
+  };
+
+  if (
+    params.previousRequest !== null
+    && request.width === params.previousRequest.width
+    && request.height === params.previousRequest.height
+  ) {
+    request.height += params.attempt % 2 === 0 ? 1 : -1;
+  }
+  return request;
 }
 
 export function configureElectronE2eSecretStorageEnv(

--- a/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   closeElectronApplication,
   configureElectronE2eSecretStorageEnv,
+  nextRendererViewportRequest,
 } from "../../../e2e/fixtures/electron-app";
 import {
   E2E_MEMORY_SECRET_STORAGE_ENV,
@@ -35,5 +36,38 @@ describe("Electron E2E fixture teardown", () => {
 
     expect(env[SECRET_STORAGE_DISABLED_ENV]).toBe("1");
     expect(env[E2E_MEMORY_SECRET_STORAGE_ENV]).toBeUndefined();
+  });
+
+  it("compensates a near-target renderer size exactly", () => {
+    expect(
+      nextRendererViewportRequest({
+        attempt: 0,
+        observed: { innerWidth: 1439, innerHeight: 901 },
+        previousRequest: null,
+        target: { width: 1440, height: 900 },
+      }),
+    ).toEqual({ width: 1441, height: 899 });
+  });
+
+  it("nudges stale far-from-target resizes without feeding back a large error", () => {
+    expect(
+      nextRendererViewportRequest({
+        attempt: 1,
+        observed: { innerWidth: 1200, innerHeight: 760 },
+        previousRequest: { width: 1440, height: 900 },
+        target: { width: 1440, height: 900 },
+      }),
+    ).toEqual({ width: 1440, height: 901 });
+  });
+
+  it("forces a real native frame change when compensation repeats", () => {
+    expect(
+      nextRendererViewportRequest({
+        attempt: 1,
+        observed: { innerWidth: 1439, innerHeight: 901 },
+        previousRequest: { width: 1441, height: 899 },
+        target: { width: 1440, height: 900 },
+      }),
+    ).toEqual({ width: 1441, height: 898 });
   });
 });


### PR DESCRIPTION
## What changed

- compensate exact Electron renderer viewport requests from observed near-target error while preserving strict `innerWidth`/`innerHeight` contracts
- cover the 1439x901-to-1440x900 correction, stale-size nudging, and repeated-request behavior with focused unit tests
- keep repository lab guidance generic: ask the operator for a pointer to an available off-desktop Windows or macOS E2E lab repository or skill

## Why

PwrAgent's shared E2E fixture made one exact `setContentSize` request and then required exact renderer dimensions. Under platform scaling, Electron can map a 1440x900 native content request to a 1439x901 Chromium viewport. The fixture now compensates the native request from renderer truth without broadening layout assertions or timeouts.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test apps/desktop/src/main/__tests__/electron-e2e-fixture.test.ts apps/desktop/src/main/__tests__/electron-app-close.test.ts` — 2 files / 7 tests passed
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` — 0 errors; 139 existing warnings
- `pnpm build`
- `pnpm lint:boundaries` — 1209 modules / 3791 dependencies; no violations
- `pnpm lint:codex-storage`
- `git diff --check`

No headed E2E ran on the user's desktop. Focused repeated Windows E2E remains follow-up validation through an operator-provided off-desktop lab.
