### PR TITLE
feat(desktop): add project directory affordance

### DIFF
--- a/.agents/skills/pwragent-dev-profile/SKILL.md
+++ b/.agents/skills/pwragent-dev-profile/SKILL.md
@@ -45,14 +45,24 @@ Verify that a previously started instance is still up:
 
 1. Run `status` first when the user asks what is running or when closing processes may be surprising.
 2. Run `restart` when the user asks to start the dev profile; it closes the prior managed dev-profile instance, starts `PWRAGENT_PROFILE=dev PWRAGENT_INSTANCE_ROOT="$PWD" pnpm dev` detached from the checkout, and waits until the app writes a matching profile runtime record.
-3. Run `close` when the user only wants the dev-profile app stopped.
-4. Relay the script output and the log path to the user. The default log is `.local/pwragent-dev-profile.log`.
+3. For visual QA, use the emitted `Computer Use target` line. Target its exact
+   checkout-local `appPath`, then verify the native window title is `PwrAgnt`
+   and the AX URL matches the emitted `rendererUrl`. Never target the generic
+   `Electron` display name, shared `com.github.Electron` bundle id, or installed
+   `com.pwrdrvr.pwragent` app: those can select a sibling project, another
+   checkout, or a packaged build that does not contain the code under test.
+4. Run `close` when the user only wants the dev-profile app stopped.
+5. Relay the script output and the log path to the user. The default log is `.local/pwragent-dev-profile.log`.
 
 ## Script Notes
 
 - The script defaults to `--profile dev`, `--root "$PWD"`, `.local/pwragent-dev-profile.pid`, and `.local/pwragent-dev-profile.log`.
 - Prefer `restart` over hand-running `PWRAGENT_PROFILE=dev pnpm dev`; the script passes `PWRAGENT_INSTANCE_ROOT`, starts a detached daemon helper, then uses the app's lease-backed runtime metadata in `~/.pwragent/profiles/dev/state/state.db` to find the Electron owner process.
 - The detached daemon helper stops the `pnpm dev` supervisor when the first lease-backed Electron instance it started exits, so closing the spawned app does not leave a dev supervisor relaunching it.
+- The daemon clears inherited `ELECTRON_EXEC_PATH`, `ELECTRON_CLI_ARGS`, and
+  `ELECTRON_MAJOR_VER` before launching. An agent hosted by another Pwr-family
+  Electron app can otherwise silently start this checkout through the host
+  app's Electron installation.
 - The script only targets the app instance whose recorded root hash matches the requested checkout, plus that instance's bounded `pnpm dev` / `electron-vite` parent chain.
 - Use `leases` when debugging which process owns the profile messaging lease.
 - If verification fails, inspect the last log lines printed by the script before retrying.

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs
@@ -48,6 +48,14 @@ function sqliteValue(value) {
   return String(value).replaceAll("'", "''");
 }
 
+function readonlyDbUri(dbPath) {
+  const encodedPath = dbPath
+    .replaceAll("%", "%25")
+    .replaceAll("?", "%3F")
+    .replaceAll("#", "%23");
+  return `file:${encodedPath}?mode=ro`;
+}
+
 function readStartedInstance(options, trackedInstanceId) {
   if (!fs.existsSync(options.stateDb)) return null;
   const candidatePids = trackedInstanceId ? [] : electronDescendantPids(Number(options.childPid));
@@ -56,7 +64,7 @@ function readStartedInstance(options, trackedInstanceId) {
     ? `instance_id = '${sqliteValue(trackedInstanceId)}'`
     : `profile_name = '${sqliteValue(options.profile)}' AND cwd_hash = '${sqliteValue(options.rootHash)}' AND heartbeat_at >= ${Number(options.startedAfter)} AND process_id IN (${candidatePids.join(",")}) AND exited_at IS NULL`;
   const sql = `SELECT instance_id, process_id, coalesce(exited_at, '') FROM app_runtime_instances WHERE ${selector} ORDER BY heartbeat_at DESC LIMIT 1;`;
-  const result = spawnSync("sqlite3", ["-readonly", "-separator", "\t", options.stateDb, sql], {
+  const result = spawnSync("sqlite3", ["-separator", "\t", readonlyDbUri(options.stateDb), sql], {
     encoding: "utf8",
   });
   if (result.status !== 0) return null;
@@ -115,14 +123,18 @@ async function run(options) {
   fs.writeFileSync(options.pidFile, `${process.pid}\n`);
 
   const out = fs.openSync(options.log, "a");
+  const childEnv = {
+    ...process.env,
+    PWRAGENT_PROFILE: options.profile,
+    [INSTANCE_ROOT_ENV]: options.root,
+  };
+  for (const key of ["ELECTRON_EXEC_PATH", "ELECTRON_CLI_ARGS", "ELECTRON_MAJOR_VER"]) {
+    delete childEnv[key];
+  }
   const child = spawn("/bin/zsh", ["-lc", "exec pnpm dev"], {
     cwd: options.root,
     detached: true,
-    env: {
-      ...process.env,
-      PWRAGENT_PROFILE: options.profile,
-      [INSTANCE_ROOT_ENV]: options.root,
-    },
+    env: childEnv,
     stdio: ["ignore", out, out],
   });
   options.childPid = child.pid;

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -301,20 +301,32 @@ electron_app_path_from_command() {
   print -r -- "$app_path"
 }
 
+single_electron_window_target() {
+  (( $# == 1 )) || return 1
+  print -r -- "$1"
+}
+
 describe_dev_window_target() {
-  local pid command app_path renderer_url
+  local pid command app_path renderer_url target
+  local -a candidates
 
   renderer_url="$(sed -n 's/.*locationHref=\([^ ]*\).*/\1/p' "$log_path" 2>/dev/null | tail -n 1)"
   for pid in $(matching_dev_pids); do
     command="$(process_command "$pid")"
     app_path="$(electron_app_path_from_command "$command" 2>/dev/null || true)"
     [[ -n "$app_path" ]] || continue
-    say "Computer Use target pid=$pid appPath=$app_path expectedWindowTitle=PwrAgnt rendererUrl=${renderer_url:-unknown}"
-    return 0
+    candidates+=("$pid"$'\t'"$app_path")
   done
 
-  say "could not resolve an unambiguous checkout-local Electron window target"
-  return 1
+  target="$(single_electron_window_target "${candidates[@]}" 2>/dev/null || true)"
+  if [[ -z "$target" ]]; then
+    say "could not resolve an unambiguous checkout-local Electron window target (${#candidates[@]} main-process candidates)"
+    return 1
+  fi
+
+  pid="${target%%$'\t'*}"
+  app_path="${target#*$'\t'}"
+  say "Computer Use target pid=$pid appPath=$app_path expectedWindowTitle=PwrAgnt rendererUrl=${renderer_url:-unknown}"
 }
 
 describe_root_instances() {
@@ -548,6 +560,9 @@ run_self_test() {
   [[ "$(readonly_state_db_uri)" == "file:/Users/example/Pwr Agent/state%23dev%3F.db?mode=ro" ]] || die "self-test failed: unexpected readonly state DB URI"
   [[ "$(electron_app_path_from_command "/Users/example/Pwr Agent/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron .")" == "/Users/example/Pwr Agent/node_modules/electron/dist/Electron.app" ]] || die "self-test failed: unexpected Electron app path"
   assert_failure "Electron helper is not a main app target" electron_app_path_from_command "/Users/example/Electron.app/Contents/MacOS/Electron --type=renderer"
+  [[ "$(single_electron_window_target $'101\t/Users/example/Electron.app')" == $'101\t/Users/example/Electron.app' ]] || die "self-test failed: unexpected single Electron target"
+  assert_failure "missing Electron main target is ambiguous" single_electron_window_target
+  assert_failure "multiple Electron main targets are ambiguous" single_electron_window_target $'101\t/Users/example/Electron.app' $'202\t/Users/example/Electron.app'
   [[ "$root_hash_value" == "c976f17804e892f9" ]] || die "self-test failed: unexpected root hash $root_hash_value"
 
   say "self-test passed"

--- a/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
+++ b/.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh
@@ -171,6 +171,13 @@ state_db_path() {
   print -r -- "${pwragent_home:A}/profiles/$profile/state/state.db"
 }
 
+readonly_state_db_uri() {
+  local value="${state_db//\%/%25}"
+  value="${value//\?/%3F}"
+  value="${value//\#/%23}"
+  print -r -- "file:$value?mode=ro"
+}
+
 launch_job_label() {
   print -r -- "local.pwragent.dev-profile.$profile.$root_hash_value"
 }
@@ -198,12 +205,12 @@ cleanup_exited_launch_job() {
 
 runtime_tables_ready() {
   [[ -f "$state_db" ]] || return 1
-  sqlite3 -readonly "$state_db" "SELECT cwd_hash FROM app_runtime_instances LIMIT 0;" >/dev/null 2>&1
+  sqlite3 "$(readonly_state_db_uri)" "SELECT cwd_hash FROM app_runtime_instances LIMIT 0;" >/dev/null 2>&1
 }
 
 query_root_instances() {
   runtime_tables_ready || return 1
-  sqlite3 -readonly -separator $'\t' "$state_db" \
+  sqlite3 -separator $'\t' "$(readonly_state_db_uri)" \
     "SELECT instance_id, process_id, coalesce(cwd_hint, ''), heartbeat_at,
             desired_messaging_enabled, effective_messaging_enabled,
             coalesce(disabled_reason, '')
@@ -216,7 +223,7 @@ query_root_instances() {
 
 query_profile_instances() {
   runtime_tables_ready || return 1
-  sqlite3 -readonly -separator $'\t' "$state_db" \
+  sqlite3 -separator $'\t' "$(readonly_state_db_uri)" \
     "SELECT instance_id, process_id, coalesce(cwd_hint, ''), coalesce(cwd_hash, ''),
             heartbeat_at, desired_messaging_enabled, effective_messaging_enabled,
             coalesce(disabled_reason, ''), coalesce(exited_at, '')
@@ -228,7 +235,7 @@ query_profile_instances() {
 
 query_active_lease() {
   runtime_tables_ready || return 1
-  sqlite3 -readonly -separator $'\t' "$state_db" \
+  sqlite3 -separator $'\t' "$(readonly_state_db_uri)" \
     "SELECT l.owner_instance_id, l.heartbeat_at, l.expires_at,
             coalesce(i.process_id, ''), coalesce(i.cwd_hint, ''),
             coalesce(i.cwd_hash, ''), coalesce(i.effective_messaging_enabled, 0)
@@ -281,6 +288,33 @@ describe_matching_processes() {
   for pid in $(matching_dev_pids); do
     ps -p "$pid" -o pid=,ppid=,command= 2>/dev/null || true
   done
+}
+
+electron_app_path_from_command() {
+  local command="$1"
+  local app_path
+
+  [[ "$command" == *"/Electron.app/Contents/MacOS/Electron"* ]] || return 1
+  [[ "$command" != *" --type="* ]] || return 1
+  app_path="${command%%/Contents/MacOS/Electron*}"
+  [[ "$app_path" == *"/Electron.app" ]] || return 1
+  print -r -- "$app_path"
+}
+
+describe_dev_window_target() {
+  local pid command app_path renderer_url
+
+  renderer_url="$(sed -n 's/.*locationHref=\([^ ]*\).*/\1/p' "$log_path" 2>/dev/null | tail -n 1)"
+  for pid in $(matching_dev_pids); do
+    command="$(process_command "$pid")"
+    app_path="$(electron_app_path_from_command "$command" 2>/dev/null || true)"
+    [[ -n "$app_path" ]] || continue
+    say "Computer Use target pid=$pid appPath=$app_path expectedWindowTitle=PwrAgnt rendererUrl=${renderer_url:-unknown}"
+    return 0
+  done
+
+  say "could not resolve an unambiguous checkout-local Electron window target"
+  return 1
 }
 
 describe_root_instances() {
@@ -339,6 +373,7 @@ write_status() {
   say "$profile profile app instances for $root:"
   describe_root_instances
   describe_active_lease || true
+  describe_dev_window_target || true
 
   processes="$(describe_matching_processes)"
   if [[ -n "$processes" ]]; then
@@ -438,6 +473,7 @@ verify_app() {
       say "log: $log_path"
       describe_root_instances
       describe_active_lease || true
+      describe_dev_window_target || true
       return 0
     fi
 
@@ -508,6 +544,10 @@ run_self_test() {
   assert_success "root env-style assignment" command_mentions_root "PWD=/Users/example/PwrAgnt"
   assert_failure "sibling checkout prefix" command_mentions_root "/Users/example/PwrAgnt-old/apps/desktop"
   assert_failure "sibling checkout suffix" command_mentions_root "/Users/example/PwrAgnt2/apps/desktop"
+  state_db="/Users/example/Pwr Agent/state#dev?.db"
+  [[ "$(readonly_state_db_uri)" == "file:/Users/example/Pwr Agent/state%23dev%3F.db?mode=ro" ]] || die "self-test failed: unexpected readonly state DB URI"
+  [[ "$(electron_app_path_from_command "/Users/example/Pwr Agent/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron .")" == "/Users/example/Pwr Agent/node_modules/electron/dist/Electron.app" ]] || die "self-test failed: unexpected Electron app path"
+  assert_failure "Electron helper is not a main app target" electron_app_path_from_command "/Users/example/Electron.app/Contents/MacOS/Electron --type=renderer"
   [[ "$root_hash_value" == "c976f17804e892f9" ]] || die "self-test failed: unexpected root hash $root_hash_value"
 
   say "self-test passed"

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -98,9 +98,22 @@ pnpm dev
 ### Targeting an Existing Electron App
 
 - Confirm the intended checkout/profile with the dev-profile skill before
-  driving a window. With Computer Use, select an entry that is already running
-  (use the exact id returned by app discovery when multiple Electron instances
-  exist); do not use app lookup as an implicit launcher.
+  driving a window. Dev builds run as the generic `Electron` process and share
+  the `com.github.Electron` bundle id with every other unsigned Electron app.
+  **Never target either generic identity.** Do not target the installed
+  `com.pwrdrvr.pwragent` bundle either: it is a packaged build and does not
+  contain the checkout's code.
+- Launch or inspect with the project-local dev-profile skill. Its successful
+  `status` / `restart` / `verify` output includes a `Computer Use target` line
+  with the checkout-local Electron main PID, exact `Electron.app` path,
+  expected native window title (`PwrAgnt`), and renderer URL/port. For Computer
+  Use, target that exact app path, then confirm the returned window title and
+  AX URL match before clicking anything. The title alone is not unique when
+  another PwrAgent checkout is open; the port alone is not enough without the
+  checkout-local executable and `--app-path` process evidence.
+- If the target cannot be resolved unambiguously, stop instead of guessing.
+  An ambiguous lookup can raise or operate a sibling Pwr app, another checkout,
+  or an unrelated project's broken default Electron window.
 - With a Codex browser/Electron controller, select and reuse the existing
   PwrAgent Electron target and its window/page binding. With persistent
   `node_repl` Playwright, reuse the existing `electronApp` and `appWindow`

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1106,6 +1106,16 @@ function DesktopAppShell(props: {
   // Window-level masthead actions (Automations / Settings / New Thread).
   // Shared by the sidebar masthead's home (AppTitleBar on Windows) and the
   // thread-header relocation when the sidebar is hidden on macOS/Linux.
+  const addProjectDirectory = async (): Promise<void> => {
+    setMainView("thread");
+    // The hidden-sidebar masthead is the only visible home for this action in
+    // that layout. Restore the sidebar before opening the picker so either the
+    // newly registered directory or a validation error has a visible result.
+    if (sidebarHidden) {
+      setSidebarHiddenPersisted(false);
+    }
+    await navigation.addProjectDirectory();
+  };
   const mastheadActions = {
     addingProjectDirectory: navigation.pickingDirectory,
     automationsActive: mainView === "automations",
@@ -1115,10 +1125,7 @@ function DesktopAppShell(props: {
     newThreadDirectoryLabel: navigation.newThreadDirectoryLabel,
     onAddProjectDirectory: readRendererFederationTarget()
       ? undefined
-      : async () => {
-          setMainView("thread");
-          await navigation.addProjectDirectory();
-        },
+      : addProjectDirectory,
     onOpenAutomations: () => {
       setMainView("automations");
     },
@@ -1535,10 +1542,7 @@ function DesktopAppShell(props: {
           }}
           onAddProjectDirectory={readRendererFederationTarget()
             ? undefined
-            : async () => {
-                setMainView("thread");
-                await navigation.addProjectDirectory();
-              }}
+            : addProjectDirectory}
           onCreateSubthread={async (thread, mode) => {
             setMainView("thread");
             await navigation.createSubthread(thread, mode);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1107,11 +1107,18 @@ function DesktopAppShell(props: {
   // Shared by the sidebar masthead's home (AppTitleBar on Windows) and the
   // thread-header relocation when the sidebar is hidden on macOS/Linux.
   const mastheadActions = {
+    addingProjectDirectory: navigation.pickingDirectory,
     automationsActive: mainView === "automations",
     settingsActive: mainView === "settings",
     threadSearchActive: mainView === "search",
     creatingThread: Boolean(navigation.creatingThread),
     newThreadDirectoryLabel: navigation.newThreadDirectoryLabel,
+    onAddProjectDirectory: readRendererFederationTarget()
+      ? undefined
+      : async () => {
+          setMainView("thread");
+          await navigation.addProjectDirectory();
+        },
     onOpenAutomations: () => {
       setMainView("automations");
     },
@@ -1484,9 +1491,11 @@ function DesktopAppShell(props: {
         style={{ "--sidebar-width": `${sidebarWidthRef.current}px` } as CSSProperties}
       >
         <Sidebar
+          addingProjectDirectory={navigation.pickingDirectory}
           backends={backendSummaries.backends}
           browseMode={navigation.browseMode}
           createThreadError={navigation.createThreadError}
+          pickDirectoryError={navigation.pickDirectoryError}
           creatingThread={navigation.creatingThread}
           directories={navigation.directories}
           error={navigation.error}
@@ -1524,6 +1533,12 @@ function DesktopAppShell(props: {
               forceWorkspace: true,
             });
           }}
+          onAddProjectDirectory={readRendererFederationTarget()
+            ? undefined
+            : async () => {
+                setMainView("thread");
+                await navigation.addProjectDirectory();
+              }}
           onCreateSubthread={async (thread, mode) => {
             setMainView("thread");
             await navigation.createSubthread(thread, mode);

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -286,6 +286,96 @@ describe("App", () => {
     expect(gitSettingsButton).toHaveAttribute("aria-current", "page");
   });
 
+  it("reveals the sidebar when adding a project from the hidden-sidebar masthead", async () => {
+    const pickDirectoryFromDisk = vi.fn(async () => ({
+      canceled: false as const,
+      path: "/Users/me/repos/PwrAgent",
+    }));
+    const registerDirectoryFromDisk = vi.fn(async () => ({
+      ok: true as const,
+      directoryPath: "/Users/me/repos/PwrAgent",
+      directoryKey: "directory:/Users/me/repos/PwrAgent",
+      directoryLabel: "PwrAgent",
+      currentBranch: "main",
+      launchpad: {
+        directoryKey: "directory:/Users/me/repos/PwrAgent",
+        directoryKind: "directory" as const,
+        directoryLabel: "PwrAgent",
+        directoryPath: "/Users/me/repos/PwrAgent",
+        backend: "codex" as const,
+        executionMode: "default" as const,
+        prompt: "",
+        workMode: "local" as const,
+        createdAt: 1,
+        updatedAt: 1,
+        registeredAt: 1,
+      },
+      defaults: {
+        backend: "codex" as const,
+        executionMode: "default" as const,
+      },
+    }));
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: [],
+          threads: [],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        pickDirectoryFromDisk,
+        registerDirectoryFromDisk,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    const { container } = render(<App />);
+    await clickButton("Hide sidebar");
+
+    const shell = container.querySelector(".app-shell");
+    expect(shell).toHaveAttribute("data-sidebar-hidden", "true");
+
+    const relocatedMasthead = await waitFor(() => {
+      const masthead = container.querySelector<HTMLElement>(
+        ".thread-header__masthead",
+      );
+      expect(masthead).not.toBeNull();
+      return masthead!;
+    });
+    fireEvent.mouseEnter(
+      within(relocatedMasthead).getByRole("button", { name: "New thread" }),
+    );
+    fireEvent.click(
+      await within(relocatedMasthead).findByRole("menuitem", {
+        name: "Add a Project Directory…",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(pickDirectoryFromDisk).toHaveBeenCalledTimes(1);
+      expect(registerDirectoryFromDisk).toHaveBeenCalledTimes(1);
+      expect(shell).not.toHaveAttribute("data-sidebar-hidden");
+    });
+    expect(
+      within(screen.getByRole("complementary", { name: "Threads" })).getByText(
+        "PwrAgent",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("surfaces Codex config warnings and can trust the indicated project", async () => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
     const trustCodexProject = vi.fn(

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -3,6 +3,7 @@ import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { AppMenuBar } from "./AppMenuBar";
+import { NewThreadButton } from "./NewThreadButton";
 import { PanelToggleButtons } from "./PanelToggleButtons";
 
 export type AppTitleBarLayoutControls = {
@@ -33,12 +34,16 @@ export function AppTitleBar(props: {
   onOpenMessagingSettings?: () => void;
   layout?: AppTitleBarLayoutControls;
   actions?: {
+    addingProjectDirectory?: boolean;
     automationsActive: boolean;
+    newThreadDirectoryLabel?: string;
     settingsActive: boolean;
     creatingThread: boolean;
+    onAddProjectDirectory?: () => void | Promise<void>;
     onOpenAutomations: () => void;
     onOpenSettings: () => void;
     onCreateThread: () => void | Promise<void>;
+    onCreateThreadWithoutDirectory?: () => void | Promise<void>;
   };
 }): ReactElement | null {
   const isWindows = getDesktopApi()?.platform === "win32";
@@ -79,17 +84,16 @@ export function AppTitleBar(props: {
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
             </button>
             )}
-            <button
-              type="button"
-              aria-label="New thread"
-              className="sidebar__icon-button"
-              disabled={actions.creatingThread}
-              onClick={() => {
-                void actions.onCreateThread();
-              }}
-            >
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
-            </button>
+            <NewThreadButton
+              addingProjectDirectory={actions.addingProjectDirectory}
+              creatingThread={actions.creatingThread}
+              directoryLabel={actions.newThreadDirectoryLabel}
+              onAddProjectDirectory={actions.onAddProjectDirectory}
+              onCreateThread={actions.onCreateThread}
+              onCreateThreadWithoutDirectory={
+                actions.onCreateThreadWithoutDirectory
+              }
+            />
           </div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -10,12 +10,14 @@ import { NewThreadButton } from "./NewThreadButton";
  * styling so every placement reads identically.
  */
 export type MastheadActionsProps = {
+  addingProjectDirectory?: boolean;
   automationsActive?: boolean;
   settingsActive?: boolean;
   threadSearchActive?: boolean;
   creatingThread?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
   newThreadDirectoryLabel?: string;
+  onAddProjectDirectory?: () => void | Promise<void>;
   onOpenAutomations?: () => void;
   onOpenSettings?: () => void;
   onToggleThreadSearch?: () => void;
@@ -56,8 +58,10 @@ export function MastheadActions(props: MastheadActionsProps): ReactElement {
         <SettingsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
       </button>
       <NewThreadButton
+        addingProjectDirectory={props.addingProjectDirectory}
         creatingThread={props.creatingThread}
         directoryLabel={props.newThreadDirectoryLabel}
+        onAddProjectDirectory={props.onAddProjectDirectory}
         onCreateThread={() => props.onCreateThread?.()}
         onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
       />

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -13,27 +13,29 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
  *
  * Clicking the button keeps its original behavior: start a new thread in the
  * directory the navigation context resolves to (`onCreateThread`). Hovering or
- * focusing the button reveals a flyout that makes the two outcomes explicit:
+ * focusing the button reveals a flyout that makes the available outcomes
+ * explicit:
  *
  *   1. New chat in <directory>     → `onCreateThread` (context default)
  *   2. New chat without a directory → `onCreateThreadWithoutDirectory`
+ *   3. Add a Project Directory…     → track a repo without starting a chat
  *
- * The flyout only renders when there's a directory to contrast against the
- * workspace choice (`directoryLabel` set) and a directory-less handler exists.
- * When the context already resolves to the directory-less workspace, the two
- * items would be identical, so the button falls back to a plain "New thread"
- * tooltip — matching the hover affordance of its masthead siblings.
+ * The flyout renders when there's either a meaningful directory choice or an
+ * explicit project-registration action. That keeps "Add a Project Directory…"
+ * reachable even when the current context is already directory-less.
  *
  * Shared by the sidebar masthead and the relocated thread-header / Windows
  * title-bar placements so every surface reads identically.
  */
 export type NewThreadButtonProps = {
+  addingProjectDirectory?: boolean;
   creatingThread?: boolean;
   /**
    * Label of the directory the default action resolves to, or undefined when
    * that's the directory-less workspace (no meaningful flyout to show).
    */
   directoryLabel?: string;
+  onAddProjectDirectory?: () => void | Promise<void>;
   onCreateThread: () => void | Promise<void>;
   onCreateThreadWithoutDirectory?: () => void | Promise<void>;
 };
@@ -45,9 +47,10 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
   const menuId = useId();
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
 
-  const hasFlyout = Boolean(
+  const hasDirectoryChoice = Boolean(
     props.directoryLabel && props.onCreateThreadWithoutDirectory,
   );
+  const hasFlyout = hasDirectoryChoice || Boolean(props.onAddProjectDirectory);
   const menuOpen = open && hasFlyout && !props.creatingThread;
 
   // With no flyout to reveal, keep a plain "New thread" tooltip so the button
@@ -135,28 +138,63 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
             role="menu"
             aria-label="New thread options"
           >
-            <button
-              type="button"
-              role="menuitem"
-              className="new-thread-menu__item"
-              onClick={() => {
-                setOpen(false);
-                void props.onCreateThread();
-              }}
-            >
-              New chat in {props.directoryLabel}
-            </button>
-            <button
-              type="button"
-              role="menuitem"
-              className="new-thread-menu__item"
-              onClick={() => {
-                setOpen(false);
-                void props.onCreateThreadWithoutDirectory?.();
-              }}
-            >
-              New chat without a directory
-            </button>
+            {hasDirectoryChoice ? (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="new-thread-menu__item"
+                  onClick={() => {
+                    setOpen(false);
+                    void props.onCreateThread();
+                  }}
+                >
+                  New chat in {props.directoryLabel}
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="new-thread-menu__item"
+                  onClick={() => {
+                    setOpen(false);
+                    void props.onCreateThreadWithoutDirectory?.();
+                  }}
+                >
+                  New chat without a directory
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                role="menuitem"
+                className="new-thread-menu__item"
+                onClick={() => {
+                  setOpen(false);
+                  void props.onCreateThread();
+                }}
+              >
+                New chat without a directory
+              </button>
+            )}
+            {props.onAddProjectDirectory ? (
+              <>
+                <div className="new-thread-menu__separator" role="separator" />
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="new-thread-menu__item"
+                  disabled={props.addingProjectDirectory}
+                  onClick={() => {
+                    setOpen(false);
+                    void props.onAddProjectDirectory?.();
+                  }}
+                >
+                  {props.addingProjectDirectory
+                    ? "Adding Project Directory…"
+                    : "Add a Project Directory…"}
+                </button>
+              </>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -56,6 +56,32 @@ describe("NewThreadButton", () => {
     expect(onCreateThread).not.toHaveBeenCalled();
   });
 
+  it("offers project registration without starting or selecting a chat", async () => {
+    const onAddProjectDirectory = vi.fn();
+    const onCreateThread = vi.fn();
+    render(
+      <NewThreadButton
+        onAddProjectDirectory={onAddProjectDirectory}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "New thread" });
+    fireEvent.mouseEnter(button.parentElement as HTMLElement);
+
+    expect(
+      await screen.findByRole("menuitem", {
+        name: "New chat without a directory",
+      }),
+    ).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Add a Project Directory…" }),
+    );
+
+    expect(onAddProjectDirectory).toHaveBeenCalledTimes(1);
+    expect(onCreateThread).not.toHaveBeenCalled();
+  });
+
   it("closes the flyout on Escape while a menu item is focused (regression)", async () => {
     render(
       <NewThreadButton

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -73,6 +73,7 @@ type SidebarProps = {
   backends: BackendSummary[];
   browseMode: BrowseMode;
   createThreadError?: string;
+  pickDirectoryError?: string;
   directories: NavigationDirectorySummary[];
   error?: string;
   inboxThreads?: NavigationThreadSummary[];
@@ -111,6 +112,8 @@ type SidebarProps = {
   onBrowseModeChange: (browseMode: BrowseMode) => void;
   onCreateThread: () => Promise<void>;
   onCreateThreadWithoutDirectory?: () => Promise<void>;
+  onAddProjectDirectory?: () => Promise<void>;
+  addingProjectDirectory?: boolean;
   /** Directory the default New Thread action resolves to (flyout label). */
   newThreadDirectoryLabel?: string;
   onCreateSubthread?: (
@@ -1396,8 +1399,10 @@ export function Sidebar(props: SidebarProps) {
           </MastheadActionButton>
           )}
           <NewThreadButton
+            addingProjectDirectory={props.addingProjectDirectory}
             creatingThread={Boolean(props.creatingThread)}
             directoryLabel={props.newThreadDirectoryLabel}
+            onAddProjectDirectory={props.onAddProjectDirectory}
             onCreateThread={() => props.onCreateThread()}
             onCreateThreadWithoutDirectory={props.onCreateThreadWithoutDirectory}
           />
@@ -1477,6 +1482,8 @@ export function Sidebar(props: SidebarProps) {
 
       {props.createThreadError ? (
         <p className="sidebar-error sidebar-error--masthead">{props.createThreadError}</p>
+      ) : props.pickDirectoryError ? (
+        <p className="sidebar-error sidebar-error--masthead">{props.pickDirectoryError}</p>
       ) : props.launchpadError ? (
         <p className="sidebar-error sidebar-error--masthead">{props.launchpadError}</p>
       ) : props.archiveThreadError ? (

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -796,6 +796,7 @@ describe("Sidebar", () => {
   });
 
   it("reveals the New Thread flyout on hover when a directory is in context", async () => {
+    const onAddProjectDirectory = vi.fn(async () => undefined);
     const onCreateThread = vi.fn(async () => undefined);
     const onCreateThreadWithoutDirectory = vi.fn(async () => undefined);
 
@@ -812,6 +813,7 @@ describe("Sidebar", () => {
         newThreadDirectoryLabel="PwrAgnt"
         selectedItemKey="codex:thread-1"
         threads={[sharedThread]}
+        onAddProjectDirectory={onAddProjectDirectory}
         onBrowseModeChange={() => undefined}
         onCreateThread={onCreateThread}
         onCreateThreadWithoutDirectory={onCreateThreadWithoutDirectory}
@@ -839,6 +841,14 @@ describe("Sidebar", () => {
       await screen.findByRole("menuitem", { name: "New chat in PwrAgnt" })
     );
     expect(onCreateThread).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseEnter(newThreadButton.parentElement as HTMLElement);
+    fireEvent.click(
+      await screen.findByRole("menuitem", {
+        name: "Add a Project Directory…",
+      }),
+    );
+    expect(onAddProjectDirectory).toHaveBeenCalledTimes(1);
   });
 
   it("groups sub-threads under their parent and persists collapse clicks", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -8703,6 +8703,47 @@ describe("useThreadNavigation", () => {
       expect(result.current.pickingDirectory).toBe(false);
     });
 
+    it("addProjectDirectory tracks an empty repo and reveals the Directories lens", async () => {
+      const launchpad = buildPickedLaunchpad({ registeredAt: 1_500 });
+      const desktopApi = buildBaseDesktopApi({
+        pickDirectoryFromDisk: vi.fn(async () => ({
+          canceled: false as const,
+          path: "/Users/me/repos/PwrAgent",
+        })),
+        registerDirectoryFromDisk: vi.fn(async () => ({
+          ok: true as const,
+          directoryPath: "/Users/me/repos/PwrAgent",
+          directoryKey: launchpad.directoryKey,
+          directoryLabel: "PwrAgent",
+          currentBranch: "main",
+          launchpad,
+          defaults: launchpadDefaults,
+        })),
+      });
+
+      const { result } = renderHook(() => useThreadNavigation(desktopApi));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        await result.current.addProjectDirectory();
+      });
+
+      expect(result.current.browseMode).toBe("directories");
+      expect(result.current.selectedItemKey).toBeUndefined();
+      expect(result.current.directories).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: launchpad.directoryKey,
+            label: "PwrAgent",
+            threadKeys: [],
+            launchpad: expect.objectContaining({
+              registeredAt: launchpad.registeredAt,
+            }),
+          }),
+        ]),
+      );
+    });
+
     it("pickDirectoryForReference surfaces validation failures and resolves undefined", async () => {
       const pickDirectoryFromDisk = vi.fn(async () => ({
         canceled: false as const,

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2407,6 +2407,8 @@ export function useThreadNavigation(
   pickAndRegisterDirectory: (
     preferredBackend?: AppServerBackendKind,
   ) => Promise<void>;
+  /** Register a user-curated project, keep the current selection, and reveal the Directories lens. */
+  addProjectDirectory: () => Promise<void>;
   /** Existing-thread picker: OS dialog -> validate -> attach as an extra linked directory. */
   pickAndAttachDirectoryToSelectedThread: () => Promise<void>;
   /**
@@ -4930,6 +4932,13 @@ export function useThreadNavigation(
     }
   }, [desktopApi]);
 
+  const addProjectDirectory = useCallback(async (): Promise<void> => {
+    const picked = await pickDirectoryForReference();
+    if (picked) {
+      updateBrowseMode("directories");
+    }
+  }, [pickDirectoryForReference, updateBrowseMode]);
+
   const pickAndAttachDirectoryToSelectedThread = useCallback(async (): Promise<void> => {
     if (
       !desktopApi?.pickDirectoryFromDisk ||
@@ -6510,6 +6519,7 @@ export function useThreadNavigation(
     openDirectoryLaunchpad,
     openWorkspaceLaunchpad,
     pickAndRegisterDirectory,
+    addProjectDirectory,
     pickAndAttachDirectoryToSelectedThread,
     pickDirectoryForReference,
     attachDirectoryPathsToThread,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -615,6 +615,17 @@ textarea,
   outline: none;
 }
 
+.new-thread-menu__item:disabled {
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.new-thread-menu__separator {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--border-subtle);
+}
+
 /* macOS floats the traffic lights over the cluster's left. Match the sidebar
    masthead's wordmark offset exactly — its 16px sidebar gutter + 80px
    stoplight reservation — so the wordmark sits in the same spot whether the


### PR DESCRIPTION
## Summary

- add an “Add a Project Directory…” action to the shared new-thread flyout across sidebar, relocated masthead, and Windows title-bar chrome
- persist explicitly added repositories through the existing registered launchpad marker so empty projects remain visible without reintroducing incidental directories
- make newly added projects immediately available to the composer `@` picker and reveal them in the Directories lens
- harden dev-profile Electron targeting with checkout-local PID/app-path/renderer URL output and persist the targeting guidance

## Why

Users need to curate a project into PwrAgent before it has child threads so another thread can `@` mention its path for handoff work. Codex’s trusted-project list is permission state and can contain incidental repositories, so PwrAgent’s explicit `registeredAt` marker remains the user-curated source of truth.

During visual verification, the dev-profile helper also exposed two targeting gaps: macOS’s bundled SQLite CLI does not support `-readonly`, and generic Electron identities can select sibling apps. The launcher now uses a read-only SQLite URI, clears inherited sibling Electron overrides, and emits an unambiguous Computer Use target.

## Validation

- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:colors`
- `pnpm lint:boundaries`
- `pnpm test apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` (206 tests)
- `.agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile.zsh self-test`
- `node --check .agents/skills/pwragent-dev-profile/scripts/pwragent-dev-profile-daemon.mjs`
- manual Electron QA: exact checkout-local dev target, menu visual state, and native directory picker open/cancel flow
