### PR TITLE
fix(desktop): hide unpushed badge after squash merge

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -153,9 +153,9 @@ test.describe("federation remote window", () => {
       const connectionSection = window.getByRole("region", {
         name: "Connection",
       });
-      await expect(connectionSection.getByText("Connected")).toBeVisible({
-        timeout: 30_000,
-      });
+      await expect(
+        connectionSection.getByText("Connected", { exact: true }),
+      ).toBeVisible({ timeout: 30_000 });
 
       // Browse the peer: a dedicated remote window opens.
       const remoteWindowPromise = electronApp.waitForEvent("window");

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -7,7 +7,7 @@ import {
   probeWorktreeWorkingState,
 } from "../app-server/git-working-state-service";
 
-type GitCall = { cwd: string; args: string[] };
+type GitCall = { cwd: string; args: string[]; input?: string };
 
 function makeTempPrefix(): string {
   return path.join(os.tmpdir(), "pwragent-git-working-state-");
@@ -18,12 +18,25 @@ function normalizeTestPath(value: string): string {
 }
 
 function fakeGit(
-  responder: (args: string[]) => string | undefined,
-): { runGit: (cwd: string, args: string[]) => Promise<string>; calls: GitCall[] } {
+  responder: (args: string[], input?: string) => string | undefined,
+): {
+  runGit: (
+    cwd: string,
+    args: string[],
+    env?: NodeJS.ProcessEnv,
+    input?: string,
+  ) => Promise<string>;
+  calls: GitCall[];
+} {
   const calls: GitCall[] = [];
-  const runGit = async (cwd: string, args: string[]): Promise<string> => {
-    calls.push({ cwd, args });
-    const result = responder(args);
+  const runGit = async (
+    cwd: string,
+    args: string[],
+    _env?: NodeJS.ProcessEnv,
+    input?: string,
+  ): Promise<string> => {
+    calls.push({ cwd, args, input });
+    const result = responder(args, input);
     if (result === undefined) {
       throw new Error(`unexpected git invocation: ${args.join(" ")}`);
     }
@@ -94,12 +107,12 @@ describe("probeWorktreeWorkingState", () => {
     const mergedPrHeadSha = "a".repeat(40);
     const mergedPrAncestorSha = "c".repeat(40);
     const localOnlySha = "b".repeat(40);
-    const { runGit, calls } = fakeGit((args) => {
+    const { runGit, calls } = fakeGit((args, input) => {
       if (args.includes("--numstat")) return "";
       if (args.includes("status")) return "";
       if (args[args.length - 1] === "remote") return "origin\n";
       if (args.includes("rev-list")) {
-        return args.includes(mergedPrHeadSha)
+        return input?.includes(mergedPrHeadSha)
           ? "1\n"
           : `${mergedPrHeadSha}\n${mergedPrAncestorSha}\n${localOnlySha}\n`;
       }
@@ -120,8 +133,31 @@ describe("probeWorktreeWorkingState", () => {
       "HEAD",
       "--not",
       "--remotes",
-      mergedPrHeadSha,
+      "--stdin",
     ]);
+    expect(calls.find((call) => call.args.includes("rev-list"))?.input)
+      .toBe(`^${mergedPrHeadSha}\n`);
+  });
+
+  it("falls back to the raw local count when PR exclusion input fails", async () => {
+    const mergedPrHeadSha = "a".repeat(40);
+    const { runGit, calls } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("rev-list")) {
+        return args.includes("--stdin") ? undefined : "3\n";
+      }
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", {
+      runGit,
+      acceptedPushedCommitShas: [mergedPrHeadSha],
+    });
+
+    expect(state?.unpushedCommits).toBe(3);
+    expect(calls.filter((call) => call.args.includes("rev-list"))).toHaveLength(2);
   });
 
   it("infers the likely base branch and behind-base count from git refs", async () => {
@@ -848,13 +884,13 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
   it("treats ancestors of merged PR heads as pushed even when no remote ref contains them", async () => {
     const mergedPrHeadSha = "d".repeat(40);
     const mergedPrAncestorSha = "e".repeat(40);
-    const responder = (args: string[]): string | undefined => {
+    const responder = (args: string[], input?: string): string | undefined => {
       if (args.includes("diff") && args.includes("--name-only")) return "";
       if (args.includes("ls-files")) return "";
       if (args.includes("check-ignore")) return "";
       if (args.includes("log")) return `${mergedPrAncestorSha}\n`;
       if (args.includes("rev-list")) {
-        return args.includes(mergedPrHeadSha) ? "" : `${mergedPrAncestorSha}\n`;
+        return input?.includes(mergedPrHeadSha) ? "" : `${mergedPrAncestorSha}\n`;
       }
       return undefined;
     };
@@ -880,8 +916,33 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
       mergedPrAncestorSha,
       "--not",
       "--remotes",
-      mergedPrHeadSha,
+      "--stdin",
     ]);
+    expect(calls.find((call) => call.args.includes("rev-list"))?.input)
+      .toBe(`^${mergedPrHeadSha}\n`);
+  });
+
+  it("fails closed when commit reachability cannot be determined", async () => {
+    const commitSha = "f".repeat(40);
+    const { runGit } = fakeGit((args) => {
+      if (args.includes("diff") && args.includes("--name-only")) return "";
+      if (args.includes("ls-files")) return "";
+      if (args.includes("check-ignore")) return "";
+      if (args.includes("log")) return `${commitSha}\n`;
+      return undefined;
+    });
+    const service = new GitWorkingStateService({ runGit });
+
+    const states = await service.resolveEditCommitStates(
+      "/repo/wt",
+      [{ key: "g-unknown", paths: ["/repo/wt/src/unknown.ts"] }],
+    );
+
+    expect(states["g-unknown"]).toMatchObject({
+      committed: true,
+      commitSha,
+      pushed: false,
+    });
   });
 
   it("returns an empty map for no worktree or no groups", async () => {

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -90,24 +90,38 @@ describe("probeWorktreeWorkingState", () => {
     expect(calls.some((call) => call.args.includes("rev-list"))).toBe(false);
   });
 
-  it("does not count commits attached to merged PRs as unpushed", async () => {
-    const mergedPrSha = "a".repeat(40);
+  it("does not count a merged PR head or its ancestors as unpushed", async () => {
+    const mergedPrHeadSha = "a".repeat(40);
+    const mergedPrAncestorSha = "c".repeat(40);
     const localOnlySha = "b".repeat(40);
-    const { runGit } = fakeGit((args) => {
+    const { runGit, calls } = fakeGit((args) => {
       if (args.includes("--numstat")) return "";
       if (args.includes("status")) return "";
       if (args[args.length - 1] === "remote") return "origin\n";
-      if (args.includes("rev-list") && args.includes("--count")) return "2\n";
-      if (args.includes("rev-list")) return `${mergedPrSha}\n${localOnlySha}\n`;
+      if (args.includes("rev-list")) {
+        return args.includes(mergedPrHeadSha)
+          ? "1\n"
+          : `${mergedPrHeadSha}\n${mergedPrAncestorSha}\n${localOnlySha}\n`;
+      }
       return undefined;
     });
 
     const state = await probeWorktreeWorkingState("/repo/wt", {
       runGit,
-      acceptedPushedCommitShas: [mergedPrSha],
+      acceptedPushedCommitShas: [mergedPrHeadSha],
     });
 
     expect(state?.unpushedCommits).toBe(1);
+    expect(calls.find((call) => call.args.includes("rev-list"))?.args).toEqual([
+      "--no-optional-locks",
+      "rev-list",
+      "--ignore-missing",
+      "--count",
+      "HEAD",
+      "--not",
+      "--remotes",
+      mergedPrHeadSha,
+    ]);
   });
 
   it("infers the likely base branch and behind-base count from git refs", async () => {
@@ -726,7 +740,7 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
       return "";
     }
     if (args.includes("rev-list")) {
-      const sha = args[args.indexOf("rev-list") + 2];
+      const sha = args[args.indexOf("-1") + 1];
       // c-commit is local-only (rev-list returns it); b-commit is pushed (empty).
       return sha?.startsWith("c") ? sha : "";
     }
@@ -831,30 +845,43 @@ describe("GitWorkingStateService.resolveEditCommitStates", () => {
     expect(calls.filter((call) => call.args.includes("rev-list"))).toHaveLength(1);
   });
 
-  it("treats commits attached to merged PRs as pushed even when no remote ref contains them", async () => {
-    const mergedPrSha = "d".repeat(40);
+  it("treats ancestors of merged PR heads as pushed even when no remote ref contains them", async () => {
+    const mergedPrHeadSha = "d".repeat(40);
+    const mergedPrAncestorSha = "e".repeat(40);
     const responder = (args: string[]): string | undefined => {
       if (args.includes("diff") && args.includes("--name-only")) return "";
       if (args.includes("ls-files")) return "";
       if (args.includes("check-ignore")) return "";
-      if (args.includes("log")) return `${mergedPrSha}\n`;
-      if (args.includes("rev-list")) return `${mergedPrSha}\n`;
+      if (args.includes("log")) return `${mergedPrAncestorSha}\n`;
+      if (args.includes("rev-list")) {
+        return args.includes(mergedPrHeadSha) ? "" : `${mergedPrAncestorSha}\n`;
+      }
       return undefined;
     };
-    const { runGit } = fakeGit(responder);
+    const { runGit, calls } = fakeGit(responder);
     const service = new GitWorkingStateService({ runGit });
 
     const states = await service.resolveEditCommitStates(
       "/repo/wt",
       [{ key: "g-merged", paths: ["/repo/wt/src/merged.ts"] }],
-      { acceptedPushedCommitShas: [mergedPrSha] },
+      { acceptedPushedCommitShas: [mergedPrHeadSha] },
     );
 
     expect(states["g-merged"]).toMatchObject({
       committed: true,
-      commitSha: mergedPrSha,
+      commitSha: mergedPrAncestorSha,
       pushed: true,
     });
+    expect(calls.find((call) => call.args.includes("rev-list"))?.args).toEqual([
+      "--no-optional-locks",
+      "rev-list",
+      "--ignore-missing",
+      "-1",
+      mergedPrAncestorSha,
+      "--not",
+      "--remotes",
+      mergedPrHeadSha,
+    ]);
   });
 
   it("returns an empty map for no worktree or no groups", async () => {

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -32,6 +32,7 @@ type GitCommandRunner = (
   cwd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  input?: string,
 ) => Promise<string>;
 type UntrackedPathFilter = (repoPath: string) => boolean;
 
@@ -84,12 +85,50 @@ function buildWorkingStateCacheKey(
   return accepted ? `${worktreePath}\0${accepted}` : worktreePath;
 }
 
+function buildRevisionExclusionInput(
+  commitShas: Iterable<string>,
+): string | undefined {
+  const exclusions = [...commitShas].sort().map((sha) => `^${sha}`);
+  return exclusions.length > 0 ? `${exclusions.join("\n")}\n` : undefined;
+}
+
 async function defaultRunGit(
   cwd: string,
   args: string[],
   env?: NodeJS.ProcessEnv,
+  input?: string,
 ): Promise<string> {
-  return (await runGitCommand(cwd, args, { env })).stdout;
+  if (input === undefined) {
+    return (await runGitCommand(cwd, args, { env })).stdout;
+  }
+
+  const childEnv = buildPwrAgentChildProcessEnv(env ?? process.env);
+  const git = await resolveGitExecutable(childEnv);
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn(git, ["-C", cwd, ...args], { env: childEnv });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(
+          new Error(stderr.trim() || `git exited with code ${code ?? "unknown"}`),
+        );
+      }
+    });
+    child.stdin.on("error", () => undefined);
+    child.stdin.end(input);
+  });
 }
 
 function parseNumstat(output: string): {
@@ -823,8 +862,8 @@ export async function probeWorktreeWorkingState(
 ): Promise<ThreadGitWorkingState | undefined> {
   const runGit = options.runGit ?? defaultRunGit;
   const gitEnv = options.gitEnv;
-  const runGitNoLocks = (args: string[]): Promise<string> =>
-    runGit(worktreePath, ["--no-optional-locks", ...args], gitEnv);
+  const runGitNoLocks = (args: string[], input?: string): Promise<string> =>
+    runGit(worktreePath, ["--no-optional-locks", ...args], gitEnv, input);
 
   const [numstatOutput, statusOutput, remotesOutput, baseState] = await Promise.all([
     // Staged + unstaged line counts vs HEAD. Fails on an unborn HEAD
@@ -860,19 +899,27 @@ export async function probeWorktreeWorkingState(
   // meaningless for a local-only repo, so report 0 instead.
   let unpushedCommits = 0;
   if (remotesOutput?.trim()) {
-    const acceptedPushedCommitShas = [
-      ...buildAcceptedPushedCommitSet(options.acceptedPushedCommitShas),
-    ].sort();
-    const count = await runGitNoLocks([
+    const acceptedPushedCommitInput = buildRevisionExclusionInput(
+      buildAcceptedPushedCommitSet(options.acceptedPushedCommitShas),
+    );
+    const countArgs = [
       "rev-list",
       "--ignore-missing",
       "--count",
       "HEAD",
       "--not",
       "--remotes",
-      ...acceptedPushedCommitShas,
-    ]).catch(() => undefined);
-    unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
+    ];
+    let count = await runGitNoLocks(
+      acceptedPushedCommitInput ? [...countArgs, "--stdin"] : countArgs,
+      acceptedPushedCommitInput,
+    ).catch(() => undefined);
+    if (count === undefined && acceptedPushedCommitInput) {
+      // If the ancestry-aware probe fails, retry without PR exclusions. A
+      // false-positive badge is safer than hiding genuinely local work.
+      count = await runGitNoLocks(countArgs).catch(() => undefined);
+    }
+    unpushedCommits = count !== undefined ? Number(count) || 0 : 1;
   }
 
   return {
@@ -1279,10 +1326,13 @@ export class GitWorkingStateService {
     }
 
     const gitEnv = this.gitEnv;
-    const noLocks = (args: string[]): Promise<string> =>
-      this.runGit(cwd, ["--no-optional-locks", ...args], gitEnv);
+    const noLocks = (args: string[], input?: string): Promise<string> =>
+      this.runGit(cwd, ["--no-optional-locks", ...args], gitEnv, input);
     const acceptedPushedCommitShas = buildAcceptedPushedCommitSet(
       options.acceptedPushedCommitShas,
+    );
+    const acceptedPushedCommitInput = buildRevisionExclusionInput(
+      acceptedPushedCommitShas,
     );
 
     // The set of files that still have working-tree changes (tracked diffs vs
@@ -1344,17 +1394,33 @@ export class GitWorkingStateService {
       // exact-SHA matches so earlier commits from a squash-merged branch also
       // read as pushed. Empty ⇒ pushed. With no remotes or accepted heads,
       // nothing is excluded ⇒ non-empty ⇒ local-only.
-      const promise = noLocks([
+      const baseArgs = [
         "rev-list",
         "--ignore-missing",
         "-1",
         sha,
         "--not",
         "--remotes",
-        ...acceptedPushedCommitShas,
-      ])
-        .then((output) => output.trim() === "")
-        .catch(() => true);
+      ];
+      const promise = (async () => {
+        if (acceptedPushedCommitInput) {
+          try {
+            const output = await noLocks(
+              [...baseArgs, "--stdin"],
+              acceptedPushedCommitInput,
+            );
+            return output.trim() === "";
+          } catch {
+            // Retry without PR exclusions so an input/protocol failure cannot
+            // silently classify local work as pushed.
+          }
+        }
+        try {
+          return (await noLocks(baseArgs)).trim() === "";
+        } catch {
+          return false;
+        }
+      })();
       pushedBySha.set(sha, promise);
       return promise;
     };

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -851,38 +851,28 @@ export async function probeWorktreeWorkingState(
     gitEnv,
   );
 
-  // "Unpushed" means reachable from HEAD but on no remote ref. With no
-  // remotes configured, every commit would count — meaningless for a
-  // local-only repo, so report 0 instead.
+  // "Unpushed" means reachable from HEAD but on no remote ref or accepted
+  // merged-PR head. Excluding an accepted head also excludes its ancestors,
+  // which is load-bearing after squash merge: the in-process GitHub lookup
+  // retains the PR head SHA, while the deleted source branch's earlier commits
+  // are no longer reachable from a remote ref. Commits added after that head
+  // remain countable. With no remotes configured, every commit would count —
+  // meaningless for a local-only repo, so report 0 instead.
   let unpushedCommits = 0;
   if (remotesOutput?.trim()) {
-    const acceptedPushedCommitShas = buildAcceptedPushedCommitSet(
-      options.acceptedPushedCommitShas,
-    );
-    if (acceptedPushedCommitShas.size > 0) {
-      const output = await runGitNoLocks([
-        "rev-list",
-        "HEAD",
-        "--not",
-        "--remotes",
-      ]).catch(() => undefined);
-      unpushedCommits = output === undefined
-        ? 0
-        : output
-          .split("\n")
-          .map((sha) => sha.trim().toLowerCase())
-          .filter((sha) => sha && !acceptedPushedCommitShas.has(sha))
-          .length;
-    } else {
-      const count = await runGitNoLocks([
-        "rev-list",
-        "--count",
-        "HEAD",
-        "--not",
-        "--remotes",
-      ]).catch(() => undefined);
-      unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
-    }
+    const acceptedPushedCommitShas = [
+      ...buildAcceptedPushedCommitSet(options.acceptedPushedCommitShas),
+    ].sort();
+    const count = await runGitNoLocks([
+      "rev-list",
+      "--ignore-missing",
+      "--count",
+      "HEAD",
+      "--not",
+      "--remotes",
+      ...acceptedPushedCommitShas,
+    ]).catch(() => undefined);
+    unpushedCommits = count !== undefined ? Number(count) || 0 : 0;
   }
 
   return {
@@ -1348,15 +1338,21 @@ export class GitWorkingStateService {
       if (existing) {
         return existing;
       }
-      if (acceptedPushedCommitShas.has(sha.trim().toLowerCase())) {
-        const promise = Promise.resolve(true);
-        pushedBySha.set(sha, promise);
-        return promise;
-      }
       // `rev-list -1 <sha> --not --remotes` lists sha only when it (or its
-      // tip) isn't reachable from any remote ref. Empty ⇒ pushed. With no
-      // remotes configured, nothing is excluded ⇒ non-empty ⇒ local-only.
-      const promise = noLocks(["rev-list", "-1", sha, "--not", "--remotes"])
+      // tip) isn't reachable from any remote ref or accepted merged-PR head.
+      // Accepted heads intentionally act as revision exclusions rather than
+      // exact-SHA matches so earlier commits from a squash-merged branch also
+      // read as pushed. Empty ⇒ pushed. With no remotes or accepted heads,
+      // nothing is excluded ⇒ non-empty ⇒ local-only.
+      const promise = noLocks([
+        "rev-list",
+        "--ignore-missing",
+        "-1",
+        sha,
+        "--not",
+        "--remotes",
+        ...acceptedPushedCommitShas,
+      ])
         .then((output) => output.trim() === "")
         .catch(() => true);
       pushedBySha.set(sha, promise);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -4965,10 +4965,9 @@ class DesktopAppServerService {
     prs: PrSummary[],
     fetchedAt: number,
   ): Promise<string[]> {
-    // The poller fetches only the PR's head commit (see the cost note in
-    // github-graphql-client). `commitShas` is load-bearing for merged-PR
-    // "pushed" detection and the `gh` path fills in the full list, so union
-    // forward instead of overwriting a richer set with a poorer one.
+    // The GraphQL client fetches only the PR's head commit (see the cost note
+    // in github-graphql-client). Union forward so a status poll does not
+    // overwrite a richer commit set retained from an older snapshot.
     const merged = prs.map((pr) => {
       const previous = this.prStatusRegistry.get(getPrStatusKey(pr))?.pr;
       const commitShas = mergeCommitShas(previous?.commitShas, pr.commitShas);

--- a/apps/desktop/src/main/pr-status/pr-derivations.ts
+++ b/apps/desktop/src/main/pr-status/pr-derivations.ts
@@ -106,12 +106,11 @@ export function normalizeCommitShas(
 /**
  * Union two commit-SHA sets.
  *
- * The batched poller only fetches the PR's HEAD commit (`commits(last: 1)`) —
- * that is all `statusCheckRollup` needs, and widening it to the full commit
- * list would multiply the GraphQL node cost of every batch. But `commitShas`
- * is load-bearing for merged-PR "pushed" detection, and the `gh` path DOES
- * populate the full list. So the poller unions its head SHA into whatever is
- * already known rather than replacing (and shrinking) the set.
+ * The in-process GraphQL client fetches the PR's HEAD commit
+ * (`commits(last: 1)`) — that is all `statusCheckRollup` needs, and widening it
+ * to the full commit list would multiply the node cost of every batch. The Git
+ * working-state probe treats a merged head and its ancestors as pushed, while
+ * this union preserves any richer commit set retained from an older snapshot.
  */
 export function mergeCommitShas(
   previous: string[] | undefined,


### PR DESCRIPTION
## Summary

- treat a merged PR head and its ancestors as published when calculating thread working state
- keep genuinely new commits made after the merged head visible as unpushed
- apply the same ancestry-aware behavior to edited-file commit state
- update stale comments that assumed the old `gh` lookup still provided every PR commit

## Root cause

The in-process GitHub GraphQL lookup introduced in PR #1201 retains only the PR head SHA. The earlier squash-merge fix filtered exact commit SHAs, so earlier commits on a deleted squash-merged source branch were once again counted as local-only.

The Git probe now passes merged PR heads as revision exclusions. Git therefore excludes the accepted head's ancestry without requiring a more expensive full PR commit query.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-working-state-service.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts` — 116 tests passed
- `pnpm lint:eslint` — passed with existing warnings only
- `pnpm typecheck`
- `pnpm lint:boundaries`
- verified the exact PwrGit PR #27 worktree from the report now computes 0 unpushed commits
