### PR TITLE
fix(desktop): keep PR lookups in process

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -539,6 +539,7 @@ const supersedeThreadPrStatusWatches = vi.fn(async () => 0);
 const listActiveThreadPrStatusWatches = vi.fn(async () => []);
 const cancelThreadPrStatusWatchesForPr = vi.fn(async () => 0);
 const isGhAvailable = vi.fn(async () => true);
+const invalidateGhCaches = vi.fn();
 const getAuthStatus = vi.fn(async () => ({
   installed: true,
   loggedIn: true,
@@ -752,6 +753,7 @@ vi.mock("../pr-status/github-pr-fetcher", () => ({
   GithubPrFetcher: vi.fn(function GithubPrFetcher() {
     return {
       isGhAvailable,
+      invalidateGhCaches,
       getAuthStatus,
       fetchPullRequestByUrl,
     };
@@ -872,6 +874,7 @@ describe("app server ipc", () => {
     cancelThreadPrStatusWatchesForPr.mockClear();
     isGhAvailable.mockClear();
     isGhAvailable.mockResolvedValue(true);
+    invalidateGhCaches.mockClear();
     getAuthStatus.mockClear();
     fetchPullRequestByUrl.mockReset();
     fetchPullRequestByUrl.mockResolvedValue(undefined);
@@ -900,6 +903,31 @@ describe("app server ipc", () => {
     await disposeAppServerIpcHandlers();
 
     expect(backendRegistryLifecycle.get).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the GraphQL token during an auth recheck", async () => {
+    const { GithubGraphqlPrClient } = await import(
+      "../pr-status/github-graphql-client"
+    );
+    const invalidateToken = vi.spyOn(
+      GithubGraphqlPrClient.prototype,
+      "invalidateToken",
+    );
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_GET_GH_STATUS_CHANNEL } = await import("../../shared/ipc");
+    registerAppServerIpcHandlers();
+
+    try {
+      await handlers.get(NAVIGATION_GET_GH_STATUS_CHANNEL)?.({}, {
+        recheck: true,
+      });
+
+      expect(invalidateGhCaches).toHaveBeenCalledTimes(1);
+      expect(invalidateToken).toHaveBeenCalledTimes(1);
+      expect(getAuthStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      invalidateToken.mockRestore();
+    }
   });
 
   it("identifies explicitly selected extensionless PDFs by their magic bytes", async () => {

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -113,6 +113,13 @@ const resolveGitHubRepoForDirectory = vi.hoisted(() =>
     > => undefined,
   ),
 );
+const resolveGitHubReposForDirectory = vi.hoisted(() =>
+  vi.fn(
+    async (): Promise<
+      Array<{ host: string; owner: string; repo: string }>
+    > => [],
+  ),
+);
 
 const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const listThreads = vi.fn(async (request?: {
@@ -762,6 +769,7 @@ vi.mock("../pr-status/git-remote", async () => {
   return {
     ...actual,
     resolveGitHubRepoForDirectory,
+    resolveGitHubReposForDirectory,
   };
 });
 
@@ -871,6 +879,8 @@ describe("app server ipc", () => {
     detectPullRequestsForThread.mockResolvedValue([]);
     resolveGitHubRepoForDirectory.mockReset();
     resolveGitHubRepoForDirectory.mockResolvedValue(undefined);
+    resolveGitHubReposForDirectory.mockReset();
+    resolveGitHubReposForDirectory.mockResolvedValue([]);
     mockAppServerLog.debug.mockClear();
     mockAppServerLog.error.mockClear();
     mockAppServerLog.info.mockClear();

--- a/apps/desktop/src/main/__tests__/git-remote.test.ts
+++ b/apps/desktop/src/main/__tests__/git-remote.test.ts
@@ -4,6 +4,7 @@ import {
   hasGitHubRemoteForDirectory,
   parseGitHubRemote,
   resolveGitHubRepoForDirectory,
+  resolveGitHubReposForDirectory,
 } from "../pr-status/git-remote";
 
 describe("parseGitHubRemote", () => {
@@ -124,6 +125,11 @@ describe("resolveGitHubRepoForDirectory", () => {
     await expect(
       resolveGitHubRepoForDirectory("/repo", { readRemotes }),
     ).resolves.toEqual({ host: "gitlab.com", owner: "group", repo: "project" });
+    await expect(
+      resolveGitHubReposForDirectory("/repo", { readRemotes }),
+    ).resolves.toEqual([
+      { host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" },
+    ]);
   });
 
   it("recognizes a GitHub SSH HostName behind a remote host alias", async () => {
@@ -148,6 +154,21 @@ describe("resolveGitHubRepoForDirectory", () => {
     ).resolves.toEqual({ host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" });
     expect(resolveSshHostname).toHaveBeenCalledOnce();
     expect(resolveSshHostname).toHaveBeenCalledWith("github-work");
+  });
+
+  it("resolves every distinct GitHub fork and upstream remote", async () => {
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@github.com:operator/PwrAgent.git" },
+      { name: "upstream", url: "git@github.com:pwrdrvr/PwrAgent.git" },
+      { name: "backup", url: "https://github.com/pwrdrvr/PwrAgent.git" },
+    ]);
+
+    await expect(
+      resolveGitHubReposForDirectory("/repo", { readRemotes }),
+    ).resolves.toEqual([
+      { host: "github.com", owner: "operator", repo: "PwrAgent" },
+      { host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" },
+    ]);
   });
 
   it("does not apply SSH host aliases to HTTPS remotes", async () => {

--- a/apps/desktop/src/main/__tests__/git-remote.test.ts
+++ b/apps/desktop/src/main/__tests__/git-remote.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearGitHubRemoteCache,
+  hasGitHubRemoteForDirectory,
   parseGitHubRemote,
   resolveGitHubRepoForDirectory,
 } from "../pr-status/git-remote";
@@ -26,6 +27,14 @@ describe("parseGitHubRemote", () => {
     expect(parseGitHubRemote("git@github.com:PwrDrvr/PwrAgent.git")).toEqual({
       host: "github.com",
       owner: "PwrDrvr",
+      repo: "PwrAgent",
+    });
+  });
+
+  it("parses scp-style SSH aliases without an explicit user", () => {
+    expect(parseGitHubRemote("github-work:pwrdrvr/PwrAgent.git")).toEqual({
+      host: "github-work",
+      owner: "pwrdrvr",
       repo: "PwrAgent",
     });
   });
@@ -63,46 +72,121 @@ describe("resolveGitHubRepoForDirectory", () => {
   });
 
   it("resolves a directory through its origin remote", async () => {
-    const readRemoteUrl = vi.fn(async () => "git@github.com:pwrdrvr/PwrAgent.git");
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@github.com:pwrdrvr/PwrAgent.git" },
+    ]);
     await expect(
-      resolveGitHubRepoForDirectory("/repo", { readRemoteUrl }),
+      resolveGitHubRepoForDirectory("/repo", { readRemotes }),
     ).resolves.toEqual({ host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" });
   });
 
   it("caches so a sweep does not re-shell per directory", async () => {
-    const readRemoteUrl = vi.fn(async () => "git@github.com:pwrdrvr/PwrAgent.git");
-    await resolveGitHubRepoForDirectory("/repo", { readRemoteUrl });
-    await resolveGitHubRepoForDirectory("/repo", { readRemoteUrl });
-    expect(readRemoteUrl).toHaveBeenCalledTimes(1);
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@github.com:pwrdrvr/PwrAgent.git" },
+    ]);
+    await resolveGitHubRepoForDirectory("/repo", { readRemotes });
+    await hasGitHubRemoteForDirectory("/repo", { readRemotes });
+    expect(readRemotes).toHaveBeenCalledTimes(1);
   });
 
   it("caches the negative result too, so a non-git dir does not re-shell", async () => {
-    const readRemoteUrl = vi.fn(async () => undefined);
+    const readRemotes = vi.fn(async () => []);
     await expect(
-      resolveGitHubRepoForDirectory("/plain", { readRemoteUrl }),
+      resolveGitHubRepoForDirectory("/plain", { readRemotes }),
     ).resolves.toBeUndefined();
-    await resolveGitHubRepoForDirectory("/plain", { readRemoteUrl });
-    expect(readRemoteUrl).toHaveBeenCalledTimes(1);
+    await expect(
+      hasGitHubRemoteForDirectory("/plain", { readRemotes }),
+    ).resolves.toBe(false);
+    expect(readRemotes).toHaveBeenCalledTimes(1);
   });
 
-  it("returns undefined when git throws, so the caller falls back to gh", async () => {
-    const readRemoteUrl = vi.fn(async () => {
+  it("returns an authoritative negative result when git throws", async () => {
+    const readRemotes = vi.fn(async () => {
       throw new Error("not a git repository");
     });
     await expect(
-      resolveGitHubRepoForDirectory("/broken", { readRemoteUrl }),
+      resolveGitHubRepoForDirectory("/broken", { readRemotes }),
     ).resolves.toBeUndefined();
+    await expect(
+      hasGitHubRemoteForDirectory("/broken", { readRemotes }),
+    ).resolves.toBe(false);
+  });
+
+  it("recognizes GitHub on a non-origin configured remote", async () => {
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@gitlab.com:group/project.git" },
+      { name: "upstream", url: "git@github.com:pwrdrvr/PwrAgent.git" },
+    ]);
+
+    await expect(
+      hasGitHubRemoteForDirectory("/repo", { readRemotes }),
+    ).resolves.toBe(true);
+    await expect(
+      resolveGitHubRepoForDirectory("/repo", { readRemotes }),
+    ).resolves.toEqual({ host: "gitlab.com", owner: "group", repo: "project" });
+  });
+
+  it("recognizes a GitHub SSH HostName behind a remote host alias", async () => {
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@github-work:pwrdrvr/PwrAgent.git" },
+    ]);
+    const resolveSshHostname = vi.fn(async (host: string) =>
+      host === "github-work" ? "github.com" : host,
+    );
+
+    await expect(
+      hasGitHubRemoteForDirectory("/repo", {
+        readRemotes,
+        resolveSshHostname,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      resolveGitHubRepoForDirectory("/repo", {
+        readRemotes,
+        resolveSshHostname,
+      }),
+    ).resolves.toEqual({ host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" });
+    expect(resolveSshHostname).toHaveBeenCalledOnce();
+    expect(resolveSshHostname).toHaveBeenCalledWith("github-work");
+  });
+
+  it("does not apply SSH host aliases to HTTPS remotes", async () => {
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "https://github-work/pwrdrvr/PwrAgent.git" },
+    ]);
+    const resolveSshHostname = vi.fn(async () => "github.com");
+
+    await expect(
+      hasGitHubRemoteForDirectory("/repo", {
+        readRemotes,
+        resolveSshHostname,
+      }),
+    ).resolves.toBe(false);
+    expect(resolveSshHostname).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repo whose configured remotes do not point to GitHub", async () => {
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@gitlab.com:group/project.git" },
+      { name: "backup", url: "/srv/git/project.git" },
+    ]);
+
+    await expect(
+      hasGitHubRemoteForDirectory("/repo", { readRemotes }),
+    ).resolves.toBe(false);
   });
 
   it("re-probes once the cache entry ages out", async () => {
-    const readRemoteUrl = vi.fn(async () => "git@github.com:pwrdrvr/PwrAgent.git");
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@github.com:pwrdrvr/PwrAgent.git" },
+    ]);
     let clock = 1_000_000;
     const now = () => clock;
 
-    await resolveGitHubRepoForDirectory("/repo", { readRemoteUrl, now });
+    await resolveGitHubRepoForDirectory("/repo", { readRemotes, now });
     clock += 10 * 60_000;
-    await resolveGitHubRepoForDirectory("/repo", { readRemoteUrl, now });
+    await resolveGitHubRepoForDirectory("/repo", { readRemotes, now });
 
-    expect(readRemoteUrl).toHaveBeenCalledTimes(2);
+    expect(readRemotes).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -7,6 +7,7 @@ import {
   buildBranchPrQuery,
   mapGraphqlPrNode,
   parsePrRefFromUrl,
+  readGithubDotComAuthToken,
   retryDelayMs,
 } from "../pr-status/github-graphql-client";
 import type { GraphqlPrNode, PrRef } from "../pr-status/github-graphql-client";
@@ -573,5 +574,20 @@ describe("GithubGraphqlPrClient", () => {
     });
     await expect(noToken.fetchPullRequests(refs)).resolves.toEqual([]);
     expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("readGithubDotComAuthToken", () => {
+  it("requests the token for github.com explicitly", async () => {
+    const run = vi.fn(async () => ({ stdout: "github-token\n" }));
+
+    await expect(readGithubDotComAuthToken("/opt/homebrew/bin/gh", run))
+      .resolves.toBe("github-token");
+    expect(run).toHaveBeenCalledWith("/opt/homebrew/bin/gh", [
+      "auth",
+      "token",
+      "--hostname",
+      "github.com",
+    ]);
   });
 });

--- a/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-fetcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { PrSummary } from "@pwragent/shared";
 import {
   GithubPrFetcher,
   deriveChipState,
@@ -386,34 +387,78 @@ describe("parseGhAuthStatus", () => {
 });
 
 describe("GithubPrFetcher", () => {
+  const primedPr = {
+    provider: "github.com",
+    number: 42,
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    state: "passing" as const,
+    checkState: "passing" as const,
+    lifecycleState: "open" as const,
+    url: "https://github.com/pwrdrvr/PwrAgent/pull/42",
+  };
+  const mergedPr = parseGhPrPayload(rawMergedPr());
+
   function buildFetcher(overrides: {
-    stdout?: string;
-    error?: Error;
+    branchError?: Error;
+    branchResults?: (ref: {
+      owner: string;
+      repo: string;
+      branch: string;
+    }) => PrSummary[] | undefined;
     ghAvailable?: boolean;
+    repos?: Array<{ host: string; owner: string; repo: string }>;
+    retainedError?: Error;
+    retainedPrs?: PrSummary[];
   } = {}) {
-    const exec = vi.fn(async (_cwd: string, _args: string[]) => {
-      if (overrides.error) throw overrides.error;
-      return { stdout: overrides.stdout ?? "[]", stderr: "" };
+    const fetchPullRequestsForBranches = vi.fn(async (refs: Array<{
+      owner: string;
+      repo: string;
+      branch: string;
+    }>) => {
+      if (overrides.branchError) throw overrides.branchError;
+      return new Map(
+        refs.flatMap((ref) => {
+          const prs = overrides.branchResults?.(ref) ?? [];
+          return [[
+            `${ref.owner.toLowerCase()}/${ref.repo.toLowerCase()}#${ref.branch}`,
+            prs,
+          ] as const];
+        }),
+      );
     });
+    const fetchPullRequests = vi.fn(async () => {
+      if (overrides.retainedError) throw overrides.retainedError;
+      return overrides.retainedPrs ?? [];
+    });
+    const resolveGitHubRepos = vi.fn(async () =>
+      overrides.repos ?? [{
+        host: "github.com",
+        owner: "pwrdrvr",
+        repo: "PwrAgent",
+      }],
+    );
     const probeGhAvailable = vi.fn(async () => overrides.ghAvailable ?? true);
-    const fetcher = new GithubPrFetcher({ exec, probeGhAvailable });
-    return { fetcher, exec, probeGhAvailable };
+    const fetcher = new GithubPrFetcher({
+      graphqlClient: {
+        fetchPullRequests,
+        fetchPullRequestsForBranches,
+      },
+      probeGhAvailable,
+      resolveGitHubRepos,
+    });
+    return {
+      fetcher,
+      fetchPullRequests,
+      fetchPullRequestsForBranches,
+      probeGhAvailable,
+      resolveGitHubRepos,
+    };
   }
 
   describe("primeBranchLookup (batched in-process discovery)", () => {
-    const primedPr = {
-      provider: "github.com",
-      number: 42,
-      org: "pwrdrvr",
-      repo: "PwrAgent",
-      state: "passing" as const,
-      checkState: "passing" as const,
-      lifecycleState: "open" as const,
-      url: "https://github.com/pwrdrvr/PwrAgent/pull/42",
-    };
-
-    it("answers from the primed value without spawning gh", async () => {
-      const { fetcher, exec } = buildFetcher();
+    it("answers from the primed value without another GraphQL request", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       fetcher.primeBranchLookup([
         { cwd: "/repo", branch: "feat/x", prs: [primedPr] },
       ]);
@@ -424,21 +469,21 @@ describe("GithubPrFetcher", () => {
       });
 
       expect(result).toEqual([primedPr]);
-      expect(exec).not.toHaveBeenCalled();
+      expect(fetchPullRequestsForBranches).not.toHaveBeenCalled();
     });
 
     it("honors a primed empty answer — that is an authoritative 'no PRs'", async () => {
-      const { fetcher, exec } = buildFetcher();
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       fetcher.primeBranchLookup([{ cwd: "/repo", branch: "feat/x", prs: [] }]);
 
       await expect(
         fetcher.fetchAllPullRequestsForBranch({ cwd: "/repo", branch: "feat/x" }),
       ).resolves.toEqual([]);
-      expect(exec).not.toHaveBeenCalled();
+      expect(fetchPullRequestsForBranches).not.toHaveBeenCalled();
     });
 
     it("is single-use, so a later refresh gets its own fresh read", async () => {
-      const { fetcher, exec } = buildFetcher();
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       fetcher.primeBranchLookup([
         { cwd: "/repo", branch: "feat/x", prs: [primedPr] },
       ]);
@@ -452,9 +497,7 @@ describe("GithubPrFetcher", () => {
         branch: "feat/x",
       });
 
-      // Second call fell through to gh rather than silently reusing the
-      // prefetch a user-triggered refresh did not ask for.
-      expect(exec).toHaveBeenCalledTimes(1);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledTimes(1);
     });
 
     it("discards a primed discovery result for an authoritative user refresh", async () => {
@@ -462,22 +505,8 @@ describe("GithubPrFetcher", () => {
         ...primedPr,
         mergeState: "conflicting" as const,
       };
-      const { fetcher, exec } = buildFetcher({
-        stdout: JSON.stringify([{
-          number: freshPr.number,
-          title: "Fresh PR state",
-          url: freshPr.url,
-          state: "OPEN",
-          isDraft: false,
-          mergeable: "CONFLICTING",
-          mergeStateStatus: "DIRTY",
-          mergedAt: null,
-          commits: [],
-          headRefName: "feat/x",
-          headRepository: { name: freshPr.repo },
-          headRepositoryOwner: { login: freshPr.org },
-          statusCheckRollup: [],
-        }]),
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        branchResults: () => [freshPr],
       });
       fetcher.primeBranchLookup([
         { cwd: "/repo", branch: "feat/x", prs: [primedPr] },
@@ -495,17 +524,17 @@ describe("GithubPrFetcher", () => {
           mergeState: "conflicting",
         }),
       ]);
-      expect(exec).toHaveBeenCalledOnce();
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledOnce();
 
       await fetcher.fetchAllPullRequestsForBranch({
         cwd: "/repo",
         branch: "feat/x",
       });
-      expect(exec).toHaveBeenCalledTimes(2);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledTimes(2);
     });
 
     it("does not answer for a different branch or directory", async () => {
-      const { fetcher, exec } = buildFetcher();
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       fetcher.primeBranchLookup([
         { cwd: "/repo", branch: "feat/x", prs: [primedPr] },
       ]);
@@ -519,11 +548,11 @@ describe("GithubPrFetcher", () => {
         branch: "feat/x",
       });
 
-      expect(exec).toHaveBeenCalledTimes(2);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledTimes(2);
     });
 
-    it("falls back to gh once the primed value has expired", async () => {
-      const { fetcher, exec } = buildFetcher();
+    it("runs GraphQL once the primed value has expired", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       fetcher.primeBranchLookup(
         [{ cwd: "/repo", branch: "feat/x", prs: [primedPr] }],
         -1,
@@ -534,53 +563,58 @@ describe("GithubPrFetcher", () => {
         branch: "feat/x",
       });
 
-      expect(exec).toHaveBeenCalledTimes(1);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("fetchOpenPullRequests (batched by repo)", () => {
-    it("returns [] without invoking gh when gh is not available", async () => {
-      const { fetcher, exec } = buildFetcher({ ghAvailable: false });
+    it("returns [] without GraphQL when gh auth is not available", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        ghAvailable: false,
+      });
       const result = await fetcher.fetchOpenPullRequests({
         cwd: "/tmp/repo",
         branches: ["feat/x"],
       });
       expect(result).toEqual([]);
-      expect(exec).not.toHaveBeenCalled();
+      expect(fetchPullRequestsForBranches).not.toHaveBeenCalled();
     });
 
-    it("returns [] without invoking gh when no branches are requested", async () => {
-      const { fetcher, exec } = buildFetcher();
+    it("returns [] without GraphQL when no branches are requested", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher();
       const result = await fetcher.fetchOpenPullRequests({
         cwd: "/tmp/repo",
         branches: [],
       });
       expect(result).toEqual([]);
-      expect(exec).not.toHaveBeenCalled();
+      expect(fetchPullRequestsForBranches).not.toHaveBeenCalled();
     });
 
-    it("filters gh output by requested branches", async () => {
-      const { fetcher, exec } = buildFetcher({
-        stdout: JSON.stringify([
-          { ...rawMergedPr(), state: "OPEN", headRefName: "feat/a", number: 1 },
-          { ...rawMergedPr(), state: "OPEN", headRefName: "feat/b", number: 2 },
-          { ...rawMergedPr(), state: "OPEN", headRefName: "feat/c", number: 3 },
-        ]),
+    it("combines requested branches and filters terminal PRs", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        branchResults: (ref) => [
+          {
+            ...primedPr,
+            number: ref.branch === "feat/a" ? 1 : 3,
+            url: `${primedPr.url}-${ref.branch}`,
+          },
+          mergedPr,
+        ],
       });
       const result = await fetcher.fetchOpenPullRequests({
         cwd: "/tmp/repo",
         branches: ["feat/a", "feat/c"],
       });
       expect(result.map((pr) => pr.number)).toEqual([1, 3]);
-      expect(exec).toHaveBeenCalledTimes(1);
-      const args = exec.mock.calls[0]![1];
-      expect(args).toContain("--state");
-      expect(args).toContain("open");
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledWith([
+        { owner: "pwrdrvr", repo: "PwrAgent", branch: "feat/a" },
+        { owner: "pwrdrvr", repo: "PwrAgent", branch: "feat/c" },
+      ]);
     });
 
-    it("returns [] on subprocess failure (no caching — overlay handles persistence)", async () => {
-      const { fetcher, exec } = buildFetcher({
-        error: new Error("gh: not authorized"),
+    it("returns [] on in-process lookup failure", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        branchError: new Error("GraphQL unavailable"),
       });
       const first = await fetcher.fetchOpenPullRequests({
         cwd: "/tmp/repo",
@@ -592,108 +626,109 @@ describe("GithubPrFetcher", () => {
       });
       expect(first).toEqual([]);
       expect(second).toEqual([]);
-      expect(exec).toHaveBeenCalledTimes(2);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not probe gh or GraphQL for a non-GitHub checkout", async () => {
+      const {
+        fetcher,
+        fetchPullRequestsForBranches,
+        probeGhAvailable,
+      } = buildFetcher({ repos: [] });
+
+      await expect(fetcher.fetchOpenPullRequests({
+        cwd: "/tmp/repo",
+        branches: ["feat/x"],
+      })).resolves.toEqual([]);
+      expect(probeGhAvailable).not.toHaveBeenCalled();
+      expect(fetchPullRequestsForBranches).not.toHaveBeenCalled();
     });
   });
 
   describe("fetchAllPullRequestsForBranch (single thread, all states)", () => {
-    it("uses --state all so we catch merged + closed too", async () => {
-      const { fetcher, exec } = buildFetcher({
-        stdout: JSON.stringify([rawMergedPr()]),
+    it("uses the in-process all-state branch query", async () => {
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        branchResults: () => [mergedPr],
       });
       const result = await fetcher.fetchAllPullRequestsForBranch({
         cwd: "/tmp/repo",
         branch: "feat/x",
       });
-      expect(result).toEqual([
-        {
-          provider: "github.com",
-          number: 178,
-          org: "pwrdrvr",
-          repo: "PwrAgent",
-          title: "Retain thread pull request history",
-          baseRefName: "agent/github-pr-auto-fix-settings",
-          headRefName: "feat/desktop-thread-reactions-and-pr-chips",
-          state: "passing",
-          checkState: "passing",
-          lifecycleState: "merged",
-          reviewState: "ready_for_review",
-          mergeState: "unknown",
-          headSha: "b".repeat(40),
-          commitShas: ["a".repeat(40), "b".repeat(40)],
-          url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
-        },
+      expect(result).toEqual([mergedPr]);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledWith([
+        { owner: "pwrdrvr", repo: "PwrAgent", branch: "feat/x" },
       ]);
-      const args = exec.mock.calls[0]![1];
-      expect(args).toEqual([
-        "pr",
-        "list",
-        "--state",
-        "all",
-        "--head",
-        "feat/x",
-        "--json",
-        expect.any(String),
-        "--limit",
-        "5",
-      ]);
-      expect(args[args.indexOf("--json") + 1]).toContain("title");
-      expect(args[args.indexOf("--json") + 1]).toContain("baseRefName");
-      expect(args[args.indexOf("--json") + 1]).toContain("headRefName");
     });
 
-    it("returns [] on subprocess failure", async () => {
-      const { fetcher } = buildFetcher({ error: new Error("gh failed") });
+    it("returns [] on in-process lookup failure", async () => {
+      const { fetcher } = buildFetcher({
+        branchError: new Error("GraphQL unavailable"),
+      });
       const result = await fetcher.fetchAllPullRequestsForBranch({
         cwd: "/tmp/repo",
         branch: "feat/x",
       });
       expect(result).toEqual([]);
     });
+
+    it("queries fork and upstream remotes and deduplicates their answers", async () => {
+      const upstreamPr = { ...primedPr, number: 43, url: `${primedPr.url}-43` };
+      const { fetcher, fetchPullRequestsForBranches } = buildFetcher({
+        repos: [
+          { host: "github.com", owner: "operator", repo: "PwrAgent" },
+          { host: "github.com", owner: "pwrdrvr", repo: "PwrAgent" },
+        ],
+        branchResults: (ref) =>
+          ref.owner === "operator"
+            ? [primedPr]
+            : [primedPr, upstreamPr],
+      });
+
+      await expect(fetcher.fetchAllPullRequestsForBranch({
+        cwd: "/tmp/repo",
+        branch: "feat/x",
+      })).resolves.toEqual([primedPr, upstreamPr]);
+      expect(fetchPullRequestsForBranches).toHaveBeenCalledWith([
+        { owner: "operator", repo: "PwrAgent", branch: "feat/x" },
+        { owner: "pwrdrvr", repo: "PwrAgent", branch: "feat/x" },
+      ]);
+    });
   });
 
   describe("fetchPullRequestByUrl", () => {
-    it("uses gh pr view for retained PR chips whose head branch is no longer current", async () => {
-      const { fetcher, exec } = buildFetcher({
-        stdout: JSON.stringify(rawMergedPr()),
+    it("uses the in-process by-number query for retained PR chips", async () => {
+      const { fetcher, fetchPullRequests } = buildFetcher({
+        retainedPrs: [mergedPr],
       });
       const result = await fetcher.fetchPullRequestByUrl({
         cwd: "/tmp/repo",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
       });
-      expect(result).toEqual({
-        provider: "github.com",
-        number: 178,
-        org: "pwrdrvr",
-        repo: "PwrAgent",
-        title: "Retain thread pull request history",
-        baseRefName: "agent/github-pr-auto-fix-settings",
-        headRefName: "feat/desktop-thread-reactions-and-pr-chips",
-        state: "passing",
-        checkState: "passing",
-        lifecycleState: "merged",
-        reviewState: "ready_for_review",
-        mergeState: "unknown",
-        headSha: "b".repeat(40),
-        commitShas: ["a".repeat(40), "b".repeat(40)],
-        url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
-      });
-      expect(exec).toHaveBeenCalledWith("/tmp/repo", [
-        "pr",
-        "view",
-        "https://github.com/pwrdrvr/PwrAgent/pull/178",
-        "--json",
-        expect.any(String),
+      expect(result).toEqual(mergedPr);
+      expect(fetchPullRequests).toHaveBeenCalledWith([
+        { owner: "pwrdrvr", repo: "PwrAgent", number: 178 },
       ]);
     });
 
-    it("returns undefined on subprocess failure", async () => {
-      const { fetcher } = buildFetcher({ error: new Error("gh failed") });
+    it("returns undefined on in-process lookup failure", async () => {
+      const { fetcher } = buildFetcher({
+        retainedError: new Error("GraphQL unavailable"),
+      });
       const result = await fetcher.fetchPullRequestByUrl({
         cwd: "/tmp/repo",
         url: "https://github.com/pwrdrvr/PwrAgent/pull/178",
       });
       expect(result).toBeUndefined();
+    });
+
+    it("rejects a URL that does not identify a GitHub pull request", async () => {
+      const { fetcher, fetchPullRequests } = buildFetcher();
+
+      await expect(fetcher.fetchPullRequestByUrl({
+        cwd: "/tmp/repo",
+        url: "https://github.com/pwrdrvr/PwrAgent/issues/178",
+      })).resolves.toBeUndefined();
+      expect(fetchPullRequests).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -334,6 +334,23 @@ describe("detectPullRequestsForThread", () => {
     expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
+  it("skips named-branch lookups for deleted worktree paths", async () => {
+    const staleDirectory = await createNonGitDirectory();
+    await rm(staleDirectory, { recursive: true, force: true });
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix/pr-chip",
+      directoryPaths: [staleDirectory],
+    });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
   it("skips named-branch lookups for git repositories with no remotes", async () => {
     const repo = await createRepoWithBranch("fix/local-only");
     const fetcher = {

--- a/apps/desktop/src/main/__tests__/pr-detection.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-detection.test.ts
@@ -195,6 +195,7 @@ describe("detectPullRequestsForThread", () => {
   it("does not use another local branch configured as the upstream", async () => {
     const branch = "fix/local-upstream";
     const repo = await createRepoWithBranch(branch);
+    await addGitHubRemote(repo);
     await git(repo, "branch", "feature/parent");
     await git(repo, "config", `branch.${branch}.remote`, ".");
     await git(
@@ -266,6 +267,7 @@ describe("detectPullRequestsForThread", () => {
   it("uses the local branch when it has no upstream", async () => {
     const branch = "fix/untracked-pr";
     const repo = await createRepoWithBranch(branch);
+    await addGitHubRemote(repo);
     await git(repo, "checkout", branch);
     const expectedPr = {
       number: 13270,
@@ -295,6 +297,7 @@ describe("detectPullRequestsForThread", () => {
   it("forwards authoritative lookup intent so user refreshes bypass discovery primes", async () => {
     const branch = "fix/authoritative-pr-refresh";
     const repo = await createRepoWithBranch(branch);
+    await addGitHubRemote(repo);
     const fetcher = {
       fetchAllPullRequestsForBranch: vi.fn(async () => []),
     } as unknown as GithubPrFetcher;
@@ -313,7 +316,7 @@ describe("detectPullRequestsForThread", () => {
     });
   });
 
-  it("lets named-branch lookups degrade through the fetcher for invalid directories", async () => {
+  it("skips named-branch lookups for invalid directories", async () => {
     const staleDirectory = await createNonGitDirectory();
     const fetcher = {
       fetchAllPullRequestsForBranch: vi.fn(async () => {
@@ -328,10 +331,23 @@ describe("detectPullRequestsForThread", () => {
     });
 
     expect(prs).toEqual([]);
-    expect(fetcher.fetchAllPullRequestsForBranch).toHaveBeenCalledWith({
-      cwd: staleDirectory,
-      branch: "fix/pr-chip",
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
+  });
+
+  it("skips named-branch lookups for git repositories with no remotes", async () => {
+    const repo = await createRepoWithBranch("fix/local-only");
+    const fetcher = {
+      fetchAllPullRequestsForBranch: vi.fn(async () => []),
+    } as unknown as GithubPrFetcher;
+
+    const prs = await detectPullRequestsForThread({
+      fetcher,
+      branch: "fix/local-only",
+      directoryPaths: [repo],
     });
+
+    expect(prs).toEqual([]);
+    expect(fetcher.fetchAllPullRequestsForBranch).not.toHaveBeenCalled();
   });
 
   it("does not reject detached HEAD lookups for invalid directories", async () => {
@@ -421,6 +437,7 @@ async function createRepoWithDefaultBranch(branch: string): Promise<string> {
     `refs/remotes/origin/${branch}`,
   );
   await git(repo, "branch", "--set-upstream-to", `origin/${branch}`, branch);
+  await git(repo, "remote", "set-url", "origin", githubRemoteUrl());
   return repo;
 }
 
@@ -456,6 +473,7 @@ async function createRepoWithRenamedTrackedBranch(params: {
     params.localBranch,
   );
   await git(repo, "checkout", params.localBranch);
+  await git(repo, "remote", "set-url", "origin", githubRemoteUrl());
   return repo;
 }
 
@@ -478,6 +496,14 @@ async function createNonGitDirectory(): Promise<string> {
   tempDirs.push(directory);
   await mkdir(path.join(directory, "nested"));
   return directory;
+}
+
+async function addGitHubRemote(cwd: string): Promise<void> {
+  await git(cwd, "remote", "add", "origin", githubRemoteUrl());
+}
+
+function githubRemoteUrl(): string {
+  return "git@github.com:Giphy/giphy-services.git";
 }
 
 async function git(cwd: string, ...args: string[]): Promise<string> {

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4964,6 +4964,7 @@ class DesktopAppServerService {
     const fetcher = this.getPrFetcher();
     if (request.recheck) {
       fetcher.invalidateGhCaches();
+      this.getPrGraphqlClient().invalidateToken();
     }
     // The fetcher logs once per fresh probe (cache + in-flight dedup
     // keep StrictMode mount duplicates silent). The IPC layer just

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -240,6 +240,7 @@ import type { BranchRef } from "../pr-status/github-graphql-client";
 import {
   parseGitHubRemote,
   resolveGitHubRepoForDirectory,
+  resolveGitHubReposForDirectory,
 } from "../pr-status/git-remote";
 import { PrPollingScheduler } from "../pr-status/pr-polling-scheduler";
 import type { PrPollTarget } from "../pr-status/pr-polling-scheduler";
@@ -3304,7 +3305,7 @@ class DesktopAppServerService {
       });
     }
     // Terminal-state short-circuit: once every cached PR for a lookup is
-    // merged or closed, we do not need to re-query gh for the same
+    // merged or closed, we do not need to re-query GitHub for the same
     // branch/directory lookup.
     // A different lookup can mean the thread moved to a new branch after
     // merging an older PR, so stale terminal chips must not block it.
@@ -4525,8 +4526,8 @@ class DesktopAppServerService {
     }
 
     // Answer every due branch lookup in one batched in-process request, then
-    // let the normal refresh path consume those answers. Best-effort: anything
-    // not primed simply falls back to the `gh` subprocess.
+    // let the normal refresh path consume those answers. Anything not primed
+    // gets a fresh in-process request through the normal refresh path.
     void this.primeDiscoveryBranchLookups(dueContexts)
       .catch((error) => {
         appServerLog.debug("pr discovery prefetch failed", {
@@ -4542,14 +4543,17 @@ class DesktopAppServerService {
    * Resolve each due (directory, branch) to a GitHub repo and look them all up
    * in one batched GraphQL request, priming the fetcher with the results.
    *
-   * This is what keeps discovery from spawning one `gh pr list` per branch.
-   * Only branches GitHub actually answered for are primed — a missing answer
-   * falls through to `gh` rather than being recorded as "no PRs".
+   * This keeps discovery to one batched request instead of one request per
+   * branch. Only directory/branch pairs whose every configured GitHub repo
+   * answered are primed; a missing answer is not recorded as "no PRs".
    */
   private async primeDiscoveryBranchLookups(
     contexts: ThreadPrRefreshContext[],
   ): Promise<void> {
-    const wanted = new Map<string, { cwd: string; branch: string; ref: BranchRef }>();
+    const wanted = new Map<
+      string,
+      { cwd: string; branch: string; refs: BranchRef[] }
+    >();
     for (const context of contexts) {
       const branch = context.branch.trim();
       // "HEAD" contexts are not branch lookups, and the detection path skips
@@ -4562,14 +4566,18 @@ class DesktopAppServerService {
         if (wanted.has(dedupeKey)) {
           continue;
         }
-        const repo = await resolveGitHubRepoForDirectory(cwd);
-        if (!repo || repo.host !== DEFAULT_PULL_REQUEST_PROVIDER) {
+        const repos = await resolveGitHubReposForDirectory(cwd);
+        if (repos.length === 0) {
           continue;
         }
         wanted.set(dedupeKey, {
           cwd,
           branch,
-          ref: { owner: repo.owner, repo: repo.repo, branch },
+          refs: repos.map((repo) => ({
+            owner: repo.owner,
+            repo: repo.repo,
+            branch,
+          })),
         });
       }
     }
@@ -4579,15 +4587,21 @@ class DesktopAppServerService {
     }
 
     const entries = [...wanted.values()];
+    const refs = entries.flatMap((entry) => entry.refs);
     const byRefKey = await this.getPrGraphqlClient().fetchPullRequestsForBranches(
-      entries.map((entry) => entry.ref),
+      refs,
     );
     const primed = entries
-      .map((entry) => ({
-        cwd: entry.cwd,
-        branch: entry.branch,
-        prs: byRefKey.get(branchRefKey(entry.ref)),
-      }))
+      .map((entry) => {
+        const answers = entry.refs.map((ref) => byRefKey.get(branchRefKey(ref)));
+        return {
+          cwd: entry.cwd,
+          branch: entry.branch,
+          prs: answers.some((answer) => answer === undefined)
+            ? undefined
+            : dedupePrsByStatusKey(answers.flatMap((answer) => answer ?? [])),
+        };
+      })
       .filter(
         (entry): entry is { cwd: string; branch: string; prs: PrSummary[] } =>
           entry.prs !== undefined,
@@ -4597,7 +4611,7 @@ class DesktopAppServerService {
     }
     this.getPrFetcher().primeBranchLookup(primed);
     appServerLog.debug("pr discovery primed branch lookups", {
-      requested: entries.length,
+      requested: refs.length,
       primed: primed.length,
     });
   }
@@ -5724,7 +5738,9 @@ class DesktopAppServerService {
 
   private getPrFetcher(): GithubPrFetcher {
     if (!this.prFetcher) {
-      this.prFetcher = new GithubPrFetcher();
+      this.prFetcher = new GithubPrFetcher({
+        graphqlClient: this.getPrGraphqlClient(),
+      });
     }
     return this.prFetcher;
   }

--- a/apps/desktop/src/main/pr-status/git-remote.ts
+++ b/apps/desktop/src/main/pr-status/git-remote.ts
@@ -4,17 +4,16 @@ import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 
 const execFileAsync = promisify(execFile);
 const GIT_REMOTE_TIMEOUT_MS = 2_000;
-/** Remotes effectively never change for a checkout; re-probing is wasted work. */
+/** Remotes change infrequently; re-probing on every PR refresh is wasted work. */
 const REMOTE_CACHE_TTL_MS = 5 * 60_000;
 
 /**
  * Resolving a working directory to its GitHub `owner/repo`.
  *
- * The `gh` CLI never needs this — it infers the repo from the cwd's remote
- * itself. The in-process GraphQL client does need it, because
- * `repository(owner:, name:)` is how you address a repo in the API. This is the
- * one capability the subprocess path got for free that the batched path has to
- * do explicitly.
+ * The `gh` CLI can infer the repo from the cwd's remotes, while the in-process
+ * GraphQL client needs an explicit owner/repo for `repository(owner:, name:)`.
+ * PwrAgent still reads the configured remotes before invoking `gh` so a local
+ * or non-GitHub checkout cannot accidentally start a GitHub lookup.
  */
 
 export type GitHubRepoRef = {
@@ -29,6 +28,7 @@ export type GitHubRepoRef = {
  *
  * Handles the shapes git actually produces:
  *   git@github.com:owner/repo.git
+ *   github-work:owner/repo.git
  *   ssh://git@github.com/owner/repo.git
  *   https://github.com/owner/repo(.git)
  *   git://github.com/owner/repo.git
@@ -40,8 +40,11 @@ export function parseGitHubRemote(remoteUrl: string): GitHubRepoRef | undefined 
     return undefined;
   }
 
-  // scp-like syntax (`git@host:owner/repo.git`) is not a URL, so handle it first.
-  const scpLike = url.match(/^[^@/]+@([^:]+):(.+)$/);
+  // scp-like syntax (`[user@]host:owner/repo.git`) is not a URL, so handle it
+  // first. The user is optional, especially when `host` is an SSH config alias.
+  const scpLike = url.includes("://")
+    ? undefined
+    : url.match(/^(?:[^@/:]+@)?([^/:]+):(.+\/.+)$/);
   const parsed = scpLike
     ? { host: scpLike[1]!, path: scpLike[2]! }
     : parseStandardUrl(url);
@@ -79,8 +82,17 @@ function parseStandardUrl(url: string): { host: string; path: string } | undefin
   }
 }
 
+export type GitRemote = {
+  name: string;
+  url: string;
+};
+
+type ParsedGitRemote = GitRemote & {
+  repo: GitHubRepoRef | undefined;
+};
+
 type RemoteCacheEntry = {
-  value: GitHubRepoRef | undefined;
+  value: ParsedGitRemote[];
   fetchedAt: number;
 };
 
@@ -91,56 +103,166 @@ export function clearGitHubRemoteCache(): void {
 }
 
 export type ResolveGitHubRepoOptions = {
-  /** Override the git runner — tests inject canned remote URLs. */
-  readRemoteUrl?: (cwd: string) => Promise<string | undefined>;
+  /** Override the git runner — tests inject canned configured remotes. */
+  readRemotes?: (cwd: string) => Promise<GitRemote[]>;
+  /** Override OpenSSH hostname expansion — tests inject SSH alias results. */
+  resolveSshHostname?: (host: string) => Promise<string | undefined>;
   now?: () => number;
 };
 
 /**
- * Resolve a working directory to its `origin` GitHub repo, cached.
+ * Resolve a working directory to its `origin` repo, cached.
  *
  * Returns `undefined` for a non-git directory, a missing `origin`, or a remote
- * that isn't parseable — every caller treats that as "fall back to the `gh`
- * subprocess path", so a failure here is a slow path, never a wrong answer.
- * Negative results are cached too, so a non-GitHub checkout doesn't re-shell
- * on every sweep.
+ * that isn't parseable. Callers that require GitHub must still check `host`.
+ * Negative results are cached too, so a local checkout doesn't re-shell on
+ * every sweep.
  */
 export async function resolveGitHubRepoForDirectory(
   cwd: string,
   options: ResolveGitHubRepoOptions = {},
 ): Promise<GitHubRepoRef | undefined> {
+  const remotes = await readParsedGitRemotes(cwd, options);
+  return remotes.find((remote) => remote.name === "origin")?.repo;
+}
+
+/**
+ * Return whether the checkout has any configured GitHub remote.
+ *
+ * PR discovery uses this as an eligibility gate before invoking `gh`. Looking
+ * at every fetch URL (rather than only `origin`) preserves repositories whose
+ * GitHub remote is named `upstream` or another custom name. SSH host aliases
+ * are expanded through the local OpenSSH configuration without connecting. A
+ * non-git path, a local repository with no remotes, and a repository whose
+ * remotes all point elsewhere are authoritative negative answers until the
+ * short cache expires.
+ */
+export async function hasGitHubRemoteForDirectory(
+  cwd: string,
+  options: ResolveGitHubRepoOptions = {},
+): Promise<boolean> {
+  const remotes = await readParsedGitRemotes(cwd, options);
+  return remotes.some((remote) => remote.repo?.host === "github.com");
+}
+
+async function readParsedGitRemotes(
+  cwd: string,
+  options: ResolveGitHubRepoOptions,
+): Promise<ParsedGitRemote[]> {
   const now = options.now ?? (() => Date.now());
   const cached = remoteCache.get(cwd);
   if (cached && now() - cached.fetchedAt < REMOTE_CACHE_TTL_MS) {
     return cached.value;
   }
 
-  const readRemoteUrl = options.readRemoteUrl ?? defaultReadRemoteUrl;
-  let value: GitHubRepoRef | undefined;
+  const readRemotes = options.readRemotes ?? defaultReadRemotes;
+  const resolveSshHostname =
+    options.resolveSshHostname ?? defaultResolveSshHostname;
+  let value: ParsedGitRemote[];
   try {
-    const remoteUrl = await readRemoteUrl(cwd);
-    value = remoteUrl ? parseGitHubRemote(remoteUrl) : undefined;
+    value = await Promise.all(
+      (await readRemotes(cwd)).map(async (remote) => {
+        const repo = parseGitHubRemote(remote.url);
+        const sshHost = readSshHost(remote.url);
+        const resolvedHost = sshHost
+          ? await resolveSshHostname(sshHost)
+          : undefined;
+        return {
+          ...remote,
+          repo: repo && resolvedHost
+            ? { ...repo, host: resolvedHost.toLowerCase() }
+            : repo,
+        };
+      }),
+    );
   } catch {
-    value = undefined;
+    value = [];
   }
 
   remoteCache.set(cwd, { value, fetchedAt: now() });
   return value;
 }
 
-async function defaultReadRemoteUrl(cwd: string): Promise<string | undefined> {
+async function defaultReadRemotes(cwd: string): Promise<GitRemote[]> {
+  const childEnv = buildPwrAgentChildProcessEnv(process.env);
+  const { stdout } = await execFileAsync("git", ["remote"], {
+    cwd,
+    env: childEnv,
+    maxBuffer: 64 * 1024,
+    timeout: GIT_REMOTE_TIMEOUT_MS,
+  });
+  const names = uniqueNonEmptyLines(stdout);
+  const entries = await Promise.all(
+    names.map(async (name): Promise<GitRemote[]> => {
+      try {
+        const result = await execFileAsync(
+          "git",
+          ["remote", "get-url", "--all", name],
+          {
+            cwd,
+            env: childEnv,
+            maxBuffer: 64 * 1024,
+            timeout: GIT_REMOTE_TIMEOUT_MS,
+          },
+        );
+        return uniqueNonEmptyLines(result.stdout).map((url) => ({ name, url }));
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return entries.flat();
+}
+
+function uniqueNonEmptyLines(value: string): string[] {
+  return [
+    ...new Set(
+      value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
+    ),
+  ];
+}
+
+function readSshHost(remoteUrl: string): string | undefined {
+  const url = remoteUrl.trim();
+  if (!url) {
+    return undefined;
+  }
+  if (!url.includes("://")) {
+    return url.match(/^(?:[^@/:]+@)?([^/:]+):(.+\/.+)$/)?.[1];
+  }
   try {
+    const parsed = new URL(url);
+    return ["ssh:", "git+ssh:", "ssh+git:"].includes(parsed.protocol)
+      ? parsed.hostname || undefined
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultResolveSshHostname(
+  host: string,
+): Promise<string | undefined> {
+  try {
+    // `ssh -G` evaluates and prints the effective OpenSSH configuration, then
+    // exits without connecting. Disabling hostname canonicalization prevents a
+    // DNS lookup while still expanding `Host alias` / `HostName github.com`.
     const { stdout } = await execFileAsync(
-      "git",
-      ["remote", "get-url", "origin"],
+      "ssh",
+      ["-G", "-o", "CanonicalizeHostname=no", host],
       {
-        cwd,
         env: buildPwrAgentChildProcessEnv(process.env),
-        maxBuffer: 64 * 1024,
+        maxBuffer: 256 * 1024,
         timeout: GIT_REMOTE_TIMEOUT_MS,
       },
     );
-    return stdout.trim() || undefined;
+    for (const line of stdout.split(/\r?\n/)) {
+      const match = line.match(/^hostname\s+(.+)$/i);
+      if (match?.[1]) {
+        return match[1].trim() || undefined;
+      }
+    }
+    return undefined;
   } catch {
     return undefined;
   }

--- a/apps/desktop/src/main/pr-status/git-remote.ts
+++ b/apps/desktop/src/main/pr-status/git-remote.ts
@@ -141,8 +141,30 @@ export async function hasGitHubRemoteForDirectory(
   cwd: string,
   options: ResolveGitHubRepoOptions = {},
 ): Promise<boolean> {
+  return (await resolveGitHubReposForDirectory(cwd, options)).length > 0;
+}
+
+/**
+ * Resolve every distinct GitHub repository in the checkout's configured
+ * remotes. Branch PR lookup queries all of them because a fork checkout may
+ * have `origin` pointing at the fork while the PR belongs to `upstream`.
+ */
+export async function resolveGitHubReposForDirectory(
+  cwd: string,
+  options: ResolveGitHubRepoOptions = {},
+): Promise<GitHubRepoRef[]> {
   const remotes = await readParsedGitRemotes(cwd, options);
-  return remotes.some((remote) => remote.repo?.host === "github.com");
+  const repos = new Map<string, GitHubRepoRef>();
+  for (const remote of remotes) {
+    if (remote.repo?.host !== "github.com") {
+      continue;
+    }
+    const key = `${remote.repo.owner.toLowerCase()}/${remote.repo.repo.toLowerCase()}`;
+    if (!repos.has(key)) {
+      repos.set(key, remote.repo);
+    }
+  }
+  return [...repos.values()];
 }
 
 async function readParsedGitRemotes(

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -18,21 +18,16 @@ const execFileAsync = promisify(execFile);
 const graphqlLog = getMainLogger("pwragent:pr-graphql");
 
 /**
- * In-process batched GitHub client for the background PR-status poller.
+ * In-process batched GitHub client for PR discovery and status refresh.
  *
- * Why this exists alongside `github-pr-fetcher.ts` (the `gh pr list`
- * subprocess): `gh` has no way to ask about many PRs across DIFFERENT repos in
- * one call — it is one invocation per branch, per repo. That is fine for the
- * one selected thread, and far too expensive to sweep 20-30 open projects on a
- * timer.
- *
- * GraphQL can: aliased top-level `repository(...)` selections put N PRs from
+ * Aliased top-level `repository(...)` selections put N PRs from
  * arbitrary repos into ONE request. GitHub bills GraphQL on a node/point model
  * against 5,000 points/hr. The query keeps its connections bounded to one head
  * commit and pages status contexts in batches of 100, stopping as soon as it
  * finds a running check. That lets it preserve failure-while-running state
- * without returning check output. That is the entire reason the poller does
- * not shell out to `gh`.
+ * without returning check output. All PR data requests use this client; the
+ * `gh` subprocess is limited to exporting its auth token and reporting
+ * installation/login status in Settings.
  *
  * Auth is still `gh`'s: we mint a token with `gh auth token` rather than asking
  * the operator for a PAT, so there is no new credential to store.
@@ -265,9 +260,7 @@ export function buildBatchedStatusContextQuery(refs: StatusContextPageRef[]): {
 }
 
 /**
- * A branch to look up PRs for. Used by discovery: "does this branch have a PR?"
- * — the question the `gh pr list --head <branch>` subprocess answers one branch
- * at a time.
+ * A branch to look up PRs for: "does this branch have a PR?"
  */
 export type BranchRef = {
   owner: string;
@@ -281,9 +274,8 @@ export function branchRefKey(ref: BranchRef): string {
 }
 
 /**
- * How many PRs to return per branch. `gh pr list --head <branch>` uses
- * `--limit 5`; matching it means a branch that has both a merged PR and a newer
- * open one still surfaces both, exactly as the subprocess path did.
+ * How many PRs to return per branch. Five preserves the established behavior:
+ * a branch that has both a merged PR and a newer open one still surfaces both.
  */
 const PRS_PER_BRANCH = 5;
 
@@ -526,9 +518,9 @@ export class GithubGraphqlPrClient {
    * Returns a map keyed by `branchRefKey`. A key is present ONLY when GitHub
    * actually answered for that branch — an empty array then means an
    * authoritative "this branch has no PRs". A missing key means we don't know
-   * (batch failed, repo inaccessible), and the caller must fall back rather
-   * than record a false negative. That distinction is the whole contract here:
-   * conflating the two would let one failed request blank out every chip.
+   * (batch failed, repo inaccessible), and the caller must retain prior state
+   * rather than record a false negative. That distinction is the whole contract
+   * here: conflating the two would let one failed request blank out every chip.
    */
   async fetchPullRequestsForBranches(
     refs: BranchRef[],
@@ -572,7 +564,7 @@ export class GithubGraphqlPrClient {
       answers.forEach(({ ref, repository, nodes }) => {
         if (!repository || nodes.some((node) => !checksStillRunning.has(node))) {
           // An unresolved alias or context page is not an authoritative answer;
-          // leave the key absent so the caller falls back to `gh`.
+          // leave the key absent so callers retain prior state.
           return;
         }
         results.set(

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -44,6 +44,30 @@ const MAX_BACKOFF_MS = 60_000;
 /** How long a minted `gh auth token` stays fresh in memory. */
 const TOKEN_TTL_MS = 5 * 60_000;
 
+type GhAuthTokenRunner = (
+  command: string,
+  args: string[],
+) => Promise<{ stdout: string }>;
+
+/** Export the credential for the same host this client queries. */
+export async function readGithubDotComAuthToken(
+  command: string,
+  run: GhAuthTokenRunner = async (executable, args) =>
+    await execFileAsync(executable, args, {
+      env: buildPwrAgentChildProcessEnv(process.env),
+      timeout: 10_000,
+      encoding: "utf8",
+    }),
+): Promise<string | null> {
+  const { stdout } = await run(command, [
+    "auth",
+    "token",
+    "--hostname",
+    "github.com",
+  ]);
+  return stdout.trim() || null;
+}
+
 /**
  * The repo + number that identify a PR *for querying*. This is the PR's BASE
  * repo — a PR number belongs to the repo it was opened against, which for a
@@ -849,12 +873,7 @@ export class GithubGraphqlPrClient {
       if (!command) {
         return null;
       }
-      const { stdout } = await execFileAsync(command, ["auth", "token"], {
-        env: buildPwrAgentChildProcessEnv(process.env),
-        timeout: 10_000,
-        encoding: "utf8",
-      });
-      const token = stdout.trim();
+      const token = await readGithubDotComAuthToken(command);
       if (!token) {
         return null;
       }

--- a/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-fetcher.ts
@@ -9,8 +9,12 @@ import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import { discoverGhCommands } from "../settings/gh-discovery";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
-import { parseGhPrPayload } from "./pr-derivations";
-import type { GhPrPayload } from "./pr-derivations";
+import { resolveGitHubReposForDirectory } from "./git-remote";
+import {
+  branchRefKey,
+  GithubGraphqlPrClient,
+  parsePrRefFromUrl,
+} from "./github-graphql-client";
 
 // The PrSummary derivations are shared with the batched GraphQL poller and
 // live in `pr-derivations.ts`. Re-exported here because this module was
@@ -28,27 +32,6 @@ export type { GhCheckRunPayload, GhPrPayload } from "./pr-derivations";
 const execFileAsync = promisify(execFile);
 const fetcherLog = getMainLogger("pwragent:pr-fetcher");
 
-/** Fields requested from `gh pr list --json …`. Pinned by characterization
- *  against `gh 2.88.1` against pwrdrvr/PwrAgent on 2026-05-04. */
-const GH_FIELDS = [
-  "number",
-  "title",
-  "url",
-  "state",
-  "isDraft",
-  "mergeable",
-  "mergeStateStatus",
-  "mergedAt",
-  "commits",
-  "baseRefName",
-  "headRefName",
-  "headRepository",
-  "headRepositoryOwner",
-  "statusCheckRollup",
-].join(",");
-
-/** Default per-call subprocess timeout. */
-const DEFAULT_TIMEOUT_MS = 5_000;
 /** Default re-probe cadence for `gh --version`. */
 const DEFAULT_GH_AVAILABLE_CACHE_TTL_MS = 60_000;
 /**
@@ -85,12 +68,13 @@ function primedBranchLookupKey(cwd: string, branch: string): string {
 export type GhAuthStatus = GhStatus;
 
 export type GithubPrFetcherOptions = {
-  timeoutMs?: number;
-  /** Override the subprocess runner — used by tests to inject canned output. */
-  exec?: (
-    cwd: string,
-    args: string[],
-  ) => Promise<{ stdout: string; stderr: string }>;
+  /** Share the app's in-process GraphQL client; tests inject a stub. */
+  graphqlClient?: Pick<
+    GithubGraphqlPrClient,
+    "fetchPullRequests" | "fetchPullRequestsForBranches"
+  >;
+  /** Override configured-remote resolution — used by tests. */
+  resolveGitHubRepos?: typeof resolveGitHubReposForDirectory;
   /** Override `gh --version` probe — used by tests. */
   probeGhAvailable?: () => Promise<boolean>;
   /** Override gh discovery — used by tests. */
@@ -112,8 +96,12 @@ export type GithubPrFetcherOptions = {
 };
 
 export class GithubPrFetcher {
-  private readonly timeoutMs: number;
-  private readonly exec: NonNullable<GithubPrFetcherOptions["exec"]>;
+  private readonly graphqlClient: NonNullable<
+    GithubPrFetcherOptions["graphqlClient"]
+  >;
+  private readonly resolveGitHubRepos: NonNullable<
+    GithubPrFetcherOptions["resolveGitHubRepos"]
+  >;
   private readonly probeGhAvailable: NonNullable<
     GithubPrFetcherOptions["probeGhAvailable"]
   > | undefined;
@@ -146,7 +134,9 @@ export class GithubPrFetcher {
   >();
 
   constructor(options: GithubPrFetcherOptions = {}) {
-    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.graphqlClient = options.graphqlClient ?? new GithubGraphqlPrClient();
+    this.resolveGitHubRepos =
+      options.resolveGitHubRepos ?? resolveGitHubReposForDirectory;
     this.probeGhAvailable = options.probeGhAvailable;
     this.discoverGhCommands =
       options.discoverGhCommands
@@ -158,7 +148,6 @@ export class GithubPrFetcher {
               getDesktopSettingsService().resolveGhCommandPreference(),
             env: process.env,
           }));
-    this.exec = options.exec ?? defaultExec(this.timeoutMs, () => this.resolveGhCommand());
     this.runGhAuthStatus =
       options.runGhAuthStatus
       ?? defaultRunGhAuthStatus(() => this.resolveGhCommand());
@@ -183,17 +172,16 @@ export class GithubPrFetcher {
   }
 
   /**
-   * Fetch all open PRs for the given branches in a single `gh pr list` call.
-   * Caller batches by cwd (each cwd is a separate repo from gh's POV).
+   * Fetch all open PRs for the given branches in one in-process GraphQL call.
+   * Caller batches by cwd; fork and upstream remotes share the same request.
    *
    * Why open-only: merged/closed PRs are terminal lifecycle states. Once we've
    * stored a terminal lifecycle on the overlay, we never re-fetch through this
    * open-only path — it only needs to surface non-terminal PRs we might want
    * to refresh.
    *
-   * Filter by headRefName client-side: gh's `--head` flag accepts only one
-   * branch, but `--state open --json …` over the whole repo returns at most
-   * a few dozen open PRs which we filter cheaply.
+   * GraphQL answers by branch, then this compatibility method filters terminal
+   * lifecycle states and deduplicates any repeated PR URLs.
    */
   async fetchOpenPullRequests(params: {
     cwd: string;
@@ -202,28 +190,31 @@ export class GithubPrFetcher {
     if (params.branches.length === 0) {
       return [];
     }
-    if (!(await this.isGhAvailable())) {
+    const repos = await this.resolveGitHubRepos(params.cwd);
+    if (repos.length === 0 || !(await this.isGhAvailable())) {
       return [];
     }
 
-    const wanted = new Set(params.branches);
     try {
-      const { stdout } = await this.exec(params.cwd, [
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--json",
-        GH_FIELDS,
-        "--limit",
-        "30",
-      ]);
-      const payload = JSON.parse(stdout) as GhPrPayload[];
-      return payload
-        .filter((row) => wanted.has(row.headRefName))
-        .map(parseGhPrPayload);
+      const refs = repos.flatMap((repo) =>
+        params.branches.map((branch) => ({
+          owner: repo.owner,
+          repo: repo.repo,
+          branch,
+        })),
+      );
+      const byBranch = await this.graphqlClient.fetchPullRequestsForBranches(refs);
+      const byUrl = new Map<string, PrSummary>();
+      for (const ref of refs) {
+        for (const pr of byBranch.get(branchRefKey(ref)) ?? []) {
+          if (pr.lifecycleState === "open") {
+            byUrl.set(pr.url, pr);
+          }
+        }
+      }
+      return [...byUrl.values()];
     } catch (error) {
-      fetcherLog.warn("gh pr list failed", {
+      fetcherLog.debug("in-process open PR lookup failed", {
         cwd: params.cwd,
         branchCount: params.branches.length,
         error: error instanceof Error ? error.message : String(error),
@@ -233,11 +224,9 @@ export class GithubPrFetcher {
   }
 
   /**
-   * Fetch the latest state for a single (possibly terminal) PR. Uses
-   * `gh pr list --state all --head <branch>` so we catch merged/closed
-   * states too — this is the one place the renderer asks "give me the
-   * authoritative state for this PR right now," typically on first
-   * selection of a thread.
+   * Fetch the latest state for a single branch, including merged/closed PRs.
+   * This is the renderer's authoritative on-selection/user-refresh path, now
+   * using the same in-process GraphQL transport as background discovery.
    */
   async fetchAllPullRequestsForBranch(params: {
     cwd: string;
@@ -258,26 +247,26 @@ export class GithubPrFetcher {
     if (params.allowPrimed !== false && primed) {
       return primed;
     }
-    if (!(await this.isGhAvailable())) {
+    const repos = await this.resolveGitHubRepos(params.cwd);
+    if (repos.length === 0 || !(await this.isGhAvailable())) {
       return [];
     }
     try {
-      const { stdout } = await this.exec(params.cwd, [
-        "pr",
-        "list",
-        "--state",
-        "all",
-        "--head",
-        params.branch,
-        "--json",
-        GH_FIELDS,
-        "--limit",
-        "5",
-      ]);
-      const payload = JSON.parse(stdout) as GhPrPayload[];
-      return payload.map(parseGhPrPayload);
+      const refs = repos.map((repo) => ({
+        owner: repo.owner,
+        repo: repo.repo,
+        branch: params.branch,
+      }));
+      const byBranch = await this.graphqlClient.fetchPullRequestsForBranches(refs);
+      const byUrl = new Map<string, PrSummary>();
+      for (const ref of refs) {
+        for (const pr of byBranch.get(branchRefKey(ref)) ?? []) {
+          byUrl.set(pr.url, pr);
+        }
+      }
+      return [...byUrl.values()];
     } catch (error) {
-      fetcherLog.warn("gh pr list (single-branch) failed", {
+      fetcherLog.debug("in-process branch PR lookup failed", {
         cwd: params.cwd,
         branch: params.branch,
         error: error instanceof Error ? error.message : String(error),
@@ -287,9 +276,9 @@ export class GithubPrFetcher {
   }
 
   /**
-   * Fetch the latest state for a retained PR chip by URL. This covers thread
-   * history chips whose original head branch no longer matches the thread's
-   * current branch lookup.
+   * Fetch the latest state for a retained PR chip by URL through the
+   * in-process by-number GraphQL query. The URL identifies the base repository,
+   * so this does not depend on the linked directory still existing.
    */
   async fetchPullRequestByUrl(params: {
     cwd: string;
@@ -298,19 +287,14 @@ export class GithubPrFetcher {
     if (!(await this.isGhAvailable())) {
       return undefined;
     }
+    const ref = parsePrRefFromUrl(params.url);
+    if (!ref) {
+      return undefined;
+    }
     try {
-      const { stdout } = await this.exec(params.cwd, [
-        "pr",
-        "view",
-        params.url,
-        "--json",
-        GH_FIELDS,
-      ]);
-      const payload = JSON.parse(stdout) as GhPrPayload;
-      return parseGhPrPayload(payload);
+      return (await this.graphqlClient.fetchPullRequests([ref]))[0];
     } catch (error) {
-      fetcherLog.warn("gh pr view failed", {
-        cwd: params.cwd,
+      fetcherLog.debug("in-process retained PR lookup failed", {
         url: params.url,
         error: error instanceof Error ? error.message : String(error),
       });
@@ -398,9 +382,9 @@ export class GithubPrFetcher {
    *
    * Entries are **single-use** and short-lived on purpose: a primed value is
    * consumed by the one refresh it was fetched for, so a later user-triggered
-   * refresh always gets its own fresh read rather than silently reusing
-   * someone else's fetch. Only prime branches GitHub actually answered for —
-   * priming `[]` for a failed lookup would record a false "no PRs".
+   * refresh gets its own in-process read rather than silently reusing someone
+   * else's fetch. Only prime branches GitHub actually answered for — priming
+   * `[]` for a failed lookup would record a false "no PRs".
    */
   primeBranchLookup(
     entries: { cwd: string; branch: string; prs: PrSummary[] }[],
@@ -519,23 +503,6 @@ export function parseGhAuthStatus(input: {
         ? undefined
         : "Token is missing the `repo` scope. Run `gh auth refresh -s repo` to grant it."
       : "Run `gh auth login` to sign in to github.com.",
-  };
-}
-
-function defaultExec(
-  timeoutMs: number,
-  resolveGhCommand: () => Promise<string>,
-): NonNullable<GithubPrFetcherOptions["exec"]> {
-  return async (cwd, args) => {
-    const command = await resolveGhCommand();
-    const result = await execFileAsync(command, args, {
-      cwd,
-      env: buildPwrAgentChildProcessEnv(process.env),
-      timeout: timeoutMs,
-      maxBuffer: 1024 * 1024,
-      encoding: "utf8",
-    });
-    return { stdout: result.stdout, stderr: result.stderr };
   };
 }
 

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -27,12 +27,11 @@ type TrackedRemoteBranch = {
 
 /**
  * Detect PRs for a single thread by walking the resolved directory paths that
- * have a configured GitHub remote and asking
- * `gh pr list --head <branch> --state all` per eligible directory.
+ * have a configured GitHub remote and querying each branch in-process.
  * Aggregates results, dedupes by URL (in case multiple linked dirs point
  * at the same repo).
  *
- * `--state all` is intentional: this is the on-focus / on-selection
+ * All lifecycle states are intentional: this is the on-focus / on-selection
  * authoritative fetch, so we want to surface merged/closed PRs too.
  * That state then sticks in the persistence overlay and the IPC layer
  * short-circuits future refreshes once any PR reaches a terminal state.

--- a/apps/desktop/src/main/pr-status/pr-detection.ts
+++ b/apps/desktop/src/main/pr-status/pr-detection.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { LinkedDirectorySummary, PrSummary } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { hasGitHubRemoteForDirectory } from "./git-remote";
 import type { GithubPrFetcher } from "./github-pr-fetcher";
 
 const execFileAsync = promisify(execFile);
@@ -25,8 +26,9 @@ type TrackedRemoteBranch = {
 };
 
 /**
- * Detect PRs for a single thread by walking the resolved directory paths
- * and asking `gh pr list --head <branch> --state all` per directory.
+ * Detect PRs for a single thread by walking the resolved directory paths that
+ * have a configured GitHub remote and asking
+ * `gh pr list --head <branch> --state all` per eligible directory.
  * Aggregates results, dedupes by URL (in case multiple linked dirs point
  * at the same repo).
  *
@@ -53,6 +55,9 @@ export async function detectPullRequestsForThread(params: {
 
   const results = await Promise.all(
     dirs.map(async (cwd) => {
+      if (!(await hasGitHubRemoteForDirectory(cwd))) {
+        return [];
+      }
       const branches = await resolvePrLookupBranches({ branch, cwd });
       const prsByBranch = await Promise.all(
         branches.map((lookupBranch) =>

--- a/apps/desktop/src/main/pr-status/pr-discovery.ts
+++ b/apps/desktop/src/main/pr-status/pr-discovery.ts
@@ -3,9 +3,9 @@
  *
  * The fast GraphQL poller (`pr-polling-scheduler.ts`) keeps the status of PRs
  * we ALREADY track fresh. It cannot find a PR we don't know about yet — it
- * polls by number. Discovery closes that gap by re-running the branch-based
- * lookup (`gh pr list --head <branch>`) across EVERY open thread, not just the
- * selected one, on a slow rotation.
+ * polls by number. Discovery closes that gap by re-running the in-process
+ * branch-based lookup across EVERY open thread, not just the selected one, on
+ * a slow rotation.
  *
  * Why branch-lookup rather than a GitHub search/`since` crawl: PwrAgent attaches
  * PRs to a thread by matching the thread's branch. A raw "list PRs updated since
@@ -15,7 +15,7 @@
  * This is the periodic refresh across open repos that was lost.
  *
  * The selection below is a pure function so the rotation logic is testable
- * without timers or a live `gh`.
+ * without timers or a live GitHub request.
  */
 
 export type DiscoveryDueSelection = {


### PR DESCRIPTION
## Summary

- I gate branch-based pull request discovery on the checkout having at least one configured GitHub fetch remote before PwrAgent makes a GitHub API request.
- I cache the full configured-remote snapshot, including negative results, for five minutes and recognize GitHub remotes named `upstream` or another custom name.
- I resolve SSH host aliases through the local OpenSSH configuration without connecting, so remotes such as `git@github-work:owner/repo.git` still qualify when `Host github-work` maps to `HostName github.com`.
- I moved the remaining selected-thread, user, post-turn, and retained-PR data refreshes from `gh pr list/view` subprocesses to the shared in-process Octokit GraphQL client.
- I query every distinct configured GitHub repository together so fork checkouts can discover PRs from both `origin` and `upstream` without relying on `gh` repository inference.

## Verification

- I verified 240 PR-status and app-server tests pass, including new coverage for deleted worktree paths, repositories with no remotes, non-GitHub remotes, GitHub remotes not named `origin`, SSH aliases that resolve to GitHub, and fork/upstream lookups.
- I ran the workspace TypeScript typecheck successfully.
- I ran ESLint successfully with only the repository's pre-existing warnings.
- I ran dependency-boundary validation successfully.

## Notes

- The original `not a git repository` report failed while `gh` was resolving the local repository, before it could make a GitHub API request. The later `spawn /opt/homebrew/bin/gh ENOENT` reports also came from deleted worktree `cwd` paths; the `gh` executable itself exists, but Node reports the spawn as `ENOENT` when its working directory is missing.
- PwrAgent now uses `gh` only to check installation/login status and export the short-lived auth token consumed by Octokit. No PR data command launches `gh` with a repository working directory.
