### PR TITLE
feat(messaging): add terminal private responses

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1722,6 +1722,7 @@ describe("MessagingController", () => {
     deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
     now?: () => number;
     resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+    responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
     sleepUntil?: MessagingControllerOptions["sleepUntil"];
     streamingResponsesDefault?: boolean;
   }) {
@@ -1754,6 +1755,7 @@ describe("MessagingController", () => {
             channel: "slack" as const,
             conversation: {
               id: "D012HAROLD",
+              isDirectMessage: true,
               kind: "thread" as const,
               parentConversationId: "D012HAROLD",
               parentId: surface.id,
@@ -1809,6 +1811,9 @@ describe("MessagingController", () => {
       navigation,
       ...(options?.now ? { now: options.now } : {}),
       resolvePrivateConversation,
+      ...(options?.responseModeForConversation
+        ? { responseModeForConversation: options.responseModeForConversation }
+        : {}),
       ...(options?.resolveDeliveryScope
         ? { resolveDeliveryScope: options.resolveDeliveryScope }
         : {}),
@@ -1845,7 +1850,9 @@ describe("MessagingController", () => {
       channel,
       harness,
       resolvePrivateConversation,
-    } = await createSlackPrivateResponseHarness();
+    } = await createSlackPrivateResponseHarness({
+      responseModeForConversation: () => "mention_only",
+    });
 
     const response = await harness.controller.handlePwrAgentMessagingRequest({
       operation: "send_private_response",
@@ -1872,7 +1879,9 @@ describe("MessagingController", () => {
       source: channel,
       routingState: { opaque: { channelId: "C012SIGNALS" } },
     });
-    expect(harness.delivered).toEqual([
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
       expect.objectContaining({
         audit: expect.objectContaining({
           actor: expect.objectContaining({ platformUserId: "user-1" }),
@@ -1911,6 +1920,7 @@ describe("MessagingController", () => {
         channel: "slack",
         conversation: {
           id: "D012HAROLD",
+          isDirectMessage: true,
           kind: "thread",
           parentConversationId: "D012HAROLD",
           parentId: expect.stringContaining("surface:private-response"),
@@ -1919,6 +1929,12 @@ describe("MessagingController", () => {
       targetKind: "agent_thread",
       threadId: "thread-1",
     });
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "activity" && intent.state === "idle",
+      ),
+    ).toHaveLength(2);
+    expect(harness.recordMessagingBindingTransition).not.toHaveBeenCalled();
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -1936,7 +1952,14 @@ describe("MessagingController", () => {
       },
     });
 
-    expect(harness.delivered).toHaveLength(1);
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toHaveLength(1);
+    expect(
+      harness.delivered.filter(
+        (intent) => intent.kind === "activity" && intent.state === "active",
+      ),
+    ).toHaveLength(0);
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -2059,7 +2082,7 @@ describe("MessagingController", () => {
     });
 
     expect(response).toMatchObject({ ok: true });
-    expect(delivered.at(-1)).toMatchObject({
+    expect(delivered.findLast((intent) => intent.kind === "dismiss")).toMatchObject({
       kind: "dismiss",
       reason: "terminal_private_response",
       targetSurface: {
@@ -2176,7 +2199,7 @@ describe("MessagingController", () => {
     const [, response] = await Promise.all([sourceDelivery, privateRequest]);
 
     expect(response).toMatchObject({ ok: true });
-    expect(delivered.at(-1)).toMatchObject({
+    expect(delivered.findLast((intent) => intent.kind === "dismiss")).toMatchObject({
       kind: "dismiss",
       reason: "terminal_private_response",
       targetSurface: {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1907,8 +1907,8 @@ describe("MessagingController", () => {
           }),
         }),
         attribution: {
-          label: "Signals Agent · Private response",
-          hint: "Reply in this message's thread to continue with this agent.",
+          label: "Signals Agent",
+          hint: "Private Request · Reply in Thread to Respond to this Agent",
         },
         kind: "message",
         parts: [
@@ -2095,6 +2095,16 @@ describe("MessagingController", () => {
       ok: true,
       data: { awaitingReply: true },
     });
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        attribution: {
+          label: "Signals Agent",
+          hint:
+            "Private Request · Reply in Thread to Respond to this Agent; Completion Returns to the Original Conversation",
+        },
+        kind: "message",
+      }),
+    );
 
     const continuationBinding = (
       await harness.store.findActiveBindingsForThread({
@@ -2352,7 +2362,7 @@ describe("MessagingController", () => {
     ).toEqual([
       expect.objectContaining({
         attribution: expect.objectContaining({
-          label: "Signals Agent · Private response",
+          label: "Signals Agent",
         }),
         parts: [expect.objectContaining({
           text: expect.stringContaining("PRIVATE-CODE"),

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1734,6 +1734,45 @@ describe("MessagingController", () => {
         workspaceId: "T012WORKSPACE",
       },
     };
+    let harnessDelivered: MessagingSurfaceIntent[] | undefined;
+    const deliver = options?.deliver ?? (async (intent: MessagingSurfaceIntent) => {
+      harnessDelivered?.push(intent);
+      const surface = {
+        channel: "slack" as const,
+        id: `surface:${intent.id}`,
+        state: {
+          opaque: {
+            channelId: "D012HAROLD",
+            ts: `surface:${intent.id}`,
+          },
+        },
+      };
+      return {
+        channel: "slack" as const,
+        continuation: {
+          channel: {
+            channel: "slack" as const,
+            conversation: {
+              id: "D012HAROLD",
+              kind: "thread" as const,
+              parentConversationId: "D012HAROLD",
+              parentId: surface.id,
+              workspaceId: "T012WORKSPACE",
+            },
+          },
+          routingState: {
+            opaque: {
+              channelId: "D012HAROLD",
+              teamId: "T012WORKSPACE",
+              threadTs: surface.id,
+            },
+          },
+        },
+        deliveredAt: 1000,
+        outcome: "presented" as const,
+        surface,
+      };
+    });
     const resolvePrivateConversation = vi.fn(async () => ({
       channel: "slack" as const,
       conversation: {
@@ -1766,7 +1805,7 @@ describe("MessagingController", () => {
       ...(options?.deliveryBudget
         ? { deliveryBudget: options.deliveryBudget }
         : {}),
-      ...(options?.deliver ? { deliver: options.deliver } : {}),
+      deliver,
       navigation,
       ...(options?.now ? { now: options.now } : {}),
       resolvePrivateConversation,
@@ -1778,6 +1817,7 @@ describe("MessagingController", () => {
         ? {}
         : { streamingResponsesDefault: options.streamingResponsesDefault }),
     });
+    harnessDelivered = harness.delivered;
     await harness.store.upsertBinding({
       id: "binding-slack-signals",
       authorizedActorIds: ["user-1"],
@@ -1844,6 +1884,10 @@ describe("MessagingController", () => {
             }),
           }),
         }),
+        attribution: {
+          label: "Signals Agent · Private response",
+          hint: "Reply in this message's thread to continue with this agent.",
+        },
         kind: "message",
         parts: [
           expect.objectContaining({
@@ -1855,6 +1899,26 @@ describe("MessagingController", () => {
         }),
       }),
     ]);
+    const continuationBinding = (
+      await harness.store.findActiveBindingsForThread({
+        backend: "codex",
+        threadId: "thread-1",
+      })
+    ).find((binding) => binding.channel.conversation.id === "D012HAROLD");
+    expect(continuationBinding).toMatchObject({
+      authorizedActorIds: ["user-1"],
+      channel: {
+        channel: "slack",
+        conversation: {
+          id: "D012HAROLD",
+          kind: "thread",
+          parentConversationId: "D012HAROLD",
+          parentId: expect.stringContaining("surface:private-response"),
+        },
+      },
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+    });
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -1908,6 +1972,26 @@ describe("MessagingController", () => {
     expect(
       harness.delivered.filter((intent) => intent.kind === "message"),
     ).toHaveLength(1);
+
+    if (!continuationBinding) {
+      throw new Error("Expected the private reply continuation binding");
+    }
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("I approved the AWS login.", {
+        channel: continuationBinding.channel,
+        routingState: continuationBinding.routingState,
+      }),
+    );
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        backend: "codex",
+        threadId: "thread-1",
+        input: [expect.objectContaining({
+          text: "I approved the AWS login.",
+          type: "text",
+        })],
+      }),
+    );
   });
 
   it("dismisses an existing source stream before private delivery succeeds", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1721,6 +1721,7 @@ describe("MessagingController", () => {
     deliveryBudget?: MessagingDeliveryBudget;
     deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
     inboundText?: string;
+    inputDebounceMs?: number;
     now?: () => number;
     resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
     responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
@@ -1813,6 +1814,9 @@ describe("MessagingController", () => {
         ? { deliveryBudget: options.deliveryBudget }
         : {}),
       deliver,
+      ...(options?.inputDebounceMs === undefined
+        ? {}
+        : { inputDebounceMs: options.inputDebounceMs }),
       navigation,
       ...(options?.now ? { now: options.now } : {}),
       resolvePrivateConversation,
@@ -2135,6 +2139,10 @@ describe("MessagingController", () => {
       }),
     );
 
+    expect(await harness.store.getBinding(continuationBinding.id)).toMatchObject({
+      revokedAt: expect.any(Number),
+    });
+
     expect(harness.startTurn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         input: [
@@ -2159,6 +2167,14 @@ describe("MessagingController", () => {
     expect(activeActivity).not.toContainEqual(
       expect.objectContaining({ bindingId: continuationBinding.id }),
     );
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("A second reply must not reuse the callback.", {
+        channel: continuationBinding.channel,
+        routingState: continuationBinding.routingState,
+      }),
+    );
+    expect(harness.startTurn).toHaveBeenCalledTimes(2);
 
     await harness.controller.handleBackendEvent({
       backend: "codex",
@@ -2235,6 +2251,68 @@ describe("MessagingController", () => {
     expect(harness.onBindingChanged).toHaveBeenCalled();
   });
 
+  it("keeps a private request from a later debounced message private", async () => {
+    vi.useFakeTimers();
+    const { channel, harness } = await createSlackPrivateResponseHarness({
+      inboundText: "Use the context in my next message.",
+      inputDebounceMs: 500,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("DM me the AWS SSO link and code", {
+        botMention: true,
+        channel,
+        routingState: { opaque: { channelId: "C012SIGNALS" } },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining("If that tool is unavailable"),
+          }),
+        ]),
+      }),
+    );
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{
+              type: "text",
+              text: "Open the private link and enter `BUNDLED-CODE`.",
+            }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) =>
+          intent.kind === "message"
+          && intent.audit?.channel.conversation.id === "C012SIGNALS",
+      ),
+    ).toEqual([]);
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        parts: [expect.objectContaining({
+          text: expect.stringContaining("BUNDLED-CODE"),
+        })],
+      }),
+    );
+  });
+
   it("privately delivers an explicit DM request when the thread lacks the tool", async () => {
     const { harness } = await createSlackPrivateResponseHarness();
     expect(harness.startTurn).toHaveBeenCalledWith(
@@ -2288,6 +2366,85 @@ describe("MessagingController", () => {
           && intent.audit?.channel.conversation.id === "C012SIGNALS",
       ),
     ).toEqual([]);
+  });
+
+  it("privately delivers delta-only fallback output", async () => {
+    const { harness } = await createSlackPrivateResponseHarness();
+
+    for (const delta of ["Open the AWS SSO URL and enter ", "`DELTA-CODE`."]) {
+      await harness.controller.handleBackendEvent({
+        backend: "codex",
+        notification: {
+          method: "item/agentMessage/delta",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            itemId: "assistant-private-delta-only",
+            delta,
+          },
+        },
+      } satisfies AgentEvent);
+    }
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter(
+        (intent) =>
+          intent.kind === "message"
+          && intent.audit?.channel.conversation.id === "C012SIGNALS",
+      ),
+    ).toEqual([]);
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        parts: [expect.objectContaining({
+          text: "Open the AWS SSO URL and enter `DELTA-CODE`.",
+        })],
+      }),
+    ]);
+  });
+
+  it("honors explicit negation when detecting private response requests", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      inboundText: "I don't want you to DM me; reply here publicly.",
+    });
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.not.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining("If that tool is unavailable"),
+          }),
+        ]),
+      }),
+    );
+  });
+
+  it("detects a private request after a separate public-post negation", async () => {
+    const { harness } = await createSlackPrivateResponseHarness({
+      inboundText: "Do not post this publicly, DM me the result.",
+    });
+
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining("If that tool is unavailable"),
+          }),
+        ]),
+      }),
+    );
   });
 
   it("dismisses an existing source stream before private delivery succeeds", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1725,6 +1725,7 @@ describe("MessagingController", () => {
     resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
     responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
     sleepUntil?: MessagingControllerOptions["sleepUntil"];
+    startTurn?: NonNullable<MessagingBackendBridge["startTurn"]>;
     streamingResponsesDefault?: boolean;
     toolUpdateDefaultMode?:
       | MessagingToolUpdateMode
@@ -1822,6 +1823,7 @@ describe("MessagingController", () => {
         ? { resolveDeliveryScope: options.resolveDeliveryScope }
         : {}),
       ...(options?.sleepUntil ? { sleepUntil: options.sleepUntil } : {}),
+      ...(options?.startTurn ? { startTurn: options.startTurn } : {}),
       ...(options?.streamingResponsesDefault === undefined
         ? {}
         : { streamingResponsesDefault: options.streamingResponsesDefault }),
@@ -2027,6 +2029,210 @@ describe("MessagingController", () => {
     expect(
       harness.delivered.filter((intent) => intent.kind === "status"),
     ).toEqual([]);
+  });
+
+  it("returns a requested private reply to the source and retires its one-shot binding", async () => {
+    let startedTurnCount = 0;
+    const controllerDuringStart: { current?: MessagingController } = {};
+    const { harness } = await createSlackPrivateResponseHarness({
+      startTurn: async (request) => {
+        const turnId = `turn-${++startedTurnCount}`;
+        if (turnId === "turn-2") {
+          await controllerDuringStart.current?.handleBackendEvent({
+            backend: "codex",
+            notification: {
+              method: "turn/started",
+              params: {
+                threadId: "thread-1",
+                turnId: "pending:thread-1",
+                turn: {
+                  id: "pending:thread-1",
+                  status: "in_progress",
+                },
+              },
+            },
+          } satisfies AgentEvent);
+          await controllerDuringStart.current?.handleBackendEvent({
+            backend: "codex",
+            notification: {
+              method: "thread/status/changed",
+              params: {
+                threadId: "thread-1",
+                status: { type: "active" },
+              },
+            },
+          } satisfies AgentEvent);
+        }
+        return {
+          backend: request.backend,
+          threadId: request.threadId,
+          turnId,
+        };
+      },
+    });
+    controllerDuringStart.current = harness.controller;
+
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "send_private_response",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+        args: {
+          awaitReply: true,
+          replyInstructions:
+            "Report only whether the operator approved. Do not repeat any code.",
+          text: "Can you approve the AWS SSO login?",
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      data: { awaitingReply: true },
+    });
+
+    const continuationBinding = (
+      await harness.store.findActiveBindingsForThread({
+        backend: "codex",
+        threadId: "thread-1",
+      })
+    ).find((binding) => binding.privateReplyContinuation);
+    expect(continuationBinding).toMatchObject({
+      privateReplyContinuation: {
+        instructions:
+          "Report only whether the operator approved. Do not repeat any code.",
+        source: {
+          id: "binding-slack-signals",
+          channel: {
+            conversation: { id: "C012SIGNALS" },
+          },
+        },
+      },
+      statusPresentation: "on_demand",
+    });
+    if (!continuationBinding) {
+      throw new Error("Expected the private reply continuation binding");
+    }
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      },
+    } satisfies AgentEvent);
+    harness.delivered.length = 0;
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("Approved with private code 123456", {
+        channel: continuationBinding.channel,
+        routingState: continuationBinding.routingState,
+      }),
+    );
+
+    expect(harness.startTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        input: [
+          expect.objectContaining({
+            text: expect.stringContaining(
+              "Your final answer will be delivered to the originating messaging surface",
+            ),
+          }),
+          { type: "text", text: "Approved with private code 123456" },
+        ],
+      }),
+    );
+    const activeActivity = harness.delivered.filter(
+      (intent) => intent.kind === "activity" && intent.state === "active",
+    );
+    expect(activeActivity.length).toBeGreaterThan(0);
+    expect(activeActivity).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ bindingId: "binding-slack-signals" }),
+      ]),
+    );
+    expect(activeActivity).not.toContainEqual(
+      expect.objectContaining({ bindingId: continuationBinding.id }),
+    );
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          item: {
+            id: "private-reply-commentary",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "The private code was 123456.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(
+      harness.delivered.some(
+        (intent) =>
+          intent.kind === "message"
+          && intent.parts.some(
+            (part) => part.type === "text" && part.text.includes("123456"),
+          ),
+      ),
+    ).toBe(false);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          item: {
+            id: "private-reply-final",
+            type: "agentMessage",
+            text: "Harold approved the AWS SSO login.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          channel: expect.objectContaining({
+            conversation: expect.objectContaining({ id: "C012SIGNALS" }),
+          }),
+        }),
+        bindingId: "binding-slack-signals",
+        kind: "message",
+        parts: [
+          expect.objectContaining({
+            text: "Harold approved the AWS SSO login.",
+          }),
+        ],
+      }),
+    );
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-2",
+          turn: { id: "turn-2", status: "completed", output: [] },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(await harness.store.getBinding(continuationBinding.id)).toMatchObject({
+      revokedAt: expect.any(Number),
+    });
+    expect(harness.onBindingChanged).toHaveBeenCalled();
   });
 
   it("privately delivers an explicit DM request when the thread lacks the tool", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1717,7 +1717,14 @@ describe("MessagingController", () => {
     expect(assistantReplies[0]?.bindingId).toMatch(/^default-agent-route:/);
   });
 
-  it("delivers a terminal private response to the requesting Slack user", async () => {
+  async function createSlackPrivateResponseHarness(options?: {
+    deliveryBudget?: MessagingDeliveryBudget;
+    deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+    now?: () => number;
+    resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+    sleepUntil?: MessagingControllerOptions["sleepUntil"];
+    streamingResponsesDefault?: boolean;
+  }) {
     const channel = {
       channel: "slack" as const,
       conversation: {
@@ -1756,8 +1763,20 @@ describe("MessagingController", () => {
     };
     const harness = await createHarness({
       channel: "slack",
+      ...(options?.deliveryBudget
+        ? { deliveryBudget: options.deliveryBudget }
+        : {}),
+      ...(options?.deliver ? { deliver: options.deliver } : {}),
       navigation,
+      ...(options?.now ? { now: options.now } : {}),
       resolvePrivateConversation,
+      ...(options?.resolveDeliveryScope
+        ? { resolveDeliveryScope: options.resolveDeliveryScope }
+        : {}),
+      ...(options?.sleepUntil ? { sleepUntil: options.sleepUntil } : {}),
+      ...(options?.streamingResponsesDefault === undefined
+        ? {}
+        : { streamingResponsesDefault: options.streamingResponsesDefault }),
     });
     await harness.store.upsertBinding({
       id: "binding-slack-signals",
@@ -1778,6 +1797,15 @@ describe("MessagingController", () => {
       }),
     );
     harness.delivered.length = 0;
+    return { channel, harness, resolvePrivateConversation };
+  }
+
+  it("delivers a terminal private response to the requesting Slack user", async () => {
+    const {
+      channel,
+      harness,
+      resolvePrivateConversation,
+    } = await createSlackPrivateResponseHarness();
 
     const response = await harness.controller.handlePwrAgentMessagingRequest({
       operation: "send_private_response",
@@ -1880,6 +1908,316 @@ describe("MessagingController", () => {
     expect(
       harness.delivered.filter((intent) => intent.kind === "message"),
     ).toHaveLength(1);
+  });
+
+  it("dismisses an existing source stream before private delivery succeeds", async () => {
+    let now = 1000;
+    const delivered: MessagingSurfaceIntent[] = [];
+    const { harness } = await createSlackPrivateResponseHarness({
+      now: () => now,
+      streamingResponsesDefault: true,
+      deliver: async (intent) => {
+        delivered.push(intent);
+        const surface = intent.kind === "dismiss"
+          ? intent.targetSurface
+          : intent.kind === "stream_update" && intent.targetSurface
+            ? intent.targetSurface
+            : { channel: "slack" as const, id: `surface:${intent.id}` };
+        return {
+          channel: "slack",
+          deliveredAt: now,
+          outcome: intent.kind === "dismiss"
+            ? "dismissed"
+            : intent.kind === "stream_update" && intent.delivery?.mode === "update"
+              ? "updated"
+              : "presented",
+          surface,
+        };
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: "Open the AWS SSO link",
+        },
+      },
+    } satisfies AgentEvent);
+    now += 500;
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: " and use the code.",
+        },
+      },
+    } satisfies AgentEvent);
+
+    const sourceStream = delivered.find((intent) => intent.kind === "stream_update");
+    expect(sourceStream).toBeDefined();
+    const response = await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private AWS SSO instructions." },
+    });
+
+    expect(response).toMatchObject({ ok: true });
+    expect(delivered.at(-1)).toMatchObject({
+      kind: "dismiss",
+      reason: "terminal_private_response",
+      targetSurface: {
+        channel: "slack",
+        id: `surface:${sourceStream!.id}`,
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Do not post this publicly." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(delivered.filter((intent) => intent.kind === "stream_update")).toHaveLength(1);
+    expect(
+      delivered.filter((intent) => intent.kind === "message" && intent.role === "assistant"),
+    ).toHaveLength(1);
+  });
+
+  it("retracts a source stream that finishes while private delivery is in flight", async () => {
+    let now = 1000;
+    let releaseSourceStream!: () => void;
+    let resolveSourceStreamStarted!: () => void;
+    const sourceStreamStarted = new Promise<void>((resolve) => {
+      resolveSourceStreamStarted = resolve;
+    });
+    const sourceStreamRelease = new Promise<void>((resolve) => {
+      releaseSourceStream = resolve;
+    });
+    const delivered: MessagingSurfaceIntent[] = [];
+    const { harness } = await createSlackPrivateResponseHarness({
+      now: () => now,
+      streamingResponsesDefault: true,
+      deliver: async (intent) => {
+        delivered.push(intent);
+        if (intent.kind === "stream_update") {
+          resolveSourceStreamStarted();
+          await sourceStreamRelease;
+          return {
+            channel: "slack",
+            deliveredAt: now,
+            outcome: "presented",
+            surface: { channel: "slack", id: "surface:late-source-stream" },
+          };
+        }
+        return {
+          channel: "slack",
+          deliveredAt: now,
+          outcome: intent.kind === "dismiss" ? "dismissed" : "presented",
+          surface: intent.kind === "dismiss"
+            ? intent.targetSurface
+            : { channel: "slack", id: `surface:${intent.id}` },
+        };
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: "AWS SSO",
+        },
+      },
+    } satisfies AgentEvent);
+    now += 500;
+    const sourceDelivery = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: " secret",
+        },
+      },
+    } satisfies AgentEvent);
+    await sourceStreamStarted;
+
+    let privateRequestSettled = false;
+    const privateRequest = harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private AWS SSO instructions." },
+    }).finally(() => {
+      privateRequestSettled = true;
+    });
+    await vi.waitFor(() => {
+      expect(
+        delivered.some((intent) => intent.kind === "message"),
+      ).toBe(true);
+    });
+    expect(privateRequestSettled).toBe(false);
+
+    releaseSourceStream();
+    const [, response] = await Promise.all([sourceDelivery, privateRequest]);
+
+    expect(response).toMatchObject({ ok: true });
+    expect(delivered.at(-1)).toMatchObject({
+      kind: "dismiss",
+      reason: "terminal_private_response",
+      targetSurface: {
+        channel: "slack",
+        id: "surface:late-source-stream",
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{ type: "text", text: "Do not recreate the source stream." }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    expect(delivered.filter((intent) => intent.kind === "stream_update")).toHaveLength(1);
+    expect(
+      delivered.filter((intent) => intent.kind === "message" && intent.role === "assistant"),
+    ).toHaveLength(1);
+  });
+
+  it("cancels a budget-deferred source stream without waiting for its retry", async () => {
+    let now = 1000;
+    let resolveBudgetDelayStarted!: () => void;
+    const budgetDelayStarted = new Promise<void>((resolve) => {
+      resolveBudgetDelayStarted = resolve;
+    });
+    const neverReleaseBudgetDelay = new Promise<void>(() => undefined);
+    const scope: MessagingDeliveryScope = {
+      platform: "slack",
+      id: "slack:channel:C012SIGNALS",
+      kind: "channel",
+      budget: { limit: 10, intervalMs: 60_000, reserved: 1 },
+    };
+    const deliveryBudget = {
+      admit: vi.fn(
+        (request: Parameters<MessagingDeliveryBudget["admit"]>[0]) =>
+          request.priority === "stream_partial"
+            ? {
+                outcome: "deferred" as const,
+                reason: "budget-exhausted" as const,
+                retryAt: 61_000,
+                slowMode: false,
+              }
+            : { outcome: "admitted" as const, slowMode: false },
+      ),
+      recordRateLimit: vi.fn(),
+    } as unknown as MessagingDeliveryBudget;
+    const delivered: MessagingSurfaceIntent[] = [];
+    const { harness } = await createSlackPrivateResponseHarness({
+      deliveryBudget,
+      now: () => now,
+      resolveDeliveryScope: () => scope,
+      sleepUntil: async () => {
+        resolveBudgetDelayStarted();
+        await neverReleaseBudgetDelay;
+      },
+      streamingResponsesDefault: true,
+      deliver: async (intent) => {
+        delivered.push(intent);
+        return {
+          channel: "slack",
+          deliveredAt: now,
+          outcome: "presented",
+          surface: { channel: "slack", id: `surface:${intent.id}` },
+        };
+      },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: "AWS SSO",
+        },
+      },
+    } satisfies AgentEvent);
+    now += 500;
+    const sourceDelivery = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "assistant-private-stream",
+          delta: " secret",
+        },
+      },
+    } satisfies AgentEvent);
+    await budgetDelayStarted;
+
+    const response = await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private AWS SSO instructions." },
+    });
+    await sourceDelivery;
+
+    expect(response).toMatchObject({ ok: true });
+    expect(delivered.filter((intent) => intent.kind === "stream_update")).toEqual([]);
+    expect(
+      delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        kind: "message",
+        parts: [expect.objectContaining({ text: "Private AWS SSO instructions." })],
+      }),
+    ]);
   });
 
   it("keeps the source response when private delivery is unavailable", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -2038,7 +2038,7 @@ describe("MessagingController", () => {
   it("returns a requested private reply to the source and retires its one-shot binding", async () => {
     let startedTurnCount = 0;
     const controllerDuringStart: { current?: MessagingController } = {};
-    const { harness } = await createSlackPrivateResponseHarness({
+    const { harness, resolvePrivateConversation } = await createSlackPrivateResponseHarness({
       startTurn: async (request) => {
         const turnId = `turn-${++startedTurnCount}`;
         if (turnId === "turn-2") {
@@ -2095,6 +2095,9 @@ describe("MessagingController", () => {
       ok: true,
       data: { awaitingReply: true },
     });
+    expect(resolvePrivateConversation).toHaveBeenCalledWith(
+      expect.objectContaining({ replyContinuationRequired: true }),
+    );
     expect(harness.delivered).toContainEqual(
       expect.objectContaining({
         attribution: {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1720,11 +1720,15 @@ describe("MessagingController", () => {
   async function createSlackPrivateResponseHarness(options?: {
     deliveryBudget?: MessagingDeliveryBudget;
     deliver?: (intent: MessagingSurfaceIntent) => Promise<MessagingDeliveryResult>;
+    inboundText?: string;
     now?: () => number;
     resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
     responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
     sleepUntil?: MessagingControllerOptions["sleepUntil"];
     streamingResponsesDefault?: boolean;
+    toolUpdateDefaultMode?:
+      | MessagingToolUpdateMode
+      | ((targetKind: "thread" | "agent_thread") => MessagingToolUpdateMode);
   }) {
     const channel = {
       channel: "slack" as const,
@@ -1821,6 +1825,9 @@ describe("MessagingController", () => {
       ...(options?.streamingResponsesDefault === undefined
         ? {}
         : { streamingResponsesDefault: options.streamingResponsesDefault }),
+      ...(options?.toolUpdateDefaultMode
+        ? { toolUpdateDefaultMode: options.toolUpdateDefaultMode }
+        : {}),
     });
     harnessDelivered = harness.delivered;
     await harness.store.upsertBinding({
@@ -1835,7 +1842,7 @@ describe("MessagingController", () => {
       updatedAt: 1000,
     });
     await harness.controller.handleInboundEvent(
-      buildTextEvent("DM me the AWS SSO link and code", {
+      buildTextEvent(options?.inboundText ?? "DM me the AWS SSO link and code", {
         botMention: true,
         channel,
         routingState: { opaque: { channelId: "C012SIGNALS" } },
@@ -2017,10 +2024,66 @@ describe("MessagingController", () => {
     );
   });
 
+  it("privately delivers an explicit DM request when the thread lacks the tool", async () => {
+    const { harness } = await createSlackPrivateResponseHarness();
+    expect(harness.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining(
+              "If that tool is unavailable",
+            ),
+            type: "text",
+          }),
+        ]),
+      }),
+    );
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [{
+              type: "text",
+              text: "Open the AWS SSO URL and enter `PRIVATE-CODE`.",
+            }],
+          },
+        },
+      },
+    } satisfies AgentEvent);
+
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toEqual([
+      expect.objectContaining({
+        attribution: expect.objectContaining({
+          label: "Signals Agent · Private response",
+        }),
+        parts: [expect.objectContaining({
+          text: expect.stringContaining("PRIVATE-CODE"),
+        })],
+      }),
+    ]);
+    expect(
+      harness.delivered.filter(
+        (intent) =>
+          intent.kind === "message"
+          && intent.audit?.channel.conversation.id === "C012SIGNALS",
+      ),
+    ).toEqual([]);
+  });
+
   it("dismisses an existing source stream before private delivery succeeds", async () => {
     let now = 1000;
     const delivered: MessagingSurfaceIntent[] = [];
     const { harness } = await createSlackPrivateResponseHarness({
+      inboundText: "Help me with the AWS SSO link and code",
       now: () => now,
       streamingResponsesDefault: true,
       deliver: async (intent) => {
@@ -2124,6 +2187,7 @@ describe("MessagingController", () => {
     });
     const delivered: MessagingSurfaceIntent[] = [];
     const { harness } = await createSlackPrivateResponseHarness({
+      inboundText: "Help me with the AWS SSO link and code",
       now: () => now,
       streamingResponsesDefault: true,
       deliver: async (intent) => {
@@ -2259,6 +2323,7 @@ describe("MessagingController", () => {
     const delivered: MessagingSurfaceIntent[] = [];
     const { harness } = await createSlackPrivateResponseHarness({
       deliveryBudget,
+      inboundText: "Help me with the AWS SSO link and code",
       now: () => now,
       resolveDeliveryScope: () => scope,
       sleepUntil: async () => {
@@ -2325,6 +2390,133 @@ describe("MessagingController", () => {
         parts: [expect.objectContaining({ text: "Private AWS SSO instructions." })],
       }),
     ]);
+  });
+
+  it("retracts an in-flight working update before private success", async () => {
+    let releaseWorkingUpdate!: () => void;
+    let resolveWorkingUpdateStarted!: () => void;
+    const workingUpdateStarted = new Promise<void>((resolve) => {
+      resolveWorkingUpdateStarted = resolve;
+    });
+    const workingUpdateRelease = new Promise<void>((resolve) => {
+      releaseWorkingUpdate = resolve;
+    });
+    const delivered: MessagingSurfaceIntent[] = [];
+    const { harness } = await createSlackPrivateResponseHarness({
+      inboundText: "Help me with the AWS SSO link and code",
+      toolUpdateDefaultMode: "show_all",
+      deliver: async (intent) => {
+        delivered.push(intent);
+        if (intent.id.startsWith("tool-update")) {
+          resolveWorkingUpdateStarted();
+          await workingUpdateRelease;
+          return {
+            channel: "slack",
+            deliveredAt: 1000,
+            outcome: "presented",
+            surface: {
+              channel: "slack",
+              id: "late-working-update",
+              state: {
+                opaque: {
+                  channelId: "C012SIGNALS",
+                  ts: "late-working-update",
+                },
+              },
+            },
+          };
+        }
+        if (intent.kind === "dismiss") {
+          return {
+            channel: "slack",
+            deliveredAt: 1000,
+            outcome: "dismissed",
+          };
+        }
+        const surface = {
+          channel: "slack" as const,
+          id: `surface:${intent.id}`,
+        };
+        return {
+          channel: "slack",
+          continuation: {
+            channel: {
+              channel: "slack",
+              conversation: {
+                id: "D012HAROLD",
+                isDirectMessage: true,
+                kind: "thread" as const,
+                parentConversationId: "D012HAROLD",
+                parentId: surface.id,
+                workspaceId: "T012WORKSPACE",
+              },
+            },
+            routingState: {
+              opaque: {
+                channelId: "D012HAROLD",
+                teamId: "T012WORKSPACE",
+                threadTs: surface.id,
+              },
+            },
+          },
+          deliveredAt: 1000,
+          outcome: "presented" as const,
+          surface,
+        };
+      },
+    });
+
+    const workingUpdate = harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-setup",
+            type: "agentMessage",
+            phase: "commentary",
+            text: "Preparing the private AWS response.",
+          },
+        },
+      },
+    } satisfies AgentEvent);
+    await workingUpdateStarted;
+
+    const privateRequest = harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: { text: "Private AWS SSO instructions." },
+    });
+    await vi.waitFor(() => {
+      expect(
+        delivered.some(
+          (intent) =>
+            intent.kind === "message"
+            && intent.parts.some(
+              (part) => part.type === "text" && part.text.includes("Private AWS"),
+            ),
+        ),
+      ).toBe(true);
+    });
+    releaseWorkingUpdate();
+    const [, response] = await Promise.all([workingUpdate, privateRequest]);
+
+    expect(response).toMatchObject({ ok: true });
+    expect(delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "dismiss",
+        reason: "terminal_private_response",
+        targetSurface: expect.objectContaining({
+          id: "late-working-update",
+        }),
+      }),
+    );
   });
 
   it("keeps the source response when private delivery is unavailable", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1717,6 +1717,232 @@ describe("MessagingController", () => {
     expect(assistantReplies[0]?.bindingId).toMatch(/^default-agent-route:/);
   });
 
+  it("delivers a terminal private response to the requesting Slack user", async () => {
+    const channel = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012SIGNALS",
+        kind: "channel" as const,
+        title: "p-search-signals-project",
+        workspaceId: "T012WORKSPACE",
+      },
+    };
+    const resolvePrivateConversation = vi.fn(async () => ({
+      channel: "slack" as const,
+      conversation: {
+        id: "user-1",
+        kind: "dm" as const,
+        title: "Harold Hunt",
+        workspaceId: "T012WORKSPACE",
+      },
+      outcome: "resolved" as const,
+      routingState: {
+        opaque: {
+          channelId: "user-1",
+          teamId: "T012WORKSPACE",
+        },
+      },
+      updatedAt: 1000,
+    }));
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Signals Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({
+      channel: "slack",
+      navigation,
+      resolvePrivateConversation,
+    });
+    await harness.store.upsertBinding({
+      id: "binding-slack-signals",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      routingState: { opaque: { channelId: "C012SIGNALS" } },
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("DM me the AWS SSO link and code", {
+        botMention: true,
+        channel,
+        routingState: { opaque: { channelId: "C012SIGNALS" } },
+      }),
+    );
+    harness.delivered.length = 0;
+
+    const response = await harness.controller.handlePwrAgentMessagingRequest({
+      operation: "send_private_response",
+      context: {
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-1",
+      },
+      args: {
+        text: "Open https://device.sso.us-east-1.amazonaws.com and enter `ABCD-EFGH`.",
+      },
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      data: {
+        channel: "slack",
+        outcome: "delivered",
+        recipient: { platformUserId: "user-1" },
+      },
+    });
+    expect(resolvePrivateConversation).toHaveBeenCalledWith({
+      actor: expect.objectContaining({ platformUserId: "user-1" }),
+      source: channel,
+      routingState: { opaque: { channelId: "C012SIGNALS" } },
+    });
+    expect(harness.delivered).toEqual([
+      expect.objectContaining({
+        audit: expect.objectContaining({
+          actor: expect.objectContaining({ platformUserId: "user-1" }),
+          channel: expect.objectContaining({
+            channel: "slack",
+            conversation: expect.objectContaining({
+              id: "user-1",
+              kind: "dm",
+            }),
+          }),
+        }),
+        kind: "message",
+        parts: [
+          expect.objectContaining({
+            text: expect.stringContaining("ABCD-EFGH"),
+          }),
+        ],
+        targetSurface: expect.objectContaining({
+          state: { opaque: { channelId: "user-1", teamId: "T012WORKSPACE" } },
+        }),
+      }),
+    ]);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-private-ack",
+            type: "agentMessage",
+            text: "Sent it privately.",
+          },
+        },
+      },
+    });
+
+    expect(harness.delivered).toHaveLength(1);
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            output: [],
+          },
+        },
+      },
+    });
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-private-ack-late",
+            type: "agentMessage",
+            text: "Sent it privately.",
+          },
+        },
+      },
+    });
+
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "message"),
+    ).toHaveLength(1);
+  });
+
+  it("keeps the source response when private delivery is unavailable", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = {
+      ...navigation.threads[0]!,
+      agent: {
+        name: "Private Reply Agent",
+        instructionLineCount: 1,
+        instructionsTooLong: false,
+        updatedAt: 1000,
+      },
+    };
+    const harness = await createHarness({ navigation });
+    await bindThread(harness);
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("send this privately"),
+    );
+    harness.delivered.length = 0;
+
+    await expect(
+      harness.controller.handlePwrAgentMessagingRequest({
+        operation: "send_private_response",
+        context: {
+          backend: "codex",
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+        args: { text: "private text" },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "unsupported_operation" },
+    });
+
+    await harness.controller.handleBackendEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            id: "assistant-private-failed",
+            type: "agentMessage",
+            text: "I could not send that privately.",
+          },
+        },
+      },
+    });
+
+    expect(harness.delivered).toContainEqual(
+      expect.objectContaining({
+        kind: "message",
+        parts: [
+          expect.objectContaining({
+            text: "I could not send that privately.",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("lets a default Agent explicitly attach a thread to its unbound source", async () => {
     const navigation = buildNavigationSnapshot();
     navigation.threads[0] = {
@@ -19478,6 +19704,7 @@ async function createHarness(options?: {
   onFullAccessPolicyViolation?: MessagingControllerOptions["onFullAccessPolicyViolation"];
   onDeliveryBudgetEvent?: MessagingControllerOptions["onDeliveryBudgetEvent"];
   resolveDeliveryScope?: MessagingAdapter["resolveDeliveryScope"];
+  resolvePrivateConversation?: MessagingAdapter["resolvePrivateConversation"];
   responseModeForConversation?: MessagingControllerOptions["responseModeForConversation"];
   getManagedConversationRights?: MessagingAdapter["getManagedConversationRights"];
   createManagedConversation?: MessagingAdapter["createManagedConversation"];
@@ -19586,14 +19813,17 @@ async function createHarness(options?: {
       options?.deliver ??
         (async (intent) => {
           delivered.push(intent);
+          const channel = intent.audit?.channel.channel
+            ?? options?.channel
+            ?? "telegram";
           return {
-            channel: "telegram" as const,
+            channel,
             deliveredAt: 1000,
             outcome: intent.kind === "status" && intent.delivery?.pin
               ? "pinned" as const
               : "presented" as const,
             surface: {
-              channel: "telegram" as const,
+              channel,
               id: `surface:${intent.id}`,
             },
           };
@@ -19607,6 +19837,9 @@ async function createHarness(options?: {
       : {}),
     ...(options?.createManagedConversation
       ? { createManagedConversation: options.createManagedConversation }
+      : {}),
+    ...(options?.resolvePrivateConversation
+      ? { resolvePrivateConversation: options.resolvePrivateConversation }
       : {}),
     ...(options?.closeManagedConversation
       ? { closeManagedConversation: options.closeManagedConversation }

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -1933,6 +1933,7 @@ describe("MessagingController", () => {
           parentId: expect.stringContaining("surface:private-response"),
         },
       },
+      statusPresentation: "on_demand",
       targetKind: "agent_thread",
       threadId: "thread-1",
     });
@@ -2006,6 +2007,7 @@ describe("MessagingController", () => {
     if (!continuationBinding) {
       throw new Error("Expected the private reply continuation binding");
     }
+    harness.delivered.length = 0;
     await harness.controller.handleInboundEvent(
       buildTextEvent("I approved the AWS login.", {
         channel: continuationBinding.channel,
@@ -2022,6 +2024,9 @@ describe("MessagingController", () => {
         })],
       }),
     );
+    expect(
+      harness.delivered.filter((intent) => intent.kind === "status"),
+    ).toEqual([]);
   });
 
   it("privately delivers an explicit DM request when the thread lacks the tool", async () => {

--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -530,6 +530,51 @@ describe("DesktopMessagingRuntime", () => {
     );
   });
 
+  it("dispatches ambient replies in a native thread inside a 1:1 DM", async () => {
+    const { adapter, bridge } = await startMentionOnlyRuntime({
+      automationInboundHandler: vi.fn(async () => false),
+      automationInboundMatches: vi.fn(() => false),
+    });
+    const { getDesktopMessagingStore } = await import(
+      "../messaging/desktop-messaging-store"
+    );
+    const channel = {
+      channel: "telegram" as const,
+      conversation: {
+        id: "dm-1",
+        isDirectMessage: true,
+        kind: "thread" as const,
+        parentConversationId: "dm-1",
+        parentId: "private-response-1",
+      },
+    };
+    await getDesktopMessagingStore().upsertBinding({
+      id: "binding:telegram:thread:private-response-1:dm-1:codex:thread-1",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel,
+      createdAt: 1000,
+      targetKind: "agent_thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+
+    await adapter.listener?.({
+      ...ambientEvent,
+      channel,
+      id: "dm-thread-reply",
+      text: "continue without a mention",
+    });
+    await waitFor(() => vi.mocked(bridge.startTurn).mock.calls.length > 0);
+
+    expect(bridge.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-1",
+        input: [{ type: "text", text: "continue without a mention" }],
+      }),
+    );
+  });
+
   it("does not enforce response modes without bot-mention reporting", async () => {
     const { adapter, bridge } = await startMentionOnlyRuntime({
       automationInboundHandler: vi.fn(async () => false),

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -302,6 +302,38 @@ describe("buildBindingStatusIntent", () => {
     );
   });
 
+  it("hides response-mode controls in a native thread inside a 1:1 DM", () => {
+    const binding = {
+      ...buildBinding(),
+      channel: {
+        channel: "slack" as const,
+        conversation: {
+          id: "D012ABCDEF0",
+          isDirectMessage: true,
+          kind: "thread" as const,
+          parentConversationId: "D012ABCDEF0",
+          parentId: "1712023032.123456",
+        },
+      },
+    };
+    const intent = buildBindingStatusIntent({
+      id: "status-dm-thread-response-mode",
+      binding,
+      capabilityProfile: PERMISSIVE_CAPABILITY_PROFILE,
+      createdAt: 1000,
+      responseModeDefault: "mention_only",
+      threadState: resolveMessagingThreadState({
+        binding,
+        navigation: buildNavigationSnapshot(),
+      }),
+    });
+
+    expect(intent.text).not.toContain("Responses:");
+    expect(intent.actions).not.toContainEqual(
+      expect.objectContaining({ id: "status:response-mode" }),
+    );
+  });
+
   it("redacts backend account email in shared conversations", () => {
     const binding = {
       ...buildBinding(),

--- a/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts
@@ -57,6 +57,7 @@ describe("PwrAgent messaging agent tools", () => {
     expect(specs[0]?.type === "namespace" ? specs[0].tools.map((tool) => tool.name) : [])
       .toEqual([
       "get_current_messaging_surface",
+      "send_private_response",
       "attach_thread_here",
       "inspect_messaging_pdfs",
       "search_messaging_pdf_text",
@@ -64,6 +65,7 @@ describe("PwrAgent messaging agent tools", () => {
     ]);
     expect(router.buildMcpTools().map((tool) => tool.name)).toEqual([
       "get_current_messaging_surface",
+      "send_private_response",
       "attach_thread_here",
     ]);
     expect(

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts
@@ -30,7 +30,7 @@ describe("PwrAgent task monitor agent tools", () => {
       "render_messaging_pdf_pages",
       "search_messaging_pdf_text",
     ]);
-    expect(dynamicTools).toHaveLength(30);
+    expect(dynamicTools).toHaveLength(31);
     expect(mcpTools).toEqual(
       dynamicTools.filter((tool) => !dynamicOnlyToolNames.has(tool.name)),
     );

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -118,6 +118,8 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
       return "Deprecated alias for get_current_messaging_surface. Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "get_current_messaging_surface":
       return "Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
+    case "send_private_response":
+      return "Send the terminal response privately to the user who initiated the current messaging turn. Use this only when the user explicitly asks for a private reply or the response contains secrets that should not be posted to the source conversation. On success, PwrAgent suppresses the normal final response on the source surface; end the turn without repeating the private content. This cannot target an arbitrary user or be called outside an active messaging turn.";
     case "attach_thread_here":
       return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. This does not rename the PwrAgent thread.";
     case "inspect_messaging_pdfs":
@@ -139,6 +141,21 @@ function inputSchemaForOperation(
         type: "object",
         additionalProperties: false,
         properties: {},
+      };
+    case "send_private_response":
+      return {
+        type: "object",
+        additionalProperties: false,
+        required: ["text"],
+        properties: {
+          text: {
+            type: "string",
+            minLength: 1,
+            maxLength: 40_000,
+            description:
+              "Complete private response to deliver to the requesting user. Do not include an additional public copy in the final response.",
+          },
+        },
       };
     case "attach_thread_here":
       return {

--- a/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-messaging-agent-tools.ts
@@ -119,7 +119,7 @@ function descriptionForOperation(operation: PwrAgentMessagingOperationName): str
     case "get_current_messaging_surface":
       return "Inspect the messaging platform, actor, conversation, binding, compact bound-thread identity, and native thread/topic creation capability for the surface that started this Agent turn.";
     case "send_private_response":
-      return "Send the terminal response privately to the user who initiated the current messaging turn. Use this only when the user explicitly asks for a private reply or the response contains secrets that should not be posted to the source conversation. On success, PwrAgent suppresses the normal final response on the source surface; end the turn without repeating the private content. This cannot target an arbitrary user or be called outside an active messaging turn.";
+      return "Send the terminal response privately to the user who initiated the current messaging turn. Use this only when the user explicitly asks for a private reply or the response contains secrets that should not be posted to the source conversation. On success, PwrAgent suppresses the normal final response on the source surface; end the turn without repeating the private content. Set awaitReply=true with replyInstructions when the private message asks the user for a response: their first reply starts a one-shot continuation turn whose final answer is delivered back to the originating surface, and PwrAgent then removes the temporary private-thread route. This cannot target an arbitrary user or be called outside an active messaging turn.";
     case "attach_thread_here":
       return "Attach a known PwrAgent thread to the current messaging surface, creating a native child thread/topic when the provider supports it. This does not rename the PwrAgent thread.";
     case "inspect_messaging_pdfs":
@@ -148,6 +148,18 @@ function inputSchemaForOperation(
         additionalProperties: false,
         required: ["text"],
         properties: {
+          awaitReply: {
+            type: "boolean",
+            description:
+              "Whether the first reply in the private message thread should start a one-shot continuation whose final response returns to the originating surface. Requires replyInstructions.",
+          },
+          replyInstructions: {
+            type: "string",
+            minLength: 1,
+            maxLength: 4_000,
+            description:
+              "Instructions for turning the user's private reply into the final response returned to the originating surface, including what must not be repeated there. Used only when awaitReply is true.",
+          },
           text: {
             type: "string",
             minLength: 1,

--- a/apps/desktop/src/main/messaging/core/messaging-adapter.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-adapter.ts
@@ -71,6 +71,8 @@ import type {
   MessagingManagedConversationCreateResult,
   MessagingManagedConversationRightsRequest,
   MessagingManagedConversationRightsResult,
+  MessagingPrivateConversationResolveRequest,
+  MessagingPrivateConversationResolveResult,
   MessagingReconnectInfo,
   MessagingSurfaceIntent,
 } from "@pwragent/messaging-interface";
@@ -125,6 +127,9 @@ export type MessagingAdapter = {
   createManagedConversation?(
     request: MessagingManagedConversationCreateRequest,
   ): Promise<MessagingManagedConversationCreateResult>;
+  resolvePrivateConversation?(
+    request: MessagingPrivateConversationResolveRequest,
+  ): Promise<MessagingPrivateConversationResolveResult>;
   closeManagedConversation?(
     request: MessagingManagedConversationActionRequest,
   ): Promise<MessagingManagedConversationActionResult>;

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -698,6 +698,12 @@ type PendingNewThreadPromptBundle = {
 
 type MessagingDeliveryGuard = {
   isCancelled: () => boolean;
+  onCancelledDelivery?: (result: MessagingDeliveryResult) => Promise<void>;
+  whenCancelled?: Promise<void>;
+};
+
+type MessagingCancellationSignal = MessagingDeliveryGuard & {
+  cancel: () => void;
 };
 
 export type MessagingControllerOptions = {
@@ -762,6 +768,11 @@ export class MessagingController {
   private readonly deliveredAssistantMessageKeys = new Set<string>();
   private readonly assistantStreamBuffers = new Map<string, AssistantStreamBuffer>();
   private readonly assistantStreamDeliveryQueues = new Map<string, Promise<void>>();
+  private readonly assistantStreamCancellationFailures = new Set<string>();
+  private readonly assistantStreamCancellationSignals = new Map<
+    string,
+    MessagingCancellationSignal
+  >();
   private readonly automationTurnsByTurnKey = new Map<
     string,
     AutomationTurnMessagingContext
@@ -5185,6 +5196,15 @@ export class MessagingController {
     delta: AssistantStreamDelta,
     binding: MessagingBindingRecord,
   ): Promise<void> {
+    if (
+      this.isTerminalPrivateResponseTurn(
+        binding.backend,
+        binding.threadId,
+        delta.turnId,
+      )
+    ) {
+      return;
+    }
     const bufferKey = this.assistantStreamBufferKey(delta.streamKey, binding);
     const now = this.now();
     const existing = this.assistantStreamBuffers.get(bufferKey);
@@ -5244,11 +5264,13 @@ export class MessagingController {
   ): Promise<boolean> {
     const streamingEnabled = this.isStreamingResponsesEnabledForBinding(binding);
     let deliveredFinalStream = false;
+    const completedTurnIds = new Set<string>();
     for (const bufferKey of this.assistantStreamBufferKeysForEvent(event, binding)) {
       const buffer = this.assistantStreamBuffers.get(bufferKey);
       if (!buffer) {
         continue;
       }
+      completedTurnIds.add(buffer.turnId);
       // Streaming off: drop the accumulator without emitting a final
       // `stream_update`. Returning `false` routes the caller to
       // `deliverAssistantMessage`, so the turn lands as a single message
@@ -5269,6 +5291,11 @@ export class MessagingController {
       this.assistantStreamBuffers.delete(bufferKey);
       this.assistantStreamDeliveryQueues.delete(bufferKey);
     }
+    for (const turnId of completedTurnIds) {
+      this.assistantStreamCancellationSignals.delete(
+        this.turnProseKey(binding.id, turnId),
+      );
+    }
     return deliveredFinalStream;
   }
 
@@ -5281,11 +5308,13 @@ export class MessagingController {
       identity: AssistantMessageDeliveryIdentity;
       text: string;
     }> = [];
+    const completedTurnIds = new Set<string>();
     for (const bufferKey of this.assistantStreamBufferKeysForEvent(event, binding)) {
       const buffer = this.assistantStreamBuffers.get(bufferKey);
       if (!buffer) {
         continue;
       }
+      completedTurnIds.add(buffer.turnId);
       const text = buffer.text.trim();
       if (!text) {
         this.assistantStreamBuffers.delete(bufferKey);
@@ -5327,6 +5356,12 @@ export class MessagingController {
       }
       this.assistantStreamBuffers.delete(bufferKey);
       this.assistantStreamDeliveryQueues.delete(bufferKey);
+    }
+
+    for (const turnId of completedTurnIds) {
+      this.assistantStreamCancellationSignals.delete(
+        this.turnProseKey(binding.id, turnId),
+      );
     }
 
     for (const fallback of fallbackMessages) {
@@ -5415,6 +5450,11 @@ export class MessagingController {
     binding: MessagingBindingRecord,
     isFinal: boolean,
   ): Promise<MessagingDeliveryResult> {
+    const cancellationKey = this.turnProseKey(binding.id, buffer.turnId);
+    const cancellation = this.ensureAssistantStreamCancellationSignal(
+      binding,
+      buffer.turnId,
+    );
     const now = this.now();
     const intent: MessagingStreamUpdateIntent = {
       id: this.newIntentId(isFinal ? "assistant-stream-final" : "assistant-stream"),
@@ -5443,7 +5483,31 @@ export class MessagingController {
         isFinal,
       },
     };
-    const result = await this.deliver(intent, binding);
+    const result = await this.deliver(intent, binding, undefined, {
+      isCancelled: cancellation.isCancelled,
+      whenCancelled: cancellation.whenCancelled,
+      onCancelledDelivery: async (cancelledResult) => {
+        if (
+          cancelledResult.surface
+          && isVisibleAssistantStreamDelivery(cancelledResult)
+          && !isSameMessagingSurface(cancelledResult.surface, buffer.surface)
+        ) {
+          const dismissed = await this.dismissAssistantStreamSurface(
+            binding,
+            buffer.turnId,
+            cancelledResult.surface,
+          );
+          if (!dismissed) {
+            this.assistantStreamCancellationFailures.add(cancellationKey);
+          }
+        }
+      },
+    });
+    if (cancellation.isCancelled()) {
+      const bufferKey = this.assistantStreamBufferKey(buffer.streamKey, binding);
+      this.assistantStreamBuffers.delete(bufferKey);
+      return result;
+    }
     const surface =
       result.surface && isVisibleAssistantStreamDelivery(result)
         ? result.surface
@@ -5464,18 +5528,146 @@ export class MessagingController {
     return `${binding.id}\0${streamKey}`;
   }
 
-  private discardAssistantStreamsForTurn(
+  private ensureAssistantStreamCancellationSignal(
     binding: MessagingBindingRecord,
     turnId: string,
-  ): void {
+  ): MessagingCancellationSignal {
+    const key = this.turnProseKey(binding.id, turnId);
+    const existing = this.assistantStreamCancellationSignals.get(key);
+    if (existing) {
+      return existing;
+    }
+    let cancelled = this.isTerminalPrivateResponseTurn(
+      binding.backend,
+      binding.threadId,
+      turnId,
+    );
+    let resolveCancellation!: () => void;
+    const whenCancelled = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const cancellation: MessagingCancellationSignal = {
+      cancel: () => {
+        if (cancelled) {
+          return;
+        }
+        cancelled = true;
+        resolveCancellation();
+      },
+      isCancelled: () =>
+        cancelled
+        || this.isTerminalPrivateResponseTurn(
+          binding.backend,
+          binding.threadId,
+          turnId,
+        ),
+      whenCancelled,
+    };
+    if (cancelled) {
+      resolveCancellation();
+    }
+    this.assistantStreamCancellationSignals.set(key, cancellation);
+    return cancellation;
+  }
+
+  private async cancelAssistantStreamsForTurn(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): Promise<boolean> {
+    const cancellationKey = this.turnProseKey(binding.id, turnId);
+    const deliveries = new Set<Promise<void>>();
+    const surfaces = new Map<string, MessagingSurfaceRef>();
+    this.assistantStreamCancellationFailures.delete(cancellationKey);
+    this.assistantStreamCancellationSignals.get(cancellationKey)?.cancel();
     for (const [bufferKey, buffer] of this.assistantStreamBuffers) {
       if (
         bufferKey.startsWith(`${binding.id}\0`)
         && buffer.turnId === turnId
       ) {
+        if (buffer.surface) {
+          surfaces.set(messagingSurfaceKey(buffer.surface), buffer.surface);
+        }
+        const delivery = this.assistantStreamDeliveryQueues.get(bufferKey);
+        if (delivery) {
+          deliveries.add(delivery);
+        }
+        this.assistantStreamBuffers.delete(bufferKey);
+      }
+    }
+    await Promise.allSettled(deliveries);
+
+    // A delivery already awaiting its adapter can finish after the buffers are
+    // cleared. The delivery guard retracts a newly-created surface; make one
+    // final sweep for an existing surface before reporting private success.
+    for (const [bufferKey, buffer] of this.assistantStreamBuffers) {
+      if (
+        bufferKey.startsWith(`${binding.id}\0`)
+        && buffer.turnId === turnId
+      ) {
+        if (buffer.surface) {
+          surfaces.set(messagingSurfaceKey(buffer.surface), buffer.surface);
+        }
         this.assistantStreamBuffers.delete(bufferKey);
         this.assistantStreamDeliveryQueues.delete(bufferKey);
       }
+    }
+    for (const surface of surfaces.values()) {
+      const dismissed = await this.dismissAssistantStreamSurface(
+        binding,
+        turnId,
+        surface,
+      );
+      if (!dismissed) {
+        this.assistantStreamCancellationFailures.add(cancellationKey);
+      }
+    }
+    const cancelledCleanly = !this.assistantStreamCancellationFailures.has(
+      cancellationKey,
+    );
+    this.assistantStreamCancellationFailures.delete(cancellationKey);
+    this.assistantStreamCancellationSignals.delete(cancellationKey);
+    return cancelledCleanly;
+  }
+
+  private async dismissAssistantStreamSurface(
+    binding: MessagingBindingRecord,
+    turnId: string,
+    surface: MessagingSurfaceRef,
+  ): Promise<boolean> {
+    try {
+      const result = await this.deliver(
+        {
+          id: this.newIntentId("assistant-stream-private-response-dismiss"),
+          kind: "dismiss",
+          bindingId: binding.id,
+          createdAt: this.now(),
+          delivery: { mode: "dismiss" },
+          reason: "terminal_private_response",
+          targetSurface: surface,
+        },
+        binding,
+      );
+      if (result.outcome === "dismissed") {
+        return true;
+      }
+      this.logger.warn?.("messaging private response stream dismissal failed", {
+        bindingId: binding.id,
+        errorMessage: result.errorMessage,
+        outcome: result.outcome,
+        surfaceId: surface.id,
+        threadId: binding.threadId,
+        turnId,
+      });
+      return false;
+    } catch (error) {
+      this.logger.warn?.("messaging private response stream dismissal failed", {
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        surfaceId: surface.id,
+        threadId: binding.threadId,
+        turnId,
+      });
+      return false;
     }
   }
 
@@ -5782,6 +5974,11 @@ export class MessagingController {
     this.completedTaskMonitorTurns.clear();
     this.activeAgentMessagingOriginsByTurnKey.clear();
     this.terminalPrivateResponseTurnKeys.clear();
+    this.assistantStreamCancellationFailures.clear();
+    for (const cancellation of this.assistantStreamCancellationSignals.values()) {
+      cancellation.cancel();
+    }
+    this.assistantStreamCancellationSignals.clear();
     this.queuedAgentMessagingOriginsByQueueKey.clear();
   }
 
@@ -14151,7 +14348,15 @@ export class MessagingController {
             slowMode: admission.slowMode,
           });
           this.notifyDeliveryBudgetEvent(budgetEvent);
-          await (this.options.sleepUntil ?? sleepUntil)(admission.retryAt, this.now);
+          const delay = (this.options.sleepUntil ?? sleepUntil)(
+            admission.retryAt,
+            this.now,
+          );
+          if (guard?.whenCancelled) {
+            await Promise.race([delay, guard.whenCancelled]);
+          } else {
+            await delay;
+          }
           if (guard?.isCancelled()) {
             return cancelledResult();
           }
@@ -14199,6 +14404,10 @@ export class MessagingController {
         return cancelledResult();
       }
       const result = await this.options.adapter.deliver(routedIntent);
+      if (guard?.isCancelled()) {
+        await guard.onCancelledDelivery?.(result);
+        return cancelledResult();
+      }
       this.logDeliveryResult(routedIntent, binding, result);
       if (this.deliveryBudget && result.rateLimit) {
         scope = result.rateLimit.scope;
@@ -14855,6 +15064,7 @@ export class MessagingController {
       request.context.turnId,
     );
     rememberBoundedKey(this.terminalPrivateResponseTurnKeys, turnKey);
+    let sourceStreamsCancelled = true;
     if (sourceBinding) {
       this.toolUpdatePolicy.flush({
         bindingId: sourceBinding.id,
@@ -14862,10 +15072,20 @@ export class MessagingController {
         turnId: request.context.turnId,
       });
       this.clearTurnProse(sourceBinding.id, request.context.turnId);
-      this.discardAssistantStreamsForTurn(
+      sourceStreamsCancelled = await this.cancelAssistantStreamsForTurn(
         sourceBinding,
         request.context.turnId,
       );
+    }
+    if (!sourceStreamsCancelled) {
+      return {
+        ok: false,
+        error: {
+          code: "internal_error",
+          message:
+            "The private response was delivered, but an existing source stream could not be retracted. Further source output remains suppressed.",
+        },
+      };
     }
     return {
       ok: true,
@@ -18183,6 +18403,21 @@ function isVisibleAssistantStreamDelivery(result: MessagingDeliveryResult): bool
     result.outcome === "presented_new" ||
     result.outcome === "updated" ||
     result.outcome === "pinned"
+  );
+}
+
+function messagingSurfaceKey(surface: MessagingSurfaceRef): string {
+  return `${surface.channel}\0${surface.id}`;
+}
+
+function isSameMessagingSurface(
+  left: MessagingSurfaceRef,
+  right: MessagingSurfaceRef | undefined,
+): boolean {
+  return Boolean(
+    right
+    && left.channel === right.channel
+    && left.id === right.id,
   );
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15759,10 +15759,10 @@ export class MessagingController {
         createdAt: this.now(),
         role: "assistant",
         attribution: {
-          label: `${attributionLabel} · Private response`,
+          label: attributionLabel,
           hint: awaitReply
-            ? "Reply in this message's thread; this agent will return the completion to the original conversation."
-            : "Reply in this message's thread to continue with this agent.",
+            ? "Private Request · Reply in Thread to Respond to this Agent; Completion Returns to the Original Conversation"
+            : "Private Request · Reply in Thread to Respond to this Agent",
         },
         parts: [{ type: "text", text, markdown: "markdown" }],
       },

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -318,6 +318,13 @@ const EXPLICIT_PRIVATE_RESPONSE_REQUEST_PATTERN = new RegExp(
   ].join("|"),
   "i",
 );
+const NEGATED_PRIVATE_RESPONSE_PREFIX_PATTERN = new RegExp(
+  [
+    "\\b(?:(?:do\\s+not|don't|dont|never)(?:\\s+\\w+){0,8}(?:\\s+to)?",
+    "|not(?:\\s+(?:asking|requesting|telling|wanting|going|trying|supposed|allowed|permitted|send|reply|respond|dm)){1,8}(?:\\s+to)?)\\s*$",
+  ].join(""),
+  "i",
+);
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 
@@ -388,6 +395,7 @@ type ActiveAgentMessagingOrigin = {
   deliveryBinding?: MessagingBindingRecord;
   event: MessagingInboundEvent;
   privateReplyContinuationBindingId?: string;
+  privateResponseRequested?: boolean;
 };
 
 type AgentMessagingOriginResolution =
@@ -1626,11 +1634,13 @@ export class MessagingController {
       if (
         assistantDelta
         && !reviewTurnEvent
-        && !suppressSourceResponse
+        && !terminalPrivateResponse
         && !privateReplyCompletion
       ) {
         if (!automationTurnEvent) {
-          await this.deliverAssistantStreamUpdate(assistantDelta, binding);
+          await this.deliverAssistantStreamUpdate(assistantDelta, binding, {
+            bufferOnly: privateResponseFallback,
+          });
         }
       }
 
@@ -1649,6 +1659,26 @@ export class MessagingController {
             binding,
             event,
             text: assistantText,
+            turnId: fallbackTurnId,
+          });
+        }
+      } else if (
+        privateResponseFallback
+        && !terminalPrivateResponse
+        && isTerminalTurnLifecycle(activeTurn)
+        && !assistantDelta
+      ) {
+        await this.waitForAssistantStreamDeliveriesForEvent(event, binding);
+        const bufferedText = this.takeBufferedAssistantTextForTerminalEvent(
+          event,
+          binding,
+        );
+        const fallbackTurnId = eventTurnId ?? activeTurn?.turnId;
+        if (bufferedText && fallbackTurnId) {
+          await this.deliverPrivateResponseFallback({
+            binding,
+            event,
+            text: bufferedText,
             turnId: fallbackTurnId,
           });
         }
@@ -3249,6 +3279,9 @@ export class MessagingController {
       prepared,
       currentBinding,
     );
+    if (currentBinding.privateReplyContinuation) {
+      await this.completePrivateReplyContinuation(currentBinding.id);
+    }
     const consumedSkillBinding = currentBinding.pendingSkillSelection
       ? bindingWithoutPendingSkillSelection(currentBinding)
       : currentBinding;
@@ -3262,6 +3295,7 @@ export class MessagingController {
         event: bundle.events[0],
         input: preparedWithSkill.input,
         pdfAttachments: preparedWithSkill.pdfAttachments,
+        privateResponseRequested: preparedWithSkill.privateResponseRequested,
         preview: preparedWithSkill.preview,
         threadKey: bundle.threadKey,
       });
@@ -3275,6 +3309,7 @@ export class MessagingController {
       binding: consumedSkillBinding,
       input: preparedWithSkill.input,
       pdfAttachments: preparedWithSkill.pdfAttachments,
+      privateResponseRequested: preparedWithSkill.privateResponseRequested,
       preview: preparedWithSkill.preview,
       threadKey: bundle.threadKey,
       event: bundle.events[0],
@@ -3289,12 +3324,14 @@ export class MessagingController {
     prepared: {
       input: AppServerTurnInputItem[];
       pdfAttachments: PendingPdfAttachment[];
+      privateResponseRequested: boolean;
       preview: string;
     },
     binding: MessagingBindingRecord,
   ): {
     input: AppServerTurnInputItem[];
     pdfAttachments: PendingPdfAttachment[];
+    privateResponseRequested: boolean;
     preview: string;
   } {
     const selection = binding.pendingSkillSelection;
@@ -3309,6 +3346,7 @@ export class MessagingController {
         ...prepared.input,
       ],
       pdfAttachments: prepared.pdfAttachments,
+      privateResponseRequested: prepared.privateResponseRequested,
       preview: `${prefix}\n${prepared.preview}`,
     };
   }
@@ -3457,6 +3495,7 @@ export class MessagingController {
     | {
         input: AppServerTurnInputItem[];
         pdfAttachments: PendingPdfAttachment[];
+        privateResponseRequested: boolean;
         preview: string;
       }
     | undefined
@@ -3559,6 +3598,7 @@ export class MessagingController {
     return {
       input,
       pdfAttachments,
+      privateResponseRequested,
       preview: buildQueuedInputPreview(previewParts),
     };
   }
@@ -3643,6 +3683,7 @@ export class MessagingController {
     input: AppServerTurnInputItem[];
     navigation?: NavigationSnapshot;
     pdfAttachments?: PendingPdfAttachment[];
+    privateResponseRequested?: boolean;
     preview: string;
     queueOnConcurrentStart?: boolean;
     threadKey: string;
@@ -3663,6 +3704,7 @@ export class MessagingController {
         binding: params.binding,
         event: params.event,
         navigation,
+        privateResponseRequested: params.privateResponseRequested,
       });
       if (startingOrigin) {
         this.startingAgentMessagingOriginsByThreadKey.set(
@@ -3787,6 +3829,7 @@ export class MessagingController {
             event: params.event,
             input: params.input,
             pdfAttachments: params.pdfAttachments,
+            privateResponseRequested: params.privateResponseRequested,
             preview: params.preview,
             threadKey: params.threadKey,
           });
@@ -3884,6 +3927,7 @@ export class MessagingController {
     event?: MessagingInboundEvent;
     input: AppServerTurnInputItem[];
     pdfAttachments?: PendingPdfAttachment[];
+    privateResponseRequested?: boolean;
     preview: string;
     threadKey: string;
   }): Promise<void> {
@@ -4081,6 +4125,7 @@ export class MessagingController {
       event: entry.event,
       input: entry.input,
       pdfAttachments: entry.pdfAttachments,
+      privateResponseRequested: entry.privateResponseRequested,
       preview: entry.preview,
       queueOnConcurrentStart: false,
       threadKey,
@@ -5423,6 +5468,7 @@ export class MessagingController {
   private async deliverAssistantStreamUpdate(
     delta: AssistantStreamDelta,
     binding: MessagingBindingRecord,
+    options?: { bufferOnly?: boolean },
   ): Promise<void> {
     if (
       this.isTerminalPrivateResponseTurn(
@@ -5457,6 +5503,10 @@ export class MessagingController {
     // flush re-creates an entry that no later terminal event clears. Cap it so
     // those orphans are reclaimed rather than accumulating for the process life.
     evictStaleStreamAnchors(this.assistantStreamBuffers);
+
+    if (options?.bufferOnly) {
+      return;
+    }
 
     // Streaming off: keep accumulating deltas (the terminal flush still needs
     // the buffered text — e.g. ACP turns whose only output arrives as deltas)
@@ -5601,6 +5651,34 @@ export class MessagingController {
         fallback.identity,
       );
     }
+  }
+
+  private takeBufferedAssistantTextForTerminalEvent(
+    event: AgentEvent,
+    binding: MessagingBindingRecord,
+  ): string | undefined {
+    const completedTurnIds = new Set<string>();
+    const messages: string[] = [];
+    for (const bufferKey of this.assistantStreamBufferKeysForEvent(event, binding)) {
+      const buffer = this.assistantStreamBuffers.get(bufferKey);
+      if (!buffer) {
+        continue;
+      }
+      completedTurnIds.add(buffer.turnId);
+      const text = buffer.text.trim();
+      if (text) {
+        messages.push(text);
+      }
+      this.assistantStreamBuffers.delete(bufferKey);
+      this.assistantStreamDeliveryQueues.delete(bufferKey);
+    }
+    for (const turnId of completedTurnIds) {
+      this.assistantStreamCancellationSignals.delete(
+        this.turnProseKey(binding.id, turnId),
+      );
+    }
+    const text = messages.join("\n\n").trim();
+    return text || undefined;
   }
 
   private async waitForAssistantStreamDeliveriesForEvent(
@@ -13995,7 +14073,10 @@ export class MessagingController {
     if (origin.privateReplyContinuationBindingId) {
       rememberBoundedKey(this.privateReplyCompletionTurnKeys, turnKey);
     }
-    if (requestsExplicitPrivateResponse(origin.event)) {
+    if (
+      origin.privateResponseRequested
+      || requestsExplicitPrivateResponse(origin.event)
+    ) {
       rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
     }
   }
@@ -14004,6 +14085,7 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     navigation: NavigationSnapshot;
+    privateResponseRequested?: boolean;
   }): Promise<ActiveAgentMessagingOrigin | undefined> {
     if (
       !params.event
@@ -14020,6 +14102,7 @@ export class MessagingController {
         ),
         event: params.event,
         privateReplyContinuationBindingId: params.binding.id,
+        privateResponseRequested: params.privateResponseRequested,
       };
     }
     return {
@@ -14030,6 +14113,7 @@ export class MessagingController {
         ? params.binding
         : undefined,
       event: params.event,
+      privateResponseRequested: params.privateResponseRequested,
     };
   }
 
@@ -14193,7 +14277,10 @@ export class MessagingController {
       if (origin.privateReplyContinuationBindingId) {
         rememberBoundedKey(this.privateReplyCompletionTurnKeys, turnKey);
       }
-      if (requestsExplicitPrivateResponse(origin.event)) {
+      if (
+        origin.privateResponseRequested
+        || requestsExplicitPrivateResponse(origin.event)
+      ) {
         rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
       }
       const activeTurn: MessagingActiveTurnSummary = {
@@ -19878,8 +19965,18 @@ function requestsExplicitPrivateResponse(
   if (!request) {
     return false;
   }
-  const prefix = text.slice(Math.max(0, request.index - 18), request.index);
-  return !/\b(?:do\s+not|don't|never|not)\s*$/i.test(prefix);
+  const prefix = text.slice(0, request.index);
+  const clauseStart = Math.max(
+    prefix.lastIndexOf("."),
+    prefix.lastIndexOf("!"),
+    prefix.lastIndexOf("?"),
+    prefix.lastIndexOf(";"),
+    prefix.lastIndexOf(","),
+    prefix.lastIndexOf("\n"),
+  );
+  return !NEGATED_PRIVATE_RESPONSE_PREFIX_PATTERN.test(
+    prefix.slice(clauseStart + 1),
+  );
 }
 
 function describeConversation(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15701,6 +15701,7 @@ export class MessagingController {
     try {
       privateConversation = await this.options.adapter.resolvePrivateConversation({
         actor: origin.origin.event.actor,
+        ...(awaitReply ? { replyContinuationRequired: true } : {}),
         source: origin.origin.event.channel,
         routingState: origin.origin.event.routingState,
       });

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -86,6 +86,7 @@ import type {
   MessagingMonitorState,
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
+  MessagingPrivateConversationResolveResult,
   MessagingQuestionnaireAnswer,
   MessagingQuestionnaireIntent,
   MessagingReviewIntent,
@@ -769,6 +770,7 @@ export class MessagingController {
     string,
     ActiveAgentMessagingOrigin
   >();
+  private readonly terminalPrivateResponseTurnKeys = new Set<string>();
   private readonly queuedAgentMessagingOriginsByQueueKey = new Map<
     string,
     ActiveAgentMessagingOrigin
@@ -900,6 +902,8 @@ export class MessagingController {
           },
         };
       }
+      case "send_private_response":
+        return await this.sendPrivateResponseFromAgentMessagingOrigin(request);
       case "attach_thread_here":
         return await this.attachThreadHereFromAgentMessagingOrigin(request);
       case "inspect_messaging_pdfs":
@@ -1493,11 +1497,18 @@ export class MessagingController {
         }
       }
 
-      await this.deliverToolActivityForBackendEvent(
-        event,
-        binding,
-        activeTurn?.turnId,
+      const suppressSourceResponse = this.isTerminalPrivateResponseTurn(
+        event.backend,
+        binding.threadId,
+        eventTurnId ?? activeTurn?.turnId,
       );
+      if (!suppressSourceResponse) {
+        await this.deliverToolActivityForBackendEvent(
+          event,
+          binding,
+          activeTurn?.turnId,
+        );
+      }
       if (eventTurnId && isTaskMonitorCompletionEvent(event)) {
         // A monitor's terminal result wakes the parent agent, whose final
         // response is the one user-facing completion notification. Tombstone
@@ -1528,7 +1539,7 @@ export class MessagingController {
       }
 
       const assistantDelta = assistantDeltaForBackendEvent(event);
-      if (assistantDelta && !reviewTurnEvent) {
+      if (assistantDelta && !reviewTurnEvent && !suppressSourceResponse) {
         if (!automationTurnEvent) {
           await this.deliverAssistantStreamUpdate(assistantDelta, binding);
         }
@@ -1537,7 +1548,7 @@ export class MessagingController {
       const assistantText = standaloneReviewAssistantText ?? (
         isFinalReviewAssistant ? undefined : rawAssistantText
       );
-      if (assistantText) {
+      if (assistantText && !suppressSourceResponse) {
         if (
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
@@ -1600,6 +1611,7 @@ export class MessagingController {
         }
       } else {
         if (
+          !suppressSourceResponse &&
           isFinalAssistantImageResolutionEvent(event)
           && !reviewTurnEvent
           && !isTaskMonitorProgressEvent(event)
@@ -1612,6 +1624,7 @@ export class MessagingController {
           await this.deliverAssistantImages(assistantImages, event, binding);
         }
         if (
+          !suppressSourceResponse &&
           isTerminalTurnLifecycle(activeTurn)
           && !assistantDelta
           && !reviewTurnEvent
@@ -1630,14 +1643,18 @@ export class MessagingController {
 
       // Automation turns surface their own terminal output (incl. errors) via
       // handleAutomationTurnTerminal, so skip them here to avoid a double post.
-      if (!automationTurnEvent && activeTurn?.status === "failed") {
+      if (
+        !suppressSourceResponse
+        && !automationTurnEvent
+        && activeTurn?.status === "failed"
+      ) {
         const turnFailureText = errorTextForBackendEvent(event);
         if (turnFailureText) {
           await this.deliverTurnFailureMessage(turnFailureText, event, binding);
         }
       }
 
-      if (completedPlan && !automationTurnEvent) {
+      if (completedPlan && !automationTurnEvent && !suppressSourceResponse) {
         await this.deliverArtifactForBinding({
           artifact: artifactFromPlanEntry(completedPlan),
           binding,
@@ -1645,7 +1662,11 @@ export class MessagingController {
         });
       }
 
-      if (completedReviewArtifact && !automationTurnEvent) {
+      if (
+        completedReviewArtifact
+        && !automationTurnEvent
+        && !suppressSourceResponse
+      ) {
         await this.deliverArtifactForBinding({
           artifact: artifactFromReviewEntry(completedReviewArtifact),
           binding,
@@ -1653,7 +1674,11 @@ export class MessagingController {
         });
       }
 
-      if (markdownFileArtifactSelection && !automationTurnEvent) {
+      if (
+        markdownFileArtifactSelection
+        && !automationTurnEvent
+        && !suppressSourceResponse
+      ) {
         await this.deliverArtifactForBinding({
           artifact: artifactFromMarkdownFileSelection(markdownFileArtifactSelection),
           binding,
@@ -5439,6 +5464,21 @@ export class MessagingController {
     return `${binding.id}\0${streamKey}`;
   }
 
+  private discardAssistantStreamsForTurn(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): void {
+    for (const [bufferKey, buffer] of this.assistantStreamBuffers) {
+      if (
+        bufferKey.startsWith(`${binding.id}\0`)
+        && buffer.turnId === turnId
+      ) {
+        this.assistantStreamBuffers.delete(bufferKey);
+        this.assistantStreamDeliveryQueues.delete(bufferKey);
+      }
+    }
+  }
+
   private async deliverAssistantMessage(
     text: string,
     event: AgentEvent,
@@ -5741,6 +5781,7 @@ export class MessagingController {
     this.toolUpdatePolicy.dispose();
     this.completedTaskMonitorTurns.clear();
     this.activeAgentMessagingOriginsByTurnKey.clear();
+    this.terminalPrivateResponseTurnKeys.clear();
     this.queuedAgentMessagingOriginsByQueueKey.clear();
   }
 
@@ -13429,10 +13470,22 @@ export class MessagingController {
     threadId: ThreadIdentifier,
     turnId: string,
   ): void {
-    this.activeAgentMessagingOriginsByTurnKey.delete(
-      agentMessagingTurnKey(backend, threadId, turnId),
-    );
+    const turnKey = agentMessagingTurnKey(backend, threadId, turnId);
+    this.activeAgentMessagingOriginsByTurnKey.delete(turnKey);
     this.pdfAttachmentStore.releaseTurn({ backend, threadId, turnId });
+  }
+
+  private isTerminalPrivateResponseTurn(
+    backend: AppServerBackendKind,
+    threadId: ThreadIdentifier,
+    turnId: string | undefined,
+  ): boolean {
+    return Boolean(
+      turnId
+      && this.terminalPrivateResponseTurnKeys.has(
+        agentMessagingTurnKey(backend, threadId, turnId),
+      ),
+    );
   }
 
   private rememberQueuedAgentMessagingOrigin(params: {
@@ -14674,6 +14727,153 @@ export class MessagingController {
           ? "created_and_attached"
           : "attached",
         placement: resolvedPlacement.placement,
+      },
+    };
+  }
+
+  private async sendPrivateResponseFromAgentMessagingOrigin(
+    request: Extract<
+      PwrAgentMessagingRequest,
+      { operation: "send_private_response" }
+    >,
+  ): Promise<PwrAgentMessagingResponse> {
+    const text = typeof request.args?.text === "string"
+      ? request.args.text
+      : "";
+    if (!text.trim() || text.length > 40_000) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message:
+            "send_private_response requires text between 1 and 40,000 characters.",
+        },
+      };
+    }
+    if (!request.context.turnId) {
+      return {
+        ok: false,
+        error: {
+          code: "not_found",
+          message:
+            "Private responses require the active messaging turn that identified the requesting user.",
+        },
+      };
+    }
+    const origin = await this.resolveAgentMessagingOrigin(request.context);
+    if (!origin.ok) {
+      return origin;
+    }
+    if (!this.options.adapter.resolvePrivateConversation) {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported_operation",
+          message:
+            "This messaging provider cannot start a private response to the requesting user.",
+        },
+      };
+    }
+
+    let privateConversation: MessagingPrivateConversationResolveResult;
+    try {
+      privateConversation = await this.options.adapter.resolvePrivateConversation({
+        actor: origin.origin.event.actor,
+        source: origin.origin.event.channel,
+        routingState: origin.origin.event.routingState,
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "internal_error",
+          message:
+            error instanceof Error
+              ? `Could not resolve a private conversation: ${error.message}`
+              : "Could not resolve a private conversation.",
+        },
+      };
+    }
+    if (
+      privateConversation.outcome !== "resolved"
+      || !privateConversation.conversation
+      || privateConversation.channel !== origin.origin.event.channel.channel
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: privateConversation.outcome === "unsupported"
+            ? "unsupported_operation"
+            : "internal_error",
+          message:
+            privateConversation.errorMessage
+            ?? "The messaging provider could not resolve a private conversation.",
+        },
+      };
+    }
+
+    const privateEvent: MessagingInboundEvent = {
+      ...origin.origin.event,
+      id: `${origin.origin.event.id}:private-response:${this.now()}`,
+      channel: {
+        channel: privateConversation.channel,
+        conversation: privateConversation.conversation,
+      },
+      receivedAt: this.now(),
+      routingState: privateConversation.routingState,
+    };
+    const sourceBinding = origin.origin.deliveryBinding ?? origin.origin.binding;
+    const result = await this.deliver(
+      {
+        id: this.newIntentId("private-response"),
+        kind: "message",
+        bindingId: sourceBinding?.id,
+        createdAt: this.now(),
+        role: "assistant",
+        parts: [{ type: "text", text, markdown: "markdown" }],
+      },
+      undefined,
+      privateEvent,
+    );
+    if (!isVisibleAssistantStreamDelivery(result)) {
+      return {
+        ok: false,
+        error: {
+          code: result.outcome === "unsupported"
+            ? "unsupported_operation"
+            : "internal_error",
+          message:
+            result.errorMessage
+            ?? "The private response was not delivered, so the source response was not suppressed.",
+        },
+      };
+    }
+
+    const turnKey = agentMessagingTurnKey(
+      request.context.backend,
+      request.context.threadId,
+      request.context.turnId,
+    );
+    rememberBoundedKey(this.terminalPrivateResponseTurnKeys, turnKey);
+    if (sourceBinding) {
+      this.toolUpdatePolicy.flush({
+        bindingId: sourceBinding.id,
+        clear: true,
+        turnId: request.context.turnId,
+      });
+      this.clearTurnProse(sourceBinding.id, request.context.turnId);
+      this.discardAssistantStreamsForTurn(
+        sourceBinding,
+        request.context.turnId,
+      );
+    }
+    return {
+      ok: true,
+      data: {
+        channel: result.channel,
+        deliveredAt: result.deliveredAt,
+        outcome: "delivered",
+        recipient: summarizeMessagingActor(origin.origin.event.actor),
       },
     };
   }
@@ -17209,7 +17409,7 @@ function summarizeMessagingConversation(
 
 function summarizeMessagingActor(
   actor: MessagingInboundEvent["actor"],
-): PwrAgentMessagingLocationSummary["actor"] {
+): NonNullable<PwrAgentMessagingLocationSummary["actor"]> {
   return {
     platformUserId: actor.platformUserId,
     displayName: actor.displayName,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1765,7 +1765,7 @@ export class MessagingController {
       }
 
       if (isThreadNameUpdatedEvent(event)) {
-        await this.renderBindingStatus(
+        await this.renderAutomaticBindingStatus(
           binding,
           undefined,
           await this.navigationSnapshotWithThreadNameFromEvent(event),
@@ -1788,7 +1788,7 @@ export class MessagingController {
           force: true,
         });
         if (shouldRenderStatusForTurnStateChange(event, lifecycle)) {
-          await this.renderBindingStatus(binding);
+          await this.renderAutomaticBindingStatus(binding);
         }
         await this.startNextQueuedTurn(binding);
       } else if (activeTurn?.status === "waiting" && isTurnWorkActivityEvent(event, activeTurn)) {
@@ -1951,7 +1951,7 @@ export class MessagingController {
         await this.signalTurnActivity(binding, activeTurn, {
           force: true,
         });
-        await this.renderBindingStatus(binding);
+        await this.renderAutomaticBindingStatus(binding);
       }
     }
   }
@@ -3234,7 +3234,7 @@ export class MessagingController {
     });
     if (startResult !== "failed" && currentBinding.pendingSkillSelection) {
       const updatedBinding = await this.clearPendingSkillSelection(currentBinding);
-      await this.renderBindingStatus(updatedBinding, bundle.events[0]);
+      await this.renderAutomaticBindingStatus(updatedBinding, bundle.events[0]);
     }
   }
 
@@ -3646,7 +3646,11 @@ export class MessagingController {
       await this.signalTurnActivity(params.binding, activeTurn, {
         force: true,
       });
-      await this.renderBindingStatus(params.binding, undefined, navigation);
+      await this.renderAutomaticBindingStatus(
+        params.binding,
+        undefined,
+        navigation,
+      );
       return "started";
     } catch (error) {
       if (turnStarted) {
@@ -3718,7 +3722,11 @@ export class MessagingController {
       currentTurn?.turnId === params.turnId &&
       isTerminalTurnLifecycle(currentTurn)
     ) {
-      await this.renderBindingStatus(params.binding, undefined, params.navigation);
+      await this.renderAutomaticBindingStatus(
+        params.binding,
+        undefined,
+        params.navigation,
+      );
       return;
     }
     const activeTurn: MessagingActiveTurnSummary = {
@@ -3737,7 +3745,11 @@ export class MessagingController {
     await this.signalTurnActivity(params.binding, activeTurn, {
       force: true,
     });
-    await this.renderBindingStatus(params.binding, undefined, params.navigation);
+    await this.renderAutomaticBindingStatus(
+      params.binding,
+      undefined,
+      params.navigation,
+    );
   }
 
   private async queuePreparedInput(params: {
@@ -13127,6 +13139,21 @@ export class MessagingController {
     });
   }
 
+  private async renderAutomaticBindingStatus(
+    binding: MessagingBindingRecord,
+    event?: MessagingInboundEvent,
+    navigation?: NavigationSnapshot,
+  ): Promise<MessagingBindingRecord> {
+    if (
+      binding.statusPresentation === "on_demand"
+      && !binding.statusSurface
+      && !binding.pinnedStatusSurface
+    ) {
+      return binding;
+    }
+    return await this.renderBindingStatus(binding, event, navigation);
+  }
+
   private async navigationSnapshotWithThreadNameFromEvent(
     event: AgentEvent,
   ): Promise<NavigationSnapshot> {
@@ -14270,6 +14297,7 @@ export class MessagingController {
       backend: AppServerBackendKind;
       federatedThread?: FederatedThreadRef;
       recordTransition?: boolean;
+      statusPresentation?: MessagingBindingRecord["statusPresentation"];
       threadId: ThreadIdentifier;
       targetKind?: MessagingBindingRecord["targetKind"];
     },
@@ -14290,6 +14318,7 @@ export class MessagingController {
       federatedThread: target.federatedThread,
       authorizedActorIds: [event.actor.platformUserId],
       routingState: event.routingState,
+      statusPresentation: target.statusPresentation,
       createdAt: now,
       updatedAt: now,
       displayName: event.actor.displayName ?? event.actor.username,
@@ -15447,6 +15476,7 @@ export class MessagingController {
           {
             backend: request.context.backend,
             recordTransition: false,
+            statusPresentation: "on_demand",
             threadId: request.context.threadId,
             targetKind: sourceBinding.targetKind ?? "agent_thread",
           },

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -15032,6 +15032,12 @@ export class MessagingController {
       routingState: privateConversation.routingState,
     };
     const sourceBinding = origin.origin.deliveryBinding ?? origin.origin.binding;
+    const sourceThread = sourceBinding
+      ? await this.resolveBoundThreadSummary(sourceBinding)
+      : undefined;
+    const attributionLabel = sourceThread?.agentName
+      ?? sourceThread?.title
+      ?? "PwrAgent Agent";
     const result = await this.deliver(
       {
         id: this.newIntentId("private-response"),
@@ -15039,6 +15045,10 @@ export class MessagingController {
         bindingId: sourceBinding?.id,
         createdAt: this.now(),
         role: "assistant",
+        attribution: {
+          label: `${attributionLabel} · Private response`,
+          hint: "Reply in this message's thread to continue with this agent.",
+        },
         parts: [{ type: "text", text, markdown: "markdown" }],
       },
       undefined,
@@ -15086,6 +15096,37 @@ export class MessagingController {
             "The private response was delivered, but an existing source stream could not be retracted. Further source output remains suppressed.",
         },
       };
+    }
+    if (sourceBinding && result.continuation) {
+      try {
+        await this.bindChannelToThread(
+          {
+            ...privateEvent,
+            id: `${privateEvent.id}:continuation`,
+            channel: result.continuation.channel,
+            routingState: result.continuation.routingState,
+          },
+          {
+            backend: request.context.backend,
+            threadId: request.context.threadId,
+            targetKind: sourceBinding.targetKind ?? "agent_thread",
+          },
+        );
+      } catch (error) {
+        this.logger.warn?.("messaging private response continuation bind failed", {
+          backend: request.context.backend,
+          error: error instanceof Error ? error.message : String(error),
+          threadId: request.context.threadId,
+        });
+        return {
+          ok: false,
+          error: {
+            code: "internal_error",
+            message:
+              "The private response was delivered, but replies to it could not be routed back to this Agent. Further source output remains suppressed.",
+          },
+        };
+      }
     }
     return {
       ok: true,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -87,6 +87,7 @@ import type {
   MessagingMonitorSubscriptionRecord,
   MessagingPendingIntentRecord,
   MessagingPrivateConversationResolveResult,
+  MessagingPrivateReplySource,
   MessagingQuestionnaireAnswer,
   MessagingQuestionnaireIntent,
   MessagingReviewIntent,
@@ -300,6 +301,14 @@ const PRIVATE_RESPONSE_FALLBACK_INSTRUCTION =
   + "Use send_private_response if it is available. If that tool is unavailable, "
   + "put the intended private content only in your final answer; PwrAgent will "
   + "deliver that final privately and suppress it on the source surface.";
+const PRIVATE_REPLY_CONTINUATION_TTL_MS = 24 * 60 * 60 * 1_000;
+const PRIVATE_REPLY_COMPLETION_INSTRUCTION =
+  "PwrAgent is completing a one-shot private reply requested by this Agent. "
+  + "Treat the user's following message as the private response to your earlier request. "
+  + "Your final answer will be delivered to the originating messaging surface, not this private thread. "
+  + "Do not quote or expose private reply content there unless the initiating instructions explicitly require it. "
+  + "Do not emit commentary, working updates, or partial answers containing the private reply. "
+  + "If the private exchange is not complete, call send_private_response again with awaitReply and new replyInstructions; otherwise answer finally to complete the callback on the originating surface.";
 const EXPLICIT_PRIVATE_RESPONSE_REQUEST_PATTERN = new RegExp(
   [
     "\\b(?:dm|direct[\\s-]+message|private[\\s-]+message)\\s+me\\b",
@@ -378,6 +387,7 @@ type ActiveAgentMessagingOrigin = {
   binding?: MessagingBindingRecord;
   deliveryBinding?: MessagingBindingRecord;
   event: MessagingInboundEvent;
+  privateReplyContinuationBindingId?: string;
 };
 
 type AgentMessagingOriginResolution =
@@ -806,6 +816,11 @@ export class MessagingController {
     string,
     ActiveAgentMessagingOrigin
   >();
+  private readonly startingAgentMessagingOriginsByThreadKey = new Map<
+    string,
+    ActiveAgentMessagingOrigin
+  >();
+  private readonly privateReplyCompletionTurnKeys = new Set<string>();
   private readonly terminalPrivateResponseTurnKeys = new Set<string>();
   private readonly privateResponseFallbackTurnKeys = new Set<string>();
   private readonly attemptedPrivateResponseFallbackTurnKeys = new Set<string>();
@@ -954,6 +969,7 @@ export class MessagingController {
   }
 
   async startMonitoringForEnabledBindings(): Promise<void> {
+    await this.cleanupExpiredPrivateReplyContinuations();
     if (this.options.channel) {
       const subscriptions =
         await this.options.store.findActiveMonitorSubscriptionsForChannelKind({
@@ -1545,9 +1561,14 @@ export class MessagingController {
         binding.threadId,
         eventTurnId ?? activeTurn?.turnId,
       );
+      const privateReplyCompletion = this.isPrivateReplyCompletionTurn(
+        event.backend,
+        binding.threadId,
+        eventTurnId ?? activeTurn?.turnId,
+      );
       const suppressSourceResponse =
         terminalPrivateResponse || privateResponseFallback;
-      if (!suppressSourceResponse) {
+      if (!suppressSourceResponse && !privateReplyCompletion) {
         await this.deliverToolActivityForBackendEvent(
           event,
           binding,
@@ -1602,7 +1623,12 @@ export class MessagingController {
       }
 
       const assistantDelta = assistantDeltaForBackendEvent(event);
-      if (assistantDelta && !reviewTurnEvent && !suppressSourceResponse) {
+      if (
+        assistantDelta
+        && !reviewTurnEvent
+        && !suppressSourceResponse
+        && !privateReplyCompletion
+      ) {
         if (!automationTurnEvent) {
           await this.deliverAssistantStreamUpdate(assistantDelta, binding);
         }
@@ -1626,7 +1652,14 @@ export class MessagingController {
             turnId: fallbackTurnId,
           });
         }
-      } else if (assistantText && !suppressSourceResponse) {
+      } else if (
+        assistantText
+        && !suppressSourceResponse
+        && (
+          !privateReplyCompletion
+          || !isNonFinalAssistantTextForBackendEvent(event)
+        )
+      ) {
         if (
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
@@ -1824,6 +1857,18 @@ export class MessagingController {
       }
     }
     if (lifecycle && isTerminalTurnLifecycle(lifecycle)) {
+      const turnKey = agentMessagingTurnKey(
+        event.backend,
+        threadId,
+        lifecycle.turnId,
+      );
+      const origin = this.activeAgentMessagingOriginsByTurnKey.get(turnKey);
+      if (origin?.privateReplyContinuationBindingId) {
+        await this.completePrivateReplyContinuation(
+          origin.privateReplyContinuationBindingId,
+        );
+      }
+      this.privateReplyCompletionTurnKeys.delete(turnKey);
       this.forgetAutomationTurn(event.backend, threadId, lifecycle.turnId);
       this.forgetAgentMessagingOrigin(event.backend, threadId, lifecycle.turnId);
       this.planArtifactsByTurnKey.delete(artifactTurnKey(event.backend, threadId, lifecycle.turnId));
@@ -2967,7 +3012,8 @@ export class MessagingController {
       return;
     }
 
-    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    let binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    binding = await this.revokeExpiredPrivateReplyContinuation(binding);
     if (!binding) {
       if (!await this.shouldHandleAmbientSharedMessage(event)) {
         return;
@@ -3125,7 +3171,8 @@ export class MessagingController {
       return;
     }
 
-    const binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    let binding = await this.options.store.findActiveBindingForChannel(event.channel);
+    binding = await this.revokeExpiredPrivateReplyContinuation(binding);
     if (!binding) {
       if (!await this.shouldHandleAmbientSharedMessage(event)) {
         return;
@@ -3419,6 +3466,21 @@ export class MessagingController {
     const previewParts: string[] = [];
     const rejections: MessagingAttachmentRejection[] = [];
     const pdfHandling = await this.resolveMessagingPdfHandling(binding);
+    const privateReplyContinuation = binding?.privateReplyContinuation;
+    if (
+      privateReplyContinuation
+      && privateReplyContinuation.expiresAt > this.now()
+    ) {
+      input.push({
+        type: "text",
+        text: [
+          PRIVATE_REPLY_COMPLETION_INSTRUCTION,
+          "",
+          "Initiating Agent instructions:",
+          privateReplyContinuation.instructions,
+        ].join("\n"),
+      });
+    }
     const privateResponseRequested = events.some(
       (turnEvent) => requestsExplicitPrivateResponse(turnEvent),
     );
@@ -3501,6 +3563,43 @@ export class MessagingController {
     };
   }
 
+  private async revokeExpiredPrivateReplyContinuation(
+    binding: MessagingBindingRecord | undefined,
+  ): Promise<MessagingBindingRecord | undefined> {
+    if (
+      !binding?.privateReplyContinuation
+      || binding.privateReplyContinuation.expiresAt > this.now()
+    ) {
+      return binding;
+    }
+    await this.options.store.revokeBinding({
+      bindingId: binding.id,
+      revokedAt: this.now(),
+    });
+    this.notifyBindingChanged("private-reply-expired");
+    return undefined;
+  }
+
+  private async cleanupExpiredPrivateReplyContinuations(): Promise<void> {
+    const now = this.now();
+    const expired = this.filterBindingsForChannel(
+      await this.options.store.findActiveBindings(),
+    ).filter(
+      (binding) =>
+        binding.privateReplyContinuation
+        && binding.privateReplyContinuation.expiresAt <= now,
+    );
+    for (const binding of expired) {
+      await this.options.store.revokeBinding({
+        bindingId: binding.id,
+        revokedAt: now,
+      });
+    }
+    if (expired.length > 0) {
+      this.notifyBindingChanged("private-reply-expired");
+    }
+  }
+
   private async resolveMessagingPdfHandling(
     binding: MessagingBindingRecord | undefined,
   ): Promise<"model_directed" | "render_initial_pages" | "pass_through"> {
@@ -3550,11 +3649,27 @@ export class MessagingController {
   }): Promise<PreparedInputStartResult> {
     this.turnAdmission.markStarting(params.threadKey);
     let turnStarted = false;
+    let startingOrigin: ActiveAgentMessagingOrigin | undefined;
+    const startingThreadKey = agentMessagingThreadKey(
+      params.binding.backend,
+      params.binding.threadId,
+    );
 
     try {
       const navigation = params.navigation ?? await this.options.backend.getNavigationSnapshot({
         backend: "all",
       });
+      startingOrigin = await this.buildAgentMessagingOrigin({
+        binding: params.binding,
+        event: params.event,
+        navigation,
+      });
+      if (startingOrigin) {
+        this.startingAgentMessagingOriginsByThreadKey.set(
+          startingThreadKey,
+          startingOrigin,
+        );
+      }
       const turnSettings = turnSettingsForBinding(params.binding, navigation);
       const executionResolution = resolveExecutionModeForBinding(
         params.binding,
@@ -3605,6 +3720,7 @@ export class MessagingController {
           binding: params.binding,
           event: params.event,
           navigation,
+          origin: startingOrigin,
           queueEntryId: started.queueEntryId ?? started.turnId,
         });
         this.logger.info?.("messaging turn queued in shared thread FIFO", {
@@ -3628,7 +3744,6 @@ export class MessagingController {
         startedAt: this.now(),
         updatedAt: this.now(),
       };
-      this.setActiveTurn(params.binding, activeTurn);
       this.pdfAttachmentStore.bindTurn(
         {
           backend: params.binding.backend,
@@ -3641,13 +3756,18 @@ export class MessagingController {
         binding: params.binding,
         event: params.event,
         navigation,
+        origin: startingOrigin,
         turnId: started.turnId,
       });
-      await this.signalTurnActivity(params.binding, activeTurn, {
+      const deliveryBinding = startingOrigin?.deliveryBinding
+        ?? startingOrigin?.binding
+        ?? params.binding;
+      this.setActiveTurn(deliveryBinding, activeTurn);
+      await this.signalTurnActivity(deliveryBinding, activeTurn, {
         force: true,
       });
       await this.renderAutomaticBindingStatus(
-        params.binding,
+        deliveryBinding,
         undefined,
         navigation,
       );
@@ -3688,6 +3808,13 @@ export class MessagingController {
       return "failed";
     } finally {
       this.turnAdmission.clearStarting(params.threadKey);
+      if (
+        startingOrigin
+        && this.startingAgentMessagingOriginsByThreadKey.get(startingThreadKey)
+          === startingOrigin
+      ) {
+        this.startingAgentMessagingOriginsByThreadKey.delete(startingThreadKey);
+      }
     }
   }
 
@@ -6147,6 +6274,8 @@ export class MessagingController {
     this.toolUpdatePolicy.dispose();
     this.completedTaskMonitorTurns.clear();
     this.activeAgentMessagingOriginsByTurnKey.clear();
+    this.startingAgentMessagingOriginsByThreadKey.clear();
+    this.privateReplyCompletionTurnKeys.clear();
     this.terminalPrivateResponseTurnKeys.clear();
     this.privateResponseFallbackTurnKeys.clear();
     this.attemptedPrivateResponseFallbackTurnKeys.clear();
@@ -13834,12 +13963,24 @@ export class MessagingController {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     navigation: NavigationSnapshot;
+    origin?: ActiveAgentMessagingOrigin;
     turnId: string;
   }): void {
-    if (
-      !params.event ||
-      !isLiveMessagingToolOriginBinding(params.binding, params.navigation)
-    ) {
+    const origin = params.origin ?? (
+      params.event
+      && isLiveMessagingToolOriginBinding(params.binding, params.navigation)
+        ? {
+            binding: isDefaultAgentRouteBinding(params.binding)
+              ? undefined
+              : params.binding,
+            deliveryBinding: isDefaultAgentRouteBinding(params.binding)
+              ? params.binding
+              : undefined,
+            event: params.event,
+          }
+        : undefined
+    );
+    if (!origin) {
       return;
     }
     const turnKey = agentMessagingTurnKey(
@@ -13849,19 +13990,69 @@ export class MessagingController {
     );
     this.activeAgentMessagingOriginsByTurnKey.set(
       turnKey,
-      {
-        binding: isDefaultAgentRouteBinding(params.binding)
-          ? undefined
-          : params.binding,
-        deliveryBinding: isDefaultAgentRouteBinding(params.binding)
-          ? params.binding
-          : undefined,
-        event: params.event,
-      },
+      origin,
     );
-    if (requestsExplicitPrivateResponse(params.event)) {
+    if (origin.privateReplyContinuationBindingId) {
+      rememberBoundedKey(this.privateReplyCompletionTurnKeys, turnKey);
+    }
+    if (requestsExplicitPrivateResponse(origin.event)) {
       rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
     }
+  }
+
+  private async buildAgentMessagingOrigin(params: {
+    binding: MessagingBindingRecord;
+    event?: MessagingInboundEvent;
+    navigation: NavigationSnapshot;
+  }): Promise<ActiveAgentMessagingOrigin | undefined> {
+    if (
+      !params.event
+      || !isLiveMessagingToolOriginBinding(params.binding, params.navigation)
+    ) {
+      return undefined;
+    }
+    const continuation = params.binding.privateReplyContinuation;
+    if (continuation && continuation.expiresAt > this.now()) {
+      return {
+        binding: params.binding,
+        deliveryBinding: await this.resolvePrivateReplySourceBinding(
+          continuation.source,
+        ),
+        event: params.event,
+        privateReplyContinuationBindingId: params.binding.id,
+      };
+    }
+    return {
+      binding: isDefaultAgentRouteBinding(params.binding)
+        ? undefined
+        : params.binding,
+      deliveryBinding: isDefaultAgentRouteBinding(params.binding)
+        ? params.binding
+        : undefined,
+      event: params.event,
+    };
+  }
+
+  private async resolvePrivateReplySourceBinding(
+    source: MessagingPrivateReplySource,
+  ): Promise<MessagingBindingRecord> {
+    const stored = await this.options.store.getBinding(source.id);
+    if (
+      stored
+      && !stored.revokedAt
+      && stored.backend === source.backend
+      && stored.threadId === source.threadId
+    ) {
+      return stored;
+    }
+    return {
+      ...source,
+      channel: structuredClone(source.channel),
+      routingState: source.routingState
+        ? structuredClone(source.routingState)
+        : undefined,
+      statusPresentation: "on_demand",
+    };
   }
 
   private forgetAgentMessagingOrigin(
@@ -13900,16 +14091,64 @@ export class MessagingController {
     );
   }
 
+  private isPrivateReplyCompletionTurn(
+    backend: AppServerBackendKind,
+    threadId: ThreadIdentifier,
+    turnId: string | undefined,
+  ): boolean {
+    if (!turnId) {
+      return false;
+    }
+    if (
+      this.privateReplyCompletionTurnKeys.has(
+        agentMessagingTurnKey(backend, threadId, turnId),
+      )
+    ) {
+      return true;
+    }
+    return Boolean(
+      this.startingAgentMessagingOriginsByThreadKey.get(
+        agentMessagingThreadKey(backend, threadId),
+      )?.privateReplyContinuationBindingId,
+    );
+  }
+
+  private async completePrivateReplyContinuation(
+    bindingId: string,
+  ): Promise<void> {
+    const binding = await this.options.store.getBinding(bindingId);
+    if (!binding || binding.revokedAt || !binding.privateReplyContinuation) {
+      return;
+    }
+    await this.options.store.revokeBinding({
+      bindingId,
+      revokedAt: this.now(),
+    });
+    this.notifyBindingChanged("private-reply-completed");
+  }
+
   private rememberQueuedAgentMessagingOrigin(params: {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
     navigation: NavigationSnapshot;
+    origin?: ActiveAgentMessagingOrigin;
     queueEntryId: string;
   }): void {
-    if (
-      !params.event
-      || !isLiveMessagingToolOriginBinding(params.binding, params.navigation)
-    ) {
+    const origin = params.origin ?? (
+      params.event
+      && isLiveMessagingToolOriginBinding(params.binding, params.navigation)
+        ? {
+            binding: isDefaultAgentRouteBinding(params.binding)
+              ? undefined
+              : params.binding,
+            deliveryBinding: isDefaultAgentRouteBinding(params.binding)
+              ? params.binding
+              : undefined,
+            event: params.event,
+          }
+        : undefined
+    );
+    if (!origin) {
       return;
     }
     const queueKey = agentMessagingQueueKey(
@@ -13919,15 +14158,7 @@ export class MessagingController {
     );
     this.queuedAgentMessagingOriginsByQueueKey.set(
       queueKey,
-      {
-        binding: isDefaultAgentRouteBinding(params.binding)
-          ? undefined
-          : params.binding,
-        deliveryBinding: isDefaultAgentRouteBinding(params.binding)
-          ? params.binding
-          : undefined,
-        event: params.event,
-      },
+      origin,
     );
   }
 
@@ -13959,6 +14190,9 @@ export class MessagingController {
         turnKey,
         origin,
       );
+      if (origin.privateReplyContinuationBindingId) {
+        rememberBoundedKey(this.privateReplyCompletionTurnKeys, turnKey);
+      }
       if (requestsExplicitPrivateResponse(origin.event)) {
         rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
       }
@@ -14013,10 +14247,26 @@ export class MessagingController {
     persistentBindings: MessagingBindingRecord[],
   ): MessagingBindingRecord[] {
     if (!turnId) {
+      const startingOrigin = this.startingAgentMessagingOriginsByThreadKey.get(
+        agentMessagingThreadKey(backend, threadId),
+      );
+      const startingDeliveryBinding = startingOrigin?.deliveryBinding
+        ?? startingOrigin?.binding;
+      if (
+        startingDeliveryBinding
+        && this.isChannelInScope(startingDeliveryBinding.channel)
+      ) {
+        const persistedOrigin = persistentBindings.find(
+          (binding) => binding.id === startingDeliveryBinding.id,
+        );
+        return [persistedOrigin ?? startingDeliveryBinding];
+      }
       return persistentBindings;
     }
     const origin = this.activeAgentMessagingOriginsByTurnKey.get(
       agentMessagingTurnKey(backend, threadId, turnId),
+    ) ?? this.startingAgentMessagingOriginsByThreadKey.get(
+      agentMessagingThreadKey(backend, threadId),
     );
     const deliveryBinding = origin?.deliveryBinding ?? origin?.binding;
     if (!origin || !deliveryBinding || !this.isChannelInScope(deliveryBinding.channel)) {
@@ -15301,6 +15551,10 @@ export class MessagingController {
     const text = typeof request.args?.text === "string"
       ? request.args.text
       : "";
+    const awaitReply = request.args?.awaitReply === true;
+    const replyInstructions = typeof request.args?.replyInstructions === "string"
+      ? request.args.replyInstructions.trim()
+      : "";
     if (!text.trim() || text.length > 40_000) {
       return {
         ok: false,
@@ -15308,6 +15562,19 @@ export class MessagingController {
           code: "invalid_arguments",
           message:
             "send_private_response requires text between 1 and 40,000 characters.",
+        },
+      };
+    }
+    if (
+      awaitReply
+      && (!replyInstructions || replyInstructions.length > 4_000)
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: "invalid_arguments",
+          message:
+            "send_private_response requires replyInstructions between 1 and 4,000 characters when awaitReply is true.",
         },
       };
     }
@@ -15406,7 +15673,9 @@ export class MessagingController {
         role: "assistant",
         attribution: {
           label: `${attributionLabel} · Private response`,
-          hint: "Reply in this message's thread to continue with this agent.",
+          hint: awaitReply
+            ? "Reply in this message's thread; this agent will return the completion to the original conversation."
+            : "Reply in this message's thread to continue with this agent.",
         },
         parts: [{ type: "text", text, markdown: "markdown" }],
       },
@@ -15464,9 +15733,19 @@ export class MessagingController {
         request.context.turnId,
       );
     }
+    if (awaitReply && (!sourceBinding || !result.continuation)) {
+      return {
+        ok: false,
+        error: {
+          code: "unsupported_operation",
+          message:
+            "The private response was delivered, but this provider did not return a reply thread for the requested continuation. Further source output remains suppressed.",
+        },
+      };
+    }
     if (sourceBinding && result.continuation) {
       try {
-        const continuationBinding = await this.bindChannelToThread(
+        let continuationBinding = await this.bindChannelToThread(
           {
             ...privateEvent,
             id: `${privateEvent.id}:continuation`,
@@ -15481,6 +15760,19 @@ export class MessagingController {
             targetKind: sourceBinding.targetKind ?? "agent_thread",
           },
         );
+        if (awaitReply) {
+          continuationBinding = await this.options.store.upsertBinding({
+            ...continuationBinding,
+            privateReplyContinuation: {
+              createdAt: this.now(),
+              expiresAt: this.now() + PRIVATE_REPLY_CONTINUATION_TTL_MS,
+              instructions: replyInstructions,
+              source: privateReplySourceFromBinding(sourceBinding),
+            },
+            updatedAt: this.now(),
+          });
+          this.notifyBindingChanged("private-reply-awaiting");
+        }
         await this.clearTerminalPrivateResponseActivity(
           continuationBinding,
           request.context.turnId,
@@ -15504,6 +15796,7 @@ export class MessagingController {
     return {
       ok: true,
       data: {
+        awaitingReply: awaitReply,
         channel: result.channel,
         deliveredAt: result.deliveredAt,
         outcome: "delivered",
@@ -18016,6 +18309,13 @@ function agentMessagingTurnKey(
   return `${backend}:${threadId}:${turnId}`;
 }
 
+function agentMessagingThreadKey(
+  backend: AppServerBackendKind,
+  threadId: ThreadIdentifier,
+): string {
+  return `${backend}:${threadId}`;
+}
+
 function agentMessagingQueueKey(
   backend: AppServerBackendKind,
   threadId: ThreadIdentifier,
@@ -18026,6 +18326,26 @@ function agentMessagingQueueKey(
 
 function isDefaultAgentRouteBinding(binding: MessagingBindingRecord): boolean {
   return binding.id.startsWith("default-agent-route:");
+}
+
+function privateReplySourceFromBinding(
+  binding: MessagingBindingRecord,
+): MessagingPrivateReplySource {
+  return {
+    authorizedActorIds: [...binding.authorizedActorIds],
+    backend: binding.backend,
+    channel: structuredClone(binding.channel),
+    createdAt: binding.createdAt,
+    displayName: binding.displayName,
+    federatedThread: binding.federatedThread,
+    id: binding.id,
+    routingState: binding.routingState
+      ? structuredClone(binding.routingState)
+      : undefined,
+    targetKind: binding.targetKind,
+    threadId: binding.threadId,
+    updatedAt: binding.updatedAt,
+  };
 }
 
 function summarizeMessagingConversation(

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -1706,6 +1706,15 @@ export class MessagingController {
         continue;
       }
 
+      // A terminal private response owns the visible completion for this turn.
+      // Backend work events may continue after the tool returns, but must not
+      // re-arm provider typing/activity on either the source binding or the
+      // newly-created private continuation. Terminal lifecycle still flows
+      // through below so any existing activity lease is explicitly cleared.
+      if (suppressSourceResponse && activeTurn?.status === "working") {
+        continue;
+      }
+
       if (turnStateChanged && (lifecycle || (isThreadStatusIdleEvent(event) && activeTurn))) {
         await this.signalTurnActivity(binding, activeTurn!, {
           reason: event.notification.method,
@@ -3088,7 +3097,10 @@ export class MessagingController {
     event: MessagingInboundTextEvent | MessagingInboundMediaEvent,
     binding?: MessagingBindingRecord,
   ): Promise<boolean> {
-    if (event.channel.conversation.kind === "dm") {
+    if (
+      event.channel.conversation.kind === "dm"
+      || event.channel.conversation.isDirectMessage === true
+    ) {
       return true;
     }
     if (
@@ -13926,6 +13938,32 @@ export class MessagingController {
     );
   }
 
+  private async clearTerminalPrivateResponseActivity(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): Promise<void> {
+    try {
+      await this.signalTurnActivity(
+        binding,
+        {
+          turnId,
+          status: "completed",
+          updatedAt: this.now(),
+        },
+        {
+          force: true,
+          reason: "terminal_private_response",
+        },
+      );
+    } catch (error) {
+      this.logger.debug?.("messaging terminal private activity cleanup failed", {
+        bindingId: binding.id,
+        error: error instanceof Error ? error.message : String(error),
+        turnId,
+      });
+    }
+  }
+
   private logBindingTurnStateChange(
     binding: MessagingBindingRecord,
     previousTurn: MessagingActiveTurnSummary | undefined,
@@ -14050,6 +14088,7 @@ export class MessagingController {
     target: {
       backend: AppServerBackendKind;
       federatedThread?: FederatedThreadRef;
+      recordTransition?: boolean;
       threadId: ThreadIdentifier;
       targetKind?: MessagingBindingRecord["targetKind"];
     },
@@ -14091,6 +14130,7 @@ export class MessagingController {
     }
     const upserted = await this.options.store.upsertBinding(binding);
     if (
+      target.recordTransition !== false &&
       previousBinding &&
       (previousBinding.backend !== upserted.backend ||
         previousBinding.threadId !== upserted.threadId ||
@@ -14102,12 +14142,15 @@ export class MessagingController {
       await this.recordBindingTransition("unbound", previousBinding, now);
     }
     if (
-      !previousBinding ||
-      previousBinding.backend !== upserted.backend ||
-      previousBinding.threadId !== upserted.threadId ||
-      !federationRefsMatch(
-        previousBinding.federatedThread,
-        upserted.federatedThread,
+      target.recordTransition !== false &&
+      (
+        !previousBinding ||
+        previousBinding.backend !== upserted.backend ||
+        previousBinding.threadId !== upserted.threadId ||
+        !federationRefsMatch(
+          previousBinding.federatedThread,
+          upserted.federatedThread,
+        )
       )
     ) {
       await this.recordBindingTransition("bound", upserted, now);
@@ -15097,9 +15140,15 @@ export class MessagingController {
         },
       };
     }
+    if (sourceBinding) {
+      await this.clearTerminalPrivateResponseActivity(
+        sourceBinding,
+        request.context.turnId,
+      );
+    }
     if (sourceBinding && result.continuation) {
       try {
-        await this.bindChannelToThread(
+        const continuationBinding = await this.bindChannelToThread(
           {
             ...privateEvent,
             id: `${privateEvent.id}:continuation`,
@@ -15108,9 +15157,14 @@ export class MessagingController {
           },
           {
             backend: request.context.backend,
+            recordTransition: false,
             threadId: request.context.threadId,
             targetKind: sourceBinding.targetKind ?? "agent_thread",
           },
+        );
+        await this.clearTerminalPrivateResponseActivity(
+          continuationBinding,
+          request.context.turnId,
         );
       } catch (error) {
         this.logger.warn?.("messaging private response continuation bind failed", {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -294,6 +294,21 @@ type MessagingTurnProseState = {
 const DEFAULT_MESSAGING_AGENT_NAME = "Messaging Agent";
 const DEFAULT_MESSAGING_AGENT_INSTRUCTIONS =
   "You are an Agent thread created from messaging. Keep shared context for the attached messaging surfaces and use available Agent tools when they are relevant.";
+const PRIVATE_RESPONSE_FALLBACK_INSTRUCTION =
+  "PwrAgent detected an explicit request for a private terminal response. "
+  + "Do not include sensitive response content in commentary or working updates. "
+  + "Use send_private_response if it is available. If that tool is unavailable, "
+  + "put the intended private content only in your final answer; PwrAgent will "
+  + "deliver that final privately and suppress it on the source surface.";
+const EXPLICIT_PRIVATE_RESPONSE_REQUEST_PATTERN = new RegExp(
+  [
+    "\\b(?:dm|direct[\\s-]+message|private[\\s-]+message)\\s+me\\b",
+    "\\bsend\\s+me(?:\\s+\\S+){0,3}\\s+(?:dm|direct[\\s-]+message|private[\\s-]+message)\\b",
+    "\\b(?:send|reply|respond)(?:\\s+\\S+){0,6}\\s+privately\\b",
+    "\\bsend(?:\\s+\\S+){0,6}\\s+(?:only|just)\\s+to\\s+me\\b",
+  ].join("|"),
+  "i",
+);
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 
@@ -773,6 +788,16 @@ export class MessagingController {
     string,
     MessagingCancellationSignal
   >();
+  private readonly workingUpdateCancellationSignals = new Map<
+    string,
+    MessagingCancellationSignal
+  >();
+  private readonly workingUpdateDeliveries = new Map<string, Set<Promise<void>>>();
+  private readonly workingUpdateSurfaces = new Map<
+    string,
+    Map<string, MessagingSurfaceRef>
+  >();
+  private readonly workingUpdateCancellationFailures = new Set<string>();
   private readonly automationTurnsByTurnKey = new Map<
     string,
     AutomationTurnMessagingContext
@@ -782,6 +807,8 @@ export class MessagingController {
     ActiveAgentMessagingOrigin
   >();
   private readonly terminalPrivateResponseTurnKeys = new Set<string>();
+  private readonly privateResponseFallbackTurnKeys = new Set<string>();
+  private readonly attemptedPrivateResponseFallbackTurnKeys = new Set<string>();
   private readonly queuedAgentMessagingOriginsByQueueKey = new Map<
     string,
     ActiveAgentMessagingOrigin
@@ -1508,11 +1535,18 @@ export class MessagingController {
         }
       }
 
-      const suppressSourceResponse = this.isTerminalPrivateResponseTurn(
+      const terminalPrivateResponse = this.isTerminalPrivateResponseTurn(
         event.backend,
         binding.threadId,
         eventTurnId ?? activeTurn?.turnId,
       );
+      const privateResponseFallback = this.isPrivateResponseFallbackTurn(
+        event.backend,
+        binding.threadId,
+        eventTurnId ?? activeTurn?.turnId,
+      );
+      const suppressSourceResponse =
+        terminalPrivateResponse || privateResponseFallback;
       if (!suppressSourceResponse) {
         await this.deliverToolActivityForBackendEvent(
           event,
@@ -1540,12 +1574,30 @@ export class MessagingController {
           (isThreadStatusIdleEvent(event) && activeTurn))
       ) {
         const terminalTurnId = turnIdForBackendEvent(event) ?? activeTurn?.turnId;
-        await this.flushToolUpdatesForBinding(binding, {
-          clear: true,
-          turnId: terminalTurnId,
-        });
+        if (suppressSourceResponse && terminalTurnId) {
+          this.toolUpdatePolicy.flush({
+            bindingId: binding.id,
+            clear: true,
+            turnId: terminalTurnId,
+          });
+        } else {
+          await this.flushToolUpdatesForBinding(binding, {
+            clear: true,
+            turnId: terminalTurnId,
+          });
+        }
         if (terminalTurnId) {
           this.clearTurnProse(binding.id, terminalTurnId);
+          if (!privateResponseFallback) {
+            const workingUpdateKey = this.turnProseKey(
+              binding.id,
+              terminalTurnId,
+            );
+            this.workingUpdateCancellationSignals.delete(workingUpdateKey);
+            this.workingUpdateDeliveries.delete(workingUpdateKey);
+            this.workingUpdateSurfaces.delete(workingUpdateKey);
+            this.workingUpdateCancellationFailures.delete(workingUpdateKey);
+          }
         }
       }
 
@@ -1559,7 +1611,22 @@ export class MessagingController {
       const assistantText = standaloneReviewAssistantText ?? (
         isFinalReviewAssistant ? undefined : rawAssistantText
       );
-      if (assistantText && !suppressSourceResponse) {
+      if (
+        assistantText
+        && privateResponseFallback
+        && !terminalPrivateResponse
+        && !isNonFinalAssistantTextForBackendEvent(event)
+      ) {
+        const fallbackTurnId = eventTurnId ?? activeTurn?.turnId;
+        if (fallbackTurnId) {
+          await this.deliverPrivateResponseFallback({
+            binding,
+            event,
+            text: assistantText,
+            turnId: fallbackTurnId,
+          });
+        }
+      } else if (assistantText && !suppressSourceResponse) {
         if (
           !isNonFinalAssistantTextForBackendEvent(event)
           && !isTaskMonitorProgressEvent(event)
@@ -3352,6 +3419,16 @@ export class MessagingController {
     const previewParts: string[] = [];
     const rejections: MessagingAttachmentRejection[] = [];
     const pdfHandling = await this.resolveMessagingPdfHandling(binding);
+    const privateResponseRequested = events.some(
+      (turnEvent) => requestsExplicitPrivateResponse(turnEvent),
+    );
+
+    if (privateResponseRequested) {
+      input.push({
+        type: "text",
+        text: PRIVATE_RESPONSE_FALLBACK_INSTRUCTION,
+      });
+    }
 
     for (const turnEvent of events) {
       if (turnEvent.kind === "text") {
@@ -5504,7 +5581,7 @@ export class MessagingController {
           && isVisibleAssistantStreamDelivery(cancelledResult)
           && !isSameMessagingSurface(cancelledResult.surface, buffer.surface)
         ) {
-          const dismissed = await this.dismissAssistantStreamSurface(
+          const dismissed = await this.dismissTerminalPrivateResponseSurface(
             binding,
             buffer.turnId,
             cancelledResult.surface,
@@ -5624,7 +5701,7 @@ export class MessagingController {
       }
     }
     for (const surface of surfaces.values()) {
-      const dismissed = await this.dismissAssistantStreamSurface(
+      const dismissed = await this.dismissTerminalPrivateResponseSurface(
         binding,
         turnId,
         surface,
@@ -5641,7 +5718,80 @@ export class MessagingController {
     return cancelledCleanly;
   }
 
-  private async dismissAssistantStreamSurface(
+  private ensureWorkingUpdateCancellationSignal(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): MessagingCancellationSignal {
+    const key = this.turnProseKey(binding.id, turnId);
+    const existing = this.workingUpdateCancellationSignals.get(key);
+    if (existing) {
+      return existing;
+    }
+    let cancelled = this.isTerminalPrivateResponseTurn(
+      binding.backend,
+      binding.threadId,
+      turnId,
+    );
+    let resolveCancellation!: () => void;
+    const whenCancelled = new Promise<void>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    const cancellation: MessagingCancellationSignal = {
+      cancel: () => {
+        if (cancelled) {
+          return;
+        }
+        cancelled = true;
+        resolveCancellation();
+      },
+      isCancelled: () =>
+        cancelled
+        || this.isTerminalPrivateResponseTurn(
+          binding.backend,
+          binding.threadId,
+          turnId,
+        ),
+      whenCancelled,
+    };
+    if (cancelled) {
+      resolveCancellation();
+    }
+    this.workingUpdateCancellationSignals.set(key, cancellation);
+    return cancellation;
+  }
+
+  private async cancelWorkingUpdatesForTurn(
+    binding: MessagingBindingRecord,
+    turnId: string,
+  ): Promise<boolean> {
+    const key = this.turnProseKey(binding.id, turnId);
+    this.workingUpdateCancellationFailures.delete(key);
+    this.workingUpdateCancellationSignals.get(key)?.cancel();
+    await Promise.allSettled(this.workingUpdateDeliveries.get(key) ?? []);
+
+    const surfaces = this.workingUpdateSurfaces.get(key);
+    if (surfaces) {
+      for (const surface of surfaces.values()) {
+        const dismissed = await this.dismissTerminalPrivateResponseSurface(
+          binding,
+          turnId,
+          surface,
+        );
+        if (!dismissed) {
+          this.workingUpdateCancellationFailures.add(key);
+        }
+      }
+    }
+
+    const cancelledCleanly = !this.workingUpdateCancellationFailures.has(key);
+    this.workingUpdateCancellationFailures.delete(key);
+    this.workingUpdateCancellationSignals.delete(key);
+    this.workingUpdateDeliveries.delete(key);
+    this.workingUpdateSurfaces.delete(key);
+    return cancelledCleanly;
+  }
+
+  private async dismissTerminalPrivateResponseSurface(
     binding: MessagingBindingRecord,
     turnId: string,
     surface: MessagingSurfaceRef,
@@ -5649,7 +5799,7 @@ export class MessagingController {
     try {
       const result = await this.deliver(
         {
-          id: this.newIntentId("assistant-stream-private-response-dismiss"),
+          id: this.newIntentId("private-response-source-dismiss"),
           kind: "dismiss",
           bindingId: binding.id,
           createdAt: this.now(),
@@ -5662,7 +5812,7 @@ export class MessagingController {
       if (result.outcome === "dismissed") {
         return true;
       }
-      this.logger.warn?.("messaging private response stream dismissal failed", {
+      this.logger.warn?.("messaging private response source dismissal failed", {
         bindingId: binding.id,
         errorMessage: result.errorMessage,
         outcome: result.outcome,
@@ -5672,7 +5822,7 @@ export class MessagingController {
       });
       return false;
     } catch (error) {
-      this.logger.warn?.("messaging private response stream dismissal failed", {
+      this.logger.warn?.("messaging private response source dismissal failed", {
         bindingId: binding.id,
         error: error instanceof Error ? error.message : String(error),
         surfaceId: surface.id,
@@ -5986,11 +6136,20 @@ export class MessagingController {
     this.completedTaskMonitorTurns.clear();
     this.activeAgentMessagingOriginsByTurnKey.clear();
     this.terminalPrivateResponseTurnKeys.clear();
+    this.privateResponseFallbackTurnKeys.clear();
+    this.attemptedPrivateResponseFallbackTurnKeys.clear();
     this.assistantStreamCancellationFailures.clear();
     for (const cancellation of this.assistantStreamCancellationSignals.values()) {
       cancellation.cancel();
     }
     this.assistantStreamCancellationSignals.clear();
+    this.workingUpdateCancellationFailures.clear();
+    for (const cancellation of this.workingUpdateCancellationSignals.values()) {
+      cancellation.cancel();
+    }
+    this.workingUpdateCancellationSignals.clear();
+    this.workingUpdateDeliveries.clear();
+    this.workingUpdateSurfaces.clear();
     this.queuedAgentMessagingOriginsByQueueKey.clear();
   }
 
@@ -13656,12 +13815,13 @@ export class MessagingController {
     ) {
       return;
     }
+    const turnKey = agentMessagingTurnKey(
+      params.binding.backend,
+      params.binding.threadId,
+      params.turnId,
+    );
     this.activeAgentMessagingOriginsByTurnKey.set(
-      agentMessagingTurnKey(
-        params.binding.backend,
-        params.binding.threadId,
-        params.turnId,
-      ),
+      turnKey,
       {
         binding: isDefaultAgentRouteBinding(params.binding)
           ? undefined
@@ -13672,6 +13832,9 @@ export class MessagingController {
         event: params.event,
       },
     );
+    if (requestsExplicitPrivateResponse(params.event)) {
+      rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
+    }
   }
 
   private forgetAgentMessagingOrigin(
@@ -13697,6 +13860,19 @@ export class MessagingController {
     );
   }
 
+  private isPrivateResponseFallbackTurn(
+    backend: AppServerBackendKind,
+    threadId: ThreadIdentifier,
+    turnId: string | undefined,
+  ): boolean {
+    return Boolean(
+      turnId
+      && this.privateResponseFallbackTurnKeys.has(
+        agentMessagingTurnKey(backend, threadId, turnId),
+      ),
+    );
+  }
+
   private rememberQueuedAgentMessagingOrigin(params: {
     binding: MessagingBindingRecord;
     event?: MessagingInboundEvent;
@@ -13709,12 +13885,13 @@ export class MessagingController {
     ) {
       return;
     }
+    const queueKey = agentMessagingQueueKey(
+      params.binding.backend,
+      params.binding.threadId,
+      params.queueEntryId,
+    );
     this.queuedAgentMessagingOriginsByQueueKey.set(
-      agentMessagingQueueKey(
-        params.binding.backend,
-        params.binding.threadId,
-        params.queueEntryId,
-      ),
+      queueKey,
       {
         binding: isDefaultAgentRouteBinding(params.binding)
           ? undefined
@@ -13746,14 +13923,18 @@ export class MessagingController {
     }
     if (params.update.status === "started" && params.update.turnId) {
       this.queuedAgentMessagingOriginsByQueueKey.delete(queueKey);
+      const turnKey = agentMessagingTurnKey(
+        params.backend,
+        params.threadId,
+        params.update.turnId,
+      );
       this.activeAgentMessagingOriginsByTurnKey.set(
-        agentMessagingTurnKey(
-          params.backend,
-          params.threadId,
-          params.update.turnId,
-        ),
+        turnKey,
         origin,
       );
+      if (requestsExplicitPrivateResponse(origin.event)) {
+        rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
+      }
       const activeTurn: MessagingActiveTurnSummary = {
         turnId: params.update.turnId,
         status: "working",
@@ -14748,9 +14929,13 @@ export class MessagingController {
     delivery: MessagingToolUpdatePolicyDelivery,
     knownBinding?: MessagingBindingRecord,
   ): Promise<void> {
-    const isCancelled = () =>
+    const cancellationKey = this.turnProseKey(
+      delivery.bindingId,
+      delivery.turnId,
+    );
+    const isTaskMonitorCancelled = () =>
       this.isTaskMonitorTurnComplete(delivery.bindingId, delivery.turnId);
-    if (isCancelled()) {
+    if (isTaskMonitorCancelled()) {
       return;
     }
     const binding =
@@ -14783,7 +14968,59 @@ export class MessagingController {
             id: this.newIntentId("tool-update-batch"),
           });
     this.markProseActivitiesDelivered({ ...delivery, activities });
-    await this.deliver(intent, binding, undefined, { isCancelled });
+    const cancellation = this.ensureWorkingUpdateCancellationSignal(
+      binding,
+      delivery.turnId,
+    );
+    const guardedIsCancelled = () =>
+      isTaskMonitorCancelled() || cancellation.isCancelled();
+    const deliveryPromise = (async () => {
+      const result = await this.deliver(intent, binding, undefined, {
+        isCancelled: guardedIsCancelled,
+        whenCancelled: cancellation.whenCancelled,
+        onCancelledDelivery: async (cancelledResult) => {
+          if (
+            cancelledResult.surface
+            && isVisibleAssistantStreamDelivery(cancelledResult)
+          ) {
+            const dismissed = await this.dismissTerminalPrivateResponseSurface(
+              binding,
+              delivery.turnId,
+              cancelledResult.surface,
+            );
+            if (!dismissed) {
+              this.workingUpdateCancellationFailures.add(cancellationKey);
+            }
+          }
+        },
+      });
+      if (
+        !guardedIsCancelled()
+        && result.surface
+        && isVisibleAssistantStreamDelivery(result)
+      ) {
+        let surfaces = this.workingUpdateSurfaces.get(cancellationKey);
+        if (!surfaces) {
+          surfaces = new Map();
+          this.workingUpdateSurfaces.set(cancellationKey, surfaces);
+        }
+        surfaces.set(messagingSurfaceKey(result.surface), result.surface);
+      }
+    })();
+    let deliveries = this.workingUpdateDeliveries.get(cancellationKey);
+    if (!deliveries) {
+      deliveries = new Set();
+      this.workingUpdateDeliveries.set(cancellationKey, deliveries);
+    }
+    deliveries.add(deliveryPromise);
+    try {
+      await deliveryPromise;
+    } finally {
+      deliveries.delete(deliveryPromise);
+      if (deliveries.size === 0) {
+        this.workingUpdateDeliveries.delete(cancellationKey);
+      }
+    }
   }
 
   private filterUndeliveredProseActivities(
@@ -14840,6 +15077,49 @@ export class MessagingController {
     if (!result.surface) {
       state.deliveredIds.delete(latest.activityId);
     }
+  }
+
+  private async deliverPrivateResponseFallback(params: {
+    binding: MessagingBindingRecord;
+    event: AgentEvent;
+    text: string;
+    turnId: string;
+  }): Promise<void> {
+    const turnKey = agentMessagingTurnKey(
+      params.event.backend,
+      params.binding.threadId,
+      params.turnId,
+    );
+    if (this.attemptedPrivateResponseFallbackTurnKeys.has(turnKey)) {
+      return;
+    }
+    rememberBoundedKey(this.attemptedPrivateResponseFallbackTurnKeys, turnKey);
+
+    const response = await this.sendPrivateResponseFromAgentMessagingOrigin({
+      operation: "send_private_response",
+      context: {
+        backend: params.event.backend,
+        threadId: params.binding.threadId,
+        turnId: params.turnId,
+      },
+      args: { text: params.text },
+    });
+    if (response.ok) {
+      return;
+    }
+    rememberBoundedKey(this.privateResponseFallbackTurnKeys, turnKey);
+
+    await this.deliver(
+      buildErrorIntent({
+        id: this.newIntentId("private-response-fallback-failed"),
+        createdAt: this.now(),
+        title: "Private response not delivered",
+        body:
+          "PwrAgent withheld the response from this conversation because it could not confirm private delivery. Try the request again or DM the bot directly.",
+        recoverable: true,
+      }),
+      params.binding,
+    );
   }
 
   private async attachThreadHereFromAgentMessagingOrigin(
@@ -15012,6 +15292,13 @@ export class MessagingController {
         },
       };
     }
+    const turnKey = agentMessagingTurnKey(
+      request.context.backend,
+      request.context.threadId,
+      request.context.turnId,
+    );
+    this.privateResponseFallbackTurnKeys.delete(turnKey);
+    rememberBoundedKey(this.attemptedPrivateResponseFallbackTurnKeys, turnKey);
     const origin = await this.resolveAgentMessagingOrigin(request.context);
     if (!origin.ok) {
       return origin;
@@ -15111,13 +15398,9 @@ export class MessagingController {
       };
     }
 
-    const turnKey = agentMessagingTurnKey(
-      request.context.backend,
-      request.context.threadId,
-      request.context.turnId,
-    );
     rememberBoundedKey(this.terminalPrivateResponseTurnKeys, turnKey);
     let sourceStreamsCancelled = true;
+    let sourceWorkingUpdatesCancelled = true;
     if (sourceBinding) {
       this.toolUpdatePolicy.flush({
         bindingId: sourceBinding.id,
@@ -15125,18 +15408,24 @@ export class MessagingController {
         turnId: request.context.turnId,
       });
       this.clearTurnProse(sourceBinding.id, request.context.turnId);
-      sourceStreamsCancelled = await this.cancelAssistantStreamsForTurn(
-        sourceBinding,
-        request.context.turnId,
-      );
+      [sourceStreamsCancelled, sourceWorkingUpdatesCancelled] = await Promise.all([
+        this.cancelAssistantStreamsForTurn(
+          sourceBinding,
+          request.context.turnId,
+        ),
+        this.cancelWorkingUpdatesForTurn(
+          sourceBinding,
+          request.context.turnId,
+        ),
+      ]);
     }
-    if (!sourceStreamsCancelled) {
+    if (!sourceStreamsCancelled || !sourceWorkingUpdatesCancelled) {
       return {
         ok: false,
         error: {
           code: "internal_error",
           message:
-            "The private response was delivered, but an existing source stream could not be retracted. Further source output remains suppressed.",
+            "The private response was delivered, but existing source output could not be fully retracted. Further source output remains suppressed.",
         },
       };
     }
@@ -19223,6 +19512,24 @@ function messageOriginForInboundEvent(
       },
     },
   };
+}
+
+function requestsExplicitPrivateResponse(
+  event: MessagingInboundEvent | MessagingTurnInputEvent,
+): boolean {
+  if (!("text" in event) || typeof event.text !== "string") {
+    return false;
+  }
+  const text = event.text.trim();
+  if (!text) {
+    return false;
+  }
+  const request = EXPLICIT_PRIVATE_RESPONSE_REQUEST_PATTERN.exec(text);
+  if (!request) {
+    return false;
+  }
+  const prefix = text.slice(Math.max(0, request.index - 18), request.index);
+  return !/\b(?:do\s+not|don't|never|not)\s*$/i.test(prefix);
 }
 
 function describeConversation(

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -199,6 +199,7 @@ export function buildBindingStatusIntent(params: {
   );
   const showResponseModeControl =
     params.binding.channel.conversation.kind !== "dm" &&
+    params.binding.channel.conversation.isDirectMessage !== true &&
     params.capabilityProfile?.conversationInput?.reportsBotMention === true;
   const acpRuntimeMode = isAcpBackendId(params.binding.backend)
     ? buildMessagingAcpRuntimeModeSummary({

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -881,6 +881,11 @@ function sanitizeBinding(binding: MessagingBindingRecord): MessagingBindingRecor
     monitorSurface: sanitizeSurfaceRef(binding.monitorSurface),
     pinnedStatusSurface: sanitizeSurfaceRef(binding.pinnedStatusSurface),
     routingState: sanitizeAdapterState(binding.routingState),
+    statusPresentation:
+      binding.statusPresentation === "automatic"
+      || binding.statusPresentation === "on_demand"
+        ? binding.statusPresentation
+        : undefined,
     statusSurface: sanitizeSurfaceRef(binding.statusSurface),
     targetKind: normalizeMessagingBindingTargetKind(binding.targetKind),
   };

--- a/apps/desktop/src/main/messaging/core/messaging-store.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-store.ts
@@ -880,6 +880,23 @@ function sanitizeBinding(binding: MessagingBindingRecord): MessagingBindingRecor
     authorizedActorIds: [...new Set(binding.authorizedActorIds)],
     monitorSurface: sanitizeSurfaceRef(binding.monitorSurface),
     pinnedStatusSurface: sanitizeSurfaceRef(binding.pinnedStatusSurface),
+    privateReplyContinuation: binding.privateReplyContinuation
+      ? {
+          ...binding.privateReplyContinuation,
+          source: {
+            ...binding.privateReplyContinuation.source,
+            authorizedActorIds: [
+              ...new Set(binding.privateReplyContinuation.source.authorizedActorIds),
+            ],
+            channel: structuredClone(
+              binding.privateReplyContinuation.source.channel,
+            ),
+            routingState: sanitizeAdapterState(
+              binding.privateReplyContinuation.source.routingState,
+            ),
+          },
+        }
+      : undefined,
     routingState: sanitizeAdapterState(binding.routingState),
     statusPresentation:
       binding.statusPresentation === "automatic"

--- a/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-turn-admission.ts
@@ -34,6 +34,7 @@ export type MessagingQueuedTurnEntry = {
   id: string;
   input: AppServerTurnInputItem[];
   pdfAttachments?: PendingPdfAttachment[];
+  privateResponseRequested?: boolean;
   preview: string;
   status: "queued" | "steered" | "cancelled" | "submitted" | "failed";
   surface?: MessagingSurfaceRef;

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -1024,7 +1024,11 @@ export class DesktopMessagingRuntime implements MessagingAgentToolService {
     if (event.kind !== "text" && event.kind !== "media") {
       return false;
     }
-    if (event.botMention || event.channel.conversation.kind === "dm") {
+    if (
+      event.botMention
+      || event.channel.conversation.kind === "dm"
+      || event.channel.conversation.isDirectMessage === true
+    ) {
       return false;
     }
     if (!params.reportsBotMention) {

--- a/apps/desktop/src/main/messaging/messaging-runtime.ts
+++ b/apps/desktop/src/main/messaging/messaging-runtime.ts
@@ -49,6 +49,8 @@ import type {
   MessagingManagedConversationCreateResult,
   MessagingManagedConversationRightsRequest,
   MessagingManagedConversationRightsResult,
+  MessagingPrivateConversationResolveRequest,
+  MessagingPrivateConversationResolveResult,
   MessagingRateLimitInfo,
   MessagingReconnectInfo,
   MessagingRejectedInboundEvent,
@@ -130,6 +132,9 @@ export type DesktopMessagingAdapter = {
   createManagedConversation?(
     request: MessagingManagedConversationCreateRequest,
   ): Promise<MessagingManagedConversationCreateResult>;
+  resolvePrivateConversation?(
+    request: MessagingPrivateConversationResolveRequest,
+  ): Promise<MessagingPrivateConversationResolveResult>;
   closeManagedConversation?(
     request: MessagingManagedConversationActionRequest,
   ): Promise<MessagingManagedConversationActionResult>;

--- a/apps/desktop/src/main/state/messaging-store-sqlite.ts
+++ b/apps/desktop/src/main/state/messaging-store-sqlite.ts
@@ -1213,6 +1213,23 @@ function sanitizeBinding(
     authorizedActorIds: [...new Set(binding.authorizedActorIds)],
     monitorSurface: sanitizeSurfaceRef(binding.monitorSurface),
     pinnedStatusSurface: sanitizeSurfaceRef(binding.pinnedStatusSurface),
+    privateReplyContinuation: binding.privateReplyContinuation
+      ? {
+          ...binding.privateReplyContinuation,
+          source: {
+            ...binding.privateReplyContinuation.source,
+            authorizedActorIds: [
+              ...new Set(binding.privateReplyContinuation.source.authorizedActorIds),
+            ],
+            channel: structuredClone(
+              binding.privateReplyContinuation.source.channel,
+            ),
+            routingState: sanitizeAdapterState(
+              binding.privateReplyContinuation.source.routingState,
+            ),
+          },
+        }
+      : undefined,
     routingState: sanitizeAdapterState(binding.routingState),
     statusSurface: sanitizeSurfaceRef(binding.statusSurface),
     targetKind: normalizeMessagingBindingTargetKind(binding.targetKind),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -737,6 +737,79 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("does not duplicate a final reported by both item and turn completion", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread: async () => readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: {
+              id: "assistant-final-1",
+              type: "agentMessage",
+              phase: "final_answer",
+              text: "Sent.",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              output: [{ type: "text", text: "Sent." }],
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.filter(
+        (entry) =>
+          entry.type === "message"
+          && entry.role === "assistant"
+          && entry.text === "Sent."
+      )
+    ).toHaveLength(1);
+  });
+
   it("replaces a promoted optimistic user message when the completed user item arrives later", async () => {
     let now = 1_000;
     vi.spyOn(Date, "now").mockImplementation(() => {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3374,6 +3374,26 @@ function hasReviewEntryForTurn(
   );
 }
 
+function hasCompletedAssistantMessageForTurn(
+  response: AppServerReadThreadResponse | undefined,
+  turnId: string | undefined,
+  text: string | undefined
+): boolean {
+  if (!response || !turnId || !text) {
+    return false;
+  }
+
+  const normalizedText = normalizeTranscriptText(text);
+  return response.replay.entries.some(
+    (entry) =>
+      entry.type === "message" &&
+      entry.role === "assistant" &&
+      entry.phase !== "commentary" &&
+      entry.turn?.id === turnId &&
+      normalizeTranscriptText(entry.text) === normalizedText
+  );
+}
+
 function retainSessionCache(
   sessions: ThreadSessionState,
   selectedThreadKey?: string
@@ -4890,7 +4910,12 @@ export function useThreadSessionState(params: {
               : completedTurnText ?? current.pendingAssistantMessage?.text;
           const shouldAppendFinalMessage = Boolean(
             completedText &&
-              current.pendingAssistantMessage?.text !== completedText
+              current.pendingAssistantMessage?.text !== completedText &&
+              !hasCompletedAssistantMessageForTurn(
+                current.response,
+                completedTurn?.id,
+                completedText
+              )
           );
           const unphasedAssistantCompletionPhase =
             shouldAppendFinalMessage ? "commentary" : undefined;

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -186,9 +186,9 @@ When `send_private_response` requests a reply, the continuation additionally
 stores a bounded, expiring one-shot return route and Agent-authored completion
 instructions. The first private-thread reply starts the originating Agent with
 those instructions, suppresses non-final source updates, delivers the final
-answer through the original source binding, and revokes the continuation after
-the turn terminates. Providers do not implement this workflow and still see
-only normalized continuation and delivery requests.
+answer through the original source binding, and atomically consumes the
+continuation when that first reply is admitted. Providers do not implement
+this workflow and still see only normalized continuation and delivery requests.
 
 Providers set `conversation.isDirectMessage` on both a 1:1 DM and any native
 thread nested inside it. This preserves DM authorization and ambient-reply

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -182,6 +182,14 @@ from its replies must not insert the full binding status card into the private
 conversation. An explicit status command may create the card, after which
 ordinary refreshes may update it.
 
+When `send_private_response` requests a reply, the continuation additionally
+stores a bounded, expiring one-shot return route and Agent-authored completion
+instructions. The first private-thread reply starts the originating Agent with
+those instructions, suppresses non-final source updates, delivers the final
+answer through the original source binding, and revokes the continuation after
+the turn terminates. Providers do not implement this workflow and still see
+only normalized continuation and delivery requests.
+
 Providers set `conversation.isDirectMessage` on both a 1:1 DM and any native
 thread nested inside it. This preserves DM authorization and ambient-reply
 semantics after normalization changes the child conversation's `kind` to

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -163,6 +163,12 @@ to the originating Agent. Replies in that message's native thread therefore
 survive restarts and route deterministically, while a top-level DM remains
 available to the configured default Agent.
 
+Providers set `conversation.isDirectMessage` on both a 1:1 DM and any native
+thread nested inside it. This preserves DM authorization and ambient-reply
+semantics after normalization changes the child conversation's `kind` to
+`thread`; shared-channel allowlists and mention-only policies must not be
+applied to those private thread replies.
+
 ## Attachment Policy
 
 Providers expose metadata and transport:

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -147,6 +147,20 @@ the private delivery succeeds. Resolver and delivery failure leave source
 delivery unchanged. Adapters must revalidate the actor identifier at this
 boundary and reject bot actors or unsupported conversation types explicitly.
 
+Codex dynamic tool catalogs are fixed when a thread starts. For older threads
+whose catalog predates `send_private_response`, an explicit natural-language
+private-response request (for example, "DM me") activates a controller-owned
+compatibility path: source prose and working updates are suppressed, and the
+turn's final answer is delivered to the recorded actor through the same private
+resolver. If that fallback delivery fails, the private content remains withheld
+and the source receives only a generic delivery error.
+
+Before reporting private-delivery success, the controller cancels queued and
+in-flight source streams, prose, and tool updates. Adapters may still complete a
+delivery after cancellation, so any late surface returned by `deliver` must be
+retracted through `dismissSurface`; private success is withheld when an existing
+source surface cannot be dismissed.
+
 Slack resolves the requesting user ID as the initial direct-message target;
 `chat.postMessage` opens the bot's 1:1 conversation when needed and returns the
 durable `D...` conversation ID in its delivery result. This uses the existing

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -153,6 +153,16 @@ durable `D...` conversation ID in its delivery result. This uses the existing
 `chat:write` scope and does not require core workflow code to persist or inspect
 Slack-specific identifiers.
 
+When a provider can identify the native conversation where replies to a newly
+delivered surface will arrive, it should populate
+`MessagingDeliveryResult.continuation`. The continuation contains a normalized
+channel plus opaque routing state; workflow code may persist it as an ordinary
+binding but must not recover it by parsing the delivered surface state. Slack
+uses this to bind the private message's `D...` channel and root timestamp back
+to the originating Agent. Replies in that message's native thread therefore
+survive restarts and route deterministically, while a top-level DM remains
+available to the configured default Agent.
+
 ## Attachment Policy
 
 Providers expose metadata and transport:

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -177,6 +177,11 @@ to the originating Agent. Replies in that message's native thread therefore
 survive restarts and route deterministically, while a top-level DM remains
 available to the configured default Agent.
 
+That continuation is an implicit, on-demand-status binding. Starting a turn
+from its replies must not insert the full binding status card into the private
+conversation. An explicit status command may create the card, after which
+ordinary refreshes may update it.
+
 Providers set `conversation.isDirectMessage` on both a 1:1 DM and any native
 thread nested inside it. This preserves DM authorization and ambient-reply
 semantics after normalization changes the child conversation's `kind` to

--- a/docs/messaging-adapter-contract.md
+++ b/docs/messaging-adapter-contract.md
@@ -131,6 +131,28 @@ thread-reply broadcast flag, such as Slack's `reply_broadcast`, should map
 providers may fall back to a normal fresh message or return a structured
 unsupported delivery result.
 
+## Private Terminal Responses
+
+An adapter may implement `resolvePrivateConversation` when the platform can
+start or recover a 1:1 conversation with the actor who initiated an inbound
+turn. The request carries only the normalized actor, source conversation, and
+opaque provider routing state. The result returns a normalized `dm`
+conversation plus opaque routing state for ordinary `deliver(intent)` handling;
+desktop orchestration must not parse provider user IDs or DM channel IDs.
+
+This resolver is used by the scoped Agent `send_private_response` tool. The
+tool can address only the actor recorded for its active messaging turn, and the
+controller suppresses the normal source-conversation final response only after
+the private delivery succeeds. Resolver and delivery failure leave source
+delivery unchanged. Adapters must revalidate the actor identifier at this
+boundary and reject bot actors or unsupported conversation types explicitly.
+
+Slack resolves the requesting user ID as the initial direct-message target;
+`chat.postMessage` opens the bot's 1:1 conversation when needed and returns the
+durable `D...` conversation ID in its delivery result. This uses the existing
+`chat:write` scope and does not require core workflow code to persist or inspect
+Slack-specific identifiers.
+
 ## Attachment Policy
 
 Providers expose metadata and transport:

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -139,6 +139,15 @@ stores the run artifact for the assigned Agent's dynamic inspection tools.
 deliver it relative to the source inbound event. The provider still owns final
 platform translation, including source-thread targeting and broadcast flags.
 
+Agent turns can also use the scoped `send_private_response` messaging tool for
+an explicitly private terminal reply. The controller resolves the active
+turn's inbound actor, asks only that provider's optional
+`resolvePrivateConversation` hook for a normalized `dm` target, and sends the
+message through the ordinary intent/delivery-budget path. Only a successful
+private delivery suppresses the source-conversation final response. Provider
+user IDs and DM routing remain validated and opaque inside the adapter; the
+Agent cannot select an arbitrary recipient.
+
 ## 1:1 controller:adapter mapping
 
 Each adapter gets its own controller. Backend events broadcast to all controllers in parallel; each one decides whether the event is relevant to any of its bindings and renders to its own adapter.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -167,6 +167,11 @@ user-facing bound/unbound transcript transition, and its status presentation is
 on demand so the first reply does not insert a full binding card. Its normalized
 conversation retains whether it lives inside a 1:1 DM so replies bypass
 shared-channel authorization and mention-only response policy.
+If the Agent sets `awaitReply`, that binding becomes a 24-hour one-shot callback
+route. Its stored completion instructions are prepended to the private reply,
+working and streaming output are withheld, and the final answer is delivered
+back to the original source binding. Terminal turn handling revokes the
+callback binding so it disappears from the Agent's attached surfaces.
 Terminal private delivery also clears provider activity on both the source and
 continuation surfaces and
 suppresses later work events from re-arming that activity. Before it reports

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -148,6 +148,13 @@ private delivery suppresses the source-conversation final response. Provider
 user IDs and DM routing remain validated and opaque inside the adapter; the
 Agent cannot select an arbitrary recipient.
 
+Private messages carry controller-generated Agent attribution rather than a
+provider-specific sender-name override. When delivery returns a normalized
+reply continuation, the controller persists that exact native thread as a
+binding to the originating Agent. Thread replies then route back to that Agent;
+top-level DMs deliberately keep their normal default-Agent routing instead of
+using ambiguous "last Agent wins" state.
+
 ## 1:1 controller:adapter mapping
 
 Each adapter gets its own controller. Backend events broadcast to all controllers in parallel; each one decides whether the event is relevant to any of its bindings and renders to its own adapter.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -170,8 +170,9 @@ shared-channel authorization and mention-only response policy.
 If the Agent sets `awaitReply`, that binding becomes a 24-hour one-shot callback
 route. Its stored completion instructions are prepended to the private reply,
 working and streaming output are withheld, and the final answer is delivered
-back to the original source binding. Terminal turn handling revokes the
-callback binding so it disappears from the Agent's attached surfaces.
+back to the original source binding. Admitting the first reply revokes the
+callback binding before another reply can queue against it, while the admitted
+turn retains the captured return route until its final delivery completes.
 Terminal private delivery also clears provider activity on both the source and
 continuation surfaces and
 suppresses later work events from re-arming that activity. Before it reports

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -163,10 +163,12 @@ top-level DMs deliberately keep their normal default-Agent routing instead of
 using ambiguous "last Agent wins" state.
 
 The continuation binding is internal routing state: creating it does not emit a
-user-facing bound/unbound transcript transition. Its normalized conversation
-retains whether it lives inside a 1:1 DM so replies bypass shared-channel
-authorization and mention-only response policy. Terminal private delivery also
-clears provider activity on both the source and continuation surfaces and
+user-facing bound/unbound transcript transition, and its status presentation is
+on demand so the first reply does not insert a full binding card. Its normalized
+conversation retains whether it lives inside a 1:1 DM so replies bypass
+shared-channel authorization and mention-only response policy.
+Terminal private delivery also clears provider activity on both the source and
+continuation surfaces and
 suppresses later work events from re-arming that activity. Before it reports
 success, the controller cancels queued and in-flight source streams, prose, and
 tool updates and retracts any surface returned after cancellation.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -155,6 +155,13 @@ binding to the originating Agent. Thread replies then route back to that Agent;
 top-level DMs deliberately keep their normal default-Agent routing instead of
 using ambiguous "last Agent wins" state.
 
+The continuation binding is internal routing state: creating it does not emit a
+user-facing bound/unbound transcript transition. Its normalized conversation
+retains whether it lives inside a 1:1 DM so replies bypass shared-channel
+authorization and mention-only response policy. Terminal private delivery also
+clears provider activity on both the source and continuation surfaces and
+suppresses later work events from re-arming that activity.
+
 ## 1:1 controller:adapter mapping
 
 Each adapter gets its own controller. Backend events broadcast to all controllers in parallel; each one decides whether the event is relevant to any of its bindings and renders to its own adapter.

--- a/docs/messaging-architecture.md
+++ b/docs/messaging-architecture.md
@@ -148,6 +148,13 @@ private delivery suppresses the source-conversation final response. Provider
 user IDs and DM routing remain validated and opaque inside the adapter; the
 Agent cannot select an arbitrary recipient.
 
+Because Codex fixes a thread's dynamic-tool catalog at thread creation, the
+controller also recognizes explicit private-response requests as a compatibility
+path for older threads. It suppresses source output from the start of the turn
+and privately delivers the final answer to the recorded actor. A failed fallback
+withholds that answer and emits only a generic source error; an explicit tool
+attempt keeps the tool's normal success/failure semantics.
+
 Private messages carry controller-generated Agent attribution rather than a
 provider-specific sender-name override. When delivery returns a normalized
 reply continuation, the controller persists that exact native thread as a
@@ -160,7 +167,9 @@ user-facing bound/unbound transcript transition. Its normalized conversation
 retains whether it lives inside a 1:1 DM so replies bypass shared-channel
 authorization and mention-only response policy. Terminal private delivery also
 clears provider activity on both the source and continuation surfaces and
-suppresses later work events from re-arming that activity.
+suppresses later work events from re-arming that activity. Before it reports
+success, the controller cancels queued and in-flight source streams, prose, and
+tool updates and retracts any surface returned after cancellation.
 
 ## 1:1 controller:adapter mapping
 

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -440,6 +440,21 @@ export type MessagingManagedConversationCreateResult = {
   updatedAt: number;
 };
 
+export type MessagingPrivateConversationResolveRequest = {
+  actor: MessagingActorIdentity;
+  source: MessagingChannelRef;
+  routingState?: MessagingAdapterState;
+};
+
+export type MessagingPrivateConversationResolveResult = {
+  channel: MessagingChannelKind;
+  conversation?: MessagingConversationRef;
+  errorMessage?: string;
+  outcome: "resolved" | "unsupported" | "failed";
+  routingState?: MessagingAdapterState;
+  updatedAt: number;
+};
+
 export type MessagingManagedConversationActionRequest = {
   actor?: MessagingActorIdentity;
   channel: MessagingChannelRef;

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -448,6 +448,12 @@ export type MessagingManagedConversationCreateResult = {
 
 export type MessagingPrivateConversationResolveRequest = {
   actor: MessagingActorIdentity;
+  /**
+   * True when delivery must produce a conversation where this actor can reply.
+   * Providers reject resolution when their inbound policy would deny that
+   * continuation instead of promising an unusable reply route.
+   */
+  replyContinuationRequired?: boolean;
   source: MessagingChannelRef;
   routingState?: MessagingAdapterState;
 };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -803,6 +803,10 @@ export type MessagingBaseSurfaceIntent = {
 
 export type MessagingMessageIntent = MessagingBaseSurfaceIntent & {
   kind: "message";
+  attribution?: {
+    label: string;
+    hint?: string;
+  };
   parts: MessagingContentPart[];
   role?: "assistant" | "user" | "system";
 };
@@ -1147,6 +1151,15 @@ export type MessagingDeliveryResult = {
   outcome: MessagingDeliveryOutcome;
   channel: MessagingChannelKind;
   surface?: MessagingSurfaceRef;
+  /**
+   * Native conversation where a reply to the delivered surface arrives.
+   * Providers populate this only when they can identify a stable reply route
+   * without workflow code parsing opaque adapter state.
+   */
+  continuation?: {
+    channel: MessagingChannelRef;
+    routingState?: MessagingAdapterState;
+  };
   errorMessage?: string;
   /**
    * Structured provider rate-limit feedback for this delivery attempt.

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -300,6 +300,12 @@ export type MessagingConversationKind = "dm" | "channel" | "thread" | "topic";
 export type MessagingConversationRef = {
   id: string;
   kind: MessagingConversationKind;
+  /**
+   * True when this conversation is a 1:1 direct message or a child thread
+   * inside one. Thread normalization must not discard the access and ambient
+   * reply semantics inherited from its containing direct conversation.
+   */
+  isDirectMessage?: boolean;
   parentId?: string;
   /**
    * Normalized containing conversation used for scope inheritance. This is

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1509,6 +1509,12 @@ export type MessagingBindingRecord = {
   pinnedStatusSurface?: MessagingSurfaceRef;
   pendingSkillSelection?: MessagingPendingSkillSelection;
   preferences?: MessagingBindingPreferences;
+  /**
+   * `on_demand` keeps implicitly-created bindings quiet until the user asks
+   * for a status surface. Once a surface exists, ordinary refreshes may update
+   * it. Omitted bindings retain the normal automatic status-card behavior.
+   */
+  statusPresentation?: "automatic" | "on_demand";
   statusSurface?: MessagingSurfaceRef;
   threadDisplay?: MessagingThreadDisplaySummary;
 };

--- a/packages/messaging/interface/src/index.ts
+++ b/packages/messaging/interface/src/index.ts
@@ -1486,6 +1486,27 @@ export type MessagingPendingSkillSelection = {
   shortDescription?: string;
 };
 
+export type MessagingPrivateReplySource = {
+  authorizedActorIds: string[];
+  backend: AppServerBackendKind;
+  channel: MessagingChannelRef;
+  createdAt: number;
+  displayName?: string;
+  federatedThread?: FederatedThreadRef;
+  id: string;
+  routingState?: MessagingAdapterState;
+  targetKind?: MessagingBindingTargetKind;
+  threadId: ThreadIdentifier;
+  updatedAt: number;
+};
+
+export type MessagingPrivateReplyContinuation = {
+  createdAt: number;
+  expiresAt: number;
+  instructions: string;
+  source: MessagingPrivateReplySource;
+};
+
 export type MessagingBindingRecord = {
   id: string;
   channel: MessagingChannelRef;
@@ -1508,6 +1529,12 @@ export type MessagingBindingRecord = {
   monitorSurface?: MessagingSurfaceRef;
   pinnedStatusSurface?: MessagingSurfaceRef;
   pendingSkillSelection?: MessagingPendingSkillSelection;
+  /**
+   * Restart-safe, one-shot route created when an Agent asks for a private
+   * reply. The private response is supplied to the Agent, while its final
+   * completion is delivered through `source`; the binding is then revoked.
+   */
+  privateReplyContinuation?: MessagingPrivateReplyContinuation;
   preferences?: MessagingBindingPreferences;
   /**
    * `on_demand` keeps implicitly-created bindings quiet until the user asks

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -65,6 +65,7 @@ function fakeApi(spies: {
   publishedHomes?: Array<{ userId: string; view: SlackHomeView }>;
   posted?: unknown[];
   postedChannel?: string;
+  postedTimestamps?: string[];
   replies?: Record<string, string>;
   updated?: unknown[];
   users?: Record<string, { displayName?: string; realName?: string; username?: string }>;
@@ -107,7 +108,7 @@ function fakeApi(spies: {
       spies.posted?.push(params);
       return {
         channel: spies.postedChannel ?? params.channel,
-        ts: "1712023032.123456",
+        ts: spies.postedTimestamps?.shift() ?? "1712023032.123456",
       };
     },
     publishHomeView: async (params) => {
@@ -554,6 +555,61 @@ describe("SlackAdapter", () => {
         ]),
       }),
     ]);
+  });
+
+  it("rejects reply continuations that Slack DM policy would reject", async () => {
+    const source = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012ABCDEF0",
+        kind: "channel" as const,
+        workspaceId: "T012ABCDEF0",
+      },
+    };
+    const unlistedActor = {
+      platformUserId: "U999UNLISTED",
+      displayName: "Unlisted User",
+    };
+    const restrictedAdapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        channelUserAccessMode: "any_channel_user",
+        dmAccessMode: "authorized_users",
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+
+    await expect(restrictedAdapter.resolvePrivateConversation({
+      actor: unlistedActor,
+      replyContinuationRequired: true,
+      source,
+    })).resolves.toMatchObject({
+      outcome: "unsupported",
+      errorMessage: expect.stringContaining("DM access policy"),
+    });
+    await expect(restrictedAdapter.resolvePrivateConversation({
+      actor: unlistedActor,
+      source,
+    })).resolves.toMatchObject({ outcome: "resolved" });
+
+    const closedAdapter = new SlackAdapter({
+      config: { ...baseConfig, dmAccessMode: "none" },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    await expect(closedAdapter.resolvePrivateConversation({
+      actor: { platformUserId: "U012ABCDEF0", displayName: "Alice" },
+      replyContinuationRequired: true,
+      source,
+    })).resolves.toMatchObject({
+      outcome: "unsupported",
+      errorMessage: expect.stringContaining("DM access policy"),
+    });
   });
 
   it("signals Slack Assistant thread status for active typing activity", async () => {
@@ -3443,6 +3499,7 @@ describe("SlackAdapter", () => {
   });
 
   it("splits a long Markdown message across native Markdown posts", async () => {
+    const deleted: Array<{ channel: string; ts: string }> = [];
     const posted: Array<{
       blocks?: Array<{ text?: string; type: string }>;
       channel: string;
@@ -3451,30 +3508,51 @@ describe("SlackAdapter", () => {
     const adapter = new SlackAdapter({
       config: baseConfig,
       callbackHandleStore: fakeStore(),
-      api: fakeApi({ posted }),
+      api: fakeApi({
+        deleted,
+        posted,
+        postedTimestamps: [
+          "1712023032.000001",
+          "1712023032.000002",
+          "1712023032.000003",
+        ],
+      }),
       socketClient: fakeSocket(),
       now: () => 1_700_000_000_000,
     });
     const longText = "This is a full sentence that keeps going. ".repeat(320);
 
-    await expect(
-      adapter.deliver({
-        id: "assistant-message-1",
-        kind: "message",
-        createdAt: 1,
-        role: "assistant",
-        parts: [{ type: "text", text: longText, markdown: "markdown" }],
-        audit: {
-          actor: { platformUserId: "U012ABCDEF0" },
-          bindingId: "slack-binding-1",
-          channel: {
-            channel: "slack",
-            conversation: { id: "D012ABCDEF0", kind: "dm" },
-          },
-          occurredAt: 1,
+    const result = await adapter.deliver({
+      id: "assistant-message-1",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [{ type: "text", text: longText, markdown: "markdown" }],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        bindingId: "slack-binding-1",
+        channel: {
+          channel: "slack",
+          conversation: { id: "D012ABCDEF0", kind: "dm" },
         },
-      } as unknown as MessagingSurfaceIntent),
-    ).resolves.toMatchObject({ channel: "slack", outcome: "presented" });
+        occurredAt: 1,
+      },
+    } as unknown as MessagingSurfaceIntent);
+
+    expect(result).toMatchObject({
+      channel: "slack",
+      outcome: "presented",
+      surface: {
+        state: {
+          opaque: {
+            messageTimestamps: [
+              "1712023032.000001",
+              "1712023032.000002",
+            ],
+          },
+        },
+      },
+    });
 
     expect(posted.length).toBeGreaterThan(1);
     for (const post of posted) {
@@ -3483,6 +3561,19 @@ describe("SlackAdapter", () => {
       ]);
       expect(post.blocks?.[0]?.text?.length ?? 0).toBeLessThanOrEqual(12_000);
     }
+
+    await expect(adapter.deliver({
+      id: "dismiss-assistant-message-1",
+      kind: "dismiss",
+      createdAt: 2,
+      reason: "terminal_private_response",
+      targetSurface: result.surface!,
+    })).resolves.toMatchObject({ outcome: "dismissed" });
+    expect(deleted).toEqual(
+      (result.surface!.state!.opaque as { messageTimestamps: string[] })
+        .messageTimestamps
+        .map((ts) => ({ channel: "D012ABCDEF0", ts })),
+    );
   });
 
   it("splits long Markdown with images and attaches them to the final post", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -488,8 +488,8 @@ describe("SlackAdapter", () => {
       createdAt: 1,
       role: "assistant",
       attribution: {
-        label: "Signals Agent · Private response",
-        hint: "Reply in this message's thread to continue with this agent.",
+        label: "Signals Agent",
+        hint: "Private Request · Reply in Thread to Respond to this Agent",
       },
       parts: [{ type: "text", text: "Private details", markdown: "markdown" }],
       audit: {
@@ -547,7 +547,7 @@ describe("SlackAdapter", () => {
             elements: [{
               type: "plain_text",
               text:
-                "Signals Agent · Private response · Reply in this message's thread to continue with this agent.",
+                "Signals Agent · Private Request · Reply in Thread to Respond to this Agent",
               emoji: true,
             }],
           },

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -464,6 +464,7 @@ describe("SlackAdapter", () => {
       channel: "slack",
       conversation: {
         id: "U012ABCDEF0",
+        isDirectMessage: true,
         kind: "dm",
         title: "Alice",
         workspaceId: "T012ABCDEF0",
@@ -511,6 +512,7 @@ describe("SlackAdapter", () => {
           channel: "slack",
           conversation: {
             id: "D012PRIVATE0",
+            isDirectMessage: true,
             kind: "thread",
             parentConversationId: "D012PRIVATE0",
             parentId: "1712023032.123456",
@@ -2422,11 +2424,68 @@ describe("SlackAdapter", () => {
         channel: expect.objectContaining({
           conversation: expect.objectContaining({
             id: "D012ABCDEF0",
+            isDirectMessage: true,
             kind: "dm",
           }),
         }),
       }),
     ]);
+  });
+
+  it("preserves direct-message access for replies in a DM thread", async () => {
+    const socket = fakeSocket();
+    const adapter = new SlackAdapter({
+      config: {
+        ...baseConfig,
+        authorizedConversationIds: [],
+        authorizedTeamIds: [],
+        channelAuthorizationMode: "approved_only",
+        teamAuthorizationMode: "approved_only",
+      },
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({}),
+      socketClient: socket,
+      now: () => 1_700_000_000_000,
+    });
+    const events: MessagingInboundEvent[] = [];
+    const rejected: MessagingRejectedInboundEvent[] = [];
+    adapter.onInboundRejected((event) => {
+      rejected.push(event);
+    });
+    await adapter.start(async (event) => {
+      events.push(event);
+    });
+
+    await socket.emitEvent("slack_event", {
+      ack: async () => undefined,
+      event: {
+        type: "message",
+        channel: "D012ABCDEF0",
+        channel_type: "im",
+        team: "T012ABCDEF0",
+        thread_ts: "1712023032.123456",
+        ts: "1712023033.123456",
+        user: "U012ABCDEF0",
+        text: "reply without mentioning the bot",
+      },
+    });
+
+    expect(rejected).toEqual([]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        kind: "text",
+        channel: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "D012ABCDEF0",
+            isDirectMessage: true,
+            kind: "thread",
+            parentConversationId: "D012ABCDEF0",
+            parentId: "1712023032.123456",
+          }),
+        }),
+      }),
+    ]);
+    expect(events[0]).not.toHaveProperty("botMention");
   });
 
   it("allows authorized conversations without authorizing the whole workspace", async () => {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -482,7 +482,7 @@ describe("SlackAdapter", () => {
       throw new Error("Expected a resolved private Slack conversation");
     }
 
-    await expect(adapter.deliver({
+    const privateIntent = {
       id: "private-response",
       kind: "message",
       createdAt: 1,
@@ -505,7 +505,14 @@ describe("SlackAdapter", () => {
         id: "private-response-target",
         state: resolved.routingState,
       },
-    })).resolves.toMatchObject({
+    } satisfies MessagingSurfaceIntent;
+    expect(adapter.resolveDeliveryScope(privateIntent)).toMatchObject({
+      budget: { limit: 60, reserved: 0 },
+      kind: "dm",
+      label: "Slack DM",
+    });
+
+    await expect(adapter.deliver(privateIntent)).resolves.toMatchObject({
       channel: "slack",
       continuation: {
         channel: {

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -64,6 +64,7 @@ function fakeApi(spies: {
   deleteErrors?: Error[];
   publishedHomes?: Array<{ userId: string; view: SlackHomeView }>;
   posted?: unknown[];
+  postedChannel?: string;
   replies?: Record<string, string>;
   updated?: unknown[];
   users?: Record<string, { displayName?: string; realName?: string; username?: string }>;
@@ -104,7 +105,10 @@ function fakeApi(spies: {
     filesInfo: async () => undefined,
     postMessage: async (params) => {
       spies.posted?.push(params);
-      return { channel: params.channel, ts: "1712023032.123456" };
+      return {
+        channel: spies.postedChannel ?? params.channel,
+        ts: "1712023032.123456",
+      };
     },
     publishHomeView: async (params) => {
       spies.publishedHomes?.push(params);
@@ -428,7 +432,7 @@ describe("SlackAdapter", () => {
     const adapter = new SlackAdapter({
       config: baseConfig,
       callbackHandleStore: fakeStore(),
-      api: fakeApi({ posted }),
+      api: fakeApi({ posted, postedChannel: "D012PRIVATE0" }),
       socketClient: fakeSocket(),
       now: () => 1_700_000_000_000,
     });
@@ -482,6 +486,10 @@ describe("SlackAdapter", () => {
       kind: "message",
       createdAt: 1,
       role: "assistant",
+      attribution: {
+        label: "Signals Agent · Private response",
+        hint: "Reply in this message's thread to continue with this agent.",
+      },
       parts: [{ type: "text", text: "Private details", markdown: "markdown" }],
       audit: {
         actor: { platformUserId: "U012ABCDEF0" },
@@ -498,6 +506,25 @@ describe("SlackAdapter", () => {
       },
     })).resolves.toMatchObject({
       channel: "slack",
+      continuation: {
+        channel: {
+          channel: "slack",
+          conversation: {
+            id: "D012PRIVATE0",
+            kind: "thread",
+            parentConversationId: "D012PRIVATE0",
+            parentId: "1712023032.123456",
+            workspaceId: "T012ABCDEF0",
+          },
+        },
+        routingState: {
+          opaque: {
+            channelId: "D012PRIVATE0",
+            teamId: "T012ABCDEF0",
+            threadTs: "1712023032.123456",
+          },
+        },
+      },
       outcome: "presented",
     });
 
@@ -505,6 +532,17 @@ describe("SlackAdapter", () => {
       expect.objectContaining({
         channel: "U012ABCDEF0",
         text: "Private details",
+        blocks: expect.arrayContaining([
+          {
+            type: "context",
+            elements: [{
+              type: "plain_text",
+              text:
+                "Signals Agent · Private response · Reply in this message's thread to continue with this agent.",
+              emoji: true,
+            }],
+          },
+        ]),
       }),
     ]);
   });

--- a/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
+++ b/packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts
@@ -423,6 +423,92 @@ describe("SlackAdapter", () => {
     ]);
   });
 
+  it("resolves and delivers a private response to an inbound Slack actor", async () => {
+    const posted: unknown[] = [];
+    const adapter = new SlackAdapter({
+      config: baseConfig,
+      callbackHandleStore: fakeStore(),
+      api: fakeApi({ posted }),
+      socketClient: fakeSocket(),
+      now: () => 1_700_000_000_000,
+    });
+    const source = {
+      channel: "slack" as const,
+      conversation: {
+        id: "C012ABCDEF0",
+        kind: "channel" as const,
+        title: "signals-chat",
+        workspaceId: "T012ABCDEF0",
+      },
+    };
+
+    const resolved = await adapter.resolvePrivateConversation({
+      actor: {
+        platformUserId: "U012ABCDEF0",
+        displayName: "Alice",
+      },
+      source,
+      routingState: {
+        opaque: {
+          channelId: "C012ABCDEF0",
+          teamId: "T012ABCDEF0",
+        },
+      },
+    });
+
+    expect(resolved).toEqual({
+      channel: "slack",
+      conversation: {
+        id: "U012ABCDEF0",
+        kind: "dm",
+        title: "Alice",
+        workspaceId: "T012ABCDEF0",
+      },
+      outcome: "resolved",
+      routingState: {
+        opaque: {
+          channelId: "U012ABCDEF0",
+          teamId: "T012ABCDEF0",
+        },
+      },
+      updatedAt: 1_700_000_000_000,
+    });
+    if (resolved.outcome !== "resolved" || !resolved.conversation) {
+      throw new Error("Expected a resolved private Slack conversation");
+    }
+
+    await expect(adapter.deliver({
+      id: "private-response",
+      kind: "message",
+      createdAt: 1,
+      role: "assistant",
+      parts: [{ type: "text", text: "Private details", markdown: "markdown" }],
+      audit: {
+        actor: { platformUserId: "U012ABCDEF0" },
+        channel: {
+          channel: "slack",
+          conversation: resolved.conversation,
+        },
+        occurredAt: 1,
+      },
+      targetSurface: {
+        channel: "slack",
+        id: "private-response-target",
+        state: resolved.routingState,
+      },
+    })).resolves.toMatchObject({
+      channel: "slack",
+      outcome: "presented",
+    });
+
+    expect(posted).toEqual([
+      expect.objectContaining({
+        channel: "U012ABCDEF0",
+        text: "Private details",
+      }),
+    ]);
+  });
+
   it("signals Slack Assistant thread status for active typing activity", async () => {
     const assistantStatuses: Array<{ channelId: string; status: string; threadTs: string }> = [];
     const adapter = new SlackAdapter({

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -1341,7 +1341,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     } catch (error) {
       const rateLimit = this.emitRateLimitFromError(
         error,
-        { channelId: params.target.channelId },
+        params.target,
         { retryable: !deliveredAny },
       );
       return {
@@ -1550,8 +1550,15 @@ export class SlackAdapter implements SlackProviderAdapter {
     };
   }
 
-  private rateLimitScopeForTarget(target: { channelId: string }): MessagingDeliveryScope {
-    const isDm = target.channelId.startsWith("D");
+  private rateLimitScopeForTarget(target: {
+    channelId: string;
+    channelRef?: MessagingChannelRef;
+  }): MessagingDeliveryScope {
+    const conversation = target.channelRef?.conversation;
+    const isDm =
+      conversation?.kind === "dm"
+      || conversation?.isDirectMessage === true
+      || target.channelId.startsWith("D");
     return {
       platform: this.channel,
       id: `slack:channel:${target.channelId}`,
@@ -1571,7 +1578,7 @@ export class SlackAdapter implements SlackProviderAdapter {
 
   private emitRateLimitFromError(
     error: unknown,
-    target: { channelId: string },
+    target: { channelId: string; channelRef?: MessagingChannelRef },
     options?: { retryable?: boolean },
   ): MessagingRateLimitInfo | undefined {
     const retryAfterMs = retryAfterMsFromError(error);

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -238,6 +238,7 @@ export type SlackAdapterOptions = {
 
 type SlackSurfaceOpaqueState = {
   channelId?: string;
+  messageTimestamps?: string[];
   threadTs?: string;
   ts?: string;
 };
@@ -845,6 +846,24 @@ export class SlackAdapter implements SlackProviderAdapter {
         updatedAt: this.now(),
       };
     }
+    if (request.replyContinuationRequired) {
+      const dmMode = slackDmAccessMode(this.config);
+      const actorAuthorized = this.authorizedActorIds.includes(
+        request.actor.platformUserId,
+      );
+      if (
+        dmMode === "none"
+        || (dmMode === "authorized_users" && !actorAuthorized)
+      ) {
+        return {
+          channel: this.channel,
+          errorMessage:
+            "Slack DM access policy does not allow this user to reply to the private response.",
+          outcome: "unsupported",
+          updatedAt: this.now(),
+        };
+      }
+    }
     return {
       channel: this.channel,
       conversation: {
@@ -1233,7 +1252,12 @@ export class SlackAdapter implements SlackProviderAdapter {
     intent: Extract<MessagingSurfaceIntent, { kind: "dismiss" }>,
   ): Promise<MessagingDeliveryResult> {
     const target = readSlackSurfaceState(intent.targetSurface);
-    if (!target?.channelId || !target.ts) {
+    const messageTimestamps = target?.messageTimestamps?.length
+      ? target.messageTimestamps
+      : target?.ts
+        ? [target.ts]
+        : [];
+    if (!target?.channelId || messageTimestamps.length === 0) {
       return {
         outcome: "failed",
         channel: this.channel,
@@ -1242,25 +1266,32 @@ export class SlackAdapter implements SlackProviderAdapter {
       };
     }
     const channelId = target.channelId;
-    try {
-      await this.api.deleteMessage({ channel: channelId, ts: target.ts });
+    let firstError: unknown;
+    for (const ts of new Set(messageTimestamps)) {
+      try {
+        await this.api.deleteMessage({ channel: channelId, ts });
+      } catch (error) {
+        firstError ??= error;
+      }
+    }
+    if (!firstError) {
       return {
         outcome: "dismissed",
         channel: this.channel,
         deliveredAt: this.now(),
       };
-    } catch (error) {
-      const rateLimit = this.emitRateLimitFromError(error, { channelId }, {
-        retryable: true,
-      });
-      return {
-        outcome: "failed",
-        channel: this.channel,
-        deliveredAt: this.now(),
-        errorMessage: error instanceof Error ? error.message : String(error),
-        ...(rateLimit ? { rateLimit } : {}),
-      };
     }
+    const rateLimit = this.emitRateLimitFromError(firstError, { channelId }, {
+      retryable: true,
+    });
+    return {
+      outcome: "failed",
+      channel: this.channel,
+      deliveredAt: this.now(),
+      errorMessage:
+        firstError instanceof Error ? firstError.message : String(firstError),
+      ...(rateLimit ? { rateLimit } : {}),
+    };
   }
 
   /**
@@ -1268,7 +1299,8 @@ export class SlackAdapter implements SlackProviderAdapter {
    * the content is never truncated at the 3000-char section-block limit. The
    * chunks are already boundary-split by the caller. Remote image blocks and
    * uploaded data images are associated with the final chunk. Returns the first
-   * message as the surface (mirrors a single-post delivery).
+   * message as the surface and records every posted timestamp in its opaque
+   * state so a later dismissal retracts the complete delivery.
    */
   private async deliverChunkedTextMessage(params: {
     intent: Extract<MessagingSurfaceIntent, { kind: "message" }>;
@@ -1280,6 +1312,7 @@ export class SlackAdapter implements SlackProviderAdapter {
     chunks: string[];
   }): Promise<MessagingDeliveryResult> {
     let firstSurface: MessagingSurfaceRef | undefined;
+    const messageTimestamps: string[] = [];
     let deliveredAny = false;
     let lastTs: string | undefined;
     try {
@@ -1303,6 +1336,9 @@ export class SlackAdapter implements SlackProviderAdapter {
         deliveredAny = true;
         const ts = result.ts;
         lastTs = ts ?? lastTs;
+        if (ts) {
+          messageTimestamps.push(ts);
+        }
         if (ts && !firstSurface) {
           firstSurface = {
             channel: this.channel,
@@ -1322,6 +1358,20 @@ export class SlackAdapter implements SlackProviderAdapter {
         intent: params.intent,
         threadTs: params.target.threadTs ?? lastTs,
       });
+      if (firstSurface && messageTimestamps.length > 1) {
+        const firstState = readSlackSurfaceState(firstSurface);
+        firstSurface = {
+          ...firstSurface,
+          state: {
+            opaque: {
+              channelId: firstState?.channelId ?? params.target.channelId,
+              messageTimestamps,
+              ts: firstState?.ts ?? firstSurface.id,
+              ...(firstState?.threadTs ? { threadTs: firstState.threadTs } : {}),
+            },
+          },
+        };
+      }
       return {
         outcome: "presented",
         channel: this.channel,
@@ -1480,6 +1530,7 @@ export class SlackAdapter implements SlackProviderAdapter {
         evictStaleStreamAnchors(this.streamSurfaces);
       }
       const head = anchors[0]!;
+      const messageTimestamps = anchors.map((anchor) => anchor.ts);
       return {
         outcome: firstOutcome ?? "updated",
         channel: this.channel,
@@ -1490,6 +1541,7 @@ export class SlackAdapter implements SlackProviderAdapter {
           state: {
             opaque: {
               channelId: head.channelId,
+              ...(messageTimestamps.length > 1 ? { messageTimestamps } : {}),
               ts: head.ts,
               ...(head.threadTs ? { threadTs: head.threadTs } : {}),
             },
@@ -2580,8 +2632,14 @@ function readSlackOpaqueState(
     return undefined;
   }
   const record = opaque as Record<string, MessagingJsonValue>;
+  const messageTimestamps = Array.isArray(record.messageTimestamps)
+    ? record.messageTimestamps
+      .filter((value): value is string => typeof value === "string")
+      .slice(0, 100)
+    : [];
   return {
     ...(typeof record.channelId === "string" ? { channelId: record.channelId } : {}),
+    ...(messageTimestamps.length > 0 ? { messageTimestamps } : {}),
     ...(typeof record.teamId === "string" ? { teamId: record.teamId } : {}),
     ...(typeof record.threadTs === "string" ? { threadTs: record.threadTs } : {}),
     ...(typeof record.ts === "string" ? { ts: record.ts } : {}),

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -793,6 +793,10 @@ export class SlackAdapter implements SlackProviderAdapter {
       conversation: {
         id: target.channelId,
         kind: "thread",
+        ...(request.parent.conversation.kind === "dm"
+          || request.parent.conversation.isDirectMessage === true
+          ? { isDirectMessage: true }
+          : {}),
         parentId: target.threadTs,
         parentConversationId: request.parent.conversation.id,
         ...(request.parent.conversation.workspaceId
@@ -845,6 +849,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       channel: this.channel,
       conversation: {
         id: request.actor.platformUserId,
+        isDirectMessage: true,
         kind: "dm",
         ...(request.source.conversation.workspaceId
           ? { workspaceId: request.source.conversation.workspaceId }
@@ -1844,7 +1849,10 @@ export class SlackAdapter implements SlackProviderAdapter {
 
     // DMs are governed by the DM access mode alone — the team/channel gates
     // are about (shared) channel traffic and never apply to direct messages.
-    if (params.channel.conversation.kind === "dm") {
+    if (
+      params.channel.conversation.kind === "dm"
+      || params.channel.conversation.isDirectMessage === true
+    ) {
       const dmMode = slackDmAccessMode(this.config);
       if (dmMode === "none") return reject("unauthorized-conversation");
       if (dmMode === "authorized_users" && !actorAuthorized) {
@@ -1900,9 +1908,11 @@ export class SlackAdapter implements SlackProviderAdapter {
     ts: string;
   }): Promise<MessagingChannelRef> {
     const isThread = Boolean(params.threadTs && params.threadTs !== params.ts);
+    const isDirectMessage =
+      params.channelType === "im" || params.channelId.startsWith("D");
     const kind: MessagingConversationKind = isThread
       ? "thread"
-      : params.channelType === "im" || params.channelId.startsWith("D")
+      : isDirectMessage
         ? "dm"
         : "channel";
     const channelTitle =
@@ -1918,6 +1928,7 @@ export class SlackAdapter implements SlackProviderAdapter {
       conversation: {
         id: params.channelId,
         kind,
+        ...(isDirectMessage ? { isDirectMessage: true } : {}),
         ...(params.teamId ? { workspaceId: params.teamId } : {}),
         ...(kind === "dm" && channelTitle ? { title: channelTitle } : {}),
         ...(isThread && params.threadTs ? { parentId: params.threadTs } : {}),
@@ -2699,6 +2710,7 @@ function slackReplyContinuation(params: {
       channel: "slack",
       conversation: {
         id: params.channelId,
+        isDirectMessage: true,
         kind: "thread",
         parentId: params.rootTs,
         parentConversationId: params.channelId,

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -29,6 +29,8 @@ import type {
   MessagingManagedConversationCreateResult,
   MessagingManagedConversationRightsRequest,
   MessagingManagedConversationRightsResult,
+  MessagingPrivateConversationResolveRequest,
+  MessagingPrivateConversationResolveResult,
   MessagingRateLimitInfo,
   MessagingRejectedInboundEvent,
   MessagingSurfaceAction,
@@ -214,6 +216,9 @@ export type SlackProviderAdapter = {
   createManagedConversation(
     request: MessagingManagedConversationCreateRequest,
   ): Promise<MessagingManagedConversationCreateResult>;
+  resolvePrivateConversation(
+    request: MessagingPrivateConversationResolveRequest,
+  ): Promise<MessagingPrivateConversationResolveResult>;
   onInboundRejected?(listener: MessagingInboundRejectedListener): () => void;
   setConversationTitle(
     request: MessagingConversationTitleUpdateRequest,
@@ -799,6 +804,57 @@ export class SlackAdapter implements SlackProviderAdapter {
           channelId: target.channelId,
           ...(target.teamId ? { teamId: target.teamId } : {}),
           threadTs: target.threadTs,
+        },
+      },
+      updatedAt: this.now(),
+    };
+  }
+
+  async resolvePrivateConversation(
+    request: MessagingPrivateConversationResolveRequest,
+  ): Promise<MessagingPrivateConversationResolveResult> {
+    const validation = validateSlackUserId(request.actor.platformUserId);
+    if (!validation.ok) {
+      logSlackInvalidIdentifier({
+        field: "user_id",
+        logger: this.logger,
+        reason: validation.reason,
+        value: request.actor.platformUserId,
+      });
+      return {
+        channel: this.channel,
+        errorMessage: "Slack private delivery requires a valid user ID.",
+        outcome: "failed",
+        updatedAt: this.now(),
+      };
+    }
+    if (request.actor.isBot) {
+      return {
+        channel: this.channel,
+        errorMessage: "Slack private delivery is not available for bot actors.",
+        outcome: "unsupported",
+        updatedAt: this.now(),
+      };
+    }
+    return {
+      channel: this.channel,
+      conversation: {
+        id: request.actor.platformUserId,
+        kind: "dm",
+        ...(request.source.conversation.workspaceId
+          ? { workspaceId: request.source.conversation.workspaceId }
+          : {}),
+        ...(request.actor.displayName || request.actor.username
+          ? { title: request.actor.displayName ?? request.actor.username }
+          : {}),
+      },
+      outcome: "resolved",
+      routingState: {
+        opaque: {
+          channelId: request.actor.platformUserId,
+          ...(request.source.conversation.workspaceId
+            ? { teamId: request.source.conversation.workspaceId }
+            : {}),
         },
       },
       updatedAt: this.now(),

--- a/packages/messaging/providers/slack/src/slack-adapter.ts
+++ b/packages/messaging/providers/slack/src/slack-adapter.ts
@@ -667,6 +667,11 @@ export class SlackAdapter implements SlackProviderAdapter {
         outcome: updated ? "updated" : "presented",
         channel: this.channel,
         deliveredAt: this.now(),
+        continuation: slackReplyContinuation({
+          channelId,
+          channelRef: target.channelRef,
+          rootTs: target.threadTs ?? ts,
+        }),
         surface: {
           channel: this.channel,
           id: ts,
@@ -1262,7 +1267,11 @@ export class SlackAdapter implements SlackProviderAdapter {
    */
   private async deliverChunkedTextMessage(params: {
     intent: Extract<MessagingSurfaceIntent, { kind: "message" }>;
-    target: { channelId: string; threadTs?: string };
+    target: {
+      channelId: string;
+      channelRef: MessagingChannelRef;
+      threadTs?: string;
+    };
     chunks: string[];
   }): Promise<MessagingDeliveryResult> {
     let firstSurface: MessagingSurfaceRef | undefined;
@@ -1312,6 +1321,16 @@ export class SlackAdapter implements SlackProviderAdapter {
         outcome: "presented",
         channel: this.channel,
         deliveredAt: this.now(),
+        ...(firstSurface
+          ? {
+              continuation: slackReplyContinuation({
+                channelId: readSlackSurfaceState(firstSurface)?.channelId
+                  ?? params.target.channelId,
+                channelRef: params.target.channelRef,
+                rootTs: params.target.threadTs ?? firstSurface.id,
+              }),
+            }
+          : {}),
         ...(firstSurface ? { surface: firstSurface } : {}),
       };
     } catch (error) {
@@ -2667,6 +2686,40 @@ function isSlackGroupDm(params: { channelType?: string }): boolean {
 
 function callbackBindingId(intent: MessagingSurfaceIntent): string | undefined {
   return intent.audit?.bindingId ?? intent.bindingId;
+}
+
+function slackReplyContinuation(params: {
+  channelId: string;
+  channelRef: MessagingChannelRef;
+  rootTs: string;
+}): NonNullable<MessagingDeliveryResult["continuation"]> {
+  const sourceConversation = params.channelRef.conversation;
+  return {
+    channel: {
+      channel: "slack",
+      conversation: {
+        id: params.channelId,
+        kind: "thread",
+        parentId: params.rootTs,
+        parentConversationId: params.channelId,
+        ...(sourceConversation.workspaceId
+          ? { workspaceId: sourceConversation.workspaceId }
+          : {}),
+        ...(sourceConversation.title
+          ? { parentTitle: sourceConversation.title }
+          : {}),
+      },
+    },
+    routingState: {
+      opaque: {
+        channelId: params.channelId,
+        threadTs: params.rootTs,
+        ...(sourceConversation.workspaceId
+          ? { teamId: sourceConversation.workspaceId }
+          : {}),
+      },
+    },
+  };
 }
 
 function slackCallbackRecordId(

--- a/packages/messaging/providers/slack/src/slack-formatting.ts
+++ b/packages/messaging/providers/slack/src/slack-formatting.ts
@@ -211,6 +211,24 @@ export function buildSlackBlocksForIntent(params: {
     });
   }
 
+  if (params.intent.kind === "message" && params.intent.attribution) {
+    blocks.push({
+      type: "context",
+      elements: [
+        {
+          type: "plain_text",
+          text: truncateSlackPlainText(
+            [params.intent.attribution.label, params.intent.attribution.hint]
+              .filter((value): value is string => Boolean(value))
+              .join(" · "),
+            2_000,
+          ),
+          emoji: true,
+        },
+      ],
+    });
+  }
+
   if (params.intent.kind === "message") {
     for (const [index, part] of params.intent.parts.entries()) {
       if (part.type !== "image" || !/^https:\/\//iu.test(part.url)) {

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -127,6 +127,8 @@ export type PwrAgentMessagingLocationSummary = {
 export type GetCurrentMessagingSurfaceToolArgs = Record<string, never>;
 
 export type SendPrivateResponseToolArgs = {
+  awaitReply?: boolean;
+  replyInstructions?: string;
   text: string;
 };
 
@@ -168,6 +170,7 @@ export type AttachThreadHereResult = {
 };
 
 export type SendPrivateResponseResult = {
+  awaitingReply?: boolean;
   channel: MessagingChannelKind;
   deliveredAt: number;
   outcome: "delivered";

--- a/packages/shared/src/contracts/messaging-tools.ts
+++ b/packages/shared/src/contracts/messaging-tools.ts
@@ -14,6 +14,7 @@ export const PWRAGENT_MESSAGING_TOOL_NAMESPACE = "pwragent_messaging";
 
 export const PWRAGENT_MESSAGING_OPERATION_NAMES = [
   "get_current_messaging_surface",
+  "send_private_response",
   "attach_thread_here",
   "inspect_messaging_pdfs",
   "search_messaging_pdf_text",
@@ -125,6 +126,10 @@ export type PwrAgentMessagingLocationSummary = {
 
 export type GetCurrentMessagingSurfaceToolArgs = Record<string, never>;
 
+export type SendPrivateResponseToolArgs = {
+  text: string;
+};
+
 export type AttachThreadHerePlacement =
   | "auto"
   | "new_child"
@@ -160,6 +165,13 @@ export type AttachThreadHereResult = {
   location: PwrAgentMessagingLocationSummary;
   outcome: "attached" | "created_and_attached";
   placement: Exclude<AttachThreadHerePlacement, "auto">;
+};
+
+export type SendPrivateResponseResult = {
+  channel: MessagingChannelKind;
+  deliveredAt: number;
+  outcome: "delivered";
+  recipient: PwrAgentMessagingActorSummary;
 };
 
 export type PwrAgentMessagingPdfAttachmentSummary = {
@@ -215,6 +227,7 @@ export type PwrAgentMessagingToolImage = {
 export type PwrAgentMessagingToolArgsByOperation = {
   get_current_messaging_surface: GetCurrentMessagingSurfaceToolArgs;
   get_current_location: GetCurrentMessagingSurfaceToolArgs;
+  send_private_response: SendPrivateResponseToolArgs;
   attach_thread_here: AttachThreadHereToolArgs;
   inspect_messaging_pdfs: InspectMessagingPdfsToolArgs;
   search_messaging_pdf_text: SearchMessagingPdfTextToolArgs;
@@ -244,6 +257,7 @@ export type PwrAgentMessagingResponse =
         | {
             location: PwrAgentMessagingLocationSummary;
           }
+        | SendPrivateResponseResult
         | AttachThreadHereResult
         | {
             attachments: PwrAgentMessagingPdfAttachmentSummary[];


### PR DESCRIPTION
## Summary

- add a scoped `send_private_response` Agent tool to the shared dynamic-tool and MCP messaging catalog
- resolve the private target from the active inbound actor through a channel-neutral adapter hook; Slack starts or reuses the bot/user DM with `chat.postMessage`
- suppress the ordinary source-conversation final only after private delivery succeeds, including late/replayed final events
- keep arbitrary recipient selection unavailable and Slack user/DM identifiers inside the Slack adapter
- document the private terminal-response adapter contract and routing model

## Why

An Agent invoked from a shared Slack channel could inspect who sent the message, but it had no safe outbound affordance for requests such as “DM me the AWS SSO link and code.” Its only response route was the source channel, so the Agent either refused or risked posting sensitive material publicly.

This adds the narrow terminal-response case without introducing general cross-channel messaging. A failed or unsupported private delivery leaves the normal source response path intact.

## User impact

A user can ask the bot in an authorized Slack channel to reply privately. The Agent sends the complete answer to that same requesting user’s DM and does not post a redundant final acknowledgement in the source channel.

## Rollout note

Codex persists a thread's dynamic-tool catalog when the thread is created. Existing Codex Agent threads created before this feature must be recreated and rebound to receive `send_private_response`; newly created Codex Agent threads and supported MCP-backed Agent sessions receive it from the updated catalog.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/pwragent-messaging-agent-tools.test.ts apps/desktop/src/main/agent-tools/__tests__/pwragent-task-monitor-agent-tools.test.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts packages/messaging/providers/slack/src/__tests__/slack-adapter.test.ts` — 423 tests passed
- `pnpm typecheck`
- `pnpm lint:eslint` — no errors; existing warning baseline only
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

A full `pnpm test` attempt was stopped after unrelated git-worktree, keychain/config, and detached-runtime fixtures repeatedly exceeded their existing 5-second timeouts under the concurrent workspace run. The focused suites covering every changed runtime path pass.
