### PR TITLE
fix(desktop): show project-relative transcript paths

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -6,6 +6,7 @@ import type {
   DesktopApplicationsSnapshot,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
+import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 import { TranscriptCommandOutput } from "./TranscriptCommandOutput";
@@ -19,6 +20,7 @@ type TranscriptActivityProps = {
     DesktopApi,
     "copyText" | "openApplication" | "openMarkdownFileViewer" | "readMarkdownFile"
   >;
+  directoryPaths?: string[];
   entry: AppServerThreadActivityEntry;
   expanded?: boolean;
   fileViewerContext?: MarkdownFileViewerContext;
@@ -36,6 +38,11 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
   const directDetail = singleDirectDetail(props.entry);
   const images = props.entry.details.flatMap((detail) => detail.images ?? []);
   const activityCopyText = buildActivityCopyText(props.entry);
+  const displaySummary = formatActivityText(
+    props.entry.summary,
+    props.entry.details,
+    props.directoryPaths,
+  );
   const className =
     props.entry.tone === "warning"
       ? "transcript-activity transcript-activity--warning"
@@ -61,7 +68,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
               }}
             >
               <span className="transcript-activity__chevron" aria-hidden="true" />
-              <span className="transcript-activity__label">{props.entry.summary}</span>
+              <span className="transcript-activity__label">{displaySummary}</span>
             </button>
             <span className="transcript-activity__header-actions">
               <TranscriptCopyButton
@@ -85,7 +92,7 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
           </>
         ) : (
           <>
-            <span className="transcript-activity__label">{props.entry.summary}</span>
+            <span className="transcript-activity__label">{displaySummary}</span>
             <span className="transcript-activity__header-actions">
               <TranscriptCopyButton
                 className="transcript-copy-button--activity"
@@ -134,7 +141,10 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
 
       {directDetail && isExpanded ? (
         <div id={detailsId} className="transcript-activity__detail-body">
-          <TranscriptCommandOutput detail={directDetail} />
+          <TranscriptCommandOutput
+            detail={directDetail}
+            directoryPaths={props.directoryPaths}
+          />
         </div>
       ) : hasDetails && isExpanded ? (
         <ul id={detailsId} className="transcript-activity__details">
@@ -143,6 +153,11 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
             const hasNestedDetails = Boolean(detail.fileDiff || detail.command);
             const isDetailExpanded = expandedDetailIds.has(detail.id);
             const markdown = detail.markdown?.trim();
+            const displayLabel = formatActivityText(
+              detail.label,
+              [detail],
+              props.directoryPaths,
+            );
             const markdownContent =
               markdown && !hasNestedDetails ? (
                 <ThreadMarkdown
@@ -162,10 +177,10 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                 target="_blank"
                 rel="noreferrer"
               >
-                {detail.label}
+                {displayLabel}
               </a>
             ) : (
-              <span className="transcript-activity__detail-label">{detail.label}</span>
+              <span className="transcript-activity__detail-label">{displayLabel}</span>
             );
 
             return (
@@ -223,7 +238,12 @@ export function TranscriptActivity(props: TranscriptActivityProps) {
                 {hasNestedDetails && isDetailExpanded ? (
                   <div id={nestedId} className="transcript-activity__detail-body">
                     {detail.fileDiff ? <TranscriptDiff detail={detail} /> : null}
-                    {detail.command ? <TranscriptCommandOutput detail={detail} /> : null}
+                    {detail.command ? (
+                      <TranscriptCommandOutput
+                        detail={detail}
+                        directoryPaths={props.directoryPaths}
+                      />
+                    ) : null}
                   </div>
                 ) : null}
               </li>
@@ -255,6 +275,26 @@ function buildActivityCopyText(entry: AppServerThreadActivityEntry): string {
   return [entry.summary, ...entry.details.map((detail) => detail.label)]
     .filter((text) => text.trim().length > 0)
     .join("\n");
+}
+
+function formatActivityText(
+  text: string,
+  details: AppServerThreadActivityEntry["details"],
+  directoryPaths: string[] | undefined,
+): string {
+  let displayText = text;
+  const pathDetails = details
+    .filter((detail): detail is typeof detail & { path: string } => Boolean(detail.path))
+    .sort((left, right) => right.path.length - left.path.length);
+
+  for (const detail of pathDetails) {
+    const displayPath = formatPathRelativeToDirectories(detail.path, directoryPaths);
+    if (displayPath !== detail.path) {
+      displayText = displayText.replaceAll(detail.path, displayPath);
+    }
+  }
+
+  return displayText;
 }
 
 function formatActivityDetailStatus(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptActivity.tsx
@@ -282,19 +282,52 @@ function formatActivityText(
   details: AppServerThreadActivityEntry["details"],
   directoryPaths: string[] | undefined,
 ): string {
-  let displayText = text;
-  const pathDetails = details
+  const paths = details
     .filter((detail): detail is typeof detail & { path: string } => Boolean(detail.path))
-    .sort((left, right) => right.path.length - left.path.length);
+    .map((detail) => ({
+      absolutePath: detail.path,
+      displayPath: formatPathRelativeToDirectories(detail.path, directoryPaths),
+    }))
+    .sort((left, right) => right.absolutePath.length - left.absolutePath.length);
+  let displayText = "";
+  let cursor = 0;
 
-  for (const detail of pathDetails) {
-    const displayPath = formatPathRelativeToDirectories(detail.path, directoryPaths);
-    if (displayPath !== detail.path) {
-      displayText = displayText.replaceAll(detail.path, displayPath);
+  while (cursor < text.length) {
+    const matchingPath = paths.find(
+      (path) =>
+        text.startsWith(path.absolutePath, cursor)
+        && hasPathTextBoundaries(text, cursor, path.absolutePath.length),
+    );
+    if (matchingPath) {
+      displayText += matchingPath.displayPath;
+      cursor += matchingPath.absolutePath.length;
+      continue;
     }
+    displayText += text[cursor];
+    cursor += 1;
   }
 
   return displayText;
+}
+
+function hasPathTextBoundaries(
+  text: string,
+  start: number,
+  length: number,
+): boolean {
+  const before = text[start - 1];
+  const after = text[start + length];
+  return isPathTextBoundary(before, "before") && isPathTextBoundary(after, "after");
+}
+
+function isPathTextBoundary(
+  character: string | undefined,
+  position: "before" | "after",
+): boolean {
+  if (character === undefined || /[\s`'"()[\]{}<>,;:!?=|]/.test(character)) {
+    return true;
+  }
+  return position === "after" && (character === "/" || character === "\\");
 }
 
 function formatActivityDetailStatus(

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptCommandOutput.tsx
@@ -1,10 +1,14 @@
 import { useMemo, useState } from "react";
-import type { AppServerThreadActivityDetail } from "@pwragent/shared";
+import {
+  formatPathRelativeToDirectories,
+  type AppServerThreadActivityDetail,
+} from "@pwragent/shared";
 import { copyText } from "../../lib/copy-text";
 import { TranscriptSubAgentCall } from "./TranscriptSubAgentCall";
 
 type TranscriptCommandOutputProps = {
   detail: AppServerThreadActivityDetail;
+  directoryPaths?: string[];
 };
 
 const PREVIEW_LINE_LIMIT = 12;
@@ -33,6 +37,9 @@ function GenericTranscriptCommandOutput(props: TranscriptCommandOutputProps) {
     (isAgentCommand(command.rawCommand) ? "agent" : "shell");
   const sourceLabel =
     source === "agent" ? "Agent" : source === "tool" ? "Tool" : "Shell";
+  const displayCwd = command.cwd
+    ? formatPathRelativeToDirectories(command.cwd, props.directoryPaths)
+    : undefined;
 
   return (
     <div className="transcript-command">
@@ -66,7 +73,7 @@ function GenericTranscriptCommandOutput(props: TranscriptCommandOutputProps) {
       </div>
       {command.cwd ? (
         <p className="transcript-command__cwd" title={command.cwd}>
-          {command.cwd}
+          {displayCwd}
         </p>
       ) : null}
       <pre className="transcript-command__block">

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1343,6 +1343,7 @@ export function TranscriptList(props: TranscriptListProps) {
               ) : item.entry.type === "activity" ? (
                 <TranscriptActivity
                   applications={props.applications}
+                  directoryPaths={props.directoryPaths}
                   desktopApi={props.desktopApi}
                   entry={item.entry}
                   expanded={controlledExpandedActivityIds?.has(item.entry.id)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -4,6 +4,7 @@ import type {
   DesktopApplicationsSnapshot,
   MarkdownFileViewerContext,
 } from "@pwragent/shared";
+import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -29,19 +30,7 @@ function formatConfidence(value: number | undefined): string | undefined {
 }
 
 function formatPath(path: string, directoryPaths: string[] | undefined): string {
-  const normalized = normalizePath(path);
-  const matchingDirectory = normalizedDirectoryPaths(directoryPaths)
-    .filter(
-      (directoryPath) =>
-        normalized === directoryPath || normalized.startsWith(`${directoryPath}/`)
-    )
-    .sort((left, right) => right.length - left.length)[0];
-
-  if (!matchingDirectory) {
-    return normalized || path;
-  }
-
-  return normalized.slice(matchingDirectory.length).replace(/^\//, "") || normalized;
+  return formatPathRelativeToDirectories(normalizePath(path), directoryPaths);
 }
 
 function priorityLabel(priority: number | undefined): string {
@@ -286,12 +275,6 @@ export function TranscriptReview(props: TranscriptReviewProps) {
 
 function normalizePath(path: string): string {
   return path.replace(/\\/g, "/").replace(/\/+$/, "");
-}
-
-function normalizedDirectoryPaths(paths: string[] | undefined): string[] {
-  return (paths ?? [])
-    .map((path) => normalizePath(path))
-    .filter((path) => path.startsWith("/"));
 }
 
 function fileHref(path: string, line: number): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptWorkPhaseGroup.tsx
@@ -141,6 +141,7 @@ function renderEntry(params: {
     <TranscriptActivity
       key={entry.id}
       applications={params.applications}
+      directoryPaths={params.directoryPaths}
       desktopApi={params.desktopApi}
       entry={entry}
       expanded={params.expandedActivityIds?.has(entry.id)}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-activity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-activity.test.tsx
@@ -92,4 +92,40 @@ describe("TranscriptActivity", () => {
     expect(screen.getByText("Read `apps/desktop/src/main.ts`")).toBeInTheDocument();
     expect(screen.getByText(`Read \`${outsidePath}\``)).toBeInTheDocument();
   });
+
+  it("does not replace a matching path prefix inside an outside path", () => {
+    const projectPath = "/repo/PwrAgnt";
+    const outsidePath = "/repo/PwrAgnt-old/file.ts";
+
+    render(
+      <TranscriptActivity
+        directoryPaths={[projectPath]}
+        entry={{
+          type: "activity",
+          id: "shared-prefix-paths",
+          summary: `Compared \`${projectPath}\` with \`${outsidePath}\``,
+          details: [
+            {
+              id: "project-path",
+              kind: "read",
+              label: `Read \`${projectPath}\``,
+              path: projectPath,
+            },
+            {
+              id: "outside-path",
+              kind: "read",
+              label: `Read \`${outsidePath}\``,
+              path: outsidePath,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: `Compared \`.\` with \`${outsidePath}\``,
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-activity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-activity.test.tsx
@@ -1,0 +1,95 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TranscriptActivity } from "../TranscriptActivity";
+
+describe("TranscriptActivity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a direct activity path relative to the longest thread directory", async () => {
+    const copyText = vi.fn(async () => undefined);
+    const absolutePath =
+      "/Users/huntharo/.pwragent/worktrees/ms2ai7od/PwrAgnt/apps/desktop/src/main/acp/acp-runtime-capabilities.ts";
+    const label = `Read \`${absolutePath}\``;
+
+    render(
+      <TranscriptActivity
+        desktopApi={{ copyText }}
+        directoryPaths={[
+          "/Users/huntharo/pwrdrvr/PwrAgnt",
+          "/Users/huntharo/.pwragent/worktrees/ms2ai7od/PwrAgnt",
+        ]}
+        entry={{
+          type: "activity",
+          id: "read-1",
+          summary: label,
+          details: [
+            {
+              id: "read-1:detail",
+              kind: "read",
+              label,
+              path: absolutePath,
+              command: {
+                displayCommand: label,
+                source: "tool",
+                output: "Read 80 lines",
+              },
+            },
+          ],
+        }}
+      />,
+    );
+
+    const displayLabel =
+      "Read `apps/desktop/src/main/acp/acp-runtime-capabilities.ts`";
+    const toggle = screen.getByRole("button", { name: displayLabel });
+    expect(toggle).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy activity" }));
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith(`${label}\n${label}`);
+    });
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy invocation" })).toBeInTheDocument();
+  });
+
+  it("formats nested detail labels while keeping outside paths absolute", () => {
+    const projectPath = "/repo/PwrAgnt/apps/desktop/src/main.ts";
+    const outsidePath = "/repo/PwrAgnt-other/scripts/release.ts";
+
+    render(
+      <TranscriptActivity
+        directoryPaths={["/repo/PwrAgnt"]}
+        entry={{
+          type: "activity",
+          id: "reads-1",
+          summary: "Read 2 files",
+          details: [
+            {
+              id: "read-project",
+              kind: "read",
+              label: `Read \`${projectPath}\``,
+              path: projectPath,
+            },
+            {
+              id: "read-outside",
+              kind: "read",
+              label: `Read \`${outsidePath}\``,
+              path: outsidePath,
+            },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Read 2 files" }));
+
+    expect(screen.getByText("Read `apps/desktop/src/main.ts`")).toBeInTheDocument();
+    expect(screen.getByText(`Read \`${outsidePath}\``)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-command-output.test.tsx
@@ -260,4 +260,37 @@ describe("TranscriptCommandOutput", () => {
     expect(copyText).toHaveBeenNthCalledWith(1, "npm view dive");
     expect(copyText).toHaveBeenNthCalledWith(2, "line 1\nline 2");
   });
+
+  it("shortens the displayed cwd without changing executable command text", () => {
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        copyText,
+      },
+    });
+    const absolutePath = "/repo/worktree/apps/desktop/src/main.ts";
+    const command = `sed -n '1,80p' ${absolutePath}`;
+
+    render(
+      <TranscriptCommandOutput
+        directoryPaths={["/repo/worktree"]}
+        detail={{
+          id: "cmd-relative-cwd",
+          kind: "command",
+          label: command,
+          command: {
+            cwd: "/repo/worktree",
+            displayCommand: command,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(".")).toHaveAttribute("title", "/repo/worktree");
+    expect(screen.getByText(`$ ${command}`)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy command" }));
+    expect(copyText).toHaveBeenCalledWith(command);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -1878,6 +1878,93 @@ describe("TranscriptList", () => {
     });
   });
 
+  it("passes directory paths to ungrouped activities", () => {
+    const absolutePath = "/repo/worktree/PwrAgnt/apps/desktop/src/main.ts";
+
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/PwrAgnt", "/repo/worktree/PwrAgnt"]}
+        entries={[
+          {
+            type: "activity",
+            id: "ungrouped-relative-path",
+            summary: `Read \`${absolutePath}\``,
+            details: [
+              {
+                id: "ungrouped-relative-path:detail",
+                kind: "read",
+                label: `Read \`${absolutePath}\``,
+                path: absolutePath,
+              },
+            ],
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Read `apps/desktop/src/main.ts`" }),
+    ).toBeInTheDocument();
+  });
+
+  it("passes directory paths to activities inside a work phase group", async () => {
+    const absolutePath = "/repo/worktrees/PwrAgnt/apps/desktop/src/renderer/App.tsx";
+    const completedTurn = {
+      id: "turn-relative-path",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 3_000,
+      durationMs: 2_000,
+    };
+
+    render(
+      <TranscriptList
+        directoryPaths={["/repo/PwrAgnt", "/repo/worktrees/PwrAgnt"]}
+        entries={[
+          {
+            type: "activity",
+            id: "read-relative-path",
+            summary: `Read \`${absolutePath}\``,
+            details: [
+              {
+                id: "read-relative-path:detail",
+                kind: "read",
+                label: `Read \`${absolutePath}\``,
+                path: absolutePath,
+              },
+            ],
+            turn: completedTurn,
+          },
+          {
+            type: "message",
+            id: "message-relative-path",
+            role: "assistant",
+            text: "Done.",
+            turn: completedTurn,
+          },
+        ]}
+        loading={false}
+        loadingMore={false}
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous work" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: "Read `apps/desktop/src/renderer/App.tsx`",
+        }),
+      ).toBeVisible();
+    });
+  });
+
   it("anchors a freshly loaded transcript to the newest entry", () => {
     render(
       <TranscriptList

--- a/packages/shared/src/__tests__/path-display.test.ts
+++ b/packages/shared/src/__tests__/path-display.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { formatPathRelativeToDirectories } from "../path-display";
+
+describe("formatPathRelativeToDirectories", () => {
+  it("uses the longest matching directory on a path-component boundary", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "/repo/worktrees/pwragent/apps/desktop/src/main.ts",
+        ["/repo", "/repo/worktrees/pwragent"],
+      ),
+    ).toBe("apps/desktop/src/main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "/repo-other/apps/desktop/src/main.ts",
+        ["/repo"],
+      ),
+    ).toBe("/repo-other/apps/desktop/src/main.ts");
+  });
+
+  it("matches Windows paths and preserves their separators", () => {
+    expect(
+      formatPathRelativeToDirectories(
+        "C:\\repo\\worktree\\apps\\desktop\\src\\main.ts",
+        ["c:\\repo", "C:\\repo\\worktree\\"],
+      ),
+    ).toBe("apps\\desktop\\src\\main.ts");
+    expect(
+      formatPathRelativeToDirectories(
+        "C:\\repo-other\\apps\\desktop\\src\\main.ts",
+        ["c:\\repo"],
+      ),
+    ).toBe("C:\\repo-other\\apps\\desktop\\src\\main.ts");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,6 +32,7 @@ export * from "./directory-navigation";
 export * from "./inbox";
 export * from "./navigation-state";
 export * from "./pending-request-response";
+export * from "./path-display";
 export * from "./renderer-payload-boundary";
 export * from "./review-branches";
 export * from "./subthreads";

--- a/packages/shared/src/path-display.ts
+++ b/packages/shared/src/path-display.ts
@@ -1,0 +1,59 @@
+type NormalizedDirectoryPath = {
+  caseInsensitive: boolean;
+  normalized: string;
+};
+
+/**
+ * Display an absolute path relative to the longest known directory that
+ * contains it. Paths outside the known directories are returned unchanged.
+ */
+export function formatPathRelativeToDirectories(
+  value: string,
+  directoryPaths: string[] | undefined,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const normalizedValue = normalizePath(trimmed);
+  const valueIsWindowsPath = isWindowsPath(trimmed);
+  const roots = [...(directoryPaths ?? [])]
+    .map((root): NormalizedDirectoryPath => ({
+      caseInsensitive: valueIsWindowsPath || isWindowsPath(root),
+      normalized: normalizePath(root),
+    }))
+    .filter((root) => Boolean(root.normalized))
+    .sort((left, right) => right.normalized.length - left.normalized.length);
+
+  for (const root of roots) {
+    const comparisonValue = root.caseInsensitive
+      ? normalizedValue.toLowerCase()
+      : normalizedValue;
+    const comparisonRoot = root.caseInsensitive
+      ? root.normalized.toLowerCase()
+      : root.normalized;
+    if (comparisonValue === comparisonRoot) {
+      return ".";
+    }
+    const isContained = comparisonRoot === "/"
+      ? comparisonValue.startsWith("/")
+      : comparisonValue.startsWith(`${comparisonRoot}/`);
+    if (isContained) {
+      const relativeStart = comparisonRoot === "/" ? 1 : root.normalized.length + 1;
+      return trimmed.slice(relativeStart) || ".";
+    }
+  }
+
+  return trimmed;
+}
+
+function isWindowsPath(value: string): boolean {
+  const trimmed = value.trim();
+  return /^[a-z]:[\\/]/i.test(trimmed) || /^\\\\/.test(trimmed);
+}
+
+function normalizePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/");
+  return normalized.length > 1 ? normalized.replace(/\/+$/, "") : normalized;
+}

--- a/packages/shared/src/pending-request-response.ts
+++ b/packages/shared/src/pending-request-response.ts
@@ -5,6 +5,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadFileDiffRef,
 } from "./contracts/normalized-app-server";
+import { formatPathRelativeToDirectories } from "./path-display";
 
 export type PendingRequestDecision = "approve" | "decline" | "cancel";
 export type PendingRequestActionDecision =
@@ -325,27 +326,7 @@ export function formatApprovalPath(
   value: string,
   directoryPaths: string[] | undefined,
 ): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "";
-  }
-
-  const roots = [...(directoryPaths ?? [])]
-    .map((root) => normalizePath(root))
-    .filter(Boolean)
-    .sort((left, right) => right.length - left.length);
-  const normalizedValue = normalizePath(trimmed);
-
-  for (const root of roots) {
-    if (normalizedValue === root) {
-      return ".";
-    }
-    if (normalizedValue.startsWith(`${root}/`)) {
-      return normalizedValue.slice(root.length + 1) || ".";
-    }
-  }
-
-  return trimmed;
+  return formatPathRelativeToDirectories(value, directoryPaths);
 }
 
 export function buildPendingRequestResponse(
@@ -988,9 +969,4 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
-}
-
-function normalizePath(value: string): string {
-  const normalized = value.trim().replace(/\\/g, "/");
-  return normalized.length > 1 ? normalized.replace(/\/+$/, "") : normalized;
 }


### PR DESCRIPTION
## Summary

- show structured transcript activity paths relative to the longest matching linked project or worktree directory
- preserve absolute normalized activity data, copy payloads, command text, and file/action targets
- share component-boundary-aware path formatting across transcript activities, reviews, and approval context

## Root cause

`ThreadView` already supplied all linked project and worktree paths to `TranscriptList`, but those paths were forwarded only to review rendering. Generic `TranscriptActivity` rows therefore rendered normalized summaries and detail labels verbatim, including absolute managed-worktree paths.

## User impact

Reads and other structured file activity under the active project now display concise repository-relative paths in both ordinary transcript rows and grouped work phases. Paths outside known roots stay absolute. Windows matching is case-insensitive and preserves the source separator style.

Command working directories use the same display formatting, while executable/copyable command text remains unchanged.

## Validation

- `pnpm test --project desktop-renderer --project shared` (137 files, 2,063 tests)
- focused transcript activity/list/command/review and shared approval/path tests (113 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`