### PR TITLE
fix(desktop): stop the OS focus ring boxing the whole transcript

### DIFF
--- a/apps/desktop/e2e/transcript-focus-ring.spec.ts
+++ b/apps/desktop/e2e/transcript-focus-ring.spec.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+/**
+ * The transcript scroller is tabIndex=0 so keyboard users can scroll it
+ * (axe scrollable-region-focusable). Chromium promotes a click-focused
+ * element to :focus-visible on the next keystroke, which used to draw
+ * the OS-accent UA focus ring around the ENTIRE transcript — click any
+ * transcript text, press an arrow key, and the whole pane grew an
+ * outline. app.css now suppresses the outline on the scroller; this
+ * pins the repro so the UA ring can't come back.
+ */
+
+async function createTranscriptFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(
+    path.join(os.tmpdir(), "pwragent-transcript-focus-ring-"),
+  );
+  const fixturePath = path.join(rootDir, "transcript-focus-ring.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify({
+      metadata: { backend: "codex", scenario: "transcript-focus-ring" },
+      steps: [
+        {
+          id: "initialize-1",
+          kind: "response",
+          method: "initialize",
+          result: {
+            serverInfo: { name: "Replay Codex", version: "1.0.0" },
+            methods: ["thread/list", "thread/read", "skills/list", "turn/start"],
+          },
+        },
+        {
+          id: "thread-list-1",
+          kind: "response",
+          method: "thread/list",
+          result: [
+            {
+              id: "thread-focus-1",
+              title: "Focus ring thread",
+              titleSource: "explicit",
+              source: "codex",
+              executionMode: "default",
+              linkedDirectories: [],
+              updatedAt: 1_000,
+            },
+          ],
+        },
+        {
+          id: "thread-read-1",
+          kind: "response",
+          method: "thread/read",
+          result: {
+            entries: [
+              {
+                type: "message",
+                id: "message-1",
+                role: "assistant",
+                text: "Transcript body for the focus ring check.",
+              },
+            ],
+            messages: [
+              {
+                id: "message-1",
+                role: "assistant",
+                text: "Transcript body for the focus ring check.",
+              },
+            ],
+            lastAssistantMessage: "Transcript body for the focus ring check.",
+            pagination: { supportsPagination: false, hasPreviousPage: false },
+          },
+        },
+      ],
+    }),
+  );
+  return {
+    cleanup: async () => {
+      await rm(rootDir, { force: true, recursive: true });
+    },
+    fixturePath,
+  };
+}
+
+test("keystroke after clicking the transcript draws no outline around it", async () => {
+  const fixture = await createTranscriptFixture();
+  const app = await launchElectronApp({ fixturePath: fixture.fixturePath });
+  try {
+    const { window } = app;
+    await window
+      .locator(".thread-row__title", { hasText: "Focus ring thread" })
+      .click();
+    const body = window.getByText("Transcript body for the focus ring check.");
+    await expect(body).toBeVisible();
+
+    // Click focuses the tabIndex=0 scroller; the next keystroke promotes
+    // it to :focus-visible — the exact sequence that used to ring it.
+    await body.click();
+    await window.keyboard.press("ArrowDown");
+
+    const focusState = await window.evaluate(() => {
+      const items = document.querySelector(".transcript-list__items");
+      if (!items) return null;
+      const style = getComputedStyle(items);
+      return {
+        focused: items === document.activeElement,
+        outlineStyle: style.outlineStyle,
+        outlineWidth: style.outlineWidth,
+      };
+    });
+    expect(focusState).not.toBeNull();
+    // Focus itself must stay (keyboard scrolling depends on it) — only
+    // the viewport-sized ring goes.
+    expect(focusState?.focused).toBe(true);
+    expect(focusState?.outlineStyle).toBe("none");
+    expect(focusState?.outlineWidth).toBe("0px");
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9428,6 +9428,18 @@ textarea,
   padding: 16px 12px 24px 16px;
 }
 
+/* The scroller is tabIndex=0 only so keyboard users can scroll it (axe
+   scrollable-region-focusable). A click focuses it, and Chromium then
+   promotes the focus to :focus-visible on the next keystroke — drawing
+   the OS-accent UA ring around the ENTIRE transcript (repro in any
+   window: click transcript text, press an arrow key; reported from a
+   federation window). A viewport-sized ring is noise, not a usable
+   focus cue — suppress it, matching the resize-handle precedent. */
+.transcript-list__items:focus,
+.transcript-list__items:focus-visible {
+  outline: none;
+}
+
 .transcript-list__items:has(.transcript-list__pending:last-child) {
   padding-bottom: 4px;
 }


### PR DESCRIPTION
## Summary

- Fixes the orange outline that appeared around the entire transcript pane. Root cause: the transcript scroller is `tabIndex=0` (required by axe's scrollable-region-focusable rule), a click on transcript text focuses it, and Chromium promotes that focus to `:focus-visible` on the next keystroke — drawing the **OS-accent UA focus ring** around the whole scroller. On a Mac with an orange system accent, that's the orange box.
- Reported from a federation window, but reproducible in any window (click transcript, press an arrow key) — the fix is global: suppress the outline on `.transcript-list__items` focus states, matching the existing resize-handle precedent, while keeping the scroller focusable so keyboard scrolling still works.

## Verification

- New E2E `transcript-focus-ring.spec.ts` pins the exact repro: click transcript text, press ArrowDown, assert the scroller holds focus with `outline: none`. Passes locally against a built `out/`.
- `lint:colors` and ESLint pass; no token changes.

## Notes

- Diagnosed with the two-instance federation harness from #1213: computed-style inspection showed `outline: <ring> auto 1px` + `:focus-visible` matching after the keystroke in **both** local and remote windows, so this wasn't federation-specific — the remote window was just where it got noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)