### PR TITLE
feat(desktop): surface messaging adapter startup failures

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -1787,6 +1787,80 @@ describe("DesktopMessagingRuntime", () => {
     }
   }, 30_000);
 
+  it("restores errored adapter health after an explicit reconnect recovery", async () => {
+    await prepareRuntimeStore();
+    let fireReconnect: ((info: MessagingReconnectInfo) => void) | undefined;
+    let fireRuntimeError: ((reason: string) => void) | undefined;
+    const adapter = createAdapter("telegram", {
+      onReconnect: (listener: (info: MessagingReconnectInfo) => void) => {
+        fireReconnect = listener;
+        return () => {
+          fireReconnect = undefined;
+        };
+      },
+      onRuntimeError: (listener: (reason: string) => void) => {
+        fireRuntimeError = listener;
+        return () => {
+          fireRuntimeError = undefined;
+        };
+      },
+    });
+    const { DesktopMessagingRuntime: Runtime } = await import(
+      "../messaging/messaging-runtime"
+    );
+    const runtime = new Runtime({
+      adapterFactory: () => [adapter],
+      backendBridge: createBackendBridge(),
+      config: {
+        telegram: {
+          channel: "telegram",
+          botToken: "telegram-token",
+          authorizedActorIds: [{ id: "user-1", displayName: "" }],
+        },
+      },
+    });
+
+    try {
+      await runtime.start();
+      const events: unknown[] = [];
+      runtime.onPlatformStatus((event) => events.push(event));
+      fireRuntimeError?.("websocket disconnected");
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "errored",
+          platform: "telegram",
+          reason: "websocket disconnected",
+        }),
+      ]);
+
+      fireReconnect?.({ attemptCount: 4, state: "started" });
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "errored",
+          platform: "telegram",
+        }),
+      ]);
+
+      fireReconnect?.({ state: "recovered" });
+      expect(runtime.getPlatformStatuses()).toEqual([
+        expect.objectContaining({
+          health: "enabled",
+          platform: "telegram",
+          reason: undefined,
+        }),
+      ]);
+      expect(events.at(-1)).toEqual(
+        expect.objectContaining({
+          health: "enabled",
+          kind: "health-changed",
+          platform: "telegram",
+        }),
+      );
+    } finally {
+      await runtime.stop();
+    }
+  }, 30_000);
+
   it("detaches adapter runtime-error listeners on stop so a graceful shutdown does not flip to errored", async () => {
     await prepareRuntimeStore();
     let fireRuntimeError: ((reason: string) => void) | undefined;

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -106,12 +106,11 @@ export type DesktopMessagingAdapter = {
     limit?: number;
   }): Promise<MessagingInboundEvent[]>;
   /**
-   * Optional subscription for fatal runtime errors that took the
-   * adapter offline after a successful start (e.g. Telegram's 409
-   * Conflict when a second bot instance starts polling). The runtime
-   * subscribes after `start()` and flips the platform health to
-   * `errored` so the renderer status pill turns red. Adapters that
-   * cannot detect post-start failures may simply omit the method.
+   * Optional subscription for serious runtime errors after a successful
+   * start (e.g. Telegram's 409 Conflict when a second bot instance starts
+   * polling, or Mattermost's sustained reconnect failures). The runtime
+   * flips platform health to `errored`; an adapter that keeps retrying can
+   * later restore health by emitting `onReconnect({ state: "recovered" })`.
    */
   onRuntimeError?(listener: (reason: string) => void): () => void;
   onRateLimit?(listener: (info: MessagingRateLimitInfo) => void): () => void;
@@ -1819,6 +1818,13 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     const key = degradationKey(platform, "reconnecting", "adapter");
     if (info.state === "recovered") {
       this.clearPlatformDegradationReason(platform, key);
+      const previous = this.platformStatuses.get(platform);
+      if (previous?.health === "errored") {
+        const adapter = this.runningAdapters.get(platform)?.adapter;
+        this.setPlatformHealth(platform, "enabled", {
+          credentialMetadata: adapter?.readCredentialMetadata?.(),
+        });
+      }
       return;
     }
     this.addPlatformDegradationReason(platform, {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -79,6 +79,7 @@ import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
 import { resolveBackendErrorNotice } from "./features/notifications/backend-error-notice";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
+import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
 import {
   buildHeapSnapshotHandoffMessage,
   describeHeapSnapshotResult,
@@ -1822,6 +1823,7 @@ function DesktopAppShell(props: {
             notice={backendErrorNotice}
             onDismiss={() => setBackendErrorNotice(undefined)}
           />
+          <MessagingErrorNotices desktopApi={desktopApi} />
           <AppNoticeToast
             desktopApi={desktopApi}
             notice={automationLoadNotice}

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from "react";
+import type {
+  MessagingChannelKind,
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
+import { formatMessagingPlatformName } from "../../lib/messaging-platform-branding";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { AppNoticeToast, type AppNoticeToastNotice } from "./AppNoticeToast";
+
+type MessagingErrorNotice = {
+  notice: AppNoticeToastNotice;
+  platform: MessagingChannelKind;
+};
+
+export function MessagingErrorNotices(props: {
+  desktopApi?: DesktopApi;
+}) {
+  const [noticesByPlatform, setNoticesByPlatform] = useState(
+    () => new Map<MessagingChannelKind, AppNoticeToastNotice>(),
+  );
+
+  useEffect(() => {
+    if (
+      !props.desktopApi?.getMessagingPlatformStatuses
+      && !props.desktopApi?.onMessagingPlatformStatusEvent
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    const unsubscribe = props.desktopApi.onMessagingPlatformStatusEvent?.(
+      (event: MessagingPlatformStatusEvent) => {
+        if (event.kind !== "health-changed") {
+          return;
+        }
+        setNoticesByPlatform((current) => applyStatusEvent(current, event));
+      },
+    );
+
+    void props.desktopApi.getMessagingPlatformStatuses?.()
+      .then((statuses) => {
+        if (cancelled) {
+          return;
+        }
+        setNoticesByPlatform((current) => applyStatusSnapshot(current, statuses));
+      })
+      .catch(() => {
+        // Logged in main; a later pushed health event can still surface an error.
+      });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [props.desktopApi]);
+
+  const dismiss = useCallback((platform: MessagingChannelKind) => {
+    setNoticesByPlatform((current) => {
+      if (!current.has(platform)) {
+        return current;
+      }
+      const next = new Map(current);
+      next.delete(platform);
+      return next;
+    });
+  }, []);
+
+  const notices: MessagingErrorNotice[] = Array.from(
+    noticesByPlatform,
+    ([platform, notice]) => ({ notice, platform }),
+  );
+
+  return notices.map(({ notice, platform }) => (
+    <AppNoticeToast
+      key={platform}
+      desktopApi={props.desktopApi}
+      notice={notice}
+      onDismiss={() => dismiss(platform)}
+    />
+  ));
+}
+
+function applyStatusSnapshot(
+  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  statuses: MessagingPlatformStatus[],
+): Map<MessagingChannelKind, AppNoticeToastNotice> {
+  let next = current;
+  for (const status of statuses) {
+    next = applyPlatformHealth(next, status);
+  }
+  return next;
+}
+
+function applyStatusEvent(
+  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  event: Extract<MessagingPlatformStatusEvent, { kind: "health-changed" }>,
+): Map<MessagingChannelKind, AppNoticeToastNotice> {
+  return applyPlatformHealth(current, {
+    platform: event.platform,
+    health: event.health,
+    changedAt: event.at,
+    reason: event.reason,
+  });
+}
+
+function applyPlatformHealth(
+  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  status: Pick<
+    MessagingPlatformStatus,
+    "changedAt" | "health" | "platform" | "reason"
+  >,
+): Map<MessagingChannelKind, AppNoticeToastNotice> {
+  if (status.health !== "errored") {
+    if (!current.has(status.platform)) {
+      return current;
+    }
+    const next = new Map(current);
+    next.delete(status.platform);
+    return next;
+  }
+
+  const nextNotice = buildMessagingErrorNotice(status);
+  if (current.get(status.platform)?.id === nextNotice.id) {
+    return current;
+  }
+  const next = new Map(current);
+  next.set(status.platform, nextNotice);
+  return next;
+}
+
+export function buildMessagingErrorNotice(
+  status: Pick<
+    MessagingPlatformStatus,
+    "changedAt" | "platform" | "reason"
+  >,
+): AppNoticeToastNotice {
+  const platformName = formatMessagingPlatformName(status.platform);
+  return {
+    autoDismiss: false,
+    detail: status.reason?.trim() || undefined,
+    id: `messaging-platform-error:${status.platform}:${status.changedAt}`,
+    message:
+      `${platformName} isn't listening for messages and won't retry automatically. `
+      + `Fix the problem, then restart PwrAgent or turn ${platformName} off and back on.`,
+    title: `${platformName} messaging failed`,
+    tone: "error",
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -13,11 +13,17 @@ type MessagingErrorNotice = {
   platform: MessagingChannelKind;
 };
 
+type MessagingPlatformNoticeState = {
+  changedAt: number;
+  notice?: AppNoticeToastNotice;
+  source: "event" | "snapshot";
+};
+
 export function MessagingErrorNotices(props: {
   desktopApi?: DesktopApi;
 }) {
-  const [noticesByPlatform, setNoticesByPlatform] = useState(
-    () => new Map<MessagingChannelKind, AppNoticeToastNotice>(),
+  const [statusByPlatform, setStatusByPlatform] = useState(
+    () => new Map<MessagingChannelKind, MessagingPlatformNoticeState>(),
   );
 
   useEffect(() => {
@@ -34,7 +40,7 @@ export function MessagingErrorNotices(props: {
         if (event.kind !== "health-changed") {
           return;
         }
-        setNoticesByPlatform((current) => applyStatusEvent(current, event));
+        setStatusByPlatform((current) => applyStatusEvent(current, event));
       },
     );
 
@@ -43,7 +49,7 @@ export function MessagingErrorNotices(props: {
         if (cancelled) {
           return;
         }
-        setNoticesByPlatform((current) => applyStatusSnapshot(current, statuses));
+        setStatusByPlatform((current) => applyStatusSnapshot(current, statuses));
       })
       .catch(() => {
         // Logged in main; a later pushed health event can still surface an error.
@@ -56,20 +62,23 @@ export function MessagingErrorNotices(props: {
   }, [props.desktopApi]);
 
   const dismiss = useCallback((platform: MessagingChannelKind) => {
-    setNoticesByPlatform((current) => {
-      if (!current.has(platform)) {
+    setStatusByPlatform((current) => {
+      const currentState = current.get(platform);
+      if (!currentState?.notice) {
         return current;
       }
       const next = new Map(current);
-      next.delete(platform);
+      next.set(platform, { ...currentState, notice: undefined });
       return next;
     });
   }, []);
 
-  const notices: MessagingErrorNotice[] = Array.from(
-    noticesByPlatform,
-    ([platform, notice]) => ({ notice, platform }),
-  );
+  const notices: MessagingErrorNotice[] = [];
+  for (const [platform, state] of statusByPlatform) {
+    if (state.notice) {
+      notices.push({ notice: state.notice, platform });
+    }
+  }
 
   return notices.map(({ notice, platform }) => (
     <AppNoticeToast
@@ -82,50 +91,67 @@ export function MessagingErrorNotices(props: {
 }
 
 function applyStatusSnapshot(
-  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  current: Map<MessagingChannelKind, MessagingPlatformNoticeState>,
   statuses: MessagingPlatformStatus[],
-): Map<MessagingChannelKind, AppNoticeToastNotice> {
+): Map<MessagingChannelKind, MessagingPlatformNoticeState> {
   let next = current;
   for (const status of statuses) {
-    next = applyPlatformHealth(next, status);
+    next = applyPlatformHealth(next, status, "snapshot");
   }
   return next;
 }
 
 function applyStatusEvent(
-  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  current: Map<MessagingChannelKind, MessagingPlatformNoticeState>,
   event: Extract<MessagingPlatformStatusEvent, { kind: "health-changed" }>,
-): Map<MessagingChannelKind, AppNoticeToastNotice> {
+): Map<MessagingChannelKind, MessagingPlatformNoticeState> {
   return applyPlatformHealth(current, {
     platform: event.platform,
     health: event.health,
     changedAt: event.at,
     reason: event.reason,
-  });
+  }, "event");
 }
 
 function applyPlatformHealth(
-  current: Map<MessagingChannelKind, AppNoticeToastNotice>,
+  current: Map<MessagingChannelKind, MessagingPlatformNoticeState>,
   status: Pick<
     MessagingPlatformStatus,
     "changedAt" | "health" | "platform" | "reason"
   >,
-): Map<MessagingChannelKind, AppNoticeToastNotice> {
-  if (status.health !== "errored") {
-    if (!current.has(status.platform)) {
-      return current;
-    }
-    const next = new Map(current);
-    next.delete(status.platform);
-    return next;
+  source: MessagingPlatformNoticeState["source"],
+): Map<MessagingChannelKind, MessagingPlatformNoticeState> {
+  const previous = current.get(status.platform);
+  if (
+    previous
+    && (
+      status.changedAt < previous.changedAt
+      || (
+        status.changedAt === previous.changedAt
+        && previous.source === "event"
+        && source === "snapshot"
+      )
+    )
+  ) {
+    return current;
   }
 
-  const nextNotice = buildMessagingErrorNotice(status);
-  if (current.get(status.platform)?.id === nextNotice.id) {
+  const notice = status.health === "errored"
+    ? buildMessagingErrorNotice(status)
+    : undefined;
+  if (
+    previous?.changedAt === status.changedAt
+    && previous.notice?.id === notice?.id
+    && previous.source === source
+  ) {
     return current;
   }
   const next = new Map(current);
-  next.set(status.platform, nextNotice);
+  next.set(status.platform, {
+    changedAt: status.changedAt,
+    notice,
+    source,
+  });
   return next;
 }
 
@@ -141,8 +167,8 @@ export function buildMessagingErrorNotice(
     detail: status.reason?.trim() || undefined,
     id: `messaging-platform-error:${status.platform}:${status.changedAt}`,
     message:
-      `${platformName} isn't listening for messages and won't retry automatically. `
-      + `Fix the problem, then restart PwrAgent or turn ${platformName} off and back on.`,
+      `${platformName} reported an adapter error. Messages may be unavailable `
+      + "until it recovers or is restarted.",
     title: `${platformName} messaging failed`,
     tone: "error",
   };

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
@@ -32,7 +32,7 @@ describe("MessagingErrorNotices", () => {
     );
 
     expect(await screen.findByText("Slack messaging failed")).toBeInTheDocument();
-    expect(screen.getByText(/isn't listening for messages/)).toBeInTheDocument();
+    expect(screen.getByText(/Messages may be unavailable/)).toBeInTheDocument();
     expect(screen.getByText("u.WebSocket is not a constructor")).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveAttribute("data-tone", "error");
     expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
@@ -100,5 +100,86 @@ describe("MessagingErrorNotices", () => {
     expect(await screen.findByText("Telegram messaging failed")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
     expect(screen.queryByText("Telegram messaging failed")).not.toBeInTheDocument();
+  });
+
+  it("does not let an older healthy snapshot hide a newer live failure", async () => {
+    let emitStatus: ((event: MessagingPlatformStatusEvent) => void) | undefined;
+    let resolveSnapshot!: (statuses: MessagingPlatformStatus[]) => void;
+    const snapshot = new Promise<MessagingPlatformStatus[]>((resolve) => {
+      resolveSnapshot = resolve;
+    });
+
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: () => snapshot,
+          onMessagingPlatformStatusEvent: (listener) => {
+            emitStatus = listener;
+            return () => undefined;
+          },
+        }}
+      />,
+    );
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "slack",
+        health: "errored",
+        at: 200,
+        reason: "socket failed",
+      });
+    });
+    expect(screen.getByText("Slack messaging failed")).toBeInTheDocument();
+
+    await act(async () => {
+      resolveSnapshot([{
+        platform: "slack",
+        health: "enabled",
+        changedAt: 100,
+      }]);
+      await snapshot;
+    });
+    expect(screen.getByText("Slack messaging failed")).toBeInTheDocument();
+  });
+
+  it("does not let a stale errored snapshot resurrect a recovered notice", async () => {
+    let emitStatus: ((event: MessagingPlatformStatusEvent) => void) | undefined;
+    let resolveSnapshot!: (statuses: MessagingPlatformStatus[]) => void;
+    const snapshot = new Promise<MessagingPlatformStatus[]>((resolve) => {
+      resolveSnapshot = resolve;
+    });
+
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: () => snapshot,
+          onMessagingPlatformStatusEvent: (listener) => {
+            emitStatus = listener;
+            return () => undefined;
+          },
+        }}
+      />,
+    );
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "mattermost",
+        health: "enabled",
+        at: 200,
+      });
+    });
+
+    await act(async () => {
+      resolveSnapshot([{
+        platform: "mattermost",
+        health: "errored",
+        changedAt: 200,
+        reason: "websocket disconnected",
+      }]);
+      await snapshot;
+    });
+    expect(screen.queryByText("Mattermost messaging failed")).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
@@ -1,0 +1,104 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type {
+  MessagingPlatformStatus,
+  MessagingPlatformStatusEvent,
+} from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessagingErrorNotices } from "../MessagingErrorNotices";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MessagingErrorNotices", () => {
+  it("surfaces an adapter error that happened before the renderer mounted", async () => {
+    const getMessagingPlatformStatuses = vi.fn(async () => [
+      {
+        platform: "slack",
+        health: "errored",
+        changedAt: 1_785_926_400_000,
+        reason: "u.WebSocket is not a constructor",
+      },
+    ] satisfies MessagingPlatformStatus[]);
+
+    const { container } = render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses,
+          onMessagingPlatformStatusEvent: () => () => undefined,
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("Slack messaging failed")).toBeInTheDocument();
+    expect(screen.getByText(/isn't listening for messages/)).toBeInTheDocument();
+    expect(screen.getByText("u.WebSocket is not a constructor")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute("data-tone", "error");
+    expect(container.querySelector(".app-notice-toast__timer")).toBeNull();
+    expect(getMessagingPlatformStatuses).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds live failures and removes their notices when the platform recovers", async () => {
+    let emitStatus: ((event: MessagingPlatformStatusEvent) => void) | undefined;
+    const onMessagingPlatformStatusEvent = vi.fn((listener) => {
+      emitStatus = listener;
+      return () => undefined;
+    });
+
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: async () => [],
+          onMessagingPlatformStatusEvent,
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onMessagingPlatformStatusEvent).toHaveBeenCalledTimes(1);
+    });
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "discord",
+        health: "errored",
+        at: 1_785_926_400_001,
+        reason: "gateway disconnected",
+      });
+    });
+    expect(screen.getByText("Discord messaging failed")).toBeInTheDocument();
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "discord",
+        health: "enabled",
+        at: 1_785_926_400_002,
+      });
+    });
+    expect(screen.queryByText("Discord messaging failed")).not.toBeInTheDocument();
+  });
+
+  it("lets the operator acknowledge a sticky platform failure", async () => {
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: async () => [
+            {
+              platform: "telegram",
+              health: "errored",
+              changedAt: 1_785_926_400_003,
+              reason: "connection refused",
+            },
+          ],
+          onMessagingPlatformStatusEvent: () => () => undefined,
+        }}
+      />,
+    );
+
+    expect(await screen.findByText("Telegram messaging failed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(screen.queryByText("Telegram messaging failed")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed

- surface one durable error toast per messaging platform that enters the `errored` health state
- hydrate startup failures from the retained messaging status snapshot so errors that happen before the renderer mounts are still visible
- merge snapshots and live health events monotonically per provider so stale snapshots cannot hide or resurrect notices
- keep the provider error reason visible and copyable with recovery-neutral guidance
- restore runtime health and remove the notice when an automatically reconnecting adapter explicitly reports recovery
- allow operators to acknowledge each provider notice manually

## Why

A failed messaging adapter was only visible through the compact MSG indicator and activity details. That made a provider outage easy to miss until messages went unanswered.

## User impact

Operators now get a sticky, high-contrast toast such as **Slack messaging failed**. The toast stays until dismissed, includes the underlying startup/runtime error, and explains that messages may be unavailable until the adapter recovers or restarts. Automatically reconnecting adapters such as Mattermost clear their errored health and notice after reporting recovery.

## Validation

- `pnpm test apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx apps/desktop/src/main/__tests__/messaging-runtime.test.ts` (58 tests)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline only)
- `pnpm lint:boundaries`
- `git diff --check`
