### PR TITLE
fix(messaging): infer review project from working state

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -8,6 +8,7 @@ import type {
   ArchiveThreadRequest,
   AppServerListThreadsRequest,
   AppServerReadThreadResponse,
+  AppServerThreadSummary,
   GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   MarkThreadSeenRequest,
@@ -16,6 +17,7 @@ import type {
   RenameThreadRequest,
   RestoreWorktreeRequest,
   RestoreThreadRequest,
+  ThreadGitWorkingState,
 } from "@pwragent/shared";
 
 const mockAppServerLog = vi.hoisted(() => ({
@@ -280,7 +282,21 @@ const readDirectoryGitStatusCache = vi.fn(async () => ({}));
 const writeDirectoryGitStatusCacheEntry = vi.fn(async () => undefined);
 const invalidateDirectoryStatus = vi.fn((_directoryPath?: string) => undefined);
 const readThreadGitWorkingStateCache = vi.fn(async () => ({}));
-const writeThreadGitWorkingStateCacheEntry = vi.fn(async () => undefined);
+const writeThreadGitWorkingStateCacheEntry = vi.fn(async (_entry?: {
+  worktreePath: string;
+  fetchedAt: number;
+  gitWorkingState?: ThreadGitWorkingState;
+}) => undefined);
+const hydrateThreadGitWorkingStates = vi.fn(
+  async (threads: AppServerThreadSummary[]) => threads,
+);
+const rememberThreadGitWorkingStateCacheEntry = vi.fn(async (entry: {
+  worktreePath: string;
+  fetchedAt: number;
+  gitWorkingState?: ThreadGitWorkingState;
+}) => {
+  await writeThreadGitWorkingStateCacheEntry(entry);
+});
 type WorkingStateEntry = {
   worktreePath: string;
   gitWorkingState?: {
@@ -689,6 +705,8 @@ vi.mock("../app-server/backend-registry", () => {
     readDirectoryStatusEntries,
     invalidateDirectoryStatus,
     readWorktreeWorkingStateEntries,
+    hydrateThreadGitWorkingStates,
+    rememberThreadGitWorkingStateCacheEntry,
     invalidateWorktreeWorkingState,
     resolveEditCommitStates,
     onEvent,
@@ -779,6 +797,11 @@ describe("app server ipc", () => {
     readThreadGitWorkingStateCache.mockClear();
     readThreadGitWorkingStateCache.mockResolvedValue({});
     writeThreadGitWorkingStateCacheEntry.mockClear();
+    hydrateThreadGitWorkingStates.mockClear();
+    hydrateThreadGitWorkingStates.mockImplementation(
+      async (threads: AppServerThreadSummary[]) => threads,
+    );
+    rememberThreadGitWorkingStateCacheEntry.mockClear();
     readWorktreeWorkingStateEntries.mockClear();
     resolveEditCommitStates.mockClear();
     releaseEditCommitResolve = undefined;

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -723,6 +723,7 @@ vi.mock("../app-server/backend-registry", () => {
   };
   backendRegistryLifecycle.get.mockImplementation(() => registry);
   return {
+    WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS: 30_000,
     disposeDesktopBackendRegistry: vi.fn(async () => undefined),
     getDesktopBackendRegistry: backendRegistryLifecycle.get,
     getExistingDesktopBackendRegistry: () =>

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -61,6 +61,7 @@ import {
   type CodexEnvironmentCommandRunner,
 } from "../app-server/codex-environment-runtime";
 import { GitDirectoryService } from "../app-server/git-directory-service";
+import type { GitWorkingStateService } from "../app-server/git-working-state-service";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
 import type { WorktreeArchiveService } from "../app-server/worktree-archive-service";
 import type { AcpInstalledAgentRecord } from "../acp/acp-registry-types";
@@ -2315,6 +2316,151 @@ describe("DesktopBackendRegistry", () => {
       expect(events).toEqual([]);
     } finally {
       unsubscribe();
+      await registry.close();
+    }
+  });
+
+  it("hydrates review working state from the shared navigation cache", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+      baseAheadCommitCount: 16,
+    };
+    const writeThreadGitWorkingStateCacheEntry = vi.fn(async () => undefined);
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({
+        [worktreePath]: {
+          worktreePath,
+          fetchedAt: 1_000,
+          gitWorkingState,
+        },
+      })),
+      writeThreadGitWorkingStateCacheEntry,
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      overlayStore,
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath,
+        },
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+      ],
+    };
+
+    try {
+      await expect(
+        registry.hydrateThreadGitWorkingStates([thread]),
+      ).resolves.toEqual([{ ...thread, gitWorkingState }]);
+
+      const updatedState = { ...gitWorkingState, baseAheadCommitCount: 17 };
+      await registry.rememberThreadGitWorkingStateCacheEntry({
+        worktreePath,
+        fetchedAt: 2_000,
+        gitWorkingState: updatedState,
+      });
+      await expect(
+        registry.hydrateThreadGitWorkingStates([thread]),
+      ).resolves.toEqual([{ ...thread, gitWorkingState: updatedState }]);
+      expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledWith({
+        worktreePath,
+        fetchedAt: 2_000,
+        gitWorkingState: updatedState,
+      });
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("probes missing working state for a multi-project messaging review", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+      baseAheadCommitCount: 16,
+    };
+    const readWorkingStateEntries = vi.fn(() =>
+      (async function* () {
+        yield { worktreePath, gitWorkingState };
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath,
+        },
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+      ],
+    };
+
+    try {
+      await expect(
+        registry.hydrateThreadGitWorkingStates(
+          [thread],
+          { probeMissing: true },
+        ),
+      ).resolves.toEqual([{ ...thread, gitWorkingState }]);
+      expect(readWorkingStateEntries).toHaveBeenCalledWith([worktreePath]);
+      expect(overlayStore.writeThreadGitWorkingStateCacheEntry)
+        .toHaveBeenCalledWith(expect.objectContaining({
+          worktreePath,
+          gitWorkingState,
+        }));
+    } finally {
       await registry.close();
     }
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -38,6 +38,7 @@ import type {
   NavigationLaunchpadDraft,
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
+  PrSummary,
   TaskMonitorRequest,
   TaskMonitorResponse,
   ThreadExecutionMode,
@@ -2454,12 +2455,194 @@ describe("DesktopBackendRegistry", () => {
           { probeMissing: true },
         ),
       ).resolves.toEqual([{ ...thread, gitWorkingState }]);
-      expect(readWorkingStateEntries).toHaveBeenCalledWith([worktreePath]);
+      expect(readWorkingStateEntries).toHaveBeenCalledWith(
+        [worktreePath],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            [worktreePath]: [],
+          },
+        },
+      );
       expect(overlayStore.writeThreadGitWorkingStateCacheEntry)
         .toHaveBeenCalledWith(expect.objectContaining({
           worktreePath,
           gitWorkingState,
         }));
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("reprobes stale cached working state for a multi-project messaging review", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const staleGitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+      baseAheadCommitCount: 1,
+    };
+    const freshGitWorkingState = {
+      ...staleGitWorkingState,
+      baseAheadCommitCount: 16,
+    };
+    const readWorkingStateEntries = vi.fn(() =>
+      (async function* () {
+        yield { worktreePath, gitWorkingState: freshGitWorkingState };
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({
+        [worktreePath]: {
+          worktreePath,
+          fetchedAt: Date.now() - 31_000,
+          gitWorkingState: staleGitWorkingState,
+        },
+      })),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath,
+        },
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+      ],
+    };
+
+    try {
+      await expect(
+        registry.hydrateThreadGitWorkingStates(
+          [thread],
+          { probeMissing: true },
+        ),
+      ).resolves.toEqual([{ ...thread, gitWorkingState: freshGitWorkingState }]);
+      expect(readWorkingStateEntries).toHaveBeenCalledTimes(1);
+    } finally {
+      await registry.close();
+    }
+  });
+
+  it("preserves merged PR commit exclusions in review working-state probes", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const attachedCommitSha = "a".repeat(40);
+    const detachedCommitSha = "b".repeat(40);
+    const mergedPr = (params: {
+      number: number;
+      commitShas: string[];
+    }): PrSummary => ({
+      provider: "github.com",
+      number: params.number,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      state: "merged",
+      lifecycleState: "merged",
+      commitShas: params.commitShas,
+      url: `https://github.com/pwrdrvr/PwrAgent/pull/${params.number}`,
+    });
+    const readWorkingStateEntries = vi.fn(() =>
+      (async function* () {
+        yield {
+          worktreePath,
+          gitWorkingState: {
+            dirtyFiles: 0,
+            dirtyAdditions: 0,
+            dirtyDeletions: 0,
+            untrackedFiles: 0,
+            unpushedCommits: 0,
+            baseBranch: "main",
+            baseAheadCommitCount: 16,
+          },
+        };
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex",
+            threadId: "thread-1",
+            extraLinkedDirectories: [],
+            detachedPrs: [mergedPr({
+              number: 734,
+              commitShas: [detachedCommitSha],
+            })],
+          },
+        },
+      }),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      grokClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+    const thread: AppServerThreadSummary & { prs: PrSummary[] } = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath,
+        },
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+      ],
+      prs: [mergedPr({ number: 735, commitShas: [attachedCommitSha] })],
+    };
+
+    try {
+      await registry.hydrateThreadGitWorkingStates(
+        [thread],
+        { probeMissing: true },
+      );
+      expect(readWorkingStateEntries).toHaveBeenCalledWith(
+        [worktreePath],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            [worktreePath]: [attachedCommitSha, detachedCommitSha],
+          },
+        },
+      );
     } finally {
       await registry.close();
     }

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -43,7 +43,7 @@ vi.mock("../app-server/desktop-overlay-store", () => ({
 describe("DesktopMessagingBackendBridge", () => {
   it("hydrates review working state before the messenger chooses a project", async () => {
     const pwrAgentWorktree = "/worktrees/PwrAgnt";
-    const thread: AppServerThreadSummary = {
+    const listedThread: AppServerThreadSummary = {
       id: "thread-1",
       title: "PwrAgent federation dogfood PR #735",
       titleSource: "explicit",
@@ -57,6 +57,12 @@ describe("DesktopMessagingBackendBridge", () => {
           path: "/repos/PwrAgnt",
           worktreePath: pwrAgentWorktree,
         },
+      ],
+    };
+    const reconciledThread: NavigationSnapshot["threads"][number] = {
+      ...listedThread,
+      linkedDirectories: [
+        ...listedThread.linkedDirectories,
         {
           id: "pwrsnap",
           kind: "local",
@@ -64,6 +70,7 @@ describe("DesktopMessagingBackendBridge", () => {
           path: "/repos/PwrSnap",
         },
       ],
+      inbox: { inInbox: false },
     };
     const gitWorkingState = {
       dirtyFiles: 0,
@@ -74,12 +81,26 @@ describe("DesktopMessagingBackendBridge", () => {
       baseBranch: "main",
       baseAheadCommitCount: 16,
     };
+    reconcileNavigationSnapshot.mockResolvedValueOnce({
+      backend: "codex",
+      fetchedAt: 1_000,
+      unchanged: false,
+      threads: [reconciledThread],
+      inboxThreadKeys: [],
+      directories: [],
+      launchpadDefaults: {
+        backend: "codex",
+        executionMode: "default",
+      },
+    });
     const registry = {
       getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
-      hydrateThreadGitWorkingStates: vi.fn(async () => [
-        { ...thread, gitWorkingState },
-      ]),
-      listThreads: vi.fn(async () => [thread]),
+      hydrateThreadGitWorkingStates: vi.fn(async (
+        threads: NavigationSnapshot["threads"],
+      ) =>
+        threads.map((thread) => ({ ...thread, gitWorkingState }))
+      ),
+      listThreads: vi.fn(async () => [listedThread]),
       readDirectoryStatuses: vi.fn(async () => ({})),
       rememberCompleteNavigationSnapshot: vi.fn(),
     } as unknown as DesktopBackendRegistry;
@@ -88,7 +109,7 @@ describe("DesktopMessagingBackendBridge", () => {
     const snapshot = await bridge.getNavigationSnapshot({ backend: "codex" });
 
     expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
-      [thread],
+      [reconciledThread],
       { probeMissing: true },
     );
     expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import { findPreferredReviewWorkspaceCwd } from "@pwragent/shared";
 import type {
   AgentEvent,
+  AppServerThreadSummary,
   AppServerReadThreadResponse,
   AppServerThreadReplay,
   NavigationSnapshot,
@@ -12,7 +14,88 @@ import {
   type DesktopMessagingFederationBridge,
 } from "../messaging/desktop-backend-bridge";
 
+const { reconcileNavigationSnapshot } = vi.hoisted(() => ({
+  reconcileNavigationSnapshot: vi.fn(async (params: {
+    backend: NavigationSnapshot["backend"];
+    fetchedAt: number;
+    threads: AppServerThreadSummary[];
+  }): Promise<NavigationSnapshot> => ({
+    backend: params.backend,
+    fetchedAt: params.fetchedAt,
+    unchanged: false,
+    threads: params.threads.map((thread) => ({
+      ...thread,
+      inbox: { inInbox: false },
+    })),
+    inboxThreadKeys: [],
+    directories: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+  })),
+}));
+
+vi.mock("../app-server/desktop-overlay-store", () => ({
+  getDesktopOverlayStore: () => ({ reconcileNavigationSnapshot }),
+}));
+
 describe("DesktopMessagingBackendBridge", () => {
+  it("hydrates review working state before the messenger chooses a project", async () => {
+    const pwrAgentWorktree = "/worktrees/PwrAgnt";
+    const thread: AppServerThreadSummary = {
+      id: "thread-1",
+      title: "PwrAgent federation dogfood PR #735",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: pwrAgentWorktree,
+      linkedDirectories: [
+        {
+          id: "pwragent",
+          kind: "worktree",
+          label: "PwrAgnt",
+          path: "/repos/PwrAgnt",
+          worktreePath: pwrAgentWorktree,
+        },
+        {
+          id: "pwrsnap",
+          kind: "local",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+        },
+      ],
+    };
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+      baseAheadCommitCount: 16,
+    };
+    const registry = {
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      hydrateThreadGitWorkingStates: vi.fn(async () => [
+        { ...thread, gitWorkingState },
+      ]),
+      listThreads: vi.fn(async () => [thread]),
+      readDirectoryStatuses: vi.fn(async () => ({})),
+      rememberCompleteNavigationSnapshot: vi.fn(),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+
+    const snapshot = await bridge.getNavigationSnapshot({ backend: "codex" });
+
+    expect(registry.hydrateThreadGitWorkingStates).toHaveBeenCalledWith(
+      [thread],
+      { probeMissing: true },
+    );
+    expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
+      pwrAgentWorktree,
+    );
+  });
+
   it("preserves enriched messaging provenance when starting a turn", async () => {
     const submitTurn = vi.fn(async (request) => ({
       status: "started" as const,

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -7,7 +7,10 @@ import type {
   FederationProtocolEnvelope,
   NavigationSnapshot,
 } from "@pwragent/shared";
-import { FEDERATION_PROTOCOL_VERSION } from "@pwragent/shared";
+import {
+  FEDERATION_PROTOCOL_VERSION,
+  findPreferredReviewWorkspaceCwd,
+} from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
@@ -94,6 +97,16 @@ function createConnection(params: {
 
 describe("DesktopFederationRuntime", () => {
   it("preserves renderer-compatible thread keys in remote navigation lenses", async () => {
+    const pwrAgentWorktree = "/worktrees/PwrAgnt";
+    const gitWorkingState = {
+      dirtyFiles: 0,
+      dirtyAdditions: 0,
+      dirtyDeletions: 0,
+      untrackedFiles: 0,
+      unpushedCommits: 0,
+      baseBranch: "main",
+      baseAheadCommitCount: 16,
+    };
     const response: NavigationSnapshot = {
       backend: "all",
       fetchedAt: 1_000,
@@ -103,7 +116,23 @@ describe("DesktopFederationRuntime", () => {
           id: "thread-1",
           title: "Remote work",
           titleSource: "fallback",
-          linkedDirectories: [],
+          projectKey: pwrAgentWorktree,
+          linkedDirectories: [
+            {
+              id: "pwragent",
+              kind: "worktree",
+              label: "PwrAgnt",
+              path: "/repos/PwrAgnt",
+              worktreePath: pwrAgentWorktree,
+            },
+            {
+              id: "pwrsnap",
+              kind: "local",
+              label: "PwrSnap",
+              path: "/repos/PwrSnap",
+            },
+          ],
+          gitWorkingState,
           source: "codex",
           inbox: { inInbox: false },
         },
@@ -159,6 +188,10 @@ describe("DesktopFederationRuntime", () => {
     });
     expect(snapshot.inboxThreadKeys).toEqual([]);
     expect(snapshot.directories[0]?.threadKeys).toEqual(["codex:thread-1"]);
+    expect(snapshot.threads[0]?.gitWorkingState).toEqual(gitWorkingState);
+    expect(findPreferredReviewWorkspaceCwd(snapshot.threads[0])).toBe(
+      pwrAgentWorktree,
+    );
   });
 
   it("records gateway-advertised peers for client instance health and opening", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17,7 +17,11 @@ import type {
 } from "@pwragent/messaging-interface";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getAppStateDb, getAppStateMode } from "../state/app-state";
-import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
+import type {
+  OverlayStoreLike,
+  SqliteOverlayStore,
+  WorktreeGitWorkingStateCacheEntry,
+} from "../state/overlay-store-sqlite";
 import { requestShowThread } from "../window-show-thread";
 import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
@@ -717,6 +721,30 @@ function resolveThreadWorkspaceCwd(
     resolveLinkedDirectoryWorkspaceCwd(overlayDirectories) ??
     thread.projectKey
   );
+}
+
+function resolveThreadWorkingStatePath(
+  thread: Pick<AppServerThreadSummary, "projectKey" | "linkedDirectories">,
+): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey) {
+    return projectKey;
+  }
+
+  for (const directory of thread.linkedDirectories) {
+    const worktreePath = directory.worktreePath?.trim();
+    if (worktreePath) {
+      return worktreePath;
+    }
+  }
+
+  for (const directory of thread.linkedDirectories) {
+    if (directory.kind === "local" && directory.path.trim()) {
+      return directory.path.trim();
+    }
+  }
+
+  return undefined;
 }
 
 function linkedDirectoriesHaveSameWorkspaceIdentity(
@@ -5889,6 +5917,14 @@ type CodexRetryableTurnStart = {
   turnId?: string;
 };
 
+type BackendRegistryOverlayStoreLike = OverlayStoreLike & Partial<
+  Pick<
+    SqliteOverlayStore,
+    | "readThreadGitWorkingStateCache"
+    | "writeThreadGitWorkingStateCacheEntry"
+  >
+>;
+
 type PendingCodexInvalidIdRecovery = CodexRetryableTurnStart & {
   audit: ThreadCodexInvalidIdRecovery;
   failureMessage: string;
@@ -5930,9 +5966,14 @@ function buildCodexInvalidIdRecoveryCooldownMessage(
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
-  private readonly overlayStore: OverlayStoreLike;
+  private readonly overlayStore: BackendRegistryOverlayStoreLike;
   private readonly gitDirectoryService: GitDirectoryService;
   private readonly gitWorkingStateService: GitWorkingStateService;
+  private readonly workingStateByWorktree = new Map<
+    string,
+    WorktreeGitWorkingStateCacheEntry
+  >();
+  private workingStateCacheLoad: Promise<void> | undefined;
   private readonly gitWorkspaceHandoffService: GitWorkspaceHandoffService;
   private readonly worktreeArchiveService: WorktreeArchiveService;
   private readonly acpBackend: AcpBackendAdapter;
@@ -6228,7 +6269,7 @@ export class DesktopBackendRegistry {
   constructor(options?: {
     codexClient?: BackendClient;
     grokClient?: BackendClient;
-    overlayStore?: OverlayStoreLike;
+    overlayStore?: BackendRegistryOverlayStoreLike;
     gitDirectoryService?: GitDirectoryService;
     gitWorkingStateService?: GitWorkingStateService;
     gitWorkspaceHandoffService?: GitWorkspaceHandoffService;
@@ -8948,6 +8989,107 @@ export class DesktopBackendRegistry {
     options?: GitWorkingStateEntryOptions,
   ): AsyncIterable<WorktreeWorkingStateEntry> {
     return this.gitWorkingStateService.readWorkingStateEntries(worktreePaths, options);
+  }
+
+  /**
+   * Hydrate the durable working-state view at the backend boundary so every
+   * navigation consumer (renderer IPC, messaging, and future transports) sees
+   * the same review-selection evidence. Normal navigation only reads the
+   * durable cache. An explicit messenger review may opt into probing unresolved
+   * multi-project threads so its picker cannot race the background refresh.
+   */
+  async hydrateThreadGitWorkingStates<Thread extends AppServerThreadSummary>(
+    threads: Thread[],
+    options: { probeMissing?: boolean } = {},
+  ): Promise<Thread[]> {
+    const candidates = threads.filter(
+      (thread) => !thread.gitWorkingState && resolveThreadWorkingStatePath(thread),
+    );
+    if (candidates.length === 0) {
+      return threads;
+    }
+
+    await this.loadThreadGitWorkingStateCache();
+    let hydrated = this.applyCachedThreadGitWorkingStates(threads);
+    if (!options.probeMissing) {
+      return hydrated;
+    }
+
+    const missingPaths = [
+      ...new Set(
+        hydrated.flatMap((thread) => {
+          if (thread.gitWorkingState || thread.linkedDirectories.length <= 1) {
+            return [];
+          }
+          const worktreePath = resolveThreadWorkingStatePath(thread);
+          return worktreePath ? [worktreePath] : [];
+        }),
+      ),
+    ];
+    if (missingPaths.length === 0) {
+      return hydrated;
+    }
+
+    try {
+      for await (const entry of this.gitWorkingStateService.readWorkingStateEntries(
+        missingPaths,
+      )) {
+        await this.rememberThreadGitWorkingStateCacheEntry({
+          ...entry,
+          fetchedAt: Date.now(),
+        });
+      }
+    } catch (error) {
+      backendRegistryLog.warn("review working-state probe failed", {
+        error: error instanceof Error ? error.message : String(error),
+        worktreePaths: missingPaths,
+      });
+      return this.applyCachedThreadGitWorkingStates(hydrated);
+    }
+
+    hydrated = this.applyCachedThreadGitWorkingStates(hydrated);
+    return hydrated;
+  }
+
+  private applyCachedThreadGitWorkingStates<Thread extends AppServerThreadSummary>(
+    threads: Thread[],
+  ): Thread[] {
+    return threads.map((thread) => {
+      if (thread.gitWorkingState) {
+        return thread;
+      }
+      const worktreePath = resolveThreadWorkingStatePath(thread);
+      const gitWorkingState = worktreePath
+        ? this.workingStateByWorktree.get(worktreePath)?.gitWorkingState
+        : undefined;
+      return gitWorkingState ? { ...thread, gitWorkingState } : thread;
+    });
+  }
+
+  async rememberThreadGitWorkingStateCacheEntry(
+    entry: WorktreeGitWorkingStateCacheEntry,
+  ): Promise<void> {
+    await this.loadThreadGitWorkingStateCache();
+    this.workingStateByWorktree.set(entry.worktreePath, entry);
+    await this.overlayStore.writeThreadGitWorkingStateCacheEntry?.(entry);
+  }
+
+  private async loadThreadGitWorkingStateCache(): Promise<void> {
+    if (!this.workingStateCacheLoad) {
+      this.workingStateCacheLoad = (async () => {
+        const entries =
+          await this.overlayStore.readThreadGitWorkingStateCache?.() ?? {};
+        for (const entry of Object.values(entries)) {
+          this.workingStateByWorktree.set(entry.worktreePath, entry);
+        }
+      })().catch((error) => {
+        this.workingStateCacheLoad = undefined;
+        backendRegistryLog.warn("thread working-state cache load failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+    await this.workingStateCacheLoad;
   }
 
   invalidateWorktreeWorkingState(worktreePath?: string): void {
@@ -14625,6 +14767,8 @@ export class DesktopBackendRegistry {
   async close(): Promise<void> {
     this.closed = true;
     this.acceptedSteerRequests.clear();
+    this.workingStateByWorktree.clear();
+    this.workingStateCacheLoad = undefined;
     if (this.taskMonitorWatchdogTimer) {
       clearInterval(this.taskMonitorWatchdogTimer);
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -747,6 +747,27 @@ function resolveThreadWorkingStatePath(
   return undefined;
 }
 
+// Per-worktree working state changes as the agent edits/commits, but each
+// such turn pushes a fresh probe, so the background freshness window only
+// needs to catch out-of-band changes (terminal/IDE edits) on the next
+// snapshot. Shorter than the per-repo directory status TTL.
+export const WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS = 30_000;
+
+function isFreshThreadGitWorkingStateCacheEntry(
+  entry: WorktreeGitWorkingStateCacheEntry,
+  now: number,
+): boolean {
+  return now - entry.fetchedAt < WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS;
+}
+
+function mergedPrCommitShas(prs: PrSummary[]): string[] {
+  return prs
+    .filter((pr) => pr.lifecycleState === "merged" || pr.state === "merged")
+    .flatMap((pr) => pr.commitShas ?? [])
+    .map((sha) => sha.trim().toLowerCase())
+    .filter((sha) => /^[0-9a-f]{40}$/.test(sha));
+}
+
 function linkedDirectoriesHaveSameWorkspaceIdentity(
   left: LinkedDirectorySummary,
   right: LinkedDirectorySummary,
@@ -9010,29 +9031,42 @@ export class DesktopBackendRegistry {
     }
 
     await this.loadThreadGitWorkingStateCache();
-    let hydrated = this.applyCachedThreadGitWorkingStates(threads);
+    const hydrated = this.applyCachedThreadGitWorkingStates(threads);
     if (!options.probeMissing) {
       return hydrated;
     }
 
-    const missingPaths = [
+    const now = Date.now();
+    const probePaths = [
       ...new Set(
-        hydrated.flatMap((thread) => {
-          if (thread.gitWorkingState || thread.linkedDirectories.length <= 1) {
+        candidates.flatMap((thread) => {
+          if (thread.linkedDirectories.length <= 1) {
             return [];
           }
           const worktreePath = resolveThreadWorkingStatePath(thread);
-          return worktreePath ? [worktreePath] : [];
+          if (!worktreePath) {
+            return [];
+          }
+          const cached = this.workingStateByWorktree.get(worktreePath);
+          return !cached || !isFreshThreadGitWorkingStateCacheEntry(cached, now)
+            ? [worktreePath]
+            : [];
         }),
       ),
     ];
-    if (missingPaths.length === 0) {
+    if (probePaths.length === 0) {
       return hydrated;
     }
 
     try {
+      const acceptedPushedCommitShasByWorktreePath =
+        await this.readAcceptedMergedPrCommitShasByWorktreePath(
+          threads,
+          probePaths,
+        );
       for await (const entry of this.gitWorkingStateService.readWorkingStateEntries(
-        missingPaths,
+        probePaths,
+        { acceptedPushedCommitShasByWorktreePath },
       )) {
         await this.rememberThreadGitWorkingStateCacheEntry({
           ...entry,
@@ -9042,13 +9076,51 @@ export class DesktopBackendRegistry {
     } catch (error) {
       backendRegistryLog.warn("review working-state probe failed", {
         error: error instanceof Error ? error.message : String(error),
-        worktreePaths: missingPaths,
+        worktreePaths: probePaths,
       });
-      return this.applyCachedThreadGitWorkingStates(hydrated);
+      return hydrated;
     }
 
-    hydrated = this.applyCachedThreadGitWorkingStates(hydrated);
-    return hydrated;
+    return this.applyCachedThreadGitWorkingStates(threads);
+  }
+
+  private async readAcceptedMergedPrCommitShasByWorktreePath<
+    Thread extends AppServerThreadSummary,
+  >(
+    threads: Thread[],
+    worktreePaths: string[],
+  ): Promise<Record<string, string[]>> {
+    const acceptedByWorktreePath = new Map(
+      worktreePaths.map((worktreePath) => [worktreePath, new Set<string>()]),
+    );
+    await Promise.all(threads.map(async (thread) => {
+      const worktreePath = resolveThreadWorkingStatePath(thread);
+      const accepted = worktreePath
+        ? acceptedByWorktreePath.get(worktreePath)
+        : undefined;
+      if (!accepted) {
+        return;
+      }
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+      const visiblePrs = (thread as Thread & { prs?: PrSummary[] }).prs ?? [];
+      const prs = [
+        ...visiblePrs,
+        ...(overlay?.prs ?? []),
+        ...(overlay?.detachedPrs ?? []),
+      ];
+      for (const commitSha of mergedPrCommitShas(prs)) {
+        accepted.add(commitSha);
+      }
+    }));
+    return Object.fromEntries(
+      [...acceptedByWorktreePath].map(([worktreePath, commitShas]) => [
+        worktreePath,
+        [...commitShas].sort(),
+      ]),
+    );
   }
 
   private applyCachedThreadGitWorkingStates<Thread extends AppServerThreadSummary>(

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -155,6 +155,7 @@ import {
   disposeDesktopBackendRegistry,
   getExistingDesktopBackendRegistry,
   getDesktopBackendRegistry,
+  WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS,
 } from "../app-server/backend-registry";
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
@@ -298,12 +299,6 @@ const STARTUP_WORKTREE_WORKING_STATE_REFRESH_LIMIT = 8;
 const PR_DISCOVERY_TICK_INTERVAL_MS = 60_000;
 const PR_DISCOVERY_CADENCE_MS = 5 * 60_000;
 const PR_DISCOVERY_MAX_PER_TICK = 3;
-// Per-worktree working state changes as the agent edits/commits, but each
-// such turn pushes a fresh probe, so the background freshness window only
-// needs to catch out-of-band changes (terminal/IDE edits) on the next
-// snapshot. Shorter than the per-repo directory status TTL.
-const WORKTREE_WORKING_STATE_CACHE_MAX_AGE_MS = 30_000;
-
 type AppServerOverlayStoreLike = OverlayStoreLike &
   Pick<
     SqliteOverlayStore,

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1743,9 +1743,11 @@ class DesktopAppServerService {
       canonicalSnapshot.threads,
       detachedPrsByThreadKey,
     );
-    const threadsWithWorkingState =
-      threadsWithPrimaryGitRepositories.map((thread) =>
-        this.applyCachedWorktreeWorkingState(thread),
+    const threadsWithWorkingState = await getDesktopBackendRegistry()
+      .hydrateThreadGitWorkingStates(
+        threadsWithPrimaryGitRepositories.map((thread) =>
+          this.applyCachedWorktreeWorkingState(thread),
+        ),
       );
     this.startWorktreeWorkingStateRefresh({
       automatic: true,
@@ -2628,7 +2630,8 @@ class DesktopAppServerService {
       ...(params.gitWorkingState ? { gitWorkingState: params.gitWorkingState } : {}),
     };
     this.workingStateByWorktree.set(params.worktreePath, cacheEntry);
-    await this.getOverlayStore().writeThreadGitWorkingStateCacheEntry(cacheEntry);
+    await getDesktopBackendRegistry()
+      .rememberThreadGitWorkingStateCacheEntry(cacheEntry);
 
     // Skip the push when the probed value is identical to what clients
     // already hold — avoids a snapshot patch + re-render on every idle

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -109,11 +109,9 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       maxPages: request.refreshMode === "active-recent" ? 1 : undefined,
       skipArchivedMetadataRefresh: request.refreshMode === "active-recent",
     });
-    const threads = await this.registry.hydrateThreadGitWorkingStates(
+    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(
       listedThreads,
-      { probeMissing: true },
     );
-    const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const queuedExecutionModesByThreadKey =
       this.registry.getQueuedExecutionModesSnapshot();
     const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
@@ -121,23 +119,31 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       fetchedAt: Date.now(),
       messagingBindingsByThreadKey,
       queuedExecutionModesByThreadKey,
-      threads,
+      threads: listedThreads,
       workspaceRoots: resolveScratchProjectsRoots(),
     });
+    const threads = await this.registry.hydrateThreadGitWorkingStates(
+      snapshot.threads,
+      { probeMissing: true },
+    );
+    const hydratedSnapshot = {
+      ...snapshot,
+      threads,
+    };
     if (
       backend === "all"
       && !request.filter?.trim()
       && request.refreshMode !== "active-recent"
     ) {
-      this.registry.rememberCompleteNavigationSnapshot(snapshot);
+      this.registry.rememberCompleteNavigationSnapshot(hydratedSnapshot);
     }
     const directoryStatuses = await this.registry.readDirectoryStatuses(
-      snapshot.directories,
+      hydratedSnapshot.directories,
     );
 
     const localSnapshot: NavigationSnapshot = {
-      ...snapshot,
-      directories: snapshot.directories.map((directory) => ({
+      ...hydratedSnapshot,
+      directories: hydratedSnapshot.directories.map((directory) => ({
         ...directory,
         gitStatus: directoryStatuses[directory.key],
       })),

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -100,7 +100,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       );
     }
     const backend = request.backend ?? "all";
-    const threads = await this.registry.listThreads({
+    const listedThreads = await this.registry.listThreads({
       backend: backend === "all" ? undefined : backend,
       callerReason: "messaging-navigation-snapshot",
       filter: request.filter,
@@ -109,6 +109,10 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
       maxPages: request.refreshMode === "active-recent" ? 1 : undefined,
       skipArchivedMetadataRefresh: request.refreshMode === "active-recent",
     });
+    const threads = await this.registry.hydrateThreadGitWorkingStates(
+      listedThreads,
+      { probeMissing: true },
+    );
     const messagingBindingsByThreadKey = await buildMessagingBindingsByThreadKey(threads);
     const queuedExecutionModesByThreadKey =
       this.registry.getQueuedExecutionModesSnapshot();


### PR DESCRIPTION
## Summary

- hydrate thread Git working state at the backend registry boundary so desktop IPC, messaging, and federation navigation share the same review-selection evidence
- reconcile overlay-linked directories before deciding whether a multi-project review needs a working-state probe
- re-probe stale working-state cache entries using the same 30-second freshness window as desktop navigation
- preserve attached and detached merged-PR commit exclusions during review probes
- add messenger-bus, registry, and federation regressions for the PwrAgent/PwrSnap multi-project case

## Root cause

The preferred review-project helper was already shared, but its gitWorkingState input was hydrated only by the renderer-facing IPC service. The messaging bridge built a separate navigation snapshot directly from registry thread data, so /review saw the linked projects without the ahead-of-base state and rendered Project: [needs selection].

Federation navigation delegates to that same messaging bridge on the machine that owns the thread. The owner now hydrates the reconciled snapshot before returning it, and the federation projection preserves the evidence used by the shared review-project selector.

## User impact

Desktop, direct messaging, and federated messaging reviews now default to the same changed primary project. Clean multi-project threads remain intentionally ambiguous.

## Verification

- affected desktop main suites after rebasing onto current main — 554 passed
- full serial suite before the final main rebase — 5,885 passed, 3 skipped
- pnpm typecheck
- pnpm lint:eslint — no errors (existing warnings remain)
- pnpm lint:boundaries
- pnpm lint:codex-storage
