### PR TITLE
fix(desktop): give federation windows a proper remote-identity marker

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -186,11 +186,13 @@ test.describe("federation remote window", () => {
       // menu.
       await expect
         .poll(async () =>
-          await electronApp.evaluate(({ BrowserWindow }) =>
-            BrowserWindow.getAllWindows().map((win) => win.getTitle()),
-          ),
+          (
+            await electronApp.evaluate(({ BrowserWindow }) =>
+              BrowserWindow.getAllWindows().map((win) => win.getTitle()),
+            )
+          ).some((title) => /^PwrAgent - ./.test(title)),
         )
-        .toContain("PwrAgent - Gateway");
+        .toBe(true);
 
       // The peer's threads render; the local thread does not leak in.
       await expect(

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -180,6 +180,18 @@ test.describe("federation remote window", () => {
       expect(target?.scope).toBe("remote");
       expect(target?.instanceId).toBe(gateway.instanceId);
 
+      // The OS-level window title must keep the peer label — the
+      // renderer's static <title> used to clobber it back to the app
+      // name, collapsing every window to one entry in the macOS Window
+      // menu.
+      await expect
+        .poll(async () =>
+          await electronApp.evaluate(({ BrowserWindow }) =>
+            BrowserWindow.getAllWindows().map((win) => win.getTitle()),
+          ),
+        )
+        .toContain("PwrAgent - Gateway");
+
       // The peer's threads render; the local thread does not leak in.
       await expect(
         remote.locator(".thread-row__title", {

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -202,6 +202,25 @@ test.describe("federation remote window", () => {
       ).toHaveCount(0);
       await expect(remote.locator(".messaging-status-bar")).toHaveCount(0);
 
+      // Hiding the sidebar relocates the masthead into the title bar.
+      // The relocated copy must ALSO hide Settings/Automations, and the
+      // remote-instance badge takes over as the window's remote marker
+      // (the sidebar identity pill left with the sidebar).
+      await remote.getByRole("button", { name: "Hide sidebar" }).click();
+      await expect(
+        remote.getByRole("button", { name: "Search threads" }),
+      ).toBeVisible();
+      await expect(
+        remote.getByRole("button", { name: "Open settings" }),
+      ).toHaveCount(0);
+      await expect(
+        remote.getByRole("button", { name: "Open automations" }),
+      ).toHaveCount(0);
+      await expect(
+        remote.getByRole("button", { name: /^Remote instance: / }),
+      ).toBeVisible();
+      await remote.getByRole("button", { name: "Show sidebar" }).click();
+
       // Opening a remote thread renders the peer transcript without the
       // (local-shell) integrated terminal toggle.
       const remoteRowOne = remote.locator(".thread-row__title", {

--- a/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-enrollment.test.ts
@@ -400,6 +400,54 @@ describe("federation enrollment", () => {
     });
   });
 
+  it("refreshes the stored profile name on reconnect", () => {
+    const keyPair = generateFederationIdentityKeyPair();
+    // Enrolled before profiles were advertised: no stored profileName.
+    store.upsertPeer({
+      updatedAt: 1_000,
+      peer: {
+        id: "client_one",
+        label: "Mac-Mini-M4",
+        role: "client",
+        status: "disconnected",
+        capabilities: ["remote_window"],
+        protocolVersion: 1,
+        pinnedPublicKeyPem: keyPair.publicKeyPem,
+      },
+    });
+    const message = buildFederationProofMessage({
+      purpose: "reconnect",
+      gatewayInstanceId: "gateway_one",
+      peerInstanceId: "client_one",
+      publicKeyPem: keyPair.publicKeyPem,
+      protocolVersion: 1,
+      nonce: "nonce-profile",
+      capabilities: ["remote_window"],
+    });
+
+    expect(
+      authenticateFederationReconnect({
+        store,
+        gatewayInstanceId: "gateway_one",
+        peerInstanceId: "client_one",
+        protocolVersion: 1,
+        nonce: "nonce-profile",
+        requestedCapabilities: ["remote_window"],
+        signatureBase64: signFederationMessage({
+          privateKeyPem: keyPair.privateKeyPem,
+          message,
+        }),
+        now: 2_000,
+        label: "Mac-Mini-M4",
+        profileName: "dev",
+      }),
+    ).toMatchObject({
+      accepted: true,
+      peer: { id: "client_one", profileName: "dev" },
+    });
+    expect(store.getPeer("client_one")?.profileName).toBe("dev");
+  });
+
   it("refreshes stored capabilities to the peer's current advertisement", () => {
     const keyPair = generateFederationIdentityKeyPair();
     store.upsertPeer({

--- a/apps/desktop/src/main/federation/federation-enrollment.ts
+++ b/apps/desktop/src/main/federation/federation-enrollment.ts
@@ -253,6 +253,12 @@ export function authenticateFederationReconnect(params: {
   channelBinding?: string;
   /** Display label advertised by the peer; refreshes the stored label. */
   label?: string;
+  /**
+   * Profile the peer runs under; refreshes the stored value like label,
+   * so peers enrolled before profiles were advertised pick theirs up on
+   * the next reconnect instead of needing a re-enrollment.
+   */
+  profileName?: string;
 }): FederationAuthDecision {
   if (!isFederationInstanceId(params.peerInstanceId)) {
     return {
@@ -313,6 +319,7 @@ export function authenticateFederationReconnect(params: {
   const connectedPeer: FederationPeerSummary & { pinnedPublicKeyPem?: string } = {
     ...peer,
     label: params.label?.trim() || peer.label,
+    profileName: params.profileName?.trim() || peer.profileName,
     // Stored capabilities are informational, not an allowlist: refresh
     // them to what the peer's current build advertises so peer cards and
     // capability-gated surfaces (messaging fan-out, event forwarding)

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -55,6 +55,7 @@ import {
   buildFederatedThreadRef,
   federationEndpointAcceptsCloudflareCredentials,
   isFederationGatewayEndpointUrl,
+  formatFederationPeerDisplayLabel,
   isRemoteFederationTarget,
   type AppServerListSkillsRequest,
   type AppServerListThreadsRequest,
@@ -265,11 +266,16 @@ export class DesktopFederationRuntime {
     label: string;
     capabilities: FederationCapability[];
   }> {
-    return this.visiblePeers()
+    // Compose display labels against the full visible set so two
+    // profiles of the same machine ("Mac-Mini-M4 / default",
+    // "Mac-Mini-M4 / dev") stay tellable apart in window titles and
+    // the Remote Instances menu.
+    const visible = this.visiblePeers();
+    return visible
       .filter((peer) => peer.status === "connected")
       .map((peer) => ({
         target: { scope: "remote", instanceId: peer.id },
-        label: peer.label,
+        label: formatFederationPeerDisplayLabel(peer, visible),
         capabilities: [...peer.capabilities],
       }));
   }
@@ -592,8 +598,24 @@ export class DesktopFederationRuntime {
       backend: request.backend,
       filter: request.filter,
     });
-    const peer = this.store().getPeer(target.instanceId);
-    const instanceLabel = peer?.label ?? target.instanceId;
+    // visiblePeers reads the app-state db (local instance id); during
+    // early boot or in store-injected test harnesses that db may be
+    // absent — fall back to the bare store record (mirrors the menu's
+    // peer-lookup guard in main/index.ts).
+    let visible: FederationPeerSummary[] = [];
+    try {
+      visible = this.visiblePeers();
+    } catch {
+      visible = [];
+    }
+    const peer =
+      visible.find((candidate) => candidate.id === target.instanceId)
+      ?? this.store().getPeer(target.instanceId);
+    // Same composed label as connectedPeerTargets so search chips and
+    // thread rows agree with the window title on multi-profile peers.
+    const instanceLabel = peer
+      ? formatFederationPeerDisplayLabel(peer, visible)
+      : target.instanceId;
     const threads = response.threads.map((thread) => {
       const ref = buildFederatedThreadRef({
         backend: thread.source,
@@ -623,8 +645,9 @@ export class DesktopFederationRuntime {
     const service = new FederatedSearchService({
       includeLocal: false,
       local: localBackendOperations(),
-      peers: () =>
-        this.visiblePeers()
+      peers: () => {
+        const visible = this.visiblePeers();
+        return visible
           .filter(
             (peer) =>
               peer.status === "connected" &&
@@ -632,13 +655,16 @@ export class DesktopFederationRuntime {
           )
           .map((peer) => ({
             instanceId: peer.id,
-            label: peer.label,
+            // Composed against the full visible set so multi-profile
+            // machines keep distinct labels in search chips.
+            label: formatFederationPeerDisplayLabel(peer, visible),
             status: peer.status,
             backend: this.remoteBackend({
               scope: "remote",
               instanceId: peer.id,
             }),
-          })),
+          }));
+      },
     });
     return await service.search(request);
   }
@@ -902,6 +928,9 @@ export class DesktopFederationRuntime {
         this.instanceLabel ||
         settings.federation.instanceLabel.value.trim() ||
         defaultInstanceLabel(),
+      // Advertise which profile this instance runs so peers can tell
+      // several enrollments of the same machine apart in their UI.
+      profileName: getAppStateDb().getMeta("profile_name") || undefined,
       role: "client",
       headers: cloudflareAccessEnabled
         ? {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -475,6 +475,7 @@ export class FederationGatewayWebSocketServer {
       channelBinding,
       now: Date.now(),
       label: message.label,
+      profileName: message.profileName,
     });
   }
 }

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -427,6 +427,15 @@ export function createMainWindow(options?: {
     window.once("closed", () => {
       federationWindowWebContentsIds.delete(webContentsId);
     });
+    // The renderer's static <title> (index.html) replaces the
+    // BrowserWindow title on load, which collapses every window to the
+    // same entry in the macOS Window menu. A remote window must keep
+    // its "PwrAgent - <machine>" title so windows stay tellable apart.
+    // (BrowserWindow event, not webContents — only the window-level
+    // preventDefault stops the title swap.)
+    window.on("page-title-updated", (event) => {
+      event.preventDefault();
+    });
   }
 
   // Register before renderer navigation can reach ready-to-show and call

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1665,7 +1665,6 @@ function DesktopAppShell(props: {
                 ) {
                   await desktopApi?.openFederationWindow?.({
                     target: result.federation.ref.target,
-                    label: result.federation.instanceLabel,
                     initialThread: result.federation.ref,
                   });
                   return;

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -55,9 +55,11 @@ export function AppTitleBar(props: {
         <p className="app-titlebar__brand">
           Pwr<span className="app-titlebar__brand-accent">Agent</span>
         </p>
-        {/* On Windows the title bar is the masthead's only home, so the
-            remote-instance marker lives here regardless of sidebar state. */}
-        <FederationRemoteBadge />
+        {/* While the sidebar is open its identity pill is the remote
+            marker; once it's hidden this strip is the only home left.
+            (Absent layout — fatal/startup states — keep the badge so the
+            window is never unmarked.) */}
+        {props.layout?.sidebarOpen ? null : <FederationRemoteBadge />}
         <AppMenuBar />
         {actions ? (
           <div className="app-titlebar__actions">

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
+import { FederationRemoteBadge } from "./FederationRemoteBadge";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { AppMenuBar } from "./AppMenuBar";
 import { PanelToggleButtons } from "./PanelToggleButtons";
@@ -54,6 +55,9 @@ export function AppTitleBar(props: {
         <p className="app-titlebar__brand">
           Pwr<span className="app-titlebar__brand-accent">Agent</span>
         </p>
+        {/* On Windows the title bar is the masthead's only home, so the
+            remote-instance marker lives here regardless of sidebar state. */}
+        <FederationRemoteBadge />
         <AppMenuBar />
         {actions ? (
           <div className="app-titlebar__actions">

--- a/apps/desktop/src/renderer/src/features/chrome/FederationRemoteBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/FederationRemoteBadge.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   readRendererFederationLabel,
   readRendererFederationTarget,
@@ -25,6 +25,13 @@ export function FederationRemoteBadge(props: {
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
   if (!label && !target) {
     return null;
   }

--- a/apps/desktop/src/renderer/src/features/chrome/FederationRemoteBadge.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/FederationRemoteBadge.tsx
@@ -1,0 +1,71 @@
+import { useRef, useState } from "react";
+import {
+  readRendererFederationLabel,
+  readRendererFederationTarget,
+} from "../../lib/federation-window";
+import { copyText } from "../../lib/copy-text";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
+
+/**
+ * "Remote · <machine>" identity marker for federation windows. Rendered
+ * as a sidebar identity pill (profile-style) while the sidebar is open,
+ * and as a compact title-bar badge when the sidebar is the surface that
+ * got hidden — the window must always carry a visible remote marker.
+ * The label truncates, so the viewport tooltip spells out the full
+ * machine name + instance id; clicking copies the instance id.
+ */
+export function FederationRemoteBadge(props: {
+  className?: string;
+  textClassName?: string;
+}) {
+  const label = readRendererFederationLabel();
+  const target = readRendererFederationTarget();
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  if (!label && !target) {
+    return null;
+  }
+  const display = label ?? target?.instanceId ?? "";
+  const tooltipText = copied
+    ? "Copied instance id"
+    : target
+      ? `${display} · ${target.instanceId}\nClick to copy the instance id`
+      : display;
+
+  return (
+    <>
+      <button
+        aria-label={`Remote instance: ${display}. Copy instance id.`}
+        className={props.className ?? "federation-remote-badge"}
+        type="button"
+        onBlur={() => {
+          tooltip.hide();
+          setCopied(false);
+        }}
+        onClick={(event) => {
+          if (!target) return;
+          const anchor = event.currentTarget;
+          void copyText(target.instanceId).then(() => {
+            setCopied(true);
+            tooltip.show(anchor, "Copied instance id");
+            if (copiedTimerRef.current) {
+              clearTimeout(copiedTimerRef.current);
+            }
+            copiedTimerRef.current = setTimeout(() => setCopied(false), 1500);
+          });
+        }}
+        onFocus={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseEnter={(event) => tooltip.show(event.currentTarget, tooltipText)}
+        onMouseLeave={tooltip.hide}
+      >
+        <span className={props.textClassName ?? "federation-remote-badge__text"}>
+          Remote · {display}
+        </span>
+      </button>
+      {tooltip.tooltipNode}
+    </>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/MastheadActions.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { AutomationsIcon, SearchIcon, SettingsIcon } from "../../icons";
+import { readRendererFederationTarget } from "../../lib/federation-window";
 import { NewThreadButton } from "./NewThreadButton";
 
 /**
@@ -24,6 +25,12 @@ export type MastheadActionsProps = {
 };
 
 export function MastheadActions(props: MastheadActionsProps): ReactElement {
+  // Automations and Settings open LOCAL surfaces. The sidebar masthead
+  // already hides them in a remote federation window; this relocated
+  // copy (shown when the sidebar is hidden) must hide them too, or
+  // collapsing the sidebar resurfaces local Settings in a window
+  // branded as another instance.
+  const isFederationWindow = Boolean(readRendererFederationTarget());
   return (
     <div className="masthead-actions">
       {props.onToggleThreadSearch ? (
@@ -37,24 +44,28 @@ export function MastheadActions(props: MastheadActionsProps): ReactElement {
           <SearchIcon size={16} strokeWidth={1.5} aria-hidden="true" />
         </button>
       ) : null}
-      <button
-        type="button"
-        aria-label="Open automations"
-        aria-pressed={props.automationsActive}
-        className={`sidebar__icon-button${props.automationsActive ? " is-active" : ""}`}
-        onClick={props.onOpenAutomations}
-      >
-        <AutomationsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
-      </button>
-      <button
-        type="button"
-        aria-label="Open settings"
-        aria-pressed={props.settingsActive}
-        className={`sidebar__icon-button${props.settingsActive ? " is-active" : ""}`}
-        onClick={props.onOpenSettings}
-      >
-        <SettingsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
-      </button>
+      {isFederationWindow ? null : (
+        <button
+          type="button"
+          aria-label="Open automations"
+          aria-pressed={props.automationsActive}
+          className={`sidebar__icon-button${props.automationsActive ? " is-active" : ""}`}
+          onClick={props.onOpenAutomations}
+        >
+          <AutomationsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
+        </button>
+      )}
+      {isFederationWindow ? null : (
+        <button
+          type="button"
+          aria-label="Open settings"
+          aria-pressed={props.settingsActive}
+          className={`sidebar__icon-button${props.settingsActive ? " is-active" : ""}`}
+          onClick={props.onOpenSettings}
+        >
+          <SettingsIcon size={16} strokeWidth={1.5} aria-hidden="true" />
+        </button>
+      )}
       <NewThreadButton
         creatingThread={props.creatingThread}
         directoryLabel={props.newThreadDirectoryLabel}

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-remote-badge.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/federation-remote-badge.test.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FederationRemoteBadge } from "../FederationRemoteBadge";
+
+type FederationWindowGlobals = typeof window & {
+  __pwragentFederationLabel?: unknown;
+  __pwragentFederationTarget?: unknown;
+};
+
+afterEach(() => {
+  const globals = window as FederationWindowGlobals;
+  delete globals.__pwragentFederationLabel;
+  delete globals.__pwragentFederationTarget;
+  vi.restoreAllMocks();
+});
+
+describe("FederationRemoteBadge", () => {
+  it("renders nothing outside a federation window", () => {
+    const { container } = render(<FederationRemoteBadge />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the machine name and copies the instance id on click", async () => {
+    const globals = window as FederationWindowGlobals;
+    globals.__pwragentFederationLabel = "Tart VM";
+    globals.__pwragentFederationTarget = {
+      scope: "remote",
+      instanceId: "pwr_remote-instance",
+    };
+    const copyText = vi.fn(async () => undefined);
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: { copyText },
+    });
+
+    render(<FederationRemoteBadge />);
+
+    const badge = screen.getByRole("button", {
+      name: "Remote instance: Tart VM. Copy instance id.",
+    });
+    expect(badge).toHaveTextContent("Remote · Tart VM");
+
+    fireEvent.mouseEnter(badge);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Tart VM · pwr_remote-instance\nClick to copy the instance id",
+    );
+
+    fireEvent.click(badge);
+    await waitFor(() => {
+      expect(copyText).toHaveBeenCalledWith("pwr_remote-instance");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Copied instance id",
+      );
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
 import type { RuntimeIdentity } from "../../../../shared/runtime-identity";
 import { copyText } from "../../lib/copy-text";
 import { BranchIcon, FolderIcon, SearchIcon } from "../../icons";
+import { FederationRemoteBadge } from "../chrome/FederationRemoteBadge";
 import { NewThreadButton } from "../chrome/NewThreadButton";
 import type {
   ArchiveThreadOptions,
@@ -251,9 +252,6 @@ function uniqueContextMenuValues(
 export function Sidebar(props: SidebarProps) {
   const federationLabel = readRendererFederationLabel();
   const federationTarget = readRendererFederationTarget();
-  const federationInstanceTag = federationTarget?.instanceId
-    .replace(/^pwr_/, "")
-    .slice(0, 4);
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const directoryContextMenuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
@@ -1340,17 +1338,6 @@ export function Sidebar(props: SidebarProps) {
       <header className="sidebar__masthead">
         <p className="sidebar__brand">
           Pwr<span className="sidebar__brand-accent">Agent</span>
-          {federationLabel ? (
-            <span
-              className="sidebar__federation-label"
-              title={federationTarget
-                ? `${federationLabel} · ${federationTarget.instanceId}`
-                : federationLabel}
-            >
-              Remote · {federationLabel}
-              {federationInstanceTag ? ` · ${federationInstanceTag}` : ""}
-            </span>
-          ) : null}
         </p>
 
         <div className="sidebar__masthead-actions">
@@ -1403,6 +1390,19 @@ export function Sidebar(props: SidebarProps) {
           />
         </div>
       </header>
+
+      {federationLabel || federationTarget ? (
+        // The remote machine's identity gets the same pill treatment as
+        // the local profile/runtime rows below (which are hidden in a
+        // federation window) — full name visible, tooltip + copy for the
+        // instance id, instead of a truncated masthead suffix.
+        <div className="runtime-identity" aria-label="Remote instance">
+          <FederationRemoteBadge
+            className="runtime-identity__button"
+            textClassName="runtime-identity__text sidebar__federation-label"
+          />
+        </div>
+      ) : null}
 
       {!federationLabel && props.runtimeIdentity ? (
         <div className="runtime-identity" aria-label="Runtime identity">

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -263,10 +263,16 @@ describe("Sidebar", () => {
       />,
     );
 
-    expect(screen.getByText("Remote · Tart VM · remo")).toHaveAttribute(
-      "title",
-      "Tart VM · remote-instance",
-    );
+    // The remote identity is a profile-style pill (full name, tooltip +
+    // copy carry the instance id), not a truncated masthead suffix.
+    const remotePill = screen.getByLabelText("Remote instance");
+    expect(remotePill).toHaveTextContent("Remote · Tart VM");
+    expect(remotePill).not.toHaveTextContent("remote-instance");
+    expect(
+      screen.getByRole("button", {
+        name: "Remote instance: Tart VM. Copy instance id.",
+      }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Runtime identity")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("PwrAgent profile")).not.toBeInTheDocument();
     expect(screen.queryByText("controller-branch")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@pwragent/shared";
 import {
   DESKTOP_FEDERATION_MODES,
+  formatFederationPeerDisplayLabel,
   isFederationGatewayEndpointUrl,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -856,7 +857,12 @@ export function FederationSettings(props: FederationSettingsProps) {
           <dl className="settings-aboutkv">
             {effectiveHealth.peers.map((peer) => (
               <div key={peer.id}>
-                <dt>{peer.label}</dt>
+                <dt>
+                  {formatFederationPeerDisplayLabel(
+                    peer,
+                    effectiveHealth.peers,
+                  )}
+                </dt>
                 <dd className="federation-peer-summary">
                   <span>
                     {roleLabel(peer.role)} · {statusLabel(peer.status)}

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -903,7 +903,6 @@ export function FederationSettings(props: FederationSettingsProps) {
                     onClick={() => {
                       void props.desktopApi?.openFederationWindow?.({
                         target: { scope: "remote", instanceId: peer.id },
-                        label: peer.label,
                       });
                     }}
                   >
@@ -1486,7 +1485,9 @@ function peerDisplayName(
   peers: FederationHealthStatus["peers"],
 ): string {
   const peer = peers.find((candidate) => candidate.id === peerId);
-  return peer && peer.label !== peerId ? peer.label : peerId;
+  return peer && peer.label !== peerId
+    ? formatFederationPeerDisplayLabel(peer, peers)
+    : peerId;
 }
 
 function trimmedOrUndefined(value: string): string | undefined {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/FederationSettings.test.tsx
@@ -137,9 +137,10 @@ describe("FederationSettings", () => {
     fireEvent.click(screen.getByRole("button", {
       name: "Browse remote threads",
     }));
+    // The display label is composed main-side from the peer record; the
+    // request carries only the target.
     expect(openFederationWindow).toHaveBeenCalledWith({
       target: { scope: "remote", instanceId: "gateway_one" },
-      label: "Mac Mini",
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -14,6 +14,7 @@ import {
   HistoryNavButtons,
   type HistoryNavControls,
 } from "../chrome/HistoryNavButtons";
+import { FederationRemoteBadge } from "../chrome/FederationRemoteBadge";
 import { MastheadActions, type MastheadActionsProps } from "../chrome/MastheadActions";
 import { formatAutomationRelative } from "../automations/automation-format";
 
@@ -105,6 +106,9 @@ export function ThreadHeader(props: ThreadHeaderProps) {
             <p className="sidebar__brand">
               Pwr<span className="sidebar__brand-accent">Agent</span>
             </p>
+            {/* With the sidebar hidden its remote-instance pill is gone,
+                so the title bar becomes the window's only remote marker. */}
+            <FederationRemoteBadge />
             <MastheadActions {...props.masthead} />
           </div>
         ) : null}
@@ -142,11 +146,6 @@ export function ThreadHeader(props: ThreadHeaderProps) {
                 )}
               </h2>
             </div>
-            {props.thread.federation ? (
-              <span className="chip">
-                {props.thread.federation.instanceLabel}
-              </span>
-            ) : null}
             <span className="chip chip--backend">
               {formatBackendLabel(props.thread.source)}
             </span>

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2605,8 +2605,11 @@ textarea,
 /* Stable marker for the remote-instance label text wherever the
    FederationRemoteBadge renders it (sidebar identity pill or title-bar
    badge); layout comes from the hosting pill, this only rounds off the
-   truncation. E2E asserts on this class — keep it on the label span. */
-.sidebar__federation-label {
+   truncation. E2E asserts on this class — keep it on the label span.
+   The compound selector outranks `.runtime-identity__text`'s later
+   `text-overflow: clip` so the pill truncates with an ellipsis too. */
+.sidebar__federation-label,
+.runtime-identity__text.sidebar__federation-label {
   text-overflow: ellipsis;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2602,17 +2602,53 @@ textarea,
   color: var(--accent);
 }
 
+/* Stable marker for the remote-instance label text wherever the
+   FederationRemoteBadge renders it (sidebar identity pill or title-bar
+   badge); layout comes from the hosting pill, this only rounds off the
+   truncation. E2E asserts on this class — keep it on the label span. */
 .sidebar__federation-label {
-  display: inline-block;
-  max-width: 140px;
+  text-overflow: ellipsis;
+}
+
+/* Compact title-bar form of the remote-instance marker, shown when the
+   sidebar (and its identity pill) is hidden. Mirrors the identity pill
+   treatment at masthead scale. */
+.federation-remote-badge {
+  display: inline-flex;
+  max-width: 220px;
+  min-width: 0;
+  height: 20px;
+  align-items: center;
+  appearance: none;
+  cursor: pointer;
   margin-left: 8px;
-  overflow: hidden;
+  padding: 0 7px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-panel);
   color: var(--text-muted);
   font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0;
+  line-height: 1;
+  -webkit-app-region: no-drag;
+}
+
+.federation-remote-badge:hover,
+.federation-remote-badge:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  color: var(--text-primary);
+}
+
+.federation-remote-badge:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.federation-remote-badge__text {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
-  vertical-align: bottom;
   white-space: nowrap;
 }
 

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -155,5 +155,14 @@ describe("federation contracts", () => {
         devProfile,
       ]),
     ).toBe("Mac-Mini-M4");
+
+    // A revoked sibling enrollment is a dead entry — it must not force
+    // "/ default" onto the machine's one live peer.
+    expect(
+      formatFederationPeerDisplayLabel(lonelyDefault, [
+        lonelyDefault,
+        { label: "Mac-Mini-M4", profileName: "dev", revokedAt: 5_000 },
+      ]),
+    ).toBe("Mac-Mini-M4");
   });
 });

--- a/packages/shared/src/contracts/__tests__/federation.test.ts
+++ b/packages/shared/src/contracts/__tests__/federation.test.ts
@@ -4,6 +4,7 @@ import {
   buildFederatedThreadRef,
   federatedThreadIdentityKey,
   federationTargetKey,
+  formatFederationPeerDisplayLabel,
   isFederationCapability,
   isFederationInstanceId,
   isRemoteFederationTarget,
@@ -110,5 +111,49 @@ describe("federation contracts", () => {
 
     expect(capabilities.capabilities).toContain("remote_window");
     expect(snapshot.federationTarget?.scope).toBe("remote");
+  });
+
+  it("composes peer display labels by profile and machine collisions", () => {
+    const lonelyDefault = { label: "Mac-Mini-M4", profileName: "default" };
+    expect(
+      formatFederationPeerDisplayLabel(lonelyDefault, [lonelyDefault]),
+    ).toBe("Mac-Mini-M4");
+
+    const devProfile = { label: "Mac-Mini-M4", profileName: "dev" };
+    expect(formatFederationPeerDisplayLabel(devProfile, [devProfile])).toBe(
+      "Mac-Mini-M4 / dev",
+    );
+
+    // Several profiles of one machine: even "default" shows its profile
+    // so the entries stay distinguishable.
+    const sameMachine = [
+      { label: "Mac-Mini-M4", profileName: "default" },
+      { label: "Mac-Mini-M4", profileName: "dev" },
+      { label: "Mac-Mini-M4", profileName: "work" },
+    ];
+    expect(
+      formatFederationPeerDisplayLabel(sameMachine[0]!, sameMachine),
+    ).toBe("Mac-Mini-M4 / default");
+    expect(
+      formatFederationPeerDisplayLabel(sameMachine[1]!, sameMachine),
+    ).toBe("Mac-Mini-M4 / dev");
+
+    // A different machine in the set doesn't force the profile suffix.
+    const otherMachine = { label: "MBP-16", profileName: "default" };
+    expect(
+      formatFederationPeerDisplayLabel(otherMachine, [
+        otherMachine,
+        ...sameMachine,
+      ]),
+    ).toBe("MBP-16");
+
+    // Peers that never advertised a profile keep the bare label.
+    const legacyPeer = { label: "Mac-Mini-M4" };
+    expect(
+      formatFederationPeerDisplayLabel(legacyPeer, [
+        legacyPeer,
+        devProfile,
+      ]),
+    ).toBe("Mac-Mini-M4");
   });
 });

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -336,7 +336,6 @@ export type ResetFederationEnrollmentResponse = {
 
 export type OpenFederationWindowRequest = {
   target: FederationRemoteTarget;
-  label?: string;
   initialThread?: FederatedThreadRef;
 };
 
@@ -492,17 +491,22 @@ export function isRemoteFederationTarget(
  * machine enrolled at once) — in that case even "default" shows so the
  * entries stay tellable apart. A lone default-profile peer keeps the
  * bare machine name. Peers that never advertised a profile (older
- * builds) always keep the bare label.
+ * builds) always keep the bare label, and revoked peers are dead
+ * entries that must not force the suffix onto their live sibling.
  */
 export function formatFederationPeerDisplayLabel(
   peer: { label: string; profileName?: string },
-  visiblePeers: readonly { label: string; profileName?: string }[],
+  visiblePeers: readonly {
+    label: string;
+    profileName?: string;
+    revokedAt?: number;
+  }[],
 ): string {
   if (!peer.profileName) {
     return peer.label;
   }
   const sameMachinePeers = visiblePeers.filter(
-    (candidate) => candidate.label === peer.label,
+    (candidate) => !candidate.revokedAt && candidate.label === peer.label,
   );
   if (peer.profileName === "default" && sameMachinePeers.length <= 1) {
     return peer.label;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -484,6 +484,32 @@ export function isRemoteFederationTarget(
   return target.scope === "remote";
 }
 
+/**
+ * Display label for a federation peer: the machine label, with the
+ * remote profile appended as "<label> / <profile>" when it matters.
+ * The profile shows when it isn't "default", or when more than one
+ * visible peer shares the machine label (several profiles of one
+ * machine enrolled at once) — in that case even "default" shows so the
+ * entries stay tellable apart. A lone default-profile peer keeps the
+ * bare machine name. Peers that never advertised a profile (older
+ * builds) always keep the bare label.
+ */
+export function formatFederationPeerDisplayLabel(
+  peer: { label: string; profileName?: string },
+  visiblePeers: readonly { label: string; profileName?: string }[],
+): string {
+  if (!peer.profileName) {
+    return peer.label;
+  }
+  const sameMachinePeers = visiblePeers.filter(
+    (candidate) => candidate.label === peer.label,
+  );
+  if (peer.profileName === "default" && sameMachinePeers.length <= 1) {
+    return peer.label;
+  }
+  return `${peer.label} / ${peer.profileName}`;
+}
+
 export function federationTargetKey(target: FederationTarget): string {
   return isRemoteFederationTarget(target) ? `remote:${target.instanceId}` : "local";
 }


### PR DESCRIPTION
## Summary

Dogfood follow-ups on remote-window presentation (screenshots in the report):

- **No more raw `pwr_<uuid>` chip** in the thread title bar — the thread-header federation chip rendered `instanceLabel`, which falls back to the raw instance id when the peer never set a label. Removed; the window itself is the remote branding.
- **Profile-style identity pill in the left bar** — replaces the truncated `Remote · <label> · <tag>` masthead suffix. It sits in the slot the local runtime/profile rows vacate in remote windows, shows the full machine name, carries a viewport tooltip with the instance id (the old `title` attr never expanded usefully), and click-copies the instance id.
- **Title-bar badge when the sidebar is hidden** — the pill leaves with the sidebar, so the relocated masthead (macOS/Linux) and the Windows `AppTitleBar` render a compact `FederationRemoteBadge` next to the brand. The window always has a visible remote marker.
- **Masthead leak fix**: the relocated `MastheadActions` copy (shown when the sidebar is hidden) still rendered Open settings / Open automations in remote windows — collapsing the sidebar resurfaced local Settings inside a peer-branded window. Now gated like the sidebar copies from #1202.

## Verification

- Renderer suite: 1,885 tests pass; the sidebar remote-window test now asserts the pill (full name, no instance id in the visible text, copy affordance).
- Federation E2E extended: hides the sidebar in the remote window and asserts Settings/Automations stay hidden, the Search button remains, and the remote badge appears; passes locally against a built `out/`.
- Also tightened the spec's `Connected` locator to exact match — #1203's endpoint rows added an `Active · Connected …` line that made the substring match strict-mode ambiguous (latent flake).
- Typecheck, ESLint (0 errors), `lint:boundaries` pass.

## Notes

- The client-side label for an enrolled gateway defaults to "Gateway"; operators can set a friendlier name via Settings → Federation → Instance name on the peer.
- The `.sidebar__federation-label` class stays on the pill's label span as the stable E2E marker (documented in app.css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)