### PR TITLE
fix(desktop): right-align transcript activity diff stats

### DIFF
--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -12599,7 +12599,6 @@ a.transcript-message__messaging-origin:focus-visible {
 .transcript-activity__detail-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
 }
 
@@ -12639,9 +12638,16 @@ a.transcript-message__messaging-origin:focus-visible {
   color: var(--text-primary);
 }
 
+/* Stats and status pin to the row's right edge via `margin-left: auto` —
+   NOT `justify-content: space-between` on the row, which floats whichever
+   element lands in the middle (label / stats / status is a three-child row
+   for ACP backends) at a label-width-dependent position. When stats and
+   status appear together, only the stats carry the auto margin so the pair
+   stays adjacent at the right edge. */
 .transcript-activity__detail-stats {
   display: inline-flex;
   flex: 0 0 auto;
+  margin-left: auto;
   gap: 8px;
   color: var(--text-muted);
   font-family: var(--font-mono);
@@ -12650,6 +12656,7 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .transcript-activity__detail-status {
   flex: 0 0 auto;
+  margin-left: auto;
   padding: 1px 7px;
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
@@ -12657,6 +12664,10 @@ a.transcript-message__messaging-origin:focus-visible {
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.5;
+}
+
+.transcript-activity__detail-stats + .transcript-activity__detail-status {
+  margin-left: 0;
 }
 
 .transcript-activity__detail-status--completed {


### PR DESCRIPTION
## Problem

In the expanded "Edited N files" transcript activity card, the per-file `-R +A` diff counts float at an arbitrary mid-row position instead of aligning to the right edge next to the Done chip.

## Cause

`.transcript-activity__detail-row` used `justify-content: space-between`. Backends that never set a per-file status render two children (label, stats), so the stats happened to land on the right edge. ACP backends emit a `status` on every file detail, producing three children (label, stats, status chip) — and `space-between` distributes the leftover space into **both** gaps, floating the middle stats element at a position that depends on the label width.

## Fix

Drop `space-between` and pin the trailing cluster with auto margins:

- `.transcript-activity__detail-stats { margin-left: auto }` pushes stats (and anything after) to the right edge
- `.transcript-activity__detail-status { margin-left: auto }` covers stats-less rows (status only)
- `.transcript-activity__detail-stats + .transcript-activity__detail-status { margin-left: 0 }` keeps the chip snug beside the stats when both are present

Every row shape (label only, label+stats, label+status, label+stats+status) now keeps the label on the left and the stats/status cluster on the right edge.

CSS-only change; `transcript-list` and `theme-contract` suites pass (128 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)