### PR TITLE
fix(desktop): keep mid-turn commentary visible for viewers that hydrate late

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -700,6 +700,87 @@ describe("buildTranscriptRenderItems", () => {
       },
     ]);
   });
+
+  it("does not collapse in-progress turn commentary when the active turn id is unknown", () => {
+    // A viewer that hydrates mid-turn (e.g. the federation remote window) has
+    // no session activeTurnId. The transcript must still keep the running
+    // turn's commentary visible instead of eliding it as "previous messages".
+    const turn = {
+      id: "turn-1",
+      status: "in_progress" as const,
+      startedAt: 1_000,
+    };
+    const first = commentary("c1", "First update.", turn);
+    const activity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "tool-1",
+      summary: "Used 2 tools",
+      details: [],
+      turn,
+    };
+    const second = commentary("c2", "Second update.", turn);
+
+    const items = buildTranscriptRenderItems({
+      entries: [first, activity, second],
+      now: 62_000,
+    });
+
+    expect(items).toEqual([
+      { type: "entry", entry: first },
+      { type: "entry", entry: activity },
+      { type: "entry", entry: second },
+    ]);
+  });
+
+  it("keeps collapsing legacy commentary while in-progress turn commentary stays visible", () => {
+    const legacyFirst = commentary("c1", "Old note.");
+    const legacySecond = commentary("c2", "Another old note.");
+    const live = commentary("c3", "Live update.", {
+      id: "turn-2",
+      status: "in_progress",
+    });
+
+    const items = buildTranscriptRenderItems({
+      entries: [legacyFirst, legacySecond, live],
+    });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "commentary:c1:c2:complete",
+        collapsible: true,
+        entries: [legacyFirst, legacySecond],
+        label: "2 previous messages",
+      },
+      { type: "entry", entry: live },
+    ]);
+  });
+
+  it("still collapses commentary whose turn completed under mixed metadata in the fallback path", () => {
+    // Same turn id seen as both in_progress (live entry) and completed
+    // (hydrated entry): the turn is over, so the fallback may collapse it.
+    const staleLive = commentary("c1", "Streamed note.", {
+      id: "turn-3",
+      status: "in_progress",
+    });
+    const answer = final("f1", "Final answer.", {
+      id: "turn-3",
+      completedAt: 2_000,
+    });
+
+    const items = buildTranscriptRenderItems({ entries: [staleLive, answer] });
+
+    expect(items).toEqual([
+      {
+        type: "workPhaseGroup",
+        id: "commentary:c1:c1:complete",
+        collapsible: true,
+        entries: [staleLive],
+        label: "1 previous message",
+      },
+      { type: "entry", entry: answer },
+    ]);
+  });
 });
 
 function commentary(

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -213,8 +213,18 @@ function buildCommentaryOnlyGroups(entries: AppServerThreadEntry[]): RenderGroup
     currentMessages = [];
   };
 
+  const completedTurnIds = new Set<string>();
   for (const entry of entries) {
-    if (isAssistantCommentaryMessage(entry)) {
+    if (entry.turn && isCompletedTurnMetadata(entry.turn)) {
+      completedTurnIds.add(entry.turn.id);
+    }
+  }
+
+  for (const entry of entries) {
+    if (
+      isAssistantCommentaryMessage(entry) &&
+      !isLiveInProgressTurn(entry.turn, completedTurnIds)
+    ) {
       currentMessages.push(entry);
       continue;
     }
@@ -223,6 +233,29 @@ function buildCommentaryOnlyGroups(entries: AppServerThreadEntry[]): RenderGroup
 
   flushCurrent();
   return groups;
+}
+
+function isLiveInProgressTurn(
+  turn: AppServerThreadTurnMetadata | undefined,
+  completedTurnIds: ReadonlySet<string>
+): boolean {
+  return Boolean(
+    turn &&
+      turn.status === "in_progress" &&
+      !isCompletedTurnMetadata(turn) &&
+      !completedTurnIds.has(turn.id)
+  );
+}
+
+function isCompletedTurnMetadata(turn: AppServerThreadTurnMetadata): boolean {
+  return (
+    turn.status === "completed" ||
+    turn.status === "failed" ||
+    turn.status === "cancelled" ||
+    turn.status === "interrupted" ||
+    typeof turn.durationMs === "number" ||
+    typeof turn.completedAt === "number"
+  );
 }
 
 function renderWithGroups(
@@ -338,15 +371,7 @@ function readCompletedTurn(
   return entries
     .map((entry) => entry.turn)
     .find((turn): turn is AppServerThreadTurnMetadata =>
-      Boolean(
-        turn &&
-          (turn.status === "completed" ||
-            turn.status === "failed" ||
-            turn.status === "cancelled" ||
-            turn.status === "interrupted" ||
-            typeof turn.durationMs === "number" ||
-            typeof turn.completedAt === "number")
-      )
+      Boolean(turn && isCompletedTurnMetadata(turn))
     );
 }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -70,12 +70,13 @@ function readThreadResponse(params: {
   previousCursor?: string;
   supportsPagination?: boolean;
   threadId?: string;
+  threadStatus?: AppServerReadThreadResponse["threadStatus"];
 }): AppServerReadThreadResponse {
   return {
     backend: "codex",
     fetchedAt: params.fetchedAt ?? Date.now(),
     threadId: params.threadId ?? "thread-1",
-    threadStatus: "idle",
+    threadStatus: params.threadStatus ?? "idle",
     replay: {
       entries: params.entries,
       messages: params.entries
@@ -543,6 +544,90 @@ describe("useThreadSessionState", () => {
     expect(result.current.activeTurnId).toBe("turn-2");
     expect(result.current.threadBusy).toBe(true);
     expect(result.current.pendingStatusText).toBe("Thinking");
+  });
+
+  it("adopts the in-progress turn from a mid-turn hydration snapshot", async () => {
+    // A viewer that opens a thread mid-turn (a fresh window, or a federation
+    // remote viewer) never saw turn/started. The hydrated snapshot is the only
+    // signal, and without adoption the transcript collapses live commentary.
+    const liveTurn = {
+      id: "turn-live",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const response = readThreadResponse({
+      entries: [
+        {
+          type: "message",
+          id: "c1",
+          role: "assistant",
+          phase: "commentary",
+          text: "Working on it.",
+          turn: liveTurn,
+        },
+        {
+          type: "activity",
+          id: "tool-1",
+          summary: "Used 2 tools",
+          details: [],
+          turn: liveTurn,
+        },
+      ],
+      hasPreviousPage: false,
+      threadStatus: "active",
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: vi.fn(async () => response),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    expect(result.current.activeTurnId).toBe("turn-live");
+    expect(result.current.activeTurnStartedAt).toBe(5_000);
+  });
+
+  it("does not adopt a stale in-progress turn from an idle hydration snapshot", async () => {
+    const staleTurn = {
+      id: "turn-stale",
+      status: "in_progress" as const,
+      startedAt: 5_000,
+    };
+    const response = readThreadResponse({
+      entries: [
+        {
+          type: "message",
+          id: "c1",
+          role: "assistant",
+          phase: "commentary",
+          text: "Interrupted mid-flight.",
+          turn: staleTurn,
+        },
+      ],
+      hasPreviousPage: false,
+      threadStatus: "idle",
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: vi.fn(async () => response),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    expect(result.current.activeTurnId).toBeUndefined();
+    expect(result.current.activeTurnStartedAt).toBeUndefined();
   });
 
   it("keeps the optimistic user message ahead of the completed assistant reply", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1580,6 +1580,43 @@ function responseHasInProgressTurn(
   return turnEntries.some((entry) => entry.turn?.status === "in_progress");
 }
 
+function readTrailingInProgressTurn(
+  response: AppServerReadThreadResponse
+): { id: string; startedAt?: number } | undefined {
+  const entries = response.replay.entries;
+  let trailingTurnId: string | undefined;
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const turn = entries[index]?.turn;
+    if (turn) {
+      trailingTurnId = turn.id;
+      break;
+    }
+  }
+  if (!trailingTurnId) {
+    return undefined;
+  }
+
+  const turnEntries = entries.filter(
+    (entry) => entry.turn?.id === trailingTurnId
+  );
+  if (turnEntries.some((entry) => isCompletedTurnMetadata(entry.turn))) {
+    return undefined;
+  }
+  if (!turnEntries.some((entry) => entry.turn?.status === "in_progress")) {
+    return undefined;
+  }
+
+  const startedAtCandidates = turnEntries
+    .map((entry) => entry.turn?.startedAt)
+    .filter((value): value is number => typeof value === "number");
+  return {
+    id: trailingTurnId,
+    ...(startedAtCandidates.length > 0
+      ? { startedAt: Math.min(...startedAtCandidates) }
+      : {}),
+  };
+}
+
 function responseHasCompletedTurn(
   response: AppServerReadThreadResponse,
   turnId: string | undefined
@@ -3711,14 +3748,34 @@ export function useThreadSessionState(params: {
             });
           }
 
+          // A window that opens a thread mid-turn (a fresh local window, or a
+          // federation remote viewer) never saw turn/started, so the hydrated
+          // snapshot is its only signal that a turn is running. Without an
+          // active turn id the transcript collapses live commentary into
+          // "previous messages" groups while the turn is still writing them.
+          const trailingInProgressTurn =
+            !shouldClearStaleThinking && responseThreadStatus === "active"
+              ? readTrailingInProgressTurn(responseWithLoadedHistory)
+              : undefined;
+          const shouldAdoptHydratedTurn =
+            trailingInProgressTurn !== undefined
+            && shouldAdoptStartedTurn(current, trailingInProgressTurn.id);
+
           return {
             ...current,
             activeTurnId: shouldClearStaleThinking
               ? undefined
-              : current.activeTurnId,
+              : shouldAdoptHydratedTurn
+                ? trailingInProgressTurn.id
+                : current.activeTurnId,
             activeTurnStartedAt: shouldClearStaleThinking
               ? undefined
-              : current.activeTurnStartedAt,
+              : shouldAdoptHydratedTurn
+                ? trailingInProgressTurn.startedAt
+                  ?? (current.activeTurnId === trailingInProgressTurn.id
+                    ? current.activeTurnStartedAt
+                    : undefined)
+                : current.activeTurnStartedAt,
             backendReportedActive,
             error: undefined,
             expectOwnUpdate: false,


### PR DESCRIPTION
## Problem

Watching an in-progress turn on a federation remote viewer, assistant messages written between tool calls appear for an instant and then auto-collapse into "N previous messages" groups — while the local window keeps them expanded until the turn ends and only then collapses the whole group.

## Root cause

`session.activeTurnId` is only ever set by live notifications (`turn/started`, approval requests). A window that opens a thread **after** the turn started — the federation remote viewer being the common case — hydrates via `readThread` and never derives the active turn from the snapshot:

1. With the initial history limit, every loaded entry belongs to the single running turn, so `buildCompletedGroups` finds nothing.
2. `buildTranscriptRenderItems` then falls into the commentary-only fallback (`buildCommentaryOnlyGroups`), which collapses **all** assistant commentary — including the live turn's messages.
3. While a message is streaming, `pendingAssistantMessage` temporarily supplies an active turn id (via `activeMessageId` → entry turn lookup), so the message renders expanded; the moment `item/completed` clears the pending message, it snaps into a collapsed group. That's the observed flicker.

The local window renders correctly only because it happened to be subscribed when `turn/started` fired.

## Fix (two layers)

- **`transcript-render-items.ts`** — the commentary-only fallback no longer collapses commentary whose turn metadata is `in_progress` and not completed anywhere in the transcript. Live messages stay visible even when the session has no active turn id. Legacy commentary without turn metadata, and commentary whose turn shows completed metadata elsewhere (mixed live/hydrated states), keep collapsing as before.
- **`useThreadSessionState.ts`** — `loadLatest` now adopts the trailing in-progress turn (id + earliest `startedAt`) from a hydration snapshot whose thread status is `active`, using the existing `shouldAdoptStartedTurn` guard (so optimistic `pending:` turns are replaced and stray adoption is avoided). This restores full local-parity rendering for late-joining viewers, including the "Working for …" active-work group. Idle snapshots with stale `in_progress` entries are deliberately not adopted, so crashed/interrupted threads don't resurrect a bogus running state.

## Tests

Written failing-first against the buggy behavior:

- `transcript-render-items.test.ts`
  - in-progress-turn commentary with no `activeTurnId` renders expanded (was: collapsed by fallback)
  - legacy no-turn commentary still collapses while live in-progress commentary stays visible
  - mixed metadata (same turn seen `in_progress` and completed) still collapses
- `useThreadSessionState.test.tsx`
  - mid-turn hydration snapshot with `threadStatus: "active"` adopts `activeTurnId`/`activeTurnStartedAt` (was: stayed undefined)
  - idle snapshot with stale `in_progress` entries adopts nothing

Full workspace unit suite: 6009 passed. `pnpm typecheck` and `pnpm lint:eslint` clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)