### PR TITLE
fix(messaging): bundle websocket runtime for Slack

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -34,7 +34,11 @@ export default defineConfig(({ command }) => {
             "@pwragent/messaging-provider-telegram",
             "@larksuiteoapi/node-sdk",
             "protobufjs",
-            "protobufjs/minimal"
+            "protobufjs/minimal",
+            // Slack's bundled CommonJS Socket Mode client expects
+            // require("ws").WebSocket. Externalizing ws rewrites that require
+            // to an ESM default import whose constructor has no .WebSocket.
+            "ws",
           ]
         })
       ],

--- a/apps/desktop/scripts/check-main-bundle-boundary.mjs
+++ b/apps/desktop/scripts/check-main-bundle-boundary.mjs
@@ -26,6 +26,10 @@ const forbidden = [
     label: "xAI runtime endpoint",
     pattern: /api\.x\.ai\/v1\/responses/,
   },
+  {
+    label: "externalized ws runtime import",
+    pattern: /\bfrom\s+["']ws["']/,
+  },
 ];
 const violations = [];
 
@@ -42,7 +46,7 @@ for (const filePath of javascriptFiles) {
 }
 
 if (violations.length > 0) {
-  console.error("Electron main bundle contains forbidden Grok runtime code:");
+  console.error("Electron main bundle verification failed:");
   for (const violation of violations) {
     console.error(`  ${violation.file}: ${violation.label}`);
   }
@@ -50,5 +54,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `main bundle boundary: OK (${javascriptFiles.length} files, no AI SDK/xAI runtime)`,
+  `main bundle boundary: OK (${javascriptFiles.length} files, no AI SDK/xAI runtime or external ws imports)`,
 );


### PR DESCRIPTION
## Summary

- keep `ws` bundled in the Electron main process so Slack Socket Mode receives the CommonJS-compatible module shape it expects
- fail the desktop postbuild bundle check if a generated main-process chunk externalizes `ws` again
- leave durable desktop messaging error-toast behavior unchanged

## Root cause

Federation added `ws` as a direct desktop dependency. Electron Vite therefore began externalizing it. The bundled CommonJS `@slack/socket-mode` code was rewritten from `require("ws")` to an ESM default import, but the ESM default is the WebSocket constructor itself and has no `.WebSocket` property. Slack startup consequently threw `u.WebSocket is not a constructor`.

## Validation

- `pnpm --filter @pwragent/desktop build`
- `pnpm test packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` (62 passed)
- `pnpm test apps/desktop/src/main/__tests__/federation-transport.test.ts` (10 passed)
- `pnpm lint` (passes; existing ESLint warnings only)
