### PR TITLE
build(desktop): migrate electron-vite externalization

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import { defineConfig } from "electron-vite";
 
 // electron-vite defaults `build.minify` to false for all three targets.
 // For shipped builds we want minified main/preload/renderer with sourcemaps
@@ -20,8 +20,8 @@ export default defineConfig(({ command }) => {
   return {
     main: {
       define: productionDefine,
-      plugins: [
-        externalizeDepsPlugin({
+      build: {
+        externalizeDeps: {
           exclude: [
             "@pwragent/shared",
             "@pwrdrvr/codex-app-server-protocol",
@@ -40,9 +40,7 @@ export default defineConfig(({ command }) => {
             // to an ESM default import whose constructor has no .WebSocket.
             "ws",
           ]
-        })
-      ],
-      build: {
+        },
         commonjsOptions: {
           transformMixedEsModules: true
         },
@@ -62,6 +60,9 @@ export default defineConfig(({ command }) => {
     preload: {
       define: productionDefine,
       build: {
+        externalizeDeps: {
+          exclude: ["@pwragent/shared"]
+        },
         minify: "esbuild",
         sourcemap: false,
         rollupOptions: {
@@ -69,12 +70,7 @@ export default defineConfig(({ command }) => {
             format: "cjs"
           }
         }
-      },
-      plugins: [
-        externalizeDepsPlugin({
-          exclude: ["@pwragent/shared"]
-        })
-      ]
+      }
     },
     renderer: {
       plugins: [react()],

--- a/apps/desktop/scripts/check-main-bundle-boundary.mjs
+++ b/apps/desktop/scripts/check-main-bundle-boundary.mjs
@@ -28,7 +28,12 @@ const forbidden = [
   },
   {
     label: "externalized ws runtime import",
-    pattern: /\bfrom\s+["']ws["']/,
+    pattern: /\b(?:from\s+|import\(|require\()["']ws["']/,
+  },
+  {
+    label: "externalized workspace bundled-dependency import",
+    pattern:
+      /\b(?:from\s+|import\(|require\()["']@pwragent\/(?:shared|messaging-interface|messaging-provider-[^/"']+)["']/,
   },
 ];
 const violations = [];
@@ -54,5 +59,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `main bundle boundary: OK (${javascriptFiles.length} files, no AI SDK/xAI runtime or external ws imports)`,
+  `main bundle boundary: OK (${javascriptFiles.length} files, no AI SDK/xAI runtime or external bundled-dependency imports)`,
 );

--- a/apps/desktop/scripts/electron-vite-config.test.mjs
+++ b/apps/desktop/scripts/electron-vite-config.test.mjs
@@ -1,0 +1,96 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfigFromFile } from "electron-vite";
+import { describe, expect, it } from "vitest";
+
+const desktopRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const configPath = resolve(desktopRoot, "electron.vite.config.ts");
+const packageJson = JSON.parse(
+  await readFile(resolve(desktopRoot, "package.json"), "utf8"),
+);
+const dependencies = Object.keys(packageJson.dependencies);
+const workspaceMessagingPackages = dependencies.filter(
+  (name) =>
+    name === "@pwragent/messaging-interface"
+    || name.startsWith("@pwragent/messaging-provider-"),
+);
+
+async function loadDesktopConfig(command) {
+  const result = await loadConfigFromFile(
+    {
+      command,
+      mode: command === "build" ? "production" : "development",
+    },
+    configPath,
+    desktopRoot,
+  );
+  return result.config;
+}
+
+describe("electron-vite dependency policy", () => {
+  it.each(["build", "serve"])(
+    "uses supported config-driven externalization for %s",
+    async (command) => {
+      const config = await loadDesktopConfig(command);
+      const mainPlugins = config.main?.plugins ?? [];
+      const preloadPlugins = config.preload?.plugins ?? [];
+
+      expect(config.main?.build?.externalizeDeps).toBeTypeOf("object");
+      expect(config.preload?.build?.externalizeDeps).toBeTypeOf("object");
+      expect(mainPlugins).not.toContainEqual(
+        expect.objectContaining({ name: "vite:externalize-deps" }),
+      );
+      expect(preloadPlugins).not.toContainEqual(
+        expect.objectContaining({ name: "vite:externalize-deps" }),
+      );
+    },
+  );
+
+  it("bundles ws and every workspace messaging package in main", async () => {
+    const config = await loadDesktopConfig("build");
+    const excluded = config.main.build.externalizeDeps.exclude;
+
+    expect(excluded).toEqual(expect.arrayContaining([
+      "@pwragent/shared",
+      ...workspaceMessagingPackages,
+      "ws",
+    ]));
+  });
+
+  it("keeps runtime and optional native dependencies external", async () => {
+    const config = await loadDesktopConfig("build");
+    const excluded = config.main.build.externalizeDeps.exclude;
+    const explicitExternal = config.main.build.rollupOptions.external;
+    const nativeRuntimeDependencies = [
+      "@napi-rs/canvas",
+      "better-sqlite3",
+      "node-pty",
+    ];
+
+    expect(dependencies).toEqual(
+      expect.arrayContaining(nativeRuntimeDependencies),
+    );
+    for (const dependency of nativeRuntimeDependencies) {
+      expect(excluded).not.toContain(dependency);
+    }
+    expect(explicitExternal).toEqual([
+      "abort-controller",
+      "bufferutil",
+      "node-fetch",
+      "utf-8-validate",
+      "zlib-sync",
+    ]);
+  });
+
+  it("bundles only shared code into preload", async () => {
+    const config = await loadDesktopConfig("build");
+
+    expect(config.preload.build.externalizeDeps.exclude).toEqual([
+      "@pwragent/shared",
+    ]);
+  });
+});

--- a/docs/messaging-adding-a-provider.md
+++ b/docs/messaging-adding-a-provider.md
@@ -505,7 +505,7 @@ The existing pattern rules use `^packages/messaging/providers/`, so they cover y
 ### 8.4 — `electron.vite.config.ts` (mandatory — easy to miss)
 
 The desktop main process is bundled by `electron-vite`. Workspace packages
-have to be listed in the `externalizeDepsPlugin.exclude` array to be
+have to be listed in the `build.externalizeDeps.exclude` array to be
 **bundled into** the main process rather than treated as external ESM
 imports at runtime. **If you skip this step, the dynamic
 `import("@pwragent/messaging-provider-<channel>")` from the provider
@@ -522,16 +522,18 @@ in your provider's bundling. Edit
 `apps/desktop/electron.vite.config.ts`:
 
 ```diff
- externalizeDepsPlugin({
-   exclude: [
-     "@pwragent/shared",
-     "@pwrdrvr/codex-app-server-protocol",
-     "@pwragent/messaging-interface",
-     "@pwragent/messaging-provider-discord",
-+    "@pwragent/messaging-provider-<channel>",
-     "@pwragent/messaging-provider-telegram"
-   ]
- })
+ build: {
+   externalizeDeps: {
+     exclude: [
+       "@pwragent/shared",
+       "@pwrdrvr/codex-app-server-protocol",
+       "@pwragent/messaging-interface",
+       "@pwragent/messaging-provider-discord",
++      "@pwragent/messaging-provider-<channel>",
+       "@pwragent/messaging-provider-telegram"
+     ]
+   }
+ }
 ```
 
 This list looks duplicative with the workspace dependency declaration in
@@ -694,7 +696,7 @@ If your platform's SDK is Node-first (Telegram's `grammy`, Discord's
 
 ### `electron-vite` workspace bundling list (silent runtime failure)
 The desktop main process bundles workspace packages explicitly via
-`apps/desktop/electron.vite.config.ts`'s `externalizeDepsPlugin.exclude`
+`apps/desktop/electron.vite.config.ts`'s `build.externalizeDeps.exclude`
 array. Forgetting to add your new provider there typecheks clean, lints
 clean, tests clean — but at runtime the dynamic provider import fails
 with `ERR_MODULE_NOT_FOUND` pointing at `@pwragent/shared`'s internals.
@@ -786,7 +788,7 @@ Captured at the end of Phase 10 of [plan 2026-05-06-001](plans/2026-05-06-001-fe
 
 **What was missing:**
 
-- **`electron.vite.config.ts` workspace bundling list (Step 8.4).** The original guide had a four-touch wiring step (provider-loader, messaging-config, package.json, test mocks) but omitted the *fifth* required edit: adding the new provider to the desktop's electron-vite `externalizeDepsPlugin.exclude` array. Without it, typecheck and tests pass but the runtime dynamic import fails with a `ERR_MODULE_NOT_FOUND` error that misleadingly points at `@pwragent/shared` internals rather than the missing bundling config. This was the single most consequential gap in the guide — it shipped silently into the first runtime test. Now spelled out as Step 8.4 with the exact diff and the misleading error message preserved as a search-anchor.
+- **`electron.vite.config.ts` workspace bundling list (Step 8.4).** The original guide had a four-touch wiring step (provider-loader, messaging-config, package.json, test mocks) but omitted the *fifth* required edit: adding the new provider to the desktop's electron-vite `build.externalizeDeps.exclude` array. Without it, typecheck and tests pass but the runtime dynamic import fails with a `ERR_MODULE_NOT_FOUND` error that misleadingly points at `@pwragent/shared` internals rather than the missing bundling config. This was the single most consequential gap in the guide — it shipped silently into the first runtime test. Now spelled out as Step 8.4 with the exact diff and the misleading error message preserved as a search-anchor.
 - **The capability profile workshop didn't acknowledge documentation gaps.** Mattermost's docs are explicitly silent on `actions.maxActions`, `actions.maxLabelLength`, and `actions.maxCallbackPayloadBytes` per attachment. The guide now suggests `// ASSUMED — docs silent` annotations; previously it implied every value comes from a citable doc page.
 - **Step 5 (rendering) and Step 3 (adapter shape) are not strictly sequential.** In practice you bounce: write the constructor + `start`/`stop` → call into the formatting module → discover an intent's shape needs a new helper → back-fill `deliver()` for the next intent kind. The guide should expect the bounce.
 - **Slash commands are out-of-scope for v1.** Mattermost supports them, but they require *another* HTTP endpoint (separate from the interactive callback URL). The guide implies adapters take all-or-nothing on commands; in practice text-mention parsing or a `/<cmd>` prefix detection on the `posted` text covers most needs in v1.


### PR DESCRIPTION
## Summary

- replace the deprecated `externalizeDepsPlugin(...)` configuration with electron-vite 5's supported `build.externalizeDeps` API for main and preload
- preserve the exact main-process bundling exclusions, including `ws` and every workspace messaging provider, while keeping runtime/native dependencies external
- extend the postbuild gate to reject external workspace package imports as well as external `ws` imports
- add focused build/serve policy coverage and update the contributor guide

## Context

The pinned `electron-vite@5.0.0` types deprecate `externalizeDepsPlugin` in favor of `build.externalizeDeps`. Its local implementation routes the config field back through the same plugin function, so this is a configuration-only migration with no dependency upgrade.

This PR **depends on #1207**. It deliberately retains #1207's `ws` exclusion and postbuild regression gate so `@slack/socket-mode` keeps the CommonJS `require("ws").WebSocket` semantics it needs. **After #1207 merges, retarget this PR to `main`.**

No Slack adapter behavior or desktop messaging error-toast behavior changes.

## Validation

- `pnpm test apps/desktop/scripts/electron-vite-config.test.mjs`
- `pnpm --filter @pwragent/desktop build` (including postbuild boundary gate)
- pre/post migration SHA-256 comparison: every main and preload artifact was byte-identical
- arm64 DMG packaging completed; `verify-asar-contents.mjs` passed against the packaged app (9,409 entries)
- `pnpm lint` (SQL, Codex storage, colors, Electron policy, licenses, ESLint, full workspace typecheck, dependency boundaries)

## Packaging note

The universal `package:dryrun` proceeds through build, postbuild, dependency staging, and both architecture packages, then hits an existing electron-builder merge error because `@napi-rs/canvas-darwin-arm64/skia.darwin-arm64.node` appears in both trees without an `x64ArchFiles` rule. That packaging-policy issue is unrelated to this byte-identical externalization migration; the completed arm64 app and ASAR were verified separately.
