### PR TITLE
feat(desktop): add federation SSH transport and multi-path gateway endpoints

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -118,7 +118,7 @@ describe("desktop config [federation] section", () => {
     ]);
   });
 
-  it("dual-writes the first gateway endpoint into the legacy gateway_url", () => {
+  it("writes only the canonical shape for a config without a legacy gateway_url", () => {
     const edits = desktopSettingsPatchToEdits({
       federation: {
         gatewayEndpoints: [
@@ -135,9 +135,51 @@ describe("desktop config [federation] section", () => {
       "wss://studio.example.ts.net/pwragent-federation",
       "wss://federation.example.com",
     ]);
+    // docs/config-file-evolution.md: a brand-new config gets the canonical
+    // shape only; the legacy scalar is not invented for it.
+    expect(config.federation?.gatewayUrl).toBeUndefined();
+  });
+
+  it("keeps an existing legacy gateway_url in sync and marks it", () => {
+    const existing = [
+      "[federation]",
+      'mode = "client"',
+      'gateway_url = "wss://old.example.com"',
+      "",
+    ].join("\n");
+    const edits = desktopSettingsPatchToEdits(
+      {
+        federation: {
+          gatewayEndpoints: [
+            "wss://studio.example.ts.net/pwragent-federation",
+            "wss://federation.example.com",
+          ],
+        },
+      },
+      parseTomlTables(existing, "test.toml"),
+    );
+    const written = applyTomlEdits(existing, edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
     expect(config.federation?.gatewayUrl).toBe(
       "wss://studio.example.ts.net/pwragent-federation",
     );
+    expect(written).toContain("pwragent-legacy-settings");
+    expect(written).toContain("key=gateway_url");
+  });
+
+  it("drops endpoints whose scheme the transport must never dial", () => {
+    const src = [
+      "[federation]",
+      'gateway_endpoints = ["https://evil.example", "ws://ok.example:47830", "ssh://user:secret@host", "ssh://-oProxyCommand=x"]',
+      "",
+    ].join("\n");
+
+    const config = parseDesktopSettingsToml(src, "test.toml");
+
+    expect(config.federation?.gatewayEndpoints).toEqual([
+      "ws://ok.example:47830",
+    ]);
   });
 
   it("lets an explicit gatewayUrl win over the endpoint dual-write", () => {
@@ -156,7 +198,7 @@ describe("desktop config [federation] section", () => {
     ]);
   });
 
-  it("clearing the endpoint list also clears the legacy gateway_url", () => {
+  it("clearing the endpoint list preserves the legacy gateway_url", () => {
     const existing = [
       "[federation]",
       'mode = "client"',
@@ -179,7 +221,9 @@ describe("desktop config [federation] section", () => {
 
     expect(config.federation?.gatewayEndpoints).toBeUndefined();
     expect(config.federation?.advertisedEndpoints).toBeUndefined();
-    expect(config.federation?.gatewayUrl).toBeUndefined();
+    // docs/config-file-evolution.md rule 7: never delete the preserved legacy
+    // scalar an older client still reads.
+    expect(config.federation?.gatewayUrl).toBe("wss://old.example.com");
   });
 
   it("ignores unknown federation modes", () => {

--- a/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-federation.test.ts
@@ -96,6 +96,92 @@ describe("desktop config [federation] section", () => {
     expect(config.federation).toBeUndefined();
   });
 
+  it("reads ordered gateway and advertised endpoint lists", () => {
+    const src = [
+      "[federation]",
+      'mode = "client"',
+      'gateway_url = "ws://192.168.1.20:47830"',
+      'gateway_endpoints = ["ws://192.168.1.20:47830", "wss://studio.example.ts.net/pwragent-federation", "ssh://ops@gateway.lan"]',
+      'advertised_endpoints = ["wss://federation.example.com"]',
+      "",
+    ].join("\n");
+
+    const config = parseDesktopSettingsToml(src, "test.toml");
+
+    expect(config.federation?.gatewayEndpoints).toEqual([
+      "ws://192.168.1.20:47830",
+      "wss://studio.example.ts.net/pwragent-federation",
+      "ssh://ops@gateway.lan",
+    ]);
+    expect(config.federation?.advertisedEndpoints).toEqual([
+      "wss://federation.example.com",
+    ]);
+  });
+
+  it("dual-writes the first gateway endpoint into the legacy gateway_url", () => {
+    const edits = desktopSettingsPatchToEdits({
+      federation: {
+        gatewayEndpoints: [
+          " wss://studio.example.ts.net/pwragent-federation ",
+          "wss://federation.example.com",
+          "wss://federation.example.com",
+        ],
+      },
+    });
+    const written = applyTomlEdits("", edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
+    expect(config.federation?.gatewayEndpoints).toEqual([
+      "wss://studio.example.ts.net/pwragent-federation",
+      "wss://federation.example.com",
+    ]);
+    expect(config.federation?.gatewayUrl).toBe(
+      "wss://studio.example.ts.net/pwragent-federation",
+    );
+  });
+
+  it("lets an explicit gatewayUrl win over the endpoint dual-write", () => {
+    const edits = desktopSettingsPatchToEdits({
+      federation: {
+        gatewayUrl: "wss://explicit.example.com",
+        gatewayEndpoints: ["wss://first.example.com"],
+      },
+    });
+    const written = applyTomlEdits("", edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
+    expect(config.federation?.gatewayUrl).toBe("wss://explicit.example.com");
+    expect(config.federation?.gatewayEndpoints).toEqual([
+      "wss://first.example.com",
+    ]);
+  });
+
+  it("clearing the endpoint list also clears the legacy gateway_url", () => {
+    const existing = [
+      "[federation]",
+      'mode = "client"',
+      'gateway_url = "wss://old.example.com"',
+      'gateway_endpoints = ["wss://old.example.com"]',
+      'advertised_endpoints = ["wss://old.example.com"]',
+      "",
+    ].join("\n");
+    const edits = desktopSettingsPatchToEdits(
+      {
+        federation: {
+          gatewayEndpoints: [],
+          advertisedEndpoints: [],
+        },
+      },
+      parseTomlTables(existing, "test.toml"),
+    );
+    const written = applyTomlEdits(existing, edits);
+    const config = parseDesktopSettingsToml(written, "test.toml");
+
+    expect(config.federation?.gatewayEndpoints).toBeUndefined();
+    expect(config.federation?.advertisedEndpoints).toBeUndefined();
+    expect(config.federation?.gatewayUrl).toBeUndefined();
+  });
+
   it("ignores unknown federation modes", () => {
     const config = parseDesktopSettingsToml(
       '[federation]\nmode = "coordinator"\n',

--- a/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateFederationNoiseStaticKeyPair } from "../federation/federation-noise";
+import { DesktopFederationRuntime } from "../federation/federation-runtime";
+
+const metaStore = vi.hoisted(() => new Map<string, string>());
+const connectCalls = vi.hoisted(
+  () =>
+    [] as Array<{
+      url: string;
+      headers?: Record<string, string>;
+      clientCertificate?: string;
+      clientPrivateKey?: string;
+      createSocket?: () => unknown;
+    }>,
+);
+
+vi.mock("../state/app-state", () => ({
+  getAppStateDb: () => ({
+    getMeta: (key: string) => metaStore.get(key) ?? "",
+    setMeta: (key: string, value: string) => void metaStore.set(key, value),
+  }),
+  isAppStateInitialized: () => true,
+}));
+
+vi.mock("../federation/federation-transport", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  connectFederationClient: async (params: (typeof connectCalls)[number]) => {
+    connectCalls.push(params);
+    return {
+      sessionId: "federation-session:test",
+      capabilities: [],
+      sendEnvelope: () => undefined,
+      close: () => undefined,
+    };
+  },
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => {
+  const noise = generateFederationNoiseStaticKeyPair();
+  return {
+    getDesktopSettingsService: () => ({
+      readSettings: async () => ({
+        federation: {
+          cloudflareMtlsEnabled: { value: true },
+          cloudflareAccessServiceAuthEnabled: { value: true },
+        },
+      }),
+      resolveFederationCloudflareCredentials: async () => ({
+        clientCertificate: "PEM-CERT",
+        clientPrivateKey: "PEM-KEY",
+        accessClientId: "access-id",
+        accessClientSecret: "access-secret",
+      }),
+      getOrCreateFederationIdentityKeyPair: async () => ({
+        privateKeyPem: "identity-private",
+        publicKeyPem: "identity-public",
+      }),
+      getOrCreateFederationNoiseStaticKeyPair: async () => noise,
+    }),
+  };
+});
+
+type CredentialHarness = {
+  stopping: boolean;
+  connectClient: (gatewayUrl: string) => Promise<void>;
+  store: () => { appendAudit: (entry: unknown) => void };
+};
+
+function createHarness(): CredentialHarness {
+  const runtime = new DesktopFederationRuntime() as unknown as CredentialHarness;
+  runtime.stopping = false;
+  runtime.store = () => ({ appendAudit: () => undefined });
+  return runtime;
+}
+
+describe("federation endpoint credential scoping", () => {
+  beforeEach(() => {
+    connectCalls.length = 0;
+    metaStore.clear();
+    metaStore.set("federation_instance_id", "pwr_client-under-test");
+    metaStore.set("federation_gateway_instance_id", "gateway_one");
+    metaStore.set("federation_gateway_public_key_pem", "gateway-public-pem");
+    metaStore.set(
+      "federation_gateway_noise_public_key",
+      generateFederationNoiseStaticKeyPair().publicKeyBase64,
+    );
+  });
+
+  it("attaches Cloudflare credentials on wss:// endpoints", async () => {
+    await createHarness().connectClient("wss://federation.example.com");
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].url).toBe("wss://federation.example.com");
+    expect(connectCalls[0].headers).toMatchObject({
+      "CF-Access-Client-Id": "access-id",
+      "CF-Access-Client-Secret": "access-secret",
+    });
+    expect(connectCalls[0].clientCertificate).toBe("PEM-CERT");
+    expect(connectCalls[0].clientPrivateKey).toBe("PEM-KEY");
+    expect(connectCalls[0].createSocket).toBeUndefined();
+  });
+
+  it("never sends Cloudflare credentials on a plain ws:// endpoint", async () => {
+    await createHarness().connectClient("ws://192.168.1.20:47830");
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].headers).toBeUndefined();
+    expect(connectCalls[0].clientCertificate).toBeUndefined();
+    expect(connectCalls[0].clientPrivateKey).toBeUndefined();
+  });
+
+  it("dials ssh:// endpoints through the SSH forward without edge credentials", async () => {
+    await createHarness().connectClient(
+      "ssh://ops@gateway.lan/?forward=127.0.0.1:47831",
+    );
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].url).toBe("ws://127.0.0.1:47831");
+    expect(connectCalls[0].createSocket).toBeTypeOf("function");
+    expect(connectCalls[0].headers).toBeUndefined();
+    expect(connectCalls[0].clientCertificate).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
@@ -43,6 +43,7 @@ vi.mock("../settings/desktop-settings-singleton", () => {
     getDesktopSettingsService: () => ({
       readSettings: async () => ({
         federation: {
+          instanceLabel: { value: "" },
           cloudflareEndpoint: { value: cloudflareEndpoint.value },
           cloudflareMtlsEnabled: { value: true },
           cloudflareAccessServiceAuthEnabled: { value: true },

--- a/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-credential-scoping.test.ts
@@ -35,12 +35,15 @@ vi.mock("../federation/federation-transport", async (importOriginal) => ({
   },
 }));
 
+const cloudflareEndpoint = vi.hoisted(() => ({ value: "" }));
+
 vi.mock("../settings/desktop-settings-singleton", () => {
   const noise = generateFederationNoiseStaticKeyPair();
   return {
     getDesktopSettingsService: () => ({
       readSettings: async () => ({
         federation: {
+          cloudflareEndpoint: { value: cloudflareEndpoint.value },
           cloudflareMtlsEnabled: { value: true },
           cloudflareAccessServiceAuthEnabled: { value: true },
         },
@@ -62,13 +65,15 @@ vi.mock("../settings/desktop-settings-singleton", () => {
 
 type CredentialHarness = {
   stopping: boolean;
+  configuredEndpoints: string[];
   connectClient: (gatewayUrl: string) => Promise<void>;
   store: () => { appendAudit: (entry: unknown) => void };
 };
 
-function createHarness(): CredentialHarness {
+function createHarness(configuredEndpoints: string[] = []): CredentialHarness {
   const runtime = new DesktopFederationRuntime() as unknown as CredentialHarness;
   runtime.stopping = false;
+  runtime.configuredEndpoints = configuredEndpoints;
   runtime.store = () => ({ appendAudit: () => undefined });
   return runtime;
 }
@@ -76,6 +81,7 @@ function createHarness(): CredentialHarness {
 describe("federation endpoint credential scoping", () => {
   beforeEach(() => {
     connectCalls.length = 0;
+    cloudflareEndpoint.value = "";
     metaStore.clear();
     metaStore.set("federation_instance_id", "pwr_client-under-test");
     metaStore.set("federation_gateway_instance_id", "gateway_one");
@@ -86,8 +92,12 @@ describe("federation endpoint credential scoping", () => {
     );
   });
 
-  it("attaches Cloudflare credentials on wss:// endpoints", async () => {
-    await createHarness().connectClient("wss://federation.example.com");
+  it("attaches Cloudflare credentials to the designated endpoint", async () => {
+    cloudflareEndpoint.value = "wss://federation.example.com";
+    await createHarness([
+      "ws://192.168.1.20:47830",
+      "wss://federation.example.com",
+    ]).connectClient("wss://federation.example.com");
 
     expect(connectCalls).toHaveLength(1);
     expect(connectCalls[0].url).toBe("wss://federation.example.com");
@@ -100,8 +110,64 @@ describe("federation endpoint credential scoping", () => {
     expect(connectCalls[0].createSocket).toBeUndefined();
   });
 
+  // The core of the fix: these credentials ride the WebSocket upgrade, before
+  // the Noise handshake pins anything, so a different wss:// host in the
+  // fallback list must never receive them.
+  it("never sends Cloudflare credentials to a different wss:// host", async () => {
+    cloudflareEndpoint.value = "wss://federation.example.com";
+    await createHarness([
+      "wss://attacker.example",
+      "wss://federation.example.com",
+    ]).connectClient("wss://attacker.example");
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].headers).toBeUndefined();
+    expect(connectCalls[0].clientCertificate).toBeUndefined();
+    expect(connectCalls[0].clientPrivateKey).toBeUndefined();
+  });
+
+  it("withholds credentials from every host when several are configured and none is designated", async () => {
+    cloudflareEndpoint.value = "";
+    await createHarness([
+      "wss://one.example",
+      "wss://two.example",
+    ]).connectClient("wss://one.example");
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].headers).toBeUndefined();
+    expect(connectCalls[0].clientCertificate).toBeUndefined();
+  });
+
+  it("keeps single-endpoint behavior working without an explicit designation", async () => {
+    cloudflareEndpoint.value = "";
+    await createHarness(["wss://federation.example.com"]).connectClient(
+      "wss://federation.example.com",
+    );
+
+    expect(connectCalls).toHaveLength(1);
+    expect(connectCalls[0].headers).toMatchObject({
+      "CF-Access-Client-Id": "access-id",
+    });
+    expect(connectCalls[0].clientCertificate).toBe("PEM-CERT");
+  });
+
+  it("matches the designated endpoint case-insensitively and ignores its path", async () => {
+    cloudflareEndpoint.value = "WSS://Federation.Example.com/pwragent";
+    await createHarness([
+      "wss://federation.example.com/other-path",
+      "ws://lan",
+    ]).connectClient("wss://federation.example.com/other-path");
+
+    expect(connectCalls[0].headers).toMatchObject({
+      "CF-Access-Client-Id": "access-id",
+    });
+  });
+
   it("never sends Cloudflare credentials on a plain ws:// endpoint", async () => {
-    await createHarness().connectClient("ws://192.168.1.20:47830");
+    cloudflareEndpoint.value = "";
+    await createHarness(["ws://192.168.1.20:47830"]).connectClient(
+      "ws://192.168.1.20:47830",
+    );
 
     expect(connectCalls).toHaveLength(1);
     expect(connectCalls[0].headers).toBeUndefined();
@@ -110,9 +176,9 @@ describe("federation endpoint credential scoping", () => {
   });
 
   it("dials ssh:// endpoints through the SSH forward without edge credentials", async () => {
-    await createHarness().connectClient(
+    await createHarness([
       "ssh://ops@gateway.lan/?forward=127.0.0.1:47831",
-    );
+    ]).connectClient("ssh://ops@gateway.lan/?forward=127.0.0.1:47831");
 
     expect(connectCalls).toHaveLength(1);
     expect(connectCalls[0].url).toBe("ws://127.0.0.1:47831");

--- a/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
@@ -88,6 +88,36 @@ describe("federation endpoint fallback", () => {
     expect(attempts).toEqual([LAN]);
   });
 
+  // Every endpoint authenticates against the same pinned gateway identity, so
+  // an auth-class failure is a property of the pairing, not of one path.
+  // Continuing would let a later endpoint's network error mask a broken pin.
+  it("stops the walk on an auth-class failure instead of trying more endpoints", async () => {
+    const runtime = createHarness([LAN, TAILSCALE, CLOUDFLARE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      throw new Error("Invalid federation auth challenge signature");
+    };
+
+    await expect(runtime.connectToGateway()).rejects.toThrow(
+      "Invalid federation auth challenge signature",
+    );
+    expect(attempts).toEqual([LAN]);
+  });
+
+  it("keeps walking past a transport-class failure", async () => {
+    const runtime = createHarness([LAN, TAILSCALE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      if (gatewayUrl === LAN) throw new Error("connect ECONNREFUSED");
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([LAN, TAILSCALE]);
+  });
+
   it("throws the final endpoint error after a fully failed cycle", async () => {
     const runtime = createHarness([LAN, TAILSCALE]);
     runtime.connectClient = async (gatewayUrl) => {

--- a/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DesktopFederationRuntime } from "../federation/federation-runtime";
+
+const metaStore = vi.hoisted(() => new Map<string, string>());
+
+vi.mock("../state/app-state", () => ({
+  getAppStateDb: () => ({
+    getMeta: (key: string) => metaStore.get(key) ?? "",
+    setMeta: (key: string, value: string) => void metaStore.set(key, value),
+  }),
+  isAppStateInitialized: () => true,
+}));
+
+const LAN = "ws://192.168.1.20:47830";
+const TAILSCALE = "wss://studio.example.ts.net/pwragent-federation";
+const CLOUDFLARE = "wss://federation.example.com";
+const LAST_ENDPOINT_KEY = "federation_gateway_last_endpoint";
+
+type FallbackHarness = {
+  stopping: boolean;
+  configuredEndpoints: string[];
+  endpointStatuses: Map<
+    string,
+    { state: string; lastError?: string; lastConnectedAt?: number }
+  >;
+  connectClient: (gatewayUrl: string) => Promise<void>;
+  connectToGateway: () => Promise<void>;
+  markEndpointConnected: (gatewayUrl: string) => void;
+};
+
+function createHarness(endpoints: string[]): FallbackHarness {
+  const runtime = new DesktopFederationRuntime() as unknown as FallbackHarness;
+  runtime.stopping = false;
+  runtime.configuredEndpoints = endpoints;
+  return runtime;
+}
+
+describe("federation endpoint fallback", () => {
+  beforeEach(() => {
+    metaStore.clear();
+  });
+
+  it("walks endpoints in configured order and stops at the first success", async () => {
+    const runtime = createHarness([LAN, TAILSCALE, CLOUDFLARE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      if (gatewayUrl !== CLOUDFLARE) {
+        throw new Error(`connect ECONNREFUSED ${gatewayUrl}`);
+      }
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([LAN, TAILSCALE, CLOUDFLARE]);
+    expect(runtime.endpointStatuses.get(LAN)).toMatchObject({
+      state: "failed",
+    });
+    expect(runtime.endpointStatuses.get(LAN)?.lastError).toBeTruthy();
+    expect(runtime.endpointStatuses.get(TAILSCALE)).toMatchObject({
+      state: "failed",
+    });
+  });
+
+  it("tries the last endpoint that worked first", async () => {
+    metaStore.set(LAST_ENDPOINT_KEY, CLOUDFLARE);
+    const runtime = createHarness([LAN, TAILSCALE, CLOUDFLARE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([CLOUDFLARE]);
+  });
+
+  it("ignores a remembered endpoint that is no longer configured", async () => {
+    metaStore.set(LAST_ENDPOINT_KEY, "wss://removed.example.com");
+    const runtime = createHarness([LAN, TAILSCALE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([LAN]);
+  });
+
+  it("throws the final endpoint error after a fully failed cycle", async () => {
+    const runtime = createHarness([LAN, TAILSCALE]);
+    runtime.connectClient = async (gatewayUrl) => {
+      throw new Error(`connect ECONNREFUSED ${gatewayUrl}`);
+    };
+
+    await expect(runtime.connectToGateway()).rejects.toThrow(
+      `connect ECONNREFUSED ${TAILSCALE}`,
+    );
+  });
+
+  it("records the last-good endpoint only from an established connection", () => {
+    const runtime = createHarness([LAN, TAILSCALE]);
+    expect(metaStore.get(LAST_ENDPOINT_KEY)).toBeUndefined();
+
+    runtime.markEndpointConnected(TAILSCALE);
+
+    expect(metaStore.get(LAST_ENDPOINT_KEY)).toBe(TAILSCALE);
+    expect(runtime.endpointStatuses.get(TAILSCALE)).toMatchObject({
+      state: "active",
+    });
+    expect(
+      runtime.endpointStatuses.get(TAILSCALE)?.lastConnectedAt,
+    ).toBeTypeOf("number");
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-endpoints.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoints.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { orderFederationEndpointAttempts } from "../federation/federation-endpoints";
+
+const LAN = "ws://192.168.1.20:47830";
+const TAILSCALE = "wss://studio.example.ts.net/pwragent-federation";
+const CLOUDFLARE = "wss://federation.example.com";
+
+describe("orderFederationEndpointAttempts", () => {
+  it("keeps configured order without a last-good endpoint", () => {
+    expect(orderFederationEndpointAttempts([LAN, TAILSCALE, CLOUDFLARE])).toEqual(
+      [LAN, TAILSCALE, CLOUDFLARE],
+    );
+  });
+
+  it("moves the last-good endpoint to the front", () => {
+    expect(
+      orderFederationEndpointAttempts([LAN, TAILSCALE, CLOUDFLARE], CLOUDFLARE),
+    ).toEqual([CLOUDFLARE, LAN, TAILSCALE]);
+  });
+
+  it("ignores a last-good endpoint that is no longer configured", () => {
+    expect(
+      orderFederationEndpointAttempts([LAN, TAILSCALE], "wss://removed.example"),
+    ).toEqual([LAN, TAILSCALE]);
+  });
+
+  it("trims and de-duplicates configured endpoints", () => {
+    expect(
+      orderFederationEndpointAttempts([` ${LAN} `, LAN, "", TAILSCALE]),
+    ).toEqual([LAN, TAILSCALE]);
+  });
+
+  it("returns an empty list for no endpoints", () => {
+    expect(orderFederationEndpointAttempts([], LAN)).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -95,15 +95,44 @@ describe("federation enrollment", () => {
       gatewayUrl: "ws://127.0.0.1:47830",
       expiresAt: 2_000,
     };
-    for (const gatewayEndpoints of [[], ["ws://ok.example", 7], "not-a-list"]) {
+    for (const gatewayEndpoints of [
+      [],
+      ["ws://ok.example", 7],
+      "not-a-list",
+      // An invite is unsigned, attacker-authored input that never passes
+      // through the renderer, so the scheme allowlist is enforced on decode.
+      ["https://evil.example"],
+      ["ws://ok.example", "https://evil.example"],
+      ["ssh://user:secret@host"],
+      ["ssh://-oProxyCommand=touch%20pwned"],
+    ]) {
       const invite = `pwragent-federation:${Buffer.from(
         JSON.stringify({ ...base, gatewayEndpoints }),
         "utf8",
       ).toString("base64url")}`;
       expect(() => decodeFederationInvite(invite, 1_000)).toThrow(
-        "Invalid federation invite.",
+        /Invalid federation invite\.|must all be ws:\/\//,
       );
     }
+  });
+
+  it("rejects an invite whose gateway URL is not a supported endpoint", () => {
+    const invite = `pwragent-federation:${Buffer.from(
+      JSON.stringify({
+        version: FEDERATION_INVITE_VERSION,
+        token: "invite-token-bad-url",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: "gateway-key",
+        gatewayNoisePublicKey: "gateway-noise-key",
+        gatewayUrl: "https://evil.example",
+        expiresAt: 2_000,
+      }),
+      "utf8",
+    ).toString("base64url")}`;
+
+    expect(() => decodeFederationInvite(invite, 1_000)).toThrow(
+      /must be a ws:\/\/, wss:\/\/, or ssh:\/\/ endpoint/,
+    );
   });
 
   it("rejects unsupported invite versions before attempting enrollment", () => {

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -61,6 +61,51 @@ describe("federation enrollment", () => {
     );
   });
 
+  it("round-trips an ordered multi-endpoint invite at the same version", () => {
+    const gatewayKeyPair = generateFederationIdentityKeyPair();
+    const gatewayEndpoints = [
+      "ws://192.168.1.20:47830",
+      "wss://studio.example.ts.net/pwragent-federation",
+      "wss://federation.example.com",
+    ];
+    const invite = encodeFederationInvite({
+      version: FEDERATION_INVITE_VERSION,
+      token: "invite-token-multipath",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      gatewayNoisePublicKey: "gateway-noise-public-key",
+      gatewayUrl: gatewayEndpoints[0],
+      gatewayEndpoints,
+      expiresAt: 2_000,
+    });
+
+    const decoded = decodeFederationInvite(invite, 1_000);
+    expect(decoded.version).toBe(FEDERATION_INVITE_VERSION);
+    expect(decoded.gatewayUrl).toBe(gatewayEndpoints[0]);
+    expect(decoded.gatewayEndpoints).toEqual(gatewayEndpoints);
+  });
+
+  it("rejects invites with a malformed endpoint list", () => {
+    const base = {
+      version: FEDERATION_INVITE_VERSION,
+      token: "invite-token-bad-endpoints",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: "gateway-key",
+      gatewayNoisePublicKey: "gateway-noise-key",
+      gatewayUrl: "ws://127.0.0.1:47830",
+      expiresAt: 2_000,
+    };
+    for (const gatewayEndpoints of [[], ["ws://ok.example", 7], "not-a-list"]) {
+      const invite = `pwragent-federation:${Buffer.from(
+        JSON.stringify({ ...base, gatewayEndpoints }),
+        "utf8",
+      ).toString("base64url")}`;
+      expect(() => decodeFederationInvite(invite, 1_000)).toThrow(
+        "Invalid federation invite.",
+      );
+    }
+  });
+
   it("rejects unsupported invite versions before attempting enrollment", () => {
     const unsupportedInvite = `pwragent-federation:${Buffer.from(JSON.stringify({
       version: FEDERATION_INVITE_VERSION + 1,

--- a/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-reset-enrollment.test.ts
@@ -1,0 +1,102 @@
+// "Forget gateway pairing" must clear the multi-path endpoint state too.
+// Leaving `gateway_endpoints` (or the last-good endpoint memory) behind would
+// keep a dual-mode instance dialing the gateway it was just told to forget,
+// with no pinned keys left to satisfy it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopSettingsConfigPatch } from "@pwragent/shared";
+import { DesktopFederationRuntime } from "../federation/federation-runtime";
+
+const metaStore = vi.hoisted(() => new Map<string, string>());
+const configPatches = vi.hoisted(() => [] as DesktopSettingsConfigPatch[]);
+const clearedSecrets = vi.hoisted(() => [] as string[]);
+const federationMode = vi.hoisted(() => ({ value: "dual" as string }));
+
+vi.mock("../state/app-state", () => ({
+  getAppStateDb: () => ({
+    getMeta: (key: string) => metaStore.get(key) ?? "",
+    setMeta: (key: string, value: string) => void metaStore.set(key, value),
+  }),
+  isAppStateInitialized: () => true,
+}));
+
+vi.mock("../settings/desktop-settings-singleton", () => ({
+  getDesktopSettingsService: () => ({
+    readSettings: async () => ({
+      federation: { mode: { value: federationMode.value } },
+    }),
+    writeConfigPatch: async (patch: DesktopSettingsConfigPatch) => {
+      configPatches.push(patch);
+    },
+    clearSecret: async (name: string) => {
+      clearedSecrets.push(name);
+      return true;
+    },
+  }),
+}));
+
+const GATEWAY_ID_KEY = "federation_gateway_instance_id";
+const LAST_ENDPOINT_KEY = "federation_gateway_last_endpoint";
+
+type ResetHarness = {
+  restart: () => Promise<void>;
+  resetEnrollment: () => Promise<{ cleared: boolean }>;
+};
+
+function createHarness(): ResetHarness {
+  const runtime = new DesktopFederationRuntime() as unknown as ResetHarness;
+  // The real restart would boot the whole runtime; the pairing teardown is
+  // what this test is about.
+  runtime.restart = async () => undefined;
+  return runtime;
+}
+
+describe("federation resetEnrollment", () => {
+  beforeEach(() => {
+    metaStore.clear();
+    configPatches.length = 0;
+    clearedSecrets.length = 0;
+    federationMode.value = "dual";
+    metaStore.set(GATEWAY_ID_KEY, "gateway_one");
+    metaStore.set("federation_gateway_public_key_pem", "pem");
+    metaStore.set("federation_gateway_noise_public_key", "noise");
+    metaStore.set(LAST_ENDPOINT_KEY, "wss://federation.example.com");
+  });
+
+  it("clears the endpoint list and the last-good endpoint memory", async () => {
+    const result = await createHarness().resetEnrollment();
+
+    expect(result).toEqual({ cleared: true });
+    expect(metaStore.get(GATEWAY_ID_KEY)).toBe("");
+    expect(metaStore.get(LAST_ENDPOINT_KEY)).toBe("");
+    expect(configPatches).toHaveLength(1);
+    expect(configPatches[0].federation?.gatewayUrl).toBe("");
+    expect(configPatches[0].federation?.gatewayEndpoints).toEqual([]);
+  });
+
+  it("keeps a dual instance listening while dropping its client pairing", async () => {
+    await createHarness().resetEnrollment();
+
+    expect(configPatches[0].federation?.mode).toBeUndefined();
+    // Gateway/dual key material stays: enrolled clients pinned it.
+    expect(clearedSecrets).toEqual([]);
+  });
+
+  it("disables a pure client and drops its own key material", async () => {
+    federationMode.value = "client";
+
+    await createHarness().resetEnrollment();
+
+    expect(configPatches[0].federation?.mode).toBe("disabled");
+    expect(configPatches[0].federation?.gatewayEndpoints).toEqual([]);
+    expect(clearedSecrets).toEqual([
+      "federationInstancePrivateKey",
+      "federationNoiseStaticPrivateKey",
+    ]);
+  });
+
+  it("reports nothing cleared when no pairing existed", async () => {
+    metaStore.set(GATEWAY_ID_KEY, "");
+
+    expect(await createHarness().resetEnrollment()).toEqual({ cleared: false });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-ssh-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-ssh-transport.test.ts
@@ -1,0 +1,210 @@
+// Covers the shape an `ssh://` endpoint actually runs in production: the real
+// SshStdioSocket carrying a real WebSocket upgrade and the real Noise
+// handshake. The unit tests drive the duplex directly and the transport tests
+// use a plain TCP socket, so neither exercises this combination — which is
+// exactly how a bug in the child-exit path stayed invisible.
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import { createFederationEnrollmentInvite } from "../federation/federation-enrollment";
+import { generateFederationIdentityKeyPair } from "../federation/federation-identity";
+import { generateNoiseStaticKeyPair } from "../federation/federation-noise";
+import {
+  dialFederationSshEndpoint,
+  parseFederationSshEndpoint,
+} from "../federation/federation-ssh";
+import { FederationStore } from "../federation/federation-store";
+import {
+  connectFederationClient,
+  FederationGatewayWebSocketServer,
+} from "../federation/federation-transport";
+import { StateDb } from "../state/state-db";
+
+let stateDb: StateDb;
+let store: FederationStore;
+let tempDir: string;
+let server: FederationGatewayWebSocketServer | undefined;
+let gatewayKeyPair: ReturnType<typeof generateFederationIdentityKeyPair>;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-ssh-"));
+  stateDb = StateDb.open(path.join(tempDir, "state.db"));
+  store = new FederationStore(stateDb);
+  gatewayKeyPair = generateFederationIdentityKeyPair();
+});
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  stateDb.close();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+/** Stands in for `ssh -W`: relays its stdio over a real TCP connection. */
+class RelaySshChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  private readonly upstream: net.Socket;
+
+  constructor(port: number) {
+    super();
+    this.upstream = net.connect(port, "127.0.0.1");
+    this.stdin.pipe(this.upstream);
+    this.upstream.pipe(this.stdout);
+    this.upstream.on("close", () => {
+      // Real ssh exits 0 once its forwarded connection ends.
+      setImmediate(() => this.emit("close", 0, null));
+    });
+    this.upstream.on("error", () => undefined);
+  }
+
+  kill(): boolean {
+    this.upstream.destroy();
+    return true;
+  }
+}
+
+async function startGateway(noiseStatic: ReturnType<typeof generateNoiseStaticKeyPair>) {
+  server = new FederationGatewayWebSocketServer({
+    gatewayInstanceId: "gateway_one",
+    gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+    gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+    host: "127.0.0.1",
+    port: 0,
+    store,
+    noiseStatic,
+    onEnvelope: (envelope, connection) => {
+      connection.sendEnvelope({
+        id: "response-1",
+        kind: "response",
+        requestId: envelope.id,
+        protocolVersion: 1,
+        sourceInstanceId: "gateway_one",
+        targetInstanceId: connection.peerId,
+        createdAt: 2_000,
+        result: { ok: true },
+      });
+    },
+  });
+  return await server.start();
+}
+
+describe("federation ssh transport", () => {
+  it("carries the Noise handshake and envelopes over the ssh stdio forward", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-ssh-transport",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const { port } = await startGateway(gatewayNoise);
+    const endpoint = parseFederationSshEndpoint(
+      `ssh://gateway.lan/?forward=127.0.0.1:${port}`,
+    );
+
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url: `ws://127.0.0.1:${port}`,
+        createSocket: () =>
+          dialFederationSshEndpoint(endpoint, {
+            spawnFn: () =>
+              new RelaySshChild(port) as unknown as ChildProcessWithoutNullStreams,
+          }),
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+        onEnvelope: resolve,
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(reply).resolves.toMatchObject({ result: { ok: true } });
+    expect(store.getPeer("client_one")).toMatchObject({
+      status: "connected",
+      pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
+    });
+  });
+
+  it("closes an ssh-backed session without raising an uncaught error", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-ssh-close",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const { port } = await startGateway(gatewayNoise);
+    const endpoint = parseFederationSshEndpoint(
+      `ssh://gateway.lan/?forward=127.0.0.1:${port}`,
+    );
+
+    const uncaught: unknown[] = [];
+    const onUncaught = (error: unknown) => uncaught.push(error);
+    process.on("uncaughtException", onUncaught);
+    try {
+      const client = await connectFederationClient({
+        url: `ws://127.0.0.1:${port}`,
+        createSocket: () =>
+          dialFederationSshEndpoint(endpoint, {
+            spawnFn: () =>
+              new RelaySshChild(port) as unknown as ChildProcessWithoutNullStreams,
+          }),
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_two",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+      });
+      client.close();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+
+    expect(
+      uncaught.map((error) =>
+        error instanceof Error ? error.message : String(error),
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-ssh.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-ssh.test.ts
@@ -1,0 +1,162 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import {
+  buildFederationSshArgs,
+  dialFederationSshEndpoint,
+  isFederationSshEndpointUrl,
+  parseFederationSshEndpoint,
+} from "../federation/federation-ssh";
+
+class FakeSshChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  killed = false;
+
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+}
+
+function fakeSpawn(child: FakeSshChild) {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  const spawnFn = (command: string, args: string[]) => {
+    calls.push({ command, args });
+    return child as unknown as ChildProcessWithoutNullStreams;
+  };
+  return { calls, spawnFn };
+}
+
+describe("federation ssh endpoints", () => {
+  it("recognizes ssh:// endpoint URLs", () => {
+    expect(isFederationSshEndpointUrl("ssh://ops@gateway.lan")).toBe(true);
+    expect(isFederationSshEndpointUrl("  SSH://gateway.lan  ")).toBe(true);
+    expect(isFederationSshEndpointUrl("wss://gateway.example.com")).toBe(false);
+  });
+
+  it("parses user, host, port, and forward target", () => {
+    expect(
+      parseFederationSshEndpoint(
+        "ssh://ops@gateway.lan:2222/?forward=127.0.0.1:47831",
+      ),
+    ).toEqual({
+      user: "ops",
+      host: "gateway.lan",
+      sshPort: 2222,
+      forwardHost: "127.0.0.1",
+      forwardPort: 47831,
+    });
+  });
+
+  it("defaults the forward target to the federation loopback listener", () => {
+    expect(parseFederationSshEndpoint("ssh://gateway.lan")).toEqual({
+      user: undefined,
+      host: "gateway.lan",
+      sshPort: undefined,
+      forwardHost: "127.0.0.1",
+      forwardPort: 47830,
+    });
+  });
+
+  it.each([
+    ["ssh://user:secret@gateway.lan", /password/],
+    ["ssh://", /Invalid SSH federation endpoint URL|host/],
+    ["ssh://gateway.lan/somewhere", /forward=host:port/],
+    ["ssh://gateway.lan/?forward=nope", /host:port/],
+    ["ssh://gateway.lan/?forward=127.0.0.1:99999", /forward port/],
+    ["ssh://gateway.lan:0", /SSH port/],
+    ["wss://gateway.example.com", /ssh:\/\/ scheme/],
+  ])("rejects %s", (url, message) => {
+    expect(() => parseFederationSshEndpoint(url)).toThrow(message);
+  });
+
+  it("builds batch-mode ssh -W arguments without weakening host checks", () => {
+    const args = buildFederationSshArgs(
+      parseFederationSshEndpoint(
+        "ssh://ops@gateway.lan:2222/?forward=127.0.0.1:47831",
+      ),
+    );
+    expect(args).toEqual([
+      "-o",
+      "BatchMode=yes",
+      "-o",
+      "ConnectTimeout=10",
+      "-p",
+      "2222",
+      "-W",
+      "127.0.0.1:47831",
+      "ops@gateway.lan",
+    ]);
+    expect(args.join(" ")).not.toContain("StrictHostKeyChecking");
+  });
+
+  it("carries data both ways over the ssh stdio stream", async () => {
+    const child = new FakeSshChild();
+    const { calls, spawnFn } = fakeSpawn(child);
+    const socket = dialFederationSshEndpoint(
+      parseFederationSshEndpoint("ssh://gateway.lan"),
+      { spawnFn },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("ssh");
+
+    const received: Buffer[] = [];
+    socket.on("data", (chunk: Buffer) => received.push(chunk));
+    child.stdout.write(Buffer.from("from-gateway"));
+    socket.write(Buffer.from("from-client"));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(Buffer.concat(received).toString()).toBe("from-gateway");
+    expect(child.stdin.read()?.toString()).toBe("from-client");
+  });
+
+  it("destroys the stream with the stderr tail when ssh exits", async () => {
+    const child = new FakeSshChild();
+    const socket = dialFederationSshEndpoint(
+      parseFederationSshEndpoint("ssh://gateway.lan"),
+      { spawnFn: fakeSpawn(child).spawnFn },
+    );
+    const closed = new Promise<Error>((resolve) => {
+      socket.on("error", resolve);
+    });
+    child.stderr.write("Host key verification failed.\n");
+    child.emit("exit", 255, null);
+
+    const error = await closed;
+    expect(error.message).toContain("SSH federation tunnel closed");
+    expect(error.message).toContain("Host key verification failed.");
+  });
+
+  it("kills the ssh child when the stream is destroyed", async () => {
+    const child = new FakeSshChild();
+    const socket = dialFederationSshEndpoint(
+      parseFederationSshEndpoint("ssh://gateway.lan"),
+      { spawnFn: fakeSpawn(child).spawnFn },
+    );
+    socket.on("error", () => undefined);
+    socket.destroy();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(child.killed).toBe(true);
+  });
+
+  it("maps a missing ssh binary to a readable error", async () => {
+    const child = new FakeSshChild();
+    const socket = dialFederationSshEndpoint(
+      parseFederationSshEndpoint("ssh://gateway.lan"),
+      { spawnFn: fakeSpawn(child).spawnFn },
+    );
+    const failed = new Promise<Error>((resolve) => {
+      socket.on("error", resolve);
+    });
+    const enoent = Object.assign(new Error("spawn ssh ENOENT"), {
+      code: "ENOENT",
+    });
+    child.emit("error", enoent);
+
+    expect((await failed).message).toContain("OpenSSH client");
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-ssh.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-ssh.test.ts
@@ -69,6 +69,13 @@ describe("federation ssh endpoints", () => {
     ["ssh://gateway.lan/?forward=127.0.0.1:99999", /forward port/],
     ["ssh://gateway.lan:0", /SSH port/],
     ["wss://gateway.example.com", /ssh:\/\/ scheme/],
+    // Would reach ssh(1) as an option rather than a destination.
+    ["ssh://-oProxyCommand=touch%20pwned", /starting with '-'/],
+    ["ssh://-J%20evil.example", /starting with '-'/],
+    ["ssh://-ohost@gateway.lan", /starting with '-'/],
+    // Would turn the operator's SSH server into a port-scanning proxy.
+    ["ssh://gateway.lan/?forward=10.0.0.9:22", /loopback/],
+    ["ssh://gateway.lan/?forward=evil.example:443", /loopback/],
   ])("rejects %s", (url, message) => {
     expect(() => parseFederationSshEndpoint(url)).toThrow(message);
   });
@@ -114,21 +121,63 @@ describe("federation ssh endpoints", () => {
     expect(child.stdin.read()?.toString()).toBe("from-client");
   });
 
-  it("destroys the stream with the stderr tail when ssh exits", async () => {
+  it("destroys the stream with the stderr tail when ssh fails", async () => {
     const child = new FakeSshChild();
+    const failures: Error[] = [];
     const socket = dialFederationSshEndpoint(
       parseFederationSshEndpoint("ssh://gateway.lan"),
-      { spawnFn: fakeSpawn(child).spawnFn },
+      {
+        spawnFn: fakeSpawn(child).spawnFn,
+        onFailure: (error) => failures.push(error),
+      },
     );
     const closed = new Promise<Error>((resolve) => {
       socket.on("error", resolve);
     });
     child.stderr.write("Host key verification failed.\n");
-    child.emit("exit", 255, null);
+    child.emit("close", 255, null);
 
     const error = await closed;
     expect(error.message).toContain("SSH federation tunnel closed");
     expect(error.message).toContain("Host key verification failed.");
+    // The caller needs this: Node collapses the resulting socket EOF into a
+    // generic "socket hang up" before the WebSocket upgrade rejects.
+    expect(failures.map((entry) => entry.message)).toEqual([error.message]);
+  });
+
+  it("treats a clean ssh exit as a normal close, not a transport error", async () => {
+    const child = new FakeSshChild();
+    const failures: Error[] = [];
+    const socket = dialFederationSshEndpoint(
+      parseFederationSshEndpoint("ssh://gateway.lan"),
+      {
+        spawnFn: fakeSpawn(child).spawnFn,
+        onFailure: (error) => failures.push(error),
+      },
+    );
+    const errors: Error[] = [];
+    socket.on("error", (error: Error) => errors.push(error));
+
+    child.emit("close", 0, null);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(errors).toEqual([]);
+    expect(failures).toEqual([]);
+  });
+
+  it("does not emit an unhandled error on a clean exit with no error listener", async () => {
+    const child = new FakeSshChild();
+    dialFederationSshEndpoint(parseFederationSshEndpoint("ssh://gateway.lan"), {
+      spawnFn: fakeSpawn(child).spawnFn,
+    });
+    const uncaught: unknown[] = [];
+    const onUncaught = (error: unknown) => uncaught.push(error);
+    process.on("uncaughtException", onUncaught);
+    child.emit("close", 0, null);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.off("uncaughtException", onUncaught);
+
+    expect(uncaught).toEqual([]);
   });
 
   it("kills the ssh child when the stream is destroyed", async () => {

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import WebSocket, { WebSocketServer } from "ws";
@@ -315,6 +316,93 @@ describe("federation transport", () => {
       requestId: "request-1",
       result: { ok: true },
     });
+    expect(store.getPeer("client_one")).toMatchObject({
+      status: "connected",
+      pinnedPublicKeyPem: clientKeyPair.publicKeyPem,
+    });
+  });
+
+  it("carries the encrypted channel over an externally created outer socket", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-outer-socket",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received = new Promise<FederationProtocolEnvelope>((resolve) => {
+      server = new FederationGatewayWebSocketServer({
+        gatewayInstanceId: "gateway_one",
+        gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        host: "127.0.0.1",
+        port: 0,
+        store,
+        noiseStatic: gatewayNoise,
+        onEnvelope: (envelope, connection) => {
+          connection.sendEnvelope({
+            id: "response-1",
+            kind: "response",
+            requestId: envelope.id,
+            protocolVersion: 1,
+            sourceInstanceId: "gateway_one",
+            targetInstanceId: connection.peerId,
+            createdAt: 2_000,
+            result: { ok: true },
+          });
+          resolve(envelope);
+        },
+      });
+    });
+    const { port } = await server!.start();
+
+    // Stands in for an SSH stdio forward: the client never dials TCP itself;
+    // the upgrade and every Noise frame ride the supplied stream.
+    let outerSockets = 0;
+    const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
+      void connectFederationClient({
+        url: `ws://127.0.0.1:${port}`,
+        createSocket: () => {
+          outerSockets += 1;
+          return net.connect(port, "127.0.0.1");
+        },
+        mode: "enroll",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        inviteToken: invite.token,
+        label: "Client",
+        role: "client",
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
+        onEnvelope: resolve,
+      }).then((client) => {
+        client.sendEnvelope({
+          id: "request-1",
+          kind: "request",
+          method: "thread.list",
+          params: {},
+          protocolVersion: 1,
+          sourceInstanceId: "client_one",
+          targetInstanceId: "gateway_one",
+          createdAt: 1_000,
+        });
+      });
+    });
+
+    await expect(received).resolves.toMatchObject({ id: "request-1", kind: "request" });
+    await expect(reply).resolves.toMatchObject({
+      kind: "response",
+      requestId: "request-1",
+      result: { ok: true },
+    });
+    expect(outerSockets).toBe(1);
     expect(store.getPeer("client_one")).toMatchObject({
       status: "connected",
       pinnedPublicKeyPem: clientKeyPair.publicKeyPem,

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -409,6 +409,40 @@ describe("federation transport", () => {
     });
   });
 
+  it("fails the connect when a peer upgrades and then goes silent", async () => {
+    // Without a deadline this parks forever: the upgrade succeeds, so neither
+    // "open" nor "close" nor "error" ever fires, and the reader waits on a
+    // frame that never arrives. That stalled the whole endpoint walk and the
+    // reconnect loop, and wedged Settings saves behind restart().
+    rawServer = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    rawServer.on("connection", () => {
+      // Accept the upgrade and deliberately send nothing.
+    });
+    await new Promise<void>((resolve) => rawServer!.once("listening", resolve));
+    const address = rawServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
+
+    const started = Date.now();
+    await expect(
+      connectFederationClient({
+        url: `ws://127.0.0.1:${port}`,
+        connectTimeoutMs: 250,
+        mode: "reconnect",
+        gatewayInstanceId: "gateway_one",
+        gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+        peerInstanceId: "client_one",
+        privateKeyPem: clientKeyPair.privateKeyPem,
+        publicKeyPem: clientKeyPair.publicKeyPem,
+        capabilities: ["remote_window"],
+        noiseStatic: clientNoise,
+        gatewayNoisePublicKey: generateNoiseStaticKeyPair().publicKeyRaw,
+      }),
+    ).rejects.toThrow();
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
   it("advertises the required Noise transport version before the handshake", async () => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     server = new FederationGatewayWebSocketServer({

--- a/apps/desktop/src/main/federation/federation-endpoints.ts
+++ b/apps/desktop/src/main/federation/federation-endpoints.ts
@@ -1,0 +1,28 @@
+// Ordering policy for multi-path federation gateway endpoints. Endpoint
+// selection is reachability only: every candidate is authenticated against
+// the same pinned gateway signing key and Noise static key, so trying a
+// different endpoint can never reach a different gateway identity.
+
+/**
+ * Attempt order for one reconnect cycle: the last endpoint that carried a
+ * fully authenticated session first (when it is still configured), then the
+ * remaining endpoints in configured order.
+ */
+export function orderFederationEndpointAttempts(
+  endpoints: readonly string[],
+  lastGoodEndpoint?: string,
+): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const endpoint of endpoints) {
+    const trimmed = endpoint.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ordered.push(trimmed);
+  }
+  const lastGood = lastGoodEndpoint?.trim();
+  if (!lastGood || !seen.has(lastGood)) {
+    return ordered;
+  }
+  return [lastGood, ...ordered.filter((endpoint) => endpoint !== lastGood)];
+}

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -8,6 +8,7 @@ import {
   FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
   filterKnownFederationCapabilities,
+  isFederationGatewayEndpointUrl,
   isFederationInstanceId,
 } from "@pwragent/shared";
 import {
@@ -106,15 +107,28 @@ export function decodeFederationInvite(
   ) {
     throw new Error("Invalid federation invite.");
   }
+  // An invite is attacker-authored input: it is unsigned, and the operator may
+  // paste it from anywhere. Its endpoints are dialed by the main process, so
+  // enforce the scheme allowlist here rather than trusting the renderer (which
+  // this path never passes through).
+  if (!isFederationGatewayEndpointUrl(parsed.gatewayUrl)) {
+    throw new Error(
+      "Federation invite gateway URL must be a ws://, wss://, or ssh:// endpoint.",
+    );
+  }
   if (
     parsed.gatewayEndpoints !== undefined &&
     (!Array.isArray(parsed.gatewayEndpoints) ||
       parsed.gatewayEndpoints.length === 0 ||
       !parsed.gatewayEndpoints.every(
-        (endpoint) => typeof endpoint === "string" && endpoint.trim(),
+        (endpoint) =>
+          typeof endpoint === "string"
+          && isFederationGatewayEndpointUrl(endpoint),
       ))
   ) {
-    throw new Error("Invalid federation invite.");
+    throw new Error(
+      "Federation invite endpoints must all be ws://, wss://, or ssh:// URLs.",
+    );
   }
   if (parsed.expiresAt <= now) {
     throw new Error("Federation invite has expired.");

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -34,6 +34,12 @@ export type FederationInvitePayload = {
   gatewayPublicKeyPem: string;
   gatewayNoisePublicKey: string;
   gatewayUrl: string;
+  /**
+   * Ordered candidate endpoints for the same pinned gateway identity.
+   * Optional so version-1 importers that predate multi-path endpoints keep
+   * working from `gatewayUrl`; new importers treat absence as `[gatewayUrl]`.
+   */
+  gatewayEndpoints?: string[];
   expiresAt: number;
 };
 
@@ -97,6 +103,16 @@ export function decodeFederationInvite(
     typeof parsed.gatewayNoisePublicKey !== "string" ||
     typeof parsed.gatewayUrl !== "string" ||
     typeof parsed.expiresAt !== "number"
+  ) {
+    throw new Error("Invalid federation invite.");
+  }
+  if (
+    parsed.gatewayEndpoints !== undefined &&
+    (!Array.isArray(parsed.gatewayEndpoints) ||
+      parsed.gatewayEndpoints.length === 0 ||
+      !parsed.gatewayEndpoints.every(
+        (endpoint) => typeof endpoint === "string" && endpoint.trim(),
+      ))
   ) {
     throw new Error("Invalid federation invite.");
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -354,8 +354,12 @@ export class DesktopFederationRuntime {
       health.status = "degraded";
       health.unavailableReason = this.gatewayListenerError;
     }
+    // Prefer the configured endpoint list: a profile that only ever used
+    // multi-path endpoints has no legacy `gateway_url`, and the enrollment
+    // card would otherwise show a paired gateway with no address.
     health.clientEnrollment = this.readClientEnrollment(
-      settings.federation.gatewayUrl.value.trim(),
+      settings.federation.gatewayEndpoints.value[0]?.trim()
+        || settings.federation.gatewayUrl.value.trim(),
     );
     return health;
   }
@@ -391,6 +395,10 @@ export class DesktopFederationRuntime {
     stateDb.setMeta(GATEWAY_NOISE_PUBLIC_KEY_META_KEY, "");
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     stateDb.setMeta(GATEWAY_ENROLLED_AT_META_KEY, "");
+    // The endpoint list and its last-good memory belong to the pairing being
+    // forgotten. Leaving them behind would keep a dual-mode instance dialing
+    // the forgotten gateway with no pins left to satisfy it.
+    stateDb.setMeta(GATEWAY_LAST_ENDPOINT_META_KEY, "");
     const settingsService = getDesktopSettingsService();
     const settings = await settingsService.readSettings();
     const mode = settings.federation.mode.value;
@@ -407,6 +415,7 @@ export class DesktopFederationRuntime {
     await settingsService.writeConfigPatch({
       federation: {
         gatewayUrl: "",
+        gatewayEndpoints: [],
         ...(mode === "client" ? { mode: "disabled" as const } : {}),
       },
     });
@@ -747,13 +756,21 @@ export class DesktopFederationRuntime {
         return;
       } catch (error) {
         lastError = error;
+        const rawMessage =
+          error instanceof Error ? error.message : String(error);
         this.endpointStatuses.set(endpoint, {
           ...this.endpointStatuses.get(endpoint),
           state: "failed",
-          lastError: redactFederationDiagnostic(
-            error instanceof Error ? error.message : String(error),
-          ),
+          lastError: redactFederationDiagnostic(rawMessage),
         });
+        // Every endpoint authenticates against the SAME pinned gateway
+        // identity, so an auth-class failure is a property of the pairing,
+        // not of this path. Walking on would waste attempts and, worse, let
+        // a later endpoint's network error mask a broken pin behind an
+        // endless "connecting" retry instead of surfacing as "rejected".
+        if (classifyFederationClientFailure(rawMessage) === "auth") {
+          throw error;
+        }
       }
     }
     throw lastError instanceof Error

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -13,6 +13,7 @@ import type {
   FederationCapability,
   FederationConnectionState,
   FederationDiagnosticEvent,
+  FederationEndpointStatus,
   FederatedSearchRequest,
   FederatedSearchResponse,
   FederationHealthStatus,
@@ -134,6 +135,12 @@ import {
   type FederationClientWebSocketClient,
   type FederationGatewayConnection,
 } from "./federation-transport";
+import { orderFederationEndpointAttempts } from "./federation-endpoints";
+import {
+  dialFederationSshEndpoint,
+  isFederationSshEndpointUrl,
+  parseFederationSshEndpoint,
+} from "./federation-ssh";
 import { noiseKeyPairFromRawPrivate } from "./federation-noise";
 
 const log = getMainLogger("pwragent:federation-runtime");
@@ -141,6 +148,7 @@ const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const GATEWAY_PUBLIC_KEY_META_KEY = "federation_gateway_public_key_pem";
 const GATEWAY_NOISE_PUBLIC_KEY_META_KEY = "federation_gateway_noise_public_key";
+const GATEWAY_LAST_ENDPOINT_META_KEY = "federation_gateway_last_endpoint";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const GATEWAY_ENROLLED_AT_META_KEY = "federation_gateway_enrolled_at";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
@@ -175,6 +183,11 @@ export class DesktopFederationRuntime {
   private listenUrl?: string;
   private gatewayUrl?: string;
   private gatewayInstanceId?: FederationInstanceId;
+  private configuredEndpoints: string[] = [];
+  private readonly endpointStatuses = new Map<
+    string,
+    Omit<FederationEndpointStatus, "url">
+  >();
   private readonly rpcByPeer = new Map<FederationInstanceId, FederationRpcEndpoint>();
   private readonly remotePeerDirectory = new Map<
     FederationInstanceId,
@@ -284,6 +297,8 @@ export class DesktopFederationRuntime {
     this.listenUrl = undefined;
     this.gatewayUrl = undefined;
     this.gatewayInstanceId = undefined;
+    this.configuredEndpoints = [];
+    this.endpointStatuses.clear();
     this.rpcByPeer.clear();
     this.remotePeerDirectory.clear();
     this.publishedPeerStatuses.clear();
@@ -317,6 +332,15 @@ export class DesktopFederationRuntime {
             ? "connecting"
             : "disconnected";
       health.unavailableReason = this.lastConnectionError;
+      const endpoints =
+        this.configuredEndpoints.length > 0
+          ? this.configuredEndpoints
+          : settings.federation.gatewayEndpoints.value;
+      health.gatewayEndpoints = endpoints.map((url) => ({
+        url,
+        state: "idle",
+        ...this.endpointStatuses.get(url),
+      }));
     }
     if (this.gatewayListenerError) {
       health.status = "degraded";
@@ -431,7 +455,18 @@ export class DesktopFederationRuntime {
         "Invites are issued by the gateway. Switch Mode to gateway or dual first.",
       );
     }
-    const gatewayUrl = settings.federation.publicUrl.value.trim() || this.listenUrl;
+    const advertisedEndpoints = settings.federation.advertisedEndpoints.value
+      .map((endpoint) => endpoint.trim())
+      .filter((endpoint) => endpoint.length > 0);
+    const fallbackUrl =
+      settings.federation.publicUrl.value.trim() || this.listenUrl;
+    const gatewayEndpoints =
+      advertisedEndpoints.length > 0
+        ? advertisedEndpoints
+        : fallbackUrl
+          ? [fallbackUrl]
+          : [];
+    const gatewayUrl = gatewayEndpoints[0];
     if (!gatewayUrl) {
       throw new Error("Federation gateway URL is not configured.");
     }
@@ -458,6 +493,7 @@ export class DesktopFederationRuntime {
         gatewayInstanceId: this.ensureLocalInstanceId(),
         gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
         gatewayUrl,
+        gatewayEndpoints,
         gatewayNoisePublicKey: noise.publicKeyBase64,
         expiresAt,
       }),
@@ -478,6 +514,8 @@ export class DesktopFederationRuntime {
       GATEWAY_NOISE_PUBLIC_KEY_META_KEY,
       payload.gatewayNoisePublicKey,
     );
+    // A new gateway identity invalidates any endpoint memory from before.
+    stateDb.setMeta(GATEWAY_LAST_ENDPOINT_META_KEY, "");
     stateDb.setMeta(PENDING_INVITE_TOKEN_META_KEY, payload.token);
     stateDb.setMeta(GATEWAY_ENROLLED_AT_META_KEY, String(Date.now()));
     // Importing on a listening instance must not silently kill its
@@ -491,6 +529,7 @@ export class DesktopFederationRuntime {
             ? "dual"
             : "client",
         gatewayUrl: payload.gatewayUrl,
+        gatewayEndpoints: payload.gatewayEndpoints ?? [payload.gatewayUrl],
       },
     });
     await this.restart();
@@ -645,19 +684,64 @@ export class DesktopFederationRuntime {
     }
 
     if (mode === "client" || mode === "dual") {
-      const gatewayUrl = settings.federation.gatewayUrl.value.trim();
-      if (!gatewayUrl) {
+      const endpoints = settings.federation.gatewayEndpoints.value
+        .map((endpoint) => endpoint.trim())
+        .filter((endpoint) => endpoint.length > 0);
+      this.configuredEndpoints = endpoints;
+      if (endpoints.length === 0) {
         this.lastConnectionError = "Federation gateway URL is not configured.";
       } else {
-        await this.connectClient(gatewayUrl).catch((error) => {
-          this.handleClientConnectionFailure(gatewayUrl, error);
+        await this.connectToGateway().catch((error) => {
+          this.handleClientConnectionFailure(error);
         });
       }
     }
   }
 
+  // One reconnect cycle: walk the configured endpoints (last-good first) and
+  // stop at the first fully authenticated connection. Every endpoint runs the
+  // identical pinned-identity + Noise handshake, so fallback can only change
+  // reachability, never which gateway the client will trust.
+  private async connectToGateway(): Promise<void> {
+    const endpoints = this.configuredEndpoints;
+    if (endpoints.length === 0) return;
+    const lastGoodEndpoint =
+      getAppStateDb().getMeta(GATEWAY_LAST_ENDPOINT_META_KEY) || undefined;
+    const attempts = orderFederationEndpointAttempts(
+      endpoints,
+      lastGoodEndpoint,
+    );
+    let lastError: unknown;
+    for (const endpoint of attempts) {
+      if (this.stopping) return;
+      try {
+        await this.connectClient(endpoint);
+        return;
+      } catch (error) {
+        lastError = error;
+        this.endpointStatuses.set(endpoint, {
+          ...this.endpointStatuses.get(endpoint),
+          state: "failed",
+          lastError: redactFederationDiagnostic(
+            error instanceof Error ? error.message : String(error),
+          ),
+        });
+      }
+    }
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(
+          "Federation gateway is unreachable on every configured endpoint.",
+        );
+  }
+
   private async connectClient(gatewayUrl: string): Promise<void> {
     if (!gatewayUrl) return;
+    this.endpointStatuses.set(gatewayUrl, {
+      ...this.endpointStatuses.get(gatewayUrl),
+      state: "connecting",
+      lastAttemptAt: Date.now(),
+    });
     const gatewayInstanceId = getAppStateDb().getMeta(GATEWAY_INSTANCE_ID_META_KEY);
     if (!gatewayInstanceId) {
       throw new Error("Federation client mode is missing its gateway identity.");
@@ -683,9 +767,17 @@ export class DesktopFederationRuntime {
     const settings = await settingsService.readSettings();
     const cloudflareCredentials =
       await settingsService.resolveFederationCloudflareCredentials();
+    const sshEndpoint = isFederationSshEndpointUrl(gatewayUrl)
+      ? parseFederationSshEndpoint(gatewayUrl)
+      : undefined;
+    // Cloudflare edge credentials only ever travel on TLS (wss://) endpoints.
+    // A plain ws:// LAN path or an SSH forward must never carry the Access
+    // bearer token or client key material in its cleartext upgrade request.
+    const isTlsEndpoint = gatewayUrl.startsWith("wss://");
     const cloudflareMtlsEnabled =
-      settings.federation.cloudflareMtlsEnabled.value;
+      isTlsEndpoint && settings.federation.cloudflareMtlsEnabled.value;
     const cloudflareAccessEnabled =
+      isTlsEndpoint &&
       settings.federation.cloudflareAccessServiceAuthEnabled.value;
     if (
       cloudflareMtlsEnabled &&
@@ -717,7 +809,12 @@ export class DesktopFederationRuntime {
     });
     const clientSession: { id?: FederationSessionId } = {};
     const client = await connectFederationClient({
-      url: gatewayUrl,
+      url: sshEndpoint
+        ? `ws://${sshEndpoint.forwardHost}:${sshEndpoint.forwardPort}`
+        : gatewayUrl,
+      createSocket: sshEndpoint
+        ? () => dialFederationSshEndpoint(sshEndpoint)
+        : undefined,
       mode: connectionMode,
       gatewayInstanceId,
       gatewayPublicKeyPem,
@@ -775,7 +872,11 @@ export class DesktopFederationRuntime {
           this.lastConnectionError,
         );
         this.disconnectAdvertisedPeers(this.lastConnectionError);
-        this.scheduleReconnect(gatewayUrl);
+        this.endpointStatuses.set(gatewayUrl, {
+          ...this.endpointStatuses.get(gatewayUrl),
+          state: "idle",
+        });
+        this.scheduleReconnect();
       },
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
@@ -805,10 +906,23 @@ export class DesktopFederationRuntime {
     if (pendingInviteToken) {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
+    this.markEndpointConnected(gatewayUrl);
     this.reconnectAttempt = 0;
     this.lastConnectionError = undefined;
     this.lastConnectionFailureKind = undefined;
     log.info("federation client connected", { gatewayUrl });
+  }
+
+  // Only a fully authenticated session ever updates the last-good endpoint
+  // memory, so a hostile endpoint can never steer future attempt ordering.
+  private markEndpointConnected(gatewayUrl: string): void {
+    this.endpointStatuses.set(gatewayUrl, {
+      ...this.endpointStatuses.get(gatewayUrl),
+      state: "active",
+      lastConnectedAt: Date.now(),
+      lastError: undefined,
+    });
+    getAppStateDb().setMeta(GATEWAY_LAST_ENDPOINT_META_KEY, gatewayUrl);
   }
 
   private recordClientConnection(params: {
@@ -842,10 +956,7 @@ export class DesktopFederationRuntime {
     });
   }
 
-  private handleClientConnectionFailure(
-    gatewayUrl: string,
-    error: unknown,
-  ): void {
+  private handleClientConnectionFailure(error: unknown): void {
     if (this.stopping) return;
     this.client = undefined;
     const rawMessage = error instanceof Error ? error.message : String(error);
@@ -866,13 +977,15 @@ export class DesktopFederationRuntime {
       detail: this.lastConnectionError,
     });
     log.warn("federation client connection failed", {
-      gatewayUrl,
+      endpoints: this.configuredEndpoints.length,
       error: this.lastConnectionError,
     });
-    this.scheduleReconnect(gatewayUrl);
+    this.scheduleReconnect();
   }
 
-  private scheduleReconnect(gatewayUrl: string): void {
+  // Backoff applies per full cycle through the endpoint list; every cycle
+  // re-walks the endpoints last-good-first via connectToGateway.
+  private scheduleReconnect(): void {
     if (this.stopping || this.reconnectTimer) return;
     const delayMs = Math.min(
       1_000 * 2 ** this.reconnectAttempt,
@@ -882,8 +995,8 @@ export class DesktopFederationRuntime {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
       if (this.stopping) return;
-      void this.connectClient(gatewayUrl).catch((error) => {
-        this.handleClientConnectionFailure(gatewayUrl, error);
+      void this.connectToGateway().catch((error) => {
+        this.handleClientConnectionFailure(error);
       });
     }, delayMs);
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -52,6 +52,8 @@ import {
   FEDERATION_INVITE_VERSION,
   FEDERATION_PROTOCOL_VERSION,
   buildFederatedThreadRef,
+  federationEndpointAcceptsCloudflareCredentials,
+  isFederationGatewayEndpointUrl,
   isRemoteFederationTarget,
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
@@ -153,6 +155,8 @@ const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const GATEWAY_ENROLLED_AT_META_KEY = "federation_gateway_enrolled_at";
 const FEDERATION_PEER_DIRECTORY_METHOD = "federation.peerDirectory";
 const FEDERATION_RECONNECT_MAX_DELAY_MS = 30_000;
+/** A session must last this long before it counts as stable enough to reset backoff. */
+const FEDERATION_STABLE_SESSION_MS = 60_000;
 
 const DEFAULT_CAPABILITIES: FederationCapability[] = [
   "remote_window",
@@ -213,6 +217,9 @@ export class DesktopFederationRuntime {
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private reconnectAttempt = 0;
   private connectionGeneration = 0;
+  /** Bumped only by stop(), so an in-flight endpoint walk can detect teardown. */
+  private walkEpoch = 0;
+  private lastConnectedAt?: number;
   private stopping = true;
   private lastConnectionError?: string;
   private lastConnectionFailureKind?: "auth" | "transport";
@@ -272,6 +279,7 @@ export class DesktopFederationRuntime {
   async stop(): Promise<void> {
     this.stopping = true;
     this.connectionGeneration += 1;
+    this.walkEpoch += 1;
     if (isAppStateInitialized()) {
       for (const peer of this.visiblePeers()) {
         if (peer.status === "connected") {
@@ -505,6 +513,7 @@ export class DesktopFederationRuntime {
     accepted: boolean;
     gatewayInstanceId: FederationInstanceId;
     gatewayUrl: string;
+    gatewayEndpoints: string[];
   }> {
     const payload = decodeFederationInvite(invite);
     const stateDb = getAppStateDb();
@@ -522,6 +531,7 @@ export class DesktopFederationRuntime {
     // listener: gateway/dual become dual, everything else becomes client.
     const currentMode = (await getDesktopSettingsService().readSettings())
       .federation.mode.value;
+    const gatewayEndpoints = payload.gatewayEndpoints ?? [payload.gatewayUrl];
     await getDesktopSettingsService().writeConfigPatch({
       federation: {
         mode:
@@ -529,7 +539,7 @@ export class DesktopFederationRuntime {
             ? "dual"
             : "client",
         gatewayUrl: payload.gatewayUrl,
-        gatewayEndpoints: payload.gatewayEndpoints ?? [payload.gatewayUrl],
+        gatewayEndpoints,
       },
     });
     await this.restart();
@@ -537,6 +547,7 @@ export class DesktopFederationRuntime {
       accepted: true,
       gatewayInstanceId: payload.gatewayInstanceId,
       gatewayUrl: payload.gatewayUrl,
+      gatewayEndpoints,
     };
   }
 
@@ -684,12 +695,23 @@ export class DesktopFederationRuntime {
     }
 
     if (mode === "client" || mode === "dual") {
-      const endpoints = settings.federation.gatewayEndpoints.value
+      const configured = settings.federation.gatewayEndpoints.value
         .map((endpoint) => endpoint.trim())
         .filter((endpoint) => endpoint.length > 0);
+      // Last line of defense before anything is dialed: the config file is
+      // hand-editable and may predate the scheme allowlist.
+      const endpoints = configured.filter(isFederationGatewayEndpointUrl);
+      if (endpoints.length !== configured.length) {
+        log.warn("ignoring federation endpoints with an unsupported scheme", {
+          ignored: configured.length - endpoints.length,
+        });
+      }
       this.configuredEndpoints = endpoints;
       if (endpoints.length === 0) {
-        this.lastConnectionError = "Federation gateway URL is not configured.";
+        this.lastConnectionError =
+          configured.length > 0
+            ? "No federation gateway endpoint uses a supported ws://, wss://, or ssh:// scheme."
+            : "Federation gateway URL is not configured.";
       } else {
         await this.connectToGateway().catch((error) => {
           this.handleClientConnectionFailure(error);
@@ -711,9 +733,15 @@ export class DesktopFederationRuntime {
       endpoints,
       lastGoodEndpoint,
     );
+    // A restart during the walk flips `stopping` back to false, so `stopping`
+    // alone would let a superseded walk keep dialing a stale endpoint list and
+    // race the new one into `this.client`. `connectionGeneration` can't serve
+    // here because connectClient bumps it per attempt; this epoch changes only
+    // when the runtime is torn down.
+    const walkEpoch = this.walkEpoch;
     let lastError: unknown;
     for (const endpoint of attempts) {
-      if (this.stopping) return;
+      if (this.stopping || this.walkEpoch !== walkEpoch) return;
       try {
         await this.connectClient(endpoint);
         return;
@@ -770,15 +798,32 @@ export class DesktopFederationRuntime {
     const sshEndpoint = isFederationSshEndpointUrl(gatewayUrl)
       ? parseFederationSshEndpoint(gatewayUrl)
       : undefined;
-    // Cloudflare edge credentials only ever travel on TLS (wss://) endpoints.
-    // A plain ws:// LAN path or an SSH forward must never carry the Access
-    // bearer token or client key material in its cleartext upgrade request.
-    const isTlsEndpoint = gatewayUrl.startsWith("wss://");
+    // Cloudflare edge credentials ride the WebSocket upgrade, which happens
+    // BEFORE the Noise handshake pins anything. So they must be scoped to the
+    // one host the operator designated as Cloudflare-fronted — not to "any
+    // wss:// URL", which would hand the Access bearer token and the mTLS client
+    // key to every TLS endpoint in the fallback list.
+    const acceptsCloudflareCredentials =
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: gatewayUrl,
+        cloudflareEndpoint: settings.federation.cloudflareEndpoint.value,
+        configuredEndpointCount: this.configuredEndpoints.length,
+      });
     const cloudflareMtlsEnabled =
-      isTlsEndpoint && settings.federation.cloudflareMtlsEnabled.value;
+      acceptsCloudflareCredentials
+      && settings.federation.cloudflareMtlsEnabled.value;
     const cloudflareAccessEnabled =
-      isTlsEndpoint &&
-      settings.federation.cloudflareAccessServiceAuthEnabled.value;
+      acceptsCloudflareCredentials
+      && settings.federation.cloudflareAccessServiceAuthEnabled.value;
+    if (
+      !acceptsCloudflareCredentials
+      && (settings.federation.cloudflareMtlsEnabled.value
+        || settings.federation.cloudflareAccessServiceAuthEnabled.value)
+    ) {
+      log.info("federation endpoint is not the designated Cloudflare endpoint", {
+        withheldCredentials: true,
+      });
+    }
     if (
       cloudflareMtlsEnabled &&
       (!cloudflareCredentials.clientCertificate ||
@@ -808,12 +853,20 @@ export class DesktopFederationRuntime {
       detail: connectionMode,
     });
     const clientSession: { id?: FederationSessionId } = {};
+    // Node reports a failed ssh dial as a generic "socket hang up", so keep the
+    // real cause (auth, host key, timeout) and report that instead.
+    const sshFailure: { error?: Error } = {};
     const client = await connectFederationClient({
       url: sshEndpoint
         ? `ws://${sshEndpoint.forwardHost}:${sshEndpoint.forwardPort}`
         : gatewayUrl,
       createSocket: sshEndpoint
-        ? () => dialFederationSshEndpoint(sshEndpoint)
+        ? () =>
+            dialFederationSshEndpoint(sshEndpoint, {
+              onFailure: (error) => {
+                sshFailure.error ??= error;
+              },
+            })
         : undefined,
       mode: connectionMode,
       gatewayInstanceId,
@@ -880,6 +933,11 @@ export class DesktopFederationRuntime {
       },
       onEnvelope: (envelope) =>
         void this.receiveEnvelope(envelope, gatewayInstanceId),
+    }).catch((error: unknown) => {
+      throw (
+        sshFailure.error
+        ?? (error instanceof Error ? error : new Error(String(error)))
+      );
     });
     clientSession.id = client.sessionId;
     if (
@@ -907,7 +965,11 @@ export class DesktopFederationRuntime {
       getAppStateDb().setMeta(PENDING_INVITE_TOKEN_META_KEY, "");
     }
     this.markEndpointConnected(gatewayUrl);
-    this.reconnectAttempt = 0;
+    // Backoff is reset by session *durability*, not by the mere fact that a
+    // handshake succeeded — otherwise a gateway that accepts and immediately
+    // drops (restart loop, eviction) pins reconnects at 1 Hz forever, spawning
+    // a fresh ssh process every second for ssh:// endpoints.
+    this.lastConnectedAt = Date.now();
     this.lastConnectionError = undefined;
     this.lastConnectionFailureKind = undefined;
     log.info("federation client connected", { gatewayUrl });
@@ -987,6 +1049,13 @@ export class DesktopFederationRuntime {
   // re-walks the endpoints last-good-first via connectToGateway.
   private scheduleReconnect(): void {
     if (this.stopping || this.reconnectTimer) return;
+    if (
+      this.lastConnectedAt !== undefined
+      && Date.now() - this.lastConnectedAt >= FEDERATION_STABLE_SESSION_MS
+    ) {
+      this.reconnectAttempt = 0;
+    }
+    this.lastConnectedAt = undefined;
     const delayMs = Math.min(
       1_000 * 2 ** this.reconnectAttempt,
       FEDERATION_RECONNECT_MAX_DELAY_MS,

--- a/apps/desktop/src/main/federation/federation-ssh.ts
+++ b/apps/desktop/src/main/federation/federation-ssh.ts
@@ -49,6 +49,14 @@ export function parseFederationSshEndpoint(url: string): FederationSshEndpoint {
   if (!parsed.hostname) {
     throw new Error("SSH federation endpoints require a host.");
   }
+  // `ssh://-oProxyCommand=...` parses as a hostname. Passed through as argv it
+  // would reach ssh(1) as an option instead of a destination, so reject it
+  // here rather than relying on argv position to keep it inert.
+  if (parsed.hostname.startsWith("-") || parsed.username.startsWith("-")) {
+    throw new Error(
+      "SSH federation endpoints must not have a host or user starting with '-'.",
+    );
+  }
   if (parsed.pathname && parsed.pathname !== "/") {
     throw new Error(
       "SSH federation endpoints take the forward target as ?forward=host:port, not a path.",
@@ -95,6 +103,13 @@ export type FederationSshDialOptions = {
   command?: string;
   env?: NodeJS.ProcessEnv;
   spawnFn?: FederationSshSpawn;
+  /**
+   * Called with the real ssh failure (auth, host key, timeout). Node turns the
+   * resulting premature socket EOF into a generic "socket hang up" before the
+   * WebSocket upgrade resolves, so the caller needs this to report anything
+   * more useful than that.
+   */
+  onFailure?: (error: Error) => void;
 };
 
 /**
@@ -118,7 +133,7 @@ export function dialFederationSshEndpoint(
   const child = spawnFn(command, buildFederationSshArgs(endpoint), {
     env: buildPwrAgentChildProcessEnv(options.env ?? process.env),
   });
-  return new SshStdioSocket(child, endpoint);
+  return new SshStdioSocket(child, endpoint, options.onFailure);
 }
 
 // Wraps the ssh child's stdio as one duplex stream that quacks enough like a
@@ -131,6 +146,7 @@ class SshStdioSocket extends Duplex {
   constructor(
     private readonly child: ChildProcessWithoutNullStreams,
     endpoint: FederationSshEndpoint,
+    private readonly onFailure?: (error: Error) => void,
   ) {
     super();
     child.stdout.on("data", (chunk: Buffer) => {
@@ -146,24 +162,35 @@ class SshStdioSocket extends Duplex {
     });
     child.on("error", (error) => {
       this.exited = true;
-      this.destroy(
+      this.fail(
         error instanceof Error && "code" in error && error.code === "ENOENT"
           ? new Error(
               "The ssh command was not found. Install the OpenSSH client to use ssh:// federation endpoints.",
             )
-          : error,
+          : error instanceof Error
+            ? error
+            : new Error(String(error)),
       );
     });
-    child.on("exit", (code, signal) => {
+    // "close" rather than "exit": it fires after stdio has been drained and
+    // closed, so the stderr tail is complete and the readable side has already
+    // ended. "exit" can fire with output still buffered.
+    child.on("close", (code, signal) => {
       this.exited = true;
-      if (this.destroyed) return;
+      if (code === 0 && !signal) {
+        // Normal `ssh -W` teardown — the forwarded connection ended. Reporting
+        // an Error here would make every graceful disconnect look like a
+        // transport failure (and mark the endpoint failed in the UI).
+        if (!this.destroyed) this.destroy();
+        return;
+      }
       const detail = this.stderrTail.trim();
       log.warn("federation ssh tunnel exited", {
         host: endpoint.host,
         code,
         signal,
       });
-      this.destroy(
+      this.fail(
         new Error(
           detail
             ? `SSH federation tunnel closed: ${detail}`
@@ -171,6 +198,15 @@ class SshStdioSocket extends Duplex {
         ),
       );
     });
+  }
+
+  // Record before destroying: the consumer usually learns about the failure as
+  // a generic socket error, and needs the recorded reason to report the cause.
+  private fail(error: Error): void {
+    this.onFailure?.(error);
+    if (!this.destroyed) {
+      this.destroy(error);
+    }
   }
 
   _read(): void {
@@ -221,6 +257,17 @@ class SshStdioSocket extends Duplex {
   }
 }
 
+// Loopback only. The documented topology forwards to the gateway's own
+// loopback listener, and allowing an arbitrary target would turn the
+// operator's SSH server into a port-scanning proxy for anyone who can get an
+// endpoint into their config (e.g. via a pasted invite).
+const LOOPBACK_FORWARD_HOSTS = new Set([
+  "127.0.0.1",
+  "localhost",
+  "::1",
+  "[::1]",
+]);
+
 function parseForwardTarget(value: string): {
   forwardHost: string;
   forwardPort: number;
@@ -231,6 +278,11 @@ function parseForwardTarget(value: string): {
   }
   const forwardHost = value.slice(0, separator);
   const forwardPort = parsePort(value.slice(separator + 1), "forward port");
+  if (!LOOPBACK_FORWARD_HOSTS.has(forwardHost.toLowerCase())) {
+    throw new Error(
+      "SSH federation endpoints may only forward to the gateway's loopback address.",
+    );
+  }
   return { forwardHost, forwardPort };
 }
 

--- a/apps/desktop/src/main/federation/federation-ssh.ts
+++ b/apps/desktop/src/main/federation/federation-ssh.ts
@@ -1,0 +1,243 @@
+// SSH outer transport for the federation client. An `ssh://` gateway endpoint
+// is dialed with the operator's system OpenSSH client using stdio forwarding
+// (`ssh -W`), so ~/.ssh/config, key agents, and known_hosts all apply and
+// PwrAgent never stores SSH credentials or weakens host-key checking. The
+// resulting stdio stream carries the ordinary federation WebSocket, whose
+// frames remain protected by the mandatory Noise IK channel — SSH only
+// replaces the reachability hop, never the identity or encryption layer.
+import {
+  spawn as spawnChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { Duplex } from "node:stream";
+import { buildPwrAgentChildProcessEnv } from "../child-process-env";
+import { getMainLogger } from "../log";
+
+const log = getMainLogger("pwragent:federation-ssh");
+
+const DEFAULT_FORWARD_HOST = "127.0.0.1";
+const DEFAULT_FORWARD_PORT = 47830;
+const SSH_CONNECT_TIMEOUT_SECONDS = 10;
+const STDERR_TAIL_LIMIT = 2_048;
+
+export type FederationSshEndpoint = {
+  user?: string;
+  host: string;
+  sshPort?: number;
+  /** Loopback target on the gateway machine that sshd forwards to. */
+  forwardHost: string;
+  forwardPort: number;
+};
+
+export function isFederationSshEndpointUrl(url: string): boolean {
+  return url.trim().toLowerCase().startsWith("ssh://");
+}
+
+export function parseFederationSshEndpoint(url: string): FederationSshEndpoint {
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    throw new Error("Invalid SSH federation endpoint URL.");
+  }
+  if (parsed.protocol !== "ssh:") {
+    throw new Error("SSH federation endpoints must use the ssh:// scheme.");
+  }
+  if (parsed.password) {
+    throw new Error("SSH federation endpoints must not embed a password.");
+  }
+  if (!parsed.hostname) {
+    throw new Error("SSH federation endpoints require a host.");
+  }
+  if (parsed.pathname && parsed.pathname !== "/") {
+    throw new Error(
+      "SSH federation endpoints take the forward target as ?forward=host:port, not a path.",
+    );
+  }
+  const forward = parsed.searchParams.get("forward");
+  const { forwardHost, forwardPort } = forward
+    ? parseForwardTarget(forward)
+    : { forwardHost: DEFAULT_FORWARD_HOST, forwardPort: DEFAULT_FORWARD_PORT };
+  return {
+    user: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+    host: parsed.hostname,
+    sshPort: parsed.port ? parsePort(parsed.port, "SSH port") : undefined,
+    forwardHost,
+    forwardPort,
+  };
+}
+
+export function buildFederationSshArgs(
+  endpoint: FederationSshEndpoint,
+): string[] {
+  return [
+    // Fail closed instead of hanging on an interactive password or unknown
+    // host-key prompt. Host-key verification itself stays at OpenSSH's
+    // default strictness — PwrAgent never relaxes it.
+    "-o",
+    "BatchMode=yes",
+    "-o",
+    `ConnectTimeout=${SSH_CONNECT_TIMEOUT_SECONDS}`,
+    ...(endpoint.sshPort !== undefined ? ["-p", String(endpoint.sshPort)] : []),
+    "-W",
+    `${endpoint.forwardHost}:${endpoint.forwardPort}`,
+    endpoint.user ? `${endpoint.user}@${endpoint.host}` : endpoint.host,
+  ];
+}
+
+export type FederationSshSpawn = (
+  command: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv },
+) => ChildProcessWithoutNullStreams;
+
+export type FederationSshDialOptions = {
+  command?: string;
+  env?: NodeJS.ProcessEnv;
+  spawnFn?: FederationSshSpawn;
+};
+
+/**
+ * Open the SSH stdio forward for a federation endpoint. Returns the duplex
+ * stream synchronously; connection, authentication, or host-key failures
+ * surface as an error/close on the stream (with the bounded ssh stderr tail
+ * in the message), which the federation client treats like any failed dial.
+ */
+export function dialFederationSshEndpoint(
+  endpoint: FederationSshEndpoint,
+  options: FederationSshDialOptions = {},
+): Duplex {
+  const command = options.command ?? "ssh";
+  const spawnFn: FederationSshSpawn =
+    options.spawnFn
+    ?? ((cmd, args, spawnOptions) =>
+      spawnChildProcess(cmd, args, {
+        env: spawnOptions.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      }) as ChildProcessWithoutNullStreams);
+  const child = spawnFn(command, buildFederationSshArgs(endpoint), {
+    env: buildPwrAgentChildProcessEnv(options.env ?? process.env),
+  });
+  return new SshStdioSocket(child, endpoint);
+}
+
+// Wraps the ssh child's stdio as one duplex stream that quacks enough like a
+// net.Socket for Node's HTTP client (no-op setTimeout/setNoDelay/etc.), so it
+// can serve as the connection under a WebSocket upgrade.
+class SshStdioSocket extends Duplex {
+  private stderrTail = "";
+  private exited = false;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    endpoint: FederationSshEndpoint,
+  ) {
+    super();
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (!this.push(chunk)) {
+        child.stdout.pause();
+      }
+    });
+    child.stdout.on("end", () => this.push(null));
+    child.stderr.on("data", (chunk: Buffer) => {
+      this.stderrTail = (this.stderrTail + chunk.toString("utf8")).slice(
+        -STDERR_TAIL_LIMIT,
+      );
+    });
+    child.on("error", (error) => {
+      this.exited = true;
+      this.destroy(
+        error instanceof Error && "code" in error && error.code === "ENOENT"
+          ? new Error(
+              "The ssh command was not found. Install the OpenSSH client to use ssh:// federation endpoints.",
+            )
+          : error,
+      );
+    });
+    child.on("exit", (code, signal) => {
+      this.exited = true;
+      if (this.destroyed) return;
+      const detail = this.stderrTail.trim();
+      log.warn("federation ssh tunnel exited", {
+        host: endpoint.host,
+        code,
+        signal,
+      });
+      this.destroy(
+        new Error(
+          detail
+            ? `SSH federation tunnel closed: ${detail}`
+            : `SSH federation tunnel closed (exit ${code ?? signal ?? "unknown"}).`,
+        ),
+      );
+    });
+  }
+
+  _read(): void {
+    this.child.stdout.resume();
+  }
+
+  _write(
+    chunk: Buffer,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.child.stdin.write(chunk, encoding, callback);
+  }
+
+  _final(callback: (error?: Error | null) => void): void {
+    this.child.stdin.end(callback);
+  }
+
+  _destroy(
+    error: Error | null,
+    callback: (error?: Error | null) => void,
+  ): void {
+    if (!this.exited) {
+      this.child.kill();
+    }
+    callback(error);
+  }
+
+  // net.Socket surface expected by Node's HTTP client plumbing.
+  setTimeout(): this {
+    return this;
+  }
+
+  setNoDelay(): this {
+    return this;
+  }
+
+  setKeepAlive(): this {
+    return this;
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+function parseForwardTarget(value: string): {
+  forwardHost: string;
+  forwardPort: number;
+} {
+  const separator = value.lastIndexOf(":");
+  if (separator <= 0 || separator === value.length - 1) {
+    throw new Error("SSH forward target must look like host:port.");
+  }
+  const forwardHost = value.slice(0, separator);
+  const forwardPort = parsePort(value.slice(separator + 1), "forward port");
+  return { forwardHost, forwardPort };
+}
+
+function parsePort(value: string, label: string): number {
+  const port = Number.parseInt(value, 10);
+  if (!/^\d+$/.test(value) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid SSH federation ${label}.`);
+  }
+  return port;
+}

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -1,5 +1,6 @@
 import http from "node:http";
 import { randomUUID } from "node:crypto";
+import type { Duplex } from "node:stream";
 import WebSocket, { WebSocketServer } from "ws";
 import type {
   FederationCapability,
@@ -502,6 +503,14 @@ export async function connectFederationClient(params: {
   headers?: Record<string, string>;
   clientCertificate?: string;
   clientPrivateKey?: string;
+  /**
+   * Custom outer-transport socket factory (e.g. an SSH stdio forward). When
+   * set, the WebSocket upgrade runs over the returned stream instead of a
+   * direct TCP/TLS connection; `url` still names the inner listener so the
+   * upgrade Host header matches. Everything inside — Noise handshake,
+   * channel-bound auth, envelopes — is unchanged.
+   */
+  createSocket?: () => Duplex;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
@@ -509,11 +518,19 @@ export async function connectFederationClient(params: {
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
   onClose?: () => void;
 }): Promise<FederationClientWebSocketClient> {
-  const socket = new WebSocket(params.url, {
-    headers: params.headers,
-    cert: params.clientCertificate,
-    key: params.clientPrivateKey,
-  });
+  const socket = new WebSocket(
+    params.url,
+    params.createSocket
+      ? {
+          headers: params.headers,
+          agent: outerSocketAgent(params.createSocket),
+        }
+      : {
+          headers: params.headers,
+          cert: params.clientCertificate,
+          key: params.clientPrivateKey,
+        },
+  );
   // Attach the reader before "open" so no inbound frame can be missed.
   const reader = new FederationFrameReader(socket);
   await waitForOpen(socket);
@@ -747,6 +764,16 @@ class FederationFrameReader {
       this.pending = { resolve, reject };
     });
   }
+}
+
+// One-shot http.Agent that hands the WebSocket upgrade an externally created
+// stream (e.g. an SSH stdio forward) instead of dialing TCP itself.
+function outerSocketAgent(createSocket: () => Duplex): http.Agent {
+  const agent = new http.Agent({ keepAlive: false });
+  (
+    agent as http.Agent & { createConnection: () => Duplex }
+  ).createConnection = () => createSocket();
+  return agent;
 }
 
 function rawDataToBuffer(raw: WebSocket.RawData): Buffer {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -511,6 +511,13 @@ export async function connectFederationClient(params: {
    * channel-bound auth, envelopes — is unchanged.
    */
   createSocket?: () => Duplex;
+  /**
+   * Deadline for the whole pre-session exchange: TCP/TLS connect, WebSocket
+   * upgrade, transport hello, Noise handshake, and identity auth. Without it a
+   * peer that accepts the upgrade and then goes silent parks this promise
+   * forever, which stalls the caller's endpoint walk and reconnect loop.
+   */
+  connectTimeoutMs?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
   /** Pinned gateway Noise static public key (raw 32 bytes), from the invite. */
@@ -518,21 +525,66 @@ export async function connectFederationClient(params: {
   onEnvelope?: (envelope: FederationProtocolEnvelope) => void;
   onClose?: () => void;
 }): Promise<FederationClientWebSocketClient> {
+  const connectTimeoutMs =
+    params.connectTimeoutMs ?? FEDERATION_CONNECT_TIMEOUT_MS;
   const socket = new WebSocket(
     params.url,
     params.createSocket
       ? {
           headers: params.headers,
+          handshakeTimeout: connectTimeoutMs,
           agent: outerSocketAgent(params.createSocket),
         }
       : {
           headers: params.headers,
+          handshakeTimeout: connectTimeoutMs,
           cert: params.clientCertificate,
           key: params.clientPrivateKey,
         },
   );
   // Attach the reader before "open" so no inbound frame can be missed.
   const reader = new FederationFrameReader(socket);
+  // `handshakeTimeout` only covers the upgrade. This deadline also covers the
+  // frames after it, so a peer that upgrades and then stays silent still fails.
+  const connectDeadline = new FederationConnectDeadline(socket, connectTimeoutMs);
+  try {
+    return await establishFederationClient(params, socket, reader);
+  } finally {
+    connectDeadline.clear();
+  }
+}
+
+const FEDERATION_CONNECT_TIMEOUT_MS = 20_000;
+
+// Closes the socket if the pre-session exchange has not finished in time. The
+// close makes every pending `reader.next()` reject, so the caller's await
+// chain unwinds instead of parking forever.
+class FederationConnectDeadline {
+  private timer?: ReturnType<typeof setTimeout>;
+
+  constructor(socket: WebSocket, timeoutMs: number) {
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      log.warn("federation connect deadline exceeded", { timeoutMs });
+      socket.close(1002, "Federation connect timeout");
+      socket.terminate();
+    }, timeoutMs);
+    this.timer.unref?.();
+  }
+
+  clear(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
+async function establishFederationClient(
+  params: Parameters<typeof connectFederationClient>[0],
+  socket: WebSocket,
+  reader: FederationFrameReader,
+): Promise<FederationClientWebSocketClient> {
   await waitForOpen(socket);
 
   // Phase 1: Noise_IK handshake (initiator). Skipped in tunnel mode.

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -145,6 +145,8 @@ export type DesktopSettingsConfig = {
     listenPort?: number;
     publicUrl?: string;
     gatewayUrl?: string;
+    gatewayEndpoints?: string[];
+    advertisedEndpoints?: string[];
     cloudflareMtlsEnabled?: boolean;
     cloudflareAccessServiceAuthEnabled?: boolean;
   };
@@ -952,6 +954,39 @@ export function desktopSettingsPatchToEdits(
       set(["federation", "gateway_url"], patch.federation.gatewayUrl);
     }
   }
+  if (patch.federation?.gatewayEndpoints !== undefined) {
+    const gatewayEndpoints = sanitizeEndpointList(
+      patch.federation.gatewayEndpoints,
+    );
+    if (gatewayEndpoints.length === 0) {
+      edits.push({ op: "delete", path: ["federation", "gateway_endpoints"] });
+    } else {
+      set(["federation", "gateway_endpoints"], gatewayEndpoints);
+    }
+    // Dual-write the first endpoint into the legacy scalar so an older build
+    // opened against this profile after a downgrade keeps a working path. An
+    // explicit gatewayUrl in the same patch wins over the dual-write.
+    if (patch.federation.gatewayUrl === undefined) {
+      if (gatewayEndpoints.length === 0) {
+        edits.push({ op: "delete", path: ["federation", "gateway_url"] });
+      } else {
+        set(["federation", "gateway_url"], gatewayEndpoints[0]);
+      }
+    }
+  }
+  if (patch.federation?.advertisedEndpoints !== undefined) {
+    const advertisedEndpoints = sanitizeEndpointList(
+      patch.federation.advertisedEndpoints,
+    );
+    if (advertisedEndpoints.length === 0) {
+      edits.push({
+        op: "delete",
+        path: ["federation", "advertised_endpoints"],
+      });
+    } else {
+      set(["federation", "advertised_endpoints"], advertisedEndpoints);
+    }
+  }
   if (patch.federation?.cloudflareMtlsEnabled !== undefined) {
     if (patch.federation.cloudflareMtlsEnabled) {
       set(["federation", "cloudflare_mtls_enabled"], true);
@@ -1622,6 +1657,8 @@ function normalizeDesktopConfig(
       listenPort: readNumber(federation?.listen_port),
       publicUrl: readString(federation?.public_url),
       gatewayUrl: readString(federation?.gateway_url),
+      gatewayEndpoints: readStringArray(federation?.gateway_endpoints),
+      advertisedEndpoints: readStringArray(federation?.advertised_endpoints),
       cloudflareMtlsEnabled: readBoolean(
         federation?.cloudflare_mtls_enabled,
       ),
@@ -2227,6 +2264,18 @@ function readHotCpuProfileTriggerMode(
   return typeof value === "string" && isDesktopHotCpuProfileTriggerMode(value)
     ? value
     : undefined;
+}
+
+function sanitizeEndpointList(endpoints: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const sanitized: string[] = [];
+  for (const endpoint of endpoints) {
+    const trimmed = endpoint.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    sanitized.push(trimmed);
+  }
+  return sanitized;
 }
 
 function readFederationMode(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -39,6 +39,7 @@ import {
   isDesktopAppearanceTheme,
   isDesktopCodexProfileModel,
   isDesktopFederationMode,
+  isFederationGatewayEndpointUrl,
   isDesktopHotCpuProfileStartDelayMs,
   isDesktopHotCpuProfileTriggerMode,
   isDesktopIntegratedTerminalWindowsShell,
@@ -147,6 +148,7 @@ export type DesktopSettingsConfig = {
     gatewayUrl?: string;
     gatewayEndpoints?: string[];
     advertisedEndpoints?: string[];
+    cloudflareEndpoint?: string;
     cloudflareMtlsEnabled?: boolean;
     cloudflareAccessServiceAuthEnabled?: boolean;
   };
@@ -291,6 +293,7 @@ const LEGACY_AUTHORIZED_CONTACT_LAST_VERSION = "1.0.0-alpha.9";
 const LEGACY_SETTINGS_MARKER = "pwragent-legacy-settings";
 const LEGACY_CHAT_REPLY_COMPOSER_LAST_VERSION = "1.0.0-alpha.8";
 const LEGACY_BACKGROUND_PR_POLLING_LAST_VERSION = "1.0.0-beta.50";
+const LEGACY_FEDERATION_GATEWAY_URL_LAST_VERSION = "1.0.0-beta.50";
 
 export function defaultDesktopConfigDir(
   options?: DesktopConfigPathOptions,
@@ -963,13 +966,21 @@ export function desktopSettingsPatchToEdits(
     } else {
       set(["federation", "gateway_endpoints"], gatewayEndpoints);
     }
-    // Dual-write the first endpoint into the legacy scalar so an older build
-    // opened against this profile after a downgrade keeps a working path. An
-    // explicit gatewayUrl in the same patch wins over the dual-write.
-    if (patch.federation.gatewayUrl === undefined) {
-      if (gatewayEndpoints.length === 0) {
-        edits.push({ op: "delete", path: ["federation", "gateway_url"] });
-      } else {
+    // Keep the legacy scalar in sync ONLY when the profile already has one, so
+    // a downgraded build still finds a working path. Per
+    // docs/config-file-evolution.md a brand-new config gets the canonical shape
+    // only, and a preserved legacy scalar is never deleted out from under an
+    // older client. An explicit gatewayUrl in the same patch wins.
+    const hasLegacyGatewayUrl =
+      readString(currentTables?.["federation"]?.gateway_url) !== undefined;
+    if (patch.federation.gatewayUrl === undefined && hasLegacyGatewayUrl) {
+      if (gatewayEndpoints.length > 0) {
+        edits.push({
+          op: "ensureCommentBefore",
+          path: ["federation", "gateway_url"],
+          marker: LEGACY_SETTINGS_MARKER,
+          comment: legacyGatewayUrlComment(),
+        });
         set(["federation", "gateway_url"], gatewayEndpoints[0]);
       }
     }
@@ -985,6 +996,16 @@ export function desktopSettingsPatchToEdits(
       });
     } else {
       set(["federation", "advertised_endpoints"], advertisedEndpoints);
+    }
+  }
+  if (patch.federation?.cloudflareEndpoint !== undefined) {
+    if (patch.federation.cloudflareEndpoint.trim() === "") {
+      edits.push({ op: "delete", path: ["federation", "cloudflare_endpoint"] });
+    } else {
+      set(
+        ["federation", "cloudflare_endpoint"],
+        patch.federation.cloudflareEndpoint.trim(),
+      );
     }
   }
   if (patch.federation?.cloudflareMtlsEnabled !== undefined) {
@@ -1657,8 +1678,9 @@ function normalizeDesktopConfig(
       listenPort: readNumber(federation?.listen_port),
       publicUrl: readString(federation?.public_url),
       gatewayUrl: readString(federation?.gateway_url),
-      gatewayEndpoints: readStringArray(federation?.gateway_endpoints),
-      advertisedEndpoints: readStringArray(federation?.advertised_endpoints),
+      gatewayEndpoints: readEndpointList(federation?.gateway_endpoints),
+      advertisedEndpoints: readEndpointList(federation?.advertised_endpoints),
+      cloudflareEndpoint: readString(federation?.cloudflare_endpoint),
       cloudflareMtlsEnabled: readBoolean(
         federation?.cloudflare_mtls_enabled,
       ),
@@ -2266,16 +2288,42 @@ function readHotCpuProfileTriggerMode(
     : undefined;
 }
 
+// Endpoints are dialed by the main process, so the scheme allowlist is
+// enforced here rather than trusting the renderer (config.toml is
+// hand-editable, and invite-supplied endpoints never pass through the UI).
 function sanitizeEndpointList(endpoints: readonly string[]): string[] {
   const seen = new Set<string>();
   const sanitized: string[] = [];
   for (const endpoint of endpoints) {
     const trimmed = endpoint.trim();
     if (!trimmed || seen.has(trimmed)) continue;
+    if (!isFederationGatewayEndpointUrl(trimmed)) continue;
     seen.add(trimmed);
     sanitized.push(trimmed);
   }
   return sanitized;
+}
+
+// Drops entries a hand-edited config may contain that the transport must never
+// dial (wrong scheme, embedded password, option-like host).
+function readEndpointList(
+  value: TomlScalar | undefined,
+): string[] | undefined {
+  const raw = readStringArray(value);
+  if (raw === undefined) return undefined;
+  const sanitized = sanitizeEndpointList(raw);
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+function legacyGatewayUrlComment(): string {
+  return [
+    "#",
+    LEGACY_SETTINGS_MARKER,
+    "key=gateway_url",
+    "shape=string",
+    `used_through=${LEGACY_FEDERATION_GATEWAY_URL_LAST_VERSION}`,
+    "kept_for_older_clients",
+  ].join(" ");
 }
 
 function readFederationMode(

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -768,6 +768,9 @@ export class DesktopSettingsService {
         advertisedEndpoints: this.resolveFederationEndpointList(
           config.federation?.advertisedEndpoints,
         ),
+        cloudflareEndpoint: this.resolveConfigString(
+          config.federation?.cloudflareEndpoint,
+        ),
         cloudflareMtlsEnabled: this.resolveConfigBoolean(
           config.federation?.cloudflareMtlsEnabled,
           false,

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -761,6 +761,13 @@ export class DesktopSettingsService {
         listenPort: this.resolveConfigNumber(config.federation?.listenPort, 47830),
         publicUrl: this.resolveConfigString(config.federation?.publicUrl),
         gatewayUrl: this.resolveConfigString(config.federation?.gatewayUrl),
+        gatewayEndpoints: this.resolveFederationEndpointList(
+          config.federation?.gatewayEndpoints,
+          config.federation?.gatewayUrl,
+        ),
+        advertisedEndpoints: this.resolveFederationEndpointList(
+          config.federation?.advertisedEndpoints,
+        ),
         cloudflareMtlsEnabled: this.resolveConfigBoolean(
           config.federation?.cloudflareMtlsEnabled,
           false,
@@ -2011,6 +2018,23 @@ export class DesktopSettingsService {
       value: configValue ?? DESKTOP_FEDERATION_MODE_DEFAULT,
       source: configValue === undefined ? "default" : "config",
     };
+  }
+
+  private resolveFederationEndpointList(
+    configValue: string[] | undefined,
+    fallbackUrl?: string,
+  ): DesktopSettingsValue<string[]> {
+    const configured = configValue
+      ?.map((endpoint) => endpoint.trim())
+      .filter((endpoint) => endpoint.length > 0);
+    if (configured && configured.length > 0) {
+      return { value: configured, source: "config" };
+    }
+    const fallback = fallbackUrl?.trim();
+    if (fallback) {
+      return { value: [fallback], source: "config" };
+    }
+    return { value: [], source: "default" };
   }
 
   private resolveNumber(

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -484,6 +484,8 @@ describe("App", () => {
         listenPort: { value: 47830, source: "default" },
         publicUrl: { value: "", source: "default" },
         gatewayUrl: { value: "", source: "default" },
+        gatewayEndpoints: { value: [], source: "default" },
+        advertisedEndpoints: { value: [], source: "default" },
         cloudflareMtlsEnabled: { value: false, source: "default" },
         cloudflareAccessServiceAuthEnabled: {
           value: false,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -486,6 +486,7 @@ describe("App", () => {
         gatewayUrl: { value: "", source: "default" },
         gatewayEndpoints: { value: [], source: "default" },
         advertisedEndpoints: { value: [], source: "default" },
+        cloudflareEndpoint: { value: "", source: "default" },
         cloudflareMtlsEnabled: { value: false, source: "default" },
         cloudflareAccessServiceAuthEnabled: {
           value: false,

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -83,6 +83,12 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [gatewayEndpointsText, setGatewayEndpointsText] = useState(
     props.snapshot.federation.gatewayEndpoints.value.join("\n"),
   );
+  const [advertisedEndpointsText, setAdvertisedEndpointsText] = useState(
+    props.snapshot.federation.advertisedEndpoints.value.join("\n"),
+  );
+  const [cloudflareEndpoint, setCloudflareEndpoint] = useState(
+    props.snapshot.federation.cloudflareEndpoint.value,
+  );
   const [cloudflareMtlsEnabled, setCloudflareMtlsEnabled] = useState(
     props.snapshot.federation.cloudflareMtlsEnabled.value,
   );
@@ -109,6 +115,10 @@ export function FederationSettings(props: FederationSettingsProps) {
     setGatewayEndpointsText(
       props.snapshot.federation.gatewayEndpoints.value.join("\n"),
     );
+    setAdvertisedEndpointsText(
+      props.snapshot.federation.advertisedEndpoints.value.join("\n"),
+    );
+    setCloudflareEndpoint(props.snapshot.federation.cloudflareEndpoint.value);
     setCloudflareMtlsEnabled(
       props.snapshot.federation.cloudflareMtlsEnabled.value,
     );
@@ -423,6 +433,21 @@ export function FederationSettings(props: FederationSettingsProps) {
               />
             }
           />
+          <SettingsField
+            label="Advertised endpoints"
+            sub="Gateway mode: endpoints written into new enrollment invites, one per line. Defaults to the Public URL when empty."
+            control={
+              <textarea
+                aria-label="Advertised endpoints"
+                rows={3}
+                value={advertisedEndpointsText}
+                disabled={props.saving}
+                onChange={(event) =>
+                  setAdvertisedEndpointsText(event.target.value)
+                }
+              />
+            }
+          />
           <div className="settings-button-row">
             <button
               className="button button--primary"
@@ -433,12 +458,16 @@ export function FederationSettings(props: FederationSettingsProps) {
                 const gatewayEndpoints = parseGatewayEndpoints(
                   gatewayEndpointsText,
                 );
-                const invalidEndpoint = gatewayEndpoints.find(
-                  (endpoint) => !isFederationGatewayEndpointUrl(endpoint),
+                const advertisedEndpoints = parseGatewayEndpoints(
+                  advertisedEndpointsText,
                 );
+                const invalidEndpoint = [
+                  ...gatewayEndpoints,
+                  ...advertisedEndpoints,
+                ].find((endpoint) => !isFederationGatewayEndpointUrl(endpoint));
                 if (invalidEndpoint) {
                   setActionError(
-                    `Gateway endpoint "${invalidEndpoint}" must be a ws://, wss://, or ssh:// URL without an embedded password.`,
+                    `Endpoint "${invalidEndpoint}" must be a ws://, wss://, or ssh:// URL without an embedded password.`,
                   );
                   return;
                 }
@@ -450,6 +479,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                     listenPort: Number.parseInt(listenPort, 10) || 0,
                     publicUrl,
                     gatewayEndpoints,
+                    advertisedEndpoints,
                     cloudflareMtlsEnabled,
                     cloudflareAccessServiceAuthEnabled,
                   },
@@ -1074,6 +1104,19 @@ export function FederationSettings(props: FederationSettingsProps) {
       >
         <div className="settings-fields">
           <SettingsField
+            label="Cloudflare endpoint"
+            sub="The one endpoint fronted by Cloudflare. Access tokens and client certificates are sent only to this host, because they travel in the WebSocket upgrade before the gateway's pinned keys are verified."
+            control={
+              <input
+                aria-label="Cloudflare endpoint"
+                value={cloudflareEndpoint}
+                placeholder="wss://federation.example.com"
+                disabled={props.saving}
+                onChange={(event) => setCloudflareEndpoint(event.target.value)}
+              />
+            }
+          />
+          <SettingsField
             label="mTLS"
             sub="Cloudflare edge certificate gate."
             control={
@@ -1176,8 +1219,18 @@ export function FederationSettings(props: FederationSettingsProps) {
               disabled={props.saving}
               onClick={() => {
                 setActionError(undefined);
+                if (
+                  cloudflareEndpoint.trim()
+                  && !isFederationGatewayEndpointUrl(cloudflareEndpoint)
+                ) {
+                  setActionError(
+                    "Cloudflare endpoint must be a wss:// URL matching one of the gateway endpoints.",
+                  );
+                  return;
+                }
                 void saveCloudflareSettings({
                   config: {
+                    cloudflareEndpoint: cloudflareEndpoint.trim(),
                     cloudflareMtlsEnabled,
                     cloudflareAccessServiceAuthEnabled,
                   },
@@ -1245,6 +1298,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                     }
                     const written = await props.onWriteConfig({
                       federation: {
+                        cloudflareEndpoint: "",
                         cloudflareMtlsEnabled: false,
                         cloudflareAccessServiceAuthEnabled: false,
                       },
@@ -1254,6 +1308,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                         "Cloudflare edge policy could not be updated.",
                       );
                     }
+                    setCloudflareEndpoint("");
                     setCloudflareMtlsEnabled(false);
                     setCloudflareAccessServiceAuthEnabled(false);
                     await props.onSettingsChanged();
@@ -1277,6 +1332,7 @@ export function FederationSettings(props: FederationSettingsProps) {
 
 async function saveCloudflareSettings(params: {
   config: {
+    cloudflareEndpoint: string;
     cloudflareMtlsEnabled: boolean;
     cloudflareAccessServiceAuthEnabled: boolean;
   };

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -7,12 +7,16 @@ import type {
   FederationConnectionState,
   FederationCapability,
   FederationDiagnosticEvent,
+  FederationEndpointStatus,
   FederationHealthStatus,
   FederationInstanceRole,
   FederationTailscaleMode,
   FederationTailscaleStatus,
 } from "@pwragent/shared";
-import { DESKTOP_FEDERATION_MODES } from "@pwragent/shared";
+import {
+  DESKTOP_FEDERATION_MODES,
+  isFederationGatewayEndpointUrl,
+} from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { copyText } from "../../lib/copy-text";
 import { formatRunningDurationMs } from "../../lib/format-duration";
@@ -76,8 +80,8 @@ export function FederationSettings(props: FederationSettingsProps) {
   const [publicUrl, setPublicUrl] = useState(
     props.snapshot.federation.publicUrl.value,
   );
-  const [gatewayUrl, setGatewayUrl] = useState(
-    props.snapshot.federation.gatewayUrl.value,
+  const [gatewayEndpointsText, setGatewayEndpointsText] = useState(
+    props.snapshot.federation.gatewayEndpoints.value.join("\n"),
   );
   const [cloudflareMtlsEnabled, setCloudflareMtlsEnabled] = useState(
     props.snapshot.federation.cloudflareMtlsEnabled.value,
@@ -102,7 +106,9 @@ export function FederationSettings(props: FederationSettingsProps) {
     setListenHost(props.snapshot.federation.listenHost.value);
     setListenPort(String(props.snapshot.federation.listenPort.value));
     setPublicUrl(props.snapshot.federation.publicUrl.value);
-    setGatewayUrl(props.snapshot.federation.gatewayUrl.value);
+    setGatewayEndpointsText(
+      props.snapshot.federation.gatewayEndpoints.value.join("\n"),
+    );
     setCloudflareMtlsEnabled(
       props.snapshot.federation.cloudflareMtlsEnabled.value,
     );
@@ -248,13 +254,13 @@ export function FederationSettings(props: FederationSettingsProps) {
   };
 
   // Gateway-side fields only matter when this instance listens; the
-  // gateway URL only matters when it dials out. Disable (never hide)
+  // gateway endpoints only matter when it dials out. Disable (never hide)
   // the irrelevant ones so the form teaches the mode split instead of
   // accepting values that silently do nothing.
   const listensForPeers = mode === "gateway" || mode === "dual";
   const dialsGateway = mode === "client" || mode === "dual";
 
-  const effectiveHealth =
+  const effectiveHealth: FederationHealthStatus =
     health ??
     ({
       enabled: props.snapshot.federation.mode.value !== "disabled",
@@ -268,8 +274,17 @@ export function FederationSettings(props: FederationSettingsProps) {
           ? undefined
           : `ws://${props.snapshot.federation.listenHost.value}:${props.snapshot.federation.listenPort.value}`,
       publicUrl: trimmedOrUndefined(props.snapshot.federation.publicUrl.value),
+      gatewayEndpoints:
+        props.snapshot.federation.mode.value === "client" ||
+        props.snapshot.federation.mode.value === "dual"
+          ? props.snapshot.federation.gatewayEndpoints.value.map((url) => ({
+              url,
+              state: "idle" as const,
+            }))
+          : undefined,
       peers: [],
     } satisfies FederationHealthStatus);
+  const gatewayEndpointStatuses = effectiveHealth.gatewayEndpoints ?? [];
   const now = Date.now();
   const connectionRemediation = effectiveHealth.unavailableReason
     ? remediationForConnectionFailure(effectiveHealth.unavailableReason)
@@ -392,18 +407,19 @@ export function FederationSettings(props: FederationSettingsProps) {
             }
           />
           <SettingsField
-            label="Gateway URL"
+            label="Gateway endpoints"
             sub={
               dialsGateway
-                ? "Client-mode gateway WebSocket URL."
+                ? "Endpoints for one pinned gateway, one per line in fallback order. ws://, wss://, and ssh:// (user@host, optional ?forward=host:port) are supported."
                 : "Only used when Mode is client or dual."
             }
             control={
-              <input
-                aria-label="Gateway URL"
-                value={gatewayUrl}
+              <textarea
+                aria-label="Gateway endpoints"
+                rows={3}
+                value={gatewayEndpointsText}
                 disabled={props.saving || !dialsGateway}
-                onChange={(event) => setGatewayUrl(event.target.value)}
+                onChange={(event) => setGatewayEndpointsText(event.target.value)}
               />
             }
           />
@@ -414,6 +430,18 @@ export function FederationSettings(props: FederationSettingsProps) {
               disabled={props.saving}
               onClick={() => {
                 setActionError(undefined);
+                const gatewayEndpoints = parseGatewayEndpoints(
+                  gatewayEndpointsText,
+                );
+                const invalidEndpoint = gatewayEndpoints.find(
+                  (endpoint) => !isFederationGatewayEndpointUrl(endpoint),
+                );
+                if (invalidEndpoint) {
+                  setActionError(
+                    `Gateway endpoint "${invalidEndpoint}" must be a ws://, wss://, or ssh:// URL without an embedded password.`,
+                  );
+                  return;
+                }
                 void props.onWriteConfig({
                   federation: {
                     mode,
@@ -421,7 +449,7 @@ export function FederationSettings(props: FederationSettingsProps) {
                     listenHost,
                     listenPort: Number.parseInt(listenPort, 10) || 0,
                     publicUrl,
-                    gatewayUrl,
+                    gatewayEndpoints,
                     cloudflareMtlsEnabled,
                     cloudflareAccessServiceAuthEnabled,
                   },
@@ -736,13 +764,32 @@ export function FederationSettings(props: FederationSettingsProps) {
             control={<code>{effectiveHealth.publicUrl ?? "Not configured"}</code>}
           />
           <SettingsField
-            label="Gateway URL"
-            sub="Outbound target used by client mode."
+            label="Gateway endpoints"
+            sub="Outbound candidates used by client mode, tried in order. The active endpoint carries the current session."
             control={
-              <code>
-                {trimmedOrUndefined(props.snapshot.federation.gatewayUrl.value) ??
-                  "Not configured"}
-              </code>
+              gatewayEndpointStatuses.length === 0 ? (
+                <span>Not configured</span>
+              ) : (
+                <div className="federation-peer-summary">
+                  {gatewayEndpointStatuses.map((endpoint) => (
+                    <span
+                      key={endpoint.url}
+                      className="federation-peer-summary"
+                    >
+                      <code>{endpoint.url}</code>
+                      <span>
+                        {endpointStateLabel(endpoint.state)}
+                        {endpoint.lastConnectedAt
+                          ? ` · Connected ${formatTimestamp(endpoint.lastConnectedAt)}`
+                          : ""}
+                      </span>
+                      {endpoint.lastError ? (
+                        <span>{endpoint.lastError}</span>
+                      ) : null}
+                    </span>
+                  ))}
+                </div>
+              )
             }
           />
           {effectiveHealth.unavailableReason ? (
@@ -1378,6 +1425,31 @@ function peerDisplayName(
 function trimmedOrUndefined(value: string): string | undefined {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseGatewayEndpoints(text: string): string[] {
+  const seen = new Set<string>();
+  const endpoints: string[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    endpoints.push(trimmed);
+  }
+  return endpoints;
+}
+
+function endpointStateLabel(state: FederationEndpointStatus["state"]): string {
+  switch (state) {
+    case "active":
+      return "Active";
+    case "connecting":
+      return "Connecting";
+    case "failed":
+      return "Failed";
+    case "idle":
+      return "Idle";
+  }
 }
 
 function roleLabel(role: FederationInstanceRole): string {

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -674,8 +674,12 @@ export function FederationSettings(props: FederationSettingsProps) {
                   }
                 />
                 <SettingsField
-                  label="Gateway URL"
-                  sub="Where this instance dials out."
+                  label="Gateway endpoint"
+                  sub={
+                    gatewayEndpointStatuses.length > 1
+                      ? `First of ${gatewayEndpointStatuses.length} endpoints tried for this pairing.`
+                      : "Where this instance dials out."
+                  }
                   control={
                     <code>
                       {effectiveHealth.clientEnrollment.gatewayUrl ??

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -143,6 +143,140 @@ describe("FederationSettings", () => {
     });
   });
 
+  it("saves the ordered gateway endpoint list", async () => {
+    const onWriteConfig = vi.fn(async (_patch: DesktopSettingsConfigPatch) => true);
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "client",
+              status: "disconnected",
+              peers: [],
+            } satisfies FederationHealthStatus,
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+
+    const editor = screen.getByLabelText("Gateway endpoints");
+    fireEvent.change(editor, {
+      target: {
+        value: [
+          "ws://192.168.1.20:47830",
+          "wss://studio.example.ts.net/pwragent-federation",
+          "ssh://ops@gateway.lan:2222/?forward=127.0.0.1:47830",
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save federation settings" }),
+    );
+
+    await waitFor(() => expect(onWriteConfig).toHaveBeenCalled());
+    expect(onWriteConfig.mock.calls[0][0].federation?.gatewayEndpoints).toEqual([
+      "ws://192.168.1.20:47830",
+      "wss://studio.example.ts.net/pwragent-federation",
+      "ssh://ops@gateway.lan:2222/?forward=127.0.0.1:47830",
+    ]);
+  });
+
+  it("rejects an invalid gateway endpoint before saving", async () => {
+    const onWriteConfig = vi.fn(async () => true);
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationHealth: vi.fn(async () => ({
+            health: {
+              enabled: true,
+              role: "client",
+              status: "disconnected",
+              peers: [],
+            } satisfies FederationHealthStatus,
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={onWriteConfig}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Gateway endpoints"), {
+      target: { value: "https://not-a-federation-endpoint.example" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save federation settings" }),
+    );
+
+    expect(await screen.findByText(
+      /must be a ws:\/\/, wss:\/\/, or ssh:\/\/ URL/,
+    )).toBeInTheDocument();
+    expect(onWriteConfig).not.toHaveBeenCalled();
+  });
+
+  it("shows per-endpoint connection status for client mode", async () => {
+    const health: FederationHealthStatus = {
+      enabled: true,
+      role: "client",
+      status: "connected",
+      gatewayEndpoints: [
+        {
+          url: "ws://192.168.1.20:47830",
+          state: "failed",
+          lastError: "connect_failed",
+        },
+        {
+          url: "wss://studio.example.ts.net/pwragent-federation",
+          state: "active",
+          lastConnectedAt: Date.now(),
+        },
+        {
+          url: "wss://federation.example.com",
+          state: "idle",
+        },
+      ],
+      peers: [],
+    };
+    render(
+      <FederationSettings
+        desktopApi={{
+          readFederationDiagnostics: vi.fn(async () => ({
+            health,
+            events: [],
+          })),
+        }}
+        onClearSecret={vi.fn(async () => true)}
+        onReplaceSecret={vi.fn(async () => true)}
+        saving={false}
+        snapshot={settingsSnapshot()}
+        onSettingsChanged={vi.fn()}
+        onWriteConfig={vi.fn(async () => true)}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText("ws://192.168.1.20:47830")).toBeInTheDocument();
+    expect(screen.getByText(/^Failed/)).toBeInTheDocument();
+    expect(screen.getByText("connect_failed")).toBeInTheDocument();
+    expect(screen.getByText(/^Active · Connected/)).toBeInTheDocument();
+    expect(
+      screen.getByText("wss://federation.example.com"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
   it("falls back to the settings snapshot when diagnostics are unavailable", () => {
     render(
       <FederationSettings
@@ -673,8 +807,18 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
         value: "wss://client.example.com/federation",
         source: "config",
       },
+      gatewayEndpoints: {
+        value: ["wss://client.example.com/federation"],
+        source: "config",
+      },
+      advertisedEndpoints: { value: [], source: "default" },
       cloudflareMtlsEnabled: { value: true, source: "config" },
       cloudflareAccessServiceAuthEnabled: { value: false, source: "config" },
+      instancePrivateKey: {
+        configured: true,
+        source: "keychain",
+        writable: true,
+      },
       noiseStaticPrivateKey: {
         configured: true,
         source: "keychain",
@@ -701,5 +845,5 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
         writable: true,
       },
     },
-  } as DesktopSettingsSnapshot;
+  } as unknown as DesktopSettingsSnapshot;
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -687,7 +687,7 @@ describe("FederationSettings", () => {
     expect(await screen.findByLabelText("Listen host")).toBeEnabled();
     expect(screen.getByLabelText("Listen port")).toBeEnabled();
     expect(screen.getByLabelText("Public URL")).toBeEnabled();
-    expect(screen.getByLabelText("Gateway URL")).toBeDisabled();
+    expect(screen.getByLabelText("Gateway endpoints")).toBeDisabled();
     expect(
       screen.getByRole("button", { name: "Generate invite" }),
     ).toBeEnabled();
@@ -725,7 +725,7 @@ describe("FederationSettings", () => {
     expect(await screen.findByLabelText("Listen host")).toBeDisabled();
     expect(screen.getByLabelText("Listen port")).toBeDisabled();
     expect(screen.getByLabelText("Public URL")).toBeDisabled();
-    expect(screen.getByLabelText("Gateway URL")).toBeEnabled();
+    expect(screen.getByLabelText("Gateway endpoints")).toBeEnabled();
     // Only the listening side issues invites.
     expect(
       screen.getByRole("button", { name: "Generate invite" }),

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -471,6 +471,7 @@ describe("FederationSettings", () => {
       );
       expect(onWriteConfig).toHaveBeenCalledWith({
         federation: {
+          cloudflareEndpoint: "",
           cloudflareMtlsEnabled: true,
           cloudflareAccessServiceAuthEnabled: false,
         },
@@ -812,6 +813,7 @@ function settingsSnapshot(): DesktopSettingsSnapshot {
         source: "config",
       },
       advertisedEndpoints: { value: [], source: "default" },
+      cloudflareEndpoint: { value: "", source: "default" },
       cloudflareMtlsEnabled: { value: true, source: "config" },
       cloudflareAccessServiceAuthEnabled: { value: false, source: "config" },
       instancePrivateKey: {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -206,6 +206,7 @@ function createSnapshot(
       gatewayUrl: { value: "", source: "default" },
       gatewayEndpoints: { value: [], source: "default" },
       advertisedEndpoints: { value: [], source: "default" },
+      cloudflareEndpoint: { value: "", source: "default" },
       cloudflareMtlsEnabled: { value: false, source: "default" },
       cloudflareAccessServiceAuthEnabled: {
         value: false,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -204,6 +204,8 @@ function createSnapshot(
       listenPort: { value: 47830, source: "default" },
       publicUrl: { value: "", source: "default" },
       gatewayUrl: { value: "", source: "default" },
+      gatewayEndpoints: { value: [], source: "default" },
+      advertisedEndpoints: { value: [], source: "default" },
       cloudflareMtlsEnabled: { value: false, source: "default" },
       cloudflareAccessServiceAuthEnabled: {
         value: false,

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -150,7 +150,16 @@ WebSocket over that stream, so `~/.ssh/config`, key agents, and `known_hosts`
 all apply unchanged. PwrAgent never stores SSH credentials, never relaxes
 host-key checking, and runs `BatchMode=yes` so a missing key or unknown host
 fails closed with a readable error instead of hanging on a prompt. Passwords
-embedded in the endpoint URL are rejected.
+embedded in the endpoint URL are rejected, as are hosts or users beginning
+with `-` (which `ssh` would read as an option rather than a destination).
+
+The `forward` target must be a loopback address on the gateway machine. That
+matches the documented topology and keeps a supplied endpoint from using the
+operator's SSH server to reach other hosts on its network.
+
+PwrAgent invokes whatever `ssh` is on `PATH`; it does not yet locate the
+Windows OpenSSH client at its System32 path, so Windows operators need `ssh`
+on `PATH` to use `ssh://` endpoints.
 
 SSH replaces only the outer reachability hop. The mandatory Noise IK channel,
 the pinned gateway Noise key, and the signed, channel-bound peer
@@ -200,20 +209,41 @@ endpoint's live status and lets the operator edit the ordered list; gateways
 can advertise multiple endpoints in enrollment invites via
 `[federation] advertised_endpoints`.
 
-Endpoint fallback is reachability only and cannot downgrade security:
+Endpoint fallback cannot redirect a client to a different gateway identity:
 
 - Every endpoint, on every attempt, runs the same Noise IK handshake against
   the pinned gateway Noise key and the same signed identity verification
   against the pinned gateway signing key. An attacker-controlled endpoint
   cannot complete the handshake and therefore can only make that endpoint
   fail, which the attacker on that path could already do.
-- Endpoints are operator-controlled input only (config, Settings, or an
-  explicitly imported invite). No endpoint is ever learned from network
-  traffic, and the last-good memory only ever holds a configured endpoint
-  that completed full authentication.
-- Cloudflare Access service tokens and mTLS client credentials are attached
-  only to `wss://` endpoints, never to plain `ws://` or `ssh://` paths, so a
-  cleartext fallback path cannot leak edge bearer credentials.
+- Every endpoint must use `ws://`, `wss://`, or `ssh://`, must not embed a
+  password, and must not have a host or user beginning with `-`. This is
+  enforced where endpoints enter the app — including on invite decode, since
+  an invite is unsigned and never passes through the Settings UI — and again
+  before anything is dialed.
+- The last-good endpoint memory only ever holds a configured endpoint that
+  completed full authentication, so it cannot be steered by a hostile peer.
+- `ssh://` endpoints may only forward to the gateway's loopback address, so a
+  supplied endpoint cannot turn the operator's SSH server into a proxy for
+  reaching other hosts on its network.
+
+Outer edge credentials need separate care, because they are **not** protected
+by the pinned keys. Cloudflare Access service tokens and mTLS client
+certificates travel in the WebSocket upgrade and the TLS handshake — both of
+which complete before the Noise handshake verifies anything. A scheme check
+alone is therefore not sufficient scoping: it would send the credential to
+every TLS endpoint in the fallback list.
+
+PwrAgent scopes those credentials to a single host:
+
+- Settings -> Federation -> Cloudflare has a **Cloudflare endpoint** field
+  naming the one endpoint that is Cloudflare-fronted. Access tokens and client
+  certificates are sent only to that host, compared by host and port,
+  case-insensitively and ignoring the path.
+- When no endpoint is designated, the credentials are used only if a single
+  gateway endpoint is configured. A multi-endpoint configuration with no
+  designated host sends them to nothing and logs that they were withheld.
+- They are never attached to `ws://` or `ssh://` endpoints.
 
 ## Tailscale
 

--- a/docs/federation-connectivity-reference.md
+++ b/docs/federation-connectivity-reference.md
@@ -30,7 +30,8 @@ confidential.
 |---|---|---|---|---|---|
 | Loopback `ws://` | Same machine only | Not needed across a network | Operating-system loopback | Required | Two isolated profiles on one machine |
 | Direct LAN `ws://` | LAN interface | None | Host firewall only | Required | Avoid unless an encrypted overlay is protecting the path |
-| SSH reverse tunnel | SSH endpoint | SSH | SSH key and server access | Required | Development, temporary administration, and VM labs |
+| PwrAgent-managed `ssh://` endpoint | SSH endpoint | SSH plus PwrAgent secure channel | SSH key and server access | Required and channel-bound | LAN or VPN paths where sshd already runs on the gateway machine |
+| SSH reverse tunnel (manual) | SSH endpoint | SSH | SSH key and server access | Required | Development, temporary administration, and VM labs |
 | PwrAgent encrypted transport | Configured listener | PwrAgent secure channel | PwrAgent enrollment | Required and channel-bound | Direct LAN or other private routed networks |
 | Tailscale Serve | Tailnet only | Tailscale/WireGuard plus HTTPS | Tailnet identity and grants | Required | Private access among the operator's enrolled devices |
 | Tailscale Funnel | Public hostname | HTTPS plus encrypted Tailscale relay | Public by default | Required | Public reachability when Cloudflare is not desired |
@@ -131,11 +132,45 @@ This protects PwrAgent traffic, but it does not provide automatic LAN discovery,
 NAT traversal, a public hostname, or a firewall. Operators still choose how one
 machine routes to the other.
 
-## SSH Reverse Tunnel
+## SSH
 
-SSH is an external transport option, not a PwrAgent-managed feature. A reverse
-tunnel is useful when a development VM can accept SSH connections but should
-not expose a PwrAgent listener to the LAN.
+### PwrAgent-managed `ssh://` endpoint
+
+A federation client can dial the gateway through SSH directly by configuring a
+gateway endpoint of the form:
+
+```text
+ssh://[user@]host[:sshPort]/?forward=127.0.0.1:47830
+```
+
+The `forward` query names the loopback listener on the gateway machine and
+defaults to `127.0.0.1:47830`. PwrAgent spawns the operator's system OpenSSH
+client with stdio forwarding (`ssh -W`) and runs the ordinary federation
+WebSocket over that stream, so `~/.ssh/config`, key agents, and `known_hosts`
+all apply unchanged. PwrAgent never stores SSH credentials, never relaxes
+host-key checking, and runs `BatchMode=yes` so a missing key or unknown host
+fails closed with a readable error instead of hanging on a prompt. Passwords
+embedded in the endpoint URL are rejected.
+
+SSH replaces only the outer reachability hop. The mandatory Noise IK channel,
+the pinned gateway Noise key, and the signed, channel-bound peer
+authentication run identically inside the SSH stream — a compromised or
+spoofed SSH host can fail the connection but cannot impersonate the pinned
+gateway. The gateway side needs no PwrAgent change: sshd terminates SSH and
+forwards a plain TCP connection to the loopback WebSocket listener.
+
+```text
+PwrAgent client
+  -> system OpenSSH (ssh -W, BatchMode)
+  -> sshd on gateway machine
+  -> gateway 127.0.0.1:47830
+  -> Noise IK handshake + PwrAgent peer authentication
+```
+
+### Manual SSH reverse tunnel
+
+A manually managed reverse tunnel remains useful when a development VM can
+accept SSH connections but should not expose a PwrAgent listener to the LAN.
 
 Example topology:
 
@@ -149,8 +184,36 @@ PwrAgent client in VM
 
 SSH encrypts the cross-machine segment and controls who may create the tunnel.
 PwrAgent still performs enrollment and signed peer authentication inside it.
-The SSH process lifecycle, host-key verification, keys, and reconnect behavior
+For a manual tunnel, the SSH process lifecycle, keys, and reconnect behavior
 remain the operator's responsibility.
+
+## Multi-Path Gateway Endpoints and Ordered Fallback
+
+A client keeps exactly one pinned gateway identity (signing key and Noise
+channel key) but may configure several candidate endpoints for reaching it in
+`[federation] gateway_endpoints` — for example a LAN `ws://` or `ssh://` path
+first, then a Tailscale Serve URL, then a Cloudflare Tunnel hostname. The
+reconnect loop tries the endpoints in order, starts each cycle with the last
+endpoint that carried a fully authenticated session, and applies reconnect
+backoff per full cycle through the list. Settings → Federation shows each
+endpoint's live status and lets the operator edit the ordered list; gateways
+can advertise multiple endpoints in enrollment invites via
+`[federation] advertised_endpoints`.
+
+Endpoint fallback is reachability only and cannot downgrade security:
+
+- Every endpoint, on every attempt, runs the same Noise IK handshake against
+  the pinned gateway Noise key and the same signed identity verification
+  against the pinned gateway signing key. An attacker-controlled endpoint
+  cannot complete the handshake and therefore can only make that endpoint
+  fail, which the attacker on that path could already do.
+- Endpoints are operator-controlled input only (config, Settings, or an
+  explicitly imported invite). No endpoint is ever learned from network
+  traffic, and the last-good memory only ever holds a configured endpoint
+  that completed full authentication.
+- Cloudflare Access service tokens and mTLS client credentials are attached
+  only to `wss://` endpoints, never to plain `ws://` or `ssh://` paths, so a
+  cleartext fallback path cannot leak edge bearer credentials.
 
 ## Tailscale
 

--- a/docs/plans/2026-08-04-001-feat-federation-ssh-multipath-endpoints-plan.md
+++ b/docs/plans/2026-08-04-001-feat-federation-ssh-multipath-endpoints-plan.md
@@ -61,10 +61,14 @@ reachable again.
 - Importing an invite seeds both `gateway_endpoints` and `gateway_url`
   (first entry) in config, alongside the existing pinned-identity meta writes.
 - Cloudflare Access service-token headers and mTLS client credentials are
-  attached only to `wss://` endpoints. They are never sent on plain `ws://`
-  (where the upgrade request crosses the network unencrypted) or on `ssh://`
-  endpoints (where they serve no purpose). This narrows today's behavior,
-  which attached them to whatever single `gateway_url` was configured.
+  scoped to a single operator-designated host (`[federation]
+  cloudflare_endpoint`), compared by host and port. A scheme-only rule was
+  tried first and was wrong: these credentials ride the WebSocket upgrade and
+  the TLS handshake, both of which complete before the Noise handshake pins
+  anything, so "any `wss://` endpoint" would hand the Access bearer token and
+  the mTLS client key to every TLS host in the fallback list. With no endpoint
+  designated they apply only to a single-endpoint configuration, which
+  preserves pre-multi-path behavior without widening it.
 - Settings → Federation:
   - The Configuration section replaces the single "Gateway URL" input with a
     "Gateway endpoints" ordered editor (one endpoint per line, first line is
@@ -91,8 +95,9 @@ reachable again.
   `{ socket, close() }`; killing/closing either side tears down the other.
   stderr is captured (bounded) so auth/host-key failures produce a readable
   error. The spawn function is injectable for tests.
-- Command discovery mirrors `federation-tailscale.ts`: `ssh` on PATH plus the
-  Windows System32 OpenSSH fallback.
+- Invokes `ssh` from `PATH`. A Windows System32 OpenSSH fallback mirroring
+  `federation-tailscale.ts` was considered and deferred; it is noted as a
+  limitation in the connectivity reference rather than silently assumed.
 
 ### Transport (`federation-transport.ts`)
 
@@ -154,14 +159,20 @@ reachable again.
 ### Enrollment (`federation-enrollment.ts`)
 
 - `FederationInvitePayload.gatewayEndpoints?: string[]` — optional; decode
-  validates it as an array of strings when present and enforces the same
-  three-scheme rule.
+  enforces the same endpoint rules as every other entry point (scheme
+  allowlist, no embedded password, no leading-dash host/user), since an invite
+  is unsigned and bypasses the Settings UI. `importInvite` returns the list it
+  applied.
 
 ### Settings UI (`FederationSettings.tsx`)
 
-- Configuration: "Gateway endpoints" textarea, one per line, ordered; parsed
-  and validated (scheme allowlist) before save; save patches both
-  `gatewayEndpoints` and `gatewayUrl`.
+- Configuration: "Gateway endpoints" and "Advertised endpoints" textareas, one
+  per line, ordered; validated against the scheme allowlist before save.
+  Renderer validation is UX only — the main process re-validates, since the
+  config file is hand-editable and invites never pass through the UI.
+- Cloudflare: a "Cloudflare endpoint" field designating the single
+  Cloudflare-fronted host that may receive Access tokens and client
+  certificates.
 - Connection: per-endpoint rows showing URL, status label, active marker,
   last error, and last connected time; retains the existing single
   listener/public URL fields.
@@ -187,17 +198,33 @@ confidentiality are pinned per gateway, not per endpoint.**
   (`connectFederationClient` throws without it) and there is deliberately no
   setting to disable Noise. `ssh://` endpoints add SSH on the outside but
   change nothing inside.
-- The endpoint list is operator-controlled input only: config file, Settings
-  editor, or an explicitly imported invite (which already carries the pinned
-  keys themselves, so it is already fully trusted). No endpoint is ever
-  learned or updated from network traffic — the gateway cannot push endpoint
-  changes to enrolled clients, and `federation_gateway_last_endpoint` only
-  ever holds a value copied from the configured list after a fully
+- No endpoint is ever learned from network traffic: the gateway cannot push
+  endpoint changes to enrolled clients, and `federation_gateway_last_endpoint`
+  only ever holds a value copied from the configured list after a fully
   authenticated session was established on it.
-- Credential scoping improves: Cloudflare Access service tokens (bearer
-  credentials) and mTLS client keys are attached only to `wss://` endpoints,
-  so a plaintext `ws://` LAN fallback or SSH path can never leak the edge
-  bearer token in a cleartext upgrade request.
+- An imported invite is **not** trusted input just because it carries pinned
+  keys. It is unsigned, operator-pasteable, and never passes through the
+  Settings UI, so its endpoints are validated on decode against the same
+  scheme allowlist (and the no-password / no-leading-dash rules), and the
+  imported list is returned to the caller so the operator can see what a
+  pasted invite configured.
+- **Outer edge credentials are not covered by the pinned keys.** Cloudflare
+  Access service tokens and mTLS client certificates travel in the WebSocket
+  upgrade and the TLS handshake, both of which complete before the Noise
+  handshake verifies anything. They are therefore scoped to a single
+  operator-designated host (`cloudflare_endpoint`), matched on host and port;
+  with none designated they apply only to a single-endpoint configuration.
+  Anything looser — including a `wss://`-only rule — sends the bearer token
+  and client key to every TLS endpoint the fallback walks, which for an
+  invite-supplied endpoint is a credential-theft primitive.
+- `ssh://` endpoints may only forward to the gateway's loopback address, so an
+  endpoint cannot use the operator's SSH server to reach other hosts on its
+  network. Hosts and users beginning with `-` are rejected so nothing reaches
+  `ssh` in option position.
+- Availability is part of the security posture here: the whole pre-session
+  exchange is bounded by a deadline, because an endpoint that accepts the
+  upgrade and then goes silent would otherwise stall the endpoint walk, the
+  reconnect loop, and (through `restart()`) the Settings write IPC.
 - SSH host-key verification remains OpenSSH's job with its normal strictness;
   PwrAgent never sets `StrictHostKeyChecking=no`. Even a spoofed SSH host
   only reaches the Noise pin failure described above.
@@ -216,9 +243,23 @@ confidentiality are pinned per gateway, not per endpoint.**
   config, empty list.
 - [x] Runtime tests: fallback walks endpoints in order and connects on a later
   endpoint after earlier failures; per-endpoint statuses and last-good meta
-  update; Cloudflare credentials only attach to `wss://`.
-- [x] Config tests: `gateway_endpoints` read, `gateway_url` fallback,
-  dual-write of the first endpoint, `advertised_endpoints` round-trip.
+  update.
+- [x] Credential-scoping tests: the designated host receives Access headers and
+  the client certificate; a different `wss://` host in the same list does not;
+  a multi-endpoint config with no designation withholds from all; a
+  single-endpoint config still works; `ws://` and `ssh://` never receive them.
+- [x] Shared parser tests: scheme allowlist, embedded-password and
+  leading-dash rejection, case/port normalization, IPv6 hosts.
+- [x] Transport test: a peer that upgrades and then goes silent fails on the
+  connect deadline instead of hanging the endpoint walk.
+- [x] SSH transport test: the real `SshStdioSocket` under a real WebSocket
+  upgrade completes the Noise handshake, streams envelopes, and closes without
+  raising an uncaught error. (The unit and transport tests each covered one
+  half of this; the gap is what hid the child-exit defect.)
+- [x] Config tests: `gateway_endpoints` read, `gateway_url` fallback, canonical
+  shape only on fresh configs, legacy marker comment on an existing
+  `gateway_url`, preserved legacy scalar when the list is cleared, and
+  unsupported schemes dropped on read.
 - [x] Enrollment tests: invite encode/decode with and without
   `gatewayEndpoints`; import seeds config list.
 - [x] `FederationSettings` tests: endpoints editor renders/saves ordered list;

--- a/docs/plans/2026-08-04-001-feat-federation-ssh-multipath-endpoints-plan.md
+++ b/docs/plans/2026-08-04-001-feat-federation-ssh-multipath-endpoints-plan.md
@@ -1,0 +1,229 @@
+---
+title: "feat: Federation SSH outer transport and multi-path gateway endpoints"
+type: feat
+date: 2026-08-04
+---
+
+# Federation SSH outer transport and multi-path gateway endpoints
+
+## Summary
+
+Two federation transport enhancements that build on the Noise/Tailscale work
+merged in PR #1191:
+
+1. **Noise over SSH.** Accept an `ssh://` endpoint as an outer transport for
+   the federation client. SSH replaces the plain WebSocket / Cloudflare /
+   Tailscale outer hop only; the mandatory Noise IK encrypted channel and the
+   signed, pinned-identity authentication run unchanged inside it.
+2. **Multi-path gateway endpoints with ordered fallback.** A client keeps one
+   pinned gateway identity (signing key + Noise key in state.db meta) but may
+   have several candidate endpoints for reaching it — e.g. LAN `ws://` or
+   `ssh://` first, then a Tailscale Serve/Funnel `wss://` URL, then a
+   Cloudflare Tunnel `wss://` URL. The reconnect loop tries them in order,
+   remembers the last endpoint that worked, and surfaces per-endpoint status.
+
+Operator motivation: the operator runs both a work and a personal tailnet.
+The personal tailnet carries PwrAgent, but on the road while attached to the
+work tailnet the personal Tailscale Serve URL is unreachable, so the client
+must fall back to a Cloudflare Tunnel (or Tailscale Funnel) endpoint without
+manual re-configuration — and return to the fast local path when it is
+reachable again.
+
+## Product Contract
+
+- The Noise IK layer stays mandatory on every path. There is no endpoint kind
+  and no fallback state that connects without the pinned gateway Noise key and
+  the pinned Ed25519 gateway identity. This matches the existing contract in
+  [docs/federation-connectivity-reference.md](../federation-connectivity-reference.md).
+- Endpoint URLs accept exactly three schemes: `ws://`, `wss://`, and the new
+  `ssh://[user@]host[:sshPort]` form with an optional
+  `?forward=<host>:<port>` query (default `127.0.0.1:47830`) naming the
+  gateway machine's loopback listener that sshd should forward to.
+- SSH endpoints are dialed with the operator's system OpenSSH client
+  (`ssh -W`), so `~/.ssh/config`, agents, keys, and `known_hosts` all apply.
+  PwrAgent never stores SSH credentials, never disables host-key checking,
+  and runs `BatchMode=yes` so a missing key or unknown host fails closed with
+  a readable error instead of hanging on an interactive prompt.
+- `[federation] gateway_endpoints` is a new ordered string-array config key.
+  When absent, the reader falls back to the existing scalar `gateway_url`.
+  Saving endpoints dual-writes the first entry back to `gateway_url` so an
+  older build downgraded onto the same profile keeps a working single path.
+- The reconnect loop tries the last endpoint that worked first (persisted in
+  state.db meta), then the remaining endpoints in configured order. Backoff
+  applies per full cycle through the list, not per endpoint, so a short list
+  is fully probed before the runtime sleeps.
+- Gateways may advertise multiple endpoints in enrollment invites via a new
+  `[federation] advertised_endpoints` ordered list (falling back to the
+  current single Public URL / listen URL behavior). The invite payload gains
+  an optional `gatewayEndpoints` array; the invite version stays 1 because
+  older importers ignore the extra field and keep using `gatewayUrl`, and new
+  importers treat a missing array as `[gatewayUrl]`.
+- Importing an invite seeds both `gateway_endpoints` and `gateway_url`
+  (first entry) in config, alongside the existing pinned-identity meta writes.
+- Cloudflare Access service-token headers and mTLS client credentials are
+  attached only to `wss://` endpoints. They are never sent on plain `ws://`
+  (where the upgrade request crosses the network unencrypted) or on `ssh://`
+  endpoints (where they serve no purpose). This narrows today's behavior,
+  which attached them to whatever single `gateway_url` was configured.
+- Settings → Federation:
+  - The Configuration section replaces the single "Gateway URL" input with a
+    "Gateway endpoints" ordered editor (one endpoint per line, first line is
+    tried first). Save still round-trips through the existing
+    `writeSettingsConfig` patch path.
+  - The Connection card lists every configured endpoint with its own status
+    (Active / Connecting / Failed / Idle), the last error for failed
+    endpoints, and marks the endpoint the current session is using.
+- Diagnostics audit entries for connection attempts and failures include the
+  endpoint being tried (redacted through the existing
+  `redactFederationDiagnostic` path).
+
+## Architecture
+
+### SSH dialer (`apps/desktop/src/main/federation/federation-ssh.ts`, new)
+
+- `parseFederationSshEndpoint(url)` → `{ user?, host, sshPort?, forwardHost,
+  forwardPort }`, rejecting anything with credentials-in-URL (`ssh://a:b@…`),
+  empty host, or a non-numeric port/forward.
+- `dialFederationSshEndpoint(endpoint, { spawn? })` spawns
+  `ssh -o BatchMode=yes -o ConnectTimeout=10 [-p sshPort] -W
+  forwardHost:forwardPort [user@]host`, wraps the child's stdio in a Duplex
+  stream, and resolves once the child is running. Returns
+  `{ socket, close() }`; killing/closing either side tears down the other.
+  stderr is captured (bounded) so auth/host-key failures produce a readable
+  error. The spawn function is injectable for tests.
+- Command discovery mirrors `federation-tailscale.ts`: `ssh` on PATH plus the
+  Windows System32 OpenSSH fallback.
+
+### Transport (`federation-transport.ts`)
+
+- `connectFederationClient` gains an optional `createSocket?: () => Duplex`
+  (plus internal cleanup on close). When present, the WebSocket is
+  constructed with a one-shot `http.Agent` whose `createConnection` returns
+  that stream, and the `url` passed to `new WebSocket(...)` is the inner
+  `ws://forwardHost:forwardPort` target so the upgrade `Host` header matches
+  the gateway listener. Everything after socket open — transport hello, Noise
+  IK handshake, channel-bound signed auth, envelope streaming — is unchanged.
+- No gateway-side transport change: sshd terminates SSH and forwards a plain
+  TCP connection to the loopback WebSocket listener, exactly like the manual
+  reverse-tunnel topology already described in the connectivity reference.
+
+### Config (`packages/shared/src/contracts/settings.ts`, `desktop-config.ts`,
+`desktop-settings-service.ts`)
+
+- `DesktopSettingsConfigPatch.federation` gains `gatewayEndpoints?: string[]`
+  and `advertisedEndpoints?: string[]`; `DesktopFederationSettingsSnapshot`
+  gains the matching `DesktopSettingsValue<string[]>` entries.
+- Reader: `gateway_endpoints` via the existing `readStringArray`, no eager
+  rewrite. Writer: empty array deletes the key; non-empty writes the array
+  and dual-writes `gateway_url` to the first entry. `advertised_endpoints`
+  follows the same pattern (no legacy scalar to dual-write).
+- Snapshot resolution: `gatewayEndpoints.value` =
+  `config.gatewayEndpoints ?? (gatewayUrl ? [gatewayUrl] : [])`, so every
+  consumer sees one ordered list regardless of config vintage.
+
+### Runtime (`federation-runtime.ts`)
+
+- New meta key `federation_gateway_last_endpoint` beside the existing
+  `GATEWAY_*` keys.
+- `connectClient(gatewayUrl)` becomes `connectToGateway(endpoints: string[])`:
+  - Attempt order = pure helper `orderFederationEndpointAttempts(endpoints,
+    lastGood)` (last-good first when still configured, then config order).
+  - Endpoints are tried sequentially; the first success records last-good
+    meta and per-endpoint `active` status. Failures record per-endpoint
+    `failed` status with a redacted error and fall through to the next.
+  - When the whole cycle fails, the existing exponential backoff
+    (`scheduleReconnect`) applies to the next full cycle.
+  - `ssh://` endpoints resolve through the SSH dialer; `ws://`/`wss://` keep
+    the direct path. Cloudflare header/mTLS options are only attached for
+    `wss://` endpoints.
+- Per-endpoint status lives in runtime memory
+  (`Map<url, FederationEndpointStatus>`) and is rebuilt on restart; `health()`
+  emits it in config order as `health.gatewayEndpoints`.
+- `generateInvite` builds the invite endpoint list from
+  `advertisedEndpoints`, falling back to `[publicUrl || listenUrl]`.
+  `importInvite` writes `gatewayEndpoints` + `gatewayUrl` and keeps the
+  existing pinned-identity meta writes.
+
+### Shared federation contract (`packages/shared/src/contracts/federation.ts`)
+
+- `FederationEndpointState` (`"active" | "connecting" | "failed" | "idle"`)
+  and `FederationEndpointStatus { url, state, lastAttemptAt?,
+  lastConnectedAt?, lastError? }`.
+- `FederationHealthStatus.gatewayEndpoints?: FederationEndpointStatus[]`.
+
+### Enrollment (`federation-enrollment.ts`)
+
+- `FederationInvitePayload.gatewayEndpoints?: string[]` — optional; decode
+  validates it as an array of strings when present and enforces the same
+  three-scheme rule.
+
+### Settings UI (`FederationSettings.tsx`)
+
+- Configuration: "Gateway endpoints" textarea, one per line, ordered; parsed
+  and validated (scheme allowlist) before save; save patches both
+  `gatewayEndpoints` and `gatewayUrl`.
+- Connection: per-endpoint rows showing URL, status label, active marker,
+  last error, and last connected time; retains the existing single
+  listener/public URL fields.
+
+## Security Review
+
+The core invariant: **endpoint selection is reachability only; identity and
+confidentiality are pinned per gateway, not per endpoint.**
+
+- Every endpoint, on every fallback attempt, runs the identical
+  `connectFederationClient` flow: transport-hello check, Noise IK handshake
+  against the pinned gateway Noise static key, and Ed25519
+  challenge/accept verification against the pinned gateway signing key, with
+  the client's signed proof bound to the Noise handshake hash. An
+  attacker-controlled endpoint (malicious DNS, hijacked tunnel hostname,
+  hostile LAN listener, compromised SSH bastion) cannot complete Noise
+  message 2 without the gateway's Noise private key, so the connection fails
+  before any federation payload is sent. Fallback therefore cannot redirect a
+  client to a different gateway identity — it can only cause that endpoint to
+  fail and the loop to move on (bounded DoS, which the attacker on that path
+  already had).
+- There is no downgrade state: client mode requires the pinned Noise key
+  (`connectFederationClient` throws without it) and there is deliberately no
+  setting to disable Noise. `ssh://` endpoints add SSH on the outside but
+  change nothing inside.
+- The endpoint list is operator-controlled input only: config file, Settings
+  editor, or an explicitly imported invite (which already carries the pinned
+  keys themselves, so it is already fully trusted). No endpoint is ever
+  learned or updated from network traffic — the gateway cannot push endpoint
+  changes to enrolled clients, and `federation_gateway_last_endpoint` only
+  ever holds a value copied from the configured list after a fully
+  authenticated session was established on it.
+- Credential scoping improves: Cloudflare Access service tokens (bearer
+  credentials) and mTLS client keys are attached only to `wss://` endpoints,
+  so a plaintext `ws://` LAN fallback or SSH path can never leak the edge
+  bearer token in a cleartext upgrade request.
+- SSH host-key verification remains OpenSSH's job with its normal strictness;
+  PwrAgent never sets `StrictHostKeyChecking=no`. Even a spoofed SSH host
+  only reaches the Noise pin failure described above.
+- Failure detail crossing the process boundary continues to flow through
+  `redactFederationDiagnostic`.
+
+## Verification
+
+- [x] `federation-ssh` tests: endpoint parsing (user/host/port/forward,
+  rejection of embedded passwords and bad schemes), spawn argument shape,
+  dial + teardown against an injected fake spawn.
+- [x] `federation-transport` test: full Noise handshake + envelope round-trip
+  over a `createSocket` stream (net socketpair to the listener), proving the
+  SSH path carries the encrypted channel unchanged.
+- [x] Endpoint-ordering helper tests: last-good-first, last-good removed from
+  config, empty list.
+- [x] Runtime tests: fallback walks endpoints in order and connects on a later
+  endpoint after earlier failures; per-endpoint statuses and last-good meta
+  update; Cloudflare credentials only attach to `wss://`.
+- [x] Config tests: `gateway_endpoints` read, `gateway_url` fallback,
+  dual-write of the first endpoint, `advertised_endpoints` round-trip.
+- [x] Enrollment tests: invite encode/decode with and without
+  `gatewayEndpoints`; import seeds config list.
+- [x] `FederationSettings` tests: endpoints editor renders/saves ordered list;
+  Connection card renders per-endpoint status.
+- [x] `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries` pass.
+- [x] [docs/federation-connectivity-reference.md](../federation-connectivity-reference.md)
+  updated: PwrAgent-managed SSH outer transport and multi-path endpoint
+  fallback sections.

--- a/packages/shared/src/contracts/__tests__/federation-endpoints.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation-endpoints.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  federationEndpointAcceptsCloudflareCredentials,
+  isFederationGatewayEndpointUrl,
+  parseFederationGatewayEndpoint,
+} from "../federation";
+
+describe("parseFederationGatewayEndpoint", () => {
+  it("normalizes scheme and host casing", () => {
+    expect(parseFederationGatewayEndpoint("WSS://Gateway.Example.com/x")).
+      toMatchObject({
+        scheme: "wss",
+        host: "gateway.example.com",
+        hostPort: "gateway.example.com",
+        isTls: true,
+      });
+  });
+
+  it("keeps the port as part of the credential-scoping identity", () => {
+    expect(parseFederationGatewayEndpoint("ws://host:47830")).toMatchObject({
+      host: "host",
+      hostPort: "host:47830",
+      isTls: false,
+    });
+  });
+
+  it("parses an ssh endpoint with a user", () => {
+    expect(parseFederationGatewayEndpoint("ssh://ops@gateway.lan")).toMatchObject(
+      { scheme: "ssh", host: "gateway.lan", user: "ops", isTls: false },
+    );
+  });
+
+  it("handles IPv6 hosts", () => {
+    expect(parseFederationGatewayEndpoint("ws://[::1]:47830")).toMatchObject({
+      host: "[::1]",
+      hostPort: "[::1]:47830",
+    });
+  });
+
+  it.each([
+    "https://gateway.example.com",
+    "http://gateway.example.com",
+    "file:///etc/passwd",
+    "ws://",
+    "not-a-url",
+    // Embedded credentials.
+    "wss://user:secret@gateway.example.com",
+    // Would reach ssh(1) as an option instead of a destination.
+    "ssh://-oProxyCommand=touch%20pwned",
+    "ssh://-ohost@gateway.lan",
+  ])("rejects %s", (value) => {
+    expect(parseFederationGatewayEndpoint(value)).toBeUndefined();
+    expect(isFederationGatewayEndpointUrl(value)).toBe(false);
+  });
+});
+
+describe("federationEndpointAcceptsCloudflareCredentials", () => {
+  const designated = "wss://federation.example.com";
+
+  it("accepts the designated endpoint", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: designated,
+        cloudflareEndpoint: designated,
+        configuredEndpointCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  // These credentials travel in the WebSocket upgrade, before the Noise
+  // handshake pins anything, so any other host must never receive them.
+  it("refuses a different wss:// host even when one is designated", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: "wss://attacker.example",
+        cloudflareEndpoint: designated,
+        configuredEndpointCount: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("refuses a host that only differs by port", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: "wss://federation.example.com:8443",
+        cloudflareEndpoint: designated,
+        configuredEndpointCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches case-insensitively and ignores the path", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: "wss://Federation.Example.com/pwragent-federation",
+        cloudflareEndpoint: "WSS://federation.example.com/other",
+        configuredEndpointCount: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it("refuses every host when several are configured and none is designated", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: "wss://one.example",
+        configuredEndpointCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps single-endpoint behavior without an explicit designation", () => {
+    expect(
+      federationEndpointAcceptsCloudflareCredentials({
+        endpoint: "wss://one.example",
+        configuredEndpointCount: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it.each(["ws://lan.example:47830", "ssh://ops@gateway.lan"])(
+    "never accepts %s",
+    (endpoint) => {
+      expect(
+        federationEndpointAcceptsCloudflareCredentials({
+          endpoint,
+          cloudflareEndpoint: endpoint,
+          configuredEndpointCount: 1,
+        }),
+      ).toBe(false);
+    },
+  );
+});

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -141,6 +141,7 @@ describe("desktop settings contracts", () => {
         gatewayUrl: { value: "", source: "default" },
         gatewayEndpoints: { value: [], source: "default" },
         advertisedEndpoints: { value: [], source: "default" },
+        cloudflareEndpoint: { value: "", source: "default" },
         cloudflareMtlsEnabled: { value: false, source: "default" },
         cloudflareAccessServiceAuthEnabled: { value: false, source: "default" },
         instancePrivateKey: {

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -139,6 +139,8 @@ describe("desktop settings contracts", () => {
         listenPort: { value: 8765, source: "default" },
         publicUrl: { value: "", source: "default" },
         gatewayUrl: { value: "", source: "default" },
+        gatewayEndpoints: { value: [], source: "default" },
+        advertisedEndpoints: { value: [], source: "default" },
         cloudflareMtlsEnabled: { value: false, source: "default" },
         cloudflareAccessServiceAuthEnabled: { value: false, source: "default" },
         instancePrivateKey: {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -106,18 +106,95 @@ export type FederationClientEnrollment = {
  * endpoint carries the same mandatory Noise IK channel and pinned-identity
  * authentication; the scheme only selects the reachability path.
  */
-export const FEDERATION_ENDPOINT_SCHEMES = ["ws:", "wss:", "ssh:"] as const;
+export const FEDERATION_ENDPOINT_SCHEMES = ["ws", "wss", "ssh"] as const;
 
-export function isFederationGatewayEndpointUrl(value: string): boolean {
-  const match = /^(ws|wss|ssh):\/\/([^/?#]+)/i.exec(value.trim());
-  if (!match) return false;
+export type FederationEndpointScheme =
+  (typeof FEDERATION_ENDPOINT_SCHEMES)[number];
+
+export type ParsedFederationEndpoint = {
+  /** Lowercased scheme, without the trailing colon. */
+  scheme: FederationEndpointScheme;
+  /** Lowercased host, without userinfo or port. Brackets kept for IPv6. */
+  host: string;
+  /** Lowercased `host` or `host:port` — the credential-scoping identity. */
+  hostPort: string;
+  /** Userinfo before `@`, if any. Never contains a password. */
+  user?: string;
+  /** True only for schemes whose outer hop is TLS. */
+  isTls: boolean;
+};
+
+/**
+ * The single parser every federation endpoint decision goes through. Keeping
+ * validation, the TLS decision, and credential scoping on one parser is
+ * deliberate: a `startsWith("wss://")` check and a case-insensitive validator
+ * disagreeing is exactly how credentials get attached to the wrong endpoint.
+ *
+ * This is written without `URL` because @pwragent/shared compiles without DOM
+ * or Node lib types.
+ */
+export function parseFederationGatewayEndpoint(
+  value: string,
+): ParsedFederationEndpoint | undefined {
+  const match = /^([A-Za-z]+):\/\/([^/?#]*)/.exec(value.trim());
+  if (!match) return undefined;
+  const scheme = match[1].toLowerCase();
+  if (
+    !(FEDERATION_ENDPOINT_SCHEMES as readonly string[]).includes(scheme)
+  ) {
+    return undefined;
+  }
   const authority = match[2];
   const at = authority.lastIndexOf("@");
-  const userinfo = at >= 0 ? authority.slice(0, at) : "";
-  const hostPort = at >= 0 ? authority.slice(at + 1) : authority;
+  const user = at >= 0 ? authority.slice(0, at) : undefined;
+  const hostPort = (at >= 0 ? authority.slice(at + 1) : authority).toLowerCase();
   // Never accept credentials embedded in an endpoint URL.
-  if (userinfo.includes(":")) return false;
-  return hostPort.length > 0;
+  if (user !== undefined && user.includes(":")) return undefined;
+  if (hostPort.length === 0) return undefined;
+  // A leading "-" on the host or user would reach ssh(1) as an option rather
+  // than a destination. Reject it everywhere rather than relying on argv
+  // position to keep it harmless.
+  if (hostPort.startsWith("-") || user?.startsWith("-")) return undefined;
+  const host = hostPort.startsWith("[")
+    ? hostPort.slice(0, hostPort.indexOf("]") + 1)
+    : hostPort.split(":")[0];
+  if (host.length === 0) return undefined;
+  return {
+    scheme: scheme as FederationEndpointScheme,
+    host,
+    hostPort,
+    user,
+    isTls: scheme === "wss",
+  };
+}
+
+export function isFederationGatewayEndpointUrl(value: string): boolean {
+  return parseFederationGatewayEndpoint(value) !== undefined;
+}
+
+/**
+ * Whether an endpoint is the operator-designated Cloudflare-fronted endpoint,
+ * and may therefore be sent Cloudflare Access tokens / mTLS client keys.
+ *
+ * Those credentials travel in the WebSocket upgrade — before the Noise
+ * handshake pins anything — so they must be scoped to a specific host the
+ * operator named, never to "any wss:// URL". When no endpoint is designated,
+ * only a single-endpoint configuration qualifies, which preserves the
+ * pre-multi-path behavior without widening it to additional hosts.
+ */
+export function federationEndpointAcceptsCloudflareCredentials(params: {
+  endpoint: string;
+  cloudflareEndpoint?: string;
+  configuredEndpointCount: number;
+}): boolean {
+  const parsed = parseFederationGatewayEndpoint(params.endpoint);
+  if (!parsed?.isTls) return false;
+  const designated = params.cloudflareEndpoint?.trim();
+  if (designated) {
+    const target = parseFederationGatewayEndpoint(designated);
+    return target !== undefined && target.hostPort === parsed.hostPort;
+  }
+  return params.configuredEndpointCount <= 1;
 }
 
 export type FederationEndpointState =
@@ -243,6 +320,12 @@ export type ImportFederationInviteResponse = {
   accepted: boolean;
   gatewayInstanceId: FederationInstanceId;
   gatewayUrl: string;
+  /**
+   * Every endpoint the invite asked this client to dial. Surfaced so the
+   * operator can see what a pasted invite configured instead of discovering
+   * it only by reading config.toml.
+   */
+  gatewayEndpoints: string[];
 };
 
 export type ResetFederationEnrollmentRequest = Record<string, never>;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -101,6 +101,39 @@ export type FederationClientEnrollment = {
   pendingInvite: boolean;
 };
 
+/**
+ * Outer-transport schemes a federation gateway endpoint may use. Every
+ * endpoint carries the same mandatory Noise IK channel and pinned-identity
+ * authentication; the scheme only selects the reachability path.
+ */
+export const FEDERATION_ENDPOINT_SCHEMES = ["ws:", "wss:", "ssh:"] as const;
+
+export function isFederationGatewayEndpointUrl(value: string): boolean {
+  const match = /^(ws|wss|ssh):\/\/([^/?#]+)/i.exec(value.trim());
+  if (!match) return false;
+  const authority = match[2];
+  const at = authority.lastIndexOf("@");
+  const userinfo = at >= 0 ? authority.slice(0, at) : "";
+  const hostPort = at >= 0 ? authority.slice(at + 1) : authority;
+  // Never accept credentials embedded in an endpoint URL.
+  if (userinfo.includes(":")) return false;
+  return hostPort.length > 0;
+}
+
+export type FederationEndpointState =
+  | "active"
+  | "connecting"
+  | "failed"
+  | "idle";
+
+export type FederationEndpointStatus = {
+  url: string;
+  state: FederationEndpointState;
+  lastAttemptAt?: number;
+  lastConnectedAt?: number;
+  lastError?: string;
+};
+
 export type FederationHealthStatus = {
   enabled: boolean;
   role: FederationInstanceRole;
@@ -109,6 +142,8 @@ export type FederationHealthStatus = {
   listenUrl?: string;
   publicUrl?: string;
   unavailableReason?: string;
+  /** Client-mode gateway endpoints in configured order with live status. */
+  gatewayEndpoints?: FederationEndpointStatus[];
   peers: FederationPeerSummary[];
   clientEnrollment?: FederationClientEnrollment;
 };

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -547,6 +547,13 @@ export type DesktopFederationSettingsSnapshot = {
   listenPort: DesktopSettingsValue<number>;
   publicUrl: DesktopSettingsValue<string>;
   gatewayUrl: DesktopSettingsValue<string>;
+  /**
+   * Ordered client-mode gateway endpoints for one pinned gateway identity.
+   * Resolved from `gateway_endpoints`, falling back to `[gateway_url]`.
+   */
+  gatewayEndpoints: DesktopSettingsValue<string[]>;
+  /** Ordered endpoints a gateway advertises in enrollment invites. */
+  advertisedEndpoints: DesktopSettingsValue<string[]>;
   cloudflareMtlsEnabled: DesktopSettingsValue<boolean>;
   cloudflareAccessServiceAuthEnabled: DesktopSettingsValue<boolean>;
   instancePrivateKey: DesktopSettingsSecretState;
@@ -942,6 +949,8 @@ export type DesktopSettingsConfigPatch = {
     listenPort?: number;
     publicUrl?: string;
     gatewayUrl?: string;
+    gatewayEndpoints?: string[];
+    advertisedEndpoints?: string[];
     cloudflareMtlsEnabled?: boolean;
     cloudflareAccessServiceAuthEnabled?: boolean;
   };

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -554,6 +554,12 @@ export type DesktopFederationSettingsSnapshot = {
   gatewayEndpoints: DesktopSettingsValue<string[]>;
   /** Ordered endpoints a gateway advertises in enrollment invites. */
   advertisedEndpoints: DesktopSettingsValue<string[]>;
+  /**
+   * The one endpoint that is Cloudflare-fronted. Access tokens and mTLS client
+   * keys are sent only to this host, because they travel in the WebSocket
+   * upgrade before any pinned key is verified.
+   */
+  cloudflareEndpoint: DesktopSettingsValue<string>;
   cloudflareMtlsEnabled: DesktopSettingsValue<boolean>;
   cloudflareAccessServiceAuthEnabled: DesktopSettingsValue<boolean>;
   instancePrivateKey: DesktopSettingsSecretState;
@@ -951,6 +957,7 @@ export type DesktopSettingsConfigPatch = {
     gatewayUrl?: string;
     gatewayEndpoints?: string[];
     advertisedEndpoints?: string[];
+    cloudflareEndpoint?: string;
     cloudflareMtlsEnabled?: boolean;
     cloudflareAccessServiceAuthEnabled?: boolean;
   };


### PR DESCRIPTION
## Summary

- Plan doc: `docs/plans/2026-08-04-001-feat-federation-ssh-multipath-endpoints-plan.md`.
- **Noise over SSH**: a federation client can dial the gateway through an `ssh://[user@]host[:port]/?forward=127.0.0.1:47830` endpoint. `federation-ssh.ts` spawns the operator's system OpenSSH with stdio forwarding (`ssh -W`, `BatchMode=yes`, host-key checking untouched); `connectFederationClient` gains a `createSocket` option so the WebSocket upgrade — and the unchanged, mandatory Noise IK channel plus channel-bound signed auth — run over that stream. No gateway-side change: sshd forwards to the loopback listener.
- **Multi-path gateway endpoints with ordered fallback**: new ordered `[federation] gateway_endpoints` for one pinned gateway identity (read-fallback to `gateway_url`). The reconnect loop walks endpoints last-good-first, with backoff per full cycle, and surfaces per-endpoint status. Invites can carry an optional `gatewayEndpoints` array sourced from a gateway-side `advertised_endpoints` list.
- Settings → Federation: ordered gateway/advertised endpoint editors, a Cloudflare endpoint designation field, and per-endpoint status in the Connection card.

## Security

Endpoint fallback cannot redirect a client to a different gateway: every endpoint on every attempt runs the same Noise IK handshake against the pinned gateway Noise key and the same Ed25519 verification against the pinned signing key, with the identity proof bound to the handshake hash. A hostile endpoint fails closed before any federation payload — and before the one-time invite token — is sent.

**Outer edge credentials are a separate problem, and the first version of this PR got it wrong.** Cloudflare Access tokens and mTLS client certificates travel in the WebSocket upgrade and TLS handshake, both of which complete *before* Noise pins anything. Gating them on `wss://` alone sent them to every TLS endpoint in the fallback list, so a multi-path config leaked the Access token to unrelated hosts and an invite-supplied endpoint became a credential-theft primitive. They are now scoped to one operator-designated host (`cloudflare_endpoint`), matched on host and port; with none designated they apply only to a single-endpoint config, preserving pre-multi-path behavior without widening it. They are never sent to `ws://` or `ssh://`.

Other hardening: endpoints are validated where they enter the app — invite decode (unsigned, attacker-authored, never passes through the UI), config read/write, and again before dialing — not just in the renderer; `ssh` hosts/users beginning with `-` are rejected; and `ssh` forwarding is restricted to the gateway's loopback address, removing a port-scan primitive against the operator's own network.

## Availability

An endpoint that accepted the upgrade and then went silent used to park forever: the walk never advanced, `scheduleReconnect` was never reached, `restartPromise` never cleared, and `onConfigPatchWritten` awaits `restart()` — so the Settings save that would remove the bad endpoint hung too, and the endpoint survived relaunch. The whole pre-session exchange is now bounded by a connect deadline plus `handshakeTimeout`. Reconnect backoff also resets only after a session survives, so a gateway that accepts then immediately drops no longer pins reconnects at 1 Hz.

## Verification

- Full workspace typecheck clean; ESLint 0 errors; `lint:boundaries`, `lint:sql`, `lint:colors` pass.
- 6,079 tests pass. New coverage includes: credential scoping (designated host receives, a different `wss://` host does not, multi-endpoint-with-no-designation withholds from all, single-endpoint still works); the shared endpoint parser (scheme allowlist, embedded-password and leading-dash rejection, case/port normalization, IPv6); a silent-after-upgrade peer failing on the deadline instead of hanging; and the real `SshStdioSocket` under a real WebSocket upgrade completing the Noise handshake and closing cleanly.
- The ssh-under-real-upgrade test closes a genuine gap: the earlier tests covered the duplex and the upgrade separately, which is what let a child-exit defect through.

## Notes

- Config changes follow `docs/config-file-evolution.md`: legacy marker comment on the preserved `gateway_url`, canonical shape only on fresh configs, and the legacy scalar is never deleted.
- `ssh` is invoked from `PATH`; a Windows System32 OpenSSH fallback is deferred and documented as a limitation rather than silently assumed.
- Still unproven: the SSH path and live multi-endpoint failover have automated coverage but no two-machine manual pass. Per the connectivity reference's conventions, a live dogfood run should happen before operator docs claim them verified end to end.

## Rebased onto the federation UX cleanup (#1202)

Rebased cleanly; three places where multi-path endpoints disagreed with the new pairing/diagnostic model are fixed in a follow-up commit:

- **Forget gateway pairing** cleared the pinned keys and `gateway_url` but not `gateway_endpoints` or the last-good endpoint memory. Since the settings resolver prefers the endpoint list over the legacy scalar, a dual-mode instance would have kept dialing the gateway it was just told to forget — with no pins left to satisfy it — and sat in `rejected` forever. `resetEnrollment` now clears both.
- **Auth-class failures stop the endpoint walk.** Every endpoint authenticates against the same pinned identity, so a bad pin belongs to the pairing, not to one path. Continuing wasted attempts and let a later endpoint's network error mask the real cause behind an endless `connecting` retry instead of surfacing as `rejected`.
- **The enrollment card** falls back to the first configured endpoint: a profile that only ever used multi-path endpoints has no legacy `gateway_url` and would have shown a paired gateway with no address. Its copy now names the endpoint count so it doesn't contradict the Connection card.

The landed mode-aware field disabling is carried onto the endpoints editor, so it's disabled outside client/dual exactly like the Gateway URL input it replaced. Re-verified after rebase: 6,106 tests pass, typecheck clean, ESLint 0 errors (no warnings in touched files), boundaries/sql/colors pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
