### PR TITLE
feat(desktop): queue durable toast notices

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type ComponentType,
@@ -20,6 +21,7 @@ import {
   type DesktopBootInfo,
   type DesktopCodexProfileModel,
   type DesktopPwrAgentProfileSummary,
+  type MessagingChannelKind,
   type NavigationThreadSummary,
   type PrAutoDispatchBudgetStatus,
 } from "@pwragent/shared";
@@ -75,9 +77,12 @@ import { useQueuedTurnRelease } from "./lib/useQueuedTurnRelease";
 import { useScheduledThreadActionProjection } from "./lib/useScheduledThreadActionProjection";
 import { useThreadQueuedMessageIndicators } from "./lib/useThreadQueuedMessageIndicators";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
-import { AppNoticeToast } from "./features/notifications/AppNoticeToast";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
-import { resolveBackendErrorNotice } from "./features/notifications/backend-error-notice";
+import { AppNoticeStack } from "./features/notifications/AppNoticeStack";
+import {
+  appNoticeReducer,
+  INITIAL_APP_NOTICE_STATE,
+} from "./features/notifications/app-notice-state";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
@@ -272,30 +277,20 @@ function DesktopAppShell(props: {
   // triggers the slim "set up `foo`?" confirmation step; everything
   // else uses the standard first-run / replay flow.
   const [bootInfo, setBootInfo] = useState<DesktopBootInfo | null>(null);
-  // Transient composer-originated notices (image attachment limit reached,
-  // pasted image rejected on a non-vision model). Rendered through the shared
-  // AppNoticeToast in the toast stack below, separate from the navigation
-  // archive notice so the two never clobber each other.
-  const [composerNotice, setComposerNotice] = useState<AppNoticeToastNotice>();
-  const [hotCpuProfileNotice, setHotCpuProfileNotice] =
-    useState<AppNoticeToastNotice>();
-  const [heapSnapshotNotice, setHeapSnapshotNotice] =
-    useState<AppNoticeToastNotice>();
-  // Sticky (manual-dismiss) notice for backend turn failures and system
-  // errors. These used to vanish silently — the turn just stopped thinking
-  // with nothing to show for it. The toast stays until dismissed so a
-  // mid-outage failure can't slip past unnoticed.
-  const [backendErrorNotice, setBackendErrorNotice] =
-    useState<AppNoticeToastNotice>();
-  // One-shot warning surfaced when the main process skipped automations it
-  // couldn't load (corrupt data, or a schedule/trigger shape written by a
-  // newer build). The skipped automations are left untouched in storage — this
-  // is the only signal the user gets that they were quietly not run, so it
-  // stays until dismissed.
-  const [automationLoadNotice, setAutomationLoadNotice] =
-    useState<AppNoticeToastNotice>();
-  const [prAutoDispatchBudgetNotice, setPrAutoDispatchBudgetNotice] =
-    useState<AppNoticeToastNotice>();
+  // Durable notices are retained in arrival order and shown one at a time.
+  // This is intentionally a queue rather than one slot per producer: backend
+  // failures can arrive while another safety notice is already visible, and
+  // every failure must remain individually reviewable and dismissible.
+  const [appNotices, dispatchAppNotice] = useReducer(
+    appNoticeReducer,
+    INITIAL_APP_NOTICE_STATE,
+  );
+  const showAppNotice = useCallback((notice: AppNoticeToastNotice): void => {
+    dispatchAppNotice({ type: "show", notice });
+  }, []);
+  const dismissAppNotice = useCallback((id: string): void => {
+    dispatchAppNotice({ type: "dismiss", id });
+  }, []);
   const [githubPrSamlEvents, setGithubPrSamlEvents] =
     useState<GithubPrSamlEnforcementEvent[]>([]);
   // Latest thread list, mirrored into a ref so the backend-error toast
@@ -310,7 +305,10 @@ function DesktopAppShell(props: {
     void desktopApi?.resumePrAutoDispatchBudget?.()
       .then((status) => {
         if (!status.paused) {
-          setPrAutoDispatchBudgetNotice(undefined);
+          dispatchAppNotice({
+            type: "dismiss-prefix",
+            prefix: "pr-auto-dispatch-budget-paused:",
+          });
         }
       })
       .catch(() => {
@@ -320,15 +318,26 @@ function DesktopAppShell(props: {
   }, [desktopApi]);
   const showPrAutoDispatchBudgetNotice = useCallback(
     (status: PrAutoDispatchBudgetStatus) => {
-      setPrAutoDispatchBudgetNotice(
-        buildPrAutoDispatchBudgetNotice({
-          onLeaveDisabled: () => setPrAutoDispatchBudgetNotice(undefined),
-          onResume: resumePrAutoDispatchBudget,
-          status,
-        }),
-      );
+      const notice = buildPrAutoDispatchBudgetNotice({
+        onLeaveDisabled: () => {
+          dispatchAppNotice({
+            type: "dismiss-prefix",
+            prefix: "pr-auto-dispatch-budget-paused:",
+          });
+        },
+        onResume: resumePrAutoDispatchBudget,
+        status,
+      });
+      if (notice) {
+        showAppNotice(notice);
+      } else {
+        dispatchAppNotice({
+          type: "dismiss-prefix",
+          prefix: "pr-auto-dispatch-budget-paused:",
+        });
+      }
     },
-    [resumePrAutoDispatchBudget],
+    [resumePrAutoDispatchBudget, showAppNotice],
   );
   // Spawning / focusing the Messaging Activity window is fire-and-forget
   // — see `apps/desktop/src/main/messaging-activity-window.ts`. The
@@ -342,6 +351,7 @@ function DesktopAppShell(props: {
     setMainView("settings");
   }, []);
   const dismissGithubPrSamlNotice = useCallback(() => {
+    dispatchAppNotice({ type: "dismiss-prefix", prefix: "github-pr-saml:" });
     setGithubPrSamlEvents((current) => current.slice(1));
   }, []);
   const openGitSettings = useCallback(() => {
@@ -359,6 +369,24 @@ function DesktopAppShell(props: {
         })
       : undefined;
   }, [dismissGithubPrSamlNotice, githubPrSamlEvents, openGitSettings]);
+
+  useEffect(() => {
+    if (githubPrSamlNotice) showAppNotice(githubPrSamlNotice);
+  }, [githubPrSamlNotice, showAppNotice]);
+
+  const syncMessagingErrorNotice = useCallback((
+    platform: MessagingChannelKind,
+    notice: AppNoticeToastNotice | undefined,
+  ): void => {
+    if (notice) {
+      showAppNotice(notice);
+      return;
+    }
+    dispatchAppNotice({
+      type: "dismiss-prefix",
+      prefix: `messaging-platform-error:${platform}:`,
+    });
+  }, [showAppNotice]);
 
   useEffect(() => {
     return desktopApi?.onGithubPrSamlEnforcement?.((event) => {
@@ -398,7 +426,7 @@ function DesktopAppShell(props: {
         heapSnapshotCount > 0
           ? ` ${heapSnapshotCount} heap snapshots captured.`
           : "";
-      setHotCpuProfileNotice({
+      showAppNotice({
         autoDismiss: false,
         copyText: buildHotCpuProfileHandoffMessage(event),
         detail: `Session: ${event.sessionDirectoryName}`,
@@ -411,7 +439,7 @@ function DesktopAppShell(props: {
         ].join(""),
       });
     });
-  }, [desktopApi]);
+  }, [desktopApi, showAppNotice]);
 
   // On-demand heap snapshots. The capture (and its countdown) run in main, so
   // the result can land here even if Settings was closed to stage the scenario.
@@ -434,7 +462,7 @@ function DesktopAppShell(props: {
             partial ? ` Not captured: ${result.errors.join("; ")}.` : "",
             ` ${HEAP_SNAPSHOT_SECRET_WARNING}`,
           ].join("");
-      setHeapSnapshotNotice({
+      showAppNotice({
         autoDismiss: false,
         copyText: buildHeapSnapshotHandoffMessage(result),
         detail: failed ? undefined : `Session: ${result.sessionDirectoryName}`,
@@ -443,7 +471,7 @@ function DesktopAppShell(props: {
         message,
       });
     });
-  }, [desktopApi]);
+  }, [desktopApi, showAppNotice]);
 
   // On startup, ask the main process whether it skipped any automations it
   // couldn't load. Startup reconciliation runs before this window exists, so a
@@ -463,7 +491,7 @@ function DesktopAppShell(props: {
         const names = issues.map((issue) => issue.name).filter(Boolean);
         const namesSummary =
           names.length > 0 ? names.slice(0, 5).join(", ") : undefined;
-        setAutomationLoadNotice({
+        showAppNotice({
           autoDismiss: false,
           id: `automation-load-issues:${issues.map((issue) => issue.id).join(",")}`,
           title:
@@ -481,14 +509,14 @@ function DesktopAppShell(props: {
     return () => {
       cancelled = true;
     };
-  }, [desktopApi]);
+  }, [desktopApi, showAppNotice]);
 
   // Surface backend turn failures + system errors as a durable toast. The
   // matching transcript entry (rendered from the thread overlay's
   // turnFailureLog) is the in-context record; this toast is the global
   // "something just broke" signal that has to be acknowledged. Notices are
-  // keyed by thread so a failure on one thread can't suppress a signal from
-  // another (see resolveBackendErrorNotice).
+  // keyed by thread and queued so a failure on one thread can't suppress a
+  // signal from another.
   useEffect(() => {
     const labelForThread = (backend: string, threadId?: string): string => {
       const match = threadId
@@ -520,19 +548,17 @@ function DesktopAppShell(props: {
           typeof rawMessage === "string" && rawMessage.trim()
             ? rawMessage
             : "The agent turn failed.";
-        setBackendErrorNotice((current) =>
-          resolveBackendErrorNotice(
-            {
-              kind: "turn-failed",
-              backend: event.backend,
-              threadId: params.threadId ?? "unknown",
-              turnId: params.turnId ?? "unknown",
-              errorMessage,
-              threadLabel: labelForThread(event.backend, params.threadId),
-            },
-            current,
-          ),
-        );
+        dispatchAppNotice({
+          type: "backend-error",
+          signal: {
+            kind: "turn-failed",
+            backend: event.backend,
+            threadId: params.threadId ?? "unknown",
+            turnId: params.turnId ?? "unknown",
+            errorMessage,
+            threadLabel: labelForThread(event.backend, params.threadId),
+          },
+        });
         return;
       }
       if (
@@ -546,20 +572,18 @@ function DesktopAppShell(props: {
           failureMessage: string;
           recoveryError?: string;
         };
-        setBackendErrorNotice((current) =>
-          resolveBackendErrorNotice(
-            {
-              kind: "codex-invalid-id-recovery",
-              failureMessage: params.failureMessage,
-              recoveryError: params.recoveryError,
-              status: params.status,
-              threadId: params.threadId,
-              threadLabel: labelForThread("codex", params.threadId),
-              turnId: params.turnId ?? "unknown",
-            },
-            current,
-          ),
-        );
+        dispatchAppNotice({
+          type: "backend-error",
+          signal: {
+            kind: "codex-invalid-id-recovery",
+            failureMessage: params.failureMessage,
+            recoveryError: params.recoveryError,
+            status: params.status,
+            threadId: params.threadId,
+            threadLabel: labelForThread("codex", params.threadId),
+            turnId: params.turnId ?? "unknown",
+          },
+        });
         return;
       }
       if (event.notification.method === "thread/status/changed") {
@@ -570,17 +594,15 @@ function DesktopAppShell(props: {
         if (params.status?.type !== "systemError") {
           return;
         }
-        setBackendErrorNotice((current) =>
-          resolveBackendErrorNotice(
-            {
-              kind: "system-error",
-              backend: event.backend,
-              threadId: params.threadId ?? "unknown",
-              threadLabel: labelForThread(event.backend, params.threadId),
-            },
-            current,
-          ),
-        );
+        dispatchAppNotice({
+          type: "backend-error",
+          signal: {
+            kind: "system-error",
+            backend: event.backend,
+            threadId: params.threadId ?? "unknown",
+            threadLabel: labelForThread(event.backend, params.threadId),
+          },
+        });
         return;
       }
     });
@@ -1173,7 +1195,7 @@ function DesktopAppShell(props: {
     desktopApi: threadDesktopApi,
     launchpadError: navigation.launchpadError,
     onProviderSelected: refreshSelectedAcpProvider,
-    onShowNotice: setComposerNotice,
+    onShowNotice: showAppNotice,
     loading: session.loading,
     loadingMore: session.loadingMore,
     messageCount: session.messages.length,
@@ -1861,50 +1883,27 @@ function DesktopAppShell(props: {
         ) : null}
 
         <CodexConfigWarningBanner desktopApi={desktopApi} />
-        <div className="app-toast-stack" aria-live="polite">
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={navigation.archiveThreadNotice}
-            onDismiss={navigation.dismissArchiveThreadNotice}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={composerNotice}
-            onDismiss={() => setComposerNotice(undefined)}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={hotCpuProfileNotice}
-            onDismiss={() => setHotCpuProfileNotice(undefined)}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={heapSnapshotNotice}
-            onDismiss={() => setHeapSnapshotNotice(undefined)}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={backendErrorNotice}
-            onDismiss={() => setBackendErrorNotice(undefined)}
-          />
-          <MessagingErrorNotices desktopApi={desktopApi} />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={automationLoadNotice}
-            onDismiss={() => setAutomationLoadNotice(undefined)}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={prAutoDispatchBudgetNotice}
-            onDismiss={() => setPrAutoDispatchBudgetNotice(undefined)}
-          />
-          <AppNoticeToast
-            desktopApi={desktopApi}
-            notice={githubPrSamlNotice}
-            onDismiss={dismissGithubPrSamlNotice}
-          />
+        <MessagingErrorNotices
+          desktopApi={desktopApi}
+          onNoticeChanged={syncMessagingErrorNotice}
+        />
+        <AppNoticeStack
+          desktopApi={desktopApi}
+          durableNotices={appNotices.durable}
+          onDismissDurable={dismissAppNotice}
+          transientNotices={[
+            {
+              notice: navigation.archiveThreadNotice,
+              onDismiss: navigation.dismissArchiveThreadNotice,
+            },
+            ...appNotices.transient.map((notice) => ({
+              notice,
+              onDismiss: () => dismissAppNotice(notice.id),
+            })),
+          ]}
+        >
           <AppUpdateBanner desktopApi={desktopApi} />
-        </div>
+        </AppNoticeStack>
       </div>
     </TranscriptLinkProvider>
   );

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -7353,11 +7353,14 @@ export function Composer(props: ComposerProps) {
     });
   };
 
-  const showComposerNotice = (notice: Omit<AppNoticeToastNotice, "id">): void => {
+  const showComposerNotice = (
+    notice: Omit<AppNoticeToastNotice, "id" | "transientSlot">,
+  ): void => {
     props.onShowNotice?.({
       id: `composer-notice-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       ...notice,
       tone: notice.tone ?? "warning",
+      transientSlot: "composer",
     });
   };
 

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeStack.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { AppNoticeToast, type AppNoticeToastNotice } from "./AppNoticeToast";
+
+export function AppNoticeStack(props: {
+  children?: ReactNode;
+  desktopApi?: Pick<DesktopApi, "copyText">;
+  durableNotices: readonly AppNoticeToastNotice[];
+  onDismissDurable: (id: string) => void;
+  transientNotices?: readonly {
+    notice?: AppNoticeToastNotice;
+    onDismiss: () => void;
+  }[];
+}) {
+  const [activeId, setActiveId] = useState<string>();
+  const lastActiveIndexRef = useRef(0);
+  const durableNotices = props.durableNotices;
+  const activeIndex = Math.max(
+    0,
+    durableNotices.findIndex((notice) => notice.id === activeId),
+  );
+  const activeNotice = durableNotices[activeIndex];
+
+  useEffect(() => {
+    if (durableNotices.length === 0) {
+      setActiveId(undefined);
+      lastActiveIndexRef.current = 0;
+      return;
+    }
+    if (activeId && durableNotices.some((notice) => notice.id === activeId)) {
+      return;
+    }
+    const nextIndex = Math.min(
+      lastActiveIndexRef.current,
+      durableNotices.length - 1,
+    );
+    setActiveId(durableNotices[nextIndex]?.id);
+  }, [activeId, durableNotices]);
+
+  const selectIndex = (index: number): void => {
+    const next = durableNotices[index];
+    if (!next) return;
+    lastActiveIndexRef.current = index;
+    setActiveId(next.id);
+  };
+
+  return (
+    <div className="app-toast-stack" aria-live="polite">
+      {props.transientNotices?.map(({ notice, onDismiss }) =>
+        notice ? (
+          <AppNoticeToast
+            key={notice.id}
+            desktopApi={props.desktopApi}
+            notice={notice}
+            onDismiss={onDismiss}
+          />
+        ) : null
+      )}
+      <AppNoticeToast
+        desktopApi={props.desktopApi}
+        notice={activeNotice}
+        navigation={activeNotice && durableNotices.length > 1
+          ? {
+              current: activeIndex + 1,
+              total: durableNotices.length,
+              onPrevious: activeIndex > 0
+                ? () => selectIndex(activeIndex - 1)
+                : undefined,
+              onNext: activeIndex < durableNotices.length - 1
+                ? () => selectIndex(activeIndex + 1)
+                : undefined,
+            }
+          : undefined}
+        onDismiss={() => {
+          if (!activeNotice) return;
+          lastActiveIndexRef.current = activeIndex;
+          props.onDismissDurable(activeNotice.id);
+        }}
+      />
+      {props.children}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -27,6 +27,8 @@ export type AppNoticeToastNotice = {
     label: string;
     state: "progress" | "success" | "error";
   };
+  /** At most one auto-dismissing notice is retained for a producer slot. */
+  transientSlot?: string;
 };
 
 export function AppNoticeToast(props: {

--- a/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/AppNoticeToast.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { CloseIcon, CopyIcon } from "../../icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CloseIcon,
+  CopyIcon,
+} from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import type { DesktopApi } from "../../lib/desktop-api";
 
@@ -26,6 +31,12 @@ export type AppNoticeToastNotice = {
 
 export function AppNoticeToast(props: {
   desktopApi?: Pick<DesktopApi, "copyText">;
+  navigation?: {
+    current: number;
+    total: number;
+    onPrevious?: () => void;
+    onNext?: () => void;
+  };
   notice?: AppNoticeToastNotice;
   onDismiss: () => void;
 }) {
@@ -147,6 +158,34 @@ export function AppNoticeToast(props: {
               </button>
             </>}
       </div>
+      {props.navigation ? (
+        <nav
+          className="app-notice-toast__navigation"
+          aria-label="Durable notices"
+        >
+          <span className="app-notice-toast__position">
+            {props.navigation.current} of {props.navigation.total}
+          </span>
+          <button
+            className="app-notice-toast__icon-button"
+            type="button"
+            aria-label="Previous notice"
+            disabled={!props.navigation.onPrevious}
+            onClick={props.navigation.onPrevious}
+          >
+            <ChevronLeftIcon size={14} aria-hidden="true" />
+          </button>
+          <button
+            className="app-notice-toast__icon-button"
+            type="button"
+            aria-label="Next notice"
+            disabled={!props.navigation.onNext}
+            onClick={props.navigation.onNext}
+          >
+            <ChevronRightIcon size={14} aria-hidden="true" />
+          </button>
+        </nav>
+      ) : null}
       {autoDismiss ? (
         <span
           className="app-notice-toast__timer"

--- a/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/MessagingErrorNotices.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   MessagingChannelKind,
   MessagingPlatformStatus,
@@ -21,9 +21,16 @@ type MessagingPlatformNoticeState = {
 
 export function MessagingErrorNotices(props: {
   desktopApi?: DesktopApi;
+  onNoticeChanged?: (
+    platform: MessagingChannelKind,
+    notice: AppNoticeToastNotice | undefined,
+  ) => void;
 }) {
   const [statusByPlatform, setStatusByPlatform] = useState(
     () => new Map<MessagingChannelKind, MessagingPlatformNoticeState>(),
+  );
+  const publishedNoticeKeysRef = useRef(
+    new Map<MessagingChannelKind, string>(),
   );
 
   useEffect(() => {
@@ -79,6 +86,20 @@ export function MessagingErrorNotices(props: {
       notices.push({ notice: state.notice, platform });
     }
   }
+
+  useEffect(() => {
+    if (!props.onNoticeChanged) return;
+    for (const [platform, state] of statusByPlatform) {
+      const noticeKey = state.notice?.id ?? `healthy:${state.changedAt}`;
+      if (publishedNoticeKeysRef.current.get(platform) === noticeKey) {
+        continue;
+      }
+      publishedNoticeKeysRef.current.set(platform, noticeKey);
+      props.onNoticeChanged(platform, state.notice);
+    }
+  }, [props.onNoticeChanged, statusByPlatform]);
+
+  if (props.onNoticeChanged) return null;
 
   return notices.map(({ notice, platform }) => (
     <AppNoticeToast

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeStack.test.tsx
@@ -1,0 +1,50 @@
+import "@testing-library/jest-dom/vitest";
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { AppNoticeStack } from "../AppNoticeStack";
+import type { AppNoticeToastNotice } from "../AppNoticeToast";
+
+afterEach(cleanup);
+
+describe("AppNoticeStack", () => {
+  it("navigates durable notices in order and dismisses each one independently", async () => {
+    const initial: AppNoticeToastNotice[] = [
+      { id: "first", title: "First", message: "One", autoDismiss: false },
+      { id: "second", title: "Second", message: "Two", autoDismiss: false },
+      { id: "third", title: "Third", message: "Three", autoDismiss: false },
+    ];
+
+    function Harness() {
+      const [notices, setNotices] = useState(initial);
+      return (
+        <AppNoticeStack
+          durableNotices={notices}
+          onDismissDurable={(id) => {
+            setNotices((current) => current.filter((notice) => notice.id !== id));
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+    expect(screen.getByText("1 of 3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Previous notice" }))
+      .toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next notice" }));
+    expect(screen.getByText("Second")).toBeInTheDocument();
+    expect(screen.getByText("2 of 3")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(await screen.findByText("Third")).toBeInTheDocument();
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous notice" }));
+    expect(screen.getByText("First")).toBeInTheDocument();
+    expect(screen.queryByText("Second")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/AppNoticeToast.test.tsx
@@ -121,6 +121,29 @@ describe("AppNoticeToast", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
+  it("renders ordered navigation controls for a durable notice stack", () => {
+    const onPrevious = vi.fn();
+    const onNext = vi.fn();
+    render(
+      <AppNoticeToast
+        notice={{ ...notice, autoDismiss: false }}
+        navigation={{
+          current: 2,
+          total: 3,
+          onPrevious,
+          onNext,
+        }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Previous notice" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next notice" }));
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
   it("uses exactly the supplied operator actions for a persistent safety notice", () => {
     vi.useFakeTimers();
     const leaveDisabled = vi.fn();

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/MessagingErrorNotices.test.tsx
@@ -12,6 +12,69 @@ afterEach(() => {
 });
 
 describe("MessagingErrorNotices", () => {
+  it("publishes notice changes to a shared stack without rendering duplicates", async () => {
+    let emitStatus: ((event: MessagingPlatformStatusEvent) => void) | undefined;
+    const onNoticeChanged = vi.fn();
+    render(
+      <MessagingErrorNotices
+        desktopApi={{
+          getMessagingPlatformStatuses: async () => [{
+            platform: "discord",
+            health: "errored",
+            changedAt: 1_785_926_400_000,
+            reason: "gateway disconnected",
+          }],
+          onMessagingPlatformStatusEvent: (listener) => {
+            emitStatus = listener;
+            return () => undefined;
+          },
+        }}
+        onNoticeChanged={onNoticeChanged}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onNoticeChanged).toHaveBeenCalledWith(
+        "discord",
+        expect.objectContaining({ title: "Discord messaging failed" }),
+      );
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    const discordPublicationCount = () => onNoticeChanged.mock.calls.filter(
+      ([platform]) => platform === "discord",
+    ).length;
+    expect(discordPublicationCount()).toBe(1);
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "slack",
+        health: "errored",
+        at: 1_785_926_400_001,
+        reason: "socket disconnected",
+      });
+    });
+    await waitFor(() => {
+      expect(onNoticeChanged).toHaveBeenCalledWith(
+        "slack",
+        expect.objectContaining({ title: "Slack messaging failed" }),
+      );
+    });
+    expect(discordPublicationCount()).toBe(1);
+
+    act(() => {
+      emitStatus?.({
+        kind: "health-changed",
+        platform: "discord",
+        health: "enabled",
+        at: 1_785_926_400_002,
+      });
+    });
+    await waitFor(() => {
+      expect(onNoticeChanged).toHaveBeenLastCalledWith("discord", undefined);
+    });
+  });
+
   it("surfaces an adapter error that happened before the renderer mounted", async () => {
     const getMessagingPlatformStatuses = vi.fn(async () => [
       {

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -91,6 +91,40 @@ describe("appNoticeReducer", () => {
     });
   });
 
+  it("replaces transient notices from the same producer slot", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "show",
+      notice: {
+        id: "composer-notice-1",
+        title: "First warning",
+        message: "First",
+        transientSlot: "composer",
+      },
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: {
+        id: "repair-succeeded",
+        title: "Repair complete",
+        message: "Repaired",
+      },
+    });
+    state = appNoticeReducer(state, {
+      type: "show",
+      notice: {
+        id: "composer-notice-2",
+        title: "Second warning",
+        message: "Second",
+        transientSlot: "composer",
+      },
+    });
+
+    expect(state.transient.map((notice) => notice.id)).toEqual([
+      "composer-notice-2",
+      "repair-succeeded",
+    ]);
+  });
+
   it("dismisses one durable notice without disturbing the rest", () => {
     let state: AppNoticeState = {
       durable: [

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  appNoticeReducer,
+  INITIAL_APP_NOTICE_STATE,
+  type AppNoticeState,
+} from "../app-notice-state";
+
+describe("appNoticeReducer", () => {
+  it("keeps failed turns in arrival order instead of overwriting them", () => {
+    let state: AppNoticeState = INITIAL_APP_NOTICE_STATE;
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: {
+        kind: "turn-failed",
+        backend: "codex",
+        threadId: "thread-a",
+        turnId: "turn-1",
+        errorMessage: "The token budget was exhausted.",
+        threadLabel: "Repair PR 1",
+      },
+    });
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: {
+        kind: "turn-failed",
+        backend: "codex",
+        threadId: "thread-b",
+        turnId: "turn-2",
+        errorMessage: "The context window was exceeded.",
+        threadLabel: "Repair PR 2",
+      },
+    });
+
+    expect(state.durable.map((notice) => notice.id)).toEqual([
+      "turn-failed:codex:thread-a:turn-1",
+      "turn-failed:codex:thread-b:turn-2",
+    ]);
+    expect(state.durable[0]?.message).toBe("The token budget was exhausted.");
+  });
+
+  it("does not add a generic system error behind a richer same-thread failure", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "backend-error",
+      signal: {
+        kind: "turn-failed",
+        backend: "codex",
+        threadId: "thread-a",
+        turnId: "turn-1",
+        errorMessage: "provider error",
+        threadLabel: "Repair PR",
+      },
+    });
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: {
+        kind: "system-error",
+        backend: "codex",
+        threadId: "thread-a",
+        threadLabel: "Repair PR",
+      },
+    });
+
+    expect(state.durable).toHaveLength(1);
+    expect(state.durable[0]?.message).toBe("provider error");
+  });
+
+  it("updates a notice in place and moves repaired success to transient", () => {
+    const repairingSignal = {
+      kind: "codex-invalid-id-recovery" as const,
+      status: "repairing" as const,
+      threadId: "thread-a",
+      turnId: "turn-1",
+      failureMessage: "invalid message id",
+      threadLabel: "Repair PR",
+    };
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, {
+      type: "backend-error",
+      signal: repairingSignal,
+    });
+    state = appNoticeReducer(state, {
+      type: "backend-error",
+      signal: { ...repairingSignal, status: "succeeded" },
+    });
+
+    expect(state.durable).toEqual([]);
+    expect(state.transient).toHaveLength(1);
+    expect(state.transient[0]).toMatchObject({
+      id: "codex-invalid-id-recovery:codex:thread-a:turn-1",
+      title: "Codex thread repaired",
+      autoDismiss: true,
+    });
+  });
+
+  it("dismisses one durable notice without disturbing the rest", () => {
+    let state: AppNoticeState = {
+      durable: [
+        { id: "first", title: "First", message: "One", autoDismiss: false },
+        { id: "second", title: "Second", message: "Two", autoDismiss: false },
+      ],
+      transient: [],
+    };
+    state = appNoticeReducer(state, { type: "dismiss", id: "first" });
+
+    expect(state.durable.map((notice) => notice.id)).toEqual(["second"]);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
@@ -64,7 +64,7 @@ function showNotice(
   if (notice.autoDismiss !== false) {
     return {
       durable: state.durable.filter((entry) => entry.id !== notice.id),
-      transient: upsertNotice(state.transient, notice),
+      transient: upsertTransientNotice(state.transient, notice),
     };
   }
 
@@ -72,6 +72,25 @@ function showNotice(
     durable: upsertNotice(state.durable, notice),
     transient: state.transient.filter((entry) => entry.id !== notice.id),
   };
+}
+
+function upsertTransientNotice(
+  notices: readonly AppNoticeToastNotice[],
+  notice: AppNoticeToastNotice,
+): AppNoticeToastNotice[] {
+  const index = notices.findIndex(
+    (entry) =>
+      entry.id === notice.id
+      || (
+        notice.transientSlot !== undefined
+        && entry.transientSlot === notice.transientSlot
+      ),
+  );
+  return index >= 0
+    ? notices.map((entry, entryIndex) =>
+        entryIndex === index ? notice : entry
+      )
+    : [...notices, notice];
 }
 
 function upsertNotice(

--- a/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
@@ -1,0 +1,114 @@
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+import {
+  resolveBackendErrorNotice,
+  type BackendErrorSignal,
+} from "./backend-error-notice";
+
+export type AppNoticeState = {
+  durable: AppNoticeToastNotice[];
+  transient: AppNoticeToastNotice[];
+};
+
+export type AppNoticeAction =
+  | { type: "show"; notice: AppNoticeToastNotice }
+  | { type: "backend-error"; signal: BackendErrorSignal }
+  | { type: "dismiss"; id: string }
+  | { type: "dismiss-prefix"; prefix: string };
+
+export const INITIAL_APP_NOTICE_STATE: AppNoticeState = {
+  durable: [],
+  transient: [],
+};
+
+export function appNoticeReducer(
+  state: AppNoticeState,
+  action: AppNoticeAction,
+): AppNoticeState {
+  if (action.type === "show") {
+    return showNotice(state, action.notice);
+  }
+
+  if (action.type === "backend-error") {
+    const current = findRelatedBackendNotice(state, action.signal);
+    const notice = resolveBackendErrorNotice(action.signal, current);
+    return notice ? showNotice(state, notice) : state;
+  }
+
+  if (action.type === "dismiss") {
+    const durable = state.durable.filter((notice) => notice.id !== action.id);
+    const transient = state.transient.filter((notice) => notice.id !== action.id);
+    if (
+      durable.length === state.durable.length
+      && transient.length === state.transient.length
+    ) return state;
+    return { durable, transient };
+  }
+
+  const durable = state.durable.filter(
+    (notice) => !notice.id.startsWith(action.prefix),
+  );
+  const transient = state.transient.filter(
+    (notice) => !notice.id.startsWith(action.prefix),
+  );
+  if (
+    durable.length === state.durable.length
+    && transient.length === state.transient.length
+  ) return state;
+  return { durable, transient };
+}
+
+function showNotice(
+  state: AppNoticeState,
+  notice: AppNoticeToastNotice,
+): AppNoticeState {
+  if (notice.autoDismiss !== false) {
+    return {
+      durable: state.durable.filter((entry) => entry.id !== notice.id),
+      transient: upsertNotice(state.transient, notice),
+    };
+  }
+
+  return {
+    durable: upsertNotice(state.durable, notice),
+    transient: state.transient.filter((entry) => entry.id !== notice.id),
+  };
+}
+
+function upsertNotice(
+  notices: readonly AppNoticeToastNotice[],
+  notice: AppNoticeToastNotice,
+): AppNoticeToastNotice[] {
+  const index = notices.findIndex((entry) => entry.id === notice.id);
+  return index >= 0
+    ? notices.map((entry, entryIndex) =>
+        entryIndex === index ? notice : entry
+      )
+    : [...notices, notice];
+}
+
+function findRelatedBackendNotice(
+  state: AppNoticeState,
+  signal: BackendErrorSignal,
+): AppNoticeToastNotice | undefined {
+  const prefixes = signal.kind === "codex-invalid-id-recovery"
+    ? [
+        `codex-invalid-id-recovery:codex:${signal.threadId}:${signal.turnId}`,
+        `turn-failed:codex:${signal.threadId}:`,
+      ]
+    : signal.kind === "turn-failed"
+      ? [`turn-failed:${signal.backend}:${signal.threadId}:${signal.turnId}`]
+      : [
+          `turn-failed:${signal.backend}:${signal.threadId}:`,
+          ...(signal.backend === "codex"
+            ? [`codex-invalid-id-recovery:codex:${signal.threadId}:`]
+            : []),
+        ];
+  const notices = [...state.durable, ...state.transient];
+  for (let index = notices.length - 1; index >= 0; index -= 1) {
+    const notice = notices[index];
+    if (notice && prefixes.some((prefix) => notice.id.startsWith(prefix))) {
+      return notice;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -5438,6 +5438,24 @@ textarea,
   align-self: start;
 }
 
+.app-notice-toast__navigation {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.app-notice-toast__position {
+  margin-right: auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
 .app-notice-toast__icon-button {
   display: inline-grid;
   width: 30px;
@@ -5455,6 +5473,14 @@ textarea,
   background: var(--accent-soft);
   color: var(--accent-bright);
   outline: none;
+}
+
+.app-notice-toast__icon-button:disabled {
+  border-color: var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+  opacity: 0.5;
 }
 
 .app-notice-toast__timer {


### PR DESCRIPTION
## Summary

- I replaced the renderer's independent notification slots with one ordered notice queue, so durable failures are retained instead of being overwritten by later notices.
- I added Previous and Next controls plus an `N of M` position indicator, while keeping dismissal scoped to the currently visible durable notice.
- I routed backend turn failures, automation budget notices, messaging failures, GitHub SAML notices, and existing system warnings through the shared queue without duplicating related errors or resurrecting dismissed notices.
- I verified the suspected PR auto-fix run did not actually exhaust its token budget: it compacted once, resolved PR #1175's merge conflict, pushed signed commit `ffe04e905`, and completed normally. The rollout did show substantial retained tool output and replay pressure, so preserving any future failure notice is still important.

## Verification

- `pnpm test MessagingErrorNotices AppNoticeStack app-notice-state app-shell`
- focused notification suite: 49 tests passed after rebasing onto `origin/main`
- `pnpm lint`
- `pnpm build`
- I verified the final commit is SSH-signed and the branch is one commit ahead of current `origin/main`.

## Notes

- Durable notices remain visible until individually dismissed. Transient success notices continue to auto-dismiss.
- The full lint run reports the repository's existing warning baseline and no errors.
