### PR TITLE
fix(desktop): refresh federation menu after peer directory updates

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -153,9 +153,9 @@ test.describe("federation remote window", () => {
       const connectionSection = window.getByRole("region", {
         name: "Connection",
       });
-      await expect(connectionSection.getByText("Connected")).toBeVisible({
-        timeout: 30_000,
-      });
+      await expect(
+        connectionSection.getByText("Connected", { exact: true }),
+      ).toBeVisible({ timeout: 30_000 });
 
       // Browse the peer: a dedicated remote window opens.
       const remoteWindowPromise = electronApp.waitForEvent("window");

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -38,6 +38,7 @@ type RuntimeHarness = {
     sourcePeerId: FederationInstanceId,
   ) => boolean;
   remotePeerDirectory: Map<FederationInstanceId, unknown>;
+  onPeerStatusChanged: (listener: () => void) => () => void;
   recordClientConnection: (params: {
     gatewayInstanceId: FederationInstanceId;
     gatewayUrl: string;
@@ -276,6 +277,60 @@ describe("DesktopFederationRuntime", () => {
     expect(runtime.visiblePeers()).toMatchObject([
       { id: "gateway_one", status: "connected" },
       { id: "client_two", status: "connected" },
+    ]);
+  });
+
+  it("publishes peer status changes after installing the full directory", () => {
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "client_one";
+    runtime.store = () => ({
+      getPeer: () => undefined,
+      listPeers: () => [],
+    });
+    const peerDirectory = (
+      id: string,
+      peers: Array<{
+        id: FederationInstanceId;
+        label: string;
+      }>,
+    ): FederationProtocolEnvelope => ({
+      id,
+      kind: "notification",
+      method: "federation.peerDirectory",
+      params: {
+        peers: peers.map((peer) => ({
+          ...peer,
+          role: peer.id === "gateway_one" ? "gateway" : "client",
+          status: "connected",
+          capabilities: ["remote_window"],
+        })),
+      },
+      protocolVersion: FEDERATION_PROTOCOL_VERSION,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "client_one",
+      createdAt: 2_000,
+    });
+
+    runtime.applyPeerDirectory(peerDirectory("peers-1", [
+      { id: "gateway_one", label: "Gateway" },
+      { id: "client_m5", label: "M5" },
+    ]));
+
+    const visibleSnapshots: FederationInstanceId[][] = [];
+    runtime.onPeerStatusChanged(() => {
+      visibleSnapshots.push(
+        runtime.connectedPeerTargets().map((peer) => peer.target.instanceId),
+      );
+    });
+
+    runtime.applyPeerDirectory(peerDirectory("peers-2", [
+      { id: "gateway_one", label: "Gateway" },
+      { id: "client_2018", label: "2018" },
+      { id: "client_m5", label: "M5" },
+    ]));
+
+    expect(visibleSnapshots).toEqual([
+      ["gateway_one", "client_2018", "client_m5"],
     ]);
   });
 

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1383,8 +1383,16 @@ export class DesktopFederationRuntime {
           canRevoke: false,
         });
         previousPeers.delete(peer.id);
-        this.publishPeerStatus(peer.id, peer.status, peer.unavailableReason);
       }
+    }
+    // Publish only after the complete snapshot is installed. Status listeners
+    // synchronously read visiblePeers() (the application menu is one of them),
+    // so notifying while this map is still being rebuilt can expose a partial
+    // directory. If the remaining peers retain their previous statuses, the
+    // deduplicating publisher will not fire again and that partial view can
+    // remain visible indefinitely.
+    for (const peer of this.remotePeerDirectory.values()) {
+      this.publishPeerStatus(peer.id, peer.status, peer.unavailableReason);
     }
     for (const peerId of previousPeers.keys()) {
       this.publishPeerStatus(


### PR DESCRIPTION
## Summary

- install each advertised federation peer-directory snapshot completely before publishing status changes
- ensure synchronous status listeners such as File → Remote Instances always read the complete directory
- add a regression test for a newly connected peer appearing ahead of an already-connected peer

## Root cause

The client cleared and rebuilt its advertised peer map incrementally while synchronously notifying status listeners inside the population loop. When a newly connected peer triggered a menu rebuild before later, already-connected peers had been reinserted, the native menu captured a partial directory. Status deduplication then suppressed another notification for those unchanged peers, leaving the menu stale even though Settings read the complete map.

## User impact

Connected sibling instances advertised through a federation gateway now remain available in File → Remote Instances after another peer connects. Federation routing and Settings behavior are unchanged.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-runtime.test.ts`
- `pnpm lint:eslint` (passes with the existing warning baseline)
- `pnpm typecheck`
- `pnpm lint:boundaries`
- `git diff --check`
